### PR TITLE
doc(runtime): clarify the purpose of several core items

### DIFF
--- a/src/runtime/dom.ts
+++ b/src/runtime/dom.ts
@@ -1,5 +1,6 @@
 import { IContainer, IResolver, DI } from '../kernel/di';
 import { ICustomElement } from './templating/custom-element';
+import { IViewOwner } from './templating/view';
 
 export interface INodeLike {
   readonly firstChild: INode | null;
@@ -281,6 +282,11 @@ function setAttribute(this: CommentProxy, qualifiedName: string, value: string):
   this.$proxyTarget.setAttribute(qualifiedName, value);
 }
 
+// This is the most common form of IView.
+// Every custom element or template controller whose view is based on an HTML template
+// has an instance of this under the hood. Anyone who wants to create a view from
+// a string of markup would also receive an instance of this.
+// CompiledTemplates create instances of TemplateViews.
 /*@internal*/
 export class TemplateView implements IView {
   private fragment: DocumentFragment;

--- a/src/runtime/dom.ts
+++ b/src/runtime/dom.ts
@@ -1,6 +1,5 @@
 import { IContainer, IResolver, DI } from '../kernel/di';
 import { ICustomElement } from './templating/custom-element';
-import { IViewOwner } from './templating/view';
 
 export interface INodeLike {
   readonly firstChild: INode | null;

--- a/src/runtime/templating/rendering-engine.ts
+++ b/src/runtime/templating/rendering-engine.ts
@@ -40,6 +40,7 @@ export interface IRenderingEngine {
 export const IRenderingEngine = DI.createInterface<IRenderingEngine>()
   .withDefault(x => x.singleton(RenderingEngine));
 
+// This is an implementation of ITemplate that always returns a view representing "no DOM" to render.
 const noViewTemplate: ITemplate = {
   renderContext: null,
   createFor(owner: IViewOwner) {
@@ -226,6 +227,12 @@ function createDefinition(definition: Immutable<ITemplateSource>): TemplateDefin
   };
 }
 
+// This is the main implementation of ITemplate.
+// It is used to create instances of IView based on a compiled TemplateDefinition.
+// TemplateDefinitions are hand-coded today, but will ultimately be the output of the
+// TemplateCompiler either through a JIT or AOT process.
+// Essentially, CompiledTemplate wraps up the small bit of code that is needed to take a TemplateDefinition
+// and create instances of it on demand.
 class CompiledTemplate implements ITemplate {
   private createView: () => IView;
   renderContext: IRenderContext;

--- a/src/runtime/templating/template.ts
+++ b/src/runtime/templating/template.ts
@@ -3,6 +3,11 @@ import { INode, IView } from "../dom";
 import { TemplatePartDefinitions } from "./instructions";
 import { IRenderContext } from "./render-context";
 
+// The basic template abstraction that allows consumers to create
+// instances of an IView on-demand. Templates are contextual in that they are, in the very least,
+// part of a particular application, with application-level resources, but they also may have thier
+// own scoped resources or be part of another view (via a template controller) which provides a
+// context for the template.
 export interface ITemplate {
   readonly renderContext: IRenderContext;
   createFor(owner: IViewOwner, host?: INode, parts?: TemplatePartDefinitions): IView;


### PR DESCRIPTION
Also, added some notes on which things are likely to go away with the removal of shadow dom emulation. In the end, I'm hopeful that a good chunk of this will be simplified. However, I think it's likely going to still be very valuable to have core abstractions like ITemplates that create IViews. The simplicity can come from the fact that you will no longer need a RenderSlot to render the IView. You can basically just have an INode (or RenderLocation, which will just be an INode) and simply append the IView at the location.