### PR TITLE
refactor(all): improving a couple of method names related to resources

### DIFF
--- a/packages/jit/src/templating/binding-command.ts
+++ b/packages/jit/src/templating/binding-command.ts
@@ -17,7 +17,7 @@ export function bindingCommand(nameOrSource: string | IBindingCommandSource) {
 export const BindingCommandResource: IResourceKind<IBindingCommandSource, IBindingCommandType> = {
   name: 'binding-command',
 
-  key(name: string): string {
+  keyFrom(name: string): string {
     return `${this.name}:${name}`;
   },
 
@@ -32,7 +32,7 @@ export const BindingCommandResource: IResourceKind<IBindingCommandSource, IBindi
     (Type as Writable<IBindingCommandType>).kind = BindingCommandResource;
     (Type as Writable<IBindingCommandType>).description = description;
     Type.register = function(container: IContainer) {
-      container.register(Registration.singleton(Type.kind.key(description.name), Type));
+      container.register(Registration.singleton(Type.kind.keyFrom(description.name), Type));
     };
 
     return Type;

--- a/packages/jit/src/templating/template-compiler.ts
+++ b/packages/jit/src/templating/template-compiler.ts
@@ -151,7 +151,7 @@ export class TemplateCompiler implements ITemplateCompiler {
               ]);
           }
         }
-        const command = resources.get(BindingCommandResource, commandName);
+        const command = resources.find(BindingCommandResource, commandName);
         if (command !== undefined) {
           const expression = this.expressionParser.parse(value, BindingType.CustomCommand);
           // TODO: implement behavior (this is just a temporary placeholder)
@@ -169,7 +169,7 @@ export class TemplateCompiler implements ITemplateCompiler {
           return new RefBindingInstruction(expression);
       }
     }
-    const attribute = resources.get(CustomAttributeResource, name);
+    const attribute = resources.find(CustomAttributeResource, name);
     if (attribute !== undefined) {
       // CustomAttribute
       // TODO: properly parse semicolon-separated bindings

--- a/packages/jit/test/unit/templating/template-compiler.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.spec.ts
@@ -23,8 +23,8 @@ describe('TemplateCompiler', () => {
     register(container);
     expressionParser = container.get(IExpressionParser);
     sut = new TemplateCompiler(expressionParser);
-    container.registerResolver(CustomAttributeResource.key('foo'), <any>{ getFactory: () => ({ type: { description: {} } }) });
-    container.registerResolver(BindingCommandResource.key('foo'), <any>{ getFactory: () => ({ type: { description: {} } }) });
+    container.registerResolver(CustomAttributeResource.keyFrom('foo'), <any>{ getFactory: () => ({ type: { description: {} } }) });
+    container.registerResolver(BindingCommandResource.keyFrom('foo'), <any>{ getFactory: () => ({ type: { description: {} } }) });
     resources = new RuntimeCompilationResources(<any>container);
   });
 
@@ -313,7 +313,7 @@ describe('TemplateCompiler', () => {
         it(inputMarkup, () => {
           outputMarkup = new Array(count + 1).join(outputMarkup);
           instructions = new Array(count).fill(instructions).reduce((acc, item) => acc.concat(item));
-          const actual = sut.compile(<any>{templateOrNode: inputMarkup, instructions:[]},<any>{get(){}});
+          const actual = sut.compile(<any>{templateOrNode: inputMarkup, instructions:[]},<any>{find(){}});
           const expected = {
             templateOrNode: createElement(outputMarkup),
             instructions: [instructions]

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1,9 +1,9 @@
-import { Collection } from './observation';
 import { IServiceLocator } from '@aurelia/kernel';
 import { IBinding } from './binding';
 import { BindingBehaviorResource } from './binding-behavior';
 import { BindingContext, IScope } from './binding-context';
 import { BindingFlags } from './binding-flags';
+import { Collection } from './observation';
 import { ISignaler } from './signaler';
 import { ValueConverterResource } from './value-converter';
 
@@ -68,7 +68,7 @@ export class BindingBehavior implements IExpression {
   private expressionHasBind: boolean;
   private expressionHasUnbind: boolean;
   constructor(public expression: IsBindingBehavior, public name: string, public args: IsAssign[]) {
-    this.behaviorKey = BindingBehaviorResource.key(this.name);
+    this.behaviorKey = BindingBehaviorResource.keyFrom(this.name);
     if ((<any>expression).expression) {
       this.expressionHasBind = !!(<any>expression).bind;
       this.expressionHasUnbind = !!(<any>expression).unbind;
@@ -125,7 +125,7 @@ export class ValueConverter implements IExpression {
   public allArgs: IsValueConverter[];
   constructor(public expression: IsValueConverter, public name: string, public args: IsAssign[]) {
     this.allArgs = [expression].concat(args);
-    this.converterKey = ValueConverterResource.key(this.name);
+    this.converterKey = ValueConverterResource.keyFrom(this.name);
   }
 
   public evaluate(flags: BindingFlags, scope: IScope, locator: IServiceLocator) {

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -16,7 +16,7 @@ export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource) {
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBindingBehaviorType> = {
   name: 'binding-behavior',
 
-  key(name: string) {
+  keyFrom(name: string) {
     return `${this.name}:${name}`;
   },
 
@@ -31,7 +31,7 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
     (Type as Writable<IBindingBehaviorType>).kind = BindingBehaviorResource;
     (Type as Writable<IBindingBehaviorType>).description = description;
     Type.register = function(container: IContainer) {
-      container.register(Registration.singleton(Type.kind.key(description.name), Type));
+      container.register(Registration.singleton(Type.kind.keyFrom(description.name), Type));
     };
 
     return Type;

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -16,7 +16,7 @@ export function valueConverter(nameOrSource: string | IValueConverterSource) {
 export const ValueConverterResource: IResourceKind<IValueConverterSource, IValueConverterType> = {
   name: 'value-converter',
 
-  key(name: string) {
+  keyFrom(name: string) {
     return `${this.name}:${name}`;
   },
 
@@ -31,7 +31,7 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
     (Type as Writable<IValueConverterType>).kind = ValueConverterResource;
     (Type as Writable<IValueConverterType>).description = description;
     Type.register = function(container: IContainer) {
-      container.register(Registration.singleton(Type.kind.key(description.name), Type));
+      container.register(Registration.singleton(Type.kind.keyFrom(description.name), Type));
     };
 
     return Type;

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -2,7 +2,7 @@ import { Constructable, Immutable, IRegistry } from '@aurelia/kernel';
 
 export interface IResourceKind<TSource, TType extends IResourceType<TSource> = IResourceType<TSource>> {
   readonly name: string;
-  key(name: string): string;
+  keyFrom(name: string): string;
   isType<T extends Constructable>(type: T): type is T & TType;
   define<T extends Constructable>(nameOrSource: string | TSource, ctor: T): T & TType;
 }
@@ -15,5 +15,5 @@ export interface IResourceType<TSource = {}, T = {}> extends Constructable<T>, I
 }
 
 export interface IResourceDescriptions {
-  get<TSource>(kind: IResourceKind<TSource>, name: string): ResourceDescription<TSource> | null;
+  find<TSource>(kind: IResourceKind<TSource>, name: string): ResourceDescription<TSource> | null;
 }

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -75,7 +75,7 @@ export function templateController(nameOrSource: string | Omit<ICustomAttributeS
 export const CustomAttributeResource: IResourceKind<ICustomAttributeSource, ICustomAttributeType> = {
   name: 'custom-attribute',
 
-  key(name: string): string {
+  keyFrom(name: string): string {
     return `${this.name}:${name}`;
   },
 
@@ -94,7 +94,7 @@ export const CustomAttributeResource: IResourceKind<ICustomAttributeSource, ICus
     (Type as Writable<ICustomAttributeType>).kind = CustomAttributeResource;
     (Type as Writable<ICustomAttributeType>).description = description;
     Type.register = function register(container: IContainer){
-      const resourceKey = Type.kind.key(description.name);
+      const resourceKey = Type.kind.keyFrom(description.name);
 
       container.register(Registration.transient(resourceKey, Type));
 

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -84,7 +84,7 @@ export interface ICustomElementResource extends IResourceKind<ITemplateSource, I
 export const CustomElementResource: ICustomElementResource = {
   name: 'custom-element',
 
-  key(name: string): string {
+  keyFrom(name: string): string {
     return `${this.name}:${name}`;
   },
 
@@ -104,7 +104,7 @@ export const CustomElementResource: ICustomElementResource = {
     (Type as Writable<ICustomElementType>).kind = CustomElementResource;
     (Type as Writable<ICustomElementType>).description = description;
     Type.register = function(container: IContainer): void {
-      container.register(Registration.transient(Type.kind.key(description.name), Type));
+      container.register(Registration.transient(Type.kind.keyFrom(description.name), Type));
     };
 
     proto.$hydrate = function(this: IInternalCustomElementImplementation, renderingEngine: IRenderingEngine, host: INode, options: IElementHydrationOptions = PLATFORM.emptyObject): void {

--- a/packages/runtime/src/templating/instructions.ts
+++ b/packages/runtime/src/templating/instructions.ts
@@ -23,7 +23,7 @@ export enum TargetedInstructionType {
 
 export interface IBuildInstruction {
   required: boolean;
-  compiler: string;
+  compiler?: string;
 }
 
 export interface ITemplateSource {

--- a/packages/runtime/src/templating/renderer.ts
+++ b/packages/runtime/src/templating/renderer.ts
@@ -135,7 +135,7 @@ export class Renderer implements IRenderer {
   public [TargetedInstructionType.hydrateElement](renderable: IRenderable, target: any, instruction: Immutable<IHydrateElementInstruction>) {
     const context = this.context;
     const operation = context.beginComponentOperation(renderable, target, instruction, null, null, target, true);
-    const component = context.get<ICustomElement>(CustomElementResource.key(instruction.res));
+    const component = context.get<ICustomElement>(CustomElementResource.keyFrom(instruction.res));
 
     this.hydrateElementInstance(renderable, target, instruction, component);
     operation.tryConnectElementToSlot(component);
@@ -148,7 +148,7 @@ export class Renderer implements IRenderer {
     const context = this.context;
     const operation = context.beginComponentOperation(renderable, target, instruction);
 
-    const component = context.get<ICustomAttribute>(CustomAttributeResource.key(instruction.res));
+    const component = context.get<ICustomAttribute>(CustomAttributeResource.keyFrom(instruction.res));
     component.$hydrate(this.renderingEngine);
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
@@ -168,7 +168,7 @@ export class Renderer implements IRenderer {
     const context = this.context;
     const operation = context.beginComponentOperation(renderable, target, instruction, factory, parts, DOM.convertToRenderLocation(target), false);
 
-    const component = context.get<ICustomAttribute>(CustomAttributeResource.key(instruction.res));
+    const component = context.get<ICustomAttribute>(CustomAttributeResource.keyFrom(instruction.res));
     component.$hydrate(this.renderingEngine);
     operation.tryConnectTemplateControllerToSlot(component);
 

--- a/packages/runtime/test/unit/templating/attribute-assistance.ts
+++ b/packages/runtime/test/unit/templating/attribute-assistance.ts
@@ -55,7 +55,7 @@ export function hydrateCustomAttribute<T>(
   }
 
   const attribute = container.get<T & ICustomAttribute>(
-    CustomAttributeResource.key(AttributeType.description.name)
+    CustomAttributeResource.keyFrom(AttributeType.description.name)
   );
 
   attribute.$hydrate(container.get(IRenderingEngine));


### PR DESCRIPTION
## In This PR

* I renamed the `get` method of `IResourceDescriptions` to `find`. I'm making a conscious movement away from calling things "get" in code as it has very little explanatory power.
* I renamed the `key` method of `IResourceKind` to `keyFrom` to make it clear that the key was being derived from the input. `key` seemed too much like a property name rather than a name for a pure function.

## Next Steps

I'd like to change the `IServiceLocator` interface to not use the `get` or `getAll` names but instead use `resolve` and `resolveAll`, or something similar. This would be a breaking change from vCurrent so this might be a case where we want to keep the old methods as an alias. I'm not sure at this time, so I'm delaying this change.