### PR TITLE
fix(runtime): dry up bindable callback behavior

### DIFF
--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -137,7 +137,8 @@ export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
   constructor(
     changeSet: IChangeSet,
     currentValue: T,
-    private selfCallback?: (newValue: T, oldValue: T) => void | T) {
+    private selfCallback?: (newValue: T, oldValue: T) => void | T
+  ) {
       this.changeSet = changeSet;
       this.currentValue = currentValue;
 
@@ -159,15 +160,15 @@ export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
       this.previousValue = previousValue;
       this.currentValue = newValue;
 
-      if (this.selfCallback !== undefined) {
-        const coercedValue = this.selfCallback(newValue, previousValue);
-
-        if (coercedValue !== undefined) {
-          this.currentValue = newValue = <T>coercedValue;
-        }
-      }
-
       if (!(flags & BindingFlags.bindOrigin)) {
+        if (this.selfCallback !== undefined) {
+          const coercedValue = this.selfCallback(newValue, previousValue);
+
+          if (coercedValue !== undefined) {
+            this.currentValue = newValue = <T>coercedValue;
+          }
+        }
+
         this.notify(newValue, previousValue);
       }
     }

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -34,7 +34,6 @@ export interface ICustomAttribute extends IBindScope, IAttach {
 
 /*@internal*/
 export interface IInternalCustomAttributeImplementation extends Writable<ICustomAttribute> {
-  $bindableCallbacks: (() => void)[];
   $behavior: IRuntimeBehavior;
   $child: IAttach;
 }
@@ -127,12 +126,6 @@ export const CustomAttributeResource: IResourceKind<ICustomAttributeSource, ICus
       }
 
       this.$scope = scope;
-
-      const bindableCallbacks = this.$bindableCallbacks;
-
-      for (let i = 0, ii = bindableCallbacks.length; i < ii; ++i) {
-        bindableCallbacks[i]();
-      }
 
       if (this.$behavior.hasBound) {
         (this as any).bound(flags | BindingFlags.bindOrigin, scope);

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -28,7 +28,6 @@ export interface ICustomElement extends IBindSelf, IAttach, Readonly<IRenderable
 
 /*@internal*/
 export interface IInternalCustomElementImplementation extends Writable<ICustomElement> {
-  $bindableCallbacks: (() => void)[];
   $behavior: IRuntimeBehavior;
   $child: IAttach;
 }
@@ -142,12 +141,6 @@ export const CustomElementResource: ICustomElementResource = {
 
       for (let i = 0, ii = bindables.length; i < ii; ++i) {
         bindables[i].$bind(flags | BindingFlags.bindOrigin, scope);
-      }
-
-      const bindableCallbacks = this.$bindableCallbacks;
-
-      for (let i = 0, ii = bindableCallbacks.length; i < ii; ++i) {
-        bindableCallbacks[i]();
       }
 
       if (this.$behavior.hasBound) {

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -19,9 +19,7 @@ export class With {
   }
 
   public valueChanged(): void {
-    if (this.$isBound) {
-      this.bindChild(BindingFlags.callbackOrigin);
-    }
+    this.bindChild(BindingFlags.callbackOrigin);
   }
 
   public bound(flags: BindingFlags): void {

--- a/packages/runtime/src/templating/runtime-behavior.ts
+++ b/packages/runtime/src/templating/runtime-behavior.ts
@@ -1,4 +1,3 @@
-import { PLATFORM } from '@aurelia/kernel';
 import { BindingFlags } from '../binding/binding-flags';
 import { IChangeSet } from '../binding/change-set';
 import { IAccessor, IPropertySubscriber, ISubscribable, MutationKind } from '../binding/observation';
@@ -93,21 +92,17 @@ export class RuntimeBehavior implements IRuntimeBehavior {
     const observers = {};
     const finalBindables = this.bindables;
     const observableNames = Object.getOwnPropertyNames(finalBindables);
-    const bindableCallbackCount = observableNames.length;
-    const bindableCallbacks =  new Array(bindableCallbackCount);
 
-    for (let i = 0, ii = bindableCallbackCount; i < ii; ++i) {
+    for (let i = 0, ii = observableNames.length; i < ii; ++i) {
       const name = observableNames[i];
       const observable = finalBindables[name];
       const changeHandler = observable.callback;
 
-      if (changeHandler in instance) {
-        bindableCallbacks[i] = () => instance[changeHandler](instance[name]);
-        observers[name] = new Observer(changeSet, instance[name], (n, o) => instance[changeHandler](n, o));
-      } else {
-        bindableCallbacks[i] = PLATFORM.noop;
-        observers[name] = new Observer(changeSet, instance[name]);
-      }
+      observers[name] = new Observer(
+        changeSet,
+        instance[name],
+        changeHandler in instance ? (n, o) => instance[changeHandler](n, o) : undefined
+      );
 
       createGetterSetter(instance, name);
     }
@@ -118,7 +113,6 @@ export class RuntimeBehavior implements IRuntimeBehavior {
     });
 
     instance.$behavior = this;
-    instance.$bindableCallbacks = bindableCallbacks;
 
     return observers;
   }

--- a/packages/runtime/test/unit/templating/resources/with.spec.ts
+++ b/packages/runtime/test/unit/templating/resources/with.spec.ts
@@ -11,7 +11,7 @@ describe('The "with" template controller', () => {
     const { attribute } = hydrateCustomAttribute(With);
     const child = attribute['$child'];
 
-    attribute.$bind(BindingFlags.none, createScope());
+    attribute.$bind(BindingFlags.bindOrigin, createScope());
 
     let withValue = {};
     attribute.value = withValue;


### PR DESCRIPTION
This PR attempts to simplify the behavior around bindable callbacks.

## Background

In vCurrent, whether or not a bindable self callback is invoked during the binding process depends on whether or not you have a `bind` callback. If you have a `bind` callback, the self callbacks for each property will not be called. However, if you don't have a `bind`, they will be called. If they are called, then they are called one by one, after each property is set, rather than all together after all properties are set.

## New Behavior

For vNext I'm proposing that bindable self callbacks never fire during initialization, regardless of whether or not you have a `bound` callback. This makes it very clear how to implement behaviors. If you need to do something upon initialization, you implement `bound`. If you need to react to changes after the initial setup, you implement a callback for the properties you care about. This also makes the `bound` callback behave similarly to other frameworks `ready` callbacks. In addition to this behavior being easier to understand, it is a pure reduction in code on our part and removes odd special-case handling for bindable callbacks.

> Note: This PR also fixes an issue with `Observable` where the binding flag for `bindOrigin` was not properly preventing normal subscribers, but only self callbacks. Now all notification is skipped in this case, treating all callbacks the same and aligning Observable with the behavior of the other observers.