### PR TITLE
refactor(dom): use uppercase tag names

### DIFF
--- a/packages/runtime/src/binding/event-manager.ts
+++ b/packages/runtime/src/binding/event-manager.ts
@@ -210,7 +210,7 @@ export class EventManager implements IEventManager {
 
   constructor() {
     this.registerElementConfiguration({
-      tagName: 'input',
+      tagName: 'INPUT',
       properties: {
         value: ['change', 'input'],
         checked: ['change', 'input'],
@@ -219,14 +219,14 @@ export class EventManager implements IEventManager {
     });
 
     this.registerElementConfiguration({
-      tagName: 'textarea',
+      tagName: 'TEXTAREA',
       properties: {
         value: ['change', 'input']
       }
     });
 
     this.registerElementConfiguration({
-      tagName: 'select',
+      tagName: 'SELECT',
       properties: {
         value: ['change']
       }
@@ -261,12 +261,12 @@ export class EventManager implements IEventManager {
   }
 
   public getElementHandler(target: INode, propertyName: string): IEventSubscriber | null {
-    let name = DOM.normalizedTagName(target);
-    let lookup = this.elementHandlerLookup;
+    const tagName = DOM.normalizedTagName(target);
+    const lookup = this.elementHandlerLookup;
 
-    if (name) {
-      if (lookup[name] && lookup[name][propertyName]) {
-        return new EventSubscriber(lookup[name][propertyName]);
+    if (tagName) {
+      if (lookup[tagName] && lookup[tagName][propertyName]) {
+        return new EventSubscriber(lookup[tagName][propertyName]);
       }
 
       if (propertyName === 'textContent' || propertyName === 'innerHTML') {

--- a/packages/runtime/src/binding/event-manager.ts
+++ b/packages/runtime/src/binding/event-manager.ts
@@ -260,7 +260,7 @@ export class EventManager implements IEventManager {
   }
 
   public getElementHandler(target: INode, propertyName: string): IEventSubscriber | null {
-    const tagName = DOM.normalizedTagName(target);
+    const tagName = target['tagName'];
     const lookup = this.elementHandlerLookup;
 
     if (tagName) {

--- a/packages/runtime/src/binding/event-manager.ts
+++ b/packages/runtime/src/binding/event-manager.ts
@@ -249,11 +249,10 @@ export class EventManager implements IEventManager {
   }
 
   public registerElementConfiguration(config: IElementConfiguration) {
-    let tagName = config.tagName.toLowerCase();
-    let properties = config.properties;
-    let lookup: Record<string, string[]> = this.elementHandlerLookup[tagName] = {};
+    const properties = config.properties;
+    const lookup: Record<string, string[]> = this.elementHandlerLookup[config.tagName] = {};
 
-    for (let propertyName in properties) {
+    for (const propertyName in properties) {
       if (properties.hasOwnProperty(propertyName)) {
         lookup[propertyName] = properties[propertyName];
       }

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -81,21 +81,20 @@ export class ObserverLocator implements IObserverLocator {
 
   public getAccessor(obj: any, propertyName: string): IBindingTargetAccessor {
     if (DOM.isNodeInstance(obj)) {
-      const normalizedTagName = DOM.normalizedTagName;
+      const tagName = obj['tagName'];
 
-      if (propertyName === 'class'
-        || propertyName === 'style' || propertyName === 'css'
-        || propertyName === 'value' && (normalizedTagName(obj) === 'INPUT' || normalizedTagName(obj) === 'SELECT')
-        || propertyName === 'checked' && normalizedTagName(obj) === 'INPUT'
-        || propertyName === 'model' && normalizedTagName(obj) === 'INPUT'
+      if (propertyName === 'class' || propertyName === 'style' || propertyName === 'css'
+        || propertyName === 'value' && (tagName === 'INPUT' || tagName === 'SELECT')
+        || propertyName === 'checked' && tagName === 'INPUT'
+        || propertyName === 'model' && tagName === 'INPUT'
         || /^xlink:.+$/.exec(propertyName)) {
         return <any>this.getObserver(obj, propertyName);
       }
 
       if (/^\w+:|^data-|^aria-/.test(propertyName)
         || this.svgAnalyzer.isStandardSvgAttribute(obj, propertyName)
-        || normalizedTagName(obj) === 'IMG' && propertyName === 'src'
-        || normalizedTagName(obj) === 'A' && propertyName === 'href'
+        || tagName === 'IMG' && propertyName === 'src'
+        || tagName === 'A' && propertyName === 'href'
       ) {
         return new DataAttributeAccessor(this.changeSet, obj, propertyName);
       }
@@ -159,7 +158,7 @@ export class ObserverLocator implements IObserverLocator {
         return new StyleAttributeAccessor(this.changeSet, <HTMLElement>obj);
       }
 
-      const tagName = DOM.normalizedTagName(obj);
+      const tagName = obj['tagName'];
       const handler = this.eventManager.getElementHandler(obj, propertyName);
       if (propertyName === 'value' && tagName === 'SELECT') {
         return new SelectValueObserver(this.changeSet, <HTMLSelectElement>obj, handler, this);

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -85,17 +85,17 @@ export class ObserverLocator implements IObserverLocator {
 
       if (propertyName === 'class'
         || propertyName === 'style' || propertyName === 'css'
-        || propertyName === 'value' && (normalizedTagName(obj) === 'input' || normalizedTagName(obj) === 'select')
-        || propertyName === 'checked' && normalizedTagName(obj) === 'input'
-        || propertyName === 'model' && normalizedTagName(obj) === 'input'
+        || propertyName === 'value' && (normalizedTagName(obj) === 'INPUT' || normalizedTagName(obj) === 'SELECT')
+        || propertyName === 'checked' && normalizedTagName(obj) === 'INPUT'
+        || propertyName === 'model' && normalizedTagName(obj) === 'INPUT'
         || /^xlink:.+$/.exec(propertyName)) {
         return <any>this.getObserver(obj, propertyName);
       }
 
       if (/^\w+:|^data-|^aria-/.test(propertyName)
         || this.svgAnalyzer.isStandardSvgAttribute(obj, propertyName)
-        || normalizedTagName(obj) === 'img' && propertyName === 'src'
-        || normalizedTagName(obj) === 'a' && propertyName === 'href'
+        || normalizedTagName(obj) === 'IMG' && propertyName === 'src'
+        || normalizedTagName(obj) === 'A' && propertyName === 'href'
       ) {
         return new DataAttributeAccessor(this.changeSet, obj, propertyName);
       }
@@ -159,12 +159,13 @@ export class ObserverLocator implements IObserverLocator {
         return new StyleAttributeAccessor(this.changeSet, <HTMLElement>obj);
       }
 
+      const tagName = DOM.normalizedTagName(obj);
       const handler = this.eventManager.getElementHandler(obj, propertyName);
-      if (propertyName === 'value' && DOM.normalizedTagName(obj) === 'select') {
+      if (propertyName === 'value' && tagName === 'SELECT') {
         return new SelectValueObserver(this.changeSet, <HTMLSelectElement>obj, handler, this);
       }
 
-      if (propertyName === 'checked' && DOM.normalizedTagName(obj) === 'input') {
+      if (propertyName === 'checked' && tagName === 'INPUT') {
         return new CheckedObserver(this.changeSet, <HTMLInputElement>obj, handler, this);
       }
 

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -138,8 +138,7 @@ export const DOM = {
   },
 
   normalizedTagName(node: INode): string {
-    const name = (<Element>node).tagName;
-    return name ? name.toLowerCase() : null;
+    return (<Element>node).tagName || null;
   },
 
   remove(node: INodeLike): void {

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -137,10 +137,6 @@ export const DOM = {
     return (<Node>node).nodeType === 3;
   },
 
-  normalizedTagName(node: INode): string {
-    return (<Element>node).tagName || null;
-  },
-
   remove(node: INodeLike): void {
     // only check the prototype once and then permanently set a polyfilled or non-polyfilled call to save a few cycles
     if (Element.prototype.remove === undefined) {


### PR DESCRIPTION
HTML spec says that `Node.tagName` is always upper case when it is an element type, so we don't really need to normalize it. Slight perf improvement.

Though I'm clueless at the moment why those 4 tests are failing @bigopon you always catch these kinds of things, any idea? :bug: