### PR TITLE
fix(runtime): remove lazy bindable location and encapsulate observer

### DIFF
--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -139,13 +139,13 @@ export class Observer implements IPropertyObserver<IIndexable, string> {
   constructor(
     changeSet: IChangeSet,
     instance: object,
-    property: string,
-    callback: string
+    propertyName: string,
+    callbackName: string
   ) {
       this.changeSet = changeSet;
-      this.currentValue = instance[property];
-      this.callback = callback in instance
-        ? instance[callback].bind(instance)
+      this.currentValue = instance[propertyName];
+      this.callback = callbackName in instance
+        ? instance[callbackName].bind(instance)
         : noop;
 
       this.subscribers = new Array();

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -105,7 +105,7 @@ export class SetterObserver implements IPropertyObserver<IIndexable, string> {
 }
 
 @propertyObserver()
-export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
+export class Observer implements IPropertyObserver<IIndexable, string> {
   /*@internal*/
   public changeSet: IChangeSet;
   public notify: (newValue: any, previousValue?: any, flags?: BindingFlags) => void;
@@ -134,13 +134,19 @@ export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
   public subscriberFlags: Array<BindingFlags>;
   public batchedSubscriberFlags: Array<BindingFlags>;
 
+  private callback: (oldValue: any, newValue: any) => any;
+
   constructor(
     changeSet: IChangeSet,
-    currentValue: T,
-    private selfCallback?: (newValue: T, oldValue: T) => void | T
+    instance: object,
+    property: string,
+    callback: string
   ) {
       this.changeSet = changeSet;
-      this.currentValue = currentValue;
+      this.currentValue = instance[property];
+      this.callback = callback in instance
+        ? instance[callback].bind(instance)
+        : noop;
 
       this.subscribers = new Array();
       this.batchedSubscribers = new Array();
@@ -153,7 +159,7 @@ export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
     return this.currentValue;
   }
 
-  public setValue(newValue: T, flags?: BindingFlags): void {
+  public setValue(newValue: any, flags?: BindingFlags): void {
     const previousValue = this.currentValue;
 
     if (previousValue !== newValue) {
@@ -161,12 +167,10 @@ export class Observer<T>  implements IPropertyObserver<IIndexable, string> {
       this.currentValue = newValue;
 
       if (!(flags & BindingFlags.bindOrigin)) {
-        if (this.selfCallback !== undefined) {
-          const coercedValue = this.selfCallback(newValue, previousValue);
+        const coercedValue = this.callback(newValue, previousValue);
 
-          if (coercedValue !== undefined) {
-            this.currentValue = newValue = <T>coercedValue;
-          }
+        if (coercedValue !== undefined) {
+          this.currentValue = newValue = coercedValue;
         }
 
         this.notify(newValue, previousValue);

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -2,6 +2,7 @@ import { inject } from '@aurelia/kernel';
 import { BindingContext, IScope } from '../../binding/binding-context';
 import { BindingFlags } from '../../binding/binding-flags';
 import { IRenderLocation } from '../../dom';
+import { bindable } from '../bindable';
 import { ICustomAttribute, templateController } from '../custom-attribute';
 import { IView, IViewFactory } from '../view';
 
@@ -9,7 +10,7 @@ export interface With extends ICustomAttribute {}
 @templateController('with')
 @inject(IViewFactory, IRenderLocation)
 export class With {
-  public value: any = null;
+  @bindable public value: any = null;
 
   private $child: IView = null;
 


### PR DESCRIPTION
## Description

This PR removes the lazy location of bindable properties based on naming conventions. This change reduces the complexity of the runtime, making component hydration a little leaner. Additionally, this PR encapsulates the way that the Observer handles "self callbacks".

## Background

For vNext, I had hoped to make it possible to have completely POJO components, with bindables being automatically inferred based on property/callback naming conventions. So, this was implemented inside of the runtime. However, this approach to solving the problem didn't align with the idea that the runtime should work only off of explicit data and AOT should enable conventions that created that data. It also added needless complexity due to the fact that bindables could come from yet another location, at another time in the initialization process.