### PR TITLE
refactor(instructions): change number type to string

### DIFF
--- a/packages/jit/src/templating/template-compiler.ts
+++ b/packages/jit/src/templating/template-compiler.ts
@@ -240,8 +240,9 @@ export class OneTimeBindingInstruction implements IPropertyBindingInstruction {
   public mode: BindingMode.oneTime;
   public srcOrExpr: string | IExpression;
   public dest: string;
-  constructor(srcOrExpr: string | IExpression) {
+  constructor(srcOrExpr: string | IExpression, dest: string) {
     this.srcOrExpr = srcOrExpr;
+    this.dest = dest;
   }
 }
 export class ToViewBindingInstruction implements IPropertyBindingInstruction {

--- a/packages/jit/test/unit/templating/template-compiler.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.spec.ts
@@ -117,7 +117,7 @@ describe('TemplateCompiler', () => {
           let expected: TargetedInstruction;
           switch (attrName.split('.')[1]) {
             case 'one-time':
-              expected = new OneTimeBindingInstruction(expr);
+              expected = new OneTimeBindingInstruction(expr, attrName.split('.')[0]);
               break;
             case 'bind':
             case 'to-view':

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -13,7 +13,7 @@ export class Call implements IBinding {
   private $scope: IScope;
 
   constructor(
-    private sourceExpression: IExpression,
+    public sourceExpression: IExpression,
     target: INode,
     targetProperty: string,
     observerLocator: IObserverLocator,

--- a/packages/runtime/src/binding/listener.ts
+++ b/packages/runtime/src/binding/listener.ts
@@ -13,10 +13,10 @@ export class Listener implements IBinding {
 
   constructor(
     public targetEvent: string,
-    private delegationStrategy: DelegationStrategy,
-    private sourceExpression: IExpression,
-    private target: INode,
-    private preventDefault: boolean,
+    public delegationStrategy: DelegationStrategy,
+    public sourceExpression: IExpression,
+    public target: INode,
+    public preventDefault: boolean,
     private eventManager: IEventManager,
     public locator: IServiceLocator
   ) { }

--- a/packages/runtime/src/binding/ref.ts
+++ b/packages/runtime/src/binding/ref.ts
@@ -9,8 +9,8 @@ export class Ref implements IBinding {
   private $scope: IScope;
 
   constructor(
-    private sourceExpression: IExpression,
-    private target: IBindingTarget,
+    public sourceExpression: IExpression,
+    public target: IBindingTarget,
     public locator: IServiceLocator) {
   }
 

--- a/packages/runtime/src/templating/instructions.ts
+++ b/packages/runtime/src/templating/instructions.ts
@@ -7,18 +7,18 @@ import { INode } from '../dom';
 import { ResourceDescription } from '../resource';
 import { IBindableDescription } from './bindable';
 
-export enum TargetedInstructionType {
-  textBinding = 1,
-  propertyBinding = 2,
-  listenerBinding = 3,
-  callBinding = 4,
-  refBinding = 5,
-  stylePropertyBinding = 6,
-  setProperty = 7,
-  setAttribute = 8,
-  hydrateElement = 9,
-  hydrateAttribute = 10,
-  hydrateTemplateController = 11
+export const enum TargetedInstructionType {
+  textBinding = 'a',
+  propertyBinding = 'b',
+  listenerBinding = 'c',
+  callBinding = 'd',
+  refBinding = 'e',
+  stylePropertyBinding = 'f',
+  setProperty = 'g',
+  setAttribute = 'h',
+  hydrateElement = 'i',
+  hydrateAttribute = 'j',
+  hydrateTemplateController = 'k'
 }
 
 export interface IBuildInstruction {

--- a/packages/runtime/test/unit/templating/renderer.spec.ts
+++ b/packages/runtime/test/unit/templating/renderer.spec.ts
@@ -1,6 +1,267 @@
-import { Renderer } from '@aurelia/runtime';
+import { Renderer, TargetedInstructionType, AccessScope, IExpressionParser, IRenderable, DOM, IRenderContext, IObserverLocator, IEventManager, IRenderingEngine, ITextBindingInstruction, Binding, BindingMode, IPropertyBindingInstruction, IExpression, ITargetedInstruction, DelegationStrategy, Listener, IListenerBindingInstruction, ICallBindingInstruction, Call, CallScope, Ref } from '@aurelia/runtime';
 import { expect } from 'chai';
+import { _, createElement } from '../util';
+import { register } from '../../../../jit/src/binding/expression-parser';
+import { CallBindingInstruction, CaptureBindingInstruction, DelegateBindingInstruction, FromViewBindingInstruction, HydrateAttributeInstruction, HydrateElementInstruction, OneTimeBindingInstruction, RefBindingInstruction, SetAttributeInstruction, SetPropertyInstruction, StylePropertyBindingInstruction, TextBindingInstruction, ToViewBindingInstruction, TriggerBindingInstruction, TwoWayBindingInstruction } from '../../../../jit/src/templating/template-compiler';
+import { DI } from '@aurelia/kernel';
+import { spy, SinonSpy } from 'sinon';
 
 describe('Renderer', () => {
+  function setup<T extends ITargetedInstruction>(instruction: T) {
+    const container = DI.createContainer();
+    register(container);
+    const parser = <IExpressionParser>container.get(IExpressionParser);
+    const renderable = <IRenderable>{ $bindables: [], $attachables: [] };
+    const wrapper = <HTMLElement>createElement('<div><au-target class="au"></au-target> </div>');
+    document.body.appendChild(wrapper);
+    const target = <HTMLElement>wrapper.firstElementChild;
+    const placeholder = <HTMLElement>target.nextSibling;
+
+    const renderContext = <IRenderContext>{
+      get(key) {
+        return { $hydrate: spy(), key }
+      },
+      beginComponentOperation(renderable, target, instruction, factory, parts, location, locationIsContainer) {
+        return <any>{
+          tryConnectElementToSlot: spy(),
+          tryConnectTemplateControllerToSlot: spy(),
+          dispose: spy()
+        }
+      }
+    };
+    spy(renderContext, 'get');
+    spy(renderContext, 'beginComponentOperation');
+    const observerLocator = <IObserverLocator>container.get(IObserverLocator);
+    const eventManager = <IEventManager>container.get(IEventManager);
+    const renderingEngine = <IRenderingEngine>container.get(IRenderingEngine);
+
+    const sut = new Renderer(renderContext, observerLocator, eventManager, parser, renderingEngine);
+
+    return { sut, renderable, target, placeholder, wrapper, renderContext, renderingEngine };
+  }
+
+  function tearDown({ wrapper }: Partial<ReturnType<typeof setup>>) {
+    document.body.removeChild(wrapper);
+  }
+
+  describe('handles ITextBindingInstruction', () => {
+    for (const srcOrExpr of ['foo', new AccessScope('foo')]) {
+      const instruction = new TextBindingInstruction(srcOrExpr);
+      it(_`instruction=${instruction}`, () => {
+        const { sut, renderable, target, placeholder, wrapper } = setup(instruction);
+
+        sut[instruction.type](renderable, target, instruction);
+
+        expect(placeholder['auInterpolationTarget']).to.be.true;
+        expect(renderable.$bindables.length).to.equal(1);
+        const bindable = <Binding>renderable.$bindables[0];
+        expect(bindable.target).to.equal(placeholder);
+        expect(bindable.sourceExpression['name']).to.equal('foo');
+        expect(bindable.mode).to.equal(BindingMode.toView);
+        expect(target.isConnected).to.be.false;
+
+        tearDown({ wrapper });
+      });
+    }
+  });
+
+  describe('handles IPropertyBindingInstruction', () => {
+    for (const Instruction of [OneTimeBindingInstruction, ToViewBindingInstruction, FromViewBindingInstruction, TwoWayBindingInstruction]) {
+      for (const dest of ['foo', 'bar']) {
+        for (const srcOrExpr of ['foo', new AccessScope('foo')]) {
+          const instruction = <IPropertyBindingInstruction>new (<any>Instruction)(srcOrExpr, dest);
+          it(_`instruction=${instruction}`, () => {
+            const { sut, renderable, target, wrapper } = setup(instruction);
+
+            sut[instruction.type](renderable, target, instruction);
+
+            expect(renderable.$bindables.length).to.equal(1);
+            const bindable = <Binding>renderable.$bindables[0];
+            expect(bindable.target).to.equal(target);
+            expect(bindable.sourceExpression['name']).to.equal('foo');
+            expect(bindable.mode).to.equal(instruction.mode);
+            expect(bindable.targetProperty).to.equal(dest);
+
+            tearDown({ wrapper });
+          });
+        }
+      }
+    }
+  });
+
+  describe('handles IListenerBindingInstruction', () => {
+    for (const Instruction of [TriggerBindingInstruction, DelegateBindingInstruction, CaptureBindingInstruction]) {
+      for (const dest of ['foo', 'bar']) {
+        for (const srcOrExpr of ['foo', new AccessScope('foo')]) {
+          const instruction = <IListenerBindingInstruction>new (<any>Instruction)(srcOrExpr, dest);
+          it(_`instruction=${instruction}`, () => {
+            const { sut, renderable, target, wrapper } = setup(instruction);
+
+            sut[instruction.type](renderable, target, instruction);
+
+            expect(renderable.$bindables.length).to.equal(1);
+            const bindable = <Listener>renderable.$bindables[0];
+            expect(bindable.target).to.equal(target);
+            expect(bindable.sourceExpression['name']).to.equal('foo');
+            expect(bindable.delegationStrategy).to.equal(instruction.strategy);
+            expect(bindable.targetEvent).to.equal(dest);
+            expect(bindable.preventDefault).to.equal(instruction.strategy === DelegationStrategy.none);
+
+            tearDown({ wrapper });
+          });
+        }
+      }
+    }
+  });
+
+  describe('handles ICallBindingInstruction', () => {
+    for (const dest of ['foo', 'bar']) {
+      for (const srcOrExpr of ['foo()', new CallScope('foo', [])]) {
+        const instruction = new CallBindingInstruction(srcOrExpr, dest);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderable.$bindables.length).to.equal(1);
+          const bindable = <Call>renderable.$bindables[0];
+          expect(bindable.targetObserver['obj']).to.equal(target);
+          expect(bindable.targetObserver['propertyKey']).to.equal(dest);
+          expect(bindable.sourceExpression['name']).to.equal('foo');
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
+
+  describe('handles IRefBindingInstruction', () => {
+    for (const srcOrExpr of ['foo', new AccessScope('foo')]) {
+      const instruction = new RefBindingInstruction(srcOrExpr);
+      it(_`instruction=${instruction}`, () => {
+        const { sut, renderable, target, wrapper } = setup(instruction);
+
+        sut[instruction.type](renderable, target, instruction);
+
+        expect(renderable.$bindables.length).to.equal(1);
+        const bindable = <Ref>renderable.$bindables[0];
+        expect(bindable.target).to.equal(target);
+        expect(bindable.sourceExpression['name']).to.equal('foo');
+
+        tearDown({ wrapper });
+      });
+    }
+  });
+
+  describe('handles IStyleBindingInstruction', () => {
+    for (const dest of ['foo', 'bar']) {
+      for (const srcOrExpr of ['foo', new AccessScope('foo')]) {
+        const instruction = new StylePropertyBindingInstruction(srcOrExpr, dest);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderable.$bindables.length).to.equal(1);
+          const bindable = <Binding>renderable.$bindables[0];
+          expect(bindable.target).to.equal(target.style);
+          expect(bindable.sourceExpression['name']).to.equal('foo');
+          expect(bindable.mode).to.equal(BindingMode.toView);
+          expect(bindable.targetProperty).to.equal(dest);
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
+
+  describe('handles ISetPropertyInstruction', () => {
+    for (const dest of ['foo', 'bar']) {
+      for (const value of ['foo', 42, {}]) {
+        const instruction = new SetPropertyInstruction(value, dest);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderable.$bindables.length).to.equal(0);
+          expect(target[dest]).to.equal(value);
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
+
+  describe('handles ISetAttributeInstruction', () => {
+    for (const dest of ['id', 'accesskey', 'slot', 'tabindex']) {
+      for (const value of ['foo', 42, null]) {
+        const instruction = new SetAttributeInstruction(value, dest);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderable.$bindables.length).to.equal(0);
+          expect(target.getAttribute(dest)).to.equal(value+'');
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
+
+  describe('handles IHydrateElementInstruction', () => {
+    for (const res of ['foo', 'bar']) {
+      for (const instructions of [[], [,]]) {
+        const instruction = new HydrateElementInstruction(res, instructions);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper, renderContext } = setup(instruction);
+          sut.hydrateElementInstance = spy();
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderContext.beginComponentOperation).to.have.been.calledWith(renderable, target, instruction, null, null, target, true);
+          expect(renderContext.get).to.have.been.calledWith(`custom-element:${res}`);
+          const component = (<SinonSpy>renderContext.get).getCalls()[0].returnValue;
+          expect(sut.hydrateElementInstance).to.have.been.calledWith(renderable, target, instruction, component);
+          const operation = (<SinonSpy>renderContext.beginComponentOperation).getCalls()[0].returnValue;
+          expect(operation.tryConnectElementToSlot).to.have.been.calledWith(component);
+          expect(operation.dispose).to.have.been.called;
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
+
+  describe('handles IHydrateAttributeInstruction', () => {
+    for (const res of ['if', 'else', 'repeat']) {
+      for (const instructions of [[], [new SetPropertyInstruction('bar', 'foo')]]) {
+        const instruction = new HydrateAttributeInstruction(res, instructions);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper, renderContext, renderingEngine } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderContext.beginComponentOperation).to.have.been.calledWith(renderable, target, instruction);
+          expect(renderContext.get).to.have.been.calledWith(`custom-attribute:${res}`);
+          const component = (<SinonSpy>renderContext.get).getCalls()[0].returnValue;
+          expect(component.$hydrate).to.have.been.calledWith(renderingEngine);
+          if (instructions.length) {
+            expect(component.foo).to.equal('bar');
+          }
+          const operation = (<SinonSpy>renderContext.beginComponentOperation).getCalls()[0].returnValue;
+          expect(operation.dispose).to.have.been.called;
+          expect(renderable.$bindables.length).to.equal(1);
+          expect(renderable.$attachables.length).to.equal(1);
+          expect(renderable.$bindables[0]).to.equal(component);
+          expect(renderable.$attachables[0]).to.equal(component);
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
 
 });


### PR DESCRIPTION
Closes #84 

- Changes `instruction.type` from number to string. Also converts the enum to const enum (preserve const enums is enabled) for better performance by inlining.

- Added some unit tests to the renderer as an initial effort to improve test coverage in that area, and to have some lower level verification that the instructions work

- Made a few binding properties public on the classes themselves. Primarily for unit testing, but I believe it makes sense for them to be exposed (if you go so far as to cast to a concrete binding class, you probably want to access some of its properties too).
