### PR TITLE
fix(di): convert invokers to an array

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
   },
   "cSpell.words": [
     "Constructable",
+    "Injectable",
     "Renderable",
     "attachables",
     "bindables"


### PR DESCRIPTION
This PR converters the invoker lookup to an array, ordered by dependency count. Previously, it was an object with the dependency count as key and the invoker as value.

