### PR TITLE
refactor(runtime): lift resource methods

### DIFF
--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -38,7 +38,7 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
   }
 };
 
-function register(this: IResourceType<IBindingBehaviorSource>, container: IContainer): void {
+function register(this: IBindingBehaviorType, container: IContainer): void {
   container.register(
     Registration.singleton(
       BindingBehaviorResource.keyFrom(this.description.name),

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -16,7 +16,7 @@ export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource) {
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBindingBehaviorType> = {
   name: 'binding-behavior',
 
-  keyFrom(name: string) {
+  keyFrom(name: string): string {
     return `${this.name}:${name}`;
   },
 
@@ -25,15 +25,24 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
   },
 
   define<T extends Constructable>(nameOrSource: string | IBindingBehaviorSource, ctor: T): T & IBindingBehaviorType {
-    const description = typeof nameOrSource === 'string' ? { name: nameOrSource } : nameOrSource;
-    const Type: T & IBindingBehaviorType = ctor as any;
+    const Type = ctor as T & IBindingBehaviorType;
+    const description = typeof nameOrSource === 'string'
+      ? { name: nameOrSource }
+      : nameOrSource;
 
     (Type as Writable<IBindingBehaviorType>).kind = BindingBehaviorResource;
     (Type as Writable<IBindingBehaviorType>).description = description;
-    Type.register = function(container: IContainer) {
-      container.register(Registration.singleton(Type.kind.keyFrom(description.name), Type));
-    };
+    Type.register = register;
 
     return Type;
   }
 };
+
+function register(this: IResourceType<IBindingBehaviorSource>, container: IContainer): void {
+  container.register(
+    Registration.singleton(
+      BindingBehaviorResource.keyFrom(this.description.name),
+      this
+    )
+  );
+}

--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -9,8 +9,18 @@ export interface IScope {
 }
 
 export const BindingContext = {
+  createScope(bindingContext: any, overrideContext?: IOverrideContext): IScope {
+    return {
+      bindingContext: bindingContext,
+      overrideContext: overrideContext || BindingContext.createOverride()
+    };
+  },
+
   createScopeFromOverride(overrideContext: IOverrideContext): IScope {
-    return { bindingContext: overrideContext.bindingContext, overrideContext };
+    return {
+      bindingContext: overrideContext.bindingContext,
+      overrideContext
+    };
   },
 
   createScopeFromParent(parentScope: IScope, bindingContext: any): IScope {

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -16,7 +16,7 @@ export function valueConverter(nameOrSource: string | IValueConverterSource) {
 export const ValueConverterResource: IResourceKind<IValueConverterSource, IValueConverterType> = {
   name: 'value-converter',
 
-  keyFrom(name: string) {
+  keyFrom(name: string): string {
     return `${this.name}:${name}`;
   },
 
@@ -25,15 +25,24 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
   },
 
   define<T extends Constructable>(nameOrSource: string | IValueConverterSource, ctor: T): T & IValueConverterType {
-    const description = typeof nameOrSource === 'string' ? { name: nameOrSource } : nameOrSource;
-    const Type: T & IValueConverterType = ctor as any;
+    const Type = ctor as T & IValueConverterType;
+    const description = typeof nameOrSource === 'string'
+      ? { name: nameOrSource }
+      : nameOrSource;
 
     (Type as Writable<IValueConverterType>).kind = ValueConverterResource;
     (Type as Writable<IValueConverterType>).description = description;
-    Type.register = function(container: IContainer) {
-      container.register(Registration.singleton(Type.kind.keyFrom(description.name), Type));
-    };
+    Type.register = register;
 
     return Type;
   }
 };
+
+function register(this: IResourceType<IValueConverterSource>, container: IContainer): void {
+  container.register(
+    Registration.singleton(
+      ValueConverterResource.keyFrom(this.description.name),
+      this
+    )
+  );
+}

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -38,7 +38,7 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
   }
 };
 
-function register(this: IResourceType<IValueConverterSource>, container: IContainer): void {
+function register(this: IValueConverterType, container: IContainer): void {
   container.register(
     Registration.singleton(
       ValueConverterResource.keyFrom(this.description.name),

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -103,7 +103,7 @@ export const CustomAttributeResource: IResourceKind<ICustomAttributeSource, ICus
   }
 };
 
-function register(this: IResourceType<ICustomAttributeSource>, container: IContainer): void {
+function register(this: ICustomAttributeType, container: IContainer): void {
   const description = this.description;
   const resourceKey = CustomAttributeResource.keyFrom(description.name);
   const aliases = description.aliases;

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -133,10 +133,7 @@ function hydrate(this: IInternalCustomElementImplementation, renderingEngine: IR
   this.$child = null;
   this.$isAttached = false;
   this.$isBound = false;
-  this.$scope = {
-    bindingContext: this,
-    overrideContext: BindingContext.createOverride()
-  };
+  this.$scope = BindingContext.createScope(this);
 
   renderingEngine.applyRuntimeBehavior(Type, this);
 


### PR DESCRIPTION
## Description

This PR refactors the internals of the `define` methods of each of the resources types so that they use shared functions rather than creating new function instances on every method invocation.

While working on the `CustomElementResource` a helper factory method for basic scopes was also factored out and placed on the `BindingContext`.