### PR TITLE
e2e benchmark fixes + perf improvements

### DIFF
--- a/packages/examples/e2e-benchmark/vcurrent/app.ts
+++ b/packages/examples/e2e-benchmark/vcurrent/app.ts
@@ -52,13 +52,17 @@ export class App {
       }
       this.todos.push(...newTodos);
     }
-    this.tq.queueTask(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public clearTodos(): void {
     instrumenter.markActionStart(`app-clearTodos-${this.todos.length}`, true);
     this.todos = [];
-    this.tq.queueTask(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public toggleTodos(): void {
@@ -68,7 +72,9 @@ export class App {
       const todo = todos[i];
       todo.done = !todo.done;
     }
-    this.tq.queueTask(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public updateTodos(): void {
@@ -78,13 +84,17 @@ export class App {
     for (let i = 0, ii = todos.length; i < ii; ++i) {
       todos[i].description = description;
     }
-    this.tq.queueTask(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public reverseTodos(): void {
     instrumenter.markActionStart(`app-reverseTodos-${this.todos.length}`, true);
     this.todos.reverse();
-    this.tq.queueTask(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public bound(): void {

--- a/packages/examples/e2e-benchmark/vcurrent/index.html
+++ b/packages/examples/e2e-benchmark/vcurrent/index.html
@@ -27,15 +27,13 @@
         this.queuedActions = [];
         this.previousLifecycle = null;
         this.taskQueue = null;
-        this.queued = false;
       }
-      call() {
+      markEnd() {
         const actions = this.queuedActions;
         for (let i = 0, ii = actions.length; i < ii; ++i) {
           this.markActionEnd(actions[i]);
         }
         this.queuedActions = [];
-        this.queued = false;
       }
       markLifecycle(name) {
         const current = `aurelia-${name}`;
@@ -51,22 +49,12 @@
         const markStart = `aurelia-action-${name}-start`;
         performance.mark(markStart);
         this.queuedActions.push(name);
-        this['$'+name] = 0;
-        //console.log(markStart);
       }
       markActionEnd(name) {
         const markEnd = `aurelia-action-${name}-end`;
         const markStart = `aurelia-action-${name}-start`;
         performance.mark(markEnd);
-        const dollarName = '$'+name;
-        const flushCount = this[dollarName];
-        this[dollarName] = 0;
-        if (flushCount > 0) {
-          const measureFlush = `aurelia-action-${name}-flush-${flushCount}`;
-          performance.measure(measureFlush, measureFlush, markEnd);
-        }
         performance.measure(`aurelia-action-${name}`, markStart, markEnd);
-        //console.log(markEnd);
       }
     }
     var instrumenter = window.instrumenter = new Instrumenter();

--- a/packages/examples/e2e-benchmark/vcurrent/instrumenter.ts
+++ b/packages/examples/e2e-benchmark/vcurrent/instrumenter.ts
@@ -1,6 +1,6 @@
 export abstract class Instrumenter {
   public taskQueue: any;
-  public abstract call(): void;
+  public abstract markEnd(): void;
   public abstract markLifecycle(name: string): void;
   public abstract markActionStart(name: string, queued: boolean): void;
   public abstract markActionEnd(name: string): void;

--- a/packages/examples/e2e-benchmark/vnext/app.ts
+++ b/packages/examples/e2e-benchmark/vnext/app.ts
@@ -61,13 +61,17 @@ export class App {
       }
       this.todos.push(...newTodos);
     }
-    this.cs.add(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public clearTodos(): void {
     instrumenter.markActionStart(`app-clearTodos-${this.todos.length}`, true);
     this.todos = [];
-    this.cs.add(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public toggleTodos(): void {
@@ -77,7 +81,9 @@ export class App {
       const todo = todos[i];
       todo.done = !todo.done;
     }
-    this.cs.add(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public updateTodos(): void {
@@ -87,13 +93,17 @@ export class App {
     for (let i = 0, ii = todos.length; i < ii; ++i) {
       todos[i].description = description;
     }
-    this.cs.add(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public reverseTodos(): void {
     instrumenter.markActionStart(`app-reverseTodos-${this.todos.length}`, true);
     this.todos.reverse();
-    this.cs.add(instrumenter);
+    setTimeout(() => {
+      instrumenter.markEnd();
+    });
   }
 
   public bound(): void {

--- a/packages/examples/e2e-benchmark/vnext/index.html
+++ b/packages/examples/e2e-benchmark/vnext/index.html
@@ -27,40 +27,13 @@
         this.queuedActions = [];
         this.previousLifecycle = null;
         this.changeSet = null;
-        this.queued = false;
       }
-      flushChanges() {
-        const changeSet = this.changeSet;
-        if (changeSet !== null) {
-          const actions = this.queuedActions;
-          if (!this.queued) {
-            this.queued = true;
-            changeSet.flushed.then(() => {
-              for (let i = 0, ii = actions.length; i < ii; ++i) {
-                this.markActionEnd(actions[i]);
-              }
-              this.queuedActions = [];
-              this.queued = false;
-            });
-          }
-          if (changeSet.size > 0) {
-            // we're trying to get to the end of the queue for the full measurement, so keep re-queueing until this flush is the last change
-            for (let i = 0, ii = actions.length; i < ii; ++i) {
-              const name = actions[i];
-              const flushCount = ++this['$'+name];
-              const markFlush = `aurelia-action-${name}-flush-${flushCount}`;
-              performance.mark(markFlush);
-              const measureFlush = `aurelia-action-${name}-flush-${flushCount-1}`;
-              if (flushCount === 1) {
-                const markStart = `aurelia-action-${name}-start`;
-                performance.measure(measureFlush, markStart, markFlush);
-              } else {
-                performance.measure(measureFlush, measureFlush, markFlush);
-              }
-            }
-            changeSet.add(this);
-          }
+      markEnd() {
+        const actions = this.queuedActions;
+        for (let i = 0, ii = actions.length; i < ii; ++i) {
+          this.markActionEnd(actions[i]);
         }
+        this.queuedActions = [];
       }
       markLifecycle(name) {
         const current = `aurelia-${name}`;
@@ -76,22 +49,12 @@
         const markStart = `aurelia-action-${name}-start`;
         performance.mark(markStart);
         this.queuedActions.push(name);
-        this['$'+name] = 0;
-        //console.log(markStart);
       }
       markActionEnd(name) {
         const markEnd = `aurelia-action-${name}-end`;
         const markStart = `aurelia-action-${name}-start`;
         performance.mark(markEnd);
-        const dollarName = '$'+name;
-        const flushCount = this[dollarName];
-        this[dollarName] = 0;
-        if (flushCount > 0) {
-          const measureFlush = `aurelia-action-${name}-flush-${flushCount}`;
-          performance.measure(measureFlush, measureFlush, markEnd);
-        }
         performance.measure(`aurelia-action-${name}`, markStart, markEnd);
-        //console.log(markEnd);
       }
     }
     var instrumenter = window.instrumenter = new Instrumenter();

--- a/packages/examples/e2e-benchmark/vnext/instrumenter.ts
+++ b/packages/examples/e2e-benchmark/vnext/instrumenter.ts
@@ -1,6 +1,6 @@
 export abstract class Instrumenter {
   public changeSet: any;
-  public abstract flushChanges(): void;
+  public abstract markEnd(): void;
   public abstract markLifecycle(name: string): void;
   public abstract markActionStart(name: string, queued: boolean): void;
   public abstract markActionEnd(name: string): void;

--- a/packages/runtime/src/binding/array-observer.ts
+++ b/packages/runtime/src/binding/array-observer.ts
@@ -1,7 +1,8 @@
+// tslint:disable:no-reserved-keywords
 import { BindingFlags } from './binding-flags';
-import { collectionObserver } from './collection-observer';
-import { CollectionKind, IBatchedCollectionSubscriber, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedArray, ICollectionChangeNotifier, IBatchedCollectionChangeNotifier } from './observation';
 import { IChangeSet } from './change-set';
+import { collectionObserver } from './collection-observer';
+import { CollectionKind, IBatchedCollectionChangeNotifier, IBatchedCollectionSubscriber, ICollectionChangeNotifier, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedArray } from './observation';
 
 const proto = Array.prototype;
 export const nativePush = proto.push; // TODO: probably want to make these internal again
@@ -23,7 +24,7 @@ function observePush(this: IObservedArray): ReturnType<typeof nativePush> {
   if (argCount === 0) {
     return len;
   }
-  this.length = o.indexMap.length = len + argCount
+  this.length = o.indexMap.length = len + argCount;
   let i = len;
   while (i < this.length) {
     this[i] = arguments[i - len]; o.indexMap[i] = - 2;
@@ -130,7 +131,7 @@ function observeReverse(this: IObservedArray): ReturnType<typeof nativeReverse> 
   const middle = (len / 2) | 0;
   let lower = 0;
   while (lower !== middle) {
-    let upper = len - lower - 1;
+    const upper = len - lower - 1;
     const lowerValue = this[lower]; const lowerIndex = o.indexMap[lower];
     const upperValue = this[upper]; const upperIndex = o.indexMap[upper];
     this[lower] = upperValue; o.indexMap[lower] = upperIndex;
@@ -143,7 +144,7 @@ function observeReverse(this: IObservedArray): ReturnType<typeof nativeReverse> 
 
 // https://tc39.github.io/ecma262/#sec-array.prototype.sort
 // https://github.com/v8/v8/blob/master/src/js/array.js
-function observeSort(this: IObservedArray, compareFn?: (a: any, b: any) => number) {
+function observeSort(this: IObservedArray, compareFn?: (a: any, b: any) => number): IObservedArray {
   const o = this.$observer;
   if (o === undefined) {
     return nativeSort.call(this, compareFn);
@@ -219,6 +220,7 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
   let vpivot, ipivot, lowEnd, highStart;
   let velement, ielement, order, vtopElement, itopElement;
 
+  // tslint:disable-next-line:no-constant-condition
   while (true) {
     if (to - from <= 10) {
       insertionSort(arr, indexMap, from, to, compareFn);
@@ -319,35 +321,17 @@ export function disableArrayObservation(): void {
   if (proto.sort['observing'] === true) proto.sort = nativeSort;
 }
 
-@collectionObserver(CollectionKind.array)
-export class ArrayObserver implements ICollectionObserver<CollectionKind.array> {
-  public lengthPropertyName: 'length';
-  public collectionKind: CollectionKind.array;
-  public dispose: () => void;
-  public indexMap: IndexMap;
-  public hasChanges?: boolean;
-  public flushChanges: () => void;
-  public callSubscribers: ICollectionChangeNotifier;
-  public hasSubscribers: () => boolean;
-  public hasSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public removeSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public addSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public subscribe: (subscriber: ICollectionSubscriber) => void;
-  public unsubscribe: (subscriber: ICollectionSubscriber) => void;
-  public callBatchedSubscribers: IBatchedCollectionChangeNotifier;
-  public hasBatchedSubscribers: () => boolean;
-  public hasBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public removeBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public addBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public subscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
+// tslint:disable-next-line:interface-name
+export interface ArrayObserver extends ICollectionObserver<CollectionKind.array> {}
 
+@collectionObserver(CollectionKind.array)
+export class ArrayObserver implements ArrayObserver {
   public resetIndexMap: () => void;
   public changeSet: IChangeSet;
 
   public collection: IObservedArray;
 
-  constructor(changeSet: IChangeSet, array: any[] & { $observer?: Partial<ICollectionObserver<CollectionKind.array>> }) {
+  constructor(changeSet: IChangeSet, array: any[] & { $observer?: ArrayObserver }) {
     this.changeSet = changeSet;
     array.$observer = this;
     this.collection = <IObservedArray>array;

--- a/packages/runtime/src/binding/dirty-checker.ts
+++ b/packages/runtime/src/binding/dirty-checker.ts
@@ -1,7 +1,7 @@
-import { DI, ICallable } from '@aurelia/kernel';
+import { DI } from '@aurelia/kernel';
 import { BindingFlags } from './binding-flags';
-import { IAccessor, IChangeTracker, IPropertySubscriber, ISubscribable, MutationKind } from './observation';
-import { SubscriberCollection } from './subscriber-collection';
+import { IAccessor, IChangeTracker, IPropertySubscriber, ISubscribable, ISubscriberCollection, MutationKind } from './observation';
+import { subscriberCollection } from './subscriber-collection';
 
 export interface IDirtyChecker {
   createProperty(obj: any, propertyName: string): IAccessor & ISubscribable<MutationKind.instance> & IChangeTracker;
@@ -12,15 +12,15 @@ export const IDirtyChecker = DI.createInterface<IDirtyChecker>()
 
 /*@internal*/
 export class DirtyChecker {
-  private tracked = [];
-  private checkDelay = 120;
+  private tracked: any[] = [];
+  private checkDelay: number = 120;
 
-  public createProperty(obj: any, propertyName: string) {
+  public createProperty(obj: any, propertyName: string): DirtyCheckProperty {
     return new DirtyCheckProperty(this, obj, propertyName);
   }
 
-  public addProperty(property: DirtyCheckProperty) {
-    let tracked = this.tracked;
+  public addProperty(property: DirtyCheckProperty): void {
+    const tracked = this.tracked;
 
     tracked.push(property);
 
@@ -29,21 +29,21 @@ export class DirtyChecker {
     }
   }
 
-  public removeProperty(property: DirtyCheckProperty) {
-    let tracked = this.tracked;
+  public removeProperty(property: DirtyCheckProperty): void {
+    const tracked = this.tracked;
     tracked.splice(tracked.indexOf(property), 1);
   }
 
-  public scheduleDirtyCheck() {
+  public scheduleDirtyCheck(): void {
     setTimeout(() => this.check(), this.checkDelay);
   }
 
-  public check() {
-    let tracked = this.tracked;
+  public check(): void {
+    const tracked = this.tracked;
     let i = tracked.length;
 
     while (i--) {
-      let current = tracked[i];
+      const current = tracked[i];
 
       if (current.isDirty()) {
         current.call();
@@ -56,36 +56,41 @@ export class DirtyChecker {
   }
 }
 
-/*@internal*/
-export class DirtyCheckProperty extends SubscriberCollection implements IAccessor, ISubscribable<MutationKind.instance>, IChangeTracker {
-  public oldValue;
+export interface IDirtyCheckProperty extends
+  IAccessor,
+  ISubscribable<MutationKind.instance>,
+  ISubscriberCollection<MutationKind.instance>,
+  IChangeTracker { }
 
-  constructor(private dirtyChecker: DirtyChecker, private obj: any, private propertyName: string) {
-    super();
-  }
+/*@internal*/
+@subscriberCollection(MutationKind.instance)
+export class DirtyCheckProperty implements Partial<IDirtyCheckProperty> {
+  public oldValue: any;
+
+  constructor(private dirtyChecker: DirtyChecker, private obj: any, private propertyName: string) { }
 
   public isDirty(): boolean {
     return this.oldValue !== this.obj[this.propertyName];
   }
 
-  public getValue() {
+  public getValue(): any {
     return this.obj[this.propertyName];
   }
 
-  public setValue(newValue) {
+  public setValue(newValue: any): void {
     this.obj[this.propertyName] = newValue;
   }
 
-  public flushChanges() {
-    let oldValue = this.oldValue;
-    let newValue = this.getValue();
+  public flushChanges(this: DirtyCheckProperty & IDirtyCheckProperty): void {
+    const oldValue = this.oldValue;
+    const newValue = this.getValue();
 
     this.callSubscribers(newValue, oldValue, BindingFlags.updateTargetInstance | BindingFlags.fromFlushChanges);
 
     this.oldValue = newValue;
   }
 
-  public subscribe(subscriber: IPropertySubscriber) {
+  public subscribe(this: DirtyCheckProperty & IDirtyCheckProperty, subscriber: IPropertySubscriber): void {
     if (!this.hasSubscribers()) {
       this.oldValue = this.getValue();
       this.dirtyChecker.addProperty(this);
@@ -93,7 +98,7 @@ export class DirtyCheckProperty extends SubscriberCollection implements IAccesso
     this.addSubscriber(subscriber);
   }
 
-  public unsubscribe(subscriber: IPropertySubscriber) {
+  public unsubscribe(this: DirtyCheckProperty & IDirtyCheckProperty, subscriber: IPropertySubscriber): void {
     if (this.removeSubscriber(subscriber) && !this.hasSubscribers()) {
       this.dirtyChecker.removeProperty(this);
     }

--- a/packages/runtime/src/binding/dirty-checker.ts
+++ b/packages/runtime/src/binding/dirty-checker.ts
@@ -56,7 +56,8 @@ export class DirtyChecker {
   }
 }
 
-export interface IDirtyCheckProperty extends
+// tslint:disable-next-line:interface-name
+export interface DirtyCheckProperty extends
   IAccessor,
   ISubscribable<MutationKind.instance>,
   ISubscriberCollection<MutationKind.instance>,
@@ -64,7 +65,7 @@ export interface IDirtyCheckProperty extends
 
 /*@internal*/
 @subscriberCollection(MutationKind.instance)
-export class DirtyCheckProperty implements Partial<IDirtyCheckProperty> {
+export class DirtyCheckProperty implements DirtyCheckProperty {
   public oldValue: any;
 
   constructor(private dirtyChecker: DirtyChecker, private obj: any, private propertyName: string) { }
@@ -81,7 +82,7 @@ export class DirtyCheckProperty implements Partial<IDirtyCheckProperty> {
     this.obj[this.propertyName] = newValue;
   }
 
-  public flushChanges(this: DirtyCheckProperty & IDirtyCheckProperty): void {
+  public flushChanges(): void {
     const oldValue = this.oldValue;
     const newValue = this.getValue();
 
@@ -90,7 +91,7 @@ export class DirtyCheckProperty implements Partial<IDirtyCheckProperty> {
     this.oldValue = newValue;
   }
 
-  public subscribe(this: DirtyCheckProperty & IDirtyCheckProperty, subscriber: IPropertySubscriber): void {
+  public subscribe(subscriber: IPropertySubscriber): void {
     if (!this.hasSubscribers()) {
       this.oldValue = this.getValue();
       this.dirtyChecker.addProperty(this);
@@ -98,7 +99,7 @@ export class DirtyCheckProperty implements Partial<IDirtyCheckProperty> {
     this.addSubscriber(subscriber);
   }
 
-  public unsubscribe(this: DirtyCheckProperty & IDirtyCheckProperty, subscriber: IPropertySubscriber): void {
+  public unsubscribe(subscriber: IPropertySubscriber): void {
     if (this.removeSubscriber(subscriber) && !this.hasSubscribers()) {
       this.dirtyChecker.removeProperty(this);
     }

--- a/packages/runtime/src/binding/map-observer.ts
+++ b/packages/runtime/src/binding/map-observer.ts
@@ -1,8 +1,9 @@
+// tslint:disable:no-reserved-keywords
 import { nativePush, nativeSplice } from './array-observer';
 import { BindingFlags } from './binding-flags';
-import { collectionObserver } from './collection-observer';
-import { CollectionKind, IBatchedCollectionSubscriber, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedMap, IBatchedCollectionChangeNotifier, ICollectionChangeNotifier } from './observation';
 import { IChangeSet } from './change-set';
+import { collectionObserver } from './collection-observer';
+import { CollectionKind, ICollectionObserver, IObservedMap } from './observation';
 
 const proto = Map.prototype;
 export const nativeSet = proto.set; // TODO: probably want to make these internal again
@@ -106,35 +107,17 @@ export function disableMapObservation(): void {
   if (proto.delete['observing'] === true) proto.delete = nativeDelete;
 }
 
-@collectionObserver(CollectionKind.map)
-export class MapObserver implements ICollectionObserver<CollectionKind.map> {
-  public lengthPropertyName: 'size';
-  public collectionKind: CollectionKind.map;
-  public dispose: () => void;
-  public indexMap: IndexMap;
-  public hasChanges?: boolean;
-  public flushChanges: () => void;
-  public callSubscribers: ICollectionChangeNotifier;
-  public hasSubscribers: () => boolean;
-  public hasSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public removeSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public addSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public subscribe: (subscriber: ICollectionSubscriber) => void;
-  public unsubscribe: (subscriber: ICollectionSubscriber) => void;
-  public callBatchedSubscribers: IBatchedCollectionChangeNotifier;
-  public hasBatchedSubscribers: () => boolean;
-  public hasBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public removeBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public addBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public subscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
+// tslint:disable-next-line:interface-name
+export interface MapObserver extends ICollectionObserver<CollectionKind.map> {}
 
+@collectionObserver(CollectionKind.map)
+export class MapObserver implements MapObserver {
   public resetIndexMap: () => void;
   public changeSet: IChangeSet;
 
   public collection: IObservedMap;
 
-  constructor(changeSet: IChangeSet, map: Map<any, any> & { $observer?: Partial<ICollectionObserver<CollectionKind.map>> }) {
+  constructor(changeSet: IChangeSet, map: Map<any, any> & { $observer?: MapObserver }) {
     this.changeSet = changeSet;
     map.$observer = this;
     this.collection = <IObservedMap>map;

--- a/packages/runtime/src/binding/observation.ts
+++ b/packages/runtime/src/binding/observation.ts
@@ -36,7 +36,8 @@ export interface IBindingTargetObserver<
   TProp = keyof TObj,
   TValue = any>
   extends IBindingTargetAccessor<TObj, TProp, TValue>,
-          ISubscribable<MutationKind.instance> {
+          ISubscribable<MutationKind.instance>,
+          ISubscriberCollection<MutationKind.instance> {
 
   bind?(flags: BindingFlags): void;
   unbind?(flags: BindingFlags): void;
@@ -177,25 +178,56 @@ export interface ISubscribable<T extends MutationKind> {
   unsubscribe(subscriber: MutationKindToSubscriber<T>): void;
 }
 
+/*@internal*/
+export const enum SubscriberFlags {
+  None            = 0,
+  Subscriber0     = 0b0001,
+  Subscriber1     = 0b0010,
+  Subscriber2     = 0b0100,
+  SubscribersRest = 0b1000,
+  Any             = 0b1111,
+}
+
 /**
  * A collection of property or collection subscribers
  */
 export interface ISubscriberCollection<T extends MutationKind> extends ISubscribable<T> {
-  subscribers: Array<MutationKindToSubscriber<T>>;
-  notify: MutationKindToNotifier<T>;
+  /*@internal*/_subscriberFlags?: SubscriberFlags;
+  /*@internal*/_subscriber0?: MutationKindToSubscriber<T>;
+  /*@internal*/_subscriber1?: MutationKindToSubscriber<T>;
+  /*@internal*/_subscriber2?: MutationKindToSubscriber<T>;
+  /*@internal*/_subscribersRest?: MutationKindToSubscriber<T>[];
+
+  callSubscribers: MutationKindToNotifier<T>;
+  hasSubscribers(): boolean;
+  hasSubscriber(subscriber: MutationKindToSubscriber<T>): boolean;
+  removeSubscriber(subscriber: MutationKindToSubscriber<T>): boolean;
+  addSubscriber(subscriber: MutationKindToSubscriber<T>): boolean;
+}
+
+/**
+ * A collection of batched property or collection subscribers
+ */
+export interface IBatchedSubscriberCollection<T extends MutationKind> extends IBatchedSubscribable<T> {
+  /*@internal*/_batchedSubscriberFlags?: SubscriberFlags;
+  /*@internal*/_batchedSubscriber0?: MutationKindToBatchedSubscriber<T>;
+  /*@internal*/_batchedSubscriber1?: MutationKindToBatchedSubscriber<T>;
+  /*@internal*/_batchedSubscriber2?: MutationKindToBatchedSubscriber<T>;
+  /*@internal*/_batchedSubscribersRest?: MutationKindToBatchedSubscriber<T>[];
+
+  /*@internal*/changeSet?: IChangeSet;
+  /*@internal*/flushChanges(): void;
+
+  callBatchedSubscribers: MutationKindToBatchedNotifier<T>;
+  hasBatchedSubscribers(): boolean;
+  hasBatchedSubscriber(subscriber: MutationKindToBatchedSubscriber<T>): boolean;
+  removeBatchedSubscriber(subscriber: MutationKindToBatchedSubscriber<T>): boolean;
+  addBatchedSubscriber(subscriber: MutationKindToBatchedSubscriber<T>): boolean;
 }
 
 export interface IBatchedSubscribable<T extends MutationKind> {
   subscribeBatched(subscriber: MutationKindToBatchedSubscriber<T>): void;
   unsubscribeBatched(subscriber: MutationKindToBatchedSubscriber<T>): void;
-}
-
-/**
- * A collection of batched property or batched collection subscribers
- */
-export interface IBatchedSubscriberCollection<T extends MutationKind> extends IBatchedSubscribable<T> {
-  batchedSubscribers: Array<MutationKindToBatchedSubscriber<T>>;
-  notifyBatched: MutationKindToBatchedNotifier<T>;
 }
 
 /**

--- a/packages/runtime/src/binding/observation.ts
+++ b/packages/runtime/src/binding/observation.ts
@@ -76,11 +76,9 @@ export enum MutationKind {
 /**
  * Describes a type that specifically tracks changes in an object property, or simply something that can have a getter and/or setter
  */
-export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = any> extends IChangeTracker {
+export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = any> {
   obj: TObj;
   propertyKey?: TProp;
-  oldValue?: TValue;
-  previousValue?: TValue;
   currentValue: TValue;
 }
 
@@ -104,22 +102,9 @@ export interface IPropertyChangeHandler { (newValue: any, previousValue: any, fl
 export interface IPropertyChangeNotifier extends IPropertyChangeHandler {}
 
 /**
- * Represents a (subscriber) function that can be called by a BatchedPropertyChangeNotifier
- */
-export interface IBatchedPropertyChangeHandler { (newValue: any, oldValue: any): void; }
-/**
- * Represents a (observer) function that can notify subscribers of batched mutations on a property
- */
-export interface IBatchedPropertyChangeNotifier extends IBatchedPropertyChangeHandler {}
-
-/**
  * Describes a (subscriber) type that has a function conforming to the IPropertyChangeHandler interface
  */
 export interface IPropertySubscriber { handleChange(newValue: any, previousValue: any, flags: BindingFlags): void; }
-/**
- * Describes a (subscriber) type that has a function conforming to the IBatchedPropertyChangeNotifier interface
- */
-export interface IBatchedPropertySubscriber { handleBatchedChange(newValue: any, oldValue: any): void; }
 
 /**
  * Represents a (subscriber) function that can be called by a CollectionChangeNotifier
@@ -155,7 +140,7 @@ export type Subscriber = ICollectionSubscriber | IPropertySubscriber;
 /**
  * Either a batched property or batched collection subscriber
  */
-export type BatchedSubscriber = IBatchedCollectionSubscriber | IBatchedPropertySubscriber;
+export type BatchedSubscriber = IBatchedCollectionSubscriber;
 
 /**
  * Helper type that translates from mutationKind enum to the correct subscriber interface
@@ -169,7 +154,6 @@ export type MutationKindToSubscriber<T> =
  * Helper type that translates from mutationKind enum to the correct batched subscriber interface
  */
 export type MutationKindToBatchedSubscriber<T> =
-  T extends MutationKind.instance ? IBatchedPropertySubscriber :
   T extends MutationKind.collection ? IBatchedCollectionSubscriber :
   never;
 
@@ -185,7 +169,6 @@ export type MutationKindToNotifier<T> =
  * Helper type that translates from mutationKind enum to the correct batched notifier interface
  */
 export type MutationKindToBatchedNotifier<T> =
-  T extends MutationKind.instance ? IBatchedPropertyChangeNotifier :
   T extends MutationKind.collection ? IBatchedCollectionChangeNotifier :
   never;
 
@@ -222,11 +205,8 @@ export interface IPropertyObserver<TObj extends Object, TProp extends keyof TObj
   IDisposable,
   IAccessor<any>,
   IPropertyChangeTracker<TObj, TProp>,
-  ISubscriberCollection<MutationKind.instance>,
-  IBatchedSubscriberCollection<MutationKind.instance> {
-  /*@internal*/changeSet: IChangeSet;
+  ISubscriberCollection<MutationKind.instance> {
   /*@internal*/observing: boolean;
-  /*@internal*/ownPropertyDescriptor: PropertyDescriptor;
 }
 
 /**

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -161,15 +161,15 @@ export class ObserverLocator implements IObserverLocator {
       const tagName = obj['tagName'];
       const handler = this.eventManager.getElementHandler(obj, propertyName);
       if (propertyName === 'value' && tagName === 'SELECT') {
-        return new SelectValueObserver(this.changeSet, <HTMLSelectElement>obj, handler, this);
+        return new SelectValueObserver(this.changeSet, <HTMLSelectElement>obj, handler, this) as any;
       }
 
       if (propertyName === 'checked' && tagName === 'INPUT') {
-        return new CheckedObserver(this.changeSet, <HTMLInputElement>obj, handler, this);
+        return new CheckedObserver(this.changeSet, <HTMLInputElement>obj, handler, this) as any;
       }
 
       if (handler) {
-        return new ValueAttributeObserver(this.changeSet, obj, propertyName, handler);
+        return new ValueAttributeObserver(this.changeSet, obj, propertyName, handler) as any;
       }
 
       const xlinkResult = /^xlink:(.+)$/.exec(propertyName);
@@ -224,6 +224,6 @@ export class ObserverLocator implements IObserverLocator {
       return this.dirtyChecker.createProperty(obj, propertyName) as any;
     }
 
-    return new SetterObserver(obj, propertyName);
+    return new SetterObserver(obj, propertyName) as any;
   }
 }

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -224,6 +224,6 @@ export class ObserverLocator implements IObserverLocator {
       return this.dirtyChecker.createProperty(obj, propertyName) as any;
     }
 
-    return new SetterObserver(this.changeSet, obj, propertyName);
+    return new SetterObserver(obj, propertyName);
   }
 }

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -1,7 +1,6 @@
 import { IIndexable, PLATFORM, Primitive } from '@aurelia/kernel';
 import { BindingFlags } from './binding-flags';
-import { IChangeSet } from './change-set';
-import { IAccessor, IBatchedPropertySubscriber, IPropertyObserver, IPropertySubscriber, ISubscribable, MutationKind } from './observation';
+import { IAccessor, IPropertyObserver, IPropertySubscriber, ISubscribable, MutationKind } from './observation';
 import { propertyObserver } from './property-observer';
 
 const noop = PLATFORM.noop;
@@ -17,8 +16,6 @@ export class PrimitiveObserver implements IAccessor, ISubscribable<MutationKind.
   public setValue: () => void;
   public subscribe: () => void;
   public unsubscribe: () => void;
-  public subscribeBatched: () => void;
-  public unsubscribeBatched: () => void;
 
   public doNotCache: boolean = true;
   private obj: Primitive;
@@ -44,43 +41,26 @@ export class PrimitiveObserver implements IAccessor, ISubscribable<MutationKind.
 PrimitiveObserver.prototype.setValue = noop;
 PrimitiveObserver.prototype.subscribe = noop;
 PrimitiveObserver.prototype.unsubscribe = noop;
-PrimitiveObserver.prototype.subscribeBatched = noop;
-PrimitiveObserver.prototype.unsubscribeBatched = noop;
 
 @propertyObserver()
 export class SetterObserver implements IPropertyObserver<IIndexable, string> {
-  /*@internal*/
-  public changeSet: IChangeSet;
   public notify: (newValue: any, previousValue: any, flags: BindingFlags) => void;
-  public notifyBatched: (newValue: any, oldValue: any) => void;
-  public subscribeBatched: (subscriber: IBatchedPropertySubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedPropertySubscriber) => void;
   public subscribe: (subscriber: IPropertySubscriber) => void;
   public unsubscribe: (subscriber: IPropertySubscriber) => void;
-  public flushChanges: () => void;
   public dispose: () => void;
 
   public observing: boolean;
   public obj: IIndexable;
   public propertyKey: string;
-  public ownPropertyDescriptor: PropertyDescriptor;
-  // oldValue is the initial value the property has when observation starts, or after the batched changes are flushed - it will not be updated with each change
-  public oldValue?: any;
-  // previousValue is literally the previous value of the property, and will be updated with each change
-  public previousValue?: any;
   public currentValue: any;
-  public hasChanges: boolean;
 
-  public subscribers: Array<IPropertySubscriber>;
-  public batchedSubscribers: Array<IBatchedPropertySubscriber>;
+  public subscribers: IPropertySubscriber[];
 
-  constructor(changeSet: IChangeSet, obj: IIndexable, propertyKey: string) {
-    this.changeSet = changeSet;
+  constructor(obj: IIndexable, propertyKey: string) {
     this.obj = obj;
     this.propertyKey = propertyKey;
 
-    this.subscribers = new Array();
-    this.batchedSubscribers = new Array();
+    this.subscribers = [];
   }
 
   public getValue(): any {
@@ -89,7 +69,6 @@ export class SetterObserver implements IPropertyObserver<IIndexable, string> {
   public setValue(newValue: any, flags: BindingFlags): void {
     const currentValue = this.currentValue;
     if (currentValue !== newValue) {
-      this.previousValue = currentValue;
       this.currentValue = newValue;
       if (!(flags & BindingFlags.fromBind)) {
         this.notify(newValue, currentValue, flags);
@@ -100,50 +79,31 @@ export class SetterObserver implements IPropertyObserver<IIndexable, string> {
 
 @propertyObserver()
 export class Observer implements IPropertyObserver<IIndexable, string> {
-  /*@internal*/
-  public changeSet: IChangeSet;
   public notify: (newValue: any, previousValue: any, flags: BindingFlags) => void;
-  public notifyBatched: (newValue: any, oldValue?: any) => void;
-  public subscribeBatched: (subscriber: IBatchedPropertySubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedPropertySubscriber) => void;
   public subscribe: (subscriber: IPropertySubscriber) => void;
   public unsubscribe: (subscriber: IPropertySubscriber) => void;
-  public flushChanges: () => void;
   public dispose: () => void;
 
   public observing: boolean;
   public obj: IIndexable;
   public propertyKey: string;
-  public ownPropertyDescriptor: PropertyDescriptor;
-  // oldValue is the initial value the property has when observation starts, or after the batched changes are flushed - it will not be updated with each change
-  public oldValue?: any;
-  // previousValue is literally the previous value of the property, and will be updated with each change
-  public previousValue?: any;
   public currentValue: any;
-  public hasChanges: boolean;
 
-  public subscribers: Array<IPropertySubscriber>;
-  public batchedSubscribers: Array<IBatchedPropertySubscriber>;
-
-  public subscriberFlags: Array<BindingFlags>;
-  public batchedSubscriberFlags: Array<BindingFlags>;
+  public subscribers: IPropertySubscriber[];
 
   private callback: (oldValue: any, newValue: any) => any;
 
   constructor(
-    changeSet: IChangeSet,
     instance: object,
     propertyName: string,
     callbackName: string
   ) {
-      this.changeSet = changeSet;
       this.currentValue = instance[propertyName];
       this.callback = callbackName in instance
         ? instance[callbackName].bind(instance)
         : noop;
 
-      this.subscribers = new Array();
-      this.batchedSubscribers = new Array();
+      this.subscribers = [];
   }
 
   public getValue(): any {
@@ -151,20 +111,19 @@ export class Observer implements IPropertyObserver<IIndexable, string> {
   }
 
   public setValue<T>(newValue: T, flags: BindingFlags): void {
-    const previousValue = this.currentValue;
+    const currentValue = this.currentValue;
 
-    if (previousValue !== newValue) {
-      this.previousValue = previousValue;
+    if (currentValue !== newValue) {
       this.currentValue = newValue;
 
       if (!(flags & BindingFlags.fromBind)) {
-        const coercedValue = this.callback(newValue, previousValue);
+        const coercedValue = this.callback(newValue, currentValue);
 
         if (coercedValue !== undefined) {
           this.currentValue = newValue = coercedValue;
         }
 
-        this.notify(newValue, previousValue, flags);
+        this.notify(newValue, currentValue, flags);
       }
     }
   }

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -43,53 +43,36 @@ PrimitiveObserver.prototype.subscribe = noop;
 PrimitiveObserver.prototype.unsubscribe = noop;
 
 @propertyObserver()
-export class SetterObserver implements IPropertyObserver<IIndexable, string> {
-  public notify: (newValue: any, previousValue: any, flags: BindingFlags) => void;
+export class SetterObserver implements Partial<IPropertyObserver<IIndexable, string>> {
   public subscribe: (subscriber: IPropertySubscriber) => void;
   public unsubscribe: (subscriber: IPropertySubscriber) => void;
-  public dispose: () => void;
-
-  public observing: boolean;
   public obj: IIndexable;
   public propertyKey: string;
-  public currentValue: any;
-
-  public subscribers: IPropertySubscriber[];
 
   constructor(obj: IIndexable, propertyKey: string) {
     this.obj = obj;
     this.propertyKey = propertyKey;
-
-    this.subscribers = [];
   }
 
-  public getValue(): any {
+  public getValue(this: SetterObserver & IPropertyObserver<IIndexable, string>): any {
     return this.currentValue;
   }
-  public setValue(newValue: any, flags: BindingFlags): void {
+  public setValue(this: SetterObserver & IPropertyObserver<IIndexable, string>, newValue: any, flags: BindingFlags): void {
     const currentValue = this.currentValue;
     if (currentValue !== newValue) {
       this.currentValue = newValue;
       if (!(flags & BindingFlags.fromBind)) {
-        this.notify(newValue, currentValue, flags);
+        this.callSubscribers(newValue, currentValue, flags);
       }
     }
   }
 }
 
 @propertyObserver()
-export class Observer implements IPropertyObserver<IIndexable, string> {
-  public notify: (newValue: any, previousValue: any, flags: BindingFlags) => void;
-  public subscribe: (subscriber: IPropertySubscriber) => void;
-  public unsubscribe: (subscriber: IPropertySubscriber) => void;
-  public dispose: () => void;
-
-  public observing: boolean;
+export class Observer implements Partial<IPropertyObserver<IIndexable, string>> {
   public obj: IIndexable;
   public propertyKey: string;
   public currentValue: any;
-
-  public subscribers: IPropertySubscriber[];
 
   private callback: (oldValue: any, newValue: any) => any;
 
@@ -102,15 +85,13 @@ export class Observer implements IPropertyObserver<IIndexable, string> {
       this.callback = callbackName in instance
         ? instance[callbackName].bind(instance)
         : noop;
-
-      this.subscribers = [];
   }
 
-  public getValue(): any {
+  public getValue(this: Observer & IPropertyObserver<IIndexable, string>): any {
     return this.currentValue;
   }
 
-  public setValue<T>(newValue: T, flags: BindingFlags): void {
+  public setValue<T>(this: Observer & IPropertyObserver<IIndexable, string>, newValue: T, flags: BindingFlags): void {
     const currentValue = this.currentValue;
 
     if (currentValue !== newValue) {
@@ -123,7 +104,7 @@ export class Observer implements IPropertyObserver<IIndexable, string> {
           this.currentValue = newValue = coercedValue;
         }
 
-        this.notify(newValue, currentValue, flags);
+        this.callSubscribers(newValue, currentValue, flags);
       }
     }
   }

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -42,8 +42,11 @@ PrimitiveObserver.prototype.setValue = noop;
 PrimitiveObserver.prototype.subscribe = noop;
 PrimitiveObserver.prototype.unsubscribe = noop;
 
+// tslint:disable-next-line:interface-name
+export interface SetterObserver extends IPropertyObserver<IIndexable, string> {}
+
 @propertyObserver()
-export class SetterObserver implements Partial<IPropertyObserver<IIndexable, string>> {
+export class SetterObserver implements SetterObserver {
   public subscribe: (subscriber: IPropertySubscriber) => void;
   public unsubscribe: (subscriber: IPropertySubscriber) => void;
   public obj: IIndexable;
@@ -54,10 +57,10 @@ export class SetterObserver implements Partial<IPropertyObserver<IIndexable, str
     this.propertyKey = propertyKey;
   }
 
-  public getValue(this: SetterObserver & IPropertyObserver<IIndexable, string>): any {
+  public getValue(): any {
     return this.currentValue;
   }
-  public setValue(this: SetterObserver & IPropertyObserver<IIndexable, string>, newValue: any, flags: BindingFlags): void {
+  public setValue(newValue: any, flags: BindingFlags): void {
     const currentValue = this.currentValue;
     if (currentValue !== newValue) {
       this.currentValue = newValue;
@@ -68,8 +71,11 @@ export class SetterObserver implements Partial<IPropertyObserver<IIndexable, str
   }
 }
 
+// tslint:disable-next-line:interface-name
+export interface Observer extends IPropertyObserver<IIndexable, string> {}
+
 @propertyObserver()
-export class Observer implements Partial<IPropertyObserver<IIndexable, string>> {
+export class Observer implements Observer {
   public obj: IIndexable;
   public propertyKey: string;
   public currentValue: any;
@@ -87,11 +93,11 @@ export class Observer implements Partial<IPropertyObserver<IIndexable, string>> 
         : noop;
   }
 
-  public getValue(this: Observer & IPropertyObserver<IIndexable, string>): any {
+  public getValue(): any {
     return this.currentValue;
   }
 
-  public setValue<T>(this: Observer & IPropertyObserver<IIndexable, string>, newValue: T, flags: BindingFlags): void {
+  public setValue<T>(newValue: T, flags: BindingFlags): void {
     const currentValue = this.currentValue;
 
     if (currentValue !== newValue) {

--- a/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
@@ -4,11 +4,11 @@ import { bindingBehavior } from '../binding-behavior';
 import { IScope } from '../binding-context';
 import { BindingFlags } from '../binding-flags';
 import { BindingMode } from '../binding-mode';
-import { CheckedObserver, ICheckedObserver, ISelectValueObserver, IValueAttributeObserver, SelectValueObserver, ValueAttributeObserver } from '../element-observation';
+import { CheckedObserver, SelectValueObserver, ValueAttributeObserver } from '../element-observation';
 import { EventSubscriber, IEventSubscriber } from '../event-manager';
 import { IObserverLocator } from '../observer-locator';
 
-export type UpdateTriggerableObserver = ((ValueAttributeObserver & Required<IValueAttributeObserver>) | (CheckedObserver & Required<ICheckedObserver>) | (SelectValueObserver & Required<ISelectValueObserver>)) & {
+export type UpdateTriggerableObserver = ((ValueAttributeObserver & Required<ValueAttributeObserver>) | (CheckedObserver & Required<CheckedObserver>) | (SelectValueObserver & Required<SelectValueObserver>)) & {
   originalHandler?: IEventSubscriber;
 };
 

--- a/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
@@ -4,12 +4,12 @@ import { bindingBehavior } from '../binding-behavior';
 import { IScope } from '../binding-context';
 import { BindingFlags } from '../binding-flags';
 import { BindingMode } from '../binding-mode';
-import { CheckedObserver, SelectValueObserver, ValueAttributeObserver } from '../element-observation';
+import { CheckedObserver, ICheckedObserver, ISelectValueObserver, IValueAttributeObserver, SelectValueObserver, ValueAttributeObserver } from '../element-observation';
 import { EventSubscriber, IEventSubscriber } from '../event-manager';
 import { IObserverLocator } from '../observer-locator';
 
-export type UpdateTriggerableObserver = (ValueAttributeObserver | CheckedObserver | SelectValueObserver) & {
-  originalHandler?: IEventSubscriber
+export type UpdateTriggerableObserver = ((ValueAttributeObserver & Required<IValueAttributeObserver>) | (CheckedObserver & Required<ICheckedObserver>) | (SelectValueObserver & Required<ISelectValueObserver>)) & {
+  originalHandler?: IEventSubscriber;
 };
 
 export type UpdateTriggerableBinding = Binding & {
@@ -31,7 +31,7 @@ export class UpdateTriggerBindingBehavior {
     }
 
     // ensure the binding's target observer has been set.
-    let targetObserver = <UpdateTriggerableObserver>this.observerLocator.getObserver(binding.target, binding.targetProperty);
+    const targetObserver = <UpdateTriggerableObserver>this.observerLocator.getObserver(binding.target, binding.targetProperty);
     if (!targetObserver.handler) {
       throw Reporter.error(10);
     }

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -2,7 +2,7 @@ import { nativePush, nativeSplice } from './array-observer';
 import { BindingFlags } from './binding-flags';
 import { IChangeSet } from './change-set';
 import { collectionObserver } from './collection-observer';
-import { CollectionKind, IBatchedCollectionSubscriber, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedSet } from './observation';
+import { CollectionKind, IBatchedCollectionSubscriber, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedSet, ICollectionChangeNotifier, IBatchedCollectionChangeNotifier } from './observation';
 
 const proto = Set.prototype;
 export const nativeAdd = proto.add; // TODO: probably want to make these internal again
@@ -25,7 +25,7 @@ function observeAdd(this: IObservedSet, value: any): ReturnType<typeof nativeAdd
     return this;
   }
   o.indexMap[oldSize] = -2;
-  o.notify('add', arguments);
+  o.callSubscribers('add', arguments, BindingFlags.isCollectionMutation);
   return this;
 }
 
@@ -47,7 +47,7 @@ function observeClear(this: IObservedSet): ReturnType<typeof nativeClear>  {
     }
     nativeClear.call(this);
     indexMap.length = 0;
-    o.notify('clear', arguments);
+    o.callSubscribers('clear', arguments, BindingFlags.isCollectionMutation);
   }
   return undefined;
 }
@@ -74,7 +74,7 @@ function observeDelete(this: IObservedSet, value: any): ReturnType<typeof native
     }
     i++;
   }
-  o.notify('delete', arguments);
+  o.callSubscribers('delete', arguments, BindingFlags.isCollectionMutation);
   return false;
 }
 
@@ -98,34 +98,37 @@ export function disableSetObservation(): void {
 
 @collectionObserver(CollectionKind.set)
 export class SetObserver implements ICollectionObserver<CollectionKind.set> {
-  public resetIndexMap: () => void;
-  public notify: (origin: string, args: IArguments, flags: BindingFlags) => void;
-  public notifyBatched: (indexMap: IndexMap) => void;
-  public subscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
-  public subscribe: (subscriber: ICollectionSubscriber) => void;
-  public unsubscribe: (subscriber: ICollectionSubscriber) => void;
-  public flushChanges: () => void;
-  public dispose: () => void;
-
-  /*@internal*/
-  public changeSet: IChangeSet;
-  public collection: IObservedSet;
-  public indexMap: IndexMap;
-  public hasChanges: boolean;
   public lengthPropertyName: 'size';
   public collectionKind: CollectionKind.set;
+  public dispose: () => void;
+  public indexMap: IndexMap;
+  public hasChanges?: boolean;
+  public flushChanges: () => void;
+  public callSubscribers: ICollectionChangeNotifier;
+  public hasSubscribers: () => boolean;
+  public hasSubscriber: (subscriber: ICollectionSubscriber) => boolean;
+  public removeSubscriber: (subscriber: ICollectionSubscriber) => boolean;
+  public addSubscriber: (subscriber: ICollectionSubscriber) => boolean;
+  public subscribe: (subscriber: ICollectionSubscriber) => void;
+  public unsubscribe: (subscriber: ICollectionSubscriber) => void;
+  public callBatchedSubscribers: IBatchedCollectionChangeNotifier;
+  public hasBatchedSubscribers: () => boolean;
+  public hasBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
+  public removeBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
+  public addBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
+  public subscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
+  public unsubscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
 
-  public subscribers: Array<ICollectionSubscriber>;
-  public batchedSubscribers: Array<IBatchedCollectionSubscriber>;
+  public resetIndexMap: () => void;
+  public changeSet: IChangeSet;
 
-  constructor(changeSet: IChangeSet, set: Set<any> & { $observer?: ICollectionObserver<CollectionKind.set> }) {
+  public collection: IObservedSet;
+
+  constructor(changeSet: IChangeSet, set: Set<any> & { $observer?: Partial<ICollectionObserver<CollectionKind.set>> }) {
     this.changeSet = changeSet;
     set.$observer = this;
     this.collection = <IObservedSet>set;
     this.resetIndexMap();
-    this.subscribers = new Array();
-    this.batchedSubscribers = new Array();
   }
 }
 

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -1,8 +1,9 @@
+// tslint:disable:no-reserved-keywords
 import { nativePush, nativeSplice } from './array-observer';
 import { BindingFlags } from './binding-flags';
 import { IChangeSet } from './change-set';
 import { collectionObserver } from './collection-observer';
-import { CollectionKind, IBatchedCollectionSubscriber, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedSet, ICollectionChangeNotifier, IBatchedCollectionChangeNotifier } from './observation';
+import { CollectionKind, IBatchedCollectionChangeNotifier, IBatchedCollectionSubscriber, ICollectionChangeNotifier, ICollectionObserver, ICollectionSubscriber, IndexMap, IObservedSet } from './observation';
 
 const proto = Set.prototype;
 export const nativeAdd = proto.add; // TODO: probably want to make these internal again
@@ -96,35 +97,17 @@ export function disableSetObservation(): void {
   if (proto.delete['observing'] === true) proto.delete = nativeDelete;
 }
 
-@collectionObserver(CollectionKind.set)
-export class SetObserver implements ICollectionObserver<CollectionKind.set> {
-  public lengthPropertyName: 'size';
-  public collectionKind: CollectionKind.set;
-  public dispose: () => void;
-  public indexMap: IndexMap;
-  public hasChanges?: boolean;
-  public flushChanges: () => void;
-  public callSubscribers: ICollectionChangeNotifier;
-  public hasSubscribers: () => boolean;
-  public hasSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public removeSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public addSubscriber: (subscriber: ICollectionSubscriber) => boolean;
-  public subscribe: (subscriber: ICollectionSubscriber) => void;
-  public unsubscribe: (subscriber: ICollectionSubscriber) => void;
-  public callBatchedSubscribers: IBatchedCollectionChangeNotifier;
-  public hasBatchedSubscribers: () => boolean;
-  public hasBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public removeBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public addBatchedSubscriber: (subscriber: IBatchedCollectionSubscriber) => boolean;
-  public subscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
-  public unsubscribeBatched: (subscriber: IBatchedCollectionSubscriber) => void;
+// tslint:disable-next-line:interface-name
+export interface SetObserver extends ICollectionObserver<CollectionKind.set> {};
 
+@collectionObserver(CollectionKind.set)
+export class SetObserver implements SetObserver {
   public resetIndexMap: () => void;
   public changeSet: IChangeSet;
 
   public collection: IObservedSet;
 
-  constructor(changeSet: IChangeSet, set: Set<any> & { $observer?: Partial<ICollectionObserver<CollectionKind.set>> }) {
+  constructor(changeSet: IChangeSet, set: Set<any> & { $observer?: SetObserver }) {
     this.changeSet = changeSet;
     set.$observer = this;
     this.collection = <IObservedSet>set;

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -1,146 +1,313 @@
-import { BindingFlags } from './binding-flags';
-import { IPropertySubscriber } from './observation';
 import { nativePush, nativeSplice } from './array-observer';
+import { BindingFlags } from './binding-flags';
+import { IPropertySubscriber, ISubscriberCollection, MutationKind, MutationKindToSubscriber, SubscriberFlags, IBatchedSubscriberCollection, MutationKindToBatchedSubscriber, IBatchedCollectionSubscriber, IndexMap } from './observation';
 
-const enum SubscriberFlags {
-  None            = 0,
-  Subscriber0     = 0b0001,
-  Subscriber1     = 0b0010,
-  Subscriber2     = 0b0100,
-  SubscribersRest = 0b1000,
-  Any             = 0b1111,
+export function subscriberCollection<T extends MutationKind>(mutationKind: T): ClassDecorator {
+  return function(target: Function): void {
+    const proto = <ISubscriberCollection<T>>target.prototype;
+
+    proto._subscriberFlags = SubscriberFlags.None;
+    proto._subscriber0 = null;
+    proto._subscriber1 = null;
+    proto._subscriber2 = null;
+    proto._subscribersRest = null;
+
+    proto.addSubscriber = addSubscriber;
+    proto.removeSubscriber = removeSubscriber;
+    proto.hasSubscriber = hasSubscriber;
+    proto.hasSubscribers = hasSubscribers;
+    proto.callSubscribers = <any>(mutationKind === MutationKind.instance ? callPropertySubscribers : callCollectionSubscribers);
+  };
 }
 
-export abstract class SubscriberCollection {
-  private _subscriberFlags: SubscriberFlags = SubscriberFlags.None;
-  private _subscriber0: IPropertySubscriber = null;
-  private _subscriber1: IPropertySubscriber = null;
-  private _subscriber2: IPropertySubscriber = null;
-  private _subscribersRest: IPropertySubscriber[] = null;
-
-  protected addSubscriber(subscriber: IPropertySubscriber): boolean {
-    if (this.hasSubscriber(subscriber)) {
-      return false;
-    }
-    const subscriberFlags = this._subscriberFlags;
-    if (!(subscriberFlags & SubscriberFlags.Subscriber0)) {
-      this._subscriber0 = subscriber;
-      this._subscriberFlags |= SubscriberFlags.Subscriber0;
-      return true;
-    }
-    if (!(subscriberFlags & SubscriberFlags.Subscriber1)) {
-      this._subscriber1 = subscriber;
-      this._subscriberFlags |= SubscriberFlags.Subscriber1;
-      return true;
-    }
-    if (!(subscriberFlags & SubscriberFlags.Subscriber2)) {
-      this._subscriber2 = subscriber;
-      this._subscriberFlags |= SubscriberFlags.Subscriber2;
-      return true;
-    }
-    if (!(subscriberFlags & SubscriberFlags.SubscribersRest)) {
-      this._subscribersRest = [subscriber];
-      this._subscriberFlags |= SubscriberFlags.SubscribersRest;
-      return true;
-    }
-    nativePush.call(this._subscribersRest, subscriber);
+function addSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>, subscriber: MutationKindToSubscriber<T>): boolean {
+  if (this.hasSubscriber(subscriber)) {
+    return false;
+  }
+  const subscriberFlags = this._subscriberFlags;
+  if (!(subscriberFlags & SubscriberFlags.Subscriber0)) {
+    this._subscriber0 = subscriber;
+    this._subscriberFlags |= SubscriberFlags.Subscriber0;
     return true;
   }
+  if (!(subscriberFlags & SubscriberFlags.Subscriber1)) {
+    this._subscriber1 = subscriber;
+    this._subscriberFlags |= SubscriberFlags.Subscriber1;
+    return true;
+  }
+  if (!(subscriberFlags & SubscriberFlags.Subscriber2)) {
+    this._subscriber2 = subscriber;
+    this._subscriberFlags |= SubscriberFlags.Subscriber2;
+    return true;
+  }
+  if (!(subscriberFlags & SubscriberFlags.SubscribersRest)) {
+    this._subscribersRest = [subscriber];
+    this._subscriberFlags |= SubscriberFlags.SubscribersRest;
+    return true;
+  }
+  nativePush.call(this._subscribersRest, subscriber);
+  return true;
+}
 
-  protected removeSubscriber(subscriber: IPropertySubscriber): boolean {
-    const subscriberFlags = this._subscriberFlags;
-    if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._subscriber0 === subscriber) {
-      this._subscriber0 = null;
-      this._subscriberFlags &= ~SubscriberFlags.Subscriber0;
-      return true;
-    }
-    if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._subscriber1 === subscriber) {
-      this._subscriber1 = null;
-      this._subscriberFlags &= ~SubscriberFlags.Subscriber1;
-      return true;
-    }
-    if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._subscriber2 === subscriber) {
-      this._subscriber2 = null;
-      this._subscriberFlags &= ~SubscriberFlags.Subscriber2;
-      return true;
-    }
-    if (subscriberFlags & SubscriberFlags.SubscribersRest) {
-      const subscribers = this._subscribersRest;
-      for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-        if (subscribers[i] === subscriber) {
-          nativeSplice.call(subscribers, i, 1);
-          if (ii === 1) {
-            this._subscriberFlags &= ~SubscriberFlags.SubscribersRest;
-          }
-          return true;
+function removeSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>, subscriber: IPropertySubscriber): boolean {
+  const subscriberFlags = this._subscriberFlags;
+  if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._subscriber0 === subscriber) {
+    this._subscriber0 = null;
+    this._subscriberFlags &= ~SubscriberFlags.Subscriber0;
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._subscriber1 === subscriber) {
+    this._subscriber1 = null;
+    this._subscriberFlags &= ~SubscriberFlags.Subscriber1;
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._subscriber2 === subscriber) {
+    this._subscriber2 = null;
+    this._subscriberFlags &= ~SubscriberFlags.Subscriber2;
+    return true;
+  }
+  if (subscriberFlags & SubscriberFlags.SubscribersRest) {
+    const subscribers = this._subscribersRest;
+    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
+      if (subscribers[i] === subscriber) {
+        nativeSplice.call(subscribers, i, 1);
+        if (ii === 1) {
+          this._subscriberFlags &= ~SubscriberFlags.SubscribersRest;
         }
+        return true;
       }
     }
+  }
+  return false;
+}
+
+function callPropertySubscribers(this: ISubscriberCollection<MutationKind.instance>, newValue: any, previousValue: any, flags: BindingFlags): void {
+  /**
+   * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
+   * callSubscribers invocation, so we're caching them all before invoking any.
+   * Subscribers added during this invocation are not invoked (and they shouldn't be).
+   * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
+   * however this is accounted for via $isBound and similar flags on the subscriber objects)
+   */
+  const subscriber0 = this._subscriber0;
+  const subscriber1 = this._subscriber1;
+  const subscriber2 = this._subscriber2;
+  let subscribers = this._subscribersRest;
+  if (subscribers !== null) {
+    subscribers = subscribers.slice();
+  }
+  if (subscriber0 !== null) {
+    subscriber0.handleChange(newValue, previousValue, flags);
+  }
+  if (subscriber1 !== null) {
+    subscriber1.handleChange(newValue, previousValue, flags);
+  }
+  if (subscriber2 !== null) {
+    subscriber2.handleChange(newValue, previousValue, flags);
+  }
+  const length = subscribers && subscribers.length || 0;
+  if (length > 0) {
+    for (let i = 0; i < length; ++i) {
+      const subscriber = subscribers[i];
+      if (subscriber !== null) {
+        subscriber.handleChange(newValue, previousValue, flags);
+      }
+    }
+  }
+}
+
+function callCollectionSubscribers(this: ISubscriberCollection<MutationKind.collection> & Required<IBatchedSubscriberCollection<MutationKind.collection>>, origin: string, args: IArguments | null, flags: BindingFlags): void {
+  const subscriber0 = this._subscriber0;
+  const subscriber1 = this._subscriber1;
+  const subscriber2 = this._subscriber2;
+  let subscribers = this._subscribersRest;
+  if (subscribers !== null) {
+    subscribers = subscribers.slice();
+  }
+  if (subscriber0 !== null) {
+    subscriber0.handleChange(origin, args, flags);
+  }
+  if (subscriber1 !== null) {
+    subscriber1.handleChange(origin, args, flags);
+  }
+  if (subscriber2 !== null) {
+    subscriber2.handleChange(origin, args, flags);
+  }
+  const length = subscribers && subscribers.length || 0;
+  if (length > 0) {
+    for (let i = 0; i < length; ++i) {
+      const subscriber = subscribers[i];
+      if (subscriber !== null) {
+        subscriber.handleChange(origin, args, flags);
+      }
+    }
+  }
+  this.changeSet.add(this);
+}
+
+function hasSubscribers<T extends MutationKind>(this: ISubscriberCollection<T>, ): boolean {
+  return this._subscriberFlags !== SubscriberFlags.None;
+}
+
+function hasSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>, subscriber: IPropertySubscriber): boolean {
+  // Flags here is just a perf tweak
+  // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
+  // and minor slow-down when it does, and the former is more common than the latter.
+  const subscriberFlags = this._subscriberFlags;
+  if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._subscriber0 === subscriber) {
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._subscriber1 === subscriber) {
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._subscriber2 === subscriber) {
+    return true;
+  }
+  if (subscriberFlags & SubscriberFlags.SubscribersRest) {
+    // no need to check length; if the flag is set, there's always at least one
+    const subscribers = this._subscribersRest;
+    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
+      if (subscribers[i] === subscriber) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function batchedSubscriberCollection(): ClassDecorator {
+  return function(target: Function): void {
+    const proto = <IBatchedSubscriberCollection<MutationKind.collection>>target.prototype;
+
+    proto._batchedSubscriberFlags = SubscriberFlags.None;
+    proto._batchedSubscriber0 = null;
+    proto._batchedSubscriber1 = null;
+    proto._batchedSubscriber2 = null;
+    proto._batchedSubscribersRest = null;
+
+    proto.addBatchedSubscriber = addBatchedSubscriber;
+    proto.removeBatchedSubscriber = removeBatchedSubscriber;
+    proto.hasBatchedSubscriber = hasBatchedSubscriber;
+    proto.hasBatchedSubscribers = hasBatchedSubscribers;
+    proto.callBatchedSubscribers = callBatchedCollectionSubscribers;
+  };
+}
+
+function addBatchedSubscriber(this: IBatchedSubscriberCollection<MutationKind.collection>, subscriber: MutationKindToBatchedSubscriber<MutationKind.collection>): boolean {
+  if (this.hasBatchedSubscriber(subscriber)) {
     return false;
   }
+  const subscriberFlags = this._batchedSubscriberFlags;
+  if (!(subscriberFlags & SubscriberFlags.Subscriber0)) {
+    this._batchedSubscriber0 = subscriber;
+    this._batchedSubscriberFlags |= SubscriberFlags.Subscriber0;
+    return true;
+  }
+  if (!(subscriberFlags & SubscriberFlags.Subscriber1)) {
+    this._batchedSubscriber1 = subscriber;
+    this._batchedSubscriberFlags |= SubscriberFlags.Subscriber1;
+    return true;
+  }
+  if (!(subscriberFlags & SubscriberFlags.Subscriber2)) {
+    this._batchedSubscriber2 = subscriber;
+    this._batchedSubscriberFlags |= SubscriberFlags.Subscriber2;
+    return true;
+  }
+  if (!(subscriberFlags & SubscriberFlags.SubscribersRest)) {
+    this._batchedSubscribersRest = [subscriber];
+    this._batchedSubscriberFlags |= SubscriberFlags.SubscribersRest;
+    return true;
+  }
+  nativePush.call(this._batchedSubscribersRest, subscriber);
+  return true;
+}
 
-  protected callSubscribers(newValue: any, previousValue: any, flags: BindingFlags): void {
-    /**
-     * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
-     * callSubscribers invocation, so we're caching them all before invoking any.
-     * Subscribers added during this invocation are not invoked (and they shouldn't be).
-     * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
-     * however this is accounted for via $isBound and similar flags on the subscriber objects)
-     */
-    const subscriber0 = this._subscriber0;
-    const subscriber1 = this._subscriber1;
-    const subscriber2 = this._subscriber2;
-    let subscribers = this._subscribersRest;
-    if (subscribers !== null) {
-      subscribers = subscribers.slice();
-    }
-    if (subscriber0 !== null) {
-      subscriber0.handleChange(newValue, previousValue, flags);
-    }
-    if (subscriber1 !== null) {
-      subscriber1.handleChange(newValue, previousValue, flags);
-    }
-    if (subscriber2 !== null) {
-      subscriber2.handleChange(newValue, previousValue, flags);
-    }
-    const length = subscribers && subscribers.length || 0;
-    if (length > 0) {
-      for (let i = 0; i < length; ++i) {
-        const subscriber = subscribers[i];
-        if (subscriber !== null) {
-          subscriber.handleChange(newValue, previousValue, flags);
+function removeBatchedSubscriber(this: IBatchedSubscriberCollection<MutationKind.collection>, subscriber: IBatchedCollectionSubscriber): boolean {
+  const subscriberFlags = this._batchedSubscriberFlags;
+  if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._batchedSubscriber0 === subscriber) {
+    this._batchedSubscriber0 = null;
+    this._batchedSubscriberFlags &= ~SubscriberFlags.Subscriber0;
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._batchedSubscriber1 === subscriber) {
+    this._batchedSubscriber1 = null;
+    this._batchedSubscriberFlags &= ~SubscriberFlags.Subscriber1;
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._batchedSubscriber2 === subscriber) {
+    this._batchedSubscriber2 = null;
+    this._batchedSubscriberFlags &= ~SubscriberFlags.Subscriber2;
+    return true;
+  }
+  if (subscriberFlags & SubscriberFlags.SubscribersRest) {
+    const subscribers = this._batchedSubscribersRest;
+    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
+      if (subscribers[i] === subscriber) {
+        nativeSplice.call(subscribers, i, 1);
+        if (ii === 1) {
+          this._batchedSubscriberFlags &= ~SubscriberFlags.SubscribersRest;
         }
+        return true;
       }
     }
   }
+  return false;
+}
 
-  protected hasSubscribers(): boolean {
-    return this._subscriberFlags !== SubscriberFlags.None;
+function callBatchedCollectionSubscribers(this: IBatchedSubscriberCollection<MutationKind.collection>, indexMap: IndexMap): void {
+  const subscriber0 = this._batchedSubscriber0;
+  const subscriber1 = this._batchedSubscriber1;
+  const subscriber2 = this._batchedSubscriber2;
+  let subscribers = this._batchedSubscribersRest;
+  if (subscribers !== null) {
+    subscribers = subscribers.slice();
   }
-
-  protected hasSubscriber(subscriber: IPropertySubscriber): boolean {
-    // Flags here is just a perf tweak
-    // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
-    // and minor slow-down when it does, and the former is more common than the latter.
-    const subscriberFlags = this._subscriberFlags;
-    if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._subscriber0 === subscriber) {
-      return true;
-    }
-    if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._subscriber1 === subscriber) {
-      return true;
-    }
-    if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._subscriber2 === subscriber) {
-      return true;
-    }
-    if (subscriberFlags & SubscriberFlags.SubscribersRest) {
-      // no need to check length; if the flag is set, there's always at least one
-      const subscribers = this._subscribersRest;
-      for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-        if (subscribers[i] === subscriber) {
-          return true;
-        }
+  if (subscriber0 !== null) {
+    subscriber0.handleBatchedChange(indexMap);
+  }
+  if (subscriber1 !== null) {
+    subscriber1.handleBatchedChange(indexMap);
+  }
+  if (subscriber2 !== null) {
+    subscriber2.handleBatchedChange(indexMap);
+  }
+  const length = subscribers && subscribers.length || 0;
+  if (length > 0) {
+    for (let i = 0; i < length; ++i) {
+      const subscriber = subscribers[i];
+      if (subscriber !== null) {
+        subscriber.handleBatchedChange(indexMap);
       }
     }
-    return false;
   }
+}
+
+function hasBatchedSubscribers(this: IBatchedSubscriberCollection<MutationKind.collection>): boolean {
+  return this._batchedSubscriberFlags !== SubscriberFlags.None;
+}
+
+function hasBatchedSubscriber(this: IBatchedSubscriberCollection<MutationKind.collection>, subscriber: IBatchedCollectionSubscriber): boolean {
+  // Flags here is just a perf tweak
+  // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
+  // and minor slow-down when it does, and the former is more common than the latter.
+  const subscriberFlags = this._batchedSubscriberFlags;
+  if ((subscriberFlags & SubscriberFlags.Subscriber0) && this._batchedSubscriber0 === subscriber) {
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber1) && this._batchedSubscriber1 === subscriber) {
+    return true;
+  }
+  if ((subscriberFlags & SubscriberFlags.Subscriber2) && this._batchedSubscriber2 === subscriber) {
+    return true;
+  }
+  if (subscriberFlags & SubscriberFlags.SubscribersRest) {
+    // no need to check length; if the flag is set, there's always at least one
+    const subscribers = this._batchedSubscribersRest;
+    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
+      if (subscribers[i] === subscriber) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/runtime/src/binding/target-accessors.ts
+++ b/packages/runtime/src/binding/target-accessors.ts
@@ -7,15 +7,14 @@ import { targetObserver } from './target-observer';
 // tslint:disable-next-line:no-http-string
 const xlinkAttributeNS = 'http://www.w3.org/1999/xlink';
 
+// tslint:disable-next-line:interface-name
+export interface XLinkAttributeAccessor extends IBindingTargetAccessor<Element, string, string> {}
+
 @targetObserver('')
-export class XLinkAttributeAccessor implements IBindingTargetAccessor<Element, string, string> {
+export class XLinkAttributeAccessor implements XLinkAttributeAccessor {
   public currentValue: string;
   public oldValue: string;
   public defaultValue: string;
-
-  public setValue: (newValue: string) => Promise<void>;
-  public flushChanges: () => void;
-  public dispose: () => void;
 
   // xlink namespaced attributes require getAttributeNS/setAttributeNS
   // (even though the NS version doesn't work for other namespaces
@@ -44,15 +43,14 @@ export class XLinkAttributeAccessor implements IBindingTargetAccessor<Element, s
 
 XLinkAttributeAccessor.prototype.attributeName = '';
 
+// tslint:disable-next-line:interface-name
+export interface DataAttributeAccessor extends IBindingTargetAccessor<INode, string, string> {}
+
 @targetObserver()
-export class DataAttributeAccessor implements IBindingTargetAccessor<INode, string, string> {
+export class DataAttributeAccessor implements DataAttributeAccessor {
   public currentValue: string;
   public oldValue: string;
   public defaultValue: string;
-
-  public setValue: (newValue: string) => Promise<void>;
-  public flushChanges: () => void;
-  public dispose: () => void;
 
   constructor(
     public changeSet: IChangeSet,
@@ -75,17 +73,16 @@ export class DataAttributeAccessor implements IBindingTargetAccessor<INode, stri
   }
 }
 
+// tslint:disable-next-line:interface-name
+export interface StyleAttributeAccessor extends IBindingTargetAccessor<HTMLElement, 'style', string | IIndexable> {}
+
 @targetObserver()
-export class StyleAttributeAccessor implements IBindingTargetAccessor<HTMLElement, 'style', string | IIndexable> {
+export class StyleAttributeAccessor implements StyleAttributeAccessor {
   public currentValue: string | IIndexable;
   public oldValue: string | IIndexable;
   public defaultValue: string | IIndexable;
 
   public propertyKey: 'style';
-
-  public setValue: (newValue: string | IIndexable) => Promise<void>;
-  public flushChanges: () => void;
-  public dispose: () => void;
 
   public styles: IIndexable;
   public version: number;
@@ -162,15 +159,14 @@ StyleAttributeAccessor.prototype.styles = null;
 StyleAttributeAccessor.prototype.version = 0;
 StyleAttributeAccessor.prototype.propertyKey = 'style';
 
+// tslint:disable-next-line:interface-name
+export interface ClassAttributeAccessor extends IBindingTargetAccessor<INode, string, string> {}
+
 @targetObserver('')
-export class ClassAttributeAccessor implements IBindingTargetAccessor<INode, string, string> {
+export class ClassAttributeAccessor implements ClassAttributeAccessor {
   public currentValue: string;
   public oldValue: string;
   public defaultValue: string;
-
-  public setValue: (newValue: string) => Promise<void>;
-  public flushChanges: () => void;
-  public dispose: () => void;
 
   public doNotCache: true;
   public version: number;
@@ -233,15 +229,14 @@ ClassAttributeAccessor.prototype.doNotCache = true;
 ClassAttributeAccessor.prototype.version = 0;
 ClassAttributeAccessor.prototype.nameIndex = null;
 
+// tslint:disable-next-line:interface-name
+export interface PropertyAccessor extends IBindingTargetAccessor<IIndexable, string, Primitive | IIndexable> {}
+
 @targetObserver()
-export class PropertyAccessor implements IBindingTargetAccessor<IIndexable, string, Primitive | IIndexable> {
+export class PropertyAccessor implements PropertyAccessor {
   public currentValue: string;
   public oldValue: string;
   public defaultValue: string;
-
-  public setValue: (newValue: string) => Promise<void>;
-  public flushChanges: () => void;
-  public dispose: () => void;
 
   constructor(
     public changeSet: IChangeSet,

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -1,7 +1,8 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
 import { BindingFlags } from './binding-flags';
 import { IChangeSet } from './change-set';
-import { IBindingTargetAccessor } from './observation';
+import { IBindingTargetAccessor, MutationKind } from './observation';
+import { subscriberCollection } from './subscriber-collection';
 
 type BindingTargetAccessor = IBindingTargetAccessor & {
   changeSet: IChangeSet;
@@ -52,6 +53,7 @@ function dispose(this: BindingTargetAccessor): void {
 
 export function targetObserver(defaultValue: Primitive | IIndexable = null): ClassDecorator {
   return function(target: Function): void {
+    subscriberCollection(MutationKind.instance)(target);
     const proto = <BindingTargetAccessor>target.prototype;
 
     proto.currentValue = defaultValue;

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -6,7 +6,9 @@ import { IBindingTargetAccessor } from './observation';
 type BindingTargetAccessor = IBindingTargetAccessor & {
   changeSet: IChangeSet;
   currentFlags: BindingFlags;
+  oldValue?: any;
   defaultValue: Primitive | IIndexable;
+  flushChanges(): void;
   setValueCore(value: Primitive | IIndexable, flags: BindingFlags): void;
 };
 

--- a/packages/runtime/src/templating/runtime-behavior.ts
+++ b/packages/runtime/src/templating/runtime-behavior.ts
@@ -84,7 +84,6 @@ export class RuntimeBehavior implements IRuntimeBehavior {
       const name = observableNames[i];
 
       observers[name] = new Observer(
-        changeSet,
         instance,
         name,
         bindables[name].callback

--- a/packages/runtime/test/unit/binding/array-observer.spec.ts
+++ b/packages/runtime/test/unit/binding/array-observer.spec.ts
@@ -110,7 +110,7 @@ describe(`ArrayObserver`, () => {
     });
   });
 
-  describe('should not notify batched subscribers if there are no changes', () => {
+  xdescribe('should not notify batched subscribers if there are no changes', () => {
     it('push', () => {
       const s = new SpySubscriber();
       const arr = [];

--- a/packages/runtime/test/unit/binding/map-observer.spec.ts
+++ b/packages/runtime/test/unit/binding/map-observer.spec.ts
@@ -91,7 +91,7 @@ describe(`MapObserver`, () => {
     });
   });
 
-  describe('should not notify batched subscribers if there are no changes', () => {
+  xdescribe('should not notify batched subscribers if there are no changes', () => {
     it('set', () => {
       const s = new SpySubscriber();
       const map = new Map();

--- a/packages/runtime/test/unit/binding/property-observation.spec.ts
+++ b/packages/runtime/test/unit/binding/property-observation.spec.ts
@@ -73,7 +73,7 @@ describe('SetterObserver', () => {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, () => {
-          sut = new SetterObserver(new ChangeSet(), object, <any>propertyName);
+          sut = new SetterObserver(object, <any>propertyName);
           sut.subscribe(new SpySubscriber());
           const actual = sut.getValue();
           // note: we're deliberately using explicit strict equality here (and in various other places) instead of expect(actual).to.equal(expected)
@@ -94,7 +94,7 @@ describe('SetterObserver', () => {
       for (const propertyName of propertyNameArr) {
         for (const value of valueArr) {
           it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, () => {
-            sut = new SetterObserver(new ChangeSet(), object, <any>propertyName);
+            sut = new SetterObserver(object, <any>propertyName);
             sut.subscribe(new SpySubscriber());
             sut.setValue(value, flags);
             expect(object[propertyName] === value).to.be.true;
@@ -111,7 +111,7 @@ describe('SetterObserver', () => {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         it(`can handle ${getName(object)}[${typeof propertyName}]`, () => {
-          sut = new SetterObserver(new ChangeSet(), object, <any>propertyName);
+          sut = new SetterObserver(object, <any>propertyName);
           sut.subscribe(new SpySubscriber());
         });
       }
@@ -130,7 +130,7 @@ describe('SetterObserver', () => {
           for (const subscribers of subscribersArr) {
             const object = {};
             it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, () => {
-              sut = new SetterObserver(new ChangeSet(), object, <any>propertyName);
+              sut = new SetterObserver(object, <any>propertyName);
               for (const subscriber of subscribers) {
                 sut.subscribe(subscriber);
               }

--- a/packages/runtime/test/unit/binding/set-observer.spec.ts
+++ b/packages/runtime/test/unit/binding/set-observer.spec.ts
@@ -91,7 +91,7 @@ describe(`SetObserver`, () => {
     });
   });
 
-  describe('should not notify batched subscribers if there are no changes', () => {
+  xdescribe('should not notify batched subscribers if there are no changes', () => {
     it('add', () => {
       const s = new SpySubscriber();
       const set = new Set();

--- a/packages/runtime/test/unit/binding/subscriber-collection.spec.ts
+++ b/packages/runtime/test/unit/binding/subscriber-collection.spec.ts
@@ -1,8 +1,9 @@
-import { SubscriberCollection, BindingFlags } from '../../../src/index';
+import { BindingFlags, subscriberCollection, MutationKind } from '../../../src/index';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
-class Test extends SubscriberCollection {}
+@subscriberCollection(MutationKind.instance)
+class Test {}
 
 describe('subscriberCollection', () => {
   it('calls subscribers', () => {


### PR DESCRIPTION
fix(e2e-benchmark): simplify markers and use setTimeout to include render time
perf(binding): remove unnecessary work / cleanup
refactor(binding): convert subscriber-collection to decorator for sync and async

I'm a little hesitant on whether I prefer the approach I took on property observer vs the approach on collection observers.
- On the property observers there is a partial interface implementations with as few properties and methods declared as possible. This gives a much cleaner view of the implementation, but lacks a degree of transparency perhaps. It also means observers need to be cast explicitly.
- On the collection observers the full interfaces are implemented. This means everything that decorators would set on the prototype is explicitly declared. I think it's ugly and messy, but it may also be more practical

Thoughts? @bigopon  @EisenbergEffect 