### PR TITLE
refactor(view): increase cohesion of view code

### DIFF
--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -1,8 +1,14 @@
-import { DI } from '@aurelia/kernel';
+import { Constructable, DI, Reporter } from '@aurelia/kernel';
+import { IScope } from '../binding/binding-context';
+import { BindingFlags } from '../binding/binding-flags';
 import { IBindScope } from '../binding/observation';
+import { DOM, INode, INodeSequence } from '../dom';
+import { IAnimator } from './animator';
 import { ICustomElement } from './custom-element';
-import { IAttach } from './lifecycle';
+import { AttachLifecycle, DetachLifecycle, IAttach } from './lifecycle';
+import { IRenderContext } from './render-context';
 import { IRenderable } from './renderable';
+import { ITemplate } from './template';
 import { IViewSlot } from './view-slot';
 
 export type RenderCallback = (view: IView) => void;
@@ -33,3 +39,193 @@ export interface IViewFactory {
 }
 
 export const IViewFactory = DI.createInterface<IViewFactory>().noDefault();
+
+/*@internal*/
+export class View implements IView {
+  public $bindables: IBindScope[] = [];
+  public $attachables: IAttach[] = [];
+  public $scope: IScope = null;
+  public $nodes: INodeSequence = null;
+  public $isBound: boolean = false;
+  public $isAttached: boolean = false;
+  public $context: IRenderContext;
+  public parent: IViewSlot;
+  public onRender: RenderCallback;
+  public renderState: any;
+  public inCache: boolean = false;
+
+  private animationRoot: INode;
+
+  constructor(public factory: ViewFactory, private template: ITemplate, private animator: IAnimator) {
+    this.$nodes = this.createNodes();
+  }
+
+  public createNodes(): INodeSequence {
+    return this.template.createFor(this);
+  }
+
+  public animate(direction: MotionDirection = MotionDirection.enter): void | Promise<boolean> {
+    const element = this.getAnimationRoot();
+
+    if (element === null) {
+      return;
+    }
+
+    switch (direction) {
+      case MotionDirection.enter:
+        return this.animator.enter(element);
+      case MotionDirection.leave:
+        return this.animator.leave(element);
+      default:
+        throw Reporter.error(4, direction);
+    }
+  }
+
+  public $bind(flags: BindingFlags, scope: IScope): void {
+    if (this.$isBound) {
+      if (this.$scope === scope) {
+        return;
+      }
+
+      this.$unbind(flags);
+    }
+
+    this.$scope = scope;
+    const bindables = this.$bindables;
+
+    for (let i = 0, ii = bindables.length; i < ii; ++i) {
+      bindables[i].$bind(flags, scope);
+    }
+
+    this.$isBound = true;
+  }
+
+  public $attach(encapsulationSource: INode, lifecycle?: AttachLifecycle): void {
+    if (this.$isAttached) {
+      return;
+    }
+
+    lifecycle = AttachLifecycle.start(this, lifecycle);
+
+    const attachables = this.$attachables;
+
+    for (let i = 0, ii = attachables.length; i < ii; ++i) {
+      attachables[i].$attach(encapsulationSource, lifecycle);
+    }
+
+    this.onRender(this);
+    this.$isAttached = true;
+    lifecycle.end(this);
+  }
+
+  public $detach(lifecycle?: DetachLifecycle): void {
+    if (this.$isAttached) {
+      lifecycle = DetachLifecycle.start(this, lifecycle);
+      lifecycle.queueViewRemoval(this);
+
+      const attachables = this.$attachables;
+      let i = attachables.length;
+
+      while (i--) {
+        attachables[i].$detach(lifecycle);
+      }
+
+      this.$isAttached = false;
+      lifecycle.end(this);
+    }
+  }
+
+  public $unbind(flags: BindingFlags): void {
+    if (this.$isBound) {
+      const bindables = this.$bindables;
+      let i = bindables.length;
+
+      while (i--) {
+        bindables[i].$unbind(flags);
+      }
+
+      this.$isBound = false;
+      this.$scope = null;
+    }
+  }
+
+  public tryReturnToCache(): boolean {
+    return this.factory.tryReturnToCache(this);
+  }
+
+  private getAnimationRoot(): INode {
+    if (this.animationRoot !== undefined) {
+      return this.animationRoot;
+    }
+
+    let currentChild = this.$nodes.firstChild;
+    const lastChild = this.$nodes.lastChild;
+    const isElementNodeType = DOM.isElementNodeType;
+
+    while (currentChild !== lastChild && !isElementNodeType(currentChild)) {
+      currentChild = currentChild.nextSibling;
+    }
+
+    if (currentChild && isElementNodeType(currentChild)) {
+      return this.animationRoot = DOM.hasClass(currentChild, 'au-animate')
+        ? currentChild
+        : null;
+    }
+
+    return this.animationRoot = null;
+  }
+}
+
+/*@internal*/
+export class ViewFactory implements IViewFactory {
+  public isCaching: boolean = false;
+
+  private cacheSize: number = -1;
+  private cache: View[] = null;
+
+  constructor(public name: string, private template: ITemplate, private animator: IAnimator) {}
+
+  public setCacheSize(size: number | '*', doNotOverrideIfAlreadySet: boolean): void {
+    if (size) {
+      if (size === '*') {
+        size = Number.MAX_VALUE;
+      } else if (typeof size === 'string') {
+        size = parseInt(size, 10);
+      }
+
+      if (this.cacheSize === -1 || !doNotOverrideIfAlreadySet) {
+        this.cacheSize = size;
+      }
+    }
+
+    if (this.cacheSize > 0) {
+      this.cache = [];
+    } else {
+      this.cache = null;
+    }
+
+    this.isCaching = this.cacheSize > 0;
+  }
+
+  public tryReturnToCache(view: View): boolean {
+    if (this.cache !== null && this.cache.length < this.cacheSize) {
+      view.inCache = true;
+      this.cache.push(view);
+      return true;
+    }
+
+    return false;
+  }
+
+  public create(): IView {
+    const cache = this.cache;
+
+    if (cache !== null && cache.length > 0) {
+      const view = cache.pop();
+      view.inCache = false;
+      return view;
+    }
+
+    return new View(this, this.template, this.animator);
+  }
+}


### PR DESCRIPTION
## Description

This PR does two things:

1. Moves the View and ViewFactory code into the `view.ts` file with the related interfaces. There was a reason to have it where it was, once upon a time, I think. That reason has gone and it's better to keep things together.
2. Reworks View and ViewFactory so that a custom class doesn't need to be created for every View that a factory creates. This should be much more efficient.

## Next Steps

After the refactoring to remove the custom class generation for the primary scenarios, the component view scenario is left in an odd state. I intend to fix this up, but since it's strongly coupled to the `compose` element scenarios, I chose not to do it as part of this PR. I'd like to fix this up at the same time as the `compose` element fixups.