### PR TITLE
fix(template-compiler): template controller instrs order, linking

### DIFF
--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -509,18 +509,19 @@ describe('TemplateCompiler (integration)', () => {
     expect(host.textContent).to.equal('');
   });
 
-  // it(`if - shows and hides - toggles else`, () => {
-  //   component = createCustomElement(`<template><div if.bind="foo">bar</div><div else>baz</div></template>`);
-  //   component.foo = true;
-  //   au.app({ host, component: component }).start();
-  //   cs.flushChanges();
-  //   expect(host.innerText).to.equal('bar');
-  //   component.foo = false;
-  //   cs.flushChanges();
-  //   expect(host.innerText).to.equal('baz');
-  //   cs.flushChanges();
-  //   expect(host.innerText).to.equal('bar');
-  // });
+  it(`if - shows and hides - toggles else`, () => {
+    component = createCustomElement(`<template><div if.bind="foo">bar</div><div else>baz</div></template>`);
+    component.foo = true;
+    au.app({ host, component: component }).start();
+    cs.flushChanges();
+    expect(host.innerText).to.equal('bar');
+    component.foo = false;
+    cs.flushChanges();
+    expect(host.innerText).to.equal('baz');
+    component.foo = true;
+    cs.flushChanges();
+    expect(host.innerText).to.equal('bar');
+  });
 
   it(`custom elements`, () => {
     component = createCustomElement(


### PR DESCRIPTION
Besides some tests, I tried to add if / else linking. But it seems rather difficult to get access to resource constructor during compilation, which makes it hard to determine if a template controller requires linking. Test for if / else
https://github.com/aurelia/aurelia/blob/6bfc9e1914ec4314bb5c3b5256a2034817198d32/packages/jit/test/unit/templating/template-compiler.integration.spec.ts#L512-L524

@EisenbergEffect @fkleuver 