### PR TITLE
feat(Let): let binding

### DIFF
--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -538,7 +538,9 @@ describe('TemplateCompiler (integration)', () => {
     );
     au.app({ host, component: component }).start();
     component.firstName = 'bi';
+    expect(component.fullName).to.equal('bi undefined');
     component.lastName = 'go';
+    expect(component.fullName).to.equal('bi go');
     cs.flushChanges();
     expect(host.textContent).to.equal('bi go');
   });

--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -518,4 +518,28 @@ describe('TemplateCompiler (integration)', () => {
     cs.flushChanges();
     expect(host.textContent).to.equal('bigopon');
   });
+
+  it('<let/>', () => {
+    component = createCustomElement(
+      '<template><let full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>',
+    );
+    au.app({ host, component: component }).start();
+    expect(host.textContent).to.equal(' ');
+    component.firstName = 'bi';
+    component.lastName = 'go';
+    expect(host.textContent).to.equal(' ');
+    cs.flushChanges();
+    expect(host.textContent).to.equal('bi go');
+  });
+
+  it('<let [to-view-model] />', () => {
+    component = createCustomElement(
+      '<template><let to-view-model full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>',
+    );
+    au.app({ host, component: component }).start();
+    component.firstName = 'bi';
+    component.lastName = 'go';
+    cs.flushChanges();
+    expect(host.textContent).to.equal('bi go');
+  });
 });

--- a/packages/jit/test/unit/templating/template-compiler.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.spec.ts
@@ -13,7 +13,8 @@ import {
   bindable,
   customAttribute,
   ViewCompileFlags,
-  ILetElementInstruction
+  ILetElementInstruction,
+  ITemplateSource
 } from '../../../../runtime/src/index';
 import {
   TemplateCompiler,
@@ -92,12 +93,18 @@ describe('TemplateCompiler', () => {
       const expressionParser = container.get(IExpressionParser);
       const sut = new TemplateCompiler(expressionParser as any);
       const resources = new RuntimeCompilationResources(<any>container);
-      const instructions = [];
-      return { sut, resources, instructions };
+      const definition: any = {
+        hasSlots: false,
+        bindables: {},
+        instructions: [],
+        surrogates: []
+      } as Required<ITemplateSource>;
+      const instructions = definition.instructions;
+      return { sut, resources, definition, instructions };
     }
 
     it(`handles Element with Element nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -107,14 +114,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Element with Text nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -124,14 +131,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Element with Comment nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -141,14 +148,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles TextNode without interpolation`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileTextNode = spy(() => false)
 
@@ -163,13 +170,13 @@ describe('TemplateCompiler', () => {
       const nextSibling = document.createElement('div');
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(firstChild, parent, instructions, resources);
+      const actual = sut.compileNode(firstChild, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles TextNode with interpolation`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileTextNode = spy(() => true)
 
@@ -184,13 +191,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(document.createTextNode(' '));
       parent.appendChild(document.createElement('div'));
 
-      const actual = sut.compileNode(firstChild, parent, instructions, resources);
+      const actual = sut.compileNode(firstChild, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Element nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -198,13 +205,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Text nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -212,13 +219,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Comment nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -226,23 +233,23 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Document`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
-      const actual = sut.compileNode(document, null, instructions, resources);
+      const actual = sut.compileNode(document, null, definition, instructions, resources);
 
       expect(actual).to.equal(document.firstChild);
     });
 
     it(`handles DocumentType`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
-      const actual = <Element>sut.compileNode(document.firstChild, null, instructions, resources);
+      const actual = <Element>sut.compileNode(document.firstChild, null, definition, instructions, resources);
 
       expect(actual).to.equal(document.firstChild.nextSibling);
     });
@@ -255,12 +262,18 @@ describe('TemplateCompiler', () => {
       const expressionParser = container.get(IExpressionParser);
       const sut = new TemplateCompiler(expressionParser as any);
       const resources = new RuntimeCompilationResources(<any>container);
-      const instructions = [];
-      return { sut, resources, instructions };
+      const definition: any = {
+        hasSlots: false,
+        bindables: {},
+        instructions: [],
+        surrogates: []
+      } as Required<ITemplateSource>;
+      const instructions = definition.instructions;
+      return { sut, resources, definition, instructions };
     }
 
     it(`handles Element with Element nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -270,14 +283,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Element with Text nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -287,14 +300,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Element with Comment nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileElementNode = spy();
 
@@ -304,14 +317,14 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
-      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, instructions, resources);
+      expect(sut.compileElementNode).to.have.been.calledWith(node, parent, definition, instructions, resources);
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles TextNode without interpolation`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileTextNode = spy(() => false)
 
@@ -326,13 +339,13 @@ describe('TemplateCompiler', () => {
       const nextSibling = document.createElement('div');
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(firstChild, parent, instructions, resources);
+      const actual = sut.compileNode(firstChild, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles TextNode with interpolation`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       sut.compileTextNode = spy(() => true)
 
@@ -347,13 +360,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(document.createTextNode(' '));
       parent.appendChild(document.createElement('div'));
 
-      const actual = sut.compileNode(firstChild, parent, instructions, resources);
+      const actual = sut.compileNode(firstChild, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Element nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -361,13 +374,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Text nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -375,13 +388,13 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Comment with Comment nextSibling`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
       const parent = document.createElement('div');
       const node = document.createComment('foo');
@@ -389,23 +402,23 @@ describe('TemplateCompiler', () => {
       parent.appendChild(node);
       parent.appendChild(nextSibling);
 
-      const actual = sut.compileNode(node, parent, instructions, resources);
+      const actual = sut.compileNode(node, parent, definition, instructions, resources);
 
       expect(actual).to.equal(nextSibling);
     });
 
     it(`handles Document`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
-      const actual = sut.compileNode(document, null, instructions, resources);
+      const actual = sut.compileNode(document, null, definition, instructions, resources);
 
       expect(actual).to.equal(document.firstChild);
     });
 
     it(`handles DocumentType`, () => {
-      const { sut, resources, instructions } = setup();
+      const { sut, resources, definition, instructions } = setup();
 
-      const actual = <Element>sut.compileNode(document.firstChild, null, instructions, resources);
+      const actual = <Element>sut.compileNode(document.firstChild, null, definition, instructions, resources);
 
       expect(actual).to.equal(document.firstChild.nextSibling);
     });
@@ -690,11 +703,11 @@ describe('TemplateCompiler', () => {
 
   describe('compileElement()', () => {
 
-    it('throws on <slot/>', () => {
-      const markup = '<template><slot></slot></template>';
-      expect(() => {
-        sut.compile(<any>{ templateOrNode: markup, instructions: [] }, resources);
-      }).to.throw(/not implemented/i);
+    it('set hasSlots to true <slot/>', () => {
+      const definition = compileWith('<template><slot></slot></template>', []);
+      expect(definition.hasSlots).to.be.true;
+
+      // test this with nested slot inside template controller
     });
 
     describe('with custom element', () => {

--- a/packages/jit/test/unit/templating/template-compiler.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.spec.ts
@@ -959,7 +959,6 @@ describe('TemplateCompiler', () => {
               `Expected actual instruction to have "${prop}": ${expectedInst[prop]}. Received: ${actualInst[prop]} (on index: ${i})`
             );
           } else {
-            debugger;
             expect(
               actualInst[prop]).to.equal(expectedInst[prop],
               `Expected actual instruction to have "${prop}": ${expectedInst[prop]}. Received: ${actualInst[prop]} (on index: ${i})`

--- a/packages/jit/test/unit/templating/template-compiler.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.spec.ts
@@ -689,7 +689,7 @@ describe('TemplateCompiler', () => {
 
   describe('compileElement()', () => {
 
-    it('throws on <let/> + <slot/>', () => {
+    it('throws on <slot/>', () => {
       const markup = '<template><slot></slot></template>';
       expect(() => {
         sut.compile(<any>{ templateOrNode: markup, instructions: [] }, resources);
@@ -880,6 +880,60 @@ describe('TemplateCompiler', () => {
           ]);
         });
       });
+
+      describe('<let/> element', () => {
+
+        it('does not generate instruction when there is no bindings', () => {
+          const { instructions } = compileWith(`<template><let></let></template>`);
+          verifyInstructions(instructions as any, []);
+        });
+
+        it('ignores custom element resource', () => {
+          @customElement('let')
+          class Let {}
+
+          const { instructions } = compileWith(
+            `<template><let></let></template>`,
+            [Let]
+          );
+          expect(instructions[0]).to.be.undefined;
+        });
+
+        it('throws on any command except bind', () => {
+          const commands = ['to-view', 'one-time', 'two-way', 'from-view', 'call', 'trigger'];
+          commands.forEach(cmd => {
+            expect(() => compileWith(`<let attr.${cmd}="a"></let>`)).to.throw(/only bind command supported/i);
+          });
+        });
+
+        it('compiles', () => {
+          const { instructions } = compileWith(`<let a.bind="b" c="\${d}"></let>`);
+          verifyInstructions(instructions[0] as any, [
+            { toVerify: ['type', 'dest', 'srcOrExp'],
+              type: TargetedInstructionType.letBinding, dest: 'a', srcOrExp: 'b' },
+            { toVerify: ['type', 'dest'],
+              type: TargetedInstructionType.letBinding, dest: 'c' }
+          ]);
+        });
+
+        describe('[to-view-model]', () => {
+          it('does not compile [to-view-model]', () => {
+            const { instructions } = compileWith(`<template><let to-view-model></let></template>`);
+            expect(instructions[0]).to.be.undefined;
+          });
+
+          it('ignores [to-view-model] order', () => {
+            let letInstructions = compileWith(`<template><let a.bind="a" to-view-model></let></template>`).instructions[0];
+            verifyInstructions(letInstructions as any, [
+              { toVerify: ['type', 'toViewModel'], type: TargetedInstructionType.letBinding, toViewModel: true }
+            ]);
+            letInstructions = compileWith(`<template><let to-view-model a.bind="a"></let></template>`).instructions[0];
+            verifyInstructions(letInstructions as any, [
+              { toVerify: ['type', 'toViewModel'], type: TargetedInstructionType.letBinding, toViewModel: true }
+            ]);
+          });
+        });
+      });
     });
 
     interface IExpectedInstruction {
@@ -887,7 +941,7 @@ describe('TemplateCompiler', () => {
       [prop: string]: any;
     }
 
-    function compileWith(markup: string, extraResources: any[], viewCompileFlags?: ViewCompileFlags) {
+    function compileWith(markup: string, extraResources: any[] = [], viewCompileFlags?: ViewCompileFlags) {
       extraResources.forEach(e => e.register(container));
       return sut.compile(<any>{ templateOrNode: markup, instructions: [], surrogates: [] }, resources, viewCompileFlags);
     }

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -35,16 +35,16 @@ export class Binding implements IBinding, IPropertySubscriber {
 
   public targetObserver: AccessorOrObserver;
   /*@internal*/public __connectQueueId: number;
-  private observerSlots: number;
-  private version: number;
-  private $scope: IScope;
+  protected observerSlots: number;
+  protected version: number;
+  protected $scope: IScope;
 
   constructor(
     public sourceExpression: IExpression,
     public target: IBindingTarget,
     public targetProperty: string,
     public mode: BindingMode,
-    private observerLocator: IObserverLocator,
+    protected observerLocator: IObserverLocator,
     public locator: IServiceLocator) {
   }
 

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,25 +1,13 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IExpression } from './ast';
 import { Binding } from './binding';
-import { BindingContext, IScope } from './binding-context';
+import { IScope } from './binding-context';
 import { BindingFlags } from './binding-flags';
 import { BindingMode } from './binding-mode';
 import { IObserverLocator } from './observer-locator';
 
-const slotNames: string[] = new Array(100);
-const versionSlotNames: string[] = new Array(100);
-
-for (let i = 0; i < 100; i++) {
-  slotNames[i] = `_observer${i}`;
-  versionSlotNames[i] = `_observerVersion${i}`;
-}
-
-
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
-const { oneTime, toView, fromView } = BindingMode;
-
-// pre-combining flags for bitwise checks is a minor perf tweak
-const toViewOrOneTime = toView | oneTime;
+const { toView } = BindingMode;
 
 // tslint:disable:no-any
 export class LetBinding extends Binding {

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,0 +1,132 @@
+import { IServiceLocator, Reporter } from '@aurelia/kernel';
+import { IExpression } from './ast';
+import { Binding } from './binding';
+import { BindingContext, IScope } from './binding-context';
+import { BindingFlags } from './binding-flags';
+import { BindingMode } from './binding-mode';
+import { IObserverLocator } from './observer-locator';
+
+const slotNames: string[] = new Array(100);
+const versionSlotNames: string[] = new Array(100);
+
+for (let i = 0; i < 100; i++) {
+  slotNames[i] = `_observer${i}`;
+  versionSlotNames[i] = `_observerVersion${i}`;
+}
+
+
+// BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
+const { oneTime, toView, fromView } = BindingMode;
+
+// pre-combining flags for bitwise checks is a minor perf tweak
+const toViewOrOneTime = toView | oneTime;
+
+// tslint:disable:no-any
+export class LetBinding extends Binding {
+
+  constructor(
+    sourceExpression: IExpression,
+    targetProperty: string,
+    observerLocator: IObserverLocator,
+    locator: IServiceLocator,
+    private toViewModel: boolean = false
+  ) {
+    super(
+      sourceExpression,
+      null,
+      targetProperty,
+      toView,
+      observerLocator,
+      locator
+    );
+  }
+
+  public updateTarget(value: any): void {
+    throw new Error('Updating target not allowed in LetBinding.');
+  }
+
+  public updateSource(value: any): void {
+    throw new Error('Updating source not allowed in LetBinding.');
+  }
+
+  public handleChange(newValue: any, previousValue: any, flags: BindingFlags): void {
+    if (!this.$isBound) {
+      return;
+    }
+
+    const sourceExpression = this.sourceExpression;
+    const $scope = this.$scope;
+    const locator = this.locator;
+    const target = this.target;
+    const targetProperty = this.targetProperty;
+
+    if (flags & BindingFlags.updateTargetInstance) {
+      const currValue = target[targetProperty];
+      const newValue = sourceExpression.evaluate(flags, $scope, locator);
+      if (newValue !== currValue) {
+        target[targetProperty] = newValue;
+      }
+      return;
+    }
+
+    throw Reporter.error(15, flags);
+  }
+
+  public $bind(flags: BindingFlags, scope: IScope): void {
+    if (this.$isBound) {
+      if (this.$scope === scope) {
+        return;
+      }
+      this.$unbind(flags);
+    }
+
+    this.$isBound = true;
+    this.$scope = scope;
+    this.target = this.toViewModel ? scope.bindingContext : scope.overrideContext;
+
+    const sourceExpression = this.sourceExpression;
+    if (sourceExpression.bind) {
+      sourceExpression.bind(flags, scope, this);
+    }
+    // sourceExpression might have been changed during bind
+    this.target[this.targetProperty] = this.sourceExpression.evaluate(BindingFlags.fromBind, scope, this.locator);
+
+    const mode = this.mode;
+    if ((mode & toView) !== toView) {
+      throw new Error('Let binding only supports [toView] binding mode.');
+    }
+    this.sourceExpression.connect(flags, scope, this);
+  }
+
+  public $unbind(flags: BindingFlags): void {
+    if (!this.$isBound) {
+      return;
+    }
+    this.$isBound = false;
+
+    const sourceExpression = this.sourceExpression;
+    if (sourceExpression.unbind) {
+      sourceExpression.unbind(flags, this.$scope, this);
+    }
+    this.$scope = null;
+    this.unobserve(true);
+  }
+
+  public connect(flags: BindingFlags): void {
+    if (!this.$isBound) {
+      return;
+    }
+
+    const sourceExpression = this.sourceExpression;
+    const $scope = this.$scope;
+
+    const value = sourceExpression.evaluate(flags, $scope, this.locator);
+    // Let binding should initialize on their own
+    // not waiting to be intied
+    this.target[this.targetProperty] = value;
+
+    sourceExpression.connect(flags, $scope, this);
+  }
+  //#endregion
+}
+// tslint:enable:no-any

--- a/packages/runtime/src/templating/instructions.ts
+++ b/packages/runtime/src/templating/instructions.ts
@@ -19,8 +19,9 @@ export const enum TargetedInstructionType {
   hydrateElement = 'i',
   hydrateAttribute = 'j',
   hydrateTemplateController = 'k',
-  letBinding = 'l',
-  renderStrategy = 'm',
+  letElement = 'l',
+  letBinding = 'm',
+  renderStrategy = 'n',
 }
 
 export interface IBuildInstruction {
@@ -64,7 +65,7 @@ export type TargetedInstruction =
   IHydrateAttributeInstruction |
   IHydrateTemplateController |
   IRenderStrategyInstruction |
-  ILetBindingInstruction;
+  ILetElementInstruction;
 
 export interface ITextBindingInstruction extends ITargetedInstruction {
   type: TargetedInstructionType.textBinding;
@@ -143,9 +144,14 @@ export interface IRenderStrategyInstruction extends ITargetedInstruction {
   name: string;
 }
 
+export interface ILetElementInstruction extends ITargetedInstruction {
+  type: TargetedInstructionType.letElement;
+  instructions: ILetBindingInstruction[];
+  toViewModel: boolean;
+}
+
 export interface ILetBindingInstruction extends ITargetedInstruction {
   type: TargetedInstructionType.letBinding;
   srcOrExpr: string | IExpression;
   dest: string;
-  toViewModel: boolean;
 }

--- a/packages/runtime/src/templating/instructions.ts
+++ b/packages/runtime/src/templating/instructions.ts
@@ -19,7 +19,8 @@ export const enum TargetedInstructionType {
   hydrateElement = 'i',
   hydrateAttribute = 'j',
   hydrateTemplateController = 'k',
-  renderStrategy = 'l'
+  letBinding = 'l',
+  renderStrategy = 'm',
 }
 
 export interface IBuildInstruction {
@@ -62,7 +63,8 @@ export type TargetedInstruction =
   IHydrateElementInstruction |
   IHydrateAttributeInstruction |
   IHydrateTemplateController |
-  IRenderStrategyInstruction;
+  IRenderStrategyInstruction |
+  ILetBindingInstruction;
 
 export interface ITextBindingInstruction extends ITargetedInstruction {
   type: TargetedInstructionType.textBinding;
@@ -139,4 +141,11 @@ export interface IHydrateTemplateController extends ITargetedInstruction {
 export interface IRenderStrategyInstruction extends ITargetedInstruction {
   type: TargetedInstructionType.renderStrategy;
   name: string;
+}
+
+export interface ILetBindingInstruction extends ITargetedInstruction {
+  type: TargetedInstructionType.letBinding;
+  srcOrExpr: string | IExpression;
+  dest: string;
+  toViewModel: boolean;
 }

--- a/packages/runtime/src/templating/renderer.ts
+++ b/packages/runtime/src/templating/renderer.ts
@@ -26,7 +26,8 @@ import {
   ILetBindingInstruction,
   TargetedInstructionType,
   TemplateDefinition,
-  TemplatePartDefinitions
+  TemplatePartDefinitions,
+  ILetElementInstruction
 } from './instructions';
 import { IRenderContext } from './render-context';
 import { IRenderStrategy, RenderStrategyResource } from './render-strategy';
@@ -202,15 +203,20 @@ export class Renderer implements IRenderer {
     this[strategyName](renderable, target, instruction);
   }
 
-  public [TargetedInstructionType.letBinding](renderable: IRenderable, target: any, instruction: Immutable<ILetBindingInstruction>) {
+  public [TargetedInstructionType.letElement](renderable: IRenderable, target: any, instruction: Immutable<ILetElementInstruction>): void {
     target.remove();
-    const srcOrExpr = instruction.srcOrExpr as any;
-    renderable.$bindables.push(new LetBinding(
-      srcOrExpr.$kind ? srcOrExpr : this.parser.parse(srcOrExpr, BindingType.IsPropertyCommand),
-      instruction.dest,
-      this.observerLocator,
-      this.context,
-      instruction.toViewModel
-    ));
+    const childInstructions = instruction.instructions;
+    const toViewModel = instruction.toViewModel;
+    for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
+      const childInstruction = childInstructions[i];
+      const srcOrExpr: any = childInstruction.srcOrExpr;
+      renderable.$bindables.push(new LetBinding(
+        srcOrExpr.$kind ? srcOrExpr : this.parser.parse(srcOrExpr, BindingType.IsPropertyCommand),
+        childInstruction.dest,
+        this.observerLocator,
+        this.context,
+        toViewModel
+      ));
+    }
   }
 }

--- a/packages/runtime/test/unit/binding/let-binding.spec.ts
+++ b/packages/runtime/test/unit/binding/let-binding.spec.ts
@@ -1,0 +1,169 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import { DI, IContainer } from '../../../../kernel/src/index';
+import { LetBinding } from '../../../src/binding/let-binding';
+import { BindingContext, BindingFlags, BindingMode, ExpressionKind, IBindingTarget, IExpression, IObserverLocator, IScope } from '../../../src/index';
+
+const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
+
+describe('LetBinding', () => {
+  let container: IContainer;
+  let observerLocator: IObserverLocator;
+  let sut: LetBinding;
+  let dummySourceExpression: IExpression;
+  let dummyTarget: IBindingTarget;
+  let dummyTargetProperty: string;
+  let dummyMode: BindingMode;
+
+  beforeEach(() => {
+    container = DI.createContainer();
+    observerLocator = container.get(IObserverLocator);
+    dummySourceExpression = <any>{};
+    dummyTarget = <any>{ foo: 'bar' };
+    dummyTargetProperty = 'foo';
+    dummyMode = BindingMode.twoWay;
+    sut = new LetBinding(dummySourceExpression, dummyTargetProperty, observerLocator, container);
+  });
+
+  describe('constructor', () => {
+    const invalidInputs: any[] = [null, undefined, {}];
+
+    for (const ii of invalidInputs) {
+      it(`does not throw on invalid input parameters of type ${getName(ii)}`, () => {
+        sut = new LetBinding(ii, ii, ii, ii, ii);
+      });
+    }
+  });
+
+  describe('updateTarget()', () => {
+    it('throws when called', () => {
+      expect(() => sut.updateTarget(null)).to.throw();
+    });
+  });
+
+  describe('updateSource()', () => {
+    it('throws when called', () => {
+      expect(() => sut.updateSource(null)).to.throw();
+    });
+  });
+
+  describe('$bind()', () => {
+    it('does not change target if scope was not changed', () => {
+      const vm = {};
+      const sourceExpression = new MockExpression();
+      const scope = BindingContext.createScope(vm);
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
+      sut.$bind(BindingFlags.none, scope);
+      const target = sut.target;
+      sut.$bind(BindingFlags.none, scope);
+      expect(sut.target).to.equal(target, 'It should have not recreated target');
+    });
+
+    it('throws when binding mode is not [toView]', () => {
+      const vm = {};
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
+      sut['mode'] = BindingMode.fromView;
+      expect(() => sut.$bind(BindingFlags.none, BindingContext.createScope(vm))).to.throw();
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
+      sut['mode'] = BindingMode.toView;
+      expect(() => sut.$bind(BindingFlags.none, BindingContext.createScope(vm))).not.to.throw();
+    });
+
+    it('creates right target with toViewModel === true', () => {
+      const vm = { vm: 5 };
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
+      sut.$bind(BindingFlags.none, BindingContext.createScope(vm));
+      expect(sut.target).to.equal(vm, 'It should have used bindingContext to create target.');
+    });
+
+    it('creates right target with toViewModel === false', () => {
+      const vm = { vm: 5 };
+      const view = { view: 6 };
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
+      sut.$bind(BindingFlags.none, BindingContext.createScope(vm, <any>view));
+      expect(sut.target).to.equal(view, 'It should have used overrideContext to create target.');
+    });
+  });
+
+  describe('handleChange()', () => {
+    it('handles changes', () => {
+      const vm = { vm: 5, foo: false };
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
+      sut.$bind(BindingFlags.none, BindingContext.createScope(vm));
+      vm.foo = true;
+      expect(sourceExpression.connect).to.have.been.callCount(1);
+    });
+  });
+
+  describe('$unbind()', () => {
+    it('should not unbind if it is not already bound', () => {
+      const sourceExpression = new MockExpression();
+      const scope: any = {};
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
+      sut['$scope'] = scope;
+      sut.$unbind(BindingFlags.fromUnbind);
+      expect(sut['$scope'] === scope).to.be.true;
+    });
+
+    it('should unbind if it is bound', () => {
+      const sourceExpression = new MockExpression();
+      const scope: any = {};
+      sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
+      sut['$scope'] = scope;
+      sut.$isBound = true;
+      const unobserveSpy = spy(sut, 'unobserve');
+      const unbindSpy = sourceExpression.unbind = spy();
+      sut.$unbind(BindingFlags.fromUnbind);
+      expect(sut['$scope']).to.be.null;
+      expect(sut['$isBound']).to.be.false;
+      expect(unobserveSpy).to.have.been.calledWith(true);
+      expect(unbindSpy).to.have.been.calledWith(BindingFlags.fromUnbind, scope, sut);
+    });
+  });
+
+  describe('connect()', () => {
+    it(`does not connect if it is not bound`, () => {
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, dummyTargetProperty, observerLocator, container);
+
+      sut.connect(BindingFlags.mustEvaluate);
+
+      expect(sourceExpression.connect).not.to.have.been.called;
+      expect(sourceExpression.evaluate).not.to.have.been.called;
+    });
+
+    it(`connects the sourceExpression`, () => {
+      const sourceExpression = new MockExpression();
+      sut = new LetBinding(<any>sourceExpression, dummyTargetProperty, observerLocator, container);
+      const target = {};
+      const scope: any = {};
+      sut['target'] = target;
+      sut['$scope'] = scope;
+      sut['$isBound'] = true;
+      const flags = BindingFlags.none;
+
+      sut.connect(flags);
+
+      expect(sourceExpression.connect).to.have.been.calledWith(flags, scope, sut);
+      expect(sourceExpression.evaluate).to.have.been.called;
+    });
+  });
+});
+
+class MockExpression implements IExpression {
+  public $kind = ExpressionKind.AccessScope;
+  constructor(public value?: any) {
+    this.evaluate = spy(this, 'evaluate');
+  }
+  evaluate() {
+    return this.value;
+  }
+  connect = spy();
+  assign = spy();
+  bind = spy();
+  unbind = spy();
+}

--- a/packages/runtime/test/unit/templating/renderer.spec.ts
+++ b/packages/runtime/test/unit/templating/renderer.spec.ts
@@ -42,7 +42,8 @@ import {
   TextBindingInstruction,
   ToViewBindingInstruction,
   TriggerBindingInstruction,
-  TwoWayBindingInstruction
+  TwoWayBindingInstruction,
+  LetBindingInstruction
 } from '../../../../jit/src/index';
 import { DI } from '../../../../kernel/src/index';
 import { spy, SinonSpy } from 'sinon';
@@ -244,7 +245,7 @@ describe('Renderer', () => {
           sut[instruction.type](renderable, target, instruction);
 
           expect(renderable.$bindables.length).to.equal(0);
-          expect(target.getAttribute(dest)).to.equal(value+'');
+          expect(target.getAttribute(dest)).to.equal(value + '');
 
           tearDown({ wrapper });
         });
@@ -302,4 +303,20 @@ describe('Renderer', () => {
     }
   });
 
+  describe('handles ILetBindingInstruction', () => {
+    for (const dest of ['processedFoo', 'processedPoo']) {
+      for (const value of ['foo', new AccessScope('foo')]) {
+        const instruction = new LetBindingInstruction(value, dest);
+        it(_`instruction=${instruction}`, () => {
+          const { sut, renderable, target, wrapper } = setup(instruction);
+
+          sut[instruction.type](renderable, target, instruction);
+
+          expect(renderable.$bindables.length).to.equal(1);
+
+          tearDown({ wrapper });
+        });
+      }
+    }
+  });
 });

--- a/packages/runtime/test/unit/templating/renderer.spec.ts
+++ b/packages/runtime/test/unit/templating/renderer.spec.ts
@@ -43,7 +43,8 @@ import {
   ToViewBindingInstruction,
   TriggerBindingInstruction,
   TwoWayBindingInstruction,
-  LetBindingInstruction
+  LetBindingInstruction,
+  LetElementInstruction
 } from '../../../../jit/src/index';
 import { DI } from '../../../../kernel/src/index';
 import { spy, SinonSpy } from 'sinon';
@@ -303,20 +304,28 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles ILetBindingInstruction', () => {
-    for (const dest of ['processedFoo', 'processedPoo']) {
-      for (const value of ['foo', new AccessScope('foo')]) {
-        const instruction = new LetBindingInstruction(value, dest);
-        it(_`instruction=${instruction}`, () => {
-          const { sut, renderable, target, wrapper } = setup(instruction);
+  describe('<let/>', () => {
 
-          sut[instruction.type](renderable, target, instruction);
+    describe('ILetElementInstruction', () => {
+      for (const dest of ['processedFoo', 'processedPoo']) {
+        for (const value of ['foo', new AccessScope('foo')]) {
+          const instruction = new LetElementInstruction(
+            [new LetBindingInstruction(value, dest)],
+            Math.random() > .4
+          );
+          it(_`instruction=${instruction}`, () => {
+            const { sut, renderable, target, wrapper } = setup(instruction);
 
-          expect(renderable.$bindables.length).to.equal(1);
+            sut[instruction.type](renderable, target, instruction);
 
-          tearDown({ wrapper });
-        });
+            expect(renderable.$bindables.length).to.equal(1);
+
+            expect(document.contains(target)).to.be.false;
+
+            tearDown({ wrapper });
+          });
+        }
       }
-    }
+    });
   });
 });


### PR DESCRIPTION
With the template compiler in, I was able to verify the implementation. It's pretty ready, except I need to handle the scenario where `<let/>` is defined not at the start of a template:

```html
<template>
  <div>${fullName}</div>
  <let full-name.bind="firstName + ` ` + lastName"></let>
</template>
```

@EisenbergEffect @fkleuver Is there already a way to add a instruction without a target ? If no, probably I'll need to splice let instructions into the start of a definition instructions, beside adding some marker based on it (yak)

Note: Or we can also only support `<let/>` as is, which means if it's defined after a binding already created a property on binding context, it will just use it.