### PR TITLE
chore(ci): make the distribution of tests more sensible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,20 @@ aliases:
   - &step_attach_workspace
     attach_workspace:
       at: ~/repo
+  - &step_install_e2e_bs
+    run:
+      name: Install e2e tests
+      command: |
+        cd ./test/e2e
+        npm install
+        npm run build
+  - &step_serve_e2e_bs
+    run:
+      name: Serve the e2e app in the background
+      background: true
+      command: |
+        cd ./test/e2e
+        npm run start
 
 version: 2
 jobs:
@@ -108,12 +122,14 @@ jobs:
             ~/cc-test-reporter upload-coverage -i ~/repo/coverage-combined.json
           environment:
             CC_TEST_REPORTER_ID: 29ad19bd108faacbd91b36265a5b5e891b404571ebf937f40655157877aa71a1
+          when: always
       - run:
           name: Process coverage for Codecov
           command: |
             codecov -f ~/repo/packages/jit/coverage/coverage-final.json
             codecov -f ~/repo/packages/kernel/coverage/coverage-final.json
             codecov -f ~/repo/packages/runtime/coverage/coverage-final.json
+          when: always
       - store_test_results:
           path: ./packages/jit/junit
       - store_test_results:
@@ -139,18 +155,8 @@ jobs:
       - checkout
       - *step_restore_cache
       - *step_attach_workspace
-      - run:
-          name: Install e2e tests
-          command: |
-            cd ./test/e2e
-            npm install
-            npm run build
-      - run:
-          name: Serve the e2e app in the background
-          background: true
-          command: |
-            cd ./test/e2e
-            npm run start
+      - *step_install_e2e_bs
+      - *step_serve_e2e_bs
       - run:
           name: Run the e2e tests
           command: |
@@ -161,6 +167,7 @@ jobs:
           command: |
             cd ./test/e2e
             npm run allure:generate
+          when: always
       - store_artifacts:
           path: ./test/e2e/allure-report
       - run:
@@ -168,6 +175,31 @@ jobs:
           command: |
             cd ./test/e2e
             npm run allure:post
+          when: always
+
+  e2e_browserstack_compat:
+    <<: *defaults
+    steps:
+      - checkout
+      - *step_restore_cache
+      - *step_attach_workspace
+      - *step_install_e2e_bs
+      - *step_serve_e2e_bs
+      - run:
+          name: Run the e2e tests
+          command: |
+            cd ./test/e2e
+            npm run e2e
+          environment:
+            BS_COMPAT_CHECK: true
+      - run:
+          name: Generate allure report
+          command: |
+            cd ./test/e2e
+            npm run allure:generate
+          when: always
+      - store_artifacts:
+          path: ./test/e2e/allure-report
 
   e2e_benchmark_vnext:
     <<: *defaults
@@ -249,15 +281,30 @@ workflows:
       - unit_tests_firefox:
           requires:
             - install
+          filters:
+            branches:
+              only: master
       - e2e_browserstack:
           requires:
             - build
+          filters:
+            branches:
+              ignore: master
+      - e2e_browserstack_compat:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
       - e2e_benchmark_vnext:
           requires:
             - build
       - e2e_benchmark_vcurrent:
           requires:
             - build
+          filters:
+            branches:
+              only: master
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ jobs:
 
 workflows:
   version: 2
+  # This workflow runs on every commit to any branch (with or without PR)
   default_workflow:
     jobs:
       - install
@@ -278,18 +279,25 @@ workflows:
       - unit_tests_chrome:
           requires:
             - install
+      # Only run the tests in firefox when on master (that's the thorough testing branch)
+      # - todo: move to browserstack and add more browsers
+      # - todo: later we'll have another specialized workflow (or variant of this one) for release branch
       - unit_tests_firefox:
           requires:
             - install
           filters:
             branches:
               only: master
+      # This is the "lightweight" browserstack test set (only latest browser / latest OS)
+      # It runs on every commit on every non-master branch
       - e2e_browserstack:
           requires:
             - build
           filters:
             branches:
               ignore: master
+      # This is the full browserstack test set (last 3 versions of every browser on multiple OSes + OS versions)
+      # It runs on every commit to master
       - e2e_browserstack_compat:
           requires:
             - build
@@ -299,12 +307,16 @@ workflows:
       - e2e_benchmark_vnext:
           requires:
             - build
+      # Only run the vCurrent benchmark on commits to master (don't need to refresh data we already have on every commit to every branch)
       - e2e_benchmark_vcurrent:
           requires:
             - build
           filters:
             branches:
               only: master
+
+  # This workflow runs once per day on 0:00 UTC on the master branch
+  # - todo: add another schedule for release branch that generates change log and publishes normal release (only if there are changes and all integration+e2e tests pass)
   nightly:
     triggers:
       - schedule:
@@ -324,6 +336,7 @@ workflows:
       - unit_tests_firefox:
           requires:
             - install
+      # We only run the lightweight version of browserstack tests because failing tests on very old browsers shouldn't block a dev publish
       - e2e_browserstack:
           requires:
             - build

--- a/scripts/ci-env.ts
+++ b/scripts/ci-env.ts
@@ -227,6 +227,9 @@ export class CIEnv {
   public static get GITHUB_TOKEN(): string {
     return logSecretVariable(process.env.GITHUB_TOKEN, 'GITHUB_TOKEN');
   }
+  public static get BS_COMPAT_CHECK(): boolean {
+    return logVariable(toBoolean(process.env.BS_COMPAT_CHECK), 'BS_COMPAT_CHECK');
+  }
   public static get APP_PORT(): string {
     return logVariable(process.env.APP_PORT || '9000', 'APP_PORT');
   }

--- a/test/e2e/browserstack.conf.ts
+++ b/test/e2e/browserstack.conf.ts
@@ -48,8 +48,7 @@ exports.config = {
     'browserstack.timezone': 'UTC',
   },
 
-  // TODO: make this more explicitly configurable and flexible
-  capabilities: CIEnv.CIRCLE_BRANCH	=== 'master' && CIEnv.CIRCLE_JOB !== 'publish_nightly' ? [
+  capabilities: CIEnv.BS_COMPAT_CHECK ? [
     ...combine([
       { versions: ['68', '67', '66'], name: 'Chrome' },
       { versions: ['61', '60', '59'], name: 'Firefox' }

--- a/test/e2e/browserstack.conf.ts
+++ b/test/e2e/browserstack.conf.ts
@@ -102,7 +102,7 @@ exports.config = {
       { versions: ['61'], name: 'Firefox' }
     ], [
       { versions: ['10'], name: 'Windows' },
-      { versions: ['High Sierra'], name: 'OS X' }
+      //{ versions: ['High Sierra'], name: 'OS X' }
     ]),
     ...combine([
       { versions: ['17'], name: 'Edge' },


### PR DESCRIPTION
@EisenbergEffect 

This should fix the nightly and make the each-commit test runs a bit faster than it currently does. Browserstack tests run for the 4 major browsers on latest version for each commit. Unit tests only run in chrome.

The full test suite (60+ browsers in browserstack) including benchmarks only run on commit to master.

The nightly runs the same thing as what's run on each commit with the addition of firefox unit tests.

Also posts allure results whether the PR test run failed or not.