### PR TITLE
ci(all): add automated publish@latest script / minor tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,7 @@ jobs:
           name: Run the e2e tests
           command: |
             cd ./test/e2e
-            npm run e2e
-          environment:
-            BS_COMPAT_CHECK: true
+            npm run e2e:compat
       - run:
           name: Generate allure report
           command: |
@@ -227,7 +225,7 @@ jobs:
             cd ~/repo/packages/examples/e2e-benchmark/vcurrent
             npm run e2e
 
-  publish_nightly:
+  publish_dev:
     <<: *defaults
     steps:
       - checkout
@@ -237,50 +235,91 @@ jobs:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
-          name: Publish nightly release
+          name: Publish to @dev
           command: |
-            npm run publish:nightly
+            npm run publish:dev
+
+  merge_push_release:
+    <<: *defaults
+    steps:
+      - checkout
+      - *step_restore_cache
+      - *step_attach_workspace
+      - run:
+          name: Merge tag into release
+          command: |
+            git checkout release
+            git merge $CIRCLE_TAG --squash --no-ff
+            git push
+
+  publish_latest:
+    <<: *defaults
+    steps:
+      - checkout
+      - *step_restore_cache
+      - *step_attach_workspace
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Publish to @latest
+          command: |
+            npm run publish:latest
 
 workflows:
   version: 2
   # This workflow runs on every commit to any branch (with or without PR)
-  default_workflow:
+  build_test:
     jobs:
       - install
       - build:
           requires:
             - install
+          filters:
+            tags:
+              only: /^v.*/
       - unit_tests_chrome:
           requires:
             - install
-      # Only run the tests in firefox when on master (that's the thorough testing branch)
+          filters:
+            tags:
+              only: /^v.*/
+      # Only run the tests in firefox when on master or release (those are the thorough testing branches)
       # - todo: move to browserstack and add more browsers
-      # - todo: later we'll have another specialized workflow (or variant of this one) for release branch
       - unit_tests_firefox:
           requires:
             - install
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - release
+            tags:
+              only: /^v.*/
       # This is the "lightweight" browserstack test set (only latest browser / latest OS)
-      # It runs on every commit on every non-master branch
+      # It runs on every commit on every non-release branch
       - e2e_browserstack:
           requires:
             - build
           filters:
             branches:
-              ignore: master
+              ignore: release
+            tags:
+              only: /^v.*/
       # This is the full browserstack test set (last 3 versions of every browser on multiple OSes + OS versions)
-      # It runs on every commit to master
+      # It runs on every commit to release
       - e2e_browserstack_compat:
           requires:
             - build
           filters:
             branches:
-              only: master
+              only: release
       - e2e_benchmark_vnext:
           requires:
             - build
+          filters:
+            tags:
+              only: /^v.*/
       # Only run the vCurrent benchmark on commits to master (don't need to refresh data we already have on every commit to every branch)
       - e2e_benchmark_vcurrent:
           requires:
@@ -288,10 +327,33 @@ workflows:
           filters:
             branches:
               only: master
+      # Merge the master branch into release
+      - merge_push_release:
+          requires:
+            - build
+            - unit_tests_chrome
+            - unit_tests_firefox
+            - e2e_browserstack
+            - e2e_benchmark_vnext
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - publish_latest:
+          type: approval
+          requires:
+            - build
+            - unit_tests_chrome
+            - unit_tests_firefox
+            - e2e_browserstack_compat
+            - e2e_benchmark_vnext
+          filters:
+            branches:
+              only: release
 
   # This workflow runs once per day on 0:00 UTC on the master branch
-  # - todo: add another schedule for release branch that generates change log and publishes normal release (only if there are changes and all integration+e2e tests pass)
-  nightly:
+  build_test_deploy_dev:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -314,10 +376,11 @@ workflows:
       - e2e_browserstack:
           requires:
             - build
-      - publish_nightly:
+      - publish_dev:
           requires:
             - build
             - unit_tests_chrome
             - unit_tests_firefox
             - e2e_browserstack
+
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "test-firefox": "lerna run test-firefox",
     "test:watch": "lerna run test:watch",
     "lint": "lerna run lint",
+    "prepare-release": "lerna version --conventional-commits --no-push --no-git-tag-version --exact --loglevel verbose -y",
     "publish:local": "lerna run publish:local --parallel",
-    "publish:nightly": "ts-node -P scripts/tsconfig.json scripts/publish-nightly.ts dev",
+    "publish:dev": "ts-node -P scripts/tsconfig.json scripts/publish.ts dev",
+    "publish:latest": "ts-node -P scripts/tsconfig.json scripts/publish.ts latest",
     "combine-coverage:json": "ts-node -P scripts/tsconfig.json scripts/combine-coverage.ts json",
     "combine-coverage:lcov": "ts-node -P scripts/tsconfig.json scripts/combine-coverage.ts lcovonly",
     "refresh": "lerna clean -y && nodetouch ensurestash && git add . && git stash && git clean -xfd && git stash pop && git rm -f ensurestash && npm ci && npm run bootstrap && npm run build"

--- a/test/e2e/browserstack.conf.ts
+++ b/test/e2e/browserstack.conf.ts
@@ -56,46 +56,46 @@ exports.config = {
       { versions: ['10', '8.1', '8', '7'], name: 'Windows' },
       { versions: ['High Sierra', 'Sierra', 'El Capitan', 'Yosemite'], name: 'OS X' }
     ]),
+    // ...combine([
+    //   { versions: ['12.15', '12.16'], name: 'Opera' },
+    // ], [
+    //   { versions: ['8.1', '8', '7'], name: 'Windows' }
+    // ]),
+    // ...combine([
+    //   { versions: ['11'], name: 'IE' },
+    // ], [
+    //   { versions: ['10', '8.1', '7'], name: 'Windows' }
+    // ]),
+    // ...combine([
+    //   { versions: ['10'], name: 'IE' },
+    // ], [
+    //   { versions: ['8', '7'], name: 'Windows' }
+    // ]),
     ...combine([
-      { versions: ['12.15', '12.16'], name: 'Opera' },
-    ], [
-      { versions: ['8.1', '8', '7'], name: 'Windows' }
-    ]),
-    ...combine([
-      { versions: ['11'], name: 'IE' },
-    ], [
-      { versions: ['10', '8.1', '7'], name: 'Windows' }
-    ]),
-    ...combine([
-      { versions: ['10'], name: 'IE' },
-    ], [
-      { versions: ['8', '7'], name: 'Windows' }
-    ]),
-    ...combine([
-      { versions: ['17', '16', '15'], name: 'Edge' },
+      { versions: ['17', '16'/*, '15'*/], name: 'Edge' },
     ], [
       { versions: ['10'], name: 'Windows' }
     ]),
-    ...combine([
-      { versions: ['11.1'], name: 'Safari' },
-    ], [
-      { versions: ['High Sierra'], name: 'OS X' }
-    ]),
+    // ...combine([
+    //   { versions: ['11.1'], name: 'Safari' },
+    // ], [
+    //   { versions: ['High Sierra'], name: 'OS X' }
+    // ]),
     ...combine([
       { versions: ['10.1'], name: 'Safari' },
     ], [
       { versions: ['Sierra'], name: 'OS X' }
     ]),
-    ...combine([
-      { versions: ['9.1'], name: 'Safari' },
-    ], [
-      { versions: ['El Capitan'], name: 'OS X' }
-    ]),
-    ...combine([
-      { versions: ['8'], name: 'Safari' },
-    ], [
-      { versions: ['Yosemite'], name: 'OS X' }
-    ])
+    // ...combine([
+    //   { versions: ['9.1'], name: 'Safari' },
+    // ], [
+    //   { versions: ['El Capitan'], name: 'OS X' }
+    // ]),
+    // ...combine([
+    //   { versions: ['8'], name: 'Safari' },
+    // ], [
+    //   { versions: ['Yosemite'], name: 'OS X' }
+    // ])
   ] : [
     ...combine([
       { versions: ['68'], name: 'Chrome' },

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -5,6 +5,7 @@
     "build": "rimraf dist  && tsc && browserify src/startup.ts -p [ tsify ] -t [ stringify --applies-to [ --include-extensions [ '.html' ] ] ] > dist/bundle.js",
     "start": "http-server -c-1 -p 9000 .",
     "e2e": "rimraf allure-results && npm run build && wdio browserstack.conf.js",
+    "e2e:compat": "cross-env BS_COMPAT_CHECK=true npm run e2e",
     "allure:generate": "allure generate -c -o allure-report allure-results",
     "allure:open": "allure open allure-report",
     "allure:post": "ts-node ../../scripts/post-allure.ts"


### PR DESCRIPTION
So the process would be:

- `npm run prepare-release` -> updates all the versions and generates changelogs, but does not commit/tag/push anything
- Review that all is ok
- `git add . && git commit -m "v0.2.0" && git tag v0.2.0 -m "v0.2.0" && git push --follow-tags` (or something among those lines)
- CircleCI will build, run tests (incl e2e) and then (based on the tag it detected) do a squash merge into release and pushes to release
- The push to release then triggers the same workflow but with more extensive e2e tests, at the end of which it will start a publish job. This publish job will need manual approval. If you hit approve, it publishes to `@latest`

I'm not completely happy about this; it's a first draft of the release process. Will need to find ways to make it less redundant as well as slightly more automated?