### PR TITLE
chore(tests): use progress instead of mocha reporter to speed up the test runner

### DIFF
--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -89,7 +89,7 @@ export default function(config: IKarmaConfig): void {
     mime: {
       'text/x-typescript': ['ts']
     },
-    reporters: [process.env.CI ? 'junit' : 'mocha'],
+    reporters: [process.env.CI ? 'junit' : 'progress'],
     webpackMiddleware: {
       stats: {
         colors: true,


### PR DESCRIPTION
Should have done this a long long time ago, sorry. Anyway, this speeds up the tests by about a factor 3. 

@bigopon @EisenbergEffect 