### PR TITLE
chore(tests): add verbose test command for mocha reporter

### DIFF
--- a/packages/aot/package.json
+++ b/packages/aot/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/jit/package.json
+++ b/packages/jit/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/plugin-requirejs/package.json
+++ b/packages/plugin-requirejs/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/plugin-svg/package.json
+++ b/packages/plugin-svg/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,7 +31,9 @@
     "test": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeHeadlessOpt --single-run --coverage",
     "test-firefox": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=FirefoxHeadless --single-run --coverage",
     "test:watch": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeHeadlessOpt --coverage",
+    "test:watch:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeHeadlessOpt --coverage --reporter=mocha",
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeDebugging",
+    "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"

--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -7,6 +7,7 @@ export interface IKarmaConfig extends karma.Config, IKarmaConfigOptions {
   noInfo?: boolean;
   coverage?: boolean;
   package?: string;
+  reporter?: string;
   set(config: IKarmaConfigOptions): void;
 }
 
@@ -89,7 +90,7 @@ export default function(config: IKarmaConfig): void {
     mime: {
       'text/x-typescript': ['ts']
     },
-    reporters: [process.env.CI ? 'junit' : 'progress'],
+    reporters: [process.env.CI ? 'junit' : config.reporter || 'progress'],
     webpackMiddleware: {
       stats: {
         colors: true,


### PR DESCRIPTION
Speed aside, I noticed that it's still nice to sometimes have the more extensive logging that the mocha reporter provides. This PR adds that back in via `:verbose` test commands (only runnable on package level).
TODO for self: try to eliminate some of the duplication in the package.json test commands