### PR TITLE
ci: temporarily disable flaky and time-consuming jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ aliases:
       command: |
         cd ./test/e2e
         npm run start
+  - &step_bootstrap_build
+    run:
+      name: Bootstrap and build the packages
+      command: |
+        npm run bootstrap
+        npm run build
 
 version: 2
 jobs:
@@ -56,11 +62,7 @@ jobs:
     steps:
       - checkout
       - *step_restore_cache
-      - run:
-          name: "Bootstrap and build the packages"
-          command: |
-            npm run bootstrap
-            npm run build
+      - *step_bootstrap_build
       - run:
           name: "Create bundles with rollup"
           command: |
@@ -133,7 +135,11 @@ jobs:
     steps:
       - checkout
       - *step_restore_cache
-      - *step_attach_workspace
+      - *step_bootstrap_build
+      - run:
+          name: "Create bundles with rollup"
+          command: |
+            npm run bundle:dist
       - *step_install_e2e_bs
       - *step_serve_e2e_bs
       - run:
@@ -161,7 +167,11 @@ jobs:
     steps:
       - checkout
       - *step_restore_cache
-      - *step_attach_workspace
+      - *step_bootstrap_build
+      - run:
+          name: "Create bundles with rollup"
+          command: |
+            npm run bundle:dist
       - *step_install_e2e_bs
       - *step_serve_e2e_bs
       - run:
@@ -307,7 +317,7 @@ workflows:
       # It runs on every commit on every non-release branch
       - e2e_browserstack:
           requires:
-            - build
+            - install
           filters:
             branches:
               ignore: release
@@ -317,7 +327,7 @@ workflows:
       # It runs on every commit to release
       - e2e_browserstack_compat:
           requires:
-            - build
+            - install
           filters:
             branches:
               only: release
@@ -382,7 +392,7 @@ workflows:
       # We only run the lightweight version of browserstack tests because failing tests on very old browsers shouldn't block a dev publish
       - e2e_browserstack:
           requires:
-            - build
+            - install
       - publish_dev:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,20 +141,20 @@ jobs:
           command: |
             cd ./test/e2e
             npm run e2e
-      - run:
-          name: Generate allure report
-          command: |
-            cd ./test/e2e
-            npm run allure:generate
-          when: always
-      - store_artifacts:
-          path: ./test/e2e/allure-report
-      - run:
-          name: Post the link to allure report in PR comment
-          command: |
-            cd ./test/e2e
-            npm run allure:post
-          when: always
+      #- run:
+      #    name: Generate allure report
+      #    command: |
+      #      cd ./test/e2e
+      #      npm run allure:generate
+      #    when: always
+      #- store_artifacts:
+      #    path: ./test/e2e/allure-report
+      #- run:
+      #    name: Post the link to allure report in PR comment
+      #    command: |
+      #      cd ./test/e2e
+      #      npm run allure:post
+      #    when: always
 
   e2e_browserstack_compat:
     <<: *defaults
@@ -169,14 +169,14 @@ jobs:
           command: |
             cd ./test/e2e
             npm run e2e:compat
-      - run:
-          name: Generate allure report
-          command: |
-            cd ./test/e2e
-            npm run allure:generate
-          when: always
-      - store_artifacts:
-          path: ./test/e2e/allure-report
+      #- run:
+      #    name: Generate allure report
+      #    command: |
+      #      cd ./test/e2e
+      #      npm run allure:generate
+      #    when: always
+      #- store_artifacts:
+      #    path: ./test/e2e/allure-report
 
   e2e_benchmark_vnext:
     <<: *defaults
@@ -321,19 +321,19 @@ workflows:
           filters:
             branches:
               only: release
-      - e2e_benchmark_vnext:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^v.*/
+      #- e2e_benchmark_vnext:
+      #    requires:
+      #      - build
+      #    filters:
+      #      tags:
+      #        only: /^v.*/
       # Only run the vCurrent benchmark on commits to master (don't need to refresh data we already have on every commit to every branch)
-      - e2e_benchmark_vcurrent:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
+      #- e2e_benchmark_vcurrent:
+      #    requires:
+      #      - build
+      #    filters:
+      #      branches:
+      #        only: master
       # Merge the master branch into release
       - merge_push_release:
           requires:
@@ -341,7 +341,7 @@ workflows:
             - unit_tests_chrome
             - unit_tests_firefox
             - e2e_browserstack
-            - e2e_benchmark_vnext
+            #- e2e_benchmark_vnext
           filters:
             branches:
               ignore: /.*/
@@ -354,7 +354,7 @@ workflows:
             - unit_tests_chrome
             - unit_tests_firefox
             - e2e_browserstack_compat
-            - e2e_benchmark_vnext
+            #- e2e_benchmark_vnext
           filters:
             branches:
               only: release


### PR DESCRIPTION
With the new circleci 2.1 this will be much easier to manage. Parameterized commands will also allow us to configure individual jobs more granularly based on the workflow they're running in (e.g. only run the bundle script if it's inside the nightly workflow). For the time being, I'm disabling the benchmarks and the allure reports to make the jobs run faster and eliminate some intermittent failures