### PR TITLE
ci: actually commit to release after merging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,7 @@ jobs:
           command: |
             git checkout release
             git merge $CIRCLE_TAG --squash
+            git commit --no-edit
             git push
 
   publish_latest:


### PR DESCRIPTION
@EisenbergEffect the push was there, but the commit wasn't :) this should work now

just delete and re-create the tag from latest master after merging this