### PR TITLE
fix(template-compiler): remove node after parsing

### DIFF
--- a/packages/jit/src/templating/template-compiler.ts
+++ b/packages/jit/src/templating/template-compiler.ts
@@ -139,6 +139,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     if (typeof node === 'string') {
       domParser.innerHTML = node;
       node = definition.templateOrNode = domParser.firstElementChild;
+      domParser.removeChild(node);
     }
     const rootNode = <Element>node;
     const isTemplate = node.nodeName === 'TEMPLATE';
@@ -251,6 +252,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     for (let i = 0, ii = attributes.length; i < ii; ++i) {
       const attr = attributes.item(i);
       const { name, value } = attr;
+      if (name === 'as-element') {
+        continue;
+      }
       const [target, attribute, command] = inspectAttribute(name, resources);
 
       if (attribute !== null) {
@@ -326,6 +330,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     for (let i = 0, ii = attributes.length; ii > i; ++i) {
       const attr = attributes.item(i);
       const { name, value } = attr;
+      // tslint:disable-next-line:prefer-const
       let [target, , command] = inspectAttribute(name, resources);
       target = PLATFORM.camelCase(target);
       let letInstruction: LetBindingInstruction;

--- a/packages/jit/test/unit/util.ts
+++ b/packages/jit/test/unit/util.ts
@@ -1,3 +1,43 @@
 import { _, stringify, jsonStringify, htmlStringify, createElement, verifyEqual } from '../../../../scripts/test-lib';
 
 export { _, stringify, jsonStringify, htmlStringify, createElement, verifyEqual };
+
+const emptyArray = [];
+
+export function h<T extends keyof HTMLElementTagNameMap, TChildren extends (string | number | boolean | null | undefined | Node)[]>(
+  name: T,
+  attrs: Record<string, any> = null,
+  ...children: TChildren
+) {
+  let el = document.createElement<T>(name);
+  for (let attr in attrs) {
+    if (attr === 'class' || attr === 'className' || attr === 'cls') {
+      let value: string[] = attrs[attr];
+      value = value === undefined || value === null
+        ? emptyArray
+        : Array.isArray(value)
+          ? value
+          : ('' + value).split(' ');
+      el.classList.add(...value.filter(Boolean));
+    } else if (attr in el || attr === 'data' || attr[0] === '_') {
+      el[attr] = attrs[attr];
+    } else {
+      el.setAttribute(attr, attrs[attr]);
+    }
+  }
+  let childrenCt = el.tagName === 'TEMPLATE' ? (el as HTMLTemplateElement).content : el;
+  for (let child of children) {
+    if (child === null || child === undefined) {
+      continue;
+    }
+    childrenCt.appendChild(isNodeOrTextOrComment(child)
+      ? child
+      : document.createTextNode('' + child)
+    );
+  }
+  return el;
+}
+
+function isNodeOrTextOrComment(obj: any): obj is Text | Comment | Node {
+  return obj instanceof Node || obj instanceof Text || obj instanceof Comment;
+}


### PR DESCRIPTION
`as-element` should not go through as `propertyBinding`. This is just temporary patch probably until we have a more beautiful solution