### PR TITLE
Fixes

### DIFF
--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -64,6 +64,10 @@ export class Aurelia {
     return this;
   }
 
+  public root(): ICustomElement | null {
+    return this.components[0] || null;
+  }
+
   public start(): this {
     this.startTasks.forEach(x => x());
     this.isStarted = true;

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer, IRegistry, PLATFORM } from '@aurelia/kernel';
+import { DI, IContainer, IRegistry, PLATFORM, Registration } from '@aurelia/kernel';
 import { BindingFlags } from './binding/binding-flags';
 import { Lifecycle, LifecycleFlags } from './templating';
 import { ICustomElement } from './templating/custom-element';
@@ -13,9 +13,14 @@ export class Aurelia {
   private components: ICustomElement[] = [];
   private startTasks: (() => void)[] = [];
   private stopTasks: (() => void)[] = [];
-  private isStarted: boolean = false;
+  private isStarted = false;
+  private _root: ICustomElement = null;
 
-  constructor(private container: IContainer = DI.createContainer()) {}
+  constructor(private container: IContainer = DI.createContainer()) {
+    Registration
+      .instance(Aurelia, this)
+      .register(container, Aurelia);
+  }
 
   public register(...params: (IRegistry | Record<string, Partial<IRegistry>>)[]): this {
     this.container.register(...params);
@@ -27,6 +32,7 @@ export class Aurelia {
 
     const startTask = () => {
       if (!this.components.includes(component)) {
+        this._root = component;
         this.components.push(component);
         component.$hydrate(
           this.container.get(IRenderingEngine),
@@ -65,7 +71,7 @@ export class Aurelia {
   }
 
   public root(): ICustomElement | null {
-    return this.components[0] || null;
+    return this._root;
   }
 
   public start(): this {

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -85,13 +85,15 @@ export class SetterObserver implements SetterObserver {
 // tslint:disable-next-line:interface-name
 export interface Observer extends IPropertyObserver<IIndexable, string> {}
 
+function identity(newValue: any): any { return newValue; }
+
 @propertyObserver()
 export class Observer implements Observer {
   public obj: IIndexable;
   public propertyKey: string;
   public currentValue: IIndexable | Primitive;
 
-  private callback: (oldValue: IIndexable | Primitive, newValue: IIndexable | Primitive) => IIndexable | Primitive;
+  private callback: (newValue: IIndexable | Primitive, oldValue: IIndexable | Primitive) => IIndexable | Primitive;
 
   constructor(
     instance: object,
@@ -103,7 +105,7 @@ export class Observer implements Observer {
       this.currentValue = instance[propertyName];
       this.callback = callbackName in instance
         ? instance[callbackName].bind(instance)
-        : noop;
+        : identity;
   }
 
   public getValue(): IIndexable | Primitive {

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -85,8 +85,6 @@ export class SetterObserver implements SetterObserver {
 // tslint:disable-next-line:interface-name
 export interface Observer extends IPropertyObserver<IIndexable, string> {}
 
-function identity(newValue: any): any { return newValue; }
-
 @propertyObserver()
 export class Observer implements Observer {
   public obj: IIndexable;
@@ -105,7 +103,7 @@ export class Observer implements Observer {
       this.currentValue = instance[propertyName];
       this.callback = callbackName in instance
         ? instance[callbackName].bind(instance)
-        : identity;
+        : noop;
   }
 
   public getValue(): IIndexable | Primitive {

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -7,6 +7,7 @@ import {
   Reporter,
   Writable
 } from '@aurelia/kernel';
+import { ChangeSet } from '../binding';
 import { BindingContext } from '../binding/binding-context';
 import { BindingFlags } from '../binding/binding-flags';
 import { DOM, INode, INodeSequence, IRenderLocation } from '../dom';
@@ -190,6 +191,10 @@ function bind(this: IInternalCustomElementImplementation, flags: BindingFlags): 
   }
 
   this.$isBound = true;
+  // On application startup, changes shouldn't be delayed
+  if (flags & BindingFlags.fromStartTask) {
+    (this.$context.get(ChangeSet) as ChangeSet).flushChanges();
+  }
 
   if (behavior.hasBound) {
     (this as any).bound(flags | BindingFlags.fromBind);

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -7,7 +7,6 @@ import {
   Reporter,
   Writable
 } from '@aurelia/kernel';
-import { ChangeSet } from '../binding';
 import { BindingContext } from '../binding/binding-context';
 import { BindingFlags } from '../binding/binding-flags';
 import { DOM, INode, INodeSequence, IRenderLocation } from '../dom';
@@ -191,10 +190,6 @@ function bind(this: IInternalCustomElementImplementation, flags: BindingFlags): 
   }
 
   this.$isBound = true;
-  // On application startup, changes shouldn't be delayed
-  if (flags & BindingFlags.fromStartTask) {
-    (this.$context.get(ChangeSet) as ChangeSet).flushChanges();
-  }
 
   if (behavior.hasBound) {
     (this as any).bound(flags | BindingFlags.fromBind);

--- a/packages/runtime/src/templating/renderer.ts
+++ b/packages/runtime/src/templating/renderer.ts
@@ -90,15 +90,8 @@ export class Renderer implements IRenderer {
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const current = childInstructions[i];
       const currentType = current.type;
-      let realTarget;
 
-      if (currentType === TargetedInstructionType.stylePropertyBinding || currentType === TargetedInstructionType.listenerBinding) {
-        realTarget = target;
-      } else {
-        realTarget = component;
-      }
-
-      (this as any)[currentType](renderable, realTarget, current);
+      (this as any)[currentType](renderable, component, current);
     }
 
     renderable.$bindables.push(component);

--- a/packages/runtime/src/templating/rendering-engine.ts
+++ b/packages/runtime/src/templating/rendering-engine.ts
@@ -200,7 +200,7 @@ export class RuntimeCompilationResources implements IResourceDescriptions {
 
   public find<TSource>(kind: IResourceKind<TSource>, name: string): ResourceDescription<TSource> | null {
     const key = kind.keyFrom(name);
-    const resolver = this.context.getResolver<TSource>(key);
+    const resolver = this.context.getResolver<TSource>(key, false);
 
     if (resolver !== null && resolver.getFactory) {
       const factory = resolver.getFactory(this.context);

--- a/packages/runtime/test/unit/aurelia.spec.ts
+++ b/packages/runtime/test/unit/aurelia.spec.ts
@@ -9,6 +9,10 @@ describe('Aurelia', () => {
     sut = new Aurelia();
   });
 
+  it('should initialize container directly', () => {
+    expect(sut['container'].get(Aurelia)).to.equal(sut);
+  });
+
   it('should initialize correctly', () => {
     expect(sut['components'].length).to.equal(0);
     expect(sut['startTasks'].length).to.equal(0);

--- a/packages/runtime/test/unit/binding/property-observation.spec.ts
+++ b/packages/runtime/test/unit/binding/property-observation.spec.ts
@@ -161,11 +161,11 @@ describe('SetterObserver', () => {
 
 describe('Observer', () => {
 
-  it('use identity function as default callback', () => {
+  it('use noop function as default callback', () => {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new Observer({}, 'a', 'aChanged');
-      expect(observer['callback'](value, undefined)).to.equal(value);
+      expect(observer['callback'](value, undefined)).to.be.undefined;
     });
   });
 });

--- a/packages/runtime/test/unit/binding/property-observation.spec.ts
+++ b/packages/runtime/test/unit/binding/property-observation.spec.ts
@@ -1,6 +1,6 @@
 import { spy } from 'sinon';
 import { PLATFORM } from '../../../../kernel/src/index';
-import { PrimitiveObserver, SetterObserver, ChangeSet, BindingFlags } from '../../../src/index';
+import { PrimitiveObserver, SetterObserver, ChangeSet, BindingFlags, Observer } from '../../../src/index';
 import { expect } from 'chai';
 import { SpySubscriber } from '../util';
 
@@ -156,6 +156,15 @@ describe('SetterObserver', () => {
         }
       }
     }
+  });
+});
+
+describe('Observer', () => {
+
+  it('use identity function as default callback', () => {
+    const value = {};
+    const observer = new Observer({}, 'a', 'aChanged');
+    expect(observer['callback'](value, undefined)).to.equal(value);
   });
 });
 

--- a/packages/runtime/test/unit/binding/property-observation.spec.ts
+++ b/packages/runtime/test/unit/binding/property-observation.spec.ts
@@ -161,10 +161,12 @@ describe('SetterObserver', () => {
 
 describe('Observer', () => {
 
-  it('use identity function as default callback', () => {
-    const value = {};
-    const observer = new Observer({}, 'a', 'aChanged');
-    expect(observer['callback'](value, undefined)).to.equal(value);
+  it.only('use identity function as default callback', () => {
+    const values = createObjectArr();
+    values.forEach(value => {
+      const observer = new Observer({}, 'a', 'aChanged');
+      expect(observer['callback'](value, undefined)).to.equal(value);
+    });
   });
 });
 

--- a/packages/runtime/test/unit/binding/property-observation.spec.ts
+++ b/packages/runtime/test/unit/binding/property-observation.spec.ts
@@ -161,7 +161,7 @@ describe('SetterObserver', () => {
 
 describe('Observer', () => {
 
-  it.only('use identity function as default callback', () => {
+  it('use identity function as default callback', () => {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new Observer({}, 'a', 'aChanged');

--- a/packages/runtime/test/unit/templating/rendering-engine.spec.ts
+++ b/packages/runtime/test/unit/templating/rendering-engine.spec.ts
@@ -1,5 +1,20 @@
-import { RenderingEngine, CompiledTemplate, RuntimeCompilationResources, View, ViewFactory } from '../../../src/index';
+import {
+  RenderingEngine,
+  CompiledTemplate,
+  RuntimeCompilationResources,
+  View,
+  ViewFactory,
+  IRenderContext,
+  ExposedContext,
+  CustomElementResource,
+  CustomAttributeResource,
+  BindingBehaviorResource,
+  ValueConverterResource,
+  RenderStrategyResource
+} from '../../../src/index';
 import { expect } from 'chai';
+import { Container } from '../../../../kernel/src';
+import { BindingCommandResource } from '../../../../jit/src';
 
 
 describe('RenderingEngine', () => {
@@ -12,6 +27,22 @@ describe('CompiledTemplate', () => {
 
 describe('RuntimeCompilationResources', () => {
 
+  it('does not register while finding resource', () => {
+    const container = new Container();
+    const resources = new RuntimeCompilationResources((container as any) as ExposedContext);
+
+    [
+      CustomElementResource,
+      CustomAttributeResource,
+      BindingBehaviorResource,
+      ValueConverterResource,
+      RenderStrategyResource,
+      BindingCommandResource
+    ].forEach(r => {
+      resources.find(r, 'a');
+      expect(container.getResolver(r.keyFrom('a'), false)).to.be.null;
+    });
+  });
 });
 
 describe('View', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -70,7 +70,7 @@
     "no-increment-decrement": false,
     "no-invalid-regexp": true,
     "no-invalid-template-strings": true,
-    "no-invalid-this": true,
+    "no-invalid-this": false,
     "no-jquery-raw-elements": true,
     "no-misused-new": true,
     "no-non-null-assertion": true,


### PR DESCRIPTION
https://github.com/aurelia/aurelia/blob/beec33ffed1a75258360046ef88c55db8bdc7cb9/packages/runtime/src/aurelia.ts#L53-L55 Above is a way I think necessary for component to check in `$bind ` during startup to see if it should call `ChangeSet.flushChanges` after `binding`:
https://github.com/aurelia/aurelia/blob/beec33ffed1a75258360046ef88c55db8bdc7cb9/packages/runtime/src/templating/custom-element.ts#L181-L184
A fix to prevent unnecessary registration on checking for resource existence
```diff
- const resolver = this.context.getResolver<TSource>(key);
+ const resolver = this.context.getResolver<TSource>(key, false);
```
Beside this, will we have `registerInstance` on `IContainer` ?