### PR TITLE
template controller fixes

### DIFF
--- a/packages/jit/src/templating/element-parser.ts
+++ b/packages/jit/src/templating/element-parser.ts
@@ -19,14 +19,22 @@ export const enum NodeType {
   Notation = 12
 }
 
+const marker = DOM.createElement('au-marker') as Element;
+marker.classList.add('au');
+const createMarker: () => HTMLElement = marker.cloneNode.bind(marker, false);
+
 export class ElementSyntax {
   constructor(
     public readonly node: Node,
     public readonly name: string,
     public readonly $content: ElementSyntax | null,
-    public readonly $children: ElementSyntax[],
+    public readonly $children: ReadonlyArray<ElementSyntax>,
     public readonly $attributes: ReadonlyArray<AttrSyntax>) {
     }
+
+  public static createMarker(): ElementSyntax {
+    return new ElementSyntax(createMarker(), 'au-marker', null, PLATFORM.emptyArray, PLATFORM.emptyArray)
+  }
 }
 
 export interface IElementParser {

--- a/packages/jit/src/templating/semantic-model.ts
+++ b/packages/jit/src/templating/semantic-model.ts
@@ -1,25 +1,82 @@
-import { Immutable, PLATFORM } from '@aurelia/kernel';
-import { BindingMode, CustomAttributeResource, CustomElementResource, IBindableDescription, ICustomAttributeSource, IResourceDescriptions, ITemplateSource, TargetedInstruction } from '@aurelia/runtime';
+import { Immutable, IServiceLocator, PLATFORM } from '@aurelia/kernel';
+import { BindingMode, CustomAttributeResource, CustomElementResource, DOM, IBindableDescription, ICustomAttributeSource, IExpressionParser, IResourceDescriptions, ITemplateSource, TargetedInstruction } from '@aurelia/runtime';
 import { Char } from '../binding/expression-parser';
 import { AttrSyntax, IAttributeParser } from './attribute-parser';
 import { BindingCommandResource, IBindingCommand } from './binding-command';
-import { ElementSyntax, NodeType } from './element-parser';
+import { ElementSyntax, IElementParser, NodeType } from './element-parser';
+import { HydrateTemplateController } from './template-compiler';
 
 export class SemanticModel {
   public readonly isSemanticModel: true = true;
+  public readonly root: ElementSymbol;
+
   private readonly attrDefCache: Record<string, ICustomAttributeSource>;
   private readonly elDefCache: Record<string, ITemplateSource>;
   private readonly commandCache: Record<string, IBindingCommand>;
 
-  constructor(
+  private constructor(
+    definition: ITemplateSource,
+    public resources: IResourceDescriptions,
     public attrParser: IAttributeParser,
-    public syntaxRoot: ElementSyntax,
-    public resources: IResourceDescriptions
+    public elParser: IElementParser,
+    public exprParser: IExpressionParser
   ) {
     this.attrDefCache = {};
     this.elDefCache = {};
     this.commandCache = {};
+    const syntax = this.elParser.parse(definition.templateOrNode);
+    definition.templateOrNode = syntax.node;
+    this.root = new ElementSymbol(
+      /*   semanticModel*/this,
+      /*isDefinitionRoot*/true,
+      /* $definitionRoot*/null,
+      /*         $parent*/null,
+      /*          syntax*/syntax,
+      /*      definition*/definition
+    );
   }
+
+  public static create(
+    definition: ITemplateSource,
+    resources: IResourceDescriptions,
+    attrParser: IAttributeParser,
+    elParser: IElementParser,
+    exprParser: IExpressionParser): SemanticModel;
+  public static create(
+    definition: ITemplateSource,
+    resources: IResourceDescriptions,
+    locator: IServiceLocator): SemanticModel;
+  public static create(
+    definition: ITemplateSource,
+    resources: IResourceDescriptions,
+    attrParser: IServiceLocator | IAttributeParser,
+    elParser?: IElementParser,
+    exprParser?: IExpressionParser): SemanticModel {
+
+    if ('get' in attrParser) {
+      const locator = attrParser as IServiceLocator;
+      attrParser = locator.get<IAttributeParser>(IAttributeParser);
+      elParser = locator.get<IElementParser>(IElementParser);
+      exprParser = locator.get<IExpressionParser>(IExpressionParser);
+    }
+
+    return new SemanticModel(definition, resources, attrParser, elParser, exprParser);
+  }
+
+  // public static create(
+  //   attrParser: IAttributeParser,
+  //   elParser: IElementParser,
+  //   exprParser: IExpressionParser,
+  //   definition: ITemplateSource,
+  //   resources: IResourceDescriptions): SemanticModel {
+
+  //   const attrParser = locator.get<IAttributeParser>(IAttributeParser);
+  //   const elParser = locator.get<IElementParser>(IElementParser);
+  //   const exprParser = locator.get<IExpressionParser>(IExpressionParser);
+  //   const syntaxRoot = elParser.parse(definition.templateOrNode);
+
+  //   return new SemanticModel(attrParser, elParser, exprParser, syntaxRoot, resources);
+  // }
 
   public getAttributeDefinition(name: string): ICustomAttributeSource {
     const existing = this.attrDefCache[name];
@@ -59,26 +116,40 @@ export class SemanticModel {
     return new MultiAttributeBindingSymbol(this, parent, syntax, command);
   }
 
-  public getElementSymbol(syntax: ElementSyntax, parent: ElementSymbol, definition?: ITemplateSource): ElementSymbol {
+  public getElementSymbol(syntax: ElementSyntax, parent: ElementSymbol): ElementSymbol {
     const node = syntax.node as Element;
-    if (definition === undefined && node.nodeType === NodeType.Element) {
+    let definition: ITemplateSource;
+    if (node.nodeType === NodeType.Element) {
       const resourceKey = (node.getAttribute('as-element') || node.nodeName).toLowerCase();
       definition = this.getElementDefinition(resourceKey);
     }
 
-    return new ElementSymbol(this, false, parent.$root, parent, syntax, definition);
+    return new ElementSymbol(
+      /*   semanticModel*/this,
+      /*isDefinitionRoot*/false,
+      /* $definitionRoot*/parent.$root,
+      /*         $parent*/parent,
+      /*          syntax*/syntax,
+      /*      definition*/definition
+    );
   }
 
-  public getElementSymbolRoot(definition: ITemplateSource): ElementSymbol {
-    const $el = new ElementSymbol(this, true, null, null, this.syntaxRoot, definition);
-    $el.definition.templateOrNode = $el.node;
-    return $el;
+  public getTemplateElementSymbol(syntax: ElementSyntax, parent: ElementSymbol, definition: ITemplateSource, definitionRoot: ElementSymbol): ElementSymbol {
+    return new ElementSymbol(
+      /*   semanticModel*/this,
+      /*isDefinitionRoot*/true,
+      /* $definitionRoot*/definitionRoot,
+      /*         $parent*/parent,
+      /*          syntax*/syntax,
+      /*      definition*/definition
+    );
   }
 }
 
 export interface IAttributeSymbol {
   readonly isMultiAttrBinding: boolean;
   readonly target: string;
+  readonly res: string | null;
   readonly rawName: string;
   readonly rawValue: string;
   readonly rawCommand: string;
@@ -101,6 +172,7 @@ export interface IAttributeSymbol {
 export class MultiAttributeBindingSymbol implements IAttributeSymbol {
   public readonly isMultiAttrBinding: boolean = true;
   public readonly target: string;
+  public readonly res: string = null;
   public readonly rawName: string;
   public readonly rawValue: string;
   public readonly rawCommand: string | null;
@@ -265,13 +337,34 @@ export class AttributeSymbol implements IAttributeSymbol {
 export class ElementSymbol {
   public readonly $attributes: ReadonlyArray<AttributeSymbol>;
   public readonly $children: ReadonlyArray<ElementSymbol>;
-  public readonly $content: ElementSymbol = null;
-  public readonly isTemplate: boolean = false;
-  public readonly isSlot: boolean = false;
-  public readonly isLet: boolean = false;
-  public readonly node: Node;
-  public readonly name: string;
-  public readonly isCustomElement: boolean;
+  public readonly $liftedChildren: ReadonlyArray<ElementSymbol>;
+  public get $content(): ElementSymbol {
+    return this._$content;
+  }
+  public get isMarker(): boolean {
+    return this._isMarker;
+  }
+  public get isTemplate(): boolean {
+    return this._isTemplate;
+  }
+  public get isSlot(): boolean {
+    return this._isSlot;
+  }
+  public get isLet(): boolean {
+    return this._isLet;
+  }
+  public get node(): Node {
+    return this._node;
+  }
+  public get syntax(): ElementSyntax {
+    return this._syntax;
+  }
+  public get name(): string {
+    return this._name;
+  }
+  public get isCustomElement(): boolean {
+    return this._isCustomElement;
+  }
   public get nextSibling(): ElementSymbol {
     if (!this.$parent) {
       return null;
@@ -287,30 +380,47 @@ export class ElementSymbol {
   public get firstChild(): ElementSymbol {
     return this.$children[0] || null;
   }
+  public get componentRoot(): ElementSymbol {
+    return this.semanticModel.root;
+  }
+  public get isLifted(): boolean {
+    return this._isLifted;
+  }
+  private _$content: ElementSymbol = null;
+  private _isMarker: boolean = false;
+  private _isTemplate: boolean = false;
+  private _isSlot: boolean = false;
+  private _isLet: boolean = false;
+  private _node: Node;
+  private _syntax: ElementSyntax;
+  private _name: string;
+  private _isCustomElement: boolean;
+  private _isLifted: boolean = false;
 
   constructor(
     public readonly semanticModel: SemanticModel,
     public readonly isRoot: boolean,
     public readonly $root: ElementSymbol,
     public readonly $parent: ElementSymbol,
-    public readonly syntax: ElementSyntax,
+    syntax: ElementSyntax,
     public readonly definition: ITemplateSource | null
   ) {
     this.$root = isRoot ? this : $root;
-    this.node = syntax.node;
-    this.name = this.node.nodeName;
+    this._node = syntax.node;
+    this._syntax = syntax;
+    this._name = this.node.nodeName;
     switch (this.name) {
       case 'TEMPLATE':
-        this.isTemplate = true;
-        this.$content = this.semanticModel.getElementSymbol(syntax.$content, this, definition);
+        this._isTemplate = true;
+        this._$content = this.semanticModel.getTemplateElementSymbol(syntax.$content, this, definition, this);
         break;
       case 'SLOT':
-        this.isSlot = true;
+        this._isSlot = true;
         break;
       case 'LET':
-        this.isLet = true;
+        this._isLet = true;
     }
-    this.isCustomElement = !isRoot && !!definition;
+    this._isCustomElement = !isRoot && !!definition;
 
     const attributes = syntax.$attributes;
     const attrLen = attributes.length;
@@ -341,7 +451,62 @@ export class ElementSymbol {
     (<Element>this.node).classList.add('au');
   }
 
+  public replaceTextNodeWithMarker(): void {
+    const marker = ElementSyntax.createMarker();
+    const node = this.node;
+    node.parentNode.insertBefore(marker.node, node);
+    node.textContent = ' ';
+    while (node.nextSibling && node.nextSibling.nodeType === NodeType.Text) {
+      node.parentNode.removeChild(node.nextSibling);
+    }
+    this.setToMarker(marker);
+  }
+
+  public replaceNodeWithMarker(): void {
+    const marker = ElementSyntax.createMarker();
+    const node = this.node;
+    if (node.parentNode) {
+      node.parentNode.replaceChild(marker.node, node);
+    } else if (this.isTemplate) {
+      (<HTMLTemplateElement>node).content.appendChild(marker.node);
+    }
+    this.setToMarker(marker);
+  }
+
+  public lift(instruction: HydrateTemplateController): ElementSymbol {
+    const template = instruction.src.templateOrNode = DOM.createTemplate() as HTMLTemplateElement;
+    const node = this.node as HTMLTemplateElement;
+    if (this.isTemplate) {
+      // copy remaining attributes over to the newly created template
+      const attributes = node.attributes;
+      while (attributes.length) {
+        const attr = attributes[0];
+        template.setAttribute(attr.name, attr.value);
+        node.removeAttribute(attr.name);
+      }
+      template.content.appendChild(node.content);
+      this.replaceNodeWithMarker();
+    } else {
+      this.replaceNodeWithMarker();
+      template.content.appendChild(node);
+    }
+    this.addInstructions([instruction]);
+    this._isLifted = true;
+    return this.semanticModel.getTemplateElementSymbol(
+      this.semanticModel.elParser.parse(template), this, instruction.src, null
+    );
+  }
+
   public addInstructions(instructions: TargetedInstruction[]): void {
     this.$root.definition.instructions.push(instructions);
+  }
+
+  private setToMarker(marker: ElementSyntax): void {
+    this._$content = null;
+    this._isCustomElement = this._isLet = this._isSlot = this._isTemplate = false;
+    this._isMarker = true;
+    this._name = 'AU-MARKER';
+    this._node = marker.node;
+    this._syntax = marker;
   }
 }

--- a/packages/jit/src/templating/semantic-model.ts
+++ b/packages/jit/src/templating/semantic-model.ts
@@ -63,21 +63,6 @@ export class SemanticModel {
     return new SemanticModel(definition, resources, attrParser, elParser, exprParser);
   }
 
-  // public static create(
-  //   attrParser: IAttributeParser,
-  //   elParser: IElementParser,
-  //   exprParser: IExpressionParser,
-  //   definition: ITemplateSource,
-  //   resources: IResourceDescriptions): SemanticModel {
-
-  //   const attrParser = locator.get<IAttributeParser>(IAttributeParser);
-  //   const elParser = locator.get<IElementParser>(IElementParser);
-  //   const exprParser = locator.get<IExpressionParser>(IExpressionParser);
-  //   const syntaxRoot = elParser.parse(definition.templateOrNode);
-
-  //   return new SemanticModel(attrParser, elParser, exprParser, syntaxRoot, resources);
-  // }
-
   public getAttributeDefinition(name: string): ICustomAttributeSource {
     const existing = this.attrDefCache[name];
     if (existing !== undefined) {

--- a/packages/jit/src/templating/template-compiler.ts
+++ b/packages/jit/src/templating/template-compiler.ts
@@ -130,8 +130,11 @@ export class TemplateCompiler implements ITemplateCompiler {
   }
 
   private compileElementNode($el: ElementSymbol): void {
-    const attributeInstructions: TargetedInstruction[] = [];
+    if ($el.$attributes.length === 0) {
+      return;
+    }
     const attributes = $el.$attributes;
+    const attributeInstructions: TargetedInstruction[] = [];
     for (let i = 0, ii = attributes.length; i < ii; ++i) {
       const $attr = attributes[i];
       if ($attr.isProcessed) continue;
@@ -163,6 +166,11 @@ export class TemplateCompiler implements ITemplateCompiler {
   }
 
   private compileCustomElement($el: ElementSymbol): void {
+    if ($el.$attributes.length === 0) {
+      $el.addInstructions([new HydrateElementInstruction($el.definition.name, <any>PLATFORM.emptyArray)]);
+      $el.makeTarget();
+      return;
+    }
     const attributeInstructions: TargetedInstruction[] = [];
     // if there is a custom element, then only the attributes that map to bindables become children of the hydrate instruction,
     // otherwise they become sibling instructions; if there is no custom element, then sibling instructions are never appended to

--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -403,8 +403,9 @@ describe('TemplateCompiler (integration)', () => {
         () => [`items`,               `\${item}`,               `123`,    c=>c.items=new Set(['1','2','3'])],
         () => [`items`,               `\${item[0]}\${item[1]}`, `1a2b3c`, c=>c.items=new Map([['1','a'],['2','b'],['3','c']])]
       ],
-      <(($1: [string, string, string, (component: any) => void]) => string)[]>[
-        ([iterable, itemTemplate, textContent, initialize]) => `<template><div repeat.for="item of ${iterable}">${itemTemplate}</div></template>`
+      <(($2: [string, string, string, (component: any) => void]) => string)[]>[
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><div repeat.for="item of ${iterable}">${itemTemplate}</div></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><template repeat.for="item of ${iterable}">${itemTemplate}</template></template>`
       ]
     ], ([iterable, itemTemplate, textContent, initialize], markup) => {
       it(markup, () => {


### PR DESCRIPTION
This PR fixes template controllers on template elements, and also correctly processes multiple template controllers per element.
The fix itself could likely be distilled down to changing 2-3 lines of code, but I had to do a few cycles of refactoring to increase the clarity of the flow enough for the necessary changes to surface. That's why it's paired with a moderately sized refactor. Hopefully this refactor makes it easier to follow the flow for others as well.