### PR TITLE
template compiler tests

### DIFF
--- a/packages/jit/src/templating/semantic-model.ts
+++ b/packages/jit/src/templating/semantic-model.ts
@@ -397,7 +397,7 @@ export class ElementSymbol {
     switch (this.name) {
       case 'TEMPLATE':
         this._isTemplate = true;
-        this._$content = this.semanticModel.getTemplateElementSymbol(syntax.$content, this, definition, this);
+        this._$content = this.semanticModel.getElementSymbol(syntax.$content, this);
         break;
       case 'SLOT':
         this._isSlot = true;

--- a/packages/jit/src/templating/template-compiler.ts
+++ b/packages/jit/src/templating/template-compiler.ts
@@ -63,7 +63,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     switch (node.nodeType) {
       case NodeType.Element:
         if ($el.isSlot) {
-          $el.$parent.definition.hasSlots = true;
+          $el.$root.definition.hasSlots = true;
         } else if ($el.isLet) {
           this.compileLetElement($el);
         } else if ($el.isCustomElement) {

--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -536,18 +536,60 @@ describe('TemplateCompiler (integration)', () => {
 
   it('initial values propagate through multiple nested custom elements connected via bindables', () => {
     const build = { required: true, compiler: 'default' };
+    let boundCalls = 0;
 
-    @customElement({ name: 'foo1', templateOrNode: `<template><foo2 value.bind="value"></foo2></template>`, instructions: [], build })class Foo1 { @bindable() public value: any; }
-    @customElement({ name: 'foo2', templateOrNode: `<template><foo3 value.bind="value"></foo3></template>`, instructions: [], build })class Foo2 { @bindable() public value: any; }
-    @customElement({ name: 'foo3', templateOrNode: `<template><foo4 value.bind="value"></foo4></template>`, instructions: [], build })class Foo3 { @bindable() public value: any; }
-    @customElement({ name: 'foo4', templateOrNode: `<template><foo5 value.bind="value"></foo5></template>`, instructions: [], build })class Foo4 { @bindable() public value: any; }
-    @customElement({ name: 'foo5', templateOrNode: `<template>\${value}</template>`, instructions: [], build })class Foo5 { @bindable() public value: any; }
+    @customElement({ name: 'foo1', templateOrNode: `<template><foo2 value.bind="value"></foo2></template>`, instructions: [], build })
+    class Foo1 {
+      @bindable() public value: any;
+      public bound(): void {
+        expect(this.value).to.equal('w00t');
+        boundCalls++;
+      }
+    }
+
+    @customElement({ name: 'foo2', templateOrNode: `<template><foo3 value.bind="value"></foo3></template>`, instructions: [], build })
+    class Foo2 {
+      @bindable() public value: any;
+      public bound(): void {
+        expect(this.value).to.equal('w00t');
+        boundCalls++;
+      }
+    }
+
+    @customElement({ name: 'foo3', templateOrNode: `<template><foo4 value.bind="value"></foo4></template>`, instructions: [], build })
+    class Foo3 {
+      @bindable() public value: any;
+      public bound(): void {
+        expect(this.value).to.equal('w00t');
+        boundCalls++;
+      }
+    }
+
+    @customElement({ name: 'foo4', templateOrNode: `<template><foo5 value.bind="value"></foo5></template>`, instructions: [], build })
+    class Foo4 {
+      @bindable() public value: any;
+      public bound(): void {
+        expect(this.value).to.equal('w00t');
+        boundCalls++;
+      }
+    }
+
+    @customElement({ name: 'foo5', templateOrNode: `<template>\${value}</template>`, instructions: [], build })
+    class Foo5 {
+      @bindable() public value: any;
+      public bound(): void {
+        expect(this.value).to.equal('w00t');
+        boundCalls++;
+      }
+    }
 
     const customElementCtors: any[] = [Foo1, Foo2, Foo3, Foo4, Foo5];
     container.register(...customElementCtors);
     component = createCustomElement('<template><foo1 value.bind="value"></foo1></template>');
     component.value = 'w00t';
     au.app({ host, component }).start();
+
+    expect(boundCalls).to.equal(5);
 
     let i = 0;
     let current = component;

--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -538,47 +538,89 @@ describe('TemplateCompiler (integration)', () => {
     const build = { required: true, compiler: 'default' };
     let boundCalls = 0;
 
-    @customElement({ name: 'foo1', templateOrNode: `<template><foo2 value.bind="value"></foo2>\${value}</template>`, instructions: [], build })
+    @customElement({ name: 'foo1', templateOrNode: `<template><foo2 value.bind="value" value2.bind="value1"></foo2>\${value}</template>`, instructions: [], build })
     class Foo1 {
-      @bindable() public value: any;
+      @bindable()
+      public value: any;
+      public value1: any;
+      private valueChanged(newValue: any): void {
+        this.value1 = newValue+'1';
+      }
       public bound(): void {
         expect(this.value).to.equal('w00t');
+        expect(this.value1).to.equal('w00t1');
         boundCalls++;
       }
     }
 
-    @customElement({ name: 'foo2', templateOrNode: `<template><foo3 value.bind="value"></foo3>\${value}</template>`, instructions: [], build })
+    @customElement({ name: 'foo2', templateOrNode: `<template><foo3 value.bind="value" value2.bind="value2"></foo3>\${value}</template>`, instructions: [], build })
     class Foo2 {
-      @bindable() public value: any;
+      @bindable()
+      public value: any;
+      public value1: any;
+      private valueChanged(newValue: any): void {
+        this.value1 = newValue+'1';
+      }
+      @bindable()
+      public value2: any;
       public bound(): void {
         expect(this.value).to.equal('w00t');
+        expect(this.value1).to.equal('w00t1');
+        expect(this.value2).to.equal('w00t1');
         boundCalls++;
       }
     }
 
-    @customElement({ name: 'foo3', templateOrNode: `<template><foo4 value.bind="value"></foo4>\${value}</template>`, instructions: [], build })
+    @customElement({ name: 'foo3', templateOrNode: `<template><foo4 value.bind="value" value2.bind="value2"></foo4>\${value}</template>`, instructions: [], build })
     class Foo3 {
-      @bindable() public value: any;
+      @bindable()
+      public value: any;
+      public value1: any;
+      @bindable()
+      public value2: any;
+      private valueChanged(newValue: any): void {
+        this.value1 = newValue+'1';
+      }
       public bound(): void {
         expect(this.value).to.equal('w00t');
+        expect(this.value1).to.equal('w00t1');
+        expect(this.value2).to.equal('w00t1');
         boundCalls++;
       }
     }
 
-    @customElement({ name: 'foo4', templateOrNode: `<template><foo5 value.bind="value"></foo5>\${value}</template>`, instructions: [], build })
+    @customElement({ name: 'foo4', templateOrNode: `<template><foo5 value.bind="value" value2.bind="value2"></foo5>\${value}</template>`, instructions: [], build })
     class Foo4 {
-      @bindable() public value: any;
+      @bindable()
+      public value: any;
+      public value1: any;
+      @bindable()
+      public value2: any;
+      private valueChanged(newValue: any): void {
+        this.value1 = newValue+'1';
+      }
       public bound(): void {
         expect(this.value).to.equal('w00t');
+        expect(this.value1).to.equal('w00t1');
+        expect(this.value2).to.equal('w00t1');
         boundCalls++;
       }
     }
 
     @customElement({ name: 'foo5', templateOrNode: `<template>\${value}</template>`, instructions: [], build })
     class Foo5 {
-      @bindable() public value: any;
+      @bindable()
+      public value: any;
+      public value1: any;
+      @bindable()
+      public value2: any;
+      private valueChanged(newValue: any): void {
+        this.value1 = newValue+'1';
+      }
       public bound(): void {
         expect(this.value).to.equal('w00t');
+        expect(this.value1).to.equal('w00t1');
+        expect(this.value2).to.equal('w00t1');
         boundCalls++;
       }
     }
@@ -597,29 +639,65 @@ describe('TemplateCompiler (integration)', () => {
       const childCtor = customElementCtors[i];
       expect(current.$attachables.length).to.equal(1);
       expect(current.$attachables[0]).to.be.instanceof(childCtor);
-      expect(current.$bindables.length).to.equal(3);
 
-      const binding = current.$bindables[0];
-      expect(binding).to.be.instanceof(Binding);
-      if (i === 0) { // root component
-        expect(binding._observer0).be.instanceof(SetterObserver);
-      } else { // foo #
-        expect(binding._observer0).be.instanceof(Observer);
+      switch (i) {
+        case 0: // root component -> foo1
+          expect(current.$bindables.length).to.equal(3);
+          expect(current.$bindables[0]).to.be.instanceof(Binding);
+          expect(current.$bindables[0]._observer0).be.instanceof(SetterObserver);
+          expect(current.$bindables[0]._observer1).to.be.undefined;
+          expect(current.$bindables[0].targetObserver).to.be.instanceof(PropertyAccessor);
+
+          expect(current.$bindables[1]).to.be.instanceof(childCtor);
+
+          expect(current.$bindables[2]).to.be.instanceof(Binding);
+          expect(current.$bindables[2].target.nodeName).to.equal('#text');
+          expect(current.$bindables[2].targetObserver).to.be.instanceof(ElementPropertyAccessor);
+          current = current.$bindables[1];
+          break;
+        case 1: // foo1 -> foo2
+          expect(current.$bindables.length).to.equal(4);
+          expect(current.$bindables[0]).to.be.instanceof(Binding);
+          expect(current.$bindables[0]._observer0).be.instanceof(Observer);
+          expect(current.$bindables[0]._observer1).to.be.undefined;
+          expect(current.$bindables[0].targetObserver).to.be.instanceof(PropertyAccessor);
+
+          expect(current.$bindables[1]).to.be.instanceof(Binding);
+          expect(current.$bindables[1]._observer0).be.instanceof(SetterObserver);
+          expect(current.$bindables[1]._observer1).to.be.undefined;
+          expect(current.$bindables[1].targetObserver).to.be.instanceof(PropertyAccessor);
+
+          expect(current.$bindables[2]).to.be.instanceof(childCtor);
+          expect(current.$bindables[3]).to.be.instanceof(Binding);
+          expect(current.$bindables[3].target.nodeName).to.equal('#text');
+          expect(current.$bindables[3].targetObserver).to.be.instanceof(ElementPropertyAccessor);
+          current = current.$bindables[2];
+          break;
+        case 2:
+        case 3:
+        case 4: // foo2 -> foo3-5
+          expect(current.$bindables.length).to.equal(4);
+          expect(current.$bindables[0]).to.be.instanceof(Binding);
+          expect(current.$bindables[0]._observer0).be.instanceof(Observer);
+          expect(current.$bindables[0]._observer1).to.be.undefined;
+          expect(current.$bindables[0].targetObserver).to.be.instanceof(PropertyAccessor);
+
+          expect(current.$bindables[1]).to.be.instanceof(Binding);
+          expect(current.$bindables[1]._observer0).be.instanceof(Observer);
+          expect(current.$bindables[1]._observer1).to.be.undefined;
+          expect(current.$bindables[1].targetObserver).to.be.instanceof(PropertyAccessor);
+
+          expect(current.$bindables[2]).to.be.instanceof(childCtor);
+          expect(current.$bindables[3]).to.be.instanceof(Binding);
+          expect(current.$bindables[3].target.nodeName).to.equal('#text');
+          expect(current.$bindables[3].targetObserver).to.be.instanceof(ElementPropertyAccessor);
+          current = current.$bindables[2];
       }
-      expect(binding._observer1).to.be.undefined;
-      expect(binding.targetObserver).to.be.instanceof(PropertyAccessor);
 
-      expect(current.$bindables[1]).to.be.instanceof(childCtor);
-      expect(current.$bindables[2]).to.be.instanceof(Binding);
-      expect(current.$bindables[2].target.nodeName).to.equal('#text');
-      expect(current.$bindables[2].targetObserver).to.be.instanceof(ElementPropertyAccessor);
-      current = current.$bindables[1];
       i++;
     }
 
-    expect(current).to.be.instanceof(Foo5);
-    expect(current.value).to.equal('w00t');
-    expect(host.textContent).to.equal('      ');
+    expect(host.textContent).to.equal(' '.repeat(6));
     expect(cs.size).to.equal(6);
     const changes = cs.toArray();
     expect(changes[0]).to.be.instanceof(ElementPropertyAccessor);
@@ -628,7 +706,13 @@ describe('TemplateCompiler (integration)', () => {
     expect(changes[3]).to.be.instanceof(ElementPropertyAccessor);
     expect(changes[4]).to.be.instanceof(ElementPropertyAccessor);
     expect(changes[5]).to.be.instanceof(ElementPropertyAccessor);
+
+    component.value = 'w00t00t';
+    expect(current.value).to.equal('w00t00t');
+    expect(host.textContent).to.equal(' '.repeat(6));
+    expect(cs.size).to.equal(6);
+
     cs.flushChanges();
-    expect(host.textContent).to.equal('w00tw00tw00tw00tw00tw00t');
+    expect(host.textContent).to.equal('w00t00t'.repeat(6));
   });
 });

--- a/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/templating/template-compiler.integration.spec.ts
@@ -1,3 +1,5 @@
+import { PropertyAccessor } from './../../../../runtime/src/binding/target-accessors';
+import { Observer } from './../../../../runtime/src/binding/property-observation';
 import { IContainer, DI, PLATFORM } from '../../../../kernel/src/index';
 import { BasicConfiguration } from '../../../src/index';
 import { Aurelia, IChangeSet, CustomElementResource, valueConverter, customElement, bindable, SetterObserver, Binding } from '../../../../runtime/src/index';
@@ -554,7 +556,17 @@ describe('TemplateCompiler (integration)', () => {
       expect(current.$attachables.length).to.equal(1);
       expect(current.$attachables[0]).to.be.instanceof(childCtor);
       expect(current.$bindables.length).to.equal(2);
-      expect(current.$bindables[0]).to.be.instanceof(Binding);
+
+      const binding = current.$bindables[0];
+      expect(binding).to.be.instanceof(Binding);
+      if (i === 0) { // root component
+        expect(binding._observer0).be.instanceof(SetterObserver);
+      } else { // foo #
+        expect(binding._observer0).be.instanceof(Observer);
+      }
+      expect(binding._observer1).to.be.undefined;
+      expect(binding.targetObserver).to.be.instanceof(PropertyAccessor);
+
       expect(current.$bindables[1]).to.be.instanceof(childCtor);
       current = current.$bindables[1];
       i++;
@@ -562,5 +574,9 @@ describe('TemplateCompiler (integration)', () => {
 
     expect(current).to.be.instanceof(Foo5);
     expect(current.value).to.equal('w00t');
+
+    expect(host.textContent).to.equal(' ');
+    cs.flushChanges();
+    expect(host.textContent).to.equal('w00t');
   });
 });


### PR DESCRIPTION
@bigopon @EisenbergEffect 

I'm not sure in which scenario the flush is actually needed (is there any demo or tests to prove the situation?) because in this integration test you can see the value propagating all the way from the app to the 5th level nested custom element on startup, without a single flush..