### PR TITLE
fix(DI): alias registration param order and tests

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -129,21 +129,22 @@ export const DI = {
       };
 
       Key.register = function(container: IContainer, key?: Key<T>): IResolver<T> {
+        const trueKey = key || Key;
         return configure({
           instance(value: T): IResolver {
-            return container.registerResolver(Key, new Resolver(key || Key, ResolverStrategy.instance, value));
+            return container.registerResolver(trueKey, new Resolver(trueKey, ResolverStrategy.instance, value));
           },
           singleton(value: Function): IResolver {
-            return container.registerResolver(Key, new Resolver(key || Key, ResolverStrategy.singleton, value));
+            return container.registerResolver(trueKey, new Resolver(trueKey, ResolverStrategy.singleton, value));
           },
           transient(value: Function): IResolver {
-            return container.registerResolver(Key, new Resolver(key || Key, ResolverStrategy.transient, value));
+            return container.registerResolver(trueKey, new Resolver(trueKey, ResolverStrategy.transient, value));
           },
           callback(value: ResolveCallback): IResolver {
-            return container.registerResolver(Key, new Resolver(key || Key, ResolverStrategy.callback, value));
+            return container.registerResolver(trueKey, new Resolver(trueKey, ResolverStrategy.callback, value));
           },
           aliasTo(destinationKey: T): IResolver {
-            return container.registerResolver(destinationKey, new Resolver(key || Key, ResolverStrategy.alias, Key));
+            return container.registerResolver(trueKey, new Resolver(trueKey, ResolverStrategy.alias, destinationKey));
           },
         });
       };

--- a/packages/kernel/test/unit/di.integration.spec.ts
+++ b/packages/kernel/test/unit/di.integration.spec.ts
@@ -2,11 +2,6 @@ import { inject, DI, Registration, InterfaceSymbol, IContainer, Container } from
 import { expect } from "chai";
 import { spy } from "sinon";
 
-
-
-
-
-
 describe('DI.createInterface() -> container.get()', () => {
   let container: IContainer;
 
@@ -97,8 +92,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    // TODO: make test work
-    xit(`InterfaceSymbol alias to transient registration returns a new instance each time`, () => {
+    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, () => {
       interface IAlias{}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ITransient));
 
@@ -111,8 +105,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).not.to.equal(actual2);
     });
 
-    // TODO: make test work
-    xit(`InterfaceSymbol alias to singleton registration returns the same instance each time`, () => {
+    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, () => {
       interface IAlias{}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ISingleton));
 
@@ -125,8 +118,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).to.equal(actual2);
     });
 
-    // TODO: make test work
-    xit(`InterfaceSymbol alias to instance registration returns the same instance each time`, () => {
+    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, () => {
       interface IAlias{}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(IInstance));
 
@@ -141,7 +133,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
 
     // TODO: make test work
-    xit(`InterfaceSymbol alias to callback registration is invoked each time`, () => {
+    it(`InterfaceSymbol alias to callback registration is invoked each time`, () => {
       interface IAlias{}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ICallback));
 
@@ -151,7 +143,7 @@ describe('DI.createInterface() -> container.get()', () => {
       const actual2 = container.get(IAlias);
       expect(actual2).to.be.instanceof(Callback);
 
-      expect(callback.getCalls().length).to.equal(3);
+      expect(callback.getCalls().length).to.equal(2);
 
       expect(actual1).not.to.equal(actual2);
     });
@@ -168,9 +160,8 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).not.to.equal(actual2);
     });
 
-    // TODO: make test work
-    xit(`string alias to singleton registration returns the same instance each time`, () => {
-      container.register(Registration.alias(ITransient, 'alias'))
+    it(`string alias to singleton registration returns the same instance each time`, () => {
+      container.register(Registration.alias(ISingleton, 'alias'))
 
       const actual1 = container.get('alias');
       expect(actual1).to.be.instanceof(Singleton);
@@ -181,9 +172,8 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).to.equal(actual2);
     });
 
-    // TODO: make test work
-    xit(`string alias to instance registration returns the same instance each time`, () => {
-      container.register(Registration.alias(ITransient, 'alias'))
+    it(`string alias to instance registration returns the same instance each time`, () => {
+      container.register(Registration.alias(IInstance, 'alias'))
 
       const actual1 = container.get('alias');
       expect(actual1).to.be.instanceof(Instance);
@@ -195,9 +185,8 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual2).to.equal(instance);
     });
 
-    // TODO: make test work
-    xit(`string alias to callback registration is invoked each time`, () => {
-      container.register(Registration.alias(ITransient, 'alias'))
+    it(`string alias to callback registration is invoked each time`, () => {
+      container.register(Registration.alias(ICallback, 'alias'))
 
       const actual1 = container.get('alias');
       expect(actual1).to.be.instanceof(Callback);
@@ -205,7 +194,7 @@ describe('DI.createInterface() -> container.get()', () => {
       const actual2 = container.get('alias');
       expect(actual2).to.be.instanceof(Callback);
 
-      expect(callback.getCalls().length).to.equal(3);
+      expect(callback.getCalls().length).to.equal(2);
 
       expect(actual1).not.to.equal(actual2);
     });

--- a/packages/kernel/test/unit/di.spec.ts
+++ b/packages/kernel/test/unit/di.spec.ts
@@ -1,10 +1,9 @@
 import { Resolver, Factory, fallbackInvoker } from './../../src/di';
 import { spy } from 'sinon';
-import { DI, Container, PLATFORM, IContainer, InterfaceSymbol, IDefaultableInterfaceSymbol, ResolverStrategy, inject, all, invokeWithDynamicDependencies, lazy, classInvokers, Registration } from "../../src";
+import { DI, Container, PLATFORM, IContainer, IDefaultableInterfaceSymbol, ResolverStrategy, inject, invokeWithDynamicDependencies, classInvokers, Registration } from "../../src";
 import { expect } from "chai";
 import { _ } from "./util";
 import * as sinon from 'sinon';
-import { lazyProduct } from '../../../../scripts/test-lib';
 
 function assertIsMutableArray(arr: any[], length: number): void {
   expect(Array.isArray(arr)).to.be.true;
@@ -457,7 +456,7 @@ describe(`The DI object`, () => {
         const value = {};
         sut.withDefault(builder => builder.instance(value));
         (<any>sut).register(container, 'key');
-        expect(registerResolver).to.have.been.calledWith(sut, matchResolver('key', ResolverStrategy.instance, value));
+        expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.instance, value));
       });
 
       it(`singleton without key`, () => {
@@ -471,7 +470,7 @@ describe(`The DI object`, () => {
         class Foo {}
         sut.withDefault(builder => builder.singleton(Foo));
         (<any>sut).register(container, 'key');
-        expect(registerResolver).to.have.been.calledWith(sut, matchResolver('key', ResolverStrategy.singleton, Foo));
+        expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.singleton, Foo));
       });
 
       it(`transient without key`, () => {
@@ -485,7 +484,7 @@ describe(`The DI object`, () => {
         class Foo {}
         sut.withDefault(builder => builder.transient(Foo));
         (<any>sut).register(container, 'key');
-        expect(registerResolver).to.have.been.calledWith(sut, matchResolver('key', ResolverStrategy.transient, Foo));
+        expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.transient, Foo));
       });
 
       it(`callback without key`, () => {
@@ -499,19 +498,19 @@ describe(`The DI object`, () => {
         const callback = () => {};
         sut.withDefault(builder => builder.callback(callback));
         (<any>sut).register(container, 'key');
-        expect(registerResolver).to.have.been.calledWith(sut, matchResolver('key', ResolverStrategy.callback, callback));
+        expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.callback, callback));
       });
 
       it(`aliasTo without key`, () => {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (<any>sut).register(container);
-        expect(registerResolver).to.have.been.calledWith('key2', matchResolver(sut, ResolverStrategy.alias, sut));
+        expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.alias, 'key2'));
       });
 
       it(`aliasTo with key`, () => {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (<any>sut).register(container, 'key1');
-        expect(registerResolver).to.have.been.calledWith('key2', matchResolver('key1', ResolverStrategy.alias, sut));
+        expect(registerResolver).to.have.been.calledWith('key1', matchResolver('key1', ResolverStrategy.alias, 'key2'));
       });
     });
   });


### PR DESCRIPTION
There was a small bug in the alias registration fluent API for InterfaceSymbol and a few other minor oversights. Additionally, there were a number of errors in the tests themselves. This PR corrects all these issues and gets the full test set working with no more ignored tests.

Fixes #191