### PR TITLE
chore(view): use a more realistic cache size

### DIFF
--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -168,6 +168,7 @@ export class View implements IView {
 
 /*@internal*/
 export class ViewFactory implements IViewFactory {
+  public static maxCacheSize: number = 0xFFFF;
   public isCaching: boolean = false;
 
   private cacheSize: number = -1;
@@ -178,7 +179,7 @@ export class ViewFactory implements IViewFactory {
   public setCacheSize(size: number | '*', doNotOverrideIfAlreadySet: boolean): void {
     if (size) {
       if (size === '*') {
-        size = 0xFFFF;
+        size = ViewFactory.maxCacheSize;
       } else if (typeof size === 'string') {
         size = parseInt(size, 10);
       }

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -178,7 +178,7 @@ export class ViewFactory implements IViewFactory {
   public setCacheSize(size: number | '*', doNotOverrideIfAlreadySet: boolean): void {
     if (size) {
       if (size === '*') {
-        size = Number.MAX_VALUE;
+        size = 0xFFFF;
       } else if (typeof size === 'string') {
         size = parseInt(size, 10);
       }


### PR DESCRIPTION
@EisenbergEffect the chance that this ever matters is close to zero, but something about `Number.MAX_VALUE` just rubs me the wrong way. It's a crazy large number that can't even be displayed in non-scientific notation.
I thought about using `0xFFFFFF` instead (the max 32 bit value) because hand-wavey 32 bit integer vs 64 bit float things. But I like `0xFFFF` more. It's 65k, which may as well be unlimited, and I doubt anyone would ever utilize that much. But if they do, it's likely unintended and considering this remote possibility of some long-running app having a small memory leak this could make that small difference to prevent the memory usage from piling up to infinity. It's very tentative, I know. 
Here's an equally meaningless benchmark to give it something at least :) http://jsben.ch/IVzfI