### PR TITLE
refactor(binding-context): explicitly model scope, context and observer lookup

### DIFF
--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -1,14 +1,6 @@
-import { Reporter } from "@aurelia/kernel";
-
-export interface IOverrideContext {
-  parentOverrideContext: IOverrideContext;
-  bindingContext: any;
-}
-
-export interface IScope {
-  bindingContext: any;
-  overrideContext: IOverrideContext;
-}
+import { IIndexable, Reporter } from '@aurelia/kernel';
+import { StrictPrimitive } from './ast';
+import { BindingSourceObserver, IBindScope, ObservedCollection } from './observation';
 
 const enum RuntimeError {
   UndefinedScope = 250, // trying to evaluate on something that's not a valid binding
@@ -17,46 +9,73 @@ const enum RuntimeError {
   NilParentScope = 253
 }
 
-export const BindingContext = {
-  createScope(bindingContext: any, overrideContext?: IOverrideContext): IScope {
-    return {
-      bindingContext: bindingContext,
-      overrideContext: overrideContext || BindingContext.createOverride(bindingContext)
-    };
-  },
+export type ObserversLookup<TObj extends IIndexable = IIndexable, TKey extends keyof TObj =
+  Exclude<keyof TObj, '$synthetic' | '$observers' | 'bindingContext' | 'overrideContext' | 'parentOverrideContext'>> = Record<TKey, BindingSourceObserver> &
+  { has(key: TKey): boolean };
 
-  createScopeFromOverride(overrideContext: IOverrideContext): IScope {
-    if (overrideContext === null || overrideContext === undefined) {
-      throw Reporter.error(RuntimeError.NilOverrideContext);
+/*@internal*/
+export class InternalObserversLookup {
+  public has(key: string | number): boolean {
+    return this[key] !== undefined;
+  }
+}
+
+export interface IBindingContext {
+  [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
+  [key: number]: ObservedCollection | StrictPrimitive | IIndexable;
+
+  readonly $synthetic?: true;
+  readonly $observers?: ObserversLookup<this>;
+}
+
+export interface IOverrideContext {
+  [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
+  [key: number]: ObservedCollection | StrictPrimitive | IIndexable;
+
+  readonly $synthetic?: true;
+  readonly $observers?: ObserversLookup<this>;
+  readonly bindingContext: IBindingContext | IBindScope;
+  readonly parentOverrideContext: IOverrideContext | null;
+}
+
+export interface IScope {
+  readonly bindingContext: IBindingContext | IBindScope;
+  readonly overrideContext: IOverrideContext;
+}
+
+export class BindingContext implements IBindingContext {
+  [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
+  [key: number]: ObservedCollection | StrictPrimitive | IIndexable;
+
+  public readonly $synthetic: true = true;
+
+  public $observers: ObserversLookup<this>;
+
+  private constructor(keyOrObj?: string | IIndexable, value?: ObservedCollection | StrictPrimitive | IIndexable) {
+    if (keyOrObj !== undefined) {
+      if (value !== undefined) {
+        // if value is defined then it's just a property and a value to initialize with
+        // tslint:disable-next-line:no-any
+        this[<any>keyOrObj] = value;
+      } else {
+        // can either be some random object or another bindingContext to clone from
+        for (const prop in <IIndexable>keyOrObj) {
+          if (keyOrObj.hasOwnProperty(prop)) {
+            this[prop] = keyOrObj[prop];
+          }
+        }
+      }
     }
-    return {
-      bindingContext: overrideContext.bindingContext,
-      overrideContext
-    };
-  },
+  }
 
-  createScopeFromParent(parentScope: IScope, bindingContext: any): IScope {
-    if (parentScope === null || parentScope === undefined) {
-      throw Reporter.error(RuntimeError.NilParentScope);
-    }
-    return {
-      bindingContext: bindingContext,
-      overrideContext: BindingContext.createOverride(
-        bindingContext,
-        parentScope.overrideContext
-      )
-    };
-  },
-
-  createOverride(bindingContext?: any, parentOverrideContext?: IOverrideContext): IOverrideContext {
-    return {
-      bindingContext: bindingContext,
-      parentOverrideContext: parentOverrideContext || null
-    };
-  },
+  public static create(obj?: IIndexable): BindingContext;
+  public static create(key: string, value: ObservedCollection | StrictPrimitive | IIndexable): BindingContext;
+  public static create(keyOrObj?: string | IIndexable, value?: ObservedCollection | StrictPrimitive | IIndexable): BindingContext {
+    return new BindingContext(keyOrObj, value);
+  }
 
   // tslint:disable-next-line:no-reserved-keywords
-  get(scope: IScope, name: string, ancestor: number): any {
+  public static get(scope: IScope, name: string, ancestor: number): IBindingContext | IOverrideContext | IBindScope {
     if (scope === undefined) {
       throw Reporter.error(RuntimeError.UndefinedScope);
     }
@@ -65,15 +84,14 @@ export const BindingContext = {
     }
     let overrideContext = scope.overrideContext;
 
-    if (ancestor) {
+    if (ancestor > 0) {
       // jump up the required number of ancestor contexts (eg $parent.$parent requires two jumps)
-      while (ancestor && overrideContext) {
+      while (ancestor > 0) {
+        if (overrideContext.parentOverrideContext === null) {
+          return undefined;
+        }
         ancestor--;
         overrideContext = overrideContext.parentOverrideContext;
-      }
-
-      if (ancestor || !overrideContext) {
-        return undefined;
       }
 
       return name in overrideContext ? overrideContext : overrideContext.bindingContext;
@@ -92,4 +110,61 @@ export const BindingContext = {
     // the name wasn't found.  return the root binding context.
     return scope.bindingContext || scope.overrideContext;
   }
-};
+
+  public getObservers(): this['$observers'] {
+    let observers = this.$observers;
+    if (observers === undefined) {
+      this.$observers = observers = new InternalObserversLookup() as ObserversLookup<this>;
+    }
+    return observers;
+  }
+}
+
+export class Scope implements IScope {
+  private constructor(
+    public readonly bindingContext: IBindingContext | IBindScope,
+    public readonly overrideContext: IOverrideContext
+  ) { }
+
+  public static create(bc: IBindingContext | IBindScope, oc: IOverrideContext | null): Scope {
+    return new Scope(bc, oc === null || oc === undefined ? OverrideContext.create(bc, oc) : oc);
+  }
+
+  public static fromOverride(oc: IOverrideContext): Scope {
+    if (oc === null || oc === undefined) {
+      throw Reporter.error(RuntimeError.NilOverrideContext);
+    }
+    return new Scope(oc.bindingContext, oc);
+  }
+
+  public static fromParent(ps: IScope, bc: IBindingContext | IBindScope): Scope {
+    if (ps === null || ps === undefined) {
+      throw Reporter.error(RuntimeError.NilParentScope);
+    }
+    return new Scope(bc, OverrideContext.create(bc, ps.overrideContext));
+  }
+}
+
+export class OverrideContext implements IOverrideContext {
+  [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
+  [key: number]: ObservedCollection | StrictPrimitive | IIndexable;
+
+  public readonly $synthetic: true = true;
+
+  private constructor(
+    public readonly bindingContext: IBindingContext | IBindScope,
+    public readonly parentOverrideContext: IOverrideContext | null
+  ) { }
+
+  public static create(bc: IBindingContext | IBindScope, poc: IOverrideContext | null): OverrideContext {
+    return new OverrideContext(bc, poc === undefined ? null : poc);
+  }
+
+  public getObservers(): this['$observers'] {
+    let observers = this.$observers;
+    if (observers === undefined) {
+      this.$observers = observers = new InternalObserversLookup() as ObserversLookup<this>;
+    }
+    return observers;
+  }
+}

--- a/packages/runtime/src/binding/observation.ts
+++ b/packages/runtime/src/binding/observation.ts
@@ -45,6 +45,8 @@ export interface IBindingTargetObserver<
   unbind?(flags: BindingFlags): void;
 }
 
+export type BindingSourceObserver = PropertyObserver | CollectionObserver;
+
 export type AccessorOrObserver = IBindingTargetAccessor | IBindingTargetObserver;
 
 export type IObservable = (IIndexable | string | Node | INode | Collection) & {

--- a/packages/runtime/src/binding/observation.ts
+++ b/packages/runtime/src/binding/observation.ts
@@ -45,11 +45,10 @@ export interface IBindingTargetObserver<
   unbind?(flags: BindingFlags): void;
 }
 
-export type BindingSourceObserver = PropertyObserver | CollectionObserver;
-
 export type AccessorOrObserver = IBindingTargetAccessor | IBindingTargetObserver;
 
 export type IObservable = (IIndexable | string | Node | INode | Collection) & {
+  readonly $synthetic?: false;
   $observers?: Record<string, AccessorOrObserver>;
 };
 

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -1,17 +1,18 @@
 import { DI, IIndexable, inject, Primitive, Reporter } from '@aurelia/kernel';
 import { DOM } from '../dom';
 import { getArrayObserver } from './array-observer';
+import { IBindingContext, IOverrideContext } from './binding-context';
 import { IChangeSet } from './change-set';
 import { createComputedObserver } from './computed-observer';
 import { IDirtyChecker } from './dirty-checker';
 import { CheckedObserver, SelectValueObserver, ValueAttributeObserver } from './element-observation';
 import { IEventManager } from './event-manager';
 import { getMapObserver } from './map-observer';
-import { AccessorOrObserver, CollectionKind, IBindingTargetAccessor, IBindingTargetObserver, ICollectionObserver, IObservable, IObservedArray, IObservedMap, IObservedSet, CollectionObserver } from './observation';
+import { AccessorOrObserver, CollectionKind, CollectionObserver, IBindingTargetAccessor, IBindingTargetObserver, ICollectionObserver, IObservable, IObservedArray, IObservedMap, IObservedSet } from './observation';
 import { PrimitiveObserver, SetterObserver } from './property-observation';
 import { getSetObserver } from './set-observer';
 import { ISVGAnalyzer } from './svg-analyzer';
-import { ClassAttributeAccessor, DataAttributeAccessor, PropertyAccessor, StyleAttributeAccessor, XLinkAttributeAccessor, ElementPropertyAccessor } from './target-accessors';
+import { ClassAttributeAccessor, DataAttributeAccessor, ElementPropertyAccessor, PropertyAccessor, StyleAttributeAccessor, XLinkAttributeAccessor } from './target-accessors';
 
 const toStringTag = Object.prototype.toString;
 
@@ -56,7 +57,10 @@ export class ObserverLocator implements IObserverLocator {
     private svgAnalyzer: ISVGAnalyzer
   ) {}
 
-  public getObserver(obj: IObservable, propertyName: string): AccessorOrObserver {
+  public getObserver(obj: IObservable | IBindingContext | IOverrideContext, propertyName: string): AccessorOrObserver {
+    if (obj.$synthetic === true) {
+      return obj.getObservers().getOrCreate(obj, propertyName);
+    }
     let observersLookup = obj.$observers;
     let observer;
 

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -1,5 +1,4 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
-import { nativePush, nativeSplice } from './array-observer';
 import { BindingFlags } from './binding-flags';
 import { IBatchedCollectionSubscriber, IBatchedSubscriberCollection, IndexMap, IPropertySubscriber, ISubscriberCollection, MutationKind, MutationKindToBatchedSubscriber, MutationKindToSubscriber, SubscriberFlags } from './observation';
 
@@ -46,7 +45,7 @@ function addSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>, s
     this._subscriberFlags |= SubscriberFlags.SubscribersRest;
     return true;
   }
-  nativePush.call(this._subscribersRest, subscriber);
+  this._subscribersRest.push(subscriber);
   return true;
 }
 
@@ -71,7 +70,7 @@ function removeSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>
     const subscribers = this._subscribersRest;
     for (let i = 0, ii = subscribers.length; i < ii; ++i) {
       if (subscribers[i] === subscriber) {
-        nativeSplice.call(subscribers, i, 1);
+        subscribers.splice(i, 1);
         if (ii === 1) {
           this._subscriberFlags &= ~SubscriberFlags.SubscribersRest;
         }
@@ -223,7 +222,7 @@ function addBatchedSubscriber(this: IBatchedSubscriberCollection<MutationKind.co
     this._batchedSubscriberFlags |= SubscriberFlags.SubscribersRest;
     return true;
   }
-  nativePush.call(this._batchedSubscribersRest, subscriber);
+  this._batchedSubscribersRest.push(subscriber);
   return true;
 }
 
@@ -248,7 +247,7 @@ function removeBatchedSubscriber(this: IBatchedSubscriberCollection<MutationKind
     const subscribers = this._batchedSubscribersRest;
     for (let i = 0, ii = subscribers.length; i < ii; ++i) {
       if (subscribers[i] === subscriber) {
-        nativeSplice.call(subscribers, i, 1);
+        subscribers.splice(i, 1);
         if (ii === 1) {
           this._batchedSubscriberFlags &= ~SubscriberFlags.SubscribersRest;
         }

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -8,7 +8,7 @@ import {
   Reporter,
   Writable
 } from '@aurelia/kernel';
-import { BindingContext } from '../binding/binding-context';
+import { BindingContext, Scope } from '../binding/binding-context';
 import { BindingFlags } from '../binding/binding-flags';
 import { DOM, ICustomElementHost, INode, INodeSequence, IRenderLocation } from '../dom';
 import { IResourceKind, IResourceType } from '../resource';
@@ -145,7 +145,7 @@ function hydrate(this: IInternalCustomElementImplementation, renderingEngine: IR
   this.$attachables = [];
   this.$isAttached = false;
   this.$isBound = false;
-  this.$scope = BindingContext.createScope(this);
+  this.$scope = Scope.create(this, null); // TODO: get the parent from somewhere?
   this.$projector = determineProjector(this, host, description);
 
   renderingEngine.applyRuntimeBehavior(Type, this);

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -1,5 +1,5 @@
 import { inject } from '@aurelia/kernel';
-import { Binding, BindingContext, BindingFlags, CollectionObserver, ForOfStatement, getCollectionObserver, IBatchedCollectionSubscriber, IChangeSet, IObservedArray, IScope, ObservedCollection, SetterObserver } from '../../binding';
+import { Binding, BindingContext, BindingFlags, CollectionObserver, ForOfStatement, getCollectionObserver, IBatchedCollectionSubscriber, IChangeSet, IObservedArray, IScope, ObservedCollection, SetterObserver, Scope } from '../../binding';
 import { INode, IRenderLocation } from '../../dom';
 import { bindable } from '../bindable';
 import { ICustomAttribute, templateController } from '../custom-attribute';
@@ -113,18 +113,18 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
         forOf.iterate(items, (arr, i, item) => {
           const view = views[i];
           if (!!view.$scope && view.$scope.bindingContext[local] === item) {
-            view.$bind(flags, BindingContext.createScopeFromParent($scope, view.$scope.bindingContext));
+            view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));
           } else {
-            view.$bind(flags, BindingContext.createScopeFromParent($scope, { [local]: item }))
+            view.$bind(flags, Scope.fromParent($scope, BindingContext.create(local, item)));
           }
         });
       } else {
         forOf.iterate(items, (arr, i, item) => {
           const view = views[i];
           if (indexMap[i] === i) {
-            view.$bind(flags, BindingContext.createScopeFromParent($scope, view.$scope.bindingContext));
+            view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));
           } else {
-            view.$bind(flags, BindingContext.createScopeFromParent($scope, { [local]: item }))
+            view.$bind(flags, Scope.fromParent($scope, BindingContext.create(local, item)));
           }
         });
       }

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -1,5 +1,5 @@
 import { inject } from '@aurelia/kernel';
-import { BindingContext, IScope } from '../../binding/binding-context';
+import { BindingContext, IScope, Scope } from '../../binding/binding-context';
 import { BindingFlags } from '../../binding/binding-flags';
 import { IRenderLocation } from '../../dom';
 import { bindable } from '../bindable';
@@ -43,7 +43,7 @@ export class With {
   private bindChild(flags: BindingFlags): void {
     this.currentView.$bind(
       flags,
-      BindingContext.createScopeFromParent(this.$scope, this.value)
+      Scope.fromParent(this.$scope, this.value)
     );
   }
 }

--- a/packages/runtime/test/unit/binding/ast.spec.ts
+++ b/packages/runtime/test/unit/binding/ast.spec.ts
@@ -14,7 +14,7 @@ import {
   IScope, isPureLiteral, Binding, ObserverLocator, ChangeSet,
   connects, HtmlLiteral, ArrayBindingPattern, ObjectBindingPattern,
   BindingIdentifier, ForOfStatement, Interpolation, observes, callsFunction,
-  hasAncestor, isAssignable, isLeftHandSide, isPrimary, isResource, hasBind, hasUnbind, isLiteral, ExpressionKind, ISignaler
+  hasAncestor, isAssignable, isLeftHandSide, isPrimary, isResource, hasBind, hasUnbind, isLiteral, ExpressionKind, ISignaler, Scope, OverrideContext
 } from '../../../src/index';
 import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
@@ -1152,36 +1152,36 @@ describe('AccessScope', () => {
   });
 
   it('evaluates undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     expect(foo.evaluate(0, scope, null)).to.be.undefined;
   });
 
   it('assigns undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     foo.assign(0, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
   it('connects undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     (<any>binding.observeProperty).resetHistory();
     foo.connect(0, scope, <any>binding);
     expect(binding.observeProperty).to.have.been.calledWith(scope.overrideContext, 'foo');
   });
 
   it('evaluates null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     expect(foo.evaluate(0, scope, null)).to.be.undefined;
   });
 
   it('assigns null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     foo.assign(0, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
   it('connects null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     (<any>binding.observeProperty).resetHistory();
     foo.connect(0, scope, <any>binding);
     expect(binding.observeProperty).to.have.been.calledWith(scope.overrideContext, 'foo');
@@ -1292,7 +1292,7 @@ describe('AccessScope', () => {
 
   it('connects undefined property on first ancestor bindingContext', () => {
     const scope: any = createScopeForTest({ abc: 'xyz' }, {});
-    scope.overrideContext.parentOverrideContext.parentOverrideContext = BindingContext.createOverride({ foo: 'bar' });
+    scope.overrideContext.parentOverrideContext.parentOverrideContext = OverrideContext.create({ foo: 'bar' }, null);
     (<any>binding.observeProperty).resetHistory();
     $parentfoo.connect(0, scope, <any>binding);
     expect(binding.observeProperty).to.have.been.calledWith(scope.overrideContext.parentOverrideContext.bindingContext, 'foo');
@@ -1309,75 +1309,75 @@ describe('AccessThis', () => {
   });
 
   it('evaluates undefined bindingContext', () => {
-    const coc = BindingContext.createOverride;
+    const coc = OverrideContext.create;
 
-    let scope = { overrideContext: coc(undefined) };
+    let scope = { overrideContext: coc(undefined, null) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(undefined, coc(undefined)) };
+    scope = { overrideContext: coc(undefined, coc(undefined, null)) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(undefined, coc(undefined, coc(undefined))) };
+    scope = { overrideContext: coc(undefined, coc(undefined, coc(undefined, null))) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(undefined, coc(undefined, coc(undefined, coc(undefined)))) };
+    scope = { overrideContext: coc(undefined, coc(undefined, coc(undefined, coc(undefined, null)))) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
   });
 
   it('evaluates null bindingContext', () => {
-    const coc = BindingContext.createOverride;
+    const coc = OverrideContext.create;
 
-    let scope = { overrideContext: coc(null) };
+    let scope = { overrideContext: coc(null, null) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(null, coc(null)) };
+    scope = { overrideContext: coc(null, coc(null, null)) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(null);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(null, coc(null, coc(null))) };
+    scope = { overrideContext: coc(null, coc(null, coc(null, null))) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(null);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.equal(null);
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(null, coc(null, coc(null, coc(null)))) };
+    scope = { overrideContext: coc(null, coc(null, coc(null, coc(null, null)))) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(null);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.equal(null);
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.equal(null);
   });
 
   it('evaluates defined bindingContext', () => {
-    const coc = BindingContext.createOverride;
+    const coc = OverrideContext.create;
     const a = { a: 'a' };
     const b = { b: 'b' };
     const c = { c: 'c' };
     const d = { d: 'd' };
-    let scope = { overrideContext: coc(a) };
+    let scope = { overrideContext: coc(a, null) };
     expect($parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(a, coc(b)) };
+    scope = { overrideContext: coc(a, coc(b, null)) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(b);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(a, coc(b, coc(c))) };
+    scope = { overrideContext: coc(a, coc(b, coc(c, null))) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(b);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.equal(c);
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.be.undefined;
 
-    scope = { overrideContext: coc(a, coc(b, coc(c, coc(d)))) };
+    scope = { overrideContext: coc(a, coc(b, coc(c, coc(d, null)))) };
     expect($parent.evaluate(0, <any>scope, null)).to.equal(b);
     expect($parent$parent.evaluate(0, <any>scope, null)).to.equal(c);
     expect($parent$parent$parent.evaluate(0, <any>scope, null)).to.equal(d);
@@ -1387,7 +1387,7 @@ describe('AccessThis', () => {
 describe('Assign', () => {
   it('can chain assignments', () => {
     const foo = new Assign(new AccessScope('foo', 0), new AccessScope('bar', 0));
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     foo.assign(0, scope, <any>null, <any>1);
     expect(scope.overrideContext.foo).to.equal(1);
     expect(scope.overrideContext.bar).to.equal(1);
@@ -1611,20 +1611,20 @@ describe('CallScope', () => {
   });
 
   it('evaluates undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     expect(foo.evaluate(0, scope, null)).to.be.undefined;
     expect(hello.evaluate(0, scope, null)).to.be.undefined;
   });
 
   it('throws when mustEvaluate and evaluating undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(BindingFlags.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(BindingFlags.mustEvaluate, scope, null)).to.throw();
   });
 
   it('connects undefined bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(undefined) };
+    const scope: any = Scope.create(undefined, null);
     (<any>binding.observeProperty).resetHistory();
     foo.connect(0, scope, <any>binding);
     expect(binding.observeProperty.callCount).to.equal(0);
@@ -1633,20 +1633,20 @@ describe('CallScope', () => {
   });
 
   it('evaluates null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     expect(foo.evaluate(0, scope, null)).to.be.undefined;
     expect(hello.evaluate(0, scope, null)).to.be.undefined;
   });
 
   it('throws when mustEvaluate and evaluating null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(BindingFlags.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(BindingFlags.mustEvaluate, scope, null)).to.throw();
   });
 
   it('connects null bindingContext', () => {
-    const scope: any = { overrideContext: BindingContext.createOverride(null), bindingContext: null };
+    const scope: any = Scope.create(null, null);
     (<any>binding.observeProperty).resetHistory();
     foo.connect(0, scope, <any>binding);
     expect(binding.observeProperty.callCount).to.equal(0);
@@ -1929,7 +1929,7 @@ describe('BindingBehavior', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value });
+          const scope = Scope.create({ foo: value }, null);
           return [`foo&mock`, scope, sut, mock, locator, binding, value, []];
         },
         // test with 1 argument
@@ -1946,7 +1946,7 @@ describe('BindingBehavior', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value, a: arg1 });
+          const scope = Scope.create({ foo: value, a: arg1 }, null);
           return [`foo&mock:a`, scope, sut, mock, locator, binding, value, [arg1]];
         },
         // test with 3 arguments
@@ -1969,7 +1969,7 @@ describe('BindingBehavior', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value, a: arg1, b: arg2, c: arg3 });
+          const scope = Scope.create({ foo: value, a: arg1, b: arg2, c: arg3 }, null);
           return [`foo&mock:a:b:c`, scope, sut, mock, locator, binding, value, [arg1, arg2, arg3]];
         }
       ],
@@ -2201,7 +2201,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value });
+          const scope = Scope.create({ foo: value }, null);
           return [`foo|mock`, scope, sut, mock, locator, binding, value, [], methods];
         },
         // test without arguments, no fromView
@@ -2218,7 +2218,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value });
+          const scope = Scope.create({ foo: value }, null);
           return [`foo|mock`, scope, sut, mock, locator, binding, value, [], methods];
         },
         // test without arguments, no toView
@@ -2235,7 +2235,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value });
+          const scope = Scope.create({ foo: value }, null);
           return [`foo|mock`, scope, sut, mock, locator, binding, value, [], methods];
         },
         // test without arguments
@@ -2252,7 +2252,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value });
+          const scope = Scope.create({ foo: value }, null);
           return [`foo|mock`, scope, sut, mock, locator, binding, value, [], methods];
         },
         // test with 1 argument
@@ -2270,7 +2270,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value, a: arg1 });
+          const scope = Scope.create({ foo: value, a: arg1 }, null);
           return [`foo|mock:a`, scope, sut, mock, locator, binding, value, [arg1], methods];
         },
         // test with 3 arguments
@@ -2294,7 +2294,7 @@ describe('ValueConverter', () => {
           const observerLocator = new ObserverLocator(new ChangeSet(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
-          const scope = BindingContext.createScope({ foo: value, a: arg1, b: arg2, c: arg3 });
+          const scope = Scope.create({ foo: value, a: arg1, b: arg2, c: arg3 }, null);
           return [`foo|mock:a:b:c`, scope, sut, mock, locator, binding, value, [arg1, arg2, arg3], methods];
         }
       ],

--- a/packages/runtime/test/unit/binding/binding-context.spec.ts
+++ b/packages/runtime/test/unit/binding/binding-context.spec.ts
@@ -1,10 +1,10 @@
-import { BindingContext } from "../../../src/index";
+import { BindingContext, Scope, OverrideContext } from "../../../src/index";
 import { expect } from 'chai';
 
-describe('BindingContext', () => {
-  describe('createScope', () => {
+describe('Scope', () => {
+  describe('create', () => {
     it('undefined, undefined', () => {
-      const actual = BindingContext.createScope(undefined, undefined);
+      const actual = Scope.create(undefined, undefined);
       expect(actual.bindingContext).to.be.undefined;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -12,7 +12,7 @@ describe('BindingContext', () => {
     });
 
     it('undefined, null', () => {
-      const actual = BindingContext.createScope(undefined, null);
+      const actual = Scope.create(undefined, null);
       expect(actual.bindingContext).to.be.undefined;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -21,7 +21,7 @@ describe('BindingContext', () => {
 
     it('undefined, {}', () => {
       const overrideContext = {} as any;
-      const actual = BindingContext.createScope(undefined, overrideContext);
+      const actual = Scope.create(undefined, overrideContext);
       expect(actual.bindingContext).to.be.undefined;
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -31,7 +31,7 @@ describe('BindingContext', () => {
     it('undefined, { bindingContext }', () => {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
-      const actual = BindingContext.createScope(null, overrideContext);
+      const actual = Scope.create(null, overrideContext);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -39,7 +39,7 @@ describe('BindingContext', () => {
     });
 
     it('null, undefined', () => {
-      const actual = BindingContext.createScope(null, undefined);
+      const actual = Scope.create(null, undefined);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.null;
@@ -47,7 +47,7 @@ describe('BindingContext', () => {
     });
 
     it('null, null', () => {
-      const actual = BindingContext.createScope(null, null);
+      const actual = Scope.create(null, null);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.null;
@@ -56,7 +56,7 @@ describe('BindingContext', () => {
 
     it('null, {}', () => {
       const overrideContext = {} as any;
-      const actual = BindingContext.createScope(null, overrideContext);
+      const actual = Scope.create(null, overrideContext);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -66,7 +66,7 @@ describe('BindingContext', () => {
     it('null, { bindingContext }', () => {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
-      const actual = BindingContext.createScope(null, overrideContext);
+      const actual = Scope.create(null, overrideContext);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -75,7 +75,7 @@ describe('BindingContext', () => {
 
     it('{}, undefined', () => {
       const bindingContext = {} as any;
-      const actual = BindingContext.createScope(bindingContext, undefined);
+      const actual = Scope.create(bindingContext, undefined);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -84,7 +84,7 @@ describe('BindingContext', () => {
 
     it('{}, null', () => {
       const bindingContext = {} as any;
-      const actual = BindingContext.createScope(bindingContext, null);
+      const actual = Scope.create(bindingContext, null);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -94,7 +94,7 @@ describe('BindingContext', () => {
     it('{}, {}', () => {
       const bindingContext = {} as any;
       const overrideContext = {} as any;
-      const actual = BindingContext.createScope(bindingContext, overrideContext);
+      const actual = Scope.create(bindingContext, overrideContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -104,7 +104,7 @@ describe('BindingContext', () => {
     it('{}, { bindingContext }', () => {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
-      const actual = BindingContext.createScope(bindingContext, overrideContext);
+      const actual = Scope.create(bindingContext, overrideContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -115,7 +115,7 @@ describe('BindingContext', () => {
       const bindingContext = {} as any;
       const bindingContext2 = {} as any;
       const overrideContext = { bindingContext: bindingContext2 } as any;
-      const actual = BindingContext.createScope(bindingContext, overrideContext);
+      const actual = Scope.create(bindingContext, overrideContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext2);
@@ -123,18 +123,18 @@ describe('BindingContext', () => {
     });
   });
 
-  describe('createScopeFromOverride', () => {
+  describe('fromOverride', () => {
     it('undefined', () => {
-      expect(() => BindingContext.createScopeFromOverride(undefined)).to.throw('Code 252');
+      expect(() => Scope.fromOverride(undefined)).to.throw('Code 252');
     });
 
     it('null', () => {
-      expect(() => BindingContext.createScopeFromOverride(null)).to.throw('Code 252');
+      expect(() => Scope.fromOverride(null)).to.throw('Code 252');
     });
 
     it('{}', () => {
       const overrideContext = {} as any;
-      const actual = BindingContext.createScopeFromOverride(overrideContext);
+      const actual = Scope.fromOverride(overrideContext);
       expect(actual.bindingContext).to.be.undefined;
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -144,7 +144,7 @@ describe('BindingContext', () => {
     it('{ bindingContext }', () => {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
-      const actual = BindingContext.createScopeFromOverride(overrideContext);
+      const actual = Scope.fromOverride(overrideContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.equal(overrideContext);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -152,18 +152,18 @@ describe('BindingContext', () => {
     });
   });
 
-  describe('createScopeFromParent', () => {
+  describe('fromParent', () => {
     it('undefined', () => {
-      expect(() => BindingContext.createScopeFromParent(undefined, {})).to.throw('Code 253');
+      expect(() => Scope.fromParent(undefined, {})).to.throw('Code 253');
     });
 
     it('null', () => {
-      expect(() => BindingContext.createScopeFromParent(null, {})).to.throw('Code 253');
+      expect(() => Scope.fromParent(null, {})).to.throw('Code 253');
     });
 
     it('{}, undefined', () => {
       const parentScope = {} as any;
-      const actual = BindingContext.createScopeFromParent(parentScope, undefined);
+      const actual = Scope.fromParent(parentScope, undefined);
       expect(actual.bindingContext).to.be.undefined;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.undefined;
@@ -172,7 +172,7 @@ describe('BindingContext', () => {
 
     it('{}, null', () => {
       const parentScope = {} as any;
-      const actual = BindingContext.createScopeFromParent(parentScope, null);
+      const actual = Scope.fromParent(parentScope, null);
       expect(actual.bindingContext).to.be.null;
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.be.null;
@@ -182,7 +182,7 @@ describe('BindingContext', () => {
     it('{}, {}', () => {
       const parentScope = {} as any;
       const bindingContext = {} as any;
-      const actual = BindingContext.createScopeFromParent(parentScope, bindingContext);
+      const actual = Scope.fromParent(parentScope, bindingContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
@@ -193,14 +193,16 @@ describe('BindingContext', () => {
       const overrideContext = {} as any;
       const parentScope = { overrideContext } as any;
       const bindingContext = {} as any;
-      const actual = BindingContext.createScopeFromParent(parentScope, bindingContext);
+      const actual = Scope.fromParent(parentScope, bindingContext);
       expect(actual.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext).to.be.instanceof(Object);
       expect(actual.overrideContext.bindingContext).to.equal(bindingContext);
       expect(actual.overrideContext.parentOverrideContext).to.equal(overrideContext);
     });
   });
+});
 
+describe('BindingContext', () => {
   describe('get', () => {
     it('undefined', () => {
       expect(() => BindingContext.get(undefined, undefined, undefined)).to.throw('Code 250');
@@ -273,8 +275,8 @@ describe('BindingContext', () => {
     it('1 ancestor, null, null', () => {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       const actual = BindingContext.get(scope2, null, null);
       expect(actual).to.equal(bindingContext2);
     });
@@ -283,9 +285,9 @@ describe('BindingContext', () => {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       const actual = BindingContext.get(scope3, null, null);
       expect(actual).to.equal(bindingContext3);
     });
@@ -295,10 +297,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, null, null);
       expect(actual).to.equal(bindingContext4);
     });
@@ -306,8 +308,8 @@ describe('BindingContext', () => {
     it('1 ancestor, \'foo\', null', () => {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       const actual = BindingContext.get(scope2, 'foo', null);
       expect(actual).to.equal(bindingContext2);
     });
@@ -316,9 +318,9 @@ describe('BindingContext', () => {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       const actual = BindingContext.get(scope3, 'foo', null);
       expect(actual).to.equal(bindingContext3);
     });
@@ -328,10 +330,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext4);
     });
@@ -341,10 +343,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext1);
     });
@@ -354,10 +356,10 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext2);
     });
@@ -367,10 +369,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext3);
     });
@@ -380,10 +382,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext4);
     });
@@ -393,11 +395,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope1.overrideContext);
     });
@@ -407,11 +409,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope2.overrideContext);
     });
@@ -421,11 +423,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope3.overrideContext);
     });
@@ -435,10 +437,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       scope4.overrideContext['foo'] = 'bar';
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope4.overrideContext);
@@ -449,11 +451,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope1.overrideContext);
     });
@@ -463,11 +465,11 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope2.overrideContext);
     });
@@ -477,11 +479,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope3.overrideContext);
     });
@@ -491,10 +493,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       scope4.overrideContext['foo'] = 'bar';
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(scope4.overrideContext);
@@ -505,11 +507,11 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext2);
     });
@@ -519,11 +521,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext3);
     });
@@ -533,11 +535,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', null);
       expect(actual).to.equal(bindingContext4);
     });
@@ -547,11 +549,11 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 1);
       expect(actual).to.equal(scope3.bindingContext);
     });
@@ -561,11 +563,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 1);
       expect(actual).to.equal(bindingContext3);
     });
@@ -575,11 +577,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 1);
       expect(actual).to.equal(scope3.overrideContext);
     });
@@ -589,11 +591,11 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 2);
       expect(actual).to.equal(bindingContext2);
     });
@@ -603,11 +605,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 2);
       expect(actual).to.equal(scope2.overrideContext);
     });
@@ -617,11 +619,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 2);
       expect(actual).to.equal(bindingContext2);
     });
@@ -631,11 +633,11 @@ describe('BindingContext', () => {
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
+      const scope1 = Scope.create(bindingContext1, null);
       scope1.overrideContext['foo'] = 'bar';
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 3);
       expect(actual).to.equal(scope1.overrideContext);
     });
@@ -645,11 +647,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
       scope2.overrideContext['foo'] = 'bar';
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 3);
       expect(actual).to.equal(bindingContext1);
     });
@@ -659,11 +661,11 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = { foo: 'bar' } as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
       scope3.overrideContext['foo'] = 'bar';
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 3);
       expect(actual).to.equal(bindingContext1);
     });
@@ -673,10 +675,10 @@ describe('BindingContext', () => {
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
       const bindingContext4 = {} as any;
-      const scope1 = BindingContext.createScope(bindingContext1);
-      const scope2 = BindingContext.createScopeFromParent(scope1, bindingContext2);
-      const scope3 = BindingContext.createScopeFromParent(scope2, bindingContext3);
-      const scope4 = BindingContext.createScopeFromParent(scope3, bindingContext4);
+      const scope1 = Scope.create(bindingContext1, null);
+      const scope2 = Scope.fromParent(scope1, bindingContext2);
+      const scope3 = Scope.fromParent(scope2, bindingContext3);
+      const scope4 = Scope.fromParent(scope3, bindingContext4);
       const actual = BindingContext.get(scope4, 'foo', 4);
       expect(actual).to.be.undefined;
     });

--- a/packages/runtime/test/unit/binding/binding.spec.ts
+++ b/packages/runtime/test/unit/binding/binding.spec.ts
@@ -1,4 +1,4 @@
-import { BindingContext } from './../../../src/binding/binding-context';
+import { BindingContext, Scope } from './../../../src/binding/binding-context';
 import { spy, SinonSpy } from 'sinon';
 import { AccessMember, PrimitiveLiteral, IExpression, ExpressionKind, IBindingTargetObserver, Binding, IBindingTarget, IObserverLocator, AccessScope, BindingMode, BindingFlags, IScope, IChangeSet, SubscriberFlags, IPropertySubscriber, IPropertyChangeNotifier, SetterObserver, ObjectLiteral, PropertyAccessor, BindingType } from '../../../src/index';
 import { DI } from '../../../../kernel/src/index';
@@ -29,7 +29,7 @@ describe('Binding', () => {
   let dummyTargetProperty: string;
   let dummyMode: BindingMode;
 
-  function setup(sourceExpression: IExpression = dummySourceExpression, target: any = dummyTarget, targetProperty: string = dummyTargetProperty, mode: BindingMode = dummyMode) {
+  function setup(sourceExpression: any = dummySourceExpression, target: any = dummyTarget, targetProperty: string = dummyTargetProperty, mode: BindingMode = dummyMode) {
     const container = DI.createContainer();
     const changeSet = container.get<IChangeSet>(IChangeSet);
     const observerLocator = container.get<IObserverLocator>(IObserverLocator);
@@ -83,7 +83,7 @@ describe('Binding', () => {
     const observerLocator = container.get<IObserverLocator>(IObserverLocator);
     const target = {val: 0};
     const sut = new Binding(<any>expr, target, 'val', BindingMode.toView, observerLocator, container);
-    const scope = BindingContext.createScope(ctx);
+    const scope = Scope.create(ctx, null);
 
     sut.$bind(BindingFlags.fromBind, scope);
 
@@ -99,7 +99,7 @@ describe('Binding', () => {
     for (let i = 0; i < count; ++i) {
       ctx2[args[i]] = 3;
     }
-    const scope2 = BindingContext.createScope(ctx2);
+    const scope2 = Scope.create(ctx2, null);
 
     sut.$bind(BindingFlags.fromBind, scope2);
 

--- a/packages/runtime/test/unit/binding/let-binding.spec.ts
+++ b/packages/runtime/test/unit/binding/let-binding.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { DI, IContainer } from '../../../../kernel/src/index';
 import { LetBinding } from '../../../src/binding/let-binding';
-import { BindingContext, BindingFlags, BindingMode, ExpressionKind, IBindingTarget, IExpression, IObserverLocator, IScope } from '../../../src/index';
+import { BindingContext, BindingFlags, BindingMode, ExpressionKind, IBindingTarget, IExpression, IObserverLocator, IScope, Scope } from '../../../src/index';
 import { MockExpression } from '../mock';
 
 const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
@@ -40,7 +40,7 @@ describe('LetBinding', () => {
     it('does not change target if scope was not changed', () => {
       const vm = {};
       const sourceExpression = new MockExpression();
-      const scope = BindingContext.createScope(vm);
+      const scope = Scope.create(vm, null);
       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
       sut.$bind(BindingFlags.none, scope);
       const target = sut.target;
@@ -52,7 +52,7 @@ describe('LetBinding', () => {
       const vm = { vm: 5 };
       const sourceExpression = new MockExpression();
       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
-      sut.$bind(BindingFlags.none, BindingContext.createScope(vm));
+      sut.$bind(BindingFlags.none, Scope.create(vm, null));
       expect(sut.target).to.equal(vm, 'It should have used bindingContext to create target.');
     });
 
@@ -61,7 +61,7 @@ describe('LetBinding', () => {
       const view = { view: 6 };
       const sourceExpression = new MockExpression();
       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container);
-      sut.$bind(BindingFlags.none, BindingContext.createScope(vm, <any>view));
+      sut.$bind(BindingFlags.none, Scope.create(vm, <any>view));
       expect(sut.target).to.equal(view, 'It should have used overrideContext to create target.');
     });
   });
@@ -71,7 +71,7 @@ describe('LetBinding', () => {
       const vm = { vm: 5, foo: false };
       const sourceExpression = new MockExpression();
       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
-      sut.$bind(BindingFlags.none, BindingContext.createScope(vm));
+      sut.$bind(BindingFlags.none, Scope.create(vm, null));
       vm.foo = true;
       expect(sourceExpression.connect).to.have.been.callCount(1);
     });

--- a/packages/runtime/test/unit/binding/shared.ts
+++ b/packages/runtime/test/unit/binding/shared.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { BindingContext, IScope, IObserverLocator } from '../../../src/index';
+import { BindingContext, IScope, IObserverLocator, Scope, OverrideContext } from '../../../src/index';
 import { DI, IContainer } from '../../../../kernel/src/index';
 
 export const checkDelay = 20;
@@ -12,15 +12,9 @@ export function createObserverLocator(container: IContainer = DI.createContainer
 
 export function createScopeForTest(bindingContext: any, parentBindingContext?: any): IScope {
   if (parentBindingContext) {
-    return {
-      bindingContext,
-      overrideContext: BindingContext.createOverride(bindingContext, BindingContext.createOverride(parentBindingContext))
-    };
+    return Scope.create(bindingContext, OverrideContext.create(bindingContext, OverrideContext.create(parentBindingContext, null)));
   }
-  return {
-    bindingContext,
-    overrideContext: BindingContext.createOverride(bindingContext)
-  };
+  return Scope.create(bindingContext, OverrideContext.create(bindingContext, null));
 }
 
 

--- a/packages/runtime/test/unit/mock.ts
+++ b/packages/runtime/test/unit/mock.ts
@@ -46,7 +46,8 @@ import {
   INode,
   ExpressionKind,
   IBinding,
-  ISignaler
+  ISignaler,
+  Scope
 } from '../../src';
 import { spy } from 'sinon';
 
@@ -75,7 +76,7 @@ export class MockCustomElement implements ICustomElement {
     this.$attachables = [];
     this.$isAttached = false;
     this.$isBound = false;
-    this.$scope = BindingContext.createScope(this);
+    this.$scope = Scope.create(this, null);
 
     this.$context = createMockRenderContext(renderingEngine, <ExposedContext>renderingEngine['container'], PLATFORM.emptyArray);
     const template = new MockTemplate(renderingEngine, <ExposedContext>renderingEngine['container'], description)
@@ -357,8 +358,8 @@ export class MockTemplate implements ITemplate {
 
 export class MockTextNodeTemplate {
   constructor(
-    public sourceExpression: IExpression,
-    public observerLocator: IObserverLocator
+    public sourceExpression: any,
+    public observerLocator: any
   ) {}
 
   public createFor(renderable: { $bindables: IBindScope[] }): MockTextNodeSequence {
@@ -376,9 +377,9 @@ const expressions = {
 
 export class MockIfTextNodeTemplate {
   constructor(
-    public sourceExpression: IExpression,
-    public observerLocator: IObserverLocator,
-    public changeSet: IChangeSet
+    public sourceExpression: any,
+    public observerLocator: any,
+    public changeSet: any
   ) {}
 
   public createFor(renderable: IView): MockNodeSequence {
@@ -405,9 +406,9 @@ export class MockIfTextNodeTemplate {
 
 export class MockElseTextNodeTemplate {
   constructor(
-    public sourceExpression: IExpression,
-    public observerLocator: IObserverLocator,
-    public changeSet: IChangeSet
+    public sourceExpression: any,
+    public observerLocator: any,
+    public changeSet: any
   ) {}
 
   public createFor(renderable: IView): MockNodeSequence {
@@ -436,9 +437,9 @@ export class MockElseTextNodeTemplate {
 
 export class MockIfElseTextNodeTemplate {
   constructor(
-    public sourceExpression: IExpression,
-    public observerLocator: IObserverLocator,
-    public changeSet: IChangeSet
+    public sourceExpression: any,
+    public observerLocator: any,
+    public changeSet: any
   ) {}
 
   public createFor(renderable: IView): MockNodeSequence {

--- a/packages/runtime/test/unit/templating/scope-assistance.ts
+++ b/packages/runtime/test/unit/templating/scope-assistance.ts
@@ -1,11 +1,5 @@
-import { IScope, BindingContext } from "../../../src/index";
+import { IScope, Scope, OverrideContext } from "../../../src/index";
 
 export function createScope(bindingContext: any = {}): IScope {
-  return {
-    bindingContext,
-    overrideContext: BindingContext.createOverride(
-      bindingContext,
-      BindingContext.createOverride()
-    )
-  };
+  return Scope.create(bindingContext, OverrideContext.create(bindingContext, OverrideContext.create(null, null)))
 }

--- a/packages/runtime/test/unit/templating/view.spec.ts
+++ b/packages/runtime/test/unit/templating/view.spec.ts
@@ -25,7 +25,8 @@ import {
   INodeSequence,
   AccessScope,
   IChangeSet,
-  ChangeSet
+  ChangeSet,
+  Scope
 } from '../../../src';
 import { expect } from 'chai';
 import { eachCartesianJoin, eachCartesianJoinFactory } from '../../../../../scripts/test-lib';
@@ -212,7 +213,7 @@ describe(`View`, () => {
         }
       ],
       [
-        () => [`fromBind, {text:'foo'}`, BindingFlags.fromBind, BindingContext.createScope({text:'foo'})]
+        () => [`fromBind, {text:'foo'}`, BindingFlags.fromBind, Scope.create({text:'foo'}, null)]
       ],
       [
         () => [`       noop`, PLATFORM.noop],
@@ -228,7 +229,7 @@ describe(`View`, () => {
           // TODO: verify short-circuit if already bound (now we can only tell by debugging or looking at the coverage report, not very clean)
           sut.$bind(flags, scope);
 
-          const newScope = BindingContext.createScope({text:'foo'});
+          const newScope = Scope.create({text:'foo'}, null);
           sut.$bind(flags, newScope);
 
           expect(sut.$scope).to.equal(newScope);


### PR DESCRIPTION
## 📖 Description

This PR should lay the groundwork for more intelligent features, optimizations, and increase the precision of typings by explicitly defining classes for `Scope`, `BindingContext`, `OverrideContext` and `ObserversLookup`.

The key thing is the ability to tell the difference between a "synthetic" binding context (as indicated by the `$synthetic` property) and a regular binding context (e.g. a user view model). By checking this property, we can take certain shortcuts or do additional things that would otherwise be unsafe to do. Especially template controllers such as the repeater will benefit from this, once utilized properly.

All that aside, classes perform slightly better in terms of memory than regular objects, so memory consumption will go down with this.

### 🎫 Issues

Loosely related to anything that has to do with observation and lifecycles, and specifically:
- https://github.com/aurelia/aurelia/issues/78

This is the non-DOM equivalent of: https://github.com/aurelia/aurelia/issues/75


## 👩‍💻 Reviewer Notes

The APIs to create scopes and override contexts have moved to static methods on `Scope` resp. `OverrideContext`:

- `BindingContext.createOverride` -> `OverrideContext.create`
- `BindingContext.createScope` -> `Scope.create`
- `BindingContext.createScopeFromOverride` -> `Scope.fromOverride`
- `BindingContext.createScopeFromParent` -> `Scope.fromParent`

BindingContext can be created via `BindingContext.create`. You can pass in a single property + value (as used by the repeater), an existing object (which will clone it) or nothing (which just creates the equivalent of an empty object)

One important change is that the `parentOverrideContext` parameter is no longer optional: you should explicitly pass in null. I believe this helps with preventing accidentally not including the parent context where it should be (I think this is the case with `@customElement`, marked as a todo there)

Furthermore, the `ObserversLookup` provides a shortcut for the observer locator to just directly return a `SetterObserver` since that is the only thing you'll ever want when observing a synthetic binding context.

## 📑 Test Plan

This affects areas that were already heavily covered by tests. Fixing these tests consisted mostly of a few simple find/replaces, and explicitly passing in nulls. All tests then passed again, suggesting that this should not cause any regressions.

## ⏭ Next Steps

This leaves a few potential loose ends wrt observer-locator, `SetterObserver`, the AST and some other pieces that should now be easier to optimize. I may or may not visit those pieces on the short term. I don't want to make any too drastic changes to binding anymore in a short amount of time. No concrete plans at the moment but a few rough ideas.
