### PR TITLE
test(all): add more integration tests

### DIFF
--- a/packages/jit/test/unit/template-compiler.integration.spec.ts
+++ b/packages/jit/test/unit/template-compiler.integration.spec.ts
@@ -1,5 +1,5 @@
 import { InterpolationBinding } from './../../../runtime/src/binding/interpolation-binding';
-import { IContainer, DI, PLATFORM } from '../../../kernel/src';
+import { IContainer, DI, PLATFORM, IIndexable } from '../../../kernel/src';
 import { BasicConfiguration } from '../../src';
 import {
   Aurelia, IChangeSet, CustomElementResource, valueConverter,
@@ -9,6 +9,7 @@ import {
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { eachCartesianJoinFactory, h } from './util';
+import { eachCartesianJoin } from '../integration/util';
 
 
 @valueConverter('sort')
@@ -96,134 +97,112 @@ function stringify(o) {
   return result;
 }
 
+function setup(template: string, ...registrations: any[]) {
+  const container = DI.createContainer();
+  container.register(...registrations);
+  const cs = container.get<IChangeSet>(IChangeSet);
+  container.register(TestConfiguration, BasicConfiguration)
+  const host = document.createElement('app');
+  document.body.appendChild(host);
+  const au = new Aurelia(container);
+  const component = createCustomElement(template);
+  au.app({ host, component }).start();
+  return { container, cs, host, au, component };
+}
+
+function tearDown(au: Aurelia, cs: IChangeSet, host: HTMLElement) {
+  au.stop();
+  expect(cs.size).to.equal(0);
+  document.body.removeChild(host);
+}
 
 describe('TemplateCompiler (integration)', () => {
-  let container: IContainer;
-  let au: Aurelia;
-  let host: HTMLElement;
-  let component: ReturnType<typeof createCustomElement>;
-  let cs: IChangeSet
-
-  beforeEach(() => {
-    container = DI.createContainer();
-    cs = container.get(IChangeSet);
-    container.register(TestConfiguration, BasicConfiguration)
-    host = document.createElement('app');
-    document.body.appendChild(host);
-    au = new Aurelia(container);
-  });
-
-  afterEach(() => {
-    au.stop();
-    document.body.removeChild(host);
-  });
-
   it(`textBinding - interpolation`, () => {
-    component = createCustomElement(`<template>\${message}</template>`);
-    au.app({ host, component }).start();
-    expect(host.innerText).to.equal('');
+    const { au, host, cs, component } = setup(`<template>\${message}</template>`);
     component.message = 'hello!';
-    expect(host.innerText).to.equal('');
     cs.flushChanges();
     expect(host.innerText).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`textBinding - interpolation with template`, () => {
-    component = createCustomElement(`<template>\${\`\${message}\`}</template>`);
-    au.app({ host, component }).start();
-    expect(host.innerText).to.equal('');
+    const { au, host, cs, component } = setup(`<template>\${\`\${message}\`}</template>`);
     component.message = 'hello!';
-    expect(host.innerText).to.equal('');
     cs.flushChanges();
     expect(host.innerText).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`styleBinding - bind`, () => {
-    component = createCustomElement(`<template><div style.bind="foo"></div></template>`);
-    au.app({ host, component }).start();
-    expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div style.bind="foo"></div></template>`);
     component.foo = 'color: green;';
-    expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('');
     cs.flushChanges();
     expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('color: green;');
+    tearDown(au, cs, host);
   });
 
   it(`styleBinding - interpolation`, () => {
-    component = createCustomElement(`<template><div style="\${foo}"></div></template>`);
-    au.app({ host, component }).start();
-    expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div style="\${foo}"></div></template>`);
     component.foo = 'color: green;';
-    expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('');
     cs.flushChanges();
     expect((<HTMLElement>host.firstElementChild).style.cssText).to.equal('color: green;');
+    tearDown(au, cs, host);
   });
 
   it(`classBinding - bind`, () => {
-    component = createCustomElement(`<template><div class.bind="foo"></div></template>`);
-    au.app({ host, component }).start();
-    expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('au');
+    const { au, host, cs, component } = setup(`<template><div class.bind="foo"></div></template>`);
     component.foo = 'foo bar';
-    expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('au');
     cs.flushChanges();
     expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('au foo bar');
+    tearDown(au, cs, host);
   });
 
   it(`classBinding - interpolation`, () => {
-    component = createCustomElement(`<template><div class="\${foo}"></div></template>`);
-    au.app({ host, component }).start();
-    expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('\${foo} au');
+    const { au, host, cs, component } = setup(`<template><div class="\${foo}"></div></template>`);
     component.foo = 'foo bar';
-    expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('\${foo} au');
     cs.flushChanges();
     expect((<HTMLElement>host.firstElementChild).classList.toString()).to.equal('\${foo} au foo bar'); // TODO: fix this
+    tearDown(au, cs, host);
   });
 
   it(`oneTimeBinding - input.value`, () => {
-    component = createCustomElement(`<template><input value.one-time="message"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.one-time="message"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('');
+    tearDown(au, cs, host);
   });
 
   it(`toViewBinding - input.value`, () => {
-    component = createCustomElement(`<template><input value.to-view="message"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.to-view="message"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`fromViewBinding - input.value`, () => {
-    component = createCustomElement(`<template><input value.from-view="message"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.from-view="message"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('');
     host.firstChild['value'] = 'hello!';
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.message).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`twoWayBinding - input.value`, () => {
-    component = createCustomElement(`<template><input value.two-way="message"></template>`);
-    au.app({ host, component }).start();
-    expect(component.message).to.be.undefined;
+    const { au, host, cs, component } = setup(`<template><input value.two-way="message"></template>`);
     host.firstChild['value'] = 'hello!';
     expect(component.message).to.be.undefined;
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.message).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`twoWayBinding - input.value - jsonValueConverter`, () => {
-    component = createCustomElement(`<template><input value.two-way="message | json"></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><input value.two-way="message | json"></template>`);
     expect(component.message).to.be.undefined;
     host.firstChild['value'] = '{"foo":"bar"}';
     expect(component.message).to.be.undefined;
@@ -233,31 +212,27 @@ describe('TemplateCompiler (integration)', () => {
     expect(host.firstChild['value']).to.equal('{"foo":"bar"}');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('{"bar":"baz"}');
+    tearDown(au, cs, host);
   });
 
   it(`oneTimeBindingBehavior - input.value`, () => {
-    component = createCustomElement(`<template><input value.to-view="message & oneTime"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.to-view="message & oneTime"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('');
+    tearDown(au, cs, host);
   });
 
   it(`toViewBindingBehavior - input.value`, () => {
-    component = createCustomElement(`<template><input value.one-time="message & toView"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.one-time="message & toView"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`debounceBindingBehavior - input.value`, done => {
-    component = createCustomElement(`<template><input value.to-view="message & debounce:50"></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><input value.to-view="message & debounce:50"></template>`);
     expect(host.firstChild['value']).to.equal('');
     component.message = 'hello!';
     setTimeout(() => {
@@ -273,13 +248,14 @@ describe('TemplateCompiler (integration)', () => {
     }, 75);
     setTimeout(() => {
       expect(host.firstChild['value']).to.equal('hello!!!');
+      tearDown(au, cs, host);
       done();
     }, 175);
   });
 
   // TODO: fix throttle
   // it(`throttleBindingBehavior - input.value`, done => {
-  //   component = createCustomElement(`<template><input value.to-view="message & throttle:50"></template>`);
+  //   const { au, host, cs, component } = setup(`<template><input value.to-view="message & throttle:50"></template>`);
   //   au.app({ host, component }).start();
   //   expect(host.firstChild['value']).to.equal('');
   //   component.message = 'hello!';
@@ -300,70 +276,68 @@ describe('TemplateCompiler (integration)', () => {
   // });
 
   it(`fromViewBindingBehavior - input.value`, () => {
-    component = createCustomElement(`<template><input value.one-time="message & fromView"></template>`);
-    au.app({ host, component }).start();
-    expect(host.firstChild['value']).to.equal('');
+    const { au, host, cs, component } = setup(`<template><input value.one-time="message & fromView"></template>`);
     component.message = 'hello!';
-    expect(host.firstChild['value']).to.equal('');
     cs.flushChanges();
     expect(host.firstChild['value']).to.equal('');
     host.firstChild['value'] = 'hello!';
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.message).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`twoWayBindingBehavior - input.value`, () => {
-    component = createCustomElement(`<template><input value.one-time="message & twoWay"></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><input value.one-time="message & twoWay"></template>`);
     expect(component.message).to.be.undefined;
     host.firstChild['value'] = 'hello!';
     expect(component.message).to.be.undefined;
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.message).to.equal('hello!');
+    tearDown(au, cs, host);
   });
 
   it(`toViewBinding - input checkbox`, () => {
-    component = createCustomElement(`<template><input checked.to-view="checked" type="checkbox"></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><input checked.to-view="checked" type="checkbox"></template>`);
     expect(host.firstChild['checked']).to.be.false;
     component.checked = true;
     expect(host.firstChild['checked']).to.be.false;
     cs.flushChanges();
     expect(host.firstChild['checked']).to.be.true;
+    tearDown(au, cs, host);
   });
 
   it(`twoWayBinding - input checkbox`, () => {
-    component = createCustomElement(`<template><input checked.two-way="checked" type="checkbox"></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><input checked.two-way="checked" type="checkbox"></template>`);
     expect(component.checked).to.be.undefined;
     host.firstChild['checked'] = true;
     expect(component.checked).to.be.undefined;
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.checked).to.be.true;
+    tearDown(au, cs, host);
   });
 
   it(`toViewBinding - select single`, () => {
-    component = createCustomElement(
-      template(null,
+    const { au, host, cs, component } = setup(
+      <any>template(null,
         select(
           { 'value.to-view': 'selectedValue' },
           ...[1,2].map(v => option({ value: v }))
         )
       )
     );
-    // component = createCustomElement(`<template><select value.to-view="selectedValue"><option value="1"></option><option value="2"></option></select></template>`);
-    au.app({ host, component }).start();
+    // const { au, host, cs, component } = setup(`<template><select value.to-view="selectedValue"><option value="1"></option><option value="2"></option></select></template>`);
     expect(host.firstElementChild['value']).to.equal('1');
     component.selectedValue = '2';
     expect(host.firstElementChild['value']).to.equal('1');
     cs.flushChanges();
     expect(host.firstElementChild['value']).to.equal('2');
     expect(host.firstElementChild.childNodes.item(1)['selected']).to.be.true;
+    tearDown(au, cs, host);
   });
 
   it(`twoWayBinding - select single`, () => {
-    component = createCustomElement(
-      h('template',
+    const { au, host, cs, component } = setup(
+      <any>h('template',
         null,
         h('select',
           { 'value.two-way': 'selectedValue' },
@@ -371,40 +345,40 @@ describe('TemplateCompiler (integration)', () => {
         )
       )
     );
-    // component = createCustomElement(`<template><select value.two-way="selectedValue"><option value="1"></option><option value="2"></option></select></template>`);
-    au.app({ host, component }).start();
+    // const { au, host, cs, component } = setup(`<template><select value.two-way="selectedValue"><option value="1"></option><option value="2"></option></select></template>`);
     expect(component.selectedValue).to.be.undefined;
     host.firstChild.childNodes.item(1)['selected'] = true;
     expect(component.selectedValue).to.be.undefined;
     host.firstChild.dispatchEvent(new CustomEvent('change'));
     expect(component.selectedValue).to.equal('2');
+    tearDown(au, cs, host);
   });
 
   it(`trigger - button`, () => {
-    component = createCustomElement(`<template><button click.trigger="doStuff()"></button></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><button click.trigger="doStuff()"></button></template>`);
     component.doStuff = spy();
     host.firstChild.dispatchEvent(new CustomEvent('click'));
     expect(component.doStuff).to.have.been.called;
+    tearDown(au, cs, host);
   });
 
   it(`delegate - button`, () => {
-    component = createCustomElement(`<template><button click.delegate="doStuff()"></button></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><button click.delegate="doStuff()"></button></template>`);
     component.doStuff = spy();
     host.firstChild.dispatchEvent(new CustomEvent('click', { bubbles: true }));
     expect(component.doStuff).to.have.been.called;
+    tearDown(au, cs, host);
   });
 
   it(`capture - button`, () => {
-    component = createCustomElement(`<template><button click.capture="doStuff()"></button></template>`);
-    au.app({ host, component }).start();
+    const { au, host, cs, component } = setup(`<template><button click.capture="doStuff()"></button></template>`);
     component.doStuff = spy()
     host.firstChild.dispatchEvent(new CustomEvent('click', { bubbles: true }));
     expect(component.doStuff).to.have.been.called;
+    tearDown(au, cs, host);
   });
 
-  describe(`repeater`, () => {
+  describe(`repeater + if/else`, () => {
     eachCartesianJoinFactory([
       <(() => [string, string, string, (component: any) => void])[]>[
         () => [`[a,b,c]`,             `\${item}`,               `123`,    c => {c.a=1;c.b=2;c.c=3}],
@@ -427,107 +401,359 @@ describe('TemplateCompiler (integration)', () => {
       ],
       <(($2: [string, string, string, (component: any) => void]) => string)[]>[
         ([iterable, itemTemplate, textContent, initialize]) => `<template><div repeat.for="item of ${iterable}">${itemTemplate}</div></template>`,
-        ([iterable, itemTemplate, textContent, initialize]) => `<template><template repeat.for="item of ${iterable}">${itemTemplate}</template></template>`
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><div repeat.for="item of ${iterable}" if.bind="true">${itemTemplate}</div></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><div if.bind="true" repeat.for="item of ${iterable}">${itemTemplate}</div></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><div if.bind="false"></div><div else repeat.for="item of ${iterable}">${itemTemplate}</div></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><template repeat.for="item of ${iterable}">${itemTemplate}</template></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><template repeat.for="item of ${iterable}"><div if.bind="true">${itemTemplate}</div></template></template>`,
+        ([iterable, itemTemplate, textContent, initialize]) => `<template><template repeat.for="item of ${iterable}"><div if.bind="false"></div><div else>${itemTemplate}</div></template></template>`
       ]
     ], ([iterable, itemTemplate, textContent, initialize], markup) => {
       it(markup, () => {
-        component = createCustomElement(markup);
-        au.app({ host, component }).start();
-        expect(host.textContent.trim()).to.equal(''); // TODO: we kind of want to get rid of those spaces.. preferably
+        const { au, host, cs, component } = setup(markup);
         initialize(component)
         expect(host.textContent.trim()).to.equal('');
         cs.flushChanges();
         expect(host.textContent).to.equal(textContent);
+        tearDown(au, cs, host);
       });
     })
   });
 
+  describe(`repeater + if + custom element`, () => {
+    eachCartesianJoinFactory(
+      [
+        // Template (custom element)
+        <(() => [number, string])[]>[
+          () => [1, `<template><div repeat.for="item of items"><div if.bind="display">\${item.if}</div><div else>\${item.else}</div></div></template>`],
+          () => [2, `<template><div repeat.for="item of items"><div if.bind="display"><div if.bind="true">\${item.if}</div></div><div else>\${item.else}</div></div></template>`],
+          () => [3, `<template><div repeat.for="item of items"><div if.bind="display"><div if.bind="false">do_not_show</div><div else>\${item.if}</div></div><div else>\${item.else}</div></div></template>`],
+          () => [4, `<template><div if.bind="true" repeat.for="item of items"><div if.bind="display">\${item.if}</div><div else>\${item.else}</div></div></template>`],
+          () => [5, `<template><div if.bind="false">do_not_show</div><div else repeat.for="item of items"><div if.bind="display">\${item.if}</div><div else>\${item.else}</div></div></template>`],
+          () => [6, `<template><div repeat.for="item of items"><div if.bind="display" repeat.for="i of 1">\${item.if}</div><div else repeat.for="i of 1">\${item.else}</div></div></template>`],
+          () => [7, `<template><div if.bind="true" repeat.for="item of items"><div if.bind="display" repeat.for="i of 1">\${item.if}</div><div else repeat.for="i of 1">\${item.else}</div></div></template>`],
+          // () => [8, `<template><div repeat.for="a of 1"><div repeat.for="item of items"><div if.bind="display">\${item.if}</div><div else>\${item.else}</div></div></div></template>`], // TODO: doesn't render anything
+          // () => [9, `<template><template repeat.for="item of items"><div if.bind="display">\${item.if}</div><div else>\${item.else}</div></template></template>`], // TODO: renderLocation is removed instead of view nodes
+          // () => [10, `<template><div repeat.for="item of items"><template if.bind="display">\${item.if}</template><template else>\${item.else}</template></div></template>`], // TODO: renderLocation is removed instead of view nodes
+          // () => [11, `<template><template repeat.for="item of items"><template if.bind="display">\${item.if}</template><template else>\${item.else}</template></template></template>`], // TODO: renderLocation is removed instead of view nodes
+          () => [12, `<template><div if.bind="display" repeat.for="item of items">\${item.if}</div><div else repeat.for="item of items">\${item.else}</div></div></template>`],
+          () => [13, `<template><div if.bind="display"><div repeat.for="item of items">\${item.if}</div></div><div else><div repeat.for="item of items">\${item.else}</div></div></template>`],
+          //() => [14, `<template><div repeat.for="item of items" with.bind="item"><div if.bind="display">\${if}</div><div else>\${else}</div></div></template>`], // TODO: throws code 253
+          //() => [15, `<template><div repeat.for="item of items"><div with.bind="item"><div if.bind="display">\${if}</div><div else>\${else}</div></div></div></template>`] // TODO: throws code 253
+        ],
+        // Items (initial)
+        <(() => [number, any[], string, string])[]>[
+          () => [1, [{if: 1, else: 2}, {if: 3, else: 4}], '13', '24'],
+          () => [2, [{if: 'a', else: 'b'}, {if: 'c', else: 'd'}, {if: 'e', else: 'f'}, {if: 'g', else: 'h'}], 'aceg', 'bdfh']
+        ],
+        // Markup (app)
+        <(() => [number, string])[]>[
+          () => [1, `<template><foo repeat.for="i of count" if.bind="true" items.bind="items" display.bind="display"></foo></template>`],
+          () => [2, `<template><div repeat.for="i of count" if.bind="false">do_not_show</div><foo else items.bind="items" display.bind="display"></foo></template>`],
+          () => [3, `<template><foo repeat.for="i of count" items.bind="items" display.bind="display"></foo></template>`],
+          () => [4, `<template><foo items.bind="items" display.bind="display" if.bind="true" repeat.for="i of count"></foo></template>`],
+          () => [5, `<template><div if.bind="false">do_not_show</div><foo items.bind="items" display.bind="display" else repeat.for="i of count"></foo></template>`],
+          () => [6, `<template><foo items.bind="items" display.bind="display" repeat.for="i of count"></foo></template>`]
+        ],
+        // count
+        <(() => number)[]>[
+          () => 1,
+          //() => 3 // TODO: the outer repeater completely doesn't work, it always renders 1 foo regardless of the count property
+        ],
+        // Tests/assertions
+        <(($1: [number, string], $2: [number, any[], string, string], $3: [number, string], $4: number) => [string, (host: HTMLElement, cs: IChangeSet, component: IIndexable) => void])[]>[
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`swap the if/else`, (host, cs, component) => {
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal(ifText.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`swap the if/else twice`, (host, cs, component) => {
+            component.display = true;
+            cs.flushChanges();
+            component.display = false;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal(elseText.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`assign items with the if/else swapped`, (host, cs, component) => {
+            component.items = [{if: 2, else: 1}, {if: 4, else: 3}];
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal('13'.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`change the if/else values of the items`, (host, cs, component) => {
+            component.items[0].if = 5;
+            component.items[0].else = 6;
+            component.items[1].if = 7;
+            component.items[1].else = 8;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal(('68' + elseText.slice(2)).repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`assign an item less`, (host, cs, component) => {
+            component.items = [{if: 'a', else: 'b'}];
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal('b');
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`assign an item less + swap the if/else`, (host, cs, component) => {
+            component.items = [{if: 'a', else: 'b'}];
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal('a'.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`pop an item`, (host, cs, component) => {
+            component.items.pop();
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal(elseText.slice(0, -1).repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`pop an item + swap the if/else`, (host, cs, component) => {
+            component.items.pop();
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal(ifText.slice(0, -1).repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`assign an item more`, (host, cs, component) => {
+            component.items = [{if: 'a', else: 'b'}, {if: 'c', else: 'd'}, {if: 'e', else: 'f'}];
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal('bdf'.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`assign an item more + swap the if/else`, (host, cs, component) => {
+            component.items = [{if: 'a', else: 'b'}, {if: 'c', else: 'd'}, {if: 'e', else: 'f'}];
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal('ace'.repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`push an item`, (host, cs, component) => {
+            component.items.push({if: 5, else: 6});
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal((elseText + '6').repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`push an item + swap the if/else`, (host, cs, component) => {
+            component.items.push({if: 5, else: 6});
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal((ifText + '5').repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`reverse the items`, (host, cs, component) => {
+            component.items.reverse();
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal((elseText.split('').reverse().join('')).repeat(count));
+          }],
+
+          ($1, [$21, $22, ifText, elseText], $3, count)  => [`reverse the items + swap the if/else`, (host, cs, component) => {
+            component.items.reverse();
+            component.display = true;
+            cs.flushChanges();
+
+            expect(host.textContent).to.equal((ifText.split('').reverse().join('')).repeat(count));
+          }]
+        ]
+      ],
+      ([templateCase, template], [itemsCase, initialItems, ifText, elseText], [markupCase, markup], count, [actionText, action]) => {
+
+        @customElement({ name: 'foo', templateOrNode: template, instructions: [], build: { required: true, compiler: 'default' } })
+        class Foo { @bindable public items: any; @bindable public display: boolean; }
+
+        it(`template:${templateCase},items:${itemsCase},markup:${markupCase},count=${count}: ${actionText}`, () => {
+          const { au, host, cs, component } = setup(template);
+          component.display = false;
+          component.items = initialItems;
+          component.count = count;
+          cs.flushChanges();
+
+          expect(host.textContent).to.equal(elseText.repeat(count));
+
+          action(host, cs, component);
+
+          tearDown(au, cs, host);
+          expect(host.textContent).to.equal('');
+        });
+      }
+    )
+  });
+
+
+  it(`repeater with custom element`, () => {
+    @customElement({ name: 'foo', templateOrNode: '<template>a</template>', instructions: [], build: { required: true, compiler: 'default' } })
+    class Foo { }
+    const { au, host, cs, component } = setup(`<template><foo repeat.for="i of count"></foo></template>`, Foo);
+    component.count = 3;
+    cs.flushChanges();
+    expect(host.textContent).to.equal('aaa');
+
+    tearDown(au, cs, host);
+    expect(host.textContent).to.equal('');
+  });
+
+  it(`repeater with custom element + inner bindable with different name than outer property`, () => {
+    @customElement({ name: 'foo', templateOrNode: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
+    class Foo { @bindable text: string; }
+    const { au, host, cs, component } = setup(`<template><foo text.bind="theText" repeat.for="i of count"></foo></template>`, Foo);
+    component.count = 3;
+    component.theText = 'a';
+    cs.flushChanges();
+    expect(host.textContent).to.equal('aaa');
+
+    tearDown(au, cs, host);
+    expect(host.textContent).to.equal('');
+  });
+
+  it(`repeater with custom element + inner bindable with same name as outer property`, () => {
+    @customElement({ name: 'foo', templateOrNode: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
+    class Foo { @bindable text: string; }
+    const { au, host, cs, component } = setup(`<template><foo text.bind="text" repeat.for="i of count"></foo></template>`, Foo);
+    component.count = 3;
+    component.text = 'a';
+    cs.flushChanges();
+    expect(host.textContent).to.equal('aaa');
+
+    tearDown(au, cs, host);
+    expect(host.textContent).to.equal('');
+  });
+
+  // TODO: this doesn't work (note that this is the same as the 2 tests above but the attributes swapped around)
+  // it(`repeater with custom element + inner bindable with different name than outer property, reversed`, () => {
+  //   @customElement({ name: 'foo', templateOrNode: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
+  //   class Foo { @bindable text: string; }
+  //   const { au, host, cs, component } = setup(`<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, Foo);
+  //   component.count = 3;
+  //   component.theText = 'a';
+  //   cs.flushChanges();
+  //   expect(host.textContent).to.equal('aaa');
+
+  //   tearDown(au, cs, host);
+  //   expect(host.textContent).to.equal('');
+  // });
+
+  // it(`repeater with custom element + inner bindable with same name as outer property, reversed`, () => {
+  //   @customElement({ name: 'foo', templateOrNode: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
+  //   class Foo { @bindable text: string; }
+  //   const { au, host, cs, component } = setup(`<template><foo repeat.for="i of count" text.bind="text"></foo></template>`, Foo);
+  //   component.count = 3;
+  //   component.text = 'a';
+  //   cs.flushChanges();
+  //   expect(host.textContent).to.equal('aaa');
+
+  //   tearDown(au, cs, host);
+  //   expect(host.textContent).to.equal('');
+  // });
+
+  // TODO: this doesn't work (the repeater inside the custom element doesn't render)
+  // it(`repeater with custom element with repeater`, () => {
+  //   @customElement({ name: 'foo', templateOrNode: '<template><div repeat.for="item of todos">${item}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
+  //   class Foo { @bindable todos: any[] }
+  //   const { au, host, cs, component } = setup(`<template><foo repeat.for="i of count" todos.bind="todos"></foo></template>`, Foo);
+  //   component.count = 3;
+  //   component.items = ['a', 'b', 'c']
+  //   cs.flushChanges();
+  //   expect(host.textContent).to.equal('abcabcabc');
+
+  //   // component.count = 1;
+  //   // cs.flushChanges();
+  //   // expect(host.textContent).to.equal('abc');
+
+  //   // component.count = 3;
+  //   // cs.flushChanges();
+  //   // expect(host.textContent).to.equal('abcabcabc');
+
+  //   tearDown(au, cs, host);
+  // });
+
   it(`nested repeater - array`, () => {
-    component = createCustomElement(`<template><div repeat.for="item of items"><div repeat.for="child of item">\${child}</div></div></template>`);
-    au.app({ host, component: component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div repeat.for="item of items"><div repeat.for="child of item">\${child}</div></div></template>`);
     component.items = [['1'], ['2'], ['3']];
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('123');
+    tearDown(au, cs, host);
   });
 
   it(`repeater - sorted primitive array - asc`, () => {
-    component = createCustomElement(`<template><div repeat.for="item of items | sort">\${item}</div></template>`);
-    au.app({ host, component: component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div repeat.for="item of items | sort">\${item}</div></template>`);
     component.items = ['3', '2', '1'];
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('123');
+    tearDown(au, cs, host);
   });
 
   it(`repeater - sorted primitive array - desc`, () => {
-    component = createCustomElement(`<template><div repeat.for="item of items | sort:null:'desc'">\${item}</div></template>`);
-    au.app({ host, component: component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div repeat.for="item of items | sort:null:'desc'">\${item}</div></template>`);
     component.items = ['1', '2', '3'];
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('321');
+    tearDown(au, cs, host);
   });
 
   it(`repeater with nested if`, () => {
-    component = createCustomElement(`<template><div repeat.for="item of items"><div if.bind="$parent.show">\${item}</div></div></template>`);
-    au.app({ host, component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div repeat.for="item of items"><div if.bind="$parent.show">\${item}</div></div></template>`);
     component.items = [['1'], ['2'], ['3']];
     component.show = true;
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('123');
     component.show = false;
     expect(host.textContent.trim()).to.equal('');
+    tearDown(au, cs, host);
   });
 
   it(`repeater with sibling if`, () => {
-    component = createCustomElement(`<template><div repeat.for="item of items" if.bind="$parent.show">\${item}</div></template>`);
-    au.app({ host, component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div repeat.for="item of items" if.bind="$parent.show">\${item}</div></template>`);
     component.items = [['1'], ['2'], ['3']];
     component.show = true;
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('123');
     component.show = false;
     expect(host.textContent.trim()).to.equal('');
+    tearDown(au, cs, host);
   });
 
   it(`repeater with parent-sibling if`, () => {
-    component = createCustomElement(`<template><div if.bind="show" repeat.for="item of items">\${item}</div></template>`);
-    au.app({ host, component }).start();
-    expect(host.textContent.trim()).to.equal('');
+    const { au, host, cs, component } = setup(`<template><div if.bind="show" repeat.for="item of items">\${item}</div></template>`);
     component.items = [['1'], ['2'], ['3']];
     component.show = true;
-    expect(host.textContent.trim()).to.equal('');
     cs.flushChanges();
     expect(host.textContent).to.equal('123');
     component.show = false;
     expect(host.textContent.trim()).to.equal('');
+    tearDown(au, cs, host);
   });
 
 
   // TODO: implement this in template compiler
   it(`if - shows and hides`, () => {
-    component = createCustomElement(`<template><div if.bind="foo">bar</div></template>`);
+    const { au, host, cs, component } = setup(`<template><div if.bind="foo">bar</div></template>`);
     component.foo = true;
-    au.app({ host, component: component }).start();
     cs.flushChanges();
     expect(host.textContent).to.equal('bar');
     component.foo = false;
     cs.flushChanges();
     expect(host.textContent).to.equal('');
+    tearDown(au, cs, host);
   });
 
   it(`if - shows and hides - toggles else`, () => {
-    component = createCustomElement(`<template><div if.bind="foo">bar</div><div else>baz</div></template>`);
+    const { au, host, cs, component } = setup(`<template><div if.bind="foo">bar</div><div else>baz</div></template>`);
     component.foo = true;
-    au.app({ host, component: component }).start();
     cs.flushChanges();
     expect(host.innerText).to.equal('bar');
     component.foo = false;
@@ -536,61 +762,62 @@ describe('TemplateCompiler (integration)', () => {
     component.foo = true;
     cs.flushChanges();
     expect(host.innerText).to.equal('bar');
+    tearDown(au, cs, host);
   });
 
   it(`custom elements`, () => {
-    component = createCustomElement(
+    const { au, host, cs, component } = setup(
       `<template><name-tag name="bigopon"></name-tag></template>`,
     );
-    au.app({ host, component: component }).start();
     cs.flushChanges();
     expect(host.textContent).to.equal('bigopon');
+    tearDown(au, cs, host);
   });
 
   describe('[as-element]', () => {
 
     it('works with custom element with [as-element]', () => {
-      component = createCustomElement(
+      const { au, host, cs, component } = setup(
         `<template><div as-element="name-tag" name="bigopon"></div></template>`,
       );
-      au.app({ host, component: component }).start();
       cs.flushChanges();
       expect(host.textContent).to.equal('bigopon');
+      tearDown(au, cs, host);
     });
 
     it('ignores tag name', () => {
-      component = createCustomElement(
+      const { au, host, cs, component } = setup(
         `<template><name-tag as-element="div" name="bigopon">Fred</name-tag></template>`,
       );
-      au.app({ host, component: component }).start();
       expect(host.textContent).to.equal('Fred');
+      tearDown(au, cs, host);
     });
   });
 
   it('<let/>', () => {
-    component = createCustomElement(
+    const { au, host, cs, component } = setup(
       '<template><let full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>',
     );
-    au.app({ host, component: component }).start();
     expect(host.textContent).to.equal(' ');
     component.firstName = 'bi';
     component.lastName = 'go';
     expect(host.textContent).to.equal(' ');
     cs.flushChanges();
     expect(host.textContent).to.equal('bi go');
+    tearDown(au, cs, host);
   });
 
   it('<let [to-view-model] />', () => {
-    component = createCustomElement(
+    const { au, host, cs, component } = setup(
       '<template><let to-view-model full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>',
     );
-    au.app({ host, component: component }).start();
     component.firstName = 'bi';
     expect(component.fullName).to.equal('bi undefined');
     component.lastName = 'go';
     expect(component.fullName).to.equal('bi go');
     cs.flushChanges();
     expect(host.textContent).to.equal('bi go');
+    tearDown(au, cs, host);
   });
 
   it('initial values propagate through multiple nested custom elements connected via bindables', () => {
@@ -685,8 +912,14 @@ describe('TemplateCompiler (integration)', () => {
     }
 
     const customElementCtors: any[] = [Foo1, Foo2, Foo3, Foo4, Foo5];
+    const container = DI.createContainer();
     container.register(...customElementCtors);
-    component = createCustomElement('<template><foo1 value.bind="value"></foo1>\${value}</template>');
+    const cs = container.get<IChangeSet>(IChangeSet);
+    container.register(TestConfiguration, BasicConfiguration)
+    const host = document.createElement('app');
+    document.body.appendChild(host);
+    const au = new Aurelia(container);
+    const component = createCustomElement('<template><foo1 value.bind="value"></foo1>\${value}</template>');
     component.value = 'w00t';
     au.app({ host, component }).start();
 
@@ -773,6 +1006,7 @@ describe('TemplateCompiler (integration)', () => {
 
     cs.flushChanges();
     expect(host.textContent).to.equal('w00t00t'.repeat(6));
+    tearDown(au, cs, host);
   });
 
   function template(attrs: Record<string, any> | null, ...children: Element[]) {


### PR DESCRIPTION
## 📖 Description

This PR only adds integration tests for the app as a whole, and does not touch any framework code. The tests in particular focus on the integration between different flavors and combinations of template controllers.

I also reworked all the existing tests to explictly call setup and teardown, so that tests stay atomic even within loops, and don't accidentally share any state.

### 🎫 Issues

* Improving templating test coverage: https://github.com/aurelia/aurelia/issues/197
* bug 1 https://github.com/aurelia/aurelia/issues/218
* bug 2 https://github.com/aurelia/aurelia/issues/219

## 👩‍💻 Reviewer Notes

Quite a few (albeit exotic) combinations fail and they are commented out with // TODO's, explaining briefly what fails. Most notable:
- repeat+if/else on template elements results in the wrong nodes (namely the `<au-loc>` nodes) being removed; my initial impression is that this is a problem in the rendering process, not in the template compiler, because the compiled instructions appear to be correct as per the unit tests (and rendering has very low coverage)
- having a template controller on a custom element *before* its bindables results in those bindables not being bound. most likely cause is the parent binding context not being passed to the custom element [right here](https://github.com/aurelia/aurelia/blob/master/packages/runtime/src/templating/custom-element.ts#L148). I also commented on this in my [binding context PR](https://github.com/aurelia/aurelia/pull/216)
- `with` doesn't really appear to work, a null parent scope is passed to the binding context somewhere (see comments)

## 📑 Test Plan

The majority of tests are in the cartesian loop I added to the template-compiler.integration tests. A few more right below it specifically address the repeat+custom element binding context issue in an isolated manner

## ⏭ Next Steps

I will create appropriate issues to solve these problems. They're possibly quite tricky to tackle, but I believe these issues to be critical. Solving these may very well pave the way for an order of magnitude more complex integration tests that will allow us to validate and prove the robustness and absolute correctness of the framework.

I think me, @bigopon and @EisenbergEffect need to work together on solving these. It probably spans a large surface of the framework.
