### PR TITLE
perf(binding): reduce redundant calls to evaluate()

### DIFF
--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -1,5 +1,5 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
-import { ForOfStatement, hasBind, hasUnbind, IsBindingBehavior } from './ast';
+import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { IScope } from './binding-context';
 import { BindingFlags } from './binding-flags';
 import { BindingMode } from './binding-mode';
@@ -61,7 +61,10 @@ export class Binding implements IPartialConnectableBinding {
       const mode = this.mode;
 
       previousValue = targetObserver.getValue();
-      newValue = sourceExpression.evaluate(flags, $scope, locator);
+      // if the only observable is an AccessScope then we can assume the passed-in newValue is the correct and latest value
+      if (sourceExpression.$kind !== ExpressionKind.AccessScope || this.observerSlots > 1) {
+        newValue = sourceExpression.evaluate(flags, $scope, locator);
+      }
       if (newValue !== previousValue) {
         this.updateTarget(newValue, flags);
       }

--- a/packages/runtime/test/unit/binding/binding.spec.ts
+++ b/packages/runtime/test/unit/binding/binding.spec.ts
@@ -335,8 +335,12 @@ describe('Binding', () => {
             expect(sut.handleChange).to.have.been.calledWithExactly(newValue, srcVal, flags);
 
             // verify the behavior inside handleChange
-            expect(expr.evaluate).to.have.been.calledOnce;
-            expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            if (expr.$kind === ExpressionKind.AccessScope && sut.observerSlots < 2) {
+              expect(expr.evaluate).not.to.have.been.called;
+            } else {
+              expect(expr.evaluate).to.have.been.calledOnce;
+              expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            }
 
             expect(targetObserver.getValue).to.have.been.calledOnce;
             expect(targetObserver.getValue).to.have.been.calledWithExactly();
@@ -463,8 +467,12 @@ describe('Binding', () => {
             expect(sut.handleChange).to.have.been.calledWithExactly(newValue, initialVal, flags);
 
             // verify the behavior inside handleChange
-            expect(expr.evaluate).to.have.been.calledOnce;
-            expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            if (expr.$kind === ExpressionKind.AccessScope && sut.observerSlots < 2) {
+              expect(expr.evaluate).not.to.have.been.called;
+            } else {
+              expect(expr.evaluate).to.have.been.calledOnce;
+              expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            }
 
             expect(expr.assign).to.have.been.calledOnce;
             expect(expr.assign).to.have.been.calledWithExactly(flags, scope, container, newValue);
@@ -673,8 +681,12 @@ describe('Binding', () => {
             expect(sut.handleChange).to.have.been.calledWithExactly(newValue1, srcVal, flags);
 
             // verify the behavior inside handleChange
-            expect(expr.evaluate).to.have.been.calledTwice;
-            expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            if (expr.$kind === ExpressionKind.AccessScope && sut.observerSlots < 2) {
+              expect(expr.evaluate).not.to.have.been.called;
+            } else {
+              expect(expr.evaluate).to.have.been.calledTwice;
+              expect(expr.evaluate).to.have.been.calledWithExactly(flags, scope, container);
+            }
 
             expect(targetObserver.getValue).to.have.been.calledTwice;
             expect(targetObserver.getValue).to.have.been.calledWithExactly();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This is a small tweak with potentially big impact. When the `sourceExpression` in a Binding is an `AccessScope` and we're sure that there is at most 1 observer, then we can make these assumptions:
- The `newValue` we received into `handleChange()` is correct value (because there are no other observers that could have called the `handleChange`)
- The `newValue` we received is the latest value (because it's a naked `AccessScope` and not something that's wrapped in for example a valueConverter)

Side note: it's the `$kind` property that makes this more viable and interesting than it would be for the vCurrent AST, because there you would have to call `instanceof` which is much more expensive than direct number comparison. 

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

The existing binding tests (albeit a bit messy) are reasonably thorough in verifying the number of calls going out to observers and expressions. This change caused about 800 tests to fail there, all related to the number of `evaluate()` calls counted. The fix was to simply adjust those numbers. The rest still passes.

## ⏭ Next Steps

There are more optimizations of a similar flavor that can be done, but there is always a tradeoff between doing additional checks vs reducing redundant calls. I think we have some leeway here because the evaluate calls are much more expensive than some direct comparisons.

The other obvious things that still need to be looked into here is reducing the number of `observeProperty` calls and seeing if there is a cheaper way to observe a property, for example with a single function that checks the arguments.length

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
