### PR TITLE
chore(karma-webpack): fix double error logging and stack trace sourcemaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8106,6 +8106,15 @@
         }
       }
     },
+    "karma-source-map-support": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/karma-source-map-support/-/karma-source-map-support-1.3.0.tgz",
+      "integrity": "sha512-HcPqdAusNez/ywa+biN4EphGz62MmQyPggUsDfsHqa7tSe4jdsxgvTKuDfIazjL+IOxpVWyT7Pr4dhAV+sxX5Q==",
+      "dev": true,
+      "requires": {
+        "source-map-support": "^0.5.5"
+      }
+    },
     "karma-sourcemap-loader": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
+    "karma-source-map-support": "^1.3.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^3.0.5",
     "lerna": "^3.4.3",

--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -60,7 +60,7 @@ export default function(config: IKarmaConfig): void {
 
   const options: IKarmaConfigOptions = {
     basePath: project.path,
-    frameworks: ['mocha', 'chai'],
+    frameworks: ['source-map-support', 'mocha', 'chai'],
     files: packages.map(p => p.test.setup),
     preprocessors: packages.reduce((preprocessors, p) => {
       preprocessors[p.test.setup] = ['webpack', 'sourcemap'];
@@ -79,7 +79,7 @@ export default function(config: IKarmaConfig): void {
           return alias;
         }, {})
       },
-      devtool: 'cheap-module-eval-source-map',
+      devtool: browsers.indexOf('ChromeDebugging') > -1 ? 'eval-source-map' : 'inline-source-map',
       module: {
         rules: [{
           test: /\.ts$/,
@@ -148,7 +148,7 @@ export default function(config: IKarmaConfig): void {
       options: { esModules: true },
       test: /src[\/\\].+\.ts$/
     });
-    options.reporters.push('coverage-istanbul');
+    options.reporters = ['coverage-istanbul', ...options.reporters];
     options.coverageIstanbulReporter = {
       reports: ["html", "text-summary", "json", "lcovonly", "cobertura"],
       dir: project.coverage.path


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Failed test assertions were logged to the console twice. Fixed this by switching around coverage and progress reporters.
- Failed tests were showing useless stack traces in both normal and `ChromeDebugging` mode where everything is on line 1. Fixed this by adding `source-map-support` and switching to devtool `inline-source-map`.
- Failed tests in `ChromeDebugging` mode were linking to nonexistent files after the above change, fixed this by switching to `eval-source-map` only in debugging mode

This makes debugging and troubleshooting tests a little nicer again @EisenbergEffect @bigopon 

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
