### PR TITLE
ci: use aurelia docker image for pushing/publishing, restore cache before publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
 
   # Requires bundle_packages
   merge_and_dist:
-    executor: docker-circleci
+    executor: docker-aurelia
     parameters:
       from:
         type: string
@@ -337,12 +337,12 @@ jobs:
       - do_e2e_browserstack
 
   publish_npm:
-    executor: docker-circleci
+    executor: docker-aurelia
     parameters:
       channel:
         type: string
     steps:
-      - checkout
+      - first_restore_cache
       - do_publish:
           channel: << parameters.channel >>
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Use the aurelia circleci docker image (which has the correct git and machine config) for pushing to the repo and publishing to npm.
Also restore the `npm ci` cache before attempting to publish since we're using custom publish scripts. This caused the nightly to fail earlier.. :)
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
