### PR TITLE
ci: make post-publish wdio test jobs wait for publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,15 +234,6 @@ commands:
             npm run e2e
 
   # - git related -
-  do_git_set_config:
-    steps:
-      - run:
-          name: "Set git config user.name"
-          command: git config --local user.name "aurelia@bluespire.com"
-      - run:
-          name: "Set git config user.email"
-          command: git config --local user.email "AureliaEffect"
-
   do_git_merge:
     parameters:
       from_branch:
@@ -358,7 +349,6 @@ jobs:
         default: "dev"
     steps:
       - first_attach_workspace
-      - do_git_set_config
       - do_git_stash_dist
       - do_git_merge:
           from_branch: << parameters.from >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,26 +584,38 @@ workflows:
           <<: *filter_only_release
           name: jit-aurelia-cli-ts
           path: "latest/jit-aurelia-cli-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_release
           name: jit-browserify-ts
           path: "latest/jit-browserify-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_release
           name: jit-fuse-box-ts
           path: "latest/jit-fuse-box-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_release
           name: jit-parcel-ts
           path: "latest/jit-parcel-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_release
           name: jit-webpack-ts
           path: "latest/jit-webpack-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_release
           name: jit-iife-inline
           path: "latest/jit-iife-inline"
+          requires:
+            - publish_npm
 
   # Publishes from the develop branch to npm@dev
   # Triggered by push to develop branch
@@ -618,26 +630,38 @@ workflows:
           <<: *filter_only_develop
           name: jit-aurelia-cli-ts
           path: "dev/jit-aurelia-cli-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_develop
           name: jit-browserify-ts
           path: "dev/jit-browserify-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_develop
           name: jit-fuse-box-ts
           path: "dev/jit-fuse-box-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_develop
           name: jit-parcel-ts
           path: "dev/jit-parcel-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_develop
           name: jit-webpack-ts
           path: "dev/jit-webpack-ts"
+          requires:
+            - publish_npm
       - e2e_wdio:
           <<: *filter_only_develop
           name: jit-iife-inline
           path: "dev/jit-iife-inline"
+          requires:
+            - publish_npm
 
   # Runs build and tests, and pushes the built artifacts to the develop branch (which then triggers publish_dev)
   # Triggered by schedule once per day on 0:00 UTC on the master branch


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes two small oversights in the publish jobs:
- Run the post-publish e2e tests *after* publishing to npm (currently runs in parallel)
- Use the correct git identity for pushing to dev and release
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
