### PR TITLE
chore(di): fix get() and getAll() return types on IServiceLocator interface

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -32,14 +32,16 @@ export interface IFactory<T = any> {
 export interface IServiceLocator {
   has(key: any, searchAncestors: boolean): boolean;
 
-  get<K>(key: Constructable<unknown> | Key<unknown> | K):
+  get<K>(key: Constructable<unknown> | Key<unknown> | IResolver<unknown> | K):
     K extends InterfaceSymbol<infer T> ? T :
     K extends Constructable ? InstanceType<K> :
+    K extends IResolver<infer T1> ? T1 extends Constructable ? InstanceType<T1> : T1 :
     K;
 
-  getAll<K>(key: Constructable<unknown> | Key<unknown> | K):
+  getAll<K>(key: Constructable<unknown> | Key<unknown> | IResolver<unknown> | K):
     K extends InterfaceSymbol<infer T> ? ReadonlyArray<T> :
     K extends Constructable ? ReadonlyArray<InstanceType<K>> :
+    K extends IResolver<infer T1> ? T1 extends Constructable ? ReadonlyArray<InstanceType<T1>> : ReadonlyArray<T1> :
     ReadonlyArray<K>;
 }
 
@@ -474,7 +476,7 @@ export class Container implements IContainer {
     }
   }
 
-  public getAll(key: any): ReadonlyArray<any> {
+  public getAll(key: any): any {
     validateKey(key);
 
     let current: Container | null = this;

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -7,7 +7,7 @@ export type ResolveCallback<T = any> = (handler?: IContainer, requestor?: IConta
 
 export type Key<T> = InterfaceSymbol<T> | Primitive | IIndexable | Function;
 
-export type InterfaceSymbol<T> = (target: Injectable, property: string, index: number) => any;
+export type InterfaceSymbol<T> = (target: Injectable<T>, property: string, index: number) => any;
 
 export interface IDefaultableInterfaceSymbol<T> extends InterfaceSymbol<T> {
   withDefault(configure: (builder: IResolverBuilder<T>) => IResolver): InterfaceSymbol<T>;
@@ -32,11 +32,15 @@ export interface IFactory<T = any> {
 export interface IServiceLocator {
   has(key: any, searchAncestors: boolean): boolean;
 
-  get<T>(key: Key<T>): T;
-  get<T extends Constructable>(key: T): InstanceType<T>;
+  get<K>(key: Constructable<unknown> | Key<unknown> | K):
+    K extends InterfaceSymbol<infer T> ? T :
+    K extends Constructable ? InstanceType<K> :
+    K;
 
-  getAll<T>(key: Key<T>): ReadonlyArray<T>;
-  getAll<T extends Constructable>(key: T): ReadonlyArray<InstanceType<T>>;
+  getAll<K>(key: Constructable<unknown> | Key<unknown> | K):
+    K extends InterfaceSymbol<infer T> ? ReadonlyArray<T> :
+    K extends Constructable ? ReadonlyArray<InstanceType<K>> :
+    ReadonlyArray<K>;
 }
 
 export interface IRegistry {

--- a/packages/runtime/src/templating/renderer.ts
+++ b/packages/runtime/src/templating/renderer.ts
@@ -215,7 +215,7 @@ export class Renderer implements IRenderer {
   public [TargetedInstructionType.renderStrategy](renderable: IRenderable, target: any, instruction: Immutable<IRenderStrategyInstruction>): void {
     const strategyName = instruction.name;
     if (this[strategyName] === undefined) {
-      const strategy = this.context.get(RenderStrategyResource.keyFrom(strategyName)) as IRenderStrategy;
+      const strategy = this.context.get<IRenderStrategy>(RenderStrategyResource.keyFrom(strategyName));
       if (strategy === null || strategy === undefined) {
         throw new Error(`Unknown renderStrategy "${strategyName}"`);
       }

--- a/packages/runtime/src/templating/rendering-engine.ts
+++ b/packages/runtime/src/templating/rendering-engine.ts
@@ -190,7 +190,7 @@ export class RuntimeCompilationResources implements IResourceDescriptions {
   public create<TSource, TType extends IResourceType<TSource>>(kind: IResourceKind<TSource, TType>, name: string): InstanceType<TType> | null {
     const key = kind.keyFrom(name);
     if (this.context.has(key, false)) {
-      return this.context.get(key) || null;
+      return this.context.get<any>(key) || null;
     }
     return null;
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes the type inference of the return type for `get()` and `getAll()` against the `IContainer` or `IServiceLocator` interfaces.

Before:
```ts
const cs = container.get(IChangeSet):
// cs is of type "{}"
const cs = container.get<IChangeSet>(IChangeSet):
// cs is of type "IChangeSet" (casting or explicitly type arguments are necessary)
```

After:
```ts
const cs = container.get(IChangeSet):
// cs is of type "IChangeSet"
const cs = container.get<IChangeSet>(IChangeSet):
// cs is of type "IChangeSet"
```

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
