### PR TITLE
doc: minor grammar/typo fixes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Before you submit your pull request consider the following guidelines:
 * Search the appropriate GitHub Repository for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
 * Make your changes in a new git branch:
 
-	```shell
-	git checkout -b my-fix-branch master
-	```
+  ```shell
+  git checkout -b my-fix-branch master
+  ```
 
 * Create your patch, **including appropriate test cases**.
 * Follow our [Coding Rules](#rules).
@@ -67,17 +67,17 @@ Before you submit your pull request consider the following guidelines:
 * Commit your changes using a descriptive commit message that follows our
   [commit message conventions](#commit). Adherence to the [commit message conventions](#commit) is required because release notes are automatically generated from these messages.
 
-	```shell
-	git commit -a
-	```
+  ```shell
+  git commit -a
+  ```
 
-	> Note: The optional commit `-a` command line option will automatically "add" and "rm" edited files.
+  > Note: The optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
 * Build your changes locally to ensure all the tests pass
 
-	```shell
-	npm run test
-	```
+  ```shell
+  npm run test
+  ```
 
 * Push your branch to GitHub:
 
@@ -87,9 +87,9 @@ Before you submit your pull request consider the following guidelines:
 
 * In GitHub, send a Pull Request to the master branch.
 * If we suggest changes then:
-	* Make the required updates.
-  	* Re-run the test suite to ensure tests are still passing.
-  	* Rebase your branch and force push to your GitHub Repository (this will update your Pull Request):
+  * Make the required updates.
+  * Re-run the test suite to ensure tests are still passing.
+  * Rebase your branch and force push to your GitHub Repository (this will update your Pull Request):
 
     ```shell
     git rebase master -i
@@ -160,7 +160,7 @@ Please use one of the following:
 * **fix**: A bug fix
 * **doc**: Documentation only changes
 * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
-  semi-colons, etc)
+  semi-colons, etc.)
 * **refactor**: A code change that neither fixes a bug or adds a feature
 * **perf**: A code change that improves performance
 * **test**: Adding missing tests

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -4,7 +4,7 @@ We love our developer community and want to see that each and every developer ha
 
 ## Aurelia is doing something it should not, or is not doing something it should, and I can show you
 
-Some people feel like they need to submit code to contribute, but helping us identify bugs or gaps in functionality is one of the best ways you can help. If you think you've found a bug, or if you have a feature request, please [submit an issue on Github](https://github.com/aurelia/aurelia/issues/new/choose) and follow the instructions in the issue template. We prioritize high-quality issues, so **be sure to include a description and a working example of the current behavior** as well as a description of the desired behavio when you submit your issue.
+Some people feel like they need to submit code to contribute, but helping us identify bugs or gaps in functionality is one of the best ways you can help. If you think you've found a bug, or if you have a feature request, please [submit an issue on Github](https://github.com/aurelia/aurelia/issues/new/choose) and follow the instructions in the issue template. We prioritize high-quality issues, so **be sure to include a description and a working example of the current behavior** as well as a description of the desired behavior when you submit your issue.
 
 ## Aurelia is doing something it should not, or is not doing something it should, but I can't show you
 
@@ -12,7 +12,7 @@ Sometimes you will encounter an issue in your application, but when you try to r
 
 ## I'm trying to fix a bug or add a feature, but I'm not sure I'm doing it right
 
-We love it when Aurelia developers take the time to dive into the Aurelia codebase. Good on you! However, there's a lot of complicated code and we know first hand how intimidating that can be. For quick questions and discussions that will help you get on the right path, head over to our official Discord and post your question in the appropriate channel. We'll do our best to keep you on the right track.
+We love it when Aurelia developers take the time to dive into the Aurelia codebase. Good on you! However, there's a lot of complicated code and we know firsthand how intimidating that can be. For quick questions and discussions that will help you get on the right path, head over to our official Discord and post your question in the appropriate channel. We'll do our best to keep you on the right track.
 
 ## I want a bug fixed or a feature added but I don't think I can handle it
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some minor grammar tweaks and fixes in `CONTRIBUTING.md` and `SUPPORT.md`:
- `etc` -> `etc.`
- `behavio` -> `behavior`
- `first hand` -> `firsthand`
- And converted a couple of hard tabs to spaces, making them consistent with the rest of the file. (they indented differently in my editor making them appear weird/wrong)

### 🎫 Issues
## 👩‍💻 Reviewer Notes
## 📑 Test Plan
## ⏭ Next Steps
