### PR TITLE
style(plugin-requirejs): fix linting warnings

### DIFF
--- a/packages/plugin-requirejs/src/configuration.ts
+++ b/packages/plugin-requirejs/src/configuration.ts
@@ -1,10 +1,10 @@
 import * as componentPlugin from './component';
 import * as viewPlugin from './view';
 
-declare function define(name, deps: any[], moduleObject: {});
-let nonAnonDefine = define;
+declare function define(name: string, deps: unknown[], moduleObject: {}): void;
+const nonAnonDefine = define;
 
-export function installRequireJSPlugins() {
+export function installRequireJSPlugins(): void {
   nonAnonDefine('view', [], viewPlugin);
   nonAnonDefine('component', [], componentPlugin);
 }

--- a/packages/plugin-requirejs/src/processing.ts
+++ b/packages/plugin-requirejs/src/processing.ts
@@ -7,16 +7,16 @@ export interface ITemplateImport {
 
 export interface ITemplateDescription {
   template: string;
-  imports: ITemplateImport[]
+  imports: ITemplateImport[];
 }
 
-export function processImports(toProcess: ITemplateImport[], relativeTo): string[] {
+export function processImports(toProcess: ITemplateImport[], relativeTo: string): string[] {
   return toProcess.map(x => {
     if (x.extension === '.html' && !x.plugin) {
-      return 'component!' + relativeToFile(x.path, relativeTo) + x.extension;
+      return `component!${relativeToFile(x.path, relativeTo) + x.extension}`;
     }
 
-    let relativePath = relativeToFile(x.path, relativeTo);
+    const relativePath = relativeToFile(x.path, relativeTo);
     return x.plugin ? `${x.plugin}!${relativePath}` : relativePath;
   });
 }
@@ -24,23 +24,23 @@ export function processImports(toProcess: ITemplateImport[], relativeTo): string
 const capitalMatcher = /([A-Z])/g;
 
 /*@internal*/
-export function addHyphenAndLower(char) {
-  return '-' + char.toLowerCase();
+export function addHyphenAndLower(char: string): string {
+  return `-${char.toLowerCase()}`;
 }
 
-export function kebabCase(name) {
+export function kebabCase(name: string): string {
   return (name.charAt(0).toLowerCase() + name.slice(1)).replace(capitalMatcher, addHyphenAndLower);
 }
 
-export function escape(content: string) {
+export function escape(content: string): string {
   return content.replace(/(['\\])/g, '\\$1')
-            .replace(/[\f]/g, "\\f")
-            .replace(/[\b]/g, "\\b")
-            .replace(/[\n]/g, "\\n")
-            .replace(/[\t]/g, "\\t")
-            .replace(/[\r]/g, "\\r")
-            .replace(/[\u2028]/g, "\\u2028")
-            .replace(/[\u2029]/g, "\\u2029");
+            .replace(/[\f]/g, '\\f')
+            .replace(/[\b]/g, '\\b')
+            .replace(/[\n]/g, '\\n')
+            .replace(/[\t]/g, '\\t')
+            .replace(/[\r]/g, '\\r')
+            .replace(/[\u2028]/g, '\\u2028')
+            .replace(/[\u2029]/g, '\\u2029');
 }
 
 export function createTemplateDescription(template: string): ITemplateDescription {
@@ -107,13 +107,14 @@ export function relativeToFile(name: string, file: string): string {
 }
 
 interface Require {
-  nodeRequire(name: string): any;
+  nodeRequire(name: string): unknown;
 }
 
+// tslint:disable-next-line:no-reserved-keywords
 declare const require: Require;
 
-export function loadFromFile(url: string, callback: Function, errback: Function) {
-  const fs = require.nodeRequire('fs');
+export function loadFromFile(url: string, callback: (content: string) => void, errback: (error: Error) => void): void {
+  const fs = require.nodeRequire('fs') as {readFileSync(path: string, options?: { encoding?: string } | string): string};
 
   try {
     let file = fs.readFileSync(url, 'utf8');

--- a/packages/plugin-requirejs/src/types.ts
+++ b/packages/plugin-requirejs/src/types.ts
@@ -1,0 +1,22 @@
+// These types are duck-typed representations of parts of the RequireJs Load API [1] used by this plugin.
+// They are handcrafted as '@types/requirejs' is incomplete and it conflicts with '@types/node'. See [2] for details.
+// [1] https://requirejs.org/docs/plugins.html#apiload
+// [2] https://github.com/aurelia/aurelia/pull/256
+
+/*@internal*/
+export type Require = {
+  (name: string[], callback: (text: string) => void):
+  void; toUrl(name: string): string;
+};
+
+/*@internal*/
+export type RequireConfig = {
+  isBuild?: boolean;
+};
+
+/*@internal*/
+export type RequireOnLoad = {
+  // tslint:disable-next-line:no-reserved-keywords
+  (content: string|{}): void;
+  error?(error: Error): void;
+};

--- a/packages/plugin-requirejs/src/view.ts
+++ b/packages/plugin-requirejs/src/view.ts
@@ -1,26 +1,28 @@
 import { createTemplateDescription, escape, kebabCase, loadFromFile, parseImport, processImports } from './processing';
+import { Require, RequireConfig, RequireOnLoad } from './types';
 
 const buildMap = {};
 
 /*@internal*/
-export function finishLoad(name: string, content: string, onLoad: Function) {
+export function finishLoad(name: string, content: string, onLoad: (content: string) => void): void {
   buildMap[name] = content;
   onLoad(content);
 }
 
-export function load(name: string, req, onLoad, config) {
+export function load(name: string, req: Require, onLoad: RequireOnLoad, config: RequireConfig): void {
   if (config.isBuild) {
-    loadFromFile(req.toUrl(name),
-      function(content) { finishLoad(name, content, onLoad); },
-      function(err) { if (onLoad.error) { onLoad.error(err); } }
+    loadFromFile(
+      req.toUrl(name),
+      function(content: string): void { finishLoad(name, content, onLoad); },
+      function(error: Error): void { if (onLoad.error) { onLoad.error(error); } }
     );
   } else {
-    req(['text!' + name], function(text) {
+    req([`text!${name}`], function(text: string): void {
       const description = createTemplateDescription(text);
       const depsToLoad = processImports(description.imports, name);
       const templateImport = parseImport(name);
 
-      req(depsToLoad, function() {
+      req(depsToLoad, function(): void {
         const templateSource = {
           name: kebabCase(templateImport.basename),
           template: description.template,
@@ -37,14 +39,14 @@ export function load(name: string, req, onLoad, config) {
   }
 }
 
-export function write(pluginName: string, moduleName: string, write, config) {
+export function write(pluginName: string, moduleName: string, writer: (content: string) => void, _config: RequireConfig): void {
   if (buildMap.hasOwnProperty(moduleName)) {
     const text = buildMap[moduleName];
     const description = createTemplateDescription(text);
     const depsToLoad = processImports(description.imports, moduleName);
     const templateImport = parseImport(moduleName);
 
-    write(`define("${pluginName}!${moduleName}", [${depsToLoad.map(x => `"${x}"`).join(',')}], function() { 
+    writer(`define("${pluginName}!${moduleName}", [${depsToLoad.map(x => `"${x}"`).join(',')}], function() {
       var templateSource = {
         name: '${kebabCase(templateImport.basename)}',
         template: '${escape(description.template)}',


### PR DESCRIPTION
# Pull Request

## 📖 Description

Initial round of fixing lining warnings in `@aurelia/plugin-requirejs`.

### 🎫 Issues

Related to #249

## 👩‍💻 Reviewer Notes

Adding @types/requirejs introduces more issues than it solves. It's incomplete (i.e. isBuild is missing on the RequireConfig interface ) and it's creating conflicts:

```
node_modules/@types/node/index.d.ts(5984,5): error TS2300: Duplicate identifier 'mod'.
node_modules/@types/requirejs/index.d.ts(38,11): error TS2300: Duplicate identifier 'mod'.
node_modules/@types/requirejs/index.d.ts(422,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'require' must be of type 'NodeRequire', but here has type 'Require'.
```

So I went for a (simplified) version of duck-typing. Just enough to match the parts of the API being used.

## 📑 Test Plan

Executed without issues:
- lerna run lint --scope=@aurelia/plugin-requirejs
- npm run build
- npm run test

## ⏭ Next Steps
