### PR TITLE
Typing fixes

### DIFF
--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -29,7 +29,13 @@ export type Decorated<TOptional, TRequired> = Function & {
 
 export type Injectable<T = {}> = Constructable<T> & { inject?: unknown[] };
 
-export type IIndexable<T extends object = object> = T & { [key: string]: unknown };
+// Note: use of "any" here can perfectly well be replaced by "unknown" but that would also involve fixing consumers of this
+// interface since their indexed properties are now all returning "unknown" which is not assignable to anything else.
+// We are however not disabling this rule with "no-any" because it is a legitimate problem that tslint is warning us about,
+// and it should remind us of the fact that we have more work to do in making typings across the runtime more accurate.
+// For changing this "any" to "unknown", we could either resort to upcasting at the consumer side of things (less preferable because unsafe)
+// or we could simply return "unknown" at the API boundaries of consumers that return values from this object (more preferable but more work)
+export type IIndexable<T extends object = object> = T & { [key: string]: any };
 
 export type ImmutableObject<T> =
     T extends [infer A1, infer B1, infer C1, infer D1, infer E1, infer F1, infer G] ? ImmutableArray<[A1, B1, C1, D1, E1, F1, G]> :

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -16,7 +16,15 @@ export type Decoratable<TOptional, TRequired> = Function & {
 };
 export type Decorated<TOptional, TRequired> = Function & {
   readonly prototype: Required<TOptional> & Required<TRequired>;
-  new(...args: unknown[]): unknown;
+  // Constructor signatures are impossible to type correctly for use by decorators, because a synthetic constructor signature is expected to return "void"
+  // but a normal constructor signature is expected to return the type that they construct.
+  // Furthermore, using merged types will cause either to fail without using conditional types as well.
+  // If using conditional types correctly, they would need to have intimate knowledge of any type they might be applied to (or they will still cause typing
+  // errors in valid edge cases), which in turn is impossible to predict because there will be user code involved that might not fulfill any particular contract.
+  // In short, the type system (as of 3.1.x) is simply not (yet?) capable of correctly handling decorators and there is nothing here that will work in all cases except for "any".
+  // We can of course try again in later versions of TypeScript.
+  // tslint:disable-next-line:no-any
+  new(...args: unknown[]): any;
 };
 
 export type Injectable<T = {}> = Constructable<T> & { inject?: unknown[] };


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes two small regressions introduced by @BBosman 's otherwise excellent work on reducing the number of linting errors.

One is related to decorators which I believe is either impossible to fix at this point (see the clarifying comments), or would be so complicated that it's simply not worth the trouble right now. So I changed the `unknown` back to `any` and disabled the tslint rule for that one.

The other is related to the `IIndexable` type which can probably be changed back to `unknown` again at some point, but doing so will require a number of changes in the runtime for its various consumers. Since this one *can* be fixed, I did not disable the "no-any" rule for this line.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

@BBosman please check the comments I put in place :)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

I've simply made sure that the whole project builds again. One linting error is reintroduced and the other is suppressed.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

See if `IIndexable`'s index signature return type can be changed back to `unknown` without needing to overhaul the entire runtime's typings (if it is needed however, then it should happen at some point anyway)
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
