### PR TITLE
chore(examples): fix jit-browserify-ts

### DIFF
--- a/examples/jit-browserify-ts/src/html.d.ts
+++ b/examples/jit-browserify-ts/src/html.d.ts
@@ -1,4 +1,4 @@
 declare module '*.html' {
   const value: string;
-  export default value;
+  export = value;
 }

--- a/test/wdio/cases/dev/jit-browserify-ts/src/html.d.ts
+++ b/test/wdio/cases/dev/jit-browserify-ts/src/html.d.ts
@@ -1,4 +1,4 @@
 declare module '*.html' {
   const value: string;
-  export default value;
+  export = value;
 }

--- a/test/wdio/cases/latest/jit-browserify-ts/src/html.d.ts
+++ b/test/wdio/cases/latest/jit-browserify-ts/src/html.d.ts
@@ -1,4 +1,4 @@
 declare module '*.html' {
   const value: string;
-  export default value;
+  export = value;
 }

--- a/test/wdio/cases/local/jit-browserify-ts/src/html.d.ts
+++ b/test/wdio/cases/local/jit-browserify-ts/src/html.d.ts
@@ -1,4 +1,4 @@
 declare module '*.html' {
   const value: string;
-  export default value;
+  export = value;
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This fixes the `jit-browserify-ts` example. The typing of `html.d.ts` was incorrect because the default export was typed as a string, but browserify needs a star import so the module itself needed to be typed as a string instead.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

I verified the build+serve as well as the watch scripts locally on the branch that also contains the typing fixes from #257 
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Fix jit-aurelia-cli-ts and jit-parcel-ts at some point
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
