### PR TITLE
refactor(expression-parser): get rid of exponentiation to preserve ES2015 parser compatibility

### DIFF
--- a/packages/jit/src/expression-parser.ts
+++ b/packages/jit/src/expression-parser.ts
@@ -719,51 +719,35 @@ function scanIdentifier(state: ParserState): Token {
 }
 
 function scanNumber(state: ParserState, isFloat: boolean): Token {
-  if (isFloat) {
-    state.tokenValue = 0;
-  } else {
-    state.tokenValue = state.currentChar - Char.Zero;
-    while (nextChar(state) <= Char.Nine && state.currentChar >= Char.Zero) {
-      state.tokenValue = state.tokenValue * 10 + state.currentChar  - Char.Zero;
-    }
-  }
+  let char = state.currentChar;
+  if (isFloat === false) {
+    do {
+      char = nextChar(state);
+    } while (char <= Char.Nine && char >= Char.Zero);
 
-  if (isFloat || state.currentChar === Char.Dot) {
-    // isFloat (coming from the period scanner) means the period was already skipped
-    if (!isFloat) {
-      isFloat = true;
-      nextChar(state);
-      if (state.index >= state.length) {
-        // a trailing period is valid javascript, so return here to prevent creating a NaN down below
-        return Token.NumericLiteral;
-      }
-    }
-    // note: this essentially make member expressions on numeric literals valid;
-    // this makes sense to allow since they're always stored in variables, and they can legally be evaluated
-    // this would be consistent with declaring a literal as a normal variable and performing an operation on that
-    const current = state.currentChar;
-    if (current > Char.Nine || current < Char.Zero) {
-      state.currentChar = state.input.charCodeAt(--state.index);
+    if (char !== Char.Dot) {
+      state.tokenValue = parseInt(state.tokenRaw, 10);
       return Token.NumericLiteral;
     }
-    const start = state.index;
-    let value = state.currentChar - Char.Zero;
-    while (nextChar(state) <= Char.Nine && state.currentChar >= Char.Zero) {
-      value = value * 10 + state.currentChar  - Char.Zero;
-    }
-    state.tokenValue = state.tokenValue + value / 10 ** (state.index - start);
-  }
-
-  // in the rare case that we go over this number, re-parse the number with the (slower) native number parsing,
-  // to ensure consistency with the spec
-  if (state.tokenValue > Number.MAX_SAFE_INTEGER) {
-    if (isFloat) {
-      state.tokenValue = parseFloat(state.tokenRaw);
-    } else {
-      state.tokenValue = parseInt(state.tokenRaw, 10);
+    // past this point it's always a float
+    char = nextChar(state);
+    if (state.index >= state.length) {
+      // unless the number ends with a dot - that behaves a little different in native ES expressions
+      // but in our AST that behavior has no effect because numbers are always stored in variables
+      state.tokenValue = parseInt(state.tokenRaw.slice(0, -1), 10);
+      return Token.NumericLiteral;
     }
   }
 
+  if (char <= Char.Nine && char >= Char.Zero) {
+    do {
+      char = nextChar(state);
+    } while (char <= Char.Nine && char >= Char.Zero);
+  } else {
+    state.currentChar = state.input.charCodeAt(--state.index);
+  }
+
+  state.tokenValue = parseFloat(state.tokenRaw);
   return Token.NumericLiteral;
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

### Remove `**` usage
The built-in esprima that ships with `aurelia-cli` doesn't seem to recognize the exponentiation `**` operator introduced in ES2016.
That can be considered a bug in `aurelia-cli` that needs fixing, but on the same token if it breaks `aurelia-cli` it might break other tooling as well for unsuspecting users. So I refactored the expression-parser to stop using exponentiation.

### Use native `parseInt` / `parseFloat` instead of manual number parsing
Taking another close look, I realized, the manual number parsing is only about 25-30% faster on chrome than native and accounts for less than 1% of total parsing time. That total parsing time is typically less than 1-2ms even on large apps. And it's quite likely that chrome and friends will only get faster at this, so at some point the benefit is likely nonexistent.
So for a gain of a couple microseconds at best, I'm pretty sure a couple bytes smaller lib size from simplifying the number parsing would actually yield a greater overall performance benefit.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

This is primarily to fix `jit-aurelia-cli-ts`
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

I added a few dot edge cases to the tests just in case, because I moved the logic around a bit.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
