### PR TITLE
style(kernel): use official Reflect metadata API type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10657,6 +10657,12 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==",
+      "dev": true
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mocha": "^5.2.0",
     "npm-run-all": "^4.1.3",
     "path": "^0.12.7",
+    "reflect-metadata": "^0.1.12",
     "request": "^2.88.0",
     "rollup": "^0.66.6",
     "rollup-plugin-node-resolve": "^3.4.0",

--- a/packages/kernel/package-lock.json
+++ b/packages/kernel/package-lock.json
@@ -5207,6 +5207,12 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A==",
+      "dev": true
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -65,6 +65,7 @@
     "karma-webpack": "^3.0.5",
     "mocha": "^5.2.0",
     "path": "^0.12.7",
+    "reflect-metadata": "^0.1.12",
     "sinon": "^6.1.4",
     "sinon-chai": "^3.2.0",
     "ts-loader": "^5.2.2",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Use the official Reflect metadata API type definitions instead of rolling our own.

API proposal:
https://www.typescriptlang.org/docs/handbook/decorators.html#metadata
https://rbuckton.github.io/reflect-metadata/

Type definitions:
https://github.com/rbuckton/reflect-metadata

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

As `@types/reflect-metadata` is deprecated we use the definitions bundled with `reflect-metadata`. Because this is outside the `@types` scope we need to manually reference the type definitions.

This also reintroduces some `any` types, but as they're part of the official spec proposal it seems a valid use-case, so I suppressed those warnings.

## 📑 Test Plan

- `lerna run lint --scope=@aurelia/kernel` -> No new linting warnings
- `npm build` -> succeeds without errors.
- `npm test` -> succeeds without test failures.

## ⏭ Next Steps
