### PR TITLE
style(runtime): fix linting warnings in binding

### DIFF
--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -5,7 +5,7 @@ import { ICustomElement } from './templating/custom-element';
 import { IRenderingEngine } from './templating/rendering-engine';
 
 export interface ISinglePageApp {
-  host: any,
+  host: any;
   component: any;
 }
 

--- a/packages/runtime/src/binding/array-observer.ts
+++ b/packages/runtime/src/binding/array-observer.ts
@@ -1,7 +1,6 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
 import { BindingFlags, CollectionKind, IChangeSet, ICollectionObserver, IndexMap, IObservedArray } from '../observation';
 import { collectionObserver } from './collection-observer';
-// tslint:disable:no-reserved-keywords
 const proto = Array.prototype;
 export const nativePush = proto.push; // TODO: probably want to make these internal again
 export const nativeUnshift = proto.unshift;
@@ -93,7 +92,7 @@ function observeSplice(this: IObservedArray, start: number, deleteCount?: number
   }
   const indexMap = o.indexMap;
   if (deleteCount > 0) {
-    let i = start || 0;
+    let i = isNaN(start) ? 0 : start;
     const to = i + deleteCount;
     while (i < to) {
       if (indexMap[i] > -1) {
@@ -191,12 +190,12 @@ function preSortCompare(x: IIndexable | Primitive, y: IIndexable | Primitive): n
   return 0;
 }
 
-function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function insertionSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, toIndex: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
   let velement, ielement, vtmp, itmp, order;
   let i, j;
-  for (i = from + 1; i < to; i++) {
+  for (i = fromIndex + 1; i < toIndex; i++) {
     velement = arr[i]; ielement = indexMap[i];
-    for (j = i - 1; j >= from; j--) {
+    for (j = i - 1; j >= fromIndex; j--) {
       vtmp = arr[j]; itmp = indexMap[j];
       order = compareFn(vtmp, velement);
       if (order > 0) {
@@ -209,7 +208,7 @@ function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to
   }
 }
 
-function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function quickSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, toIndex: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
   let thirdIndex = 0, i = 0;
   let v0, v1, v2;
   let i0, i1, i2;
@@ -220,14 +219,14 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
 
   // tslint:disable-next-line:no-constant-condition
   while (true) {
-    if (to - from <= 10) {
-      insertionSort(arr, indexMap, from, to, compareFn);
+    if (toIndex - fromIndex <= 10) {
+      insertionSort(arr, indexMap, fromIndex, toIndex, compareFn);
       return;
     }
 
-    thirdIndex = from + ((to - from) >> 1);
-    v0 = arr[from];       i0 = indexMap[from];
-    v1 = arr[to - 1];     i1 = indexMap[to - 1];
+    thirdIndex = fromIndex + ((toIndex - fromIndex) >> 1);
+    v0 = arr[fromIndex];       i0 = indexMap[fromIndex];
+    v1 = arr[toIndex - 1];     i1 = indexMap[toIndex - 1];
     v2 = arr[thirdIndex]; i2 = indexMap[thirdIndex];
     c01 = compareFn(v0, v1);
     if (c01 > 0) {
@@ -249,11 +248,11 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
         v2 = vtmp; i2 = itmp;
       }
     }
-    arr[from] = v0;   indexMap[from] = i0;
-    arr[to - 1] = v2; indexMap[to - 1] = i2;
+    arr[fromIndex] = v0;   indexMap[fromIndex] = i0;
+    arr[toIndex - 1] = v2; indexMap[toIndex - 1] = i2;
     vpivot = v1;      ipivot = i1;
-    lowEnd = from + 1;
-    highStart = to - 1;
+    lowEnd = fromIndex + 1;
+    highStart = toIndex - 1;
     arr[thirdIndex] = arr[lowEnd]; indexMap[thirdIndex] = indexMap[lowEnd];
     arr[lowEnd] = vpivot;          indexMap[lowEnd] = ipivot;
 
@@ -283,12 +282,12 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
         }
       }
     }
-    if (to - highStart < lowEnd - from) {
-      quickSort(arr, indexMap, highStart, to, compareFn);
-      to = lowEnd;
+    if (toIndex - highStart < lowEnd - fromIndex) {
+      quickSort(arr, indexMap, highStart, toIndex, compareFn);
+      toIndex = lowEnd;
     } else {
-      quickSort(arr, indexMap, from, lowEnd, compareFn);
-      from = highStart;
+      quickSort(arr, indexMap, fromIndex, lowEnd, compareFn);
+      fromIndex = highStart;
     }
   }
 }

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -7,8 +7,6 @@ import { IConnectableBinding } from './connectable';
 import { ISignaler } from './signaler';
 import { ValueConverterResource } from './value-converter';
 
-// tslint:disable:no-empty
-
 /**
  * StrictAny is a somewhat strongly typed alternative to 'any', in an effort to try to get rid of all 'any''s
  * It's not even remotely foolproof however, and this can largely be attributed to the fact that TypeScript imposes
@@ -154,11 +152,10 @@ export function isLiteral(expr: IsExpressionOrStatement): expr is IsLiteral {
   return (expr.$kind & ExpressionKind.IsLiteral) === ExpressionKind.IsLiteral;
 }
 export function arePureLiterals(expressions: ReadonlyArray<IsExpressionOrStatement>): expressions is IsLiteral[] {
-  const len = expressions && expressions.length || 0;
-  if (len === 0) {
+  if (expressions.length === 0) {
     return true;
   }
-  for (let i = 0; i < len; ++i) {
+  for (let i = 0; i < expressions.length; ++i) {
     if (!isPureLiteral(expressions[i])) {
       return false;
     }
@@ -334,7 +331,7 @@ export class ValueConverter implements IExpression {
     if (signals === undefined) {
       return;
     }
-    const signaler = locator.get(ISignaler) as ISignaler;
+    const signaler = locator.get(ISignaler);
     for (let i = 0, ii = signals.length; i < ii; ++i) {
       signaler.addSignalListener(signals[i], binding);
     }
@@ -347,7 +344,7 @@ export class ValueConverter implements IExpression {
     if (signals === undefined) {
       return;
     }
-    const signaler = locator.get(ISignaler) as ISignaler;
+    const signaler = locator.get(ISignaler);
     for (let i = 0, ii = signals.length; i < ii; ++i) {
       signaler.removeSignalListener(signals[i], binding);
     }
@@ -368,7 +365,9 @@ export class Assign implements IExpression {
     return this.target.assign(flags, scope, locator, this.value.evaluate(flags, scope, locator));
   }
 
-  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void { }
+  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void {
+    return;
+  }
 
   public assign(flags: BindingFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
     this.value.assign(flags, scope, locator, value);
@@ -988,7 +987,9 @@ export class ArrayBindingPattern implements IExpression {
     // TODO
   }
 
-  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void { }
+  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void {
+    return;
+  }
 
   public accept<T>(visitor: IVisitor<T>): T {
     return visitor.visitArrayBindingPattern(this);
@@ -1013,7 +1014,9 @@ export class ObjectBindingPattern implements IExpression {
     // TODO
   }
 
-  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void { }
+  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void {
+    return;
+  }
 
   public accept<T>(visitor: IVisitor<T>): T {
     return visitor.visitObjectBindingPattern(this);
@@ -1027,7 +1030,9 @@ export class BindingIdentifier implements IExpression {
   public evaluate(flags: BindingFlags, scope: IScope, locator: IServiceLocator): StrictAny {
     return this.name;
   }
-  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void { }
+  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void {
+    return;
+  }
 
   public accept<T>(visitor: IVisitor<T>): T {
     return visitor.visitBindingIdentifier(this);
@@ -1102,7 +1107,9 @@ export class Interpolation implements IExpression {
       return parts[0] + this.firstExpression.evaluate(flags, scope, locator) + parts[1];
     }
   }
-  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void { }
+  public connect(flags: BindingFlags, scope: IScope, binding: IConnectableBinding): void {
+    return;
+  }
 
   public accept<T>(visitor: IVisitor<T>): T {
     return visitor.visitInterpolation(this);
@@ -1162,10 +1169,9 @@ function getFunction(flags: BindingFlags, obj: StrictAny, name: string): Functio
 }
 
 function isNumeric(value: StrictAny): value is number {
-  // tslint:disable-next-line:no-reserved-keywords
-  const type = typeof value;
-  if (type === 'number') return true;
-  if (type !== 'string') return false;
+  const valueType = typeof value;
+  if (valueType === 'number') return true;
+  if (valueType !== 'string') return false;
   const len = (<string>value).length;
   if (len === 0) return false;
   for (let i = 0; i < len; ++i) {
@@ -1207,8 +1213,12 @@ export const IterateForOfStatement = {
     }
     IterateForOfStatement['[object Array]'](arr, func);
   },
-  ['[object Null]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void { },
-  ['[object Undefined]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void { }
+  ['[object Null]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+    return;
+  },
+  ['[object Undefined]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+    return;
+  }
 };
 
 /*@internal*/

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -7,10 +7,10 @@ export interface IBindingBehaviorSource {
 
 export type IBindingBehaviorType = IResourceType<IBindingBehaviorSource>;
 
-export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource) {
-  return function<T extends Constructable>(target: T) {
+export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource): <T extends Constructable>(target: T) => T & IResourceType<IBindingBehaviorSource> {
+  return function<T extends Constructable>(target: T): T & IResourceType<IBindingBehaviorSource> {
     return BindingBehaviorResource.define(nameOrSource, target);
-  }
+  };
 }
 
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBindingBehaviorType> = {
@@ -20,8 +20,8 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
     return `${this.name}:${name}`;
   },
 
-  isType<T extends Constructable>(type: T): type is T & IBindingBehaviorType {
-    return (type as any).kind === this;
+  isType<T extends Constructable>(Type: T): Type is T & IBindingBehaviorType {
+    return (Type as T & IBindingBehaviorType).kind === this;
   },
 
   define<T extends Constructable>(nameOrSource: string | IBindingBehaviorSource, ctor: T): T & IBindingBehaviorType {

--- a/packages/runtime/src/binding/binding-mode.ts
+++ b/packages/runtime/src/binding/binding-mode.ts
@@ -12,4 +12,4 @@ export enum BindingMode {
   fromView = 0b0100,
   twoWay   = 0b0110,
   default  = 0b1000
-};
+}

--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -17,8 +17,7 @@ export type ComputedLookup = { computed?: Record<string, ComputedOverrides> };
 
 export function computed(config: ComputedOverrides): PropertyDecorator {
   return function(target: Object & ComputedLookup, key: string): void {
-    const computed = target.computed || (target.computed = {});
-    computed[key] = config;
+    (target.computed || (target.computed = {}))[key] = config;
   };
 }
 
@@ -239,7 +238,7 @@ export class GetterController {
 
     if (dynamicDependencies) {
       this.isCollecting = false;
-      this.dependencies.forEach(x => x.subscribe(this));
+      this.dependencies.forEach(x => { x.subscribe(this); });
     }
 
     return this.value;
@@ -258,7 +257,7 @@ export class GetterController {
   }
 
   private unsubscribeAllDependencies(): void {
-    this.dependencies.forEach(x => x.unsubscribe(this));
+    this.dependencies.forEach(x => { x.unsubscribe(this); });
     this.dependencies.length = 0;
   }
 }

--- a/packages/runtime/src/binding/dirty-checker.ts
+++ b/packages/runtime/src/binding/dirty-checker.ts
@@ -34,7 +34,7 @@ export class DirtyChecker {
   }
 
   public scheduleDirtyCheck(): void {
-    setTimeout(() => this.check(), this.checkDelay);
+    setTimeout(() => { this.check(); }, this.checkDelay);
   }
 
   public check(): void {

--- a/packages/runtime/src/binding/element-observation.ts
+++ b/packages/runtime/src/binding/element-observation.ts
@@ -123,7 +123,7 @@ const defaultHandleBatchedChangeFlags = BindingFlags.fromFlushChanges | BindingF
 
 interface IInternalInputElement extends IInputElement {
   matcher?: typeof defaultMatcher;
-  model?: any;
+  model?: Primitive | IIndexable;
   $observers?: IObserversLookup & {
     model?: SetterObserver;
     value?: ValueAttributeObserver;

--- a/packages/runtime/src/binding/map-observer.ts
+++ b/packages/runtime/src/binding/map-observer.ts
@@ -2,7 +2,6 @@ import { IIndexable, Primitive } from '@aurelia/kernel';
 import { BindingFlags, CollectionKind, IChangeSet, ICollectionObserver, IObservedMap } from '../observation';
 import { nativePush, nativeSplice } from './array-observer';
 import { collectionObserver } from './collection-observer';
-// tslint:disable:no-reserved-keywords
 
 const proto = Map.prototype;
 export const nativeSet = proto.set; // TODO: probably want to make these internal again

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -26,10 +26,9 @@ export interface IObserverLocator {
   getObserver(obj: IObservable, propertyName: string): AccessorOrObserver;
   getAccessor(obj: IObservable, propertyName: string): IBindingTargetAccessor;
   addAdapter(adapter: IObjectObservationAdapter): void;
-  getArrayObserver(array: (IIndexable | Primitive)[]): ICollectionObserver<CollectionKind.array>;
-  getMapObserver(map: Map<IIndexable | Primitive, IIndexable | Primitive>): ICollectionObserver<CollectionKind.map>;
-  // tslint:disable-next-line:no-reserved-keywords
-  getSetObserver(set: Set<IIndexable | Primitive>): ICollectionObserver<CollectionKind.set>;
+  getArrayObserver(observedArray: (IIndexable | Primitive)[]): ICollectionObserver<CollectionKind.array>;
+  getMapObserver(observedMap: Map<IIndexable | Primitive, IIndexable | Primitive>): ICollectionObserver<CollectionKind.map>;
+  getSetObserver(observedSet: Set<IIndexable | Primitive>): ICollectionObserver<CollectionKind.set>;
 }
 
 export const IObserverLocator = DI.createInterface<IObserverLocator>()
@@ -117,17 +116,16 @@ export class ObserverLocator implements IObserverLocator {
     return new PropertyAccessor(obj, propertyName);
   }
 
-  public getArrayObserver(array: IObservedArray): ICollectionObserver<CollectionKind.array> {
-    return getArrayObserver(this.changeSet, array);
+  public getArrayObserver(observedArray: IObservedArray): ICollectionObserver<CollectionKind.array> {
+    return getArrayObserver(this.changeSet, observedArray);
   }
 
-  public getMapObserver(map: IObservedMap): ICollectionObserver<CollectionKind.map>  {
-    return getMapObserver(this.changeSet, map);
+  public getMapObserver(observedMap: IObservedMap): ICollectionObserver<CollectionKind.map>  {
+    return getMapObserver(this.changeSet, observedMap);
   }
 
-  // tslint:disable-next-line:no-reserved-keywords
-  public getSetObserver(set: IObservedSet): ICollectionObserver<CollectionKind.set>  {
-    return getSetObserver(this.changeSet, set);
+  public getSetObserver(observedSet: IObservedSet): ICollectionObserver<CollectionKind.set>  {
+    return getSetObserver(this.changeSet, observedSet);
   }
 
   private getOrCreateObserversLookup(obj: IObservable): Record<string, AccessorOrObserver | IBindingTargetObserver> {

--- a/packages/runtime/src/binding/property-observer.ts
+++ b/packages/runtime/src/binding/property-observer.ts
@@ -19,7 +19,7 @@ function subscribe(this: PropertyObserver, subscriber: IPropertySubscriber): voi
     const { obj, propertyKey } = this;
     this.currentValue = obj[propertyKey];
     observedPropertyDescriptor.get = () => this.getValue();
-    observedPropertyDescriptor.set = value => this.setValue(value, BindingFlags.updateTargetInstance);
+    observedPropertyDescriptor.set = value => { this.setValue(value, BindingFlags.updateTargetInstance); };
     if (!defineProperty(obj, propertyKey, observedPropertyDescriptor)) {
       Reporter.write(1, propertyKey, obj);
     }

--- a/packages/runtime/src/binding/resources/binding-mode-behaviors.ts
+++ b/packages/runtime/src/binding/resources/binding-mode-behaviors.ts
@@ -5,17 +5,17 @@ import { BindingMode } from '../binding-mode';
 
 const { oneTime, toView, fromView, twoWay } = BindingMode;
 
-export type WithMode = { mode: BindingMode, originalMode?: BindingMode };
+export type WithMode = { mode: BindingMode; originalMode?: BindingMode };
 
 export abstract class BindingModeBehavior {
   constructor(private mode: BindingMode) {}
 
-  public bind(flags: BindingFlags, scope: IScope, binding: Binding & WithMode) {
+  public bind(flags: BindingFlags, scope: IScope, binding: Binding & WithMode): void {
     binding.originalMode = binding.mode;
     binding.mode = this.mode;
   }
 
-  public unbind(flags: BindingFlags, scope: IScope, binding: Binding & WithMode) {
+  public unbind(flags: BindingFlags, scope: IScope, binding: Binding & WithMode): void {
     binding.mode = binding.originalMode;
     binding.originalMode = null;
   }

--- a/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
@@ -8,24 +8,24 @@ import { Listener } from '../listener';
 export type DebounceableBinding = (Binding | Call | Listener) & {
   debouncedMethod: ((newValue: any, oldValue: any, flags: BindingFlags) => void) & { originalName: string };
   debounceState: {
-    callContextToDebounce: BindingFlags,
-    delay: number,
-    timeoutId: any,
-    oldValue: any
-  }
+    callContextToDebounce: BindingFlags;
+    delay: number;
+    timeoutId: any;
+    oldValue: any;
+  };
 };
 
 const unset = {};
 
 /*@internal*/
-export function debounceCallSource(event: Event) {
+export function debounceCallSource(event: Event): void {
   const state = this.debounceState;
   clearTimeout(state.timeoutId);
   state.timeoutId = setTimeout(() => this.debouncedMethod(event), state.delay);
 }
 
 /*@internal*/
-export function debounceCall(this: DebounceableBinding, newValue: any, oldValue: any, flags: BindingFlags) {
+export function debounceCall(this: DebounceableBinding, newValue: any, oldValue: any, flags: BindingFlags): void {
   const state = this.debounceState;
   clearTimeout(state.timeoutId);
   if (!(flags & state.callContextToDebounce)) {
@@ -36,18 +36,21 @@ export function debounceCall(this: DebounceableBinding, newValue: any, oldValue:
   if (state.oldValue === unset) {
     state.oldValue = oldValue;
   }
-  state.timeoutId = setTimeout(() => {
-    const ov = state.oldValue;
-    state.oldValue = unset;
-    this.debouncedMethod(newValue, ov, flags);
-  }, state.delay);
+  state.timeoutId = setTimeout(
+    () => {
+      const ov = state.oldValue;
+      state.oldValue = unset;
+      this.debouncedMethod(newValue, ov, flags);
+    },
+    state.delay
+  );
 }
 
 const fromView = BindingMode.fromView;
 
 @bindingBehavior('debounce')
 export class DebounceBindingBehavior {
-  public bind(flags: BindingFlags, scope: IScope, binding: DebounceableBinding, delay = 200) {
+  public bind(flags: BindingFlags, scope: IScope, binding: DebounceableBinding, delay: number = 200): void {
     let methodToDebounce;
     let callContextToDebounce;
     let debouncer;
@@ -80,7 +83,7 @@ export class DebounceBindingBehavior {
     };
   }
 
-  public unbind(flags: BindingFlags, scope: IScope, binding: DebounceableBinding) {
+  public unbind(flags: BindingFlags, scope: IScope, binding: DebounceableBinding): void {
     // restore the state of the binding.
     const methodToRestore = binding.debouncedMethod.originalName;
     binding[methodToRestore] = binding.debouncedMethod;

--- a/packages/runtime/src/binding/resources/sanitize.ts
+++ b/packages/runtime/src/binding/resources/sanitize.ts
@@ -33,7 +33,7 @@ export class SanitizeValueConverter {
   * Process the provided markup that flows to the view.
   * @param untrustedMarkup The untrusted markup to be sanitized.
   */
-  public toView(untrustedMarkup: string) {
+  public toView(untrustedMarkup: string): string|null {
     if (untrustedMarkup === null || untrustedMarkup === undefined) {
       return null;
     }

--- a/packages/runtime/src/binding/resources/self-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/self-binding-behavior.ts
@@ -1,25 +1,8 @@
 import { Reporter } from '@aurelia/kernel';
 import { BindingFlags, IScope } from '../../observation';
 import { bindingBehavior } from '../binding-behavior';
+import { findOriginalEventTarget } from '../event-manager';
 import { Listener } from '../listener';
-
-type CompatibleEvent = {
-  target?: EventTarget;
-
-  // legacy
-  path?: EventTarget[];
-
-  // old composedPath
-  deepPath?(): EventTarget[];
-
-  // current spec
-  composedPath?(): EventTarget[];
-};
-
-/*@internal*/
-export function findOriginalEventTarget(event: Event & CompatibleEvent): EventTarget {
-  return (event.composedPath && event.composedPath()[0]) || (event.deepPath && event.deepPath()[0]) || (event.path && event.path[0]) || event.target;
-}
 
 /*@internal*/
 export function handleSelfEvent(event: Event): ReturnType<Listener['callSource']> {

--- a/packages/runtime/src/binding/resources/signals.ts
+++ b/packages/runtime/src/binding/resources/signals.ts
@@ -13,21 +13,21 @@ export type SignalableBinding = Binding & {
 export class SignalBindingBehavior {
   constructor(private signaler: ISignaler) {}
 
-  public bind(flags: BindingFlags, scope: IScope, binding: SignalableBinding) {
+  public bind(flags: BindingFlags, scope: IScope, binding: SignalableBinding): void {
     if (!binding.updateTarget) {
       throw Reporter.error(11);
     }
 
     if (arguments.length === 4) {
-      let name = arguments[3];
+      const name = arguments[3];
       this.signaler.addSignalListener(name, binding);
       binding.signal = name;
     } else if (arguments.length > 4) {
-      let names = Array.prototype.slice.call(arguments, 3);
+      const names = Array.prototype.slice.call(arguments, 3);
       let i = names.length;
 
       while (i--) {
-        let name = names[i];
+        const name = names[i];
         this.signaler.addSignalListener(name, binding);
       }
 
@@ -37,12 +37,12 @@ export class SignalBindingBehavior {
     }
   }
 
-  public unbind(flags: BindingFlags, scope: IScope, binding: SignalableBinding) {
-    let name = binding.signal;
+  public unbind(flags: BindingFlags, scope: IScope, binding: SignalableBinding): void {
+    const name = binding.signal;
     binding.signal = null;
 
     if (Array.isArray(name)) {
-      let names = name;
+      const names = name;
       let i = names.length;
 
       while (i--) {

--- a/packages/runtime/src/binding/resources/throttle-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/throttle-binding-behavior.ts
@@ -6,19 +6,19 @@ import { Call } from '../call';
 import { Listener } from '../listener';
 
 export type ThrottleableBinding = (Binding | Call | Listener) & {
-  throttledMethod: ((value) => any) & { originalName: string };
+  throttledMethod: ((value: any) => any) & { originalName: string };
   throttleState: {
-    delay: number,
-    timeoutId: any,
-    last: any,
-    newValue?: any
-  }
+    delay: number;
+    timeoutId: any;
+    last: any;
+    newValue?: any;
+  };
 };
 
 /*@internal*/
-export function throttle(this: ThrottleableBinding, newValue: any) {
-  let state = this.throttleState;
-  let elapsed = +new Date() - state.last;
+export function throttle(this: ThrottleableBinding, newValue: any): void {
+  const state = this.throttleState;
+  const elapsed = +new Date() - state.last;
 
   if (elapsed >= state.delay) {
     clearTimeout(state.timeoutId);
@@ -31,17 +31,20 @@ export function throttle(this: ThrottleableBinding, newValue: any) {
   state.newValue = newValue;
 
   if (state.timeoutId === null) {
-    state.timeoutId = setTimeout(() => {
+    state.timeoutId = setTimeout(
+      () => {
         state.timeoutId = null;
         state.last = +new Date();
         this.throttledMethod(state.newValue);
-      }, state.delay - elapsed);
+      },
+      state.delay - elapsed
+    );
   }
 }
 
 @bindingBehavior('throttle')
 export class ThrottleBindingBehavior {
-  public bind(flags: BindingFlags, scope: IScope, binding: ThrottleableBinding, delay = 200) {
+  public bind(flags: BindingFlags, scope: IScope, binding: ThrottleableBinding, delay: number = 200): void {
     let methodToThrottle: string;
 
     if (binding instanceof Binding) {
@@ -71,9 +74,9 @@ export class ThrottleBindingBehavior {
     };
   }
 
-  public unbind(flags: BindingFlags, scope: IScope, binding: ThrottleableBinding) {
+  public unbind(flags: BindingFlags, scope: IScope, binding: ThrottleableBinding): void {
     // restore the state of the binding.
-    let methodToRestore = binding.throttledMethod.originalName;
+    const methodToRestore = binding.throttledMethod.originalName;
     binding[methodToRestore] = binding.throttledMethod;
     binding.throttledMethod = null;
     clearTimeout(binding.throttleState.timeoutId);

--- a/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
@@ -20,7 +20,7 @@ export type UpdateTriggerableBinding = Binding & {
 export class UpdateTriggerBindingBehavior {
   constructor(private observerLocator: IObserverLocator) {}
 
-  public bind(flags: BindingFlags, scope: IScope, binding: UpdateTriggerableBinding, ...events: string[]) {
+  public bind(flags: BindingFlags, scope: IScope, binding: UpdateTriggerableBinding, ...events: string[]): void {
     if (events.length === 0) {
       throw Reporter.error(9);
     }
@@ -44,7 +44,7 @@ export class UpdateTriggerBindingBehavior {
     targetObserver.handler = new EventSubscriber(events);
   }
 
-  public unbind(flags: BindingFlags, scope: IScope, binding: UpdateTriggerableBinding) {
+  public unbind(flags: BindingFlags, scope: IScope, binding: UpdateTriggerableBinding): void {
     // restore the state of the binding.
     binding.targetObserver.handler.dispose();
     binding.targetObserver.handler = binding.targetObserver.originalHandler;

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -1,6 +1,5 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
 import { BindingFlags, CollectionKind, IChangeSet, ICollectionObserver, IObservedSet } from '../observation';
-// tslint:disable:no-reserved-keywords
 import { nativePush, nativeSplice } from './array-observer';
 import { collectionObserver } from './collection-observer';
 
@@ -105,14 +104,14 @@ export class SetObserver implements SetObserver {
 
   public collection: IObservedSet;
 
-  constructor(changeSet: IChangeSet, set: IObservedSet) {
+  constructor(changeSet: IChangeSet, observedSet: IObservedSet) {
     this.changeSet = changeSet;
-    set.$observer = this;
-    this.collection = set;
+    observedSet.$observer = this;
+    this.collection = observedSet;
     this.resetIndexMap();
   }
 }
 
-export function getSetObserver(changeSet: IChangeSet, set: IObservedSet): SetObserver {
-  return (set.$observer as SetObserver) || new SetObserver(changeSet, set);
+export function getSetObserver(changeSet: IChangeSet, observedSet: IObservedSet): SetObserver {
+  return (observedSet.$observer as SetObserver) || new SetObserver(changeSet, observedSet);
 }

--- a/packages/runtime/src/binding/signaler.ts
+++ b/packages/runtime/src/binding/signaler.ts
@@ -34,7 +34,7 @@ export class Signaler implements ISignaler {
     const signals = this.signals;
     const listeners = signals[name];
     if (listeners === undefined) {
-      signals[name] = new Set([listener])
+      signals[name] = new Set([listener]);
     } else {
       listeners.add(listener);
     }

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -112,8 +112,8 @@ function callPropertySubscribers(
   if (subscriber2 !== null) {
     subscriber2.handleChange(newValue, previousValue, flags);
   }
-  const length = subscribers && subscribers.length || 0;
-  if (length > 0) {
+  const length = subscribers && subscribers.length;
+  if (length !== undefined && length > 0) {
     for (let i = 0; i < length; ++i) {
       const subscriber = subscribers[i];
       if (subscriber !== null) {
@@ -140,8 +140,8 @@ function callCollectionSubscribers(this: ISubscriberCollection<MutationKind.coll
   if (subscriber2 !== null) {
     subscriber2.handleChange(origin, args, flags);
   }
-  const length = subscribers && subscribers.length || 0;
-  if (length > 0) {
+  const length = subscribers && subscribers.length;
+  if (length !== undefined && length > 0) {
     for (let i = 0; i < length; ++i) {
       const subscriber = subscribers[i];
       if (subscriber !== null) {
@@ -278,8 +278,8 @@ function callBatchedCollectionSubscribers(this: IBatchedSubscriberCollection<Mut
   if (subscriber2 !== null) {
     subscriber2.handleBatchedChange(indexMap);
   }
-  const length = subscribers && subscribers.length || 0;
-  if (length > 0) {
+  const length = subscribers && subscribers.length;
+  if (length !== undefined && length > 0) {
     for (let i = 0; i < length; ++i) {
       const subscriber = subscribers[i];
       if (subscriber !== null) {

--- a/packages/runtime/src/binding/svg-analyzer.ts
+++ b/packages/runtime/src/binding/svg-analyzer.ts
@@ -7,7 +7,7 @@ export interface ISVGAnalyzer {
 
 export const ISVGAnalyzer = DI.createInterface<ISVGAnalyzer>()
   .withDefault(x => x.singleton(class {
-    isStandardSvgAttribute(node: INode, attributeName: string): boolean {
+    public isStandardSvgAttribute(node: INode, attributeName: string): boolean {
       return false;
     }
   })

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -11,7 +11,7 @@ type BindingTargetAccessor = IBindingTargetAccessor & {
   setValueCore(value: Primitive | IIndexable, flags: BindingFlags): void;
 };
 
-function setValue(this: BindingTargetAccessor, newValue: Primitive | IIndexable, flags: BindingFlags): Promise<void> {
+async function setValue(this: BindingTargetAccessor, newValue: Primitive | IIndexable, flags: BindingFlags): Promise<void> {
   const currentValue = this.currentValue;
   newValue = newValue === null || newValue === undefined ? this.defaultValue : newValue;
   if (currentValue !== newValue) {

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -7,10 +7,10 @@ export interface IValueConverterSource {
 
 export type IValueConverterType = IResourceType<IValueConverterSource>;
 
-export function valueConverter(nameOrSource: string | IValueConverterSource) {
-  return function<T extends Constructable>(target: T) {
+export function valueConverter(nameOrSource: string | IValueConverterSource): <T extends Constructable>(target: T) => T & IResourceType<IValueConverterSource> {
+  return function<T extends Constructable>(target: T): T & IResourceType<IValueConverterSource> {
     return ValueConverterResource.define(nameOrSource, target);
-  }
+  };
 }
 
 export const ValueConverterResource: IResourceKind<IValueConverterSource, IValueConverterType> = {
@@ -20,8 +20,8 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
     return `${this.name}:${name}`;
   },
 
-  isType<T extends Constructable>(type: T): type is T & IValueConverterType {
-    return (type as any).kind === this;
+  isType<T extends Constructable>(Type: T): Type is T & IValueConverterType {
+    return (Type as T & IValueConverterType).kind === this;
   },
 
   define<T extends Constructable>(nameOrSource: string | IValueConverterSource, ctor: T): T & IValueConverterType {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Linting fixes in the `binding` part of `@aurelia/runtime`

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

Mostly syntactical linting fixes, but also a couple of strict type checks which could use some scrutiny.

Hit a few files also touched in #250, but I think these changes are compatible.

## 📑 Test Plan

- `lerna run lint --scope=@aurelia/runtime` -> Significant drop in the number of reported warnings
- `npm run build` -> Succeeded without errors.
- `npm run test` -> Succeeded without test failures.

## ⏭ Next Steps

Once #250 lands the linting warnings that have a bit more impact in `binding` can be tackled, together with the warnings in the root and templating files.

Another follow up would be implementing the outcome of https://github.com/aurelia/aurelia/pull/262#discussion_r230880271 outside `binding` and work on https://github.com/aurelia/aurelia/pull/262#discussion_r230879707
