### PR TITLE
docs(interfaces): add explanation and example for decorator helper types

### DIFF
--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -82,6 +82,19 @@ vm4.attach(); // no errors because we're instantiating the
 ```
  */
 // tslint:enable:jsdoc-format
+/* Note: the intent of TOptional on Decoratable was/is to have those properties declared
+on the prototype of the incoming class so that you would not get a type error when trying
+to assign properties/methods to the prototype to an incoming prototype of type `{}`.
+But actually applying this requires a certain interplay with the Constructable type
+(it requires type constraints on the type of the `prototype` property) that doesn't work
+too well (yet) in the type system as of version 3.0.x.
+We tried this, but it results in various false negatives where target classes seem to not
+conform to the Constructable type.
+With the incoming prototype currently being of type `any`, the TOptional type argument
+on Decoratable technically has no effect whatsoever, but the intent is to try and make
+it work like this at some point - either if the type system supports this design or if
+we learn some trick to accomplish this in another way.
+*/
 export type Decoratable<TOptional, TRequired> = Function & {
   readonly prototype: Partial<TOptional> & Required<TRequired>;
   new(...args: unknown[]): Partial<TOptional> & Required<TRequired>;

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -45,9 +45,7 @@ export type Constructable<T = {}> = {
 interface IBind { bind(): void; }
 interface IAttach { attach(): void; }
 
-function customElement1<T extends Constructable>(
-  target: Decoratable<IBind & IAttach, T>):
-    Decorated<IBind & IAttach, T> {
+function customElement1<T extends Constructable>(target: Decoratable<IBind & IAttach, T>):  Decorated<IBind & IAttach, T> {
   target.prototype.bind = () => {};
   target.prototype.attach = () => {};
   return target;
@@ -56,9 +54,7 @@ function customElement1<T extends Constructable>(
 class ViewModel1 {}
 
 // IBind is now required instead of optional
-function customElement2<T extends Constructable>(
-  target: Decoratable<IAttach, T & IBind>):
-    Decorated<IAttach, T & IBind> {
+function customElement2<T extends Constructable>(target: Decoratable<IAttach, T & IBind>): Decorated<IAttach, T & IBind> {
   // this decorator apparently needs a bind()
   // method to already be defined
   target.prototype.attach = () => {};

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -10,10 +10,91 @@ export type Constructable<T = {}> = {
   new(...args: unknown[]): T;
 };
 
+// tslint:disable:jsdoc-format
+/**
+ * A helper interface for declaring strongly typed decorators.
+ *
+ * The `Decoratable` and `Decorated` types are intended to be used together, where
+ * `Decoratable` describes the (not yet decorated) target class and `Decorated`
+ * describes the same target class *after* the decorator was applied to it.
+ *
+ * `TRequired` dictates the preconditions that the target class must conform to,
+ * and `TOptional` describes the postconditions that the decorator will make the class conform
+ * to. The end result (return value of the decorator) is a combination of `TOptional & TRequired`
+ * where all properties/methods are defined.
+ *
+ * ### How it works:
+ *
+ * The `TOptional` and `TRequired` type arguments in the `Decoratable` interface relate
+ * to the target class that the decorator will be applied to.
+ * As the names imply, properties/methods defined in the `TOptional` type are optional
+ * and those defined in `TRequired` are required.
+ *
+ * In the `Decorated` interface, the `TOptional` type argument's name is a bit misleading.
+ * It is in fact transformed into a required property: it's the decorator's job to
+ * add it to the prototype. They are named the same to emphasize that the type arguments
+ * passed to `Decoratable` and `Decorated` must be the same.
+ *
+ * Example:
+ *
+```ts
+// Neither bind() nor attach() need to be present,
+// so we pass them both to TOptional. The only constraint
+// for TRequired is that it must be a class, so we give
+// it a type that must extend Constructable
+interface IBind { bind(): void; }
+interface IAttach { attach(): void; }
+
+function customElement1<T extends Constructable>(
+  target: Decoratable<IBind & IAttach, T>):
+    Decorated<IBind & IAttach, T> {
+  target.prototype.bind = () => {};
+  target.prototype.attach = () => {};
+  return target;
+}
+@customElement1 // no errors
+class ViewModel1 {}
+
+// IBind is now required instead of optional
+function customElement2<T extends Constructable>(
+  target: Decoratable<IAttach, T & IBind>):
+    Decorated<IAttach, T & IBind> {
+  // this decorator apparently needs a bind()
+  // method to already be defined
+  target.prototype.attach = () => {};
+  return target;
+}
+@customElement2 // type error: property 'bind' is missing
+class ViewModel2 {}
+
+@customElement2 // no errors
+class ViewModel3 { public bind(): void {} }
+
+const vm3 = new ViewModel3();
+vm3.attach(); // type error: property 'attach' does not exist
+// (eventhough the decorator added it)
+
+const ViewModel4 = customElement2(ViewModel3);
+const vm4 = new ViewModel4();
+vm4.attach(); // no errors because we're instantiating the
+// returned value from the decorator, which is the
+// modified type
+```
+ */
+// tslint:enable:jsdoc-format
 export type Decoratable<TOptional, TRequired> = Function & {
   readonly prototype: Partial<TOptional> & Required<TRequired>;
   new(...args: unknown[]): Partial<TOptional> & Required<TRequired>;
 };
+
+/**
+ * A helper interface for declaring strongly typed decorators.
+ *
+ * The `Decoratable` and `Decorated` types are intended to be used together.
+ *
+ * Please refer to the `Decoratable` type for an explanation of its application.
+ *
+ */
 export type Decorated<TOptional, TRequired> = Function & {
   readonly prototype: Required<TOptional> & Required<TRequired>;
   // Constructor signatures are impossible to type correctly for use by decorators, because a synthetic constructor signature is expected to return "void"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
This PR adds some clarifying JSDoc comments to the `Decoratable` and `Decorated` interfaces because the way I designed it (which can likely be improved) makes it a bit tricky to make sense of them. It's a side effect I believe, of making it easier to use them once you *do* understand them.

### 🎫 Issues

Loosely related to https://github.com/aurelia/aurelia/issues/249
Motivated by discussion in https://github.com/aurelia/aurelia/pull/262

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

I would like to invite @BBosman specifically (and @EisenbergEffect / @bigopon if you've got time) to look at the (intellisense rendered by the) JSDoc comment I added, and tell me if the types make sense after reading just that. If it does not, I need to do a better job obviously :)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

This PR does not contain any code changes - the test is to verify whether the comments provide enough clarification to others
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Hopefully @BBosman will be able to make use of the `Decoratable` and `Decorated` types and if not, I may need to revisit and think of a different way to strongly type decorators
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
