### PR TITLE
feat(di): add transient and singleton decorators

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -76,6 +76,10 @@ export interface IResolverBuilder<T> {
   aliasTo(destinationKey: Key<T>): IResolver;
 }
 
+export type RegisterSelf<T extends Constructable> = {
+  register(container: IContainer): IResolver<InstanceType<T>>;
+};
+
 // Shims to augment the Reflect object with methods used from the Reflect Metadata API proposal:
 // https://www.typescriptlang.org/docs/handbook/decorators.html#metadata
 // https://rbuckton.github.io/reflect-metadata/
@@ -191,6 +195,34 @@ export const DI = {
         }
       }
     };
+  },
+
+  /**
+   * Registers the `target` class as a transient dependency; each time the dependency is resolved
+   * a new instance will be created.
+   *
+   * @param target The class / constructor function to register as transient.
+   * @returns The same class, with a static `register` method that takes a container and returns the appropriate resolver.
+   */
+  transient<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
+    target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
+      return Registration.transient(target, target).register(container, target);
+    };
+    return <T & RegisterSelf<T>>target;
+  },
+
+  /**
+   * Registers the `target` class as a singleton dependency; the class will only be created once. Each
+   * consecutive time the dependency is resolved, the same instance will be returned.
+   *
+   * @param target The class / constructor function to register as a singleton.
+   * @returns The same class, with a static `register` method that takes a container and returns the appropriate resolver.
+   */
+  singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
+    target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
+      return Registration.singleton(target, target).register(container, target);
+    };
+    return <T & RegisterSelf<T>>target;
   }
 };
 
@@ -214,6 +246,86 @@ function createResolver(
 }
 
 export const inject = DI.inject;
+
+function transientDecorator<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
+  return DI.transient(target);
+}
+// tslint:disable:jsdoc-format
+/**
+ * Registers the decorated class as a transient dependency; each time the dependency is resolved
+ * a new instance will be created.
+ *
+ * Example usage:
+```ts
+@transient
+class Foo { }
+```
+ */
+// tslint:enable:jsdoc-format
+export function transient<T extends Constructable>(): typeof transientDecorator;
+// tslint:disable:jsdoc-format
+/**
+ * Registers the `target` class as a transient dependency; each time the dependency is resolved
+ * a new instance will be created.
+ *
+ * @param target The class / constructor function to register as transient.
+ *
+ * Example usages:
+```ts
+// As a decorator
+@transient()
+class Foo { }
+
+// As a function expression
+class Foo { }
+transient(Foo)()
+```
+ */
+// tslint:enable:jsdoc-format
+export function transient<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
+export function transient<T extends Constructable>(target?: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> | typeof transientDecorator {
+  return target === undefined ? transientDecorator : transientDecorator(target);
+}
+
+function singletonDecorator<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
+  return DI.singleton(target);
+}
+// tslint:disable:jsdoc-format
+/**
+ * Registers the decorated class as a singleton dependency; the class will only be created once. Each
+ * consecutive time the dependency is resolved, the same instance will be returned.
+ *
+ * Example usage:
+```ts
+@singleton
+class Foo { }
+```
+ */
+// tslint:enable:jsdoc-format
+export function singleton<T extends Constructable>(): typeof singletonDecorator;
+// tslint:disable:jsdoc-format
+/**
+ * Registers the `target` class as a singleton dependency; the class will only be created once. Each
+ * consecutive time the dependency is resolved, the same instance will be returned.
+ *
+ * @param target The class / constructor function to register as a singleton.
+ *
+ * Example usages:
+```ts
+// As a decorator
+@singleton()
+class Foo { }
+
+// As a function expression
+class Foo { }
+singleton(Foo)()
+```
+ */
+// tslint:enable:jsdoc-format
+export function singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
+export function singleton<T extends Constructable>(target?: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> | typeof singletonDecorator {
+  return target === undefined ? singletonDecorator : singletonDecorator(target);
+}
 
 export const all = createResolver((key: any, handler: IContainer, requestor: IContainer) => requestor.getAll(key));
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -197,13 +197,27 @@ export const DI = {
     };
   },
 
+  // tslint:disable:jsdoc-format
   /**
    * Registers the `target` class as a transient dependency; each time the dependency is resolved
    * a new instance will be created.
    *
    * @param target The class / constructor function to register as transient.
    * @returns The same class, with a static `register` method that takes a container and returns the appropriate resolver.
+   *
+   * Example usage:
+```ts
+// On an existing class
+class Foo { }
+DI.transient(Foo);
+
+// Inline declaration
+const Foo = DI.transient(class { });
+// Foo is now strongly typed with register
+Foo.register(container);
+```
    */
+  // tslint:enable:jsdoc-format
   transient<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
     target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
       return Registration.transient(target, target).register(container, target);
@@ -211,13 +225,26 @@ export const DI = {
     return <T & RegisterSelf<T>>target;
   },
 
+  // tslint:disable:jsdoc-format
   /**
    * Registers the `target` class as a singleton dependency; the class will only be created once. Each
    * consecutive time the dependency is resolved, the same instance will be returned.
    *
    * @param target The class / constructor function to register as a singleton.
    * @returns The same class, with a static `register` method that takes a container and returns the appropriate resolver.
+   * Example usage:
+```ts
+// On an existing class
+class Foo { }
+DI.singleton(Foo);
+
+// Inline declaration
+const Foo = DI.singleton(class { });
+// Foo is now strongly typed with register
+Foo.register(container);
+```
    */
+  // tslint:enable:jsdoc-format
   singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
     target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
       return Registration.singleton(target, target).register(container, target);
@@ -270,15 +297,10 @@ export function transient<T extends Constructable>(): typeof transientDecorator;
  *
  * @param target The class / constructor function to register as transient.
  *
- * Example usages:
+ * Example usage:
 ```ts
-// As a decorator
 @transient()
 class Foo { }
-
-// As a function expression
-class Foo { }
-transient(Foo)()
 ```
  */
 // tslint:enable:jsdoc-format
@@ -310,15 +332,10 @@ export function singleton<T extends Constructable>(): typeof singletonDecorator;
  *
  * @param target The class / constructor function to register as a singleton.
  *
- * Example usages:
+ * Example usage:
 ```ts
-// As a decorator
 @singleton()
 class Foo { }
-
-// As a function expression
-class Foo { }
-singleton(Foo)()
 ```
  */
 // tslint:enable:jsdoc-format

--- a/packages/kernel/test/unit/di.spec.ts
+++ b/packages/kernel/test/unit/di.spec.ts
@@ -1,4 +1,4 @@
-import { Resolver, Factory, fallbackInvoker } from './../../src/di';
+import { Resolver, Factory, fallbackInvoker, transient, singleton } from './../../src/di';
 import { spy } from 'sinon';
 import { DI, Container, PLATFORM, IContainer, IDefaultableInterfaceSymbol, ResolverStrategy, inject, invokeWithDynamicDependencies, classInvokers, Registration } from "../../src";
 import { expect } from "chai";
@@ -561,6 +561,66 @@ describe(`The inject decorator`, () => {
     expect(Foo['inject'].dep1).to.be.undefined;
     expect(Foo['inject'].dep2).to.be.undefined;
     expect(Foo['inject'].dep3).to.be.undefined;
+  });
+});
+
+describe(`The transient decorator`, () => {
+  it(`works as a plain decorator`, () => {
+    @transient
+    class Foo {}
+
+    expect(Foo['register']).to.be.a('function');
+
+    const container = DI.createContainer();
+
+    const foo1 = container.get(Foo);
+    const foo2 = container.get(Foo);
+
+    expect(foo1).not.to.equal(foo2);
+  });
+
+  it(`works as an invocation`, () => {
+    @transient()
+    class Foo {}
+
+    expect(Foo['register']).to.be.a('function');
+
+    const container = DI.createContainer();
+
+    const foo1 = container.get(Foo);
+    const foo2 = container.get(Foo);
+
+    expect(foo1).not.to.equal(foo2);
+  });
+});
+
+describe(`The singleton decorator`, () => {
+  it(`works as a plain decorator`, () => {
+    @singleton
+    class Foo {}
+
+    expect(Foo['register']).to.be.a('function');
+
+    const container = DI.createContainer();
+
+    const foo1 = container.get(Foo);
+    const foo2 = container.get(Foo);
+
+    expect(foo1).to.equal(foo2);
+  });
+
+  it(`works as an invocation`, () => {
+    @singleton()
+    class Foo {}
+
+    expect(Foo['register']).to.be.a('function');
+
+    const container = DI.createContainer();
+
+    const foo1 = container.get(Foo);
+    const foo2 = container.get(Foo);
+
+    expect(foo1).to.equal(foo2);
   });
 });
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR adds the `@transient` and `@singleton` decorators "back" (they already existed in vCurrent and were gone). The primary methods are exposed on the `DI` object for consistency with `inject` and `Resource.define`. They can be used as decorators and as expressions. Some examples:

```ts


// 1. declaration + decorator
@transient
class Foo { }

// 2. declaration + decorator expression
@transient()
class Foo { }

// 3. declaration + member expression
class Foo { }
DI.transient(Foo);

// 4. declaration + function expression (1. decorator)
class Foo { }
transient(Foo);

// 5. declaration + function expression (2. decorator expression)
class Foo { }
transient()(Foo);

// 6. class expression + member expression (returns class with strongly typed static register)
const Foo = DI.transient(class {});

// 7. class expression + function expression (returns class with strongly typed static register)
const Foo = transient(class {})();
```

We probably wouldn't want to encourage usage 4, 5 or 7. For inline declarations usage 3 and 6 would be the recommended way.

Other than that, usage 1. vs 2. would depend both on preference/style/standard as well as potentially needing any options we may add in the future (in which case usage 2 is needed)

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

No related issues
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

They simply put a static register method on the class that returns a resolver directly. It's how I've seen it done elsewhere with vNext DI by @EisenbergEffect 

Furthermore I've applied overload signatures to give alternative docs/examples based on the kind of invocation (something I've done with other decorators in templating as well)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Two simple unit tests are added for each that verify both decorator and decorator expression. The actual registrations and such are already verified by other tests, so didn't bother spending too much time on combinations etc.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

This PR is in the light of end user experience, so follow up steps would involve improving typings, method signatures and jsdoc comments. No concrete plans for those however, so anyone is free to pick that up as well.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
