### PR TITLE
fix(binding): add null check to check for existing behaviorKey

### DIFF
--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -241,7 +241,7 @@ export class BindingBehavior implements IExpression {
     if (!behavior) {
       throw Reporter.error(RuntimeError.NoBehaviorFound, this);
     }
-    if (binding[behaviorKey] !== undefined) {
+    if (binding[behaviorKey] !== undefined && binding[behaviorKey] !== null) {
       throw Reporter.error(RuntimeError.BehaviorAlreadyApplied, this);
     }
     binding[behaviorKey] = behavior;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes an issue with binding behaviors that had no test coverage yet. It surfaced when @Alexander-Taran tried to run the krausest benchmark. When re-binding a binding behavior it only checks if the behaviorKey is undefined, but it needs to check for null as well since that's what it's set to during unbind.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

n/a
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

It's just one line of code :)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Verified the fix by running the krausest benchmark. Breaks no existing tests. Need to add additional tests (was already on my todo) for repeater mutations + binding behaviors after the lifecycle PR is merged in, since the test would break right after merging otherwise.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Add the appropriate tests
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
