### PR TITLE
test(runtime): fix error in arePureLiterals during tests (for now)

### DIFF
--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -152,7 +152,7 @@ export function isLiteral(expr: IsExpressionOrStatement): expr is IsLiteral {
   return (expr.$kind & ExpressionKind.IsLiteral) === ExpressionKind.IsLiteral;
 }
 export function arePureLiterals(expressions: ReadonlyArray<IsExpressionOrStatement>): expressions is IsLiteral[] {
-  if (expressions.length === 0) {
+  if (expressions === undefined || expressions.length === 0) {
     return true;
   }
   for (let i = 0; i < expressions.length; ++i) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently on `master` the tests fail with the error:
```
	TypeError: Cannot read property 'length' of undefined
	    at length (packages/runtime/test/webpack:/src/binding/ast.ts:96:21)
	    at Object.arePureLiterals [as isPureLiteral] (packages/runtime/test/webpack:/src/binding/ast.ts:111:24)
	    at Context.it (packages/runtime/test/webpack:/test/unit/binding/ast.spec.ts:2830:12)
```

This PR partially reverts the change discussed in https://github.com/aurelia/aurelia/pull/262#discussion_r231972721 to fix this problem.

I also don't understand why this didn't surface when running `npm run test` while working on #262 😞.

### 🎫 Issues

Related to #262.

## 👩‍💻 Reviewer Notes

Added back the (in theory unneeded) type check for `undefined`. This gets `master` back in a working state and we can go from there.

## 📑 Test Plan

Ran:
- `npm run build` without errors.
- `npm run test` without test failures.

## ⏭ Next Steps

Figure out why the type check is (un)needed.