### PR TITLE
chore(runtime): decorate bindingBehavior

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -59,9 +59,7 @@ export interface IContainer extends IServiceLocator {
   register(...params: Record<string, Partial<IRegistry>>[]): void;
   register(...params: (IRegistry | Record<string, Partial<IRegistry>>)[]): void;
   register(registry: Record<string, Partial<IRegistry>>): void;
-  // tslint:disable-next-line:unified-signatures
   register(registry: IRegistry): void;
-  // tslint:disable-next-line:unified-signatures
   register(registry: IRegistry | Record<string, Partial<IRegistry>>): void;
 
   registerResolver<T>(key: Key<T>, resolver: IResolver<T>): IResolver<T>;

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -1,16 +1,26 @@
-import { Constructable, IContainer, Registration, Writable } from '@aurelia/kernel';
+import { Constructable, Decoratable, Decorated, IContainer, Registration, Writable } from '@aurelia/kernel';
+import { IScope, LifecycleFlags } from '../observation';
 import { IResourceKind, IResourceType } from '../resource';
+import { IBinding } from './binding';
+
+export interface IBindingBehavior {
+  bind(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
+  unbind(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
+}
 
 export interface IBindingBehaviorSource {
   name: string;
 }
 
-export type IBindingBehaviorType = IResourceType<IBindingBehaviorSource>;
+export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorSource> {
+}
 
-export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource): <T extends Constructable>(target: T) => T & IResourceType<IBindingBehaviorSource> {
-  return function<T extends Constructable>(target: T): T & IResourceType<IBindingBehaviorSource> {
-    return BindingBehaviorResource.define(nameOrSource, target);
-  };
+type BindingBehaviorDecorator = <T extends Constructable>(target: Decoratable<IBindingBehavior, T>) => Decorated<IBindingBehavior, T> & IBindingBehaviorType;
+
+export function bindingBehavior(name: string): BindingBehaviorDecorator;
+export function bindingBehavior(source: IBindingBehaviorSource): BindingBehaviorDecorator;
+export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource): BindingBehaviorDecorator {
+  return target => BindingBehaviorResource.define(nameOrSource, target);
 }
 
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBindingBehaviorType> = {

--- a/scripts/generate-tests/util.ts
+++ b/scripts/generate-tests/util.ts
@@ -56,8 +56,6 @@ import {
   VariableStatement
 } from 'typescript';
 
-// tslint:disable:unified-signatures
-
 export function emit(path: string, ...nodes: Node[]): void {
   const emptyFile: SourceFile = createSourceFile('', '', ScriptTarget.Latest);
   const printer: Printer = createPrinter({ removeComments: false });

--- a/scripts/test-suite.ts
+++ b/scripts/test-suite.ts
@@ -342,7 +342,6 @@ export class TestSuite<A=a,B=a,C=a,D=a,E=a,F=a,G=a,H=a,I=a,J=a,K=a,L=a,M=a,N=a,O
    *
    * @param name The name for the new slot to add. This is only used for generating the title of the test.
    */
-  // tslint:disable-next-line:unified-signatures
   public addActionSlot(name: string): this['asHead'];
   public addActionSlot(nameOrSlot?: this['asHead'] | string): this['asHead'] {
     if (!(nameOrSlot instanceof TestActionSlot)) {

--- a/tslint.json
+++ b/tslint.json
@@ -191,7 +191,7 @@
       "member-variable-declaration"
     ],
     "underscore-consistent-invocation": true,
-    "unified-signatures": true,
+    "unified-signatures": false,
     "use-default-type-parameter": true,
     "variable-name": [true, "ban-keywords", "allow-leading-underscore", "allow-pascal-case"],
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add `Decorate` and `Decorated` typeguards to `@bindingBehavior`.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/pull/262#discussion_r230879707 and #264.

## 👩‍💻 Reviewer Notes

Just `@bandingBehaviour` for now, to validate my interpretation of #264. 

## 📑 Test Plan

Ran:
- `npm run lint` without introducing new warnings
- `npm run build` without errors
- `npm run test` without test failures

## ⏭ Next Steps

Once this is done, I'll start rolling this out to other decorators.