### PR TITLE
chore: more linting fixes

### DIFF
--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -1,4 +1,4 @@
-import { Constructable, IContainer, Registration, Writable } from '@aurelia/kernel';
+import { Constructable, IContainer, IRegistry, Registration, Writable } from '@aurelia/kernel';
 import { BindingType, IExpressionParser, IResourceKind, IResourceType, ITemplateDefinition, TargetedInstruction } from '@aurelia/runtime';
 import {
   CallBindingInstruction,
@@ -39,9 +39,8 @@ export const BindingCommandResource: IResourceKind<IBindingCommandSource, IBindi
     return `${this.name}:${name}`;
   },
 
-  // tslint:disable-next-line:no-reserved-keywords
-  isType<T extends Constructable>(type: T): type is T & IBindingCommandType {
-    return (type as T & {kind?: unknown}).kind === this;
+  isType<T extends Constructable & Partial<IBindingCommandType>>(Type: T): Type is T & IBindingCommandType {
+    return Type.kind === this;
   },
 
   define<T extends Constructable>(nameOrSource: string | IBindingCommandSource, ctor: T): T & IBindingCommandType {
@@ -71,6 +70,7 @@ export interface OneTimeBindingCommand extends IBindingCommand {}
 @bindingCommand('one-time')
 export class OneTimeBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new OneTimeBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.OneTimeCommand), $symbol.to);
@@ -82,6 +82,7 @@ export interface ToViewBindingCommand extends IBindingCommand {}
 @bindingCommand('to-view')
 export class ToViewBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new ToViewBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.ToViewCommand), $symbol.to);
@@ -93,6 +94,7 @@ export interface FromViewBindingCommand extends IBindingCommand {}
 @bindingCommand('from-view')
 export class FromViewBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new FromViewBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.FromViewCommand), $symbol.to);
@@ -104,6 +106,7 @@ export interface TwoWayBindingCommand extends IBindingCommand {}
 @bindingCommand('two-way')
 export class TwoWayBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new TwoWayBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.TwoWayCommand), $symbol.to);
@@ -119,6 +122,7 @@ export interface DefaultBindingCommand extends IBindingCommand {}
 @bindingCommand('bind')
 export class DefaultBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   public $1: typeof OneTimeBindingCommand.prototype.compile;
   public $2: typeof ToViewBindingCommand.prototype.compile;
   public $4: typeof FromViewBindingCommand.prototype.compile;
@@ -141,6 +145,7 @@ export interface TriggerBindingCommand extends IBindingCommand {}
 @bindingCommand('trigger')
 export class TriggerBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new TriggerBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.TriggerCommand), $symbol.to);
@@ -152,6 +157,7 @@ export interface DelegateBindingCommand extends IBindingCommand {}
 @bindingCommand('delegate')
 export class DelegateBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new DelegateBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.DelegateCommand), $symbol.to);
@@ -163,6 +169,7 @@ export interface CaptureBindingCommand extends IBindingCommand {}
 @bindingCommand('capture')
 export class CaptureBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new CaptureBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.CaptureCommand), $symbol.to);
@@ -174,6 +181,7 @@ export interface CallBindingCommand extends IBindingCommand {}
 @bindingCommand('call')
 export class CallBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     return new CallBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.CallCommand), $symbol.to);
@@ -183,6 +191,7 @@ export class CallBindingCommand implements IBindingCommand {
 @bindingCommand('for')
 export class ForBindingCommand implements IBindingCommand {
   public static inject: Function[] = [IExpressionParser];
+  public static register: IRegistry['register'];
   constructor(private parser: IExpressionParser) {}
   public compile($symbol: IAttributeSymbol): TargetedInstruction {
     const def: ITemplateDefinition = {
@@ -190,11 +199,11 @@ export class ForBindingCommand implements IBindingCommand {
       template: $symbol.$element.node,
       instructions: []
     };
-    return new HydrateTemplateController(def, 'repeat', [
+    const instructions = [
       new IteratorBindingInstruction(this.parser.parse($symbol.rawValue, BindingType.ForCommand), 'items'),
       new SetPropertyInstruction('item', 'local')
-    // tslint:disable-next-line:align
-    ], false);
+    ];
+    return new HydrateTemplateController(def, 'repeat', instructions, false);
   }
 
   public handles($symbol: IAttributeSymbol): boolean {

--- a/packages/jit/src/configuration.ts
+++ b/packages/jit/src/configuration.ts
@@ -1,4 +1,4 @@
-import { IContainer, Registration } from '@aurelia/kernel';
+import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
 import {
   AttrBindingBehavior,
   Compose,
@@ -34,7 +34,7 @@ import {
 import { ParserRegistration } from './expression-parser';
 import { TemplateCompiler } from './template-compiler';
 
-const globalResources: any[] = [
+const globalResources: IRegistry[] = [
   Compose,
   If,
   Else,
@@ -54,7 +54,7 @@ const globalResources: any[] = [
   UpdateTriggerBindingBehavior
 ];
 
-const defaultBindingLanguage: any[] = [
+const defaultBindingLanguage: IRegistry[] = [
   DefaultBindingCommand,
   OneTimeBindingCommand,
   ToViewBindingCommand,

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -113,18 +113,18 @@ export const DI = {
     return new Container();
   },
 
-  getDesignParamTypes(target: Object): any[] {
+  getDesignParamTypes(target: Function): Function[] {
     return Reflect.getOwnMetadata('design:paramtypes', target) || PLATFORM.emptyArray;
   },
 
-  getDependencies(type: Function & { inject?: any }): any[] {
-    let dependencies: any[];
+  getDependencies(type: Function | Injectable): Function[] {
+    let dependencies: Function[];
 
-    if (type.inject === undefined) {
+    if ((type as Injectable).inject === undefined) {
       dependencies = DI.getDesignParamTypes(type);
     } else {
       dependencies = [];
-      let ctor = type;
+      let ctor = type as Injectable;
 
       while (typeof ctor === 'function') {
         if (ctor.hasOwnProperty('inject')) {
@@ -181,8 +181,8 @@ export const DI = {
     return Key;
   },
 
-  inject(...dependencies: any[]): (target: any, property?: string, descriptor?: PropertyDescriptor | number) => any {
-    return function(target: any, key?: any, descriptor?: any): void {
+  inject(...dependencies: Function[]): (target: any, key?: string, descriptor?: PropertyDescriptor | number) => void {
+    return function(target: any, key?: string, descriptor?: PropertyDescriptor | number): void {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         if (!target.hasOwnProperty('inject')) {
           target.inject = DI.getDesignParamTypes(target).slice();

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -117,7 +117,7 @@ export type Decorated<TOptional, TRequired> = Function & {
   new(...args: unknown[]): any;
 };
 
-export type Injectable<T = {}> = Constructable<T> & { inject?: unknown[] };
+export type Injectable<T = {}> = Constructable<T> & { inject?: Function[] };
 
 // Note: use of "any" here can perfectly well be replaced by "unknown" but that would also involve fixing consumers of this
 // interface since their indexed properties are now all returning "unknown" which is not assignable to anything else.

--- a/packages/plugin-requirejs/src/types.ts
+++ b/packages/plugin-requirejs/src/types.ts
@@ -16,7 +16,6 @@ export type RequireConfig = {
 
 /*@internal*/
 export type RequireOnLoad = {
-  // tslint:disable-next-line:no-reserved-keywords
   (content: string|{}): void;
   error?(error: Error): void;
 };

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -20,8 +20,8 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
     return `${this.name}:${name}`;
   },
 
-  isType<T extends Constructable>(Type: T): Type is T & IBindingBehaviorType {
-    return (Type as T & IBindingBehaviorType).kind === this;
+  isType<T extends Constructable & Partial<IBindingBehaviorType>>(Type: T): Type is T & IBindingBehaviorType {
+    return Type.kind === this;
   },
 
   define<T extends Constructable>(nameOrSource: string | IBindingBehaviorSource, ctor: T): T & IBindingBehaviorType {

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -1,12 +1,10 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
 import { AccessorOrObserver, IBindingTargetObserver, IScope, LifecycleFlags } from '../observation';
-import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior } from './ast';
+import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
 import { BindingMode } from './binding-mode';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 import { IObserverLocator } from './observer-locator';
-
-// tslint:disable:no-any
 
 export interface IBinding extends IBindScope {
   readonly locator: IServiceLocator;
@@ -46,15 +44,15 @@ export class Binding implements IPartialConnectableBinding {
     this.$lifecycle = locator.get(ILifecycle);
   }
 
-  public updateTarget(value: any, flags: LifecycleFlags): void {
+  public updateTarget(value: StrictAny, flags: LifecycleFlags): void {
     this.targetObserver.setValue(value, flags | LifecycleFlags.updateTargetInstance);
   }
 
-  public updateSource(value: any, flags: LifecycleFlags): void {
+  public updateSource(value: StrictAny, flags: LifecycleFlags): void {
     this.sourceExpression.assign(flags | LifecycleFlags.updateSourceExpression, this.$scope, this.locator, value);
   }
 
-  public handleChange(newValue: any, previousValue: any, flags: LifecycleFlags): void {
+  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -1,6 +1,6 @@
 import { IIndexable, IServiceLocator, Primitive } from '@aurelia/kernel';
 import { INode } from '../dom';
-import { IBindScope, ILifecycle, State } from '../lifecycle';
+import { IBindScope, State } from '../lifecycle';
 import { IAccessor, IScope, LifecycleFlags } from '../observation';
 import { hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
 import { IConnectableBinding } from './connectable';
@@ -80,8 +80,12 @@ export class Call {
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
   }
-  // tslint:disable:no-empty no-any
-  public observeProperty(obj: StrictAny, propertyName: StrictAny): void { }
-  public handleChange(newValue: any, previousValue: any, flags: LifecycleFlags): void { }
-  // tslint:enable:no-empty no-any
+
+  public observeProperty(obj: StrictAny, propertyName: StrictAny): void {
+    return;
+  }
+
+  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
+    return;
+  }
 }

--- a/packages/runtime/src/binding/collection-observer.ts
+++ b/packages/runtime/src/binding/collection-observer.ts
@@ -37,7 +37,7 @@ function resetIndexMapKeyed(this: ICollectionObserver<CollectionKind.keyed>): vo
 }
 
 function getLengthObserver(this: CollectionObserver): CollectionLengthObserver {
-  return this.lengthObserver || <any>(this.lengthObserver = new CollectionLengthObserver(<any>this, this.lengthPropertyName));
+  return this.lengthObserver === undefined ? (this.lengthObserver = new CollectionLengthObserver(<Collection&ICollectionObserver<CollectionKind>>this, this.lengthPropertyName)) : this.lengthObserver as CollectionLengthObserver;
 }
 
 export function collectionObserver(kind: CollectionKind.array | CollectionKind.set | CollectionKind.map): ClassDecorator {

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,12 +1,10 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
-import { IExpression } from './ast';
+import { IExpression, StrictAny } from './ast';
 import { IBindingTarget } from './binding';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 import { IObserverLocator } from './observer-locator';
-
-// tslint:disable:no-any
 
 export interface LetBinding extends IConnectableBinding {}
 
@@ -30,7 +28,7 @@ export class LetBinding implements IPartialConnectableBinding {
     this.$lifecycle = locator.get(ILifecycle);
   }
 
-  public handleChange(newValue: any, previousValue: any, flags: LifecycleFlags): void {
+  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }

--- a/packages/runtime/src/binding/resources/attr-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/attr-binding-behavior.ts
@@ -1,3 +1,4 @@
+import { IRegistry } from '@aurelia/kernel';
 import { ILifecycle } from '../../lifecycle';
 import { IScope, LifecycleFlags } from '../../observation';
 import { Binding } from '../binding';
@@ -6,10 +7,13 @@ import { DataAttributeAccessor } from '../target-accessors';
 
 @bindingBehavior('attr')
 export class AttrBindingBehavior {
+  public static register: IRegistry['register'];
+
   public bind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {
     binding.targetObserver = new DataAttributeAccessor(binding.locator.get(ILifecycle), binding.target, binding.targetProperty);
   }
 
-  // tslint:disable-next-line:no-empty
-  public unbind(flags: LifecycleFlags, scope: IScope, binding: Binding): void { }
+  public unbind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {
+    return;
+  }
 }

--- a/packages/runtime/src/binding/resources/binding-mode-behaviors.ts
+++ b/packages/runtime/src/binding/resources/binding-mode-behaviors.ts
@@ -1,3 +1,4 @@
+import { IRegistry } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '../../observation';
 import { Binding } from '../binding';
 import { bindingBehavior } from '../binding-behavior';
@@ -23,6 +24,8 @@ export abstract class BindingModeBehavior {
 
 @bindingBehavior('oneTime')
 export class OneTimeBindingBehavior extends BindingModeBehavior {
+  public static register: IRegistry['register'];
+
   constructor() {
     super(oneTime);
   }
@@ -30,6 +33,8 @@ export class OneTimeBindingBehavior extends BindingModeBehavior {
 
 @bindingBehavior('toView')
 export class ToViewBindingBehavior extends BindingModeBehavior {
+  public static register: IRegistry['register'];
+
   constructor() {
     super(toView);
   }
@@ -37,6 +42,8 @@ export class ToViewBindingBehavior extends BindingModeBehavior {
 
 @bindingBehavior('fromView')
 export class FromViewBindingBehavior extends BindingModeBehavior {
+  public static register: IRegistry['register'];
+
   constructor() {
     super(fromView);
   }
@@ -44,6 +51,8 @@ export class FromViewBindingBehavior extends BindingModeBehavior {
 
 @bindingBehavior('twoWay')
 export class TwoWayBindingBehavior extends BindingModeBehavior {
+  public static register: IRegistry['register'];
+
   constructor() {
     super(twoWay);
   }

--- a/packages/runtime/src/binding/resources/sanitize.ts
+++ b/packages/runtime/src/binding/resources/sanitize.ts
@@ -1,4 +1,4 @@
-import { DI, inject } from '@aurelia/kernel';
+import { DI, inject, IRegistry } from '@aurelia/kernel';
 import { valueConverter } from '../value-converter';
 
 const SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
@@ -25,6 +25,8 @@ export const ISanitizer = DI.createInterface<ISanitizer>()
 @valueConverter('sanitize')
 @inject(ISanitizer)
 export class SanitizeValueConverter {
+  public static register: IRegistry['register'];
+
   constructor(private sanitizer: ISanitizer) {
     this.sanitizer = sanitizer;
   }

--- a/packages/runtime/src/binding/resources/self-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/self-binding-behavior.ts
@@ -1,4 +1,4 @@
-import { Reporter } from '@aurelia/kernel';
+import { IRegistry, Reporter } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '../../observation';
 import { bindingBehavior } from '../binding-behavior';
 import { findOriginalEventTarget } from '../event-manager';
@@ -21,6 +21,8 @@ export type SelfableBinding = Listener & {
 
 @bindingBehavior('self')
 export class SelfBindingBehavior {
+  public static register: IRegistry['register'];
+
   public bind(flags: LifecycleFlags, scope: IScope, binding: SelfableBinding): void {
     if (!binding.callSource || !binding.targetEvent) {
       throw Reporter.error(8);

--- a/packages/runtime/src/binding/resources/signals.ts
+++ b/packages/runtime/src/binding/resources/signals.ts
@@ -1,4 +1,4 @@
-import { inject, Reporter } from '@aurelia/kernel';
+import { inject, IRegistry, Reporter } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '../../observation';
 import { Binding } from '../binding';
 import { bindingBehavior } from '../binding-behavior';
@@ -11,15 +11,17 @@ export type SignalableBinding = Binding & {
 @bindingBehavior('signal')
 @inject(ISignaler)
 export class SignalBindingBehavior {
+  public static register: IRegistry['register'];
+
   constructor(private signaler: ISignaler) {}
 
-  public bind(flags: LifecycleFlags, scope: IScope, binding: SignalableBinding): void {
+  public bind(flags: LifecycleFlags, scope: IScope, binding: SignalableBinding, ...args: string[]): void {
     if (!binding.updateTarget) {
       throw Reporter.error(11);
     }
 
     if (arguments.length === 4) {
-      const name = arguments[3];
+      const name = args[0];
       this.signaler.addSignalListener(name, binding);
       binding.signal = name;
     } else if (arguments.length > 4) {

--- a/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
@@ -1,4 +1,4 @@
-import { inject, Reporter } from '@aurelia/kernel';
+import { inject, IRegistry, Reporter } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '../../observation';
 import { Binding } from '../binding';
 import { bindingBehavior } from '../binding-behavior';
@@ -18,6 +18,8 @@ export type UpdateTriggerableBinding = Binding & {
 @bindingBehavior('updateTrigger')
 @inject(IObserverLocator)
 export class UpdateTriggerBindingBehavior {
+  public static register: IRegistry['register'];
+
   constructor(private observerLocator: IObserverLocator) {}
 
   public bind(flags: LifecycleFlags, scope: IScope, binding: UpdateTriggerableBinding, ...events: string[]): void {

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -20,8 +20,8 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
     return `${this.name}:${name}`;
   },
 
-  isType<T extends Constructable>(Type: T): Type is T & IValueConverterType {
-    return (Type as T & IValueConverterType).kind === this;
+  isType<T extends Constructable & Partial<IValueConverterType>>(Type: T): Type is T & IValueConverterType {
+    return Type.kind === this;
   },
 
   define<T extends Constructable>(nameOrSource: string | IValueConverterSource, ctor: T): T & IValueConverterType {

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -5,6 +5,7 @@ import { BindingMode } from './binding/binding-mode';
 import { DelegationStrategy } from './binding/event-manager';
 import { INode } from './dom';
 import { ResourceDescription } from './resource';
+import { ICustomElement, ICustomElementHost } from './templating/lifecycle-render';
 
 /*@internal*/
 export const customElementName = 'custom-element';
@@ -13,8 +14,8 @@ export function customElementKey(name: string): string {
   return `${customElementName}:${name}`;
 }
 /*@internal*/
-export function customElementBehavior(node: any): any {
-  return node.$customElement || null;
+export function customElementBehavior(node: ICustomElementHost): ICustomElement {
+  return node.$customElement === undefined ? null : node.$customElement;
 }
 
 /*@internal*/

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -728,7 +728,7 @@ export class Lifecycle implements ILifecycle {
     // no effect on execution. flush() will automatically be invoked when the promise resolves,
     // or it can be manually invoked synchronously.
     if (this.flushHead === this) {
-      this.flushed = this.promise.then(() => this.processFlushQueue(LifecycleFlags.fromAsyncFlush));
+      this.flushed = this.promise.then(() => { this.processFlushQueue(LifecycleFlags.fromAsyncFlush); });
     }
     if (requestor.$nextFlush === null) {
       requestor.$nextFlush = marker;
@@ -1125,7 +1125,7 @@ export class CompositionCoordinator {
     return Registration.transient(this, this).register(container, this);
   }
 
-  public compose(value: IView, flags: LifecycleFlags): void {
+  public compose(value: IView | Promise<IView>, flags: LifecycleFlags): void {
     if (this.swapTask.done) {
       if (value instanceof Promise) {
         this.enqueue(new PromiseSwap(this, value));
@@ -1290,7 +1290,7 @@ export class AggregateLifecycleTask implements ILifecycleTask<void> {
     if (!task.done) {
       this.done = false;
       this.tasks.push(task);
-      task.wait().then(() => this.tryComplete());
+      task.wait().then(() => { this.tryComplete(); });
     }
   }
 
@@ -1319,7 +1319,7 @@ export class AggregateLifecycleTask implements ILifecycleTask<void> {
 
   public cancel(): void {
     if (this.canCancel()) {
-      this.tasks.forEach(x => x.cancel());
+      this.tasks.forEach(x => { x.cancel(); });
       this.done = false;
     }
   }

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -88,7 +88,6 @@ export interface IBindingTargetObserver<
 
 export type AccessorOrObserver = IBindingTargetAccessor | IBindingTargetObserver;
 
-
 /**
  * An array of indices, where the index of an element represents the index to map FROM, and the numeric value of the element itself represents the index to map TO
  *
@@ -208,7 +207,6 @@ export interface ISubscribable<T extends MutationKind> {
   subscribe(subscriber: MutationKindToSubscriber<T>): void;
   unsubscribe(subscriber: MutationKindToSubscriber<T>): void;
 }
-
 
 /**
  * A collection of property or collection subscribers
@@ -344,7 +342,6 @@ export interface ICollectionObserver<T extends CollectionKind> extends
     getLengthObserver(): IBindingTargetObserver;
 }
 export type CollectionObserver = ICollectionObserver<CollectionKind>;
-
 
 export interface IBindingContext {
   [key: string]: unknown;

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -3,7 +3,7 @@ import { Constructable, Immutable, IRegistry } from '@aurelia/kernel';
 export interface IResourceKind<TSource, TType extends IResourceType<TSource> = IResourceType<TSource>> {
   readonly name: string;
   keyFrom(name: string): string;
-  isType<T extends Constructable>(type: T): type is T & TType;
+  isType<T extends Constructable & Partial<TType>>(Type: T): Type is T & TType;
   define<T extends Constructable>(nameOrSource: string | TSource, ctor: T): T & TType;
 }
 

--- a/packages/runtime/src/templating/bindable.ts
+++ b/packages/runtime/src/templating/bindable.ts
@@ -37,7 +37,7 @@ export function bindable<T extends InstanceType<Constructable & Partial<WithBind
     if (!config.callback) {
       config.callback = `${$prop}Changed`;
     }
-    if (!config.mode) {
+    if (config.mode === undefined) {
       config.mode = BindingMode.toView;
     }
     if (arguments.length > 1) {
@@ -54,7 +54,8 @@ export function bindable<T extends InstanceType<Constructable & Partial<WithBind
     // Non invocation:
     // - @bindable
     config = {};
-    return decorator(configOrTarget as T, prop);
+    decorator(configOrTarget as T, prop);
+    return;
   } else if (typeof configOrTarget === 'string') {
     // ClassDecorator
     // - @bindable('bar')

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -25,7 +25,7 @@ export class RenderPlan {
 
   public get definition(): TemplateDefinition {
     return this.lazyDefinition || (this.lazyDefinition =
-      buildTemplateDefinition(null, null, this.node, null, typeof this.node === 'string', null, this.instructions, this.dependencies))
+      buildTemplateDefinition(null, null, this.node, null, typeof this.node === 'string', null, this.instructions, this.dependencies));
   }
 
   public getElementTemplate(engine: IRenderingEngine, Type?: ICustomElementType): ITemplate {

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -113,11 +113,13 @@ export function registerAttribute(this: ICustomAttributeType, container: IContai
 
 /*@internal*/
 export function createCustomAttributeDescription(def: IAttributeDefinition, Type: ICustomAttributeType): ResourceDescription<IAttributeDefinition> {
+  const aliases = def. aliases;
+  const defaultBindingMode = def.defaultBindingMode;
   return {
     name: def.name,
-    aliases: def.aliases || PLATFORM.emptyArray,
-    defaultBindingMode: def.defaultBindingMode || BindingMode.toView,
-    isTemplateController: def.isTemplateController || false,
+    aliases: aliases === undefined || aliases === null ? PLATFORM.emptyArray : aliases,
+    defaultBindingMode: defaultBindingMode === undefined || defaultBindingMode === null ? BindingMode.toView : defaultBindingMode,
+    isTemplateController: def.isTemplateController === undefined ? false : def.isTemplateController,
     bindables: {...Type.bindables, ...def.bindables}
   };
 }

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -1,4 +1,4 @@
-import { all, Constructable, Decoratable, Decorated, DI, IContainer, IDisposable, IIndexable, Immutable, ImmutableArray, inject, IResolver, Omit, PLATFORM, Registration, Reporter, Writable } from '@aurelia/kernel';
+import { all, Constructable, Decoratable, Decorated, DI, IContainer, IDisposable, IIndexable, Immutable, ImmutableArray, inject, IRegistry, IResolver, Omit, PLATFORM, Registration, Reporter, Writable } from '@aurelia/kernel';
 import { Interpolation } from '../binding/ast';
 import { Binding } from '../binding/binding';
 import { Scope } from '../binding/binding-context';
@@ -286,7 +286,7 @@ export class RenderingEngine implements IRenderingEngine {
     let factory = this.factoryLookup.get(definition);
 
     if (!factory) {
-      const validSource = buildTemplateDefinition(null, definition)
+      const validSource = buildTemplateDefinition(null, definition);
       const template = this.templateFromSource(validSource, parentContext);
       factory = new ViewFactory(validSource.name, template, this.lifecycle);
       factory.setCacheSize(validSource.cache, true);
@@ -551,7 +551,7 @@ export class ChildrenObserver implements Partial<IChildrenObserver> {
   public getValue(): ICustomElement[] {
     if (!this.observing) {
       this.observing = true;
-      this.customElement.$projector.subscribeToChildrenChange(() => this.onChildrenChanged());
+      this.customElement.$projector.subscribeToChildrenChange(() => { this.onChildrenChanged(); });
       this.children = findElements(this.customElement.$projector.children);
     }
 
@@ -613,7 +613,8 @@ export class RuntimeCompilationResources implements IResourceDescriptions {
       const factory = resolver.getFactory(this.context);
 
       if (factory !== null) {
-        return (factory.type as IResourceType<TSource>).description || null;
+        const description = (factory.type as IResourceType<TSource>).description;
+        return description === undefined ? null : description;
       }
     }
 
@@ -623,7 +624,8 @@ export class RuntimeCompilationResources implements IResourceDescriptions {
   public create<TSource, TType extends IResourceType<TSource>>(kind: IResourceKind<TSource, TType>, name: string): InstanceType<TType> | null {
     const key = kind.keyFrom(name);
     if (this.context.has(key, false)) {
-      return this.context.get<any>(key) || null;
+      const context = this.context.get<any>(key);
+      return context === undefined ? null : context;
     }
     return null;
   }
@@ -672,11 +674,10 @@ export const noViewTemplate: ITemplate = {
   }
 };
 
-
 /*@internal*/
 export type ExposedContext = IRenderContext & IDisposable & IContainer;
 
-export function createRenderContext(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<any>): IRenderContext {
+export function createRenderContext(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
   const context = <ExposedContext>parentRenderContext.createChild();
   const renderableProvider = new InstanceProvider();
   const elementProvider = new InstanceProvider();
@@ -917,7 +918,7 @@ export class Renderer implements IRenderer {
 
   public [TargetedInstructionType.stylePropertyBinding](renderable: IRenderable, target: any, instruction: Immutable<IStylePropertyBindingInstruction>): void {
     const $from = instruction.from as any;
-    addBindable(renderable, new Binding($from.$kind ? $from : this.parser.parse($from, BindingType.IsPropertyCommand | BindingMode.toView), (<any>target).style, instruction.to, BindingMode.toView, this.observerLocator, this.context));
+    addBindable(renderable, new Binding($from.$kind ? $from : this.parser.parse($from, BindingType.IsPropertyCommand | BindingMode.toView), target.style, instruction.to, BindingMode.toView, this.observerLocator, this.context));
   }
 
   public [TargetedInstructionType.setProperty](renderable: IRenderable, target: any, instruction: Immutable<ISetPropertyInstruction>): void {

--- a/packages/runtime/src/templating/resources/compose.ts
+++ b/packages/runtime/src/templating/resources/compose.ts
@@ -1,4 +1,4 @@
-import { Constructable, Immutable, inject } from '@aurelia/kernel';
+import { Constructable, Immutable, inject, IRegistry } from '@aurelia/kernel';
 import {
   IHydrateElementInstruction,
   ITargetedInstruction,
@@ -26,6 +26,8 @@ export interface Compose extends ICustomElement {}
 @customElement(composeSource)
 @inject(IRenderable, ITargetedInstruction, IRenderingEngine, CompositionCoordinator)
 export class Compose {
+  public static register: IRegistry['register'];
+
   @bindable public subject: Subject | Promise<Subject> = null;
   @bindable public composing: boolean = false;
 
@@ -44,13 +46,16 @@ export class Compose {
 
     this.properties = instruction.instructions
       .filter((x: any) => !composeProps.includes(x.to))
-      .reduce((acc, item: any) => {
-        if (item.to) {
-          acc[item.to] = item;
-        }
+      .reduce(
+        (acc, item: any) => {
+          if (item.to) {
+            acc[item.to] = item;
+          }
 
-        return acc;
-      }, {});
+          return acc;
+        },
+        {}
+      );
   }
 
   public binding(flags: LifecycleFlags): void {
@@ -75,11 +80,11 @@ export class Compose {
     this.coordinator.caching(flags);
   }
 
-  public subjectChanged(newValue: any, previousValue: any, flags: LifecycleFlags): void {
+  public subjectChanged(newValue: Subject | Promise<Subject>, previousValue: Subject | Promise<Subject>, flags: LifecycleFlags): void {
     this.startComposition(newValue, previousValue, flags);
   }
 
-  private startComposition(subject: any, previousSubject: any, flags: LifecycleFlags): void {
+  private startComposition(subject: Subject | Promise<Subject>, _previousSubject: Subject | Promise<Subject>, flags: LifecycleFlags): void {
     if (this.lastSubject === subject) {
       return;
     }
@@ -93,7 +98,7 @@ export class Compose {
     }
 
     this.composing = true;
-    this.coordinator.compose(subject, flags);
+    this.coordinator.compose(subject as IView | Promise<IView>, flags);
   }
 
   private resolveView(subject: Subject, flags: LifecycleFlags): IView {

--- a/packages/runtime/src/templating/resources/if.ts
+++ b/packages/runtime/src/templating/resources/if.ts
@@ -1,4 +1,4 @@
-import { inject } from '@aurelia/kernel';
+import { inject, IRegistry } from '@aurelia/kernel';
 import { IRenderLocation } from '../../dom';
 import { CompositionCoordinator, IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
@@ -10,6 +10,8 @@ export interface If extends ICustomAttribute {}
 @templateController('if')
 @inject(IViewFactory, IRenderLocation, CompositionCoordinator)
 export class If {
+  public static register: IRegistry['register'];
+
   @bindable public value: boolean = false;
 
   public elseFactory: IViewFactory = null;
@@ -98,6 +100,8 @@ export interface Else extends ICustomAttribute {}
 @templateController('else')
 @inject(IViewFactory)
 export class Else {
+  public static register: IRegistry['register'];
+
   constructor(private factory: IViewFactory) { }
 
   public link(ifBehavior: If): void {

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -1,4 +1,4 @@
-import { inject } from '@aurelia/kernel';
+import { inject, IRegistry } from '@aurelia/kernel';
 import { ForOfStatement } from '../../binding/ast';
 import { Binding } from '../../binding/binding';
 import { BindingContext, Scope } from '../../binding/binding-context';
@@ -16,6 +16,8 @@ export interface Repeat<T extends ObservedCollection> extends ICustomAttribute, 
 @inject(IRenderLocation, IRenderable, IViewFactory)
 @templateController('repeat')
 export class Repeat<T extends ObservedCollection = IObservedArray> {
+  public static register: IRegistry['register'];
+
   @bindable public items: T;
 
   public $scope: IScope;

--- a/packages/runtime/src/templating/resources/replaceable.ts
+++ b/packages/runtime/src/templating/resources/replaceable.ts
@@ -1,4 +1,4 @@
-import { inject } from '@aurelia/kernel';
+import { inject, IRegistry } from '@aurelia/kernel';
 import { IRenderLocation } from '../../dom';
 import { IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
@@ -9,6 +9,8 @@ export interface Replaceable extends ICustomAttribute {}
 @templateController('replaceable')
 @inject(IViewFactory, IRenderLocation)
 export class Replaceable {
+  public static register: IRegistry['register'];
+
   private currentView: IView;
 
   constructor(private factory: IViewFactory, location: IRenderLocation) {

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -1,4 +1,4 @@
-import { inject } from '@aurelia/kernel';
+import { inject, IRegistry } from '@aurelia/kernel';
 import { Scope } from '../../binding/binding-context';
 import { IRenderLocation } from '../../dom';
 import { IView, IViewFactory, State } from '../../lifecycle';
@@ -11,6 +11,8 @@ export interface With extends ICustomAttribute {}
 @templateController('with')
 @inject(IViewFactory, IRenderLocation)
 export class With {
+  public static register: IRegistry['register'];
+
   @bindable public value: any = null;
 
   private currentView: IView = null;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Next iteration of linting fixes.

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

Notable changes:
- Replaced some duck-typed types with actual types. (i.e. `{kind?: unknown}` -> `IBindingCommandType`).
- Consolidate/abstract `number` and `NodeJS.Timer` types in `setTimeout` and `clearTimeout` logic to always *look* like a `number`.
- Removed a `// tslint:disable:no-any` as it's potentially hiding unwanted usages of `any`. Fixed all `any` references in that file, except one which needs some more investigation. (It therefore introduces one known new linting warning which needs to be fixed at some point.)

## 📑 Test Plan

Ran:
- `npm run lint` with less warnings. (1 expected new one)
- `npm run build` without errors.
- `npm run test` without test failures.

## ⏭ Next Steps

n/a.