### PR TITLE
chore: disable promise-function-async linting rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -91,7 +91,7 @@
     "no-unused-expression": true,
     "no-use-before-declare": false,
     "no-with-statement": true,
-    "promise-function-async": true,
+    "promise-function-async": false, // See https://github.com/aurelia/aurelia/issues/273
     "promise-must-complete": true,
     "radix": true,
     "react-this-binding-issue": true,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Disable the `promise-function-async` rule for `tslint` for now.

Paraphrasing @fkleuver from https://github.com/aurelia/aurelia/issues/273#issuecomment-437924643:

> The Esprima parser version that ships with aurelia-cli only understands ES2015.
> Later syntax causes aurelia-cli to fail in the transform phase. 
> Until aurelia-cli is updated (and other popular bundlers!), we need to avoid ES2015 incompatible syntax altogether.

As we're not allowed to use `async` for now, it's counterproductive to have the linter complain about it missing.

### 🎫 Issues

- Related to #249 
- Fixes #273 

## 👩‍💻 Reviewer Notes

Disabling the rule altogether (for now) is a better solution than sprinkling the code with `// tslint:disable` statements imho. 

## 📑 Test Plan

Ran:
- `npm run lint` and it didn't warn about `promise-function-async` issues anymore.

## ⏭ Next Steps

Hope that Esprima and other bundlers start supporting > ES2015 syntax soon. 😜 
