### PR TITLE
refactor: add typeguards to decorators and rename Source to Definition

### DIFF
--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -1,4 +1,4 @@
-import { Constructable, IContainer, IRegistry, Registration, Writable } from '@aurelia/kernel';
+import { Constructable, Decoratable, Decorated, IContainer, IRegistry, Registration, Writable } from '@aurelia/kernel';
 import {
   BindingType,
   CallBindingInstruction,
@@ -21,19 +21,23 @@ import {
 } from '@aurelia/runtime';
 import { IAttributeSymbol } from './semantic-model';
 
-export interface IBindingCommandDefinition extends IResourceDefinition { }
-
 export interface IBindingCommand {
   compile($symbol: IAttributeSymbol): TargetedInstruction;
-  handles($symbol: IAttributeSymbol): boolean;
+  handles?($symbol: IAttributeSymbol): boolean;
 }
 
-export type IBindingCommandType = IResourceType<IBindingCommandDefinition, IBindingCommand>;
+export interface IBindingCommandDefinition extends IResourceDefinition { }
 
-export function bindingCommand(nameOrDefinition: string | IBindingCommandDefinition): any {
-  return function<T extends Constructable>(target: T): T & IResourceType<IBindingCommandDefinition, IBindingCommand> {
-    return BindingCommandResource.define(nameOrDefinition, target);
-  };
+export interface IBindingCommandType extends IResourceType<IBindingCommandDefinition, IBindingCommand> {
+  inject: Function[];
+}
+
+type BindingCommandDecorator = <T extends Constructable>(target: Decoratable<IBindingCommand, T>) => Decorated<IBindingCommand, T> & IBindingCommandType;
+
+export function bindingCommand(name: string): BindingCommandDecorator;
+export function bindingCommand(definition: IBindingCommandDefinition): BindingCommandDecorator;
+export function bindingCommand(nameOrDefinition: string | IBindingCommandDefinition): BindingCommandDecorator {
+  return target => BindingCommandResource.define(nameOrDefinition, target);
 }
 
 export const BindingCommandResource: IResourceKind<IBindingCommandDefinition, IBindingCommandType> = {

--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -7,6 +7,7 @@ import {
   FromViewBindingInstruction,
   HydrateTemplateController,
   IExpressionParser,
+  IResourceDefinition,
   IResourceKind,
   IResourceType,
   ITemplateDefinition,
@@ -18,7 +19,6 @@ import {
   TriggerBindingInstruction,
   TwoWayBindingInstruction
 } from '@aurelia/runtime';
-import { IResourceDefinition } from '../../runtime/src/resource';
 import { IAttributeSymbol } from './semantic-model';
 
 export interface IBindingCommandDefinition extends IResourceDefinition { }

--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -18,11 +18,10 @@ import {
   TriggerBindingInstruction,
   TwoWayBindingInstruction
 } from '@aurelia/runtime';
+import { IResourceDefinition } from '../../runtime/src/resource';
 import { IAttributeSymbol } from './semantic-model';
 
-export interface IBindingCommandDefinition {
-  name: string;
-}
+export interface IBindingCommandDefinition extends IResourceDefinition { }
 
 export interface IBindingCommand {
   compile($symbol: IAttributeSymbol): TargetedInstruction;

--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -20,7 +20,7 @@ import {
 } from '@aurelia/runtime';
 import { IAttributeSymbol } from './semantic-model';
 
-export interface IBindingCommandSource {
+export interface IBindingCommandDefinition {
   name: string;
 }
 
@@ -29,15 +29,15 @@ export interface IBindingCommand {
   handles($symbol: IAttributeSymbol): boolean;
 }
 
-export type IBindingCommandType = IResourceType<IBindingCommandSource, IBindingCommand>;
+export type IBindingCommandType = IResourceType<IBindingCommandDefinition, IBindingCommand>;
 
-export function bindingCommand(nameOrSource: string | IBindingCommandSource): any {
-  return function<T extends Constructable>(target: T): T & IResourceType<IBindingCommandSource, IBindingCommand> {
-    return BindingCommandResource.define(nameOrSource, target);
+export function bindingCommand(nameOrDefinition: string | IBindingCommandDefinition): any {
+  return function<T extends Constructable>(target: T): T & IResourceType<IBindingCommandDefinition, IBindingCommand> {
+    return BindingCommandResource.define(nameOrDefinition, target);
   };
 }
 
-export const BindingCommandResource: IResourceKind<IBindingCommandSource, IBindingCommandType> = {
+export const BindingCommandResource: IResourceKind<IBindingCommandDefinition, IBindingCommandType> = {
   name: 'binding-command',
 
   keyFrom(name: string): string {
@@ -48,8 +48,8 @@ export const BindingCommandResource: IResourceKind<IBindingCommandSource, IBindi
     return Type.kind === this;
   },
 
-  define<T extends Constructable>(nameOrSource: string | IBindingCommandSource, ctor: T): T & IBindingCommandType {
-    const description = typeof nameOrSource === 'string' ? { name: nameOrSource, target: null } : nameOrSource;
+  define<T extends Constructable>(nameOrDefinition: string | IBindingCommandDefinition, ctor: T): T & IBindingCommandType {
+    const description = typeof nameOrDefinition === 'string' ? { name: nameOrDefinition, target: null } : nameOrDefinition;
     const Type = ctor as T & IBindingCommandType;
 
     (Type as Writable<IBindingCommandType>).kind = BindingCommandResource;

--- a/packages/jit/src/template-compiler.ts
+++ b/packages/jit/src/template-compiler.ts
@@ -27,7 +27,7 @@ import {
   ViewCompileFlags
 } from '@aurelia/runtime';
 import { IAttributeParser } from './attribute-parser';
-import {  IElementParser, NodeType } from './element-parser';
+import { IElementParser, NodeType } from './element-parser';
 import { AttributeSymbol, ElementSymbol, IAttributeSymbol, SemanticModel } from './semantic-model';
 
 @inject(IExpressionParser, IElementParser, IAttributeParser)

--- a/packages/jit/test/integration/prepare.ts
+++ b/packages/jit/test/integration/prepare.ts
@@ -18,7 +18,7 @@ export function cleanup(): void {
 
 @valueConverter('sort')
 export class SortValueConverter {
-  public toView(arr: any[], prop?: string, dir: 'asc' | 'desc' = 'asc'): any[] {
+  public toView(arr: unknown[], prop?: string, dir: 'asc' | 'desc' = 'asc'): unknown[] {
     if (Array.isArray(arr)) {
       const factor = dir === 'asc' ? 1 : -1;
       if (prop && prop.length) {
@@ -33,10 +33,10 @@ export class SortValueConverter {
 
 @valueConverter('json')
 export class JsonValueConverter {
-  public toView(input: any): string {
+  public toView(input: unknown): string {
     return JSON.stringify(input);
   }
-  public fromView(input: string): any {
+  public fromView(input: string): unknown {
     return JSON.parse(input);
   }
 }

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -1,6 +1,7 @@
 import { DI, IContainer, IRegistry, PLATFORM, Registration } from '@aurelia/kernel';
 import { LifecycleFlags } from './observation';
-import { ICustomElement, IRenderingEngine } from './templating/lifecycle-render';
+import { ICustomElement } from './templating/custom-element';
+import { IRenderingEngine } from './templating/lifecycle-render';
 
 export interface ISinglePageApp {
   host: any;

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -20,29 +20,34 @@ export function bindingBehavior(nameOrDefinition: string | IBindingBehaviorDefin
   return target => BindingBehaviorResource.define(nameOrDefinition, target);
 }
 
+function keyFrom(name: string): string {
+  return `${this.name}:${name}`;
+}
+
+function isType<T extends Constructable & Partial<IBindingBehaviorType>>(Type: T): Type is T & IBindingBehaviorType {
+  return Type.kind === this;
+}
+
+function define<T extends Constructable>(name: string, ctor: T): T & IBindingBehaviorType;
+function define<T extends Constructable>(ndefinition: IBindingBehaviorDefinition, ctor: T): T & IBindingBehaviorType;
+function define<T extends Constructable>(nameOrDefinition: string | IBindingBehaviorDefinition, ctor: T): T & IBindingBehaviorType {
+  const Type = ctor as T & IBindingBehaviorType;
+  const description = typeof nameOrDefinition === 'string'
+    ? { name: nameOrDefinition }
+    : nameOrDefinition;
+
+  (Type as Writable<IBindingBehaviorType>).kind = BindingBehaviorResource;
+  (Type as Writable<IBindingBehaviorType>).description = description;
+  Type.register = register;
+
+  return Type;
+}
+
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorDefinition, IBindingBehaviorType> = {
   name: 'binding-behavior',
-
-  keyFrom(name: string): string {
-    return `${this.name}:${name}`;
-  },
-
-  isType<T extends Constructable & Partial<IBindingBehaviorType>>(Type: T): Type is T & IBindingBehaviorType {
-    return Type.kind === this;
-  },
-
-  define<T extends Constructable>(nameOrDefinition: string | IBindingBehaviorDefinition, ctor: T): T & IBindingBehaviorType {
-    const Type = ctor as T & IBindingBehaviorType;
-    const description = typeof nameOrDefinition === 'string'
-      ? { name: nameOrDefinition }
-      : nameOrDefinition;
-
-    (Type as Writable<IBindingBehaviorType>).kind = BindingBehaviorResource;
-    (Type as Writable<IBindingBehaviorType>).description = description;
-    Type.register = register;
-
-    return Type;
-  }
+  keyFrom,
+  isType,
+  define
 };
 
 function register(this: IBindingBehaviorType, container: IContainer): void {

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -8,22 +8,22 @@ export interface IBindingBehavior {
   unbind(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
 }
 
-export interface IBindingBehaviorSource {
+export interface IBindingBehaviorDefinition {
   name: string;
 }
 
-export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorSource> {
+export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorDefinition> {
 }
 
 type BindingBehaviorDecorator = <T extends Constructable>(target: Decoratable<IBindingBehavior, T>) => Decorated<IBindingBehavior, T> & IBindingBehaviorType;
 
 export function bindingBehavior(name: string): BindingBehaviorDecorator;
-export function bindingBehavior(source: IBindingBehaviorSource): BindingBehaviorDecorator;
-export function bindingBehavior(nameOrSource: string | IBindingBehaviorSource): BindingBehaviorDecorator {
+export function bindingBehavior(source: IBindingBehaviorDefinition): BindingBehaviorDecorator;
+export function bindingBehavior(nameOrSource: string | IBindingBehaviorDefinition): BindingBehaviorDecorator {
   return target => BindingBehaviorResource.define(nameOrSource, target);
 }
 
-export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBindingBehaviorType> = {
+export const BindingBehaviorResource: IResourceKind<IBindingBehaviorDefinition, IBindingBehaviorType> = {
   name: 'binding-behavior',
 
   keyFrom(name: string): string {
@@ -34,11 +34,11 @@ export const BindingBehaviorResource: IResourceKind<IBindingBehaviorSource, IBin
     return Type.kind === this;
   },
 
-  define<T extends Constructable>(nameOrSource: string | IBindingBehaviorSource, ctor: T): T & IBindingBehaviorType {
+  define<T extends Constructable>(nameOrDefinition: string | IBindingBehaviorDefinition, ctor: T): T & IBindingBehaviorType {
     const Type = ctor as T & IBindingBehaviorType;
-    const description = typeof nameOrSource === 'string'
-      ? { name: nameOrSource }
-      : nameOrSource;
+    const description = typeof nameOrDefinition === 'string'
+      ? { name: nameOrDefinition }
+      : nameOrDefinition;
 
     (Type as Writable<IBindingBehaviorType>).kind = BindingBehaviorResource;
     (Type as Writable<IBindingBehaviorType>).description = description;

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -10,15 +10,14 @@ export interface IBindingBehavior {
 
 export interface IBindingBehaviorDefinition extends IResourceDefinition { }
 
-export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorDefinition> {
-}
+export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorDefinition, IBindingBehavior> { }
 
 type BindingBehaviorDecorator = <T extends Constructable>(target: Decoratable<IBindingBehavior, T>) => Decorated<IBindingBehavior, T> & IBindingBehaviorType;
 
 export function bindingBehavior(name: string): BindingBehaviorDecorator;
-export function bindingBehavior(source: IBindingBehaviorDefinition): BindingBehaviorDecorator;
-export function bindingBehavior(nameOrSource: string | IBindingBehaviorDefinition): BindingBehaviorDecorator {
-  return target => BindingBehaviorResource.define(nameOrSource, target);
+export function bindingBehavior(definition: IBindingBehaviorDefinition): BindingBehaviorDecorator;
+export function bindingBehavior(nameOrDefinition: string | IBindingBehaviorDefinition): BindingBehaviorDecorator {
+  return target => BindingBehaviorResource.define(nameOrDefinition, target);
 }
 
 export const BindingBehaviorResource: IResourceKind<IBindingBehaviorDefinition, IBindingBehaviorType> = {

--- a/packages/runtime/src/binding/binding-behavior.ts
+++ b/packages/runtime/src/binding/binding-behavior.ts
@@ -1,6 +1,6 @@
 import { Constructable, Decoratable, Decorated, IContainer, Registration, Writable } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '../observation';
-import { IResourceKind, IResourceType } from '../resource';
+import { IResourceDefinition, IResourceKind, IResourceType } from '../resource';
 import { IBinding } from './binding';
 
 export interface IBindingBehavior {
@@ -8,9 +8,7 @@ export interface IBindingBehavior {
   unbind(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
 }
 
-export interface IBindingBehaviorDefinition {
-  name: string;
-}
+export interface IBindingBehaviorDefinition extends IResourceDefinition { }
 
 export interface IBindingBehaviorType extends IResourceType<IBindingBehaviorDefinition> {
 }

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -18,29 +18,34 @@ export function valueConverter(nameOrDefinition: string | IValueConverterDefinit
   return target => ValueConverterResource.define(nameOrDefinition, target);
 }
 
+function keyFrom(name: string): string {
+  return `${this.name}:${name}`;
+}
+
+function isType<T extends Constructable & Partial<IValueConverterType>>(Type: T): Type is T & IValueConverterType {
+  return Type.kind === this;
+}
+
+function define<T extends Constructable>(name: string, ctor: T): T & IValueConverterType;
+function define<T extends Constructable>(definition: IValueConverterDefinition, ctor: T): T & IValueConverterType;
+function define<T extends Constructable>(nameOrDefinition: string | IValueConverterDefinition, ctor: T): T & IValueConverterType {
+  const Type = ctor as T & IValueConverterType;
+  const description = typeof nameOrDefinition === 'string'
+    ? { name: nameOrDefinition }
+    : nameOrDefinition;
+
+  (Type as Writable<IValueConverterType>).kind = ValueConverterResource;
+  (Type as Writable<IValueConverterType>).description = description;
+  Type.register = register;
+
+  return Type;
+}
+
 export const ValueConverterResource: IResourceKind<IValueConverterDefinition, IValueConverterType> = {
   name: 'value-converter',
-
-  keyFrom(name: string): string {
-    return `${this.name}:${name}`;
-  },
-
-  isType<T extends Constructable & Partial<IValueConverterType>>(Type: T): Type is T & IValueConverterType {
-    return Type.kind === this;
-  },
-
-  define<T extends Constructable>(nameOrDefinition: string | IValueConverterDefinition, ctor: T): T & IValueConverterType {
-    const Type = ctor as T & IValueConverterType;
-    const description = typeof nameOrDefinition === 'string'
-      ? { name: nameOrDefinition }
-      : nameOrDefinition;
-
-    (Type as Writable<IValueConverterType>).kind = ValueConverterResource;
-    (Type as Writable<IValueConverterType>).description = description;
-    Type.register = register;
-
-    return Type;
-  }
+  keyFrom,
+  isType,
+  define
 };
 
 function register(this: IValueConverterType, container: IContainer): void {

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -1,9 +1,7 @@
 import { Constructable, IContainer, Registration, Writable } from '@aurelia/kernel';
-import { IResourceKind, IResourceType } from '../resource';
+import { IResourceDefinition, IResourceKind, IResourceType } from '../resource';
 
-export interface IValueConverterDefinition {
-  name: string;
-}
+export interface IValueConverterDefinition extends IResourceDefinition { }
 
 export type IValueConverterType = IResourceType<IValueConverterDefinition>;
 

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -1,19 +1,19 @@
 import { Constructable, IContainer, Registration, Writable } from '@aurelia/kernel';
 import { IResourceKind, IResourceType } from '../resource';
 
-export interface IValueConverterSource {
+export interface IValueConverterDefinition {
   name: string;
 }
 
-export type IValueConverterType = IResourceType<IValueConverterSource>;
+export type IValueConverterType = IResourceType<IValueConverterDefinition>;
 
-export function valueConverter(nameOrSource: string | IValueConverterSource): <T extends Constructable>(target: T) => T & IResourceType<IValueConverterSource> {
-  return function<T extends Constructable>(target: T): T & IResourceType<IValueConverterSource> {
-    return ValueConverterResource.define(nameOrSource, target);
+export function valueConverter(nameOrDefinition: string | IValueConverterDefinition): <T extends Constructable>(target: T) => T & IResourceType<IValueConverterDefinition> {
+  return function<T extends Constructable>(target: T): T & IResourceType<IValueConverterDefinition> {
+    return ValueConverterResource.define(nameOrDefinition, target);
   };
 }
 
-export const ValueConverterResource: IResourceKind<IValueConverterSource, IValueConverterType> = {
+export const ValueConverterResource: IResourceKind<IValueConverterDefinition, IValueConverterType> = {
   name: 'value-converter',
 
   keyFrom(name: string): string {
@@ -24,11 +24,11 @@ export const ValueConverterResource: IResourceKind<IValueConverterSource, IValue
     return Type.kind === this;
   },
 
-  define<T extends Constructable>(nameOrSource: string | IValueConverterSource, ctor: T): T & IValueConverterType {
+  define<T extends Constructable>(nameOrDefinition: string | IValueConverterDefinition, ctor: T): T & IValueConverterType {
     const Type = ctor as T & IValueConverterType;
-    const description = typeof nameOrSource === 'string'
-      ? { name: nameOrSource }
-      : nameOrSource;
+    const description = typeof nameOrDefinition === 'string'
+      ? { name: nameOrDefinition }
+      : nameOrDefinition;
 
     (Type as Writable<IValueConverterType>).kind = ValueConverterResource;
     (Type as Writable<IValueConverterType>).description = description;

--- a/packages/runtime/src/binding/value-converter.ts
+++ b/packages/runtime/src/binding/value-converter.ts
@@ -1,14 +1,21 @@
-import { Constructable, IContainer, Registration, Writable } from '@aurelia/kernel';
+import { Constructable, Decoratable, Decorated, IContainer, Registration, Writable } from '@aurelia/kernel';
 import { IResourceDefinition, IResourceKind, IResourceType } from '../resource';
+
+export interface IValueConverter {
+  toView(input: unknown, ...args: unknown[]): unknown;
+  fromView?(input: unknown, ...args: unknown[]): unknown;
+}
 
 export interface IValueConverterDefinition extends IResourceDefinition { }
 
-export type IValueConverterType = IResourceType<IValueConverterDefinition>;
+export interface IValueConverterType extends IResourceType<IValueConverterDefinition, IValueConverter> { }
 
-export function valueConverter(nameOrDefinition: string | IValueConverterDefinition): <T extends Constructable>(target: T) => T & IResourceType<IValueConverterDefinition> {
-  return function<T extends Constructable>(target: T): T & IResourceType<IValueConverterDefinition> {
-    return ValueConverterResource.define(nameOrDefinition, target);
-  };
+type ValueConverterDecorator = <T extends Constructable>(target: Decoratable<IValueConverter, T>) => Decorated<IValueConverter, T> & IValueConverterType;
+
+export function valueConverter(name: string): ValueConverterDecorator;
+export function valueConverter(definition: IValueConverterDefinition): ValueConverterDecorator;
+export function valueConverter(nameOrDefinition: string | IValueConverterDefinition): ValueConverterDecorator {
+  return target => ValueConverterResource.define(nameOrDefinition, target);
 }
 
 export const ValueConverterResource: IResourceKind<IValueConverterDefinition, IValueConverterType> = {

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -1,11 +1,12 @@
 // tslint:disable:no-reserved-keywords
-import { Constructable, DI, Immutable, Omit, PLATFORM } from '@aurelia/kernel';
+import { DI, Immutable, Omit, PLATFORM } from '@aurelia/kernel';
 import { ForOfStatement, Interpolation, IsBindingBehavior } from './binding/ast';
 import { BindingMode } from './binding/binding-mode';
 import { DelegationStrategy } from './binding/event-manager';
 import { INode } from './dom';
 import { IResourceDefinition, ResourceDescription } from './resource';
-import { ICustomElement, ICustomElementHost } from './templating/lifecycle-render';
+import { CustomElementConstructor, ICustomElement } from './templating/custom-element';
+import { ICustomElementHost } from './templating/lifecycle-render';
 
 /*@internal*/
 export const customElementName = 'custom-element';
@@ -211,12 +212,6 @@ export interface ILetBindingInstruction extends ITargetedInstruction {
   from: string | IsBindingBehavior | Interpolation;
   to: string;
 }
-
-type CustomElementStaticProperties = Pick<TemplateDefinition, 'containerless' | 'shadowOptions' | 'bindables'>;
-type CustomAttributeStaticProperties = Pick<AttributeDefinition, 'bindables'>;
-
-export type CustomElementConstructor = Constructable & CustomElementStaticProperties;
-export type CustomAttributeConstructor = Constructable & CustomAttributeStaticProperties;
 
 /*@internal*/
 export const buildRequired: IBuildInstruction = Object.freeze({

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -4,7 +4,7 @@ import { ForOfStatement, Interpolation, IsBindingBehavior } from './binding/ast'
 import { BindingMode } from './binding/binding-mode';
 import { DelegationStrategy } from './binding/event-manager';
 import { INode } from './dom';
-import { ResourceDescription } from './resource';
+import { IResourceDefinition, ResourceDescription } from './resource';
 import { ICustomElement, ICustomElementHost } from './templating/lifecycle-render';
 
 /*@internal*/
@@ -59,8 +59,7 @@ export interface IBuildInstruction {
   compiler?: string;
 }
 
-export interface ITemplateDefinition {
-  name?: string;
+export interface ITemplateDefinition extends IResourceDefinition {
   cache?: '*' | number;
   template?: string | INode;
   instructions?: TargetedInstruction[][];
@@ -77,8 +76,7 @@ export type TemplateDefinition = ResourceDescription<ITemplateDefinition>;
 export type TemplatePartDefinitions = Record<string, Immutable<ITemplateDefinition>>;
 export type BindableDefinitions = Record<string, Immutable<IBindableDescription>>;
 
-export interface IAttributeDefinition {
-  name: string;
+export interface IAttributeDefinition extends IResourceDefinition {
   defaultBindingMode?: BindingMode;
   aliases?: string[];
   isTemplateController?: boolean;

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -1,4 +1,4 @@
-import { inject, IRegistry, IContainer } from '@aurelia/kernel';
+import { IContainer, inject, IRegistry } from '@aurelia/kernel';
 import { Binding } from './binding/binding';
 import { BindingMode } from './binding/binding-mode';
 import { Call } from './binding/call';
@@ -12,7 +12,9 @@ import { Ref } from './binding/ref';
 import { customAttributeKey, customElementKey, ICallBindingInstruction, IHydrateAttributeInstruction, IHydrateElementInstruction, IHydrateTemplateController, IInterpolationInstruction, IIteratorBindingInstruction, ILetElementInstruction, IListenerBindingInstruction, IPropertyBindingInstruction, IRefBindingInstruction, ISetAttributeInstruction, ISetPropertyInstruction, IStylePropertyBindingInstruction, ITextBindingInstruction, TargetedInstructionType, TemplatePartDefinitions } from './definitions';
 import { DOM, INode, IRemovableNode } from './dom';
 import { IAttach, IAttachables, IBindables, IBindScope, IRenderable, IRenderContext } from './lifecycle';
-import { ICustomAttribute, ICustomElement, IInstructionRenderer, instructionRenderer, IRenderer, IRenderingEngine } from './templating/lifecycle-render';
+import { ICustomAttribute } from './templating/custom-attribute';
+import { ICustomElement } from './templating/custom-element';
+import { IInstructionRenderer, instructionRenderer, IRenderer, IRenderingEngine } from './templating/lifecycle-render';
 
 export function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TFrom, bindingType: BindingType): Exclude<TFrom, string> {
   if (typeof srcOrExpr === 'string') {

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -8,6 +8,9 @@ export interface IResourceKind<TSource, TType extends IResourceType<TSource> = I
   readonly name: string;
   keyFrom(name: string): string;
   isType<T extends Constructable & Partial<TType>>(Type: T): Type is T & TType;
+
+  define<T extends Constructable>(name: string, ctor: T): T & TType;
+  define<T extends Constructable>(definition: TSource, ctor: T): T & TType;
   define<T extends Constructable>(nameOrDefinition: string | TSource, ctor: T): T & TType;
 }
 

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -1,5 +1,9 @@
 import { Constructable, Immutable, IRegistry } from '@aurelia/kernel';
 
+export interface IResourceDefinition {
+  name: string;
+}
+
 export interface IResourceKind<TSource, TType extends IResourceType<TSource> = IResourceType<TSource>> {
   readonly name: string;
   keyFrom(name: string): string;

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -4,7 +4,7 @@ export interface IResourceKind<TSource, TType extends IResourceType<TSource> = I
   readonly name: string;
   keyFrom(name: string): string;
   isType<T extends Constructable & Partial<TType>>(Type: T): Type is T & TType;
-  define<T extends Constructable>(nameOrSource: string | TSource, ctor: T): T & TType;
+  define<T extends Constructable>(nameOrDefinition: string | TSource, ctor: T): T & TType;
 }
 
 export type ResourceDescription<TSource> = Immutable<Required<TSource>>;

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -2,7 +2,8 @@ import { Constructable, IIndexable } from '@aurelia/kernel';
 import { buildTemplateDefinition, isTargetedInstruction, TargetedInstruction, TargetedInstructionType, TemplateDefinition } from '../definitions';
 import { DOM, INode } from '../dom';
 import { IRenderContext, IView, IViewFactory } from '../lifecycle';
-import { ICustomElementType, IRenderingEngine, ITemplate } from './lifecycle-render';
+import { ICustomElementType } from './custom-element';
+import { IRenderingEngine, ITemplate } from './lifecycle-render';
 
 type ChildType = RenderPlan | string | INode;
 

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -1,11 +1,27 @@
-import { Constructable, Decoratable, Decorated, IContainer, Omit, PLATFORM, Registration, Writable } from '@aurelia/kernel';
+import { Constructable, Decoratable, Decorated, IContainer, Immutable, Omit, PLATFORM, Registration, Writable } from '@aurelia/kernel';
 import { BindingMode } from '../binding/binding-mode';
-import { customAttributeKey, customAttributeName, IAttributeDefinition } from '../definitions';
-import { Hooks } from '../lifecycle';
-import { IResourceKind, ResourceDescription } from '../resource';
+import { AttributeDefinition, customAttributeKey, customAttributeName, IAttributeDefinition } from '../definitions';
+import { Hooks, IAttach, IBindScope, ILifecycleHooks, ILifecycleUnbindAfterDetach, IRenderable, IState } from '../lifecycle';
+import { IChangeTracker } from '../observation';
+import { IResourceKind, IResourceType, ResourceDescription } from '../resource';
 import { $attachAttribute, $cacheAttribute, $detachAttribute } from './lifecycle-attach';
 import { $bindAttribute, $unbindAttribute } from './lifecycle-bind';
-import { $hydrateAttribute, ICustomAttribute, ICustomAttributeType } from './lifecycle-render';
+import { $hydrateAttribute, IRenderingEngine } from './lifecycle-render';
+
+type OptionalHooks = ILifecycleHooks & Omit<IRenderable, Exclude<keyof IRenderable, '$mount' | '$unmount'>>;
+type RequiredLifecycleProperties = Readonly<Pick<IRenderable, '$scope'>> & IState;
+
+type CustomAttributeStaticProperties = Pick<AttributeDefinition, 'bindables'>;
+
+export type CustomAttributeConstructor = Constructable & CustomAttributeStaticProperties;
+
+export interface ICustomAttributeType extends
+  IResourceType<IAttributeDefinition, ICustomAttribute>,
+  Immutable<Pick<Partial<IAttributeDefinition>, 'bindables'>> { }
+
+export interface ICustomAttribute extends Partial<IChangeTracker>, IBindScope, ILifecycleUnbindAfterDetach, IAttach, OptionalHooks, RequiredLifecycleProperties {
+  $hydrate(renderingEngine: IRenderingEngine): void;
+}
 
 type CustomAttributeDecorator = <T extends Constructable>(target: Decoratable<ICustomAttribute, T>) => Decorated<ICustomAttribute, T> & ICustomAttributeType;
 /**

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -49,73 +49,76 @@ export function templateController(nameOrDefinition: string | Omit<IAttributeDef
     target);
 }
 
+function isType<T extends Constructable & Partial<ICustomAttributeType>>(Type: T): Type is T & ICustomAttributeType {
+  return Type.kind === this;
+}
+
+function define<T extends Constructable>(name: string, ctor: T): T & ICustomAttributeType;
+function define<T extends Constructable>(definition: IAttributeDefinition, ctor: T): T & ICustomAttributeType;
+function define<T extends Constructable>(nameOrDefinition: string | IAttributeDefinition, ctor: T): T & ICustomAttributeType {
+  const Type = ctor as T & Writable<ICustomAttributeType>;
+  const description = createCustomAttributeDescription(typeof nameOrDefinition === 'string' ? { name: nameOrDefinition } : nameOrDefinition, <T & ICustomAttributeType>Type);
+  const proto: Writable<ICustomAttribute> = Type.prototype;
+
+  Type.kind = CustomAttributeResource;
+  Type.description = description;
+  Type.register = registerAttribute;
+
+  proto.$hydrate = $hydrateAttribute;
+  proto.$bind = $bindAttribute;
+  proto.$attach = $attachAttribute;
+  proto.$detach = $detachAttribute;
+  proto.$unbind = $unbindAttribute;
+  proto.$cache = $cacheAttribute;
+
+  proto.$prevBind = null;
+  proto.$nextBind = null;
+  proto.$prevAttach = null;
+  proto.$nextAttach = null;
+
+  proto.$nextUnbindAfterDetach = null;
+
+  proto.$scope = null;
+  proto.$hooks = 0;
+  proto.$state = 0;
+
+  if ('flush' in proto) {
+    proto.$nextFlush = null;
+  }
+
+  if ('binding' in proto) proto.$hooks |= Hooks.hasBinding;
+  if ('bound' in proto) {
+    proto.$hooks |= Hooks.hasBound;
+    proto.$nextBound = null;
+  }
+
+  if ('unbinding' in proto) proto.$hooks |= Hooks.hasUnbinding;
+  if ('unbound' in proto) {
+    proto.$hooks |= Hooks.hasUnbound;
+    proto.$nextUnbound = null;
+  }
+
+  if ('created' in proto) proto.$hooks |= Hooks.hasCreated;
+  if ('attaching' in proto) proto.$hooks |= Hooks.hasAttaching;
+  if ('attached' in proto) {
+    proto.$hooks |= Hooks.hasAttached;
+    proto.$nextAttached = null;
+  }
+  if ('detaching' in proto) proto.$hooks |= Hooks.hasDetaching;
+  if ('caching' in proto) proto.$hooks |= Hooks.hasCaching;
+  if ('detached' in proto) {
+    proto.$hooks |= Hooks.hasDetached;
+    proto.$nextDetached = null;
+  }
+
+  return <ICustomAttributeType & T>Type;
+}
+
 export const CustomAttributeResource: IResourceKind<IAttributeDefinition, ICustomAttributeType> = {
   name: customAttributeName,
-
   keyFrom: customAttributeKey,
-
-  isType<T extends Constructable & Partial<ICustomAttributeType>>(Type: T): Type is T & ICustomAttributeType {
-    return Type.kind === this;
-  },
-
-  define<T extends Constructable>(nameOrDefinition: string | IAttributeDefinition, ctor: T): T & ICustomAttributeType {
-    const Type = ctor as T & Writable<ICustomAttributeType>;
-    const description = createCustomAttributeDescription(typeof nameOrDefinition === 'string' ? { name: nameOrDefinition } : nameOrDefinition, <T & ICustomAttributeType>Type);
-    const proto: Writable<ICustomAttribute> = Type.prototype;
-
-    Type.kind = CustomAttributeResource;
-    Type.description = description;
-    Type.register = registerAttribute;
-
-    proto.$hydrate = $hydrateAttribute;
-    proto.$bind = $bindAttribute;
-    proto.$attach = $attachAttribute;
-    proto.$detach = $detachAttribute;
-    proto.$unbind = $unbindAttribute;
-    proto.$cache = $cacheAttribute;
-
-    proto.$prevBind = null;
-    proto.$nextBind = null;
-    proto.$prevAttach = null;
-    proto.$nextAttach = null;
-
-    proto.$nextUnbindAfterDetach = null;
-
-    proto.$scope = null;
-    proto.$hooks = 0;
-    proto.$state = 0;
-
-    if ('flush' in proto) {
-      proto.$nextFlush = null;
-    }
-
-    if ('binding' in proto) proto.$hooks |= Hooks.hasBinding;
-    if ('bound' in proto) {
-      proto.$hooks |= Hooks.hasBound;
-      proto.$nextBound = null;
-    }
-
-    if ('unbinding' in proto) proto.$hooks |= Hooks.hasUnbinding;
-    if ('unbound' in proto) {
-      proto.$hooks |= Hooks.hasUnbound;
-      proto.$nextUnbound = null;
-    }
-
-    if ('created' in proto) proto.$hooks |= Hooks.hasCreated;
-    if ('attaching' in proto) proto.$hooks |= Hooks.hasAttaching;
-    if ('attached' in proto) {
-      proto.$hooks |= Hooks.hasAttached;
-      proto.$nextAttached = null;
-    }
-    if ('detaching' in proto) proto.$hooks |= Hooks.hasDetaching;
-    if ('caching' in proto) proto.$hooks |= Hooks.hasCaching;
-    if ('detached' in proto) {
-      proto.$hooks |= Hooks.hasDetached;
-      proto.$nextDetached = null;
-    }
-
-    return <ICustomAttributeType & T>Type;
-  }
+  isType,
+  define
 };
 
 /*@internal*/

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -15,20 +15,23 @@ type CustomAttributeStaticProperties = Pick<AttributeDefinition, 'bindables'>;
 
 export type CustomAttributeConstructor = Constructable & CustomAttributeStaticProperties;
 
-export interface ICustomAttributeType extends
-  IResourceType<IAttributeDefinition, ICustomAttribute>,
-  Immutable<Pick<Partial<IAttributeDefinition>, 'bindables'>> { }
-
 export interface ICustomAttribute extends Partial<IChangeTracker>, IBindScope, ILifecycleUnbindAfterDetach, IAttach, OptionalHooks, RequiredLifecycleProperties {
   $hydrate(renderingEngine: IRenderingEngine): void;
 }
 
+export interface ICustomAttributeType extends
+  IResourceType<IAttributeDefinition, ICustomAttribute>,
+  Immutable<Pick<Partial<IAttributeDefinition>, 'bindables'>> { }
+
 type CustomAttributeDecorator = <T extends Constructable>(target: Decoratable<ICustomAttribute, T>) => Decorated<ICustomAttribute, T> & ICustomAttributeType;
+
 /**
  * Decorator: Indicates that the decorated class is a custom attribute.
  */
-export function customAttribute(nameOrDef: string | IAttributeDefinition): CustomAttributeDecorator {
-  return target => CustomAttributeResource.define(nameOrDef, target);
+export function customAttribute(name: string): CustomAttributeDecorator;
+export function customAttribute(definition: IAttributeDefinition): CustomAttributeDecorator;
+export function customAttribute(nameOrDefinition: string | IAttributeDefinition): CustomAttributeDecorator {
+  return target => CustomAttributeResource.define(nameOrDefinition, target);
 }
 
 /**
@@ -36,11 +39,13 @@ export function customAttribute(nameOrDef: string | IAttributeDefinition): Custo
  * attribute is placed on should be converted into a template and that this
  * attribute controls the instantiation of the template.
  */
-export function templateController(nameOrDef: string | Omit<IAttributeDefinition, 'isTemplateController'>): CustomAttributeDecorator {
+export function templateController(name: string): CustomAttributeDecorator;
+export function templateController(definition: IAttributeDefinition): CustomAttributeDecorator;
+export function templateController(nameOrDefinition: string | Omit<IAttributeDefinition, 'isTemplateController'>): CustomAttributeDecorator {
   return target => CustomAttributeResource.define(
-    typeof nameOrDef === 'string'
-    ? { isTemplateController: true , name: nameOrDef }
-    : { isTemplateController: true, ...nameOrDef },
+    typeof nameOrDefinition === 'string'
+    ? { isTemplateController: true , name: nameOrDefinition }
+    : { isTemplateController: true, ...nameOrDefinition },
     target);
 }
 

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -37,9 +37,9 @@ export const CustomAttributeResource: IResourceKind<IAttributeDefinition, ICusto
     return Type.kind === this;
   },
 
-  define<T extends Constructable>(nameOrSource: string | IAttributeDefinition, ctor: T): T & ICustomAttributeType {
+  define<T extends Constructable>(nameOrDefinition: string | IAttributeDefinition, ctor: T): T & ICustomAttributeType {
     const Type = ctor as T & Writable<ICustomAttributeType>;
-    const description = createCustomAttributeDescription(typeof nameOrSource === 'string' ? { name: nameOrSource } : nameOrSource, <T & ICustomAttributeType>Type);
+    const description = createCustomAttributeDescription(typeof nameOrDefinition === 'string' ? { name: nameOrDefinition } : nameOrDefinition, <T & ICustomAttributeType>Type);
     const proto: Writable<ICustomAttribute> = Type.prototype;
 
     Type.kind = CustomAttributeResource;

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -26,6 +26,8 @@ type CustomElementDecorator = <T extends Constructable>(target: Decoratable<ICus
 /**
  * Decorator: Indicates that the decorated class is a custom element.
  */
+export function customElement(name: string): CustomElementDecorator;
+export function customElement(definition: ITemplateDefinition): CustomElementDecorator;
 export function customElement(nameOrDefinition: string | ITemplateDefinition): CustomElementDecorator {
   return target => CustomElementResource.define(nameOrDefinition, target);
 }

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -1,9 +1,26 @@
 import { Constructable, Decoratable, Decorated, IContainer, Registration, Reporter, Writable } from '@aurelia/kernel';
-import { buildTemplateDefinition, customElementBehavior, customElementKey, customElementName, ITemplateDefinition } from '../definitions';
-import { Hooks, State } from '../lifecycle';
+import { buildTemplateDefinition, customElementBehavior, customElementKey, customElementName, ITemplateDefinition, TemplateDefinition } from '../definitions';
+import { INode } from '../dom';
+import { Hooks, IAttach, IBindSelf, ILifecycleHooks, ILifecycleUnbindAfterDetach, IMountable, IRenderable, IState, State } from '../lifecycle';
+import { IChangeTracker } from '../observation';
+import { IResourceType } from '../resource';
 import { $attachElement, $cacheElement, $detachElement, $mountElement, $unmountElement } from './lifecycle-attach';
 import { $bindElement, $unbindElement } from './lifecycle-bind';
-import { $hydrateElement, defaultShadowOptions, ICustomElement, ICustomElementHost, ICustomElementResource, ICustomElementType } from './lifecycle-render';
+import { $hydrateElement, defaultShadowOptions, ICustomElementHost, ICustomElementResource, IElementHydrationOptions, IElementProjector, ILifecycleRender, IRenderingEngine } from './lifecycle-render';
+
+type CustomElementStaticProperties = Pick<TemplateDefinition, 'containerless' | 'shadowOptions' | 'bindables'>;
+
+export type CustomElementConstructor = Constructable & CustomElementStaticProperties;
+
+export interface ICustomElementType extends
+  IResourceType<ITemplateDefinition, ICustomElement>,
+  CustomElementConstructor { }
+
+export interface ICustomElement extends Partial<IChangeTracker>, ILifecycleHooks, ILifecycleRender, IBindSelf, ILifecycleUnbindAfterDetach, IAttach, IMountable, IState, IRenderable {
+  readonly $projector: IElementProjector;
+  readonly $host: ICustomElementHost;
+  $hydrate(renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
+}
 
 type CustomElementDecorator = <T extends Constructable>(target: Decoratable<ICustomElement, T>) => Decorated<ICustomElement, T> & ICustomElementType;
 /**

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -9,8 +9,8 @@ type CustomElementDecorator = <T extends Constructable>(target: Decoratable<ICus
 /**
  * Decorator: Indicates that the decorated class is a custom element.
  */
-export function customElement(nameOrSource: string | ITemplateDefinition): CustomElementDecorator {
-  return target => CustomElementResource.define(nameOrSource, target);
+export function customElement(nameOrDefinition: string | ITemplateDefinition): CustomElementDecorator {
+  return target => CustomElementResource.define(nameOrDefinition, target);
 }
 
 type HasShadowOptions = Pick<ITemplateDefinition, 'shadowOptions'>;
@@ -66,12 +66,12 @@ export const CustomElementResource: ICustomElementResource = {
 
   behaviorFor: <(node: ICustomElementHost) => ICustomElement | null>customElementBehavior,
 
-  define<T extends Constructable>(nameOrSource: string | ITemplateDefinition, ctor: T = null): T & ICustomElementType {
-    if (!nameOrSource) {
+  define<T extends Constructable>(nameOrDefinition: string | ITemplateDefinition, ctor: T = null): T & ICustomElementType {
+    if (!nameOrDefinition) {
       throw Reporter.error(70);
     }
     const Type = (ctor === null ? class HTMLOnlyElement { /* HTML Only */ } : ctor) as T & Writable<ICustomElementType>;
-    const description = buildTemplateDefinition(<ICustomElementType><unknown>Type, nameOrSource);
+    const description = buildTemplateDefinition(<ICustomElementType><unknown>Type, nameOrDefinition);
     const proto: Writable<ICustomElement> = Type.prototype;
 
     Type.kind = CustomElementResource;

--- a/packages/runtime/src/templating/lifecycle-attach.ts
+++ b/packages/runtime/src/templating/lifecycle-attach.ts
@@ -2,7 +2,8 @@ import { Writable } from '@aurelia/kernel';
 import { IEncapsulationSource } from '../dom';
 import { Hooks, IView, State } from '../lifecycle';
 import { LifecycleFlags } from '../observation';
-import { ICustomAttribute, ICustomElement } from './lifecycle-render';
+import { ICustomAttribute } from './custom-attribute';
+import { ICustomElement } from './custom-element';
 
 /*@internal*/
 export function $attachAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {

--- a/packages/runtime/src/templating/lifecycle-bind.ts
+++ b/packages/runtime/src/templating/lifecycle-bind.ts
@@ -1,7 +1,8 @@
 import { Writable } from '@aurelia/kernel';
 import { Hooks, IView, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
-import { ICustomAttribute, ICustomElement } from './lifecycle-render';
+import { ICustomAttribute } from './custom-attribute';
+import { ICustomElement } from './custom-element';
 
 /*@internal*/
 export function $bindAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags, scope: IScope): void {

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -1,12 +1,14 @@
-import { all, Decoratable, Decorated, DI, IContainer, IDisposable, IIndexable, Immutable, ImmutableArray, inject, IRegistry, IResolver, Omit, PLATFORM, Registration, Reporter, Writable } from '@aurelia/kernel';
+import { all, Decoratable, Decorated, DI, IContainer, IDisposable, IIndexable, Immutable, ImmutableArray, inject, IRegistry, IResolver, PLATFORM, Registration, Reporter, Writable } from '@aurelia/kernel';
 import { Scope } from '../binding/binding-context';
 import { Observer } from '../binding/property-observation';
 import { subscriberCollection } from '../binding/subscriber-collection';
-import { BindableDefinitions, buildTemplateDefinition, customElementBehavior, CustomElementConstructor, IAttributeDefinition, IHydrateElementInstruction, ITargetedInstruction, ITemplateDefinition, TemplateDefinition, TemplatePartDefinitions } from '../definitions';
+import { BindableDefinitions, buildTemplateDefinition, customElementBehavior, IHydrateElementInstruction, ITargetedInstruction, ITemplateDefinition, TemplateDefinition, TemplatePartDefinitions } from '../definitions';
 import { DOM, INode, INodeSequence, INodeSequenceFactory, IRenderLocation, NodeSequence, NodeSequenceFactory } from '../dom';
-import { Hooks, IAttach, IBindScope, IBindSelf, ILifecycle, ILifecycleHooks, ILifecycleUnbindAfterDetach, IMountable, IRenderable, IRenderContext, IState, IViewFactory, State } from '../lifecycle';
-import { IAccessor, IChangeTracker, IPropertySubscriber, ISubscribable, ISubscriberCollection, LifecycleFlags, MutationKind } from '../observation';
+import { Hooks, ILifecycle, IRenderable, IRenderContext, IViewFactory, State } from '../lifecycle';
+import { IAccessor, IPropertySubscriber, ISubscribable, ISubscriberCollection, LifecycleFlags, MutationKind } from '../observation';
 import { IResourceDescriptions, IResourceKind, IResourceType, ResourceDescription } from '../resource';
+import { ICustomAttribute, ICustomAttributeType } from './custom-attribute';
+import { ICustomElement, ICustomElementType } from './custom-element';
 import { ViewFactory } from './view';
 
 export interface ITemplateCompiler {
@@ -22,17 +24,7 @@ export enum ViewCompileFlags {
   shadowDOM   = 0b0_100,
 }
 
-export interface ICustomElementType extends
-  IResourceType<ITemplateDefinition, ICustomElement>,
-  CustomElementConstructor { }
-
 export type IElementHydrationOptions = Immutable<Pick<IHydrateElementInstruction, 'parts'>>;
-
-export interface ICustomElement extends Partial<IChangeTracker>, ILifecycleHooks, ILifecycleRender, IBindSelf, ILifecycleUnbindAfterDetach, IAttach, IMountable, IState, IRenderable {
-  readonly $projector: IElementProjector;
-  readonly $host: ICustomElementHost;
-  $hydrate(renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
-}
 
 export interface ICustomElementHost extends IRenderLocation {
   $customElement?: ICustomElement;
@@ -54,13 +46,6 @@ export interface IElementProjector {
 
   subscribeToChildrenChange(callback: () => void): void;
 }
-
-export interface ICustomAttributeType extends
-  IResourceType<IAttributeDefinition, ICustomAttribute>,
-  Immutable<Pick<Partial<IAttributeDefinition>, 'bindables'>> { }
-
-type OptionalHooks = ILifecycleHooks & Omit<IRenderable, Exclude<keyof IRenderable, '$mount' | '$unmount'>>;
-type RequiredLifecycleProperties = Readonly<Pick<IRenderable, '$scope'>> & IState;
 
 export interface IElementTemplateProvider {
   getElementTemplate(renderingEngine: IRenderingEngine, customElementType: ICustomElementType): ITemplate;
@@ -91,10 +76,6 @@ export interface ILifecycleRender {
    * which can happen many times per instance), though it can happen many times per type (once for each instance)
    */
   render?(host: INode, parts: Immutable<Pick<IHydrateElementInstruction, 'parts'>>): IElementTemplateProvider | void;
-}
-
-export interface ICustomAttribute extends Partial<IChangeTracker>, IBindScope, ILifecycleUnbindAfterDetach, IAttach, OptionalHooks, RequiredLifecycleProperties {
-  $hydrate(renderingEngine: IRenderingEngine): void;
 }
 
 /*@internal*/

--- a/packages/runtime/src/templating/resources/compose.ts
+++ b/packages/runtime/src/templating/resources/compose.ts
@@ -10,8 +10,8 @@ import { CompositionCoordinator, IRenderable, IView, IViewFactory } from '../../
 import { LifecycleFlags } from '../../observation';
 import { bindable } from '../bindable';
 import { createElement, RenderPlan } from '../create-element';
-import { customElement } from '../custom-element';
-import { ICustomElement, IRenderingEngine } from '../lifecycle-render';
+import { customElement, ICustomElement } from '../custom-element';
+import { IRenderingEngine } from '../lifecycle-render';
 
 const composeSource: ITemplateDefinition = {
   name: 'au-compose',

--- a/packages/runtime/src/templating/resources/if.ts
+++ b/packages/runtime/src/templating/resources/if.ts
@@ -3,8 +3,7 @@ import { IRenderLocation } from '../../dom';
 import { CompositionCoordinator, IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
 import { bindable } from '../bindable';
-import { templateController } from '../custom-attribute';
-import { ICustomAttribute } from '../lifecycle-render';
+import { ICustomAttribute, templateController } from '../custom-attribute';
 
 export interface If extends ICustomAttribute {}
 @templateController('if')

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -8,8 +8,7 @@ import { INode, IRenderLocation } from '../../dom';
 import { IRenderable, IView, IViewFactory, State } from '../../lifecycle';
 import { CollectionObserver, IBatchedCollectionSubscriber, IObservedArray, IScope, LifecycleFlags, ObservedCollection } from '../../observation';
 import { bindable } from '../bindable';
-import { templateController } from '../custom-attribute';
-import { ICustomAttribute } from '../lifecycle-render';
+import { ICustomAttribute, templateController } from '../custom-attribute';
 
 export interface Repeat<T extends ObservedCollection> extends ICustomAttribute, IBatchedCollectionSubscriber {}
 

--- a/packages/runtime/src/templating/resources/replaceable.ts
+++ b/packages/runtime/src/templating/resources/replaceable.ts
@@ -2,8 +2,7 @@ import { inject, IRegistry } from '@aurelia/kernel';
 import { IRenderLocation } from '../../dom';
 import { IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
-import { templateController } from '../custom-attribute';
-import { ICustomAttribute } from '../lifecycle-render';
+import { ICustomAttribute, templateController } from '../custom-attribute';
 
 export interface Replaceable extends ICustomAttribute {}
 @templateController('replaceable')

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -4,8 +4,7 @@ import { IRenderLocation } from '../../dom';
 import { IView, IViewFactory, State } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
 import { bindable } from '../bindable';
-import { templateController } from '../custom-attribute';
-import { ICustomAttribute } from '../lifecycle-render';
+import { ICustomAttribute, templateController } from '../custom-attribute';
 
 export interface With extends ICustomAttribute {}
 @templateController('with')


### PR DESCRIPTION
# Pull Request

## 📖 Description

Decorated `@bindingCommand`, `@valueConverter`, `@customAttribute` and `@customElement` with `Decorate` and `Decorated` typeguards.

Also added a base `IResourceDefinition` interface per the discussion at https://github.com/aurelia/aurelia/pull/272#issuecomment-438000257.

### 🎫 Issues

Follow up to #272.

## 👩‍💻 Reviewer Notes

- This includes the next step in the `Source` to `Definition` rename. I think I got all occurrences but a check couldn't hurt.
- All decorators define their `ISomething` and `ISomethingType` interfaces in the same file, with the exception of `customElement` and `customAttribute`. I decided to move those types to their corresponding files as well for consistency. Is this the right approach?
- Added and reverse engineered `IValueConverter` from current usage in the codebase, so a check if it's valid would be appreciated.
- Did an `any` -> `unknown` conversion on all `@valueConverters` as a result of the previous item.

## 📑 Test Plan

*Works on my machine*™️ Lets hope CircleCI agrees 😜.

## ⏭ Next Steps

n/a.
