### PR TITLE
refactor: remove no-reserved-keywords suppressions and fix most of them

### DIFF
--- a/packages/debug/src/reporter.ts
+++ b/packages/debug/src/reporter.ts
@@ -9,8 +9,7 @@ const enum MessageType {
 
 interface IMessageInfo {
   message: string;
-  // tslint:disable-next-line:no-reserved-keywords
-  type: MessageType;
+  messageType: MessageType;
 }
 
 export const Reporter: typeof RuntimeReporter = {...RuntimeReporter,
@@ -18,7 +17,7 @@ export const Reporter: typeof RuntimeReporter = {...RuntimeReporter,
     const info = getMessageInfoForCode(code);
 
     // tslint:disable:no-console
-    switch (info.type) {
+    switch (info.messageType) {
       case MessageType.debug:
         console.debug(info.message, ...params);
         break;
@@ -46,162 +45,162 @@ function getMessageInfoForCode(code: number): IMessageInfo {
 
 function createInvalidCodeMessageInfo(code: number): IMessageInfo {
   return {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: `Attempted to report with unknown code ${code}.`
   };
 }
 
 const codeLookup: Record<string, IMessageInfo> = {
   0: {
-    type: MessageType.warn,
+    messageType: MessageType.warn,
     message: 'Cannot add observers to object.'
   },
   1: {
-    type: MessageType.warn,
+    messageType: MessageType.warn,
     message: 'Cannot observe property of object.'
   },
   2: {
-    type: MessageType.info,
+    messageType: MessageType.info,
     message: 'Starting application in debug mode.'
   },
   3: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Runtime expression compilation is only available when including JIT support.'
   },
   4: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid animation direction.'
   },
   5: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'key/value cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?'
   },
   6: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid resolver strategy specified.'
   },
   7: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Constructor Parameter with index cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?'
   },
   8: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Self binding behavior only supports events.'
   },
   9: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:\'blur\'">'
   },
   10: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.'
   },
   11: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Only property bindings and string interpolation bindings can be signaled. Trigger, delegate and call bindings cannot be signaled.'
   },
   12: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Signal name is required.'
   },
   14: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Property cannot be assigned.'
   },
   15: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unexpected call context.'
   },
   16: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Only one child observer per content view is supported for the life of the content view.'
   },
   17: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'You can only define one default implementation for an interface.'
   },
   18: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'You cannot observe a setter only property.'
   },
   19: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Value for expression is non-repeatable.'
   },
   20: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'No template compiler found with the specified name. JIT support or a custom compiler is required.'
   },
   21: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'You cannot combine the containerless custom element option with Shadow DOM.'
   },
   22: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'A containerless custom element cannot be the root component of an application.'
   },
   30: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'There are more targets than there are target instructions.'
   },
   31: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'There are more target instructions than there are targets.'
   },
   100: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid start of expression.'
   },
   101: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unconsumed token.'
   },
   102: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Double dot and spread operators are not supported.'
   },
   103: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid member expression.'
   },
   104: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unexpected end of expression.'
   },
   105: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Expected identifier.'
   },
   106: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid BindingIdentifier at left hand side of "of".'
   },
   107: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Invalid or unsupported property definition in object literal.'
   },
   108: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unterminated quote in string literal.'
   },
   109: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unterminated template string.'
   },
   110: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Missing expected token.'
   },
   111: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unexpected character.'
   },
   150: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Left hand side of expression is not assignable.'
   },
   151: {
-    type: MessageType.error,
+    messageType: MessageType.error,
     message: 'Unexpected keyword "of"'
   }
 };

--- a/packages/jit/test/unit/template-compiler.spec.ts
+++ b/packages/jit/test/unit/template-compiler.spec.ts
@@ -55,7 +55,7 @@ describe('TemplateCompiler', () => {
     container.register(BasicConfiguration);
     expressionParser = container.get(IExpressionParser);
     sut = new TemplateCompiler(expressionParser as any, elParser, attrParser);
-    container.registerResolver(CustomAttributeResource.keyFrom('foo'), <any>{ getFactory: () => ({ type: { description: {} } }) });
+    container.registerResolver(CustomAttributeResource.keyFrom('foo'), <any>{ getFactory: () => ({ Type: { description: {} } }) });
     resources = new RuntimeCompilationResources(<any>container);
   });
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -1,5 +1,4 @@
 /// <reference types="reflect-metadata" />
-// tslint:disable:no-reserved-keywords
 import { Constructable, IIndexable, Injectable, Primitive } from './interfaces';
 import { PLATFORM } from './platform';
 import { Reporter } from './reporter';
@@ -29,7 +28,7 @@ export interface IRegistration<T = any> {
 }
 
 export interface IFactory<T = any> {
-  readonly type: Function;
+  readonly Type: Function;
   registerTransformer(transformer: (instance: T) => T): boolean;
   construct(container: IContainer, dynamicDependencies?: any[]): T;
 }
@@ -71,7 +70,7 @@ export interface IContainer extends IServiceLocator {
   getResolver<T>(key: Key<T>, autoRegister?: boolean): IResolver<T> | null;
   getResolver<T extends Constructable>(key: T, autoRegister?: boolean): IResolver<InstanceType<T>> | null;
 
-  getFactory<T extends Constructable>(type: T): IFactory<InstanceType<T>>;
+  getFactory<T extends Constructable>(Type: T): IFactory<InstanceType<T>>;
 
   createChild(): IContainer;
 }
@@ -115,14 +114,14 @@ export const DI = {
     return Reflect.getOwnMetadata('design:paramtypes', target) || PLATFORM.emptyArray;
   },
 
-  getDependencies(type: Function | Injectable): Function[] {
+  getDependencies(Type: Function | Injectable): Function[] {
     let dependencies: Function[];
 
-    if ((type as Injectable).inject === undefined) {
-      dependencies = DI.getDesignParamTypes(type);
+    if ((Type as Injectable).inject === undefined) {
+      dependencies = DI.getDesignParamTypes(Type);
     } else {
       dependencies = [];
-      let ctor = type as Injectable;
+      let ctor = Type as Injectable;
 
       while (typeof ctor === 'function') {
         if (ctor.hasOwnProperty('inject')) {
@@ -443,29 +442,29 @@ export interface IInvoker {
 
 /*@internal*/
 export class Factory implements IFactory {
-  public type: Function;
+  public Type: Function;
   private invoker: IInvoker;
   private dependencies: any[];
   private transformers: ((instance: any) => any)[] | null;
 
-  constructor(type: Function, invoker: IInvoker, dependencies: any[]) {
-    this.type = type;
+  constructor(Type: Function, invoker: IInvoker, dependencies: any[]) {
+    this.Type = Type;
     this.invoker = invoker;
     this.dependencies = dependencies;
     this.transformers = null;
   }
 
-  public static create(type: Function): IFactory {
-    const dependencies = DI.getDependencies(type);
+  public static create(Type: Function): IFactory {
+    const dependencies = DI.getDependencies(Type);
     const invoker = classInvokers[dependencies.length] || fallbackInvoker;
-    return new Factory(type, invoker, dependencies);
+    return new Factory(Type, invoker, dependencies);
   }
 
   public construct(container: IContainer, dynamicDependencies?: any[]): any {
     const transformers = this.transformers;
     let instance = dynamicDependencies !== undefined
-      ? this.invoker.invokeWithDynamicDependencies(container, this.type, this.dependencies, dynamicDependencies)
-      : this.invoker.invoke(container, this.type, this.dependencies);
+      ? this.invoker.invokeWithDynamicDependencies(container, this.Type, this.dependencies, dynamicDependencies)
+      : this.invoker.invoke(container, this.Type, this.dependencies);
 
     if (transformers === null) {
       return instance;
@@ -611,6 +610,7 @@ export class Container implements IContainer {
       : false;
   }
 
+  // tslint:disable-next-line:no-reserved-keywords
   public get(key: any): any {
     validateKey(key);
 
@@ -657,12 +657,12 @@ export class Container implements IContainer {
     return PLATFORM.emptyArray;
   }
 
-  public getFactory(type: Function): IFactory {
-    let factory = this.factories.get(type);
+  public getFactory(Type: Function): IFactory {
+    let factory = this.factories.get(Type);
 
     if (factory === undefined) {
-      factory = Factory.create(type);
-      this.factories.set(type, factory);
+      factory = Factory.create(Type);
+      this.factories.set(Type, factory);
     }
 
     return factory;

--- a/packages/kernel/test/unit/di.spec.ts
+++ b/packages/kernel/test/unit/di.spec.ts
@@ -699,7 +699,7 @@ describe(`The Resolver class`, () => {
       const sut = new Resolver(Foo, ResolverStrategy.singleton, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.be.instanceof(Factory);
-      expect(actual.type).to.equal(Foo);;
+      expect(actual.Type).to.equal(Foo);;
     });
 
     it(`returns a new transient Factory if it does not exist`, () => {
@@ -707,7 +707,7 @@ describe(`The Resolver class`, () => {
       const sut = new Resolver(Foo, ResolverStrategy.transient, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.be.instanceof(Factory);
-      expect(actual.type).to.equal(Foo);
+      expect(actual.Type).to.equal(Foo);
     });
 
     it(`returns a null for instance strategy`, () => {
@@ -749,7 +749,7 @@ describe(`The Factory class`, () => {
         class Foo{static inject=Array(count).map(c => Bar)}
         const actual = Factory.create(Foo);
         expect(actual).to.be.instanceof(Factory);
-        expect(actual.type).to.equal(Foo);
+        expect(actual.Type).to.equal(Foo);
         if (count < 6) {
           expect(actual['invoker']).to.equal(classInvokers[count]);
         } else {
@@ -994,7 +994,7 @@ describe(`The Container class`, () => {
         class Foo{static inject=Array(count).map(c => Bar)}
         const actual = sut.getFactory(Foo);
         expect(actual).to.be.instanceof(Factory);
-        expect(actual.type).to.equal(Foo);
+        expect(actual.Type).to.equal(Foo);
         if (count < 6) {
           expect(actual['invoker']).to.equal(classInvokers[count]);
         } else {

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -1,7 +1,6 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from '../lifecycle';
 import { CollectionKind, ICollectionObserver, IObservedSet, LifecycleFlags } from '../observation';
-// tslint:disable:no-reserved-keywords
 import { nativePush, nativeSplice } from './array-observer';
 import { collectionObserver } from './collection-observer';
 

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -1,4 +1,3 @@
-// tslint:disable:no-reserved-keywords
 import { DI, Immutable, Omit, PLATFORM } from '@aurelia/kernel';
 import { ForOfStatement, Interpolation, IsBindingBehavior } from './binding/ast';
 import { BindingMode } from './binding/binding-mode';
@@ -108,8 +107,8 @@ export type TargetedInstruction =
   ILetElementInstruction;
 
 export function isTargetedInstruction(value: { type?: string }): value is TargetedInstruction {
-  const type = value.type;
-  return typeof type === 'string' && instructionTypeValues.indexOf(type) !== -1;
+  const Type = value.type;
+  return typeof Type === 'string' && instructionTypeValues.indexOf(Type) !== -1;
 }
 
 export interface ITextBindingInstruction extends ITargetedInstruction {

--- a/packages/runtime/src/resource.ts
+++ b/packages/runtime/src/resource.ts
@@ -37,7 +37,7 @@ export class RuntimeCompilationResources implements IResourceDescriptions {
       const factory = resolver.getFactory(this.context);
 
       if (factory !== null) {
-        const description = (factory.type as IResourceType<TDef, TProto>).description;
+        const description = (factory.Type as IResourceType<TDef, TProto>).description;
         return description === undefined ? null : description;
       }
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Removed and fixed almost all `no-reserved-keywords` suppressions.

There are 8 left, of which 7 are valid suppressions imho. Number 8 is in `ITargetedInstruction` and its kin, but when I started fixing those it was turtles all the way down, so I'd like to leave that one as a separate issue for now.

### 🎫 Issues

One more for #249 😄 

## 👩‍💻 Reviewer Notes

Just the usual checks and maybe validate that the remaining 7 are indeed valid suppressions.

## 📑 Test Plan

n/a

## ⏭ Next Steps

Fix `ITargetedInstruction` and its kin.