### PR TITLE
refactor(runtime): remove StrictAny in favor of unknown

### DIFF
--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -23,8 +23,7 @@ export const PLATFORM = {
   })(),
   emptyArray: Object.freeze([]),
   emptyObject: Object.freeze({}),
-  /* tslint:disable-next-line:no-empty */
-  noop(): void { },
+  noop(): void { return; },
   now(): number {
     return performance.now();
   },

--- a/packages/kernel/src/reporter.ts
+++ b/packages/kernel/src/reporter.ts
@@ -1,5 +1,4 @@
 export const Reporter = {
-  /* tslint:disable-next-line:no-empty */
-  write(code: number, ...params: unknown[]): void { },
+  write(code: number, ...params: unknown[]): void { return; },
   error(code: number, ...params: unknown[]): Error { return new Error(`Code ${code}`); }
 };

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1,24 +1,13 @@
 import { IIndexable, IServiceLocator, PLATFORM, Reporter, StrictPrimitive } from '@aurelia/kernel';
-import { Collection, IOverrideContext, IScope, LifecycleFlags, ObservedCollection } from '../observation';
+import { IBindScope } from '../lifecycle';
+import { Collection, IBindingContext, IOverrideContext, IScope, LifecycleFlags, ObservedCollection } from '../observation';
 import { IBinding } from './binding';
 import { BindingBehaviorResource } from './binding-behavior';
 import { BindingContext } from './binding-context';
 import { IConnectableBinding } from './connectable';
 import { ISignaler } from './signaler';
-import { ValueConverterResource } from './value-converter';
+import { IValueConverter, ValueConverterResource } from './value-converter';
 
-/**
- * StrictAny is a somewhat strongly typed alternative to 'any', in an effort to try to get rid of all 'any''s
- * It's not even remotely foolproof however, and this can largely be attributed to the fact that TypeScript imposes
- * far more constraints on what arithmic is allowed than vanilla JS does.
- * We don't necessarily want to impose the same constraints on users (e.g. by performing auto conversions or throwing),
- * because even though that behavior would technically be "better", it could also be experienced as unpredictable.
- * We'd generally not want to ask more of users than to simply understand how vanilla JS works, and let them account for its quirks themselves.
- * This gives end users less framework-specific things to learn.
- * Consequently, it's impossible to achieve any kind of strict type checking in the AST and generally in the observers.
- * We're trying to achieve some middle ground by applying some explicit type casts where TypeScript would otherwise not allow compilation.
- */
-export type StrictAny = StrictPrimitive | IIndexable | Function;
 export type IsPrimary = AccessThis | AccessScope | ArrayLiteral | ObjectLiteral | PrimitiveLiteral | Template;
 export type IsLiteral = ArrayLiteral | ObjectLiteral | PrimitiveLiteral | Template;
 export type IsLeftHandSide = IsPrimary | CallFunction | CallMember | CallScope | AccessMember | AccessKeyed | TaggedTemplate;
@@ -39,8 +28,7 @@ export type HasBind = BindingBehavior;
 export type HasUnbind = ValueConverter | BindingBehavior;
 export type HasAncestor = AccessThis | AccessScope | CallScope;
 
-// tslint:disable-next-line:no-any
-export interface IVisitor<T = any> {
+export interface IVisitor<T = unknown> {
   visitAccessKeyed(expr: AccessKeyed): T;
   visitAccessMember(expr: AccessMember): T;
   visitAccessScope(expr: AccessScope): T;
@@ -69,10 +57,10 @@ export interface IVisitor<T = any> {
 
 export interface IExpression {
   readonly $kind: ExpressionKind;
-  evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null): StrictAny;
+  evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null): unknown;
   connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void;
   accept<T>(visitor: IVisitor<T>): T;
-  assign?(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, value: StrictAny): StrictAny;
+  assign?(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, value: unknown): unknown;
   bind?(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
   unbind?(flags: LifecycleFlags, scope: IScope, binding: IBinding): void;
 }
@@ -209,11 +197,11 @@ export class BindingBehavior implements IExpression {
     this.expressionHasUnbind = hasUnbind(expression);
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     return this.expression.evaluate(flags, scope, locator);
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
     return this.expression.assign(flags, scope, locator, value);
   }
 
@@ -247,7 +235,7 @@ export class BindingBehavior implements IExpression {
       throw Reporter.error(RuntimeError.BehaviorAlreadyApplied, this);
     }
     binding[behaviorKey] = behavior;
-    behavior.bind.apply(behavior, (<StrictAny[]>[flags, scope, binding]).concat(evalList(flags, scope, locator, this.args)));
+    behavior.bind.apply(behavior, (<unknown[]>[flags, scope, binding]).concat(evalList(flags, scope, locator, this.args)));
   }
 
   public unbind(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -279,11 +267,11 @@ export class ValueConverter implements IExpression {
     this.converterKey = ValueConverterResource.keyFrom(this.name);
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     if (!locator) {
       throw Reporter.error(RuntimeError.NoLocator, this);
     }
-    const converter = locator.get<ValueConverter & { toView(...args: (StrictAny)[]): StrictAny }>(this.converterKey);
+    const converter = locator.get<ValueConverter & IValueConverter>(this.converterKey);
     if (!converter) {
       throw Reporter.error(RuntimeError.NoConverterFound, this);
     }
@@ -300,11 +288,11 @@ export class ValueConverter implements IExpression {
     return this.expression.evaluate(flags, scope, locator);
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
     if (!locator) {
       throw Reporter.error(RuntimeError.NoLocator, this);
     }
-    const converter = locator.get<ValueConverter & { fromView(...args: (StrictAny)[]): StrictAny }>(this.converterKey);
+    const converter = locator.get<ValueConverter & IValueConverter>(this.converterKey);
     if (!converter) {
       throw Reporter.error(RuntimeError.NoConverterFound, this);
     }
@@ -376,7 +364,7 @@ export class Assign implements IExpression {
     this.value = value;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     return this.target.assign(flags, scope, locator, this.value.evaluate(flags, scope, locator));
   }
 
@@ -384,7 +372,7 @@ export class Assign implements IExpression {
     return;
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
     this.value.assign(flags, scope, locator, value);
     return this.target.assign(flags, scope, locator, value);
   }
@@ -403,13 +391,13 @@ export class Conditional implements IExpression {
 
   constructor(condition: IsBinary, yes: IsAssign, no: IsAssign) {
     this.$kind = ExpressionKind.Conditional;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.condition = condition;
     this.yes = yes;
     this.no = no;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     return (!!this.condition.evaluate(flags, scope, locator))
       ? this.yes.evaluate(flags, scope, locator)
       : this.no.evaluate(flags, scope, locator);
@@ -441,12 +429,12 @@ export class AccessThis implements IExpression {
 
   constructor(ancestor: number = 0) {
     this.$kind = ExpressionKind.AccessThis;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.connect = PLATFORM.noop;
     this.ancestor = ancestor;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): IBindingContext | undefined {
     if (scope === undefined) {
       throw Reporter.error(RuntimeError.UndefinedScope, this);
     }
@@ -477,12 +465,12 @@ export class AccessScope implements IExpression {
     this.ancestor = ancestor;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): IBindingContext | IBindScope | IOverrideContext {
     const name = this.name;
     return BindingContext.get(scope, name, this.ancestor)[name];
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
     const name = this.name;
     const context = BindingContext.get(scope, name, this.ancestor);
     return context ? (context[name] = value) : undefined;
@@ -510,13 +498,13 @@ export class AccessMember implements IExpression {
     this.name = name;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
-    const instance = this.object.evaluate(flags, scope, locator);
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
+    const instance = this.object.evaluate(flags, scope, locator) as IIndexable;
     return instance === null || instance === undefined ? instance : instance[this.name];
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
-    let instance = this.object.evaluate(flags, scope, locator);
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
+    let instance = this.object.evaluate(flags, scope, locator) as IIndexable;
     if (instance === null || typeof instance !== 'object') {
       instance = {};
       this.object.assign(flags, scope, locator, instance);
@@ -526,7 +514,7 @@ export class AccessMember implements IExpression {
   }
 
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
-    const obj = this.object.evaluate(flags, scope, null);
+    const obj = this.object.evaluate(flags, scope, null) as IIndexable;
     this.object.connect(flags, scope, binding);
     if (obj) {
       binding.observeProperty(obj, this.name);
@@ -549,23 +537,21 @@ export class AccessKeyed implements IExpression {
     this.key = key;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
-    const instance = this.object.evaluate(flags, scope, locator);
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
+    const instance = this.object.evaluate(flags, scope, locator) as IIndexable;
     if (instance === null || instance === undefined) {
       return undefined;
     }
-    const key = this.key.evaluate(flags, scope, locator);
+    const key = this.key.evaluate(flags, scope, locator) as string;
     // note: getKeyed and setKeyed are removed because they are identical to the default spec behavior
     // and the runtime does this this faster
-    // tslint:disable-next-line:no-any
-    return instance[<any>key];
+    return instance[key];
   }
 
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: StrictAny): StrictAny {
-    const instance = this.object.evaluate(flags, scope, locator);
-    const key = this.key.evaluate(flags, scope, locator);
-    // tslint:disable-next-line:no-any
-    return instance[<any>key] = value;
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown {
+    const instance = this.object.evaluate(flags, scope, locator) as IIndexable;
+    const key = this.key.evaluate(flags, scope, locator) as string;
+    return instance[key] = value;
   }
 
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -577,7 +563,7 @@ export class AccessKeyed implements IExpression {
       // observe the property represented by the key as long as it's not an array indexer
       // (note: string indexers behave the same way as numeric indexers as long as they represent numbers)
       if (!(Array.isArray(obj) && isNumeric(key))) {
-        binding.observeProperty(obj, key);
+        binding.observeProperty(obj, key as string);
       }
     }
   }
@@ -596,13 +582,13 @@ export class CallScope implements IExpression {
 
   constructor(name: string, args: ReadonlyArray<IsAssign>, ancestor: number = 0) {
     this.$kind = ExpressionKind.CallScope;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.name = name;
     this.args = args;
     this.ancestor = ancestor;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null): unknown {
     const args = evalList(flags, scope, locator, this.args);
     const context = BindingContext.get(scope, this.name, this.ancestor);
     const func = getFunction(flags, context, this.name);
@@ -633,14 +619,14 @@ export class CallMember implements IExpression {
 
   constructor(object: IsLeftHandSide, name: string, args: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.CallMember;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.object = object;
     this.name = name;
     this.args = args;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
-    const instance = this.object.evaluate(flags, scope, locator);
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
+    const instance = this.object.evaluate(flags, scope, locator) as IIndexable;
     const args = evalList(flags, scope, locator, this.args);
     const func = getFunction(flags, instance, this.name);
     if (func) {
@@ -650,7 +636,7 @@ export class CallMember implements IExpression {
   }
 
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
-    const obj = this.object.evaluate(flags, scope, null);
+    const obj = this.object.evaluate(flags, scope, null) as IIndexable;
     this.object.connect(flags, scope, binding);
     if (getFunction(flags & ~LifecycleFlags.mustEvaluate, obj, this.name)) {
       const args = this.args;
@@ -673,13 +659,13 @@ export class CallFunction implements IExpression {
 
   constructor(func: IsLeftHandSide, args: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.CallFunction;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.func = func;
     this.args = args;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
-    const func = this.func.evaluate(flags, scope, locator) as StrictAny; // not sure why this cast is needed..
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
+    const func = this.func.evaluate(flags, scope, locator);
     if (typeof func === 'function') {
       return func.apply(null, evalList(flags, scope, locator, this.args));
     }
@@ -716,7 +702,7 @@ export class Binary implements IExpression {
 
   constructor(operation: BinaryOperator, left: IsBinary, right: IsBinary) {
     this.$kind = ExpressionKind.Binary;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.operation = operation;
     this.left = left;
     this.right = right;
@@ -724,10 +710,10 @@ export class Binary implements IExpression {
     // what we're doing here is effectively moving the large switch statement from evaluate to the constructor
     // so that the check only needs to be done once, and evaluate (which is called many times) will have a lot less
     // work to do; we can do this because the operation can't change after it's parsed
-    this.evaluate = this[operation];
+    this.evaluate = this[operation] as IExpression['evaluate'];
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     throw Reporter.error(RuntimeError.UnknownOperator, this);
   }
 
@@ -740,10 +726,10 @@ export class Binary implements IExpression {
     this.right.connect(flags, scope, binding);
   }
 
-  private ['&&'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
+  private ['&&'](f: LifecycleFlags, s: IScope, l: IServiceLocator): unknown {
     return this.left.evaluate(f, s, l) && this.right.evaluate(f, s, l);
   }
-  private ['||'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
+  private ['||'](f: LifecycleFlags, s: IScope, l: IServiceLocator): unknown {
     return this.left.evaluate(f, s, l) || this.right.evaluate(f, s, l);
   }
   private ['=='](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
@@ -770,7 +756,7 @@ export class Binary implements IExpression {
   private ['in'](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
     const right = this.right.evaluate(f, s, l);
     if (right !== null && typeof right === 'object') {
-      return this.left.evaluate(f, s, l) in right;
+      return this.left.evaluate(f, s, l) as string in right;
     }
     return false;
   }
@@ -778,37 +764,32 @@ export class Binary implements IExpression {
   // and where it isn't, you kind of want it to behave like the spec anyway (e.g. return NaN when adding a number to undefined)
   // this makes bugs in user code easier to track down for end users
   // also, skipping these checks and leaving it to the runtime is a nice little perf boost and simplifies our code
-  private ['+'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
-    // tslint:disable-next-line:no-any
-    return (<any>this.left.evaluate(f, s, l)) + (<any>this.right.evaluate(f, s, l));
+  private ['+'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
+    return (this.left.evaluate(f, s, l) as number) + (this.right.evaluate(f, s, l) as number);
   }
-  private ['-'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
-    // tslint:disable-next-line:no-any
-    return (<any>this.left.evaluate(f, s, l)) - (<any>this.right.evaluate(f, s, l));
+  private ['-'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
+    return (this.left.evaluate(f, s, l) as number) - (this.right.evaluate(f, s, l) as number);
   }
-  private ['*'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
-    // tslint:disable-next-line:no-any
-    return (<any>this.left.evaluate(f, s, l)) * (<any>this.right.evaluate(f, s, l));
+  private ['*'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
+    return (this.left.evaluate(f, s, l) as number) * (this.right.evaluate(f, s, l) as number);
   }
-  private ['/'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
-    // tslint:disable-next-line:no-any
-    return (<any>this.left.evaluate(f, s, l)) / (<any>this.right.evaluate(f, s, l));
+  private ['/'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
+    return (this.left.evaluate(f, s, l) as number) / (this.right.evaluate(f, s, l) as number);
   }
-  private ['%'](f: LifecycleFlags, s: IScope, l: IServiceLocator): StrictAny {
-    // tslint:disable-next-line:no-any
-    return (<any>this.left.evaluate(f, s, l)) % (<any>this.right.evaluate(f, s, l));
+  private ['%'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
+    return (this.left.evaluate(f, s, l) as number) % (this.right.evaluate(f, s, l) as number);
   }
   private ['<'](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
-    return this.left.evaluate(f, s, l) < this.right.evaluate(f, s, l);
+    return (this.left.evaluate(f, s, l) as number) < (this.right.evaluate(f, s, l) as number);
   }
   private ['>'](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
-    return this.left.evaluate(f, s, l) > this.right.evaluate(f, s, l);
+    return (this.left.evaluate(f, s, l) as number) > (this.right.evaluate(f, s, l) as number);
   }
   private ['<='](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
-    return this.left.evaluate(f, s, l) <= this.right.evaluate(f, s, l);
+    return (this.left.evaluate(f, s, l) as number) <= (this.right.evaluate(f, s, l) as number);
   }
   private ['>='](f: LifecycleFlags, s: IScope, l: IServiceLocator): boolean {
-    return this.left.evaluate(f, s, l) >= this.right.evaluate(f, s, l);
+    return (this.left.evaluate(f, s, l) as number) >= (this.right.evaluate(f, s, l) as number);
   }
 
   // tslint:disable-next-line:member-ordering
@@ -827,16 +808,15 @@ export class Unary implements IExpression {
 
   constructor(operation: UnaryOperator, expression: IsLeftHandSide) {
     this.$kind = ExpressionKind.Unary;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.operation = operation;
     this.expression = expression;
 
     // see Binary (we're doing the same thing here)
-    // tslint:disable-next-line:no-any
-    this.evaluate = this[operation];
+    this.evaluate = this[operation] as IExpression['evaluate'];
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     throw Reporter.error(RuntimeError.UnknownOperator, this);
   }
 
@@ -854,10 +834,10 @@ export class Unary implements IExpression {
     return !this.expression.evaluate(f, s, l);
   }
   public ['-'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
-    return -this.expression.evaluate(f, s, l);
+    return -(this.expression.evaluate(f, s, l) as number);
   }
   public ['+'](f: LifecycleFlags, s: IScope, l: IServiceLocator): number {
-    return +this.expression.evaluate(f, s, l);
+    return +(this.expression.evaluate(f, s, l) as number);
   }
 
   public accept<T>(visitor: IVisitor<T>): T {
@@ -877,7 +857,7 @@ export class PrimitiveLiteral<TValue extends StrictPrimitive = StrictPrimitive> 
 
   constructor(value: TValue) {
     this.$kind = ExpressionKind.PrimitiveLiteral;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.connect = PLATFORM.noop;
     this.value = value;
   }
@@ -898,7 +878,7 @@ export class HtmlLiteral implements IExpression {
 
   constructor(parts: ReadonlyArray<HtmlLiteral>) {
     this.$kind = ExpressionKind.HtmlLiteral;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.parts = parts;
   }
 
@@ -934,11 +914,11 @@ export class ArrayLiteral implements IExpression {
 
   constructor(elements: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.ArrayLiteral;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.elements = elements;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): ReadonlyArray<StrictAny> {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): ReadonlyArray<unknown> {
     const elements = this.elements;
     const length = elements.length;
     const result = Array(length);
@@ -969,13 +949,13 @@ export class ObjectLiteral implements IExpression {
 
   constructor(keys: ReadonlyArray<number | string>, values: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.ObjectLiteral;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.keys = keys;
     this.values = values;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): Record<string, StrictAny> {
-    const instance: Record<string, StrictAny> = {};
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): Record<string, unknown> {
+    const instance: Record<string, unknown> = {};
     const keys = this.keys;
     const values = this.values;
     for (let i = 0, ii = keys.length; i < ii; ++i) {
@@ -1006,7 +986,7 @@ export class Template implements IExpression {
 
   constructor(cooked: ReadonlyArray<string>, expressions?: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.Template;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.cooked = cooked;
     this.expressions = expressions === undefined ? PLATFORM.emptyArray : expressions;
   }
@@ -1044,7 +1024,7 @@ export class TaggedTemplate implements IExpression {
 
   constructor(cooked: ReadonlyArray<string> & { raw?: ReadonlyArray<string> }, raw: ReadonlyArray<string>, func: IsLeftHandSide, expressions?: ReadonlyArray<IsAssign>) {
     this.$kind = ExpressionKind.TaggedTemplate;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.cooked = cooked;
     this.cooked.raw = raw;
     this.func = func;
@@ -1058,7 +1038,7 @@ export class TaggedTemplate implements IExpression {
     for (let i = 0, ii = len; i < ii; ++i) {
       results[i] = expressions[i].evaluate(flags, scope, locator);
     }
-    const func = this.func.evaluate(flags, scope, locator) as StrictAny; // not sure why this cast is needed..
+    const func = this.func.evaluate(flags, scope, locator);
     if (typeof func !== 'function') {
       throw Reporter.error(RuntimeError.NotAFunction, this);
     }
@@ -1088,14 +1068,14 @@ export class ArrayBindingPattern implements IExpression {
     this.elements = elements;
   }
 
-  // tslint:disable-next-line:no-any
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): any {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     // TODO
+    return undefined;
   }
 
-  // tslint:disable-next-line:no-any
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, obj: IIndexable): any {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, obj: IIndexable): unknown {
     // TODO
+    return undefined;
   }
 
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -1119,14 +1099,14 @@ export class ObjectBindingPattern implements IExpression {
     this.values = values;
   }
 
-  // tslint:disable-next-line:no-any
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): any {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     // TODO
+    return undefined;
   }
 
-  // tslint:disable-next-line:no-any
-  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, obj: IIndexable): any {
+  public assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, obj: IIndexable): unknown {
     // TODO
+    return undefined;
   }
 
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -1147,7 +1127,7 @@ export class BindingIdentifier implements IExpression {
     this.name = name;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): string {
     return this.name;
   }
   public connect(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -1173,12 +1153,12 @@ export class ForOfStatement implements IExpression {
 
   constructor(declaration: BindingIdentifierOrPattern, iterable: IsBindingBehavior) {
     this.$kind = ExpressionKind.ForOfStatement;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.declaration = declaration;
     this.iterable = iterable;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): StrictAny {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): unknown {
     return this.iterable.evaluate(flags, scope, locator);
   }
 
@@ -1186,8 +1166,7 @@ export class ForOfStatement implements IExpression {
     return CountForOfStatement[toStringTag.call(result)](result);
   }
 
-  // tslint:disable-next-line:no-any
-  public iterate(result: ObservedCollection | number | null | undefined, func: (arr: Collection, index: number, item: any) => void): void {
+  public iterate(result: ObservedCollection | number | null | undefined, func: (arr: Collection, index: number, item: unknown) => void): void {
     IterateForOfStatement[toStringTag.call(result)](result, func);
   }
 
@@ -1215,7 +1194,7 @@ export class Interpolation implements IExpression {
   public readonly firstExpression: IsBindingBehavior;
   constructor(parts: ReadonlyArray<string>, expressions?: ReadonlyArray<IsBindingBehavior>) {
     this.$kind = ExpressionKind.Interpolation;
-    this.assign = PLATFORM.noop as () => StrictAny;
+    this.assign = PLATFORM.noop as () => unknown;
     this.parts = parts;
     this.expressions = expressions === undefined ? PLATFORM.emptyArray : expressions;
     this.isMulti = expressions.length > 1;
@@ -1278,7 +1257,7 @@ ForOfStatement.prototype.$kind = ExpressionKind.ForOfStatement;
 Interpolation.prototype.$kind = ExpressionKind.Interpolation;
 
 /// Evaluate the [list] in context of the [scope].
-function evalList(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, list: ReadonlyArray<IExpression>): StrictAny[] {
+function evalList(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, list: ReadonlyArray<IExpression>): unknown[] {
   const len = list.length;
   const result = Array(len);
   for (let i = 0; i < len; ++i) {
@@ -1287,7 +1266,7 @@ function evalList(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator
   return result;
 }
 
-function getFunction(flags: LifecycleFlags, obj: StrictAny, name: string): Function | null {
+function getFunction(flags: LifecycleFlags, obj: IIndexable, name: string): Function | null {
   const func = obj === null || obj === undefined ? null : obj[name];
   if (typeof func === 'function') {
     return func;
@@ -1298,7 +1277,7 @@ function getFunction(flags: LifecycleFlags, obj: StrictAny, name: string): Funct
   throw Reporter.error(RuntimeError.NotAFunction, obj, name, func);
 }
 
-function isNumeric(value: StrictAny): value is number {
+function isNumeric(value: unknown): value is number {
   const valueType = typeof value;
   if (valueType === 'number') return true;
   if (valueType !== 'string') return false;
@@ -1315,12 +1294,12 @@ function isNumeric(value: StrictAny): value is number {
 
 /*@internal*/
 export const IterateForOfStatement = {
-  ['[object Array]'](result: StrictAny[], func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Array]'](result: unknown[], func: (arr: Collection, index: number, item: unknown) => void): void {
     for (let i = 0, ii = result.length; i < ii; ++i) {
       func(result, i, result[i]);
     }
   },
-  ['[object Map]'](result: Map<StrictAny, StrictAny>, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Map]'](result: Map<unknown, unknown>, func: (arr: Collection, index: number, item: unknown) => void): void {
     const arr = Array(result.size);
     let i = -1;
     for (const entry of result.entries()) {
@@ -1328,7 +1307,7 @@ export const IterateForOfStatement = {
     }
     IterateForOfStatement['[object Array]'](arr, func);
   },
-  ['[object Set]'](result: Set<StrictAny>, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Set]'](result: Set<unknown>, func: (arr: Collection, index: number, item: unknown) => void): void {
     const arr = Array(result.size);
     let i = -1;
     for (const key of result.keys()) {
@@ -1336,26 +1315,26 @@ export const IterateForOfStatement = {
     }
     IterateForOfStatement['[object Array]'](arr, func);
   },
-  ['[object Number]'](result: number, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Number]'](result: number, func: (arr: Collection, index: number, item: unknown) => void): void {
     const arr = Array(result);
     for (let i = 0; i < result; ++i) {
       arr[i] = i;
     }
     IterateForOfStatement['[object Array]'](arr, func);
   },
-  ['[object Null]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Null]'](result: null, func: (arr: Collection, index: number, item: unknown) => void): void {
     return;
   },
-  ['[object Undefined]'](result: null, func: (arr: Collection, index: number, item: StrictAny) => void): void {
+  ['[object Undefined]'](result: null, func: (arr: Collection, index: number, item: unknown) => void): void {
     return;
   }
 };
 
 /*@internal*/
 export const CountForOfStatement = {
-  ['[object Array]'](result: StrictAny[]): number { return result.length; },
-  ['[object Map]'](result: Map<StrictAny, StrictAny>): number { return result.size; },
-  ['[object Set]'](result: Set<StrictAny>): number { return result.size; },
+  ['[object Array]'](result: unknown[]): number { return result.length; },
+  ['[object Map]'](result: Map<unknown, unknown>): number { return result.size; },
+  ['[object Set]'](result: Set<unknown>): number { return result.size; },
   ['[object Number]'](result: number): number { return result; },
   ['[object Null]'](result: null): number { return 0; },
   ['[object Undefined]'](result: null): number { return 0; }

--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -34,11 +34,10 @@ export class BindingContext implements IBindingContext {
     if (keyOrObj !== undefined) {
       if (value !== undefined) {
         // if value is defined then it's just a property and a value to initialize with
-        // tslint:disable-next-line:no-any
-        this[<any>keyOrObj] = value;
+        this[keyOrObj as string] = value;
       } else {
         // can either be some random object or another bindingContext to clone from
-        for (const prop in <IIndexable>keyOrObj) {
+        for (const prop in keyOrObj as IIndexable) {
           if (keyOrObj.hasOwnProperty(prop)) {
             this[prop] = keyOrObj[prop];
           }

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -1,7 +1,7 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
 import { AccessorOrObserver, IBindingTargetObserver, IScope, LifecycleFlags } from '../observation';
-import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
+import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { BindingMode } from './binding-mode';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 import { IObserverLocator } from './observer-locator';
@@ -57,15 +57,15 @@ export class Binding implements IPartialConnectableBinding {
     this.targetProperty = targetProperty;
   }
 
-  public updateTarget(value: StrictAny, flags: LifecycleFlags): void {
+  public updateTarget(value: unknown, flags: LifecycleFlags): void {
     this.targetObserver.setValue(value, flags | LifecycleFlags.updateTargetInstance);
   }
 
-  public updateSource(value: StrictAny, flags: LifecycleFlags): void {
+  public updateSource(value: unknown, flags: LifecycleFlags): void {
     this.sourceExpression.assign(flags | LifecycleFlags.updateSourceExpression, this.$scope, this.locator, value);
   }
 
-  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -2,7 +2,7 @@ import { IIndexable, IServiceLocator, Primitive } from '@aurelia/kernel';
 import { INode } from '../dom';
 import { IBindScope, State } from '../lifecycle';
 import { IAccessor, IScope, LifecycleFlags } from '../observation';
-import { hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
+import { hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { IConnectableBinding } from './connectable';
 import { IObserverLocator } from './observer-locator';
 
@@ -30,7 +30,7 @@ export class Call {
   public callSource(args: IIndexable): Primitive | IIndexable {
     const overrideContext = this.$scope.overrideContext;
     Object.assign(overrideContext, args);
-    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator);
+    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator) as IIndexable;
 
     for (const prop in args) {
       delete overrideContext[prop];
@@ -83,11 +83,11 @@ export class Call {
     this.$state &= ~(State.isBound | State.isUnbinding);
   }
 
-  public observeProperty(obj: StrictAny, propertyName: StrictAny): void {
+  public observeProperty(obj: IIndexable, propertyName: string): void {
     return;
   }
 
-  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     return;
   }
 }

--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -52,7 +52,7 @@ export function createComputedObserver(
           : new GetterObserver(overrides, instance, propertyName, descriptor, observerLocator, lifecycle);
         }
 
-      return new CustomSetterObserver(instance, propertyName, descriptor);
+      return new CustomSetterObserver(instance, propertyName, descriptor, lifecycle);
     }
 
     return noProxy
@@ -77,8 +77,9 @@ export class CustomSetterObserver implements CustomSetterObserver {
   public propertyKey: string;
 
   private descriptor: PropertyDescriptor;
+  private lifecycle: ILifecycle;
 
-  constructor(obj: IObservable, propertyKey: string, descriptor: PropertyDescriptor) {
+  constructor(obj: IObservable, propertyKey: string, descriptor: PropertyDescriptor, lifecycle: ILifecycle) {
     this.$nextFlush = null;
 
     this.obj = obj;
@@ -86,6 +87,7 @@ export class CustomSetterObserver implements CustomSetterObserver {
     this.propertyKey = propertyKey;
 
     this.descriptor = descriptor;
+    this.lifecycle = lifecycle;
   }
 
   public getValue(): IIndexable | Primitive {

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -1,6 +1,5 @@
 import { Class, IIndexable } from '@aurelia/kernel';
 import { IBindingTargetObserver, IPropertySubscriber, LifecycleFlags } from '../observation';
-import { StrictAny } from './ast';
 import { IBinding } from './binding';
 import { IObserverLocator } from './observer-locator';
 
@@ -30,7 +29,7 @@ export interface IConnectableBinding extends IPartialConnectableBinding {
   $nextPatch?: IConnectableBinding;
   observerSlots: number;
   version: number;
-  observeProperty(obj: StrictAny, propertyName: StrictAny): void;
+  observeProperty(obj: IIndexable, propertyName: string): void;
   addObserver(observer: IBindingTargetObserver): void;
   unobserve(all?: boolean): void;
   connect(flags: LifecycleFlags): void;

--- a/packages/runtime/src/binding/interpolation-binding.ts
+++ b/packages/runtime/src/binding/interpolation-binding.ts
@@ -109,11 +109,11 @@ export class InterpolationBinding implements IPartialConnectableBinding {
     this.targetObserver = observerLocator.getAccessor(target, targetProperty);
   }
 
-  public updateTarget(value: any, flags: LifecycleFlags): void {
+  public updateTarget(value: unknown, flags: LifecycleFlags): void {
     this.targetObserver.setValue(value, flags | LifecycleFlags.updateTargetInstance);
   }
 
-  public handleChange(newValue: any, previousValue: any, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,7 +1,7 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
-import { IExpression, StrictAny } from './ast';
+import { IExpression } from './ast';
 import { IBindingTarget } from './binding';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 import { IObserverLocator } from './observer-locator';
@@ -40,7 +40,7 @@ export class LetBinding implements IPartialConnectableBinding {
     this.toViewModel = toViewModel;
   }
 
-  public handleChange(newValue: StrictAny, previousValue: StrictAny, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }

--- a/packages/runtime/src/binding/listener.ts
+++ b/packages/runtime/src/binding/listener.ts
@@ -1,8 +1,8 @@
-import { IDisposable, IServiceLocator } from '@aurelia/kernel';
+import { IDisposable, IIndexable, IServiceLocator } from '@aurelia/kernel';
 import { INode } from '../dom';
 import { IBindScope, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
-import { hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
+import { hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { IBinding } from './binding';
 import { IConnectableBinding } from './connectable';
 import { DelegationStrategy, IEventManager } from './event-manager';
@@ -107,8 +107,12 @@ export class Listener implements IBinding {
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
   }
-  // tslint:disable:no-empty no-any
-  public observeProperty(obj: StrictAny, propertyName: StrictAny): void { }
-  public handleChange(newValue: any, previousValue: any, flags: LifecycleFlags): void { }
-  // tslint:enable:no-empty no-any
+
+  public observeProperty(obj: IIndexable, propertyName: string): void {
+    return;
+  }
+
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
+    return;
+  }
 }

--- a/packages/runtime/src/binding/ref.ts
+++ b/packages/runtime/src/binding/ref.ts
@@ -1,7 +1,7 @@
-import { IServiceLocator } from '@aurelia/kernel';
+import { IIndexable, IServiceLocator } from '@aurelia/kernel';
 import { IBindScope, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
-import { hasBind, hasUnbind, IsBindingBehavior, StrictAny } from './ast';
+import { hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { IBinding, IBindingTarget } from './binding';
 import { IConnectableBinding } from './connectable';
 
@@ -73,7 +73,7 @@ export class Ref implements IBinding {
     this.$state &= ~(State.isBound | State.isUnbinding);
   }
 
-  public observeProperty(obj: StrictAny, propertyName: StrictAny): void {
+  public observeProperty(obj: IIndexable, propertyName: string): void {
     return;
   }
 

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -1,7 +1,6 @@
 import { IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from '../lifecycle';
 import { CollectionKind, ICollectionObserver, IObservedSet, LifecycleFlags } from '../observation';
-// tslint:disable:no-reserved-keywords
 import { nativePush, nativeSplice } from './array-observer';
 import { collectionObserver } from './collection-observer';
 

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -372,7 +372,6 @@ export class FragmentNodeSequence implements INodeSequence {
   }
 
   public findTargets(): ArrayLike<INode> {
-    // tslint:disable-next-line:no-any
     return this.targets;
   }
 

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -1263,8 +1263,7 @@ export const LifecycleTask = {
   done: {
     done: true,
     canCancel(): boolean { return false; },
-    // tslint:disable-next-line:no-empty
-    cancel(): void {},
+    cancel(): void { return; },
     wait(): Promise<unknown> { return Promise.resolve(); }
   }
 };

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -135,7 +135,7 @@ export interface IPropertyChangeNotifier extends IPropertyChangeHandler {}
 /**
  * Describes a (subscriber) type that has a function conforming to the IPropertyChangeHandler interface
  */
-export interface IPropertySubscriber<TValue = any> { handleChange(newValue: TValue, previousValue: TValue, flags: LifecycleFlags): void; }
+export interface IPropertySubscriber<TValue = unknown> { handleChange(newValue: TValue, previousValue: TValue, flags: LifecycleFlags): void; }
 
 /**
  * Represents a (subscriber) function that can be called by a CollectionChangeNotifier

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -1,4 +1,4 @@
-import { inject, IRegistry } from '@aurelia/kernel';
+import { IIndexable, inject, IRegistry } from '@aurelia/kernel';
 import { ForOfStatement } from '../../binding/ast';
 import { Binding } from '../../binding/binding';
 import { BindingContext, Scope } from '../../binding/binding-context';
@@ -6,7 +6,7 @@ import { getCollectionObserver } from '../../binding/observer-locator';
 import { SetterObserver } from '../../binding/property-observation';
 import { INode, IRenderLocation } from '../../dom';
 import { IRenderable, IView, IViewFactory, State } from '../../lifecycle';
-import { CollectionObserver, IBatchedCollectionSubscriber, IObservedArray, IScope, LifecycleFlags, ObservedCollection } from '../../observation';
+import { CollectionObserver, IBatchedCollectionSubscriber, IObservedArray, IObservedMap, IObservedSet, IScope, LifecycleFlags, ObservedCollection } from '../../observation';
 import { bindable } from '../bindable';
 import { ICustomAttribute, templateController } from '../custom-attribute';
 
@@ -48,7 +48,7 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
       }
       current = current.$nextBind;
     }
-    this.local = this.forOf.declaration.evaluate(flags, this.$scope, null);
+    this.local = this.forOf.declaration.evaluate(flags, this.$scope, null) as string;
 
     this.processViews(null, flags);
   }
@@ -126,7 +126,7 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
 
       $lifecycle.beginBind();
       if (indexMap === null) {
-        forOf.iterate(items, (arr, i, item) => {
+        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray<unknown> | IObservedSet<unknown> | IObservedMap<unknown, unknown> | IIndexable)) => {
           const view = views[i];
           if (!!view.$scope && view.$scope.bindingContext[local] === item) {
             view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));
@@ -135,7 +135,7 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
           }
         });
       } else {
-        forOf.iterate(items, (arr, i, item) => {
+        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray<unknown> | IObservedSet<unknown> | IObservedMap<unknown, unknown> | IIndexable)) => {
           const view = views[i];
           if (indexMap[i] === i && !!view.$scope) {
             view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));


### PR DESCRIPTION
# Pull Request

## 📖 Description

@fkleuver mentioned in https://github.com/aurelia/aurelia/pull/274#discussion_r232724663 that he wanted to get rid of `StrictAny` in favour of `unknown`. This PR does just that.

### 🎫 Issues

Follow up to #274 and related to #249.

## 👩‍💻 Reviewer Notes

Notable changes:
- Mostly just a straight up search and replace for `StrictAny` to `unknown` and then upstreamed those changes to all call sites.
- As a consequence I had to introduce casting in a couple of places. The ones in `packages/runtime/src/templating/resources/repeat.ts` could probably be tightened up a bit?

I also snuck in some linting fixes:
- Removed some unneeded tslint suppressions.
- Removed all suppressions for `no-empty` and gave them a `return;`.

## 📑 Test Plan

Ran the usual tests.

## ⏭ Next Steps

See #249.
