### PR TITLE
view compiler extension point (part 1/2)

### DIFF
--- a/packages/jit/src/ast.ts
+++ b/packages/jit/src/ast.ts
@@ -1,0 +1,45 @@
+import { PLATFORM } from '@aurelia/kernel';
+import { DOM } from '@aurelia/runtime';
+
+export class AttrSyntax {
+  public readonly rawName: string;
+  public readonly rawValue: string;
+  public readonly target: string;
+  public readonly command: string | null;
+
+  constructor(rawName: string, rawValue: string, target: string, command: string | null) {
+    this.rawName = rawName;
+    this.rawValue = rawValue;
+    this.target = target;
+    this.command = command;
+  }
+}
+
+const marker = DOM.createElement('au-marker') as Element;
+marker.classList.add('au');
+const createMarker: () => HTMLElement = marker.cloneNode.bind(marker, false);
+
+export class ElementSyntax {
+  public readonly node: Node;
+  public readonly name: string;
+  public readonly $content: ElementSyntax | null;
+  public readonly $children: ReadonlyArray<ElementSyntax>;
+  public readonly $attributes: ReadonlyArray<AttrSyntax>;
+
+  constructor(
+    node: Node,
+    name: string,
+    $content: ElementSyntax | null,
+    $children: ReadonlyArray<ElementSyntax>,
+    $attributes: ReadonlyArray<AttrSyntax>) {
+    this.node = node;
+    this.name = name;
+    this.$content = $content;
+    this.$children = $children;
+    this.$attributes = $attributes;
+  }
+
+  public static createMarker(): ElementSyntax {
+    return new ElementSyntax(createMarker(), 'au-marker', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
+  }
+}

--- a/packages/jit/src/attribute-parser.ts
+++ b/packages/jit/src/attribute-parser.ts
@@ -1,7 +1,6 @@
 import { all, DI, inject } from '@aurelia/kernel';
 import { AttrSyntax } from './ast';
 import { IAttributePattern, IAttributePatternHandler, Interpretation, ISyntaxInterpreter } from './attribute-pattern';
-import { Char } from './common';
 
 export interface IAttributeParser {
   parse(name: string, value: string): AttrSyntax;
@@ -22,15 +21,11 @@ export class AttributeParser implements IAttributeParser {
     this.cache = {};
     const patterns: AttributeParser['patterns'] = this.patterns = {};
     attrPatterns.forEach(attrPattern => {
-      const patternOrPatterns = attrPattern.$patterns;
-      interpreter.add(patternOrPatterns);
-      if (Array.isArray(patternOrPatterns)) {
-        patternOrPatterns.forEach(pattern => {
-          patterns[pattern] = attrPattern as unknown as IAttributePatternHandler;
-        });
-      } else {
-        patterns[patternOrPatterns] = attrPattern as unknown as IAttributePatternHandler;
-      }
+      const defs = attrPattern.$patternDefs;
+      interpreter.add(defs);
+      defs.forEach(def => {
+        patterns[def.pattern] = attrPattern as unknown as IAttributePatternHandler;
+      });
     });
   }
 

--- a/packages/jit/src/attribute-parser.ts
+++ b/packages/jit/src/attribute-parser.ts
@@ -1,6 +1,6 @@
 import { all, DI, inject } from '@aurelia/kernel';
 import { AttrSyntax } from './ast';
-import { IAttributePattern, ISyntaxInterpreter } from './attribute-pattern';
+import { IAttributePattern, IAttributePatternHandler, Interpretation, ISyntaxInterpreter } from './attribute-pattern';
 import { Char } from './common';
 
 export interface IAttributeParser {
@@ -14,49 +14,36 @@ export const IAttributeParser = DI.createInterface<IAttributeParser>()
 @inject(ISyntaxInterpreter, all(IAttributePattern))
 export class AttributeParser implements IAttributeParser {
   private interpreter: ISyntaxInterpreter;
-  private cache: Record<string, [string, string]>;
-  private patterns: Record<string, IAttributePattern>;
+  private cache: Record<string, Interpretation>;
+  private patterns: Record<string, IAttributePatternHandler>;
 
   constructor(interpreter: ISyntaxInterpreter, attrPatterns: IAttributePattern[]) {
     this.interpreter = interpreter;
     this.cache = {};
-    const patterns = this.patterns = {};
+    const patterns: AttributeParser['patterns'] = this.patterns = {};
     attrPatterns.forEach(attrPattern => {
-      const patternOrPatterns = attrPattern.$patternOrPatterns;
+      const patternOrPatterns = attrPattern.$patterns;
+      interpreter.add(patternOrPatterns);
       if (Array.isArray(patternOrPatterns)) {
         patternOrPatterns.forEach(pattern => {
-          patterns[pattern] = attrPattern;
+          patterns[pattern] = attrPattern as unknown as IAttributePatternHandler;
         });
       } else {
-        patterns[patternOrPatterns] = attrPattern;
+        patterns[patternOrPatterns] = attrPattern as unknown as IAttributePatternHandler;
       }
     });
   }
 
   public parse(name: string, value: string): AttrSyntax {
-    let target: string;
-    let command: string;
-    const existing = this.cache[name];
-    if (existing === undefined) {
-      const interpretation = this.interpreter.interpret(name);
-      let lastIndex = 0;
-      target = name;
-      for (let i = 0, ii = name.length; i < ii; ++i) {
-        if (name.charCodeAt(i) === Char.Dot) {
-          // set the targetName to only the part that comes before the first dot
-          if (name === target) {
-            target = name.slice(0, i);
-          }
-          lastIndex = i;
-        }
-      }
-      command = lastIndex > 0 ? name.slice(lastIndex + 1) : null;
-      this.cache[name] = [target, command];
-    } else {
-      target = existing[0];
-      command = existing[1];
+    let interpretation = this.cache[name];
+    if (interpretation === undefined) {
+      interpretation = this.cache[name] = this.interpreter.interpret(name);
     }
-
-    return new AttrSyntax(name, value, target, command && command.length ? command : null);
+    const pattern = interpretation.pattern;
+    if (pattern === null) {
+      return new AttrSyntax(name, value, name, null);
+    } else {
+      return this.patterns[pattern][pattern](name, value, interpretation.parts);
+    }
   }
 }

--- a/packages/jit/src/attribute-pattern.ts
+++ b/packages/jit/src/attribute-pattern.ts
@@ -325,10 +325,11 @@ export class SyntaxInterpreter {
     const types = new SegmentTypes();
     const segments = this.parse(def, types);
     const len = segments.length;
+    const callback = (ch: ICharSpec): void => {
+      currentState = currentState.append(ch, pattern);
+    };
     for (i = 0; i < len; ++i) {
-      segments[i].eachChar(ch => {
-        currentState = currentState.append(ch, pattern);
-      });
+      segments[i].eachChar(callback);
     }
     currentState.types = types;
     currentState.isEndpoint = true;

--- a/packages/jit/src/attribute-pattern.ts
+++ b/packages/jit/src/attribute-pattern.ts
@@ -1,0 +1,327 @@
+
+export class CharSpec {
+  public chars: string;
+  public repeat: boolean;
+
+  public has: (char: string) => boolean;
+
+  constructor(chars: string, repeat: boolean) {
+    this.chars = chars;
+    this.repeat = repeat;
+    switch (chars.length) {
+      case 0:
+        this.has = this.hasOfNone;
+        break;
+      case 1:
+        this.has = this.hasOfSingle;
+        break;
+      default:
+        this.has = this.hasOfMultiple;
+    }
+  }
+
+  public equals(other: CharSpec): boolean {
+    return this.chars === other.chars;
+  }
+
+  private hasOfMultiple(char: string): boolean {
+    return this.chars.indexOf(char) !== -1;
+  }
+
+  private hasOfSingle(char: string): boolean {
+    return this.chars === char;
+  }
+
+  private hasOfNone(char: string): boolean {
+    return false;
+  }
+}
+
+const asciiCharSpecs = Array(127);
+for (let i = 0; i < 127; ++i) {
+  asciiCharSpecs[i] = new CharSpec(String.fromCharCode(i), false);
+}
+const identifierCharSpec = new CharSpec('-abcdefghijklmnopqrstuvwxyz', true);
+
+export class State {
+  public charSpec: CharSpec;
+  public nextStates: State[];
+  public types: SegmentTypes | null;
+  public pattern: string | null;
+
+  constructor(charSpec: CharSpec) {
+    this.charSpec = charSpec;
+    this.nextStates = [];
+    this.types = null;
+    this.pattern = null;
+  }
+
+  public findChild(charSpec: CharSpec): State {
+    const nextStates = this.nextStates;
+    const len = nextStates.length;
+    let child: State = null;
+    let i = 0;
+    while (i < len) {
+      child = nextStates[i];
+      if (charSpec.equals(child.charSpec)) {
+        return child;
+      }
+      ++i;
+    }
+    return null;
+  }
+
+  public append(charSpec: CharSpec): State {
+    let state = this.findChild(charSpec);
+    if (state === null) {
+      state = new State(charSpec);
+      this.nextStates.push(state);
+      if (charSpec.repeat) {
+        state.nextStates.push(state);
+      }
+    }
+    return state;
+  }
+
+  public findMatches(ch: string): State[] {
+    const results = [];
+    const nextStates = this.nextStates;
+    const len = nextStates.length;
+    let child: State = null;
+    let i = 0;
+    while (i < len) {
+      child = nextStates[i];
+      if (child.charSpec.has(ch)) {
+        results.push(child);
+      }
+      ++i;
+    }
+    return results;
+  }
+}
+
+export interface ISegment {
+  text: string;
+  eachChar(callback: (spec: CharSpec) => void): void;
+}
+
+export class StaticSegment implements ISegment {
+  public text: string;
+  private len: number;
+  private specs: CharSpec[];
+
+  constructor(text: string) {
+    this.text = text;
+    const len = this.len = text.length;
+    const specs = this.specs = [];
+    let i = 0;
+    while (i < len) {
+      specs.push(asciiCharSpecs[text[i].charCodeAt(0)]);
+      ++i;
+    }
+  }
+
+  public eachChar(callback: (spec: CharSpec) => void): void {
+    const { len, specs } = this;
+    let i = 0;
+    while (i < len) {
+      callback(specs[i]);
+      ++i;
+    }
+  }
+}
+
+export class CommandSegment implements ISegment {
+  public text: string;
+
+  constructor() {
+    this.text = 'command';
+  }
+
+  public eachChar(callback: (spec: CharSpec) => void): void {
+    callback(identifierCharSpec);
+  }
+}
+
+export class TargetSegment implements ISegment {
+  public text: string;
+
+  constructor() {
+    this.text = 'target';
+  }
+
+  public eachChar(callback: (spec: CharSpec) => void): void {
+    callback(identifierCharSpec);
+  }
+}
+
+export class SymbolSegment implements ISegment {
+  public text: string;
+  private spec: CharSpec;
+
+  constructor(text: string) {
+    this.text = text;
+    this.spec = asciiCharSpecs[this.text.charCodeAt(0)];
+  }
+
+  public eachChar(callback: (spec: CharSpec) => void): void {
+    callback(this.spec);
+  }
+}
+
+export class SegmentTypes {
+  public identifiers: number;
+  public commands: number;
+  public targets: number;
+  public symbols: number;
+
+  constructor() {
+    this.identifiers = 0;
+    this.commands = 0;
+    this.targets = 0;
+    this.symbols = 0;
+  }
+}
+
+export class SyntaxInterpreter {
+  public rootState: State;
+  private initialStates: State[];
+
+  constructor() {
+    this.rootState = new State(null);
+    this.initialStates = [this.rootState];
+  }
+
+  public add(pattern: string): State;
+  public add(patterns: string[]): State;
+  public add(patternOrPatterns: string | string[]): State {
+    let i = 0;
+    if (Array.isArray(patternOrPatterns)) {
+      const ii = patternOrPatterns.length;
+      for (; i < ii; ++i) {
+        this.add(patternOrPatterns[i]);
+      }
+      return;
+    }
+    let currentState = this.rootState;
+    const types = new SegmentTypes();
+    const segments = this.parse(patternOrPatterns, types);
+    const len = segments.length;
+    i = 0;
+    while (i < len) {
+      segments[i].eachChar(ch => {
+        currentState = currentState.append(ch);
+      });
+      ++i;
+    }
+    currentState.types = types;
+    currentState.pattern = patternOrPatterns;
+
+    return currentState;
+  }
+
+  public interpret(value: string): string | null {
+    let states = this.initialStates;
+    const len = value.length;
+    let i = 0;
+    while (i < len) {
+      states = this.getNextStates(states, value.charAt(i));
+      if (states.length === 0) {
+        break;
+      }
+      ++i;
+    }
+
+    states.sort((a, b) => {
+      const aTypes = a.types;
+      const bTypes = b.types;
+      if (aTypes.identifiers !== bTypes.identifiers) {
+        return bTypes.identifiers - aTypes.identifiers;
+      }
+      if (aTypes.commands !== bTypes.commands) {
+        return bTypes.commands - aTypes.commands;
+      }
+      if (aTypes.targets !== bTypes.targets) {
+        return bTypes.targets - aTypes.targets;
+      }
+      if (aTypes.symbols !== bTypes.symbols) {
+        return bTypes.symbols - aTypes.symbols;
+      }
+      return 0;
+    });
+
+    if (states.length === 0) {
+      return null;
+    } else {
+      return states[0].pattern;
+    }
+  }
+
+  public getNextStates(states: State[], ch: string): State[] {
+    const nextStates: State[] = [];
+    let state: State = null;
+    const len = states.length;
+    let i = 0;
+    while (i < len) {
+      state = states[i];
+      nextStates.push(...state.findMatches(ch));
+      ++i;
+    }
+
+    return nextStates;
+  }
+
+  private parse(input: string, types: SegmentTypes): ISegment[] {
+    const result = [];
+    const len = input.length;
+    let i = 0;
+    let start = 0;
+    let c = 0;
+
+    while (i < len) {
+      c = input.charCodeAt(i);
+      // ((c >= 'a' && c <= 'z') || c === '-')
+      if ((c >=  97 && c <= 122) || c ===  45) {
+        if (i === start) {
+          //  c === 't'
+          if (c === 116) {
+            if (input.slice(i, i + 6) === 'target') {
+              start = i = (i + 6);
+              result.push(new TargetSegment());
+              ++types.targets;
+            } else {
+              ++i;
+            }
+          //         c === 'c'
+          } else if (c ===  99) {
+            if (input.slice(i, i + 7) === 'command') {
+              start = i = (i + 7);
+              result.push(new CommandSegment());
+              ++types.commands;
+            } else {
+              ++i;
+            }
+          } else {
+            ++i;
+          }
+        } else {
+          ++i;
+        }
+      } else if (i !== start) {
+        result.push(new StaticSegment(input.slice(start, i)));
+        ++types.identifiers;
+        start = i;
+      } else {
+        result.push(new SymbolSegment(input.slice(start, i + 1)));
+        ++types.symbols;
+        start = ++i;
+      }
+    }
+    if (start !== i) {
+      result.push(new StaticSegment(input.slice(start, i)));
+      ++types.identifiers;
+    }
+
+    return result;
+  }
+}

--- a/packages/jit/src/configuration.ts
+++ b/packages/jit/src/configuration.ts
@@ -20,6 +20,7 @@ import {
   UpdateTriggerBindingBehavior,
   With
 } from '@aurelia/runtime';
+import { DotSeparatedAttributePattern } from './attribute-pattern';
 import {
   CallBindingCommand,
   CaptureBindingCommand,
@@ -65,7 +66,8 @@ const defaultBindingLanguage: IRegistry[] = [
   DelegateBindingCommand,
   CaptureBindingCommand,
   CallBindingCommand,
-  ForBindingCommand
+  ForBindingCommand,
+  DotSeparatedAttributePattern
 ];
 
 export const BasicConfiguration = {

--- a/packages/jit/src/element-parser.ts
+++ b/packages/jit/src/element-parser.ts
@@ -1,6 +1,7 @@
 import { DI, inject, PLATFORM } from '@aurelia/kernel';
 import { DOM, IAttr, INode } from '@aurelia/runtime';
-import { AttrSyntax, IAttributeParser } from './attribute-parser';
+import { AttrSyntax, ElementSyntax } from './ast';
+import { IAttributeParser } from './attribute-parser';
 
 const domParser = <HTMLDivElement>DOM.createElement('div');
 
@@ -17,35 +18,6 @@ export const enum NodeType {
   DocumentType = 10,
   DocumentFragment = 11,
   Notation = 12
-}
-
-const marker = DOM.createElement('au-marker') as Element;
-marker.classList.add('au');
-const createMarker: () => HTMLElement = marker.cloneNode.bind(marker, false);
-
-export class ElementSyntax {
-  public readonly node: Node;
-  public readonly name: string;
-  public readonly $content: ElementSyntax | null;
-  public readonly $children: ReadonlyArray<ElementSyntax>;
-  public readonly $attributes: ReadonlyArray<AttrSyntax>;
-
-  constructor(
-    node: Node,
-    name: string,
-    $content: ElementSyntax | null,
-    $children: ReadonlyArray<ElementSyntax>,
-    $attributes: ReadonlyArray<AttrSyntax>) {
-    this.node = node;
-    this.name = name;
-    this.$content = $content;
-    this.$children = $children;
-    this.$attributes = $attributes;
-  }
-
-  public static createMarker(): ElementSyntax {
-    return new ElementSyntax(createMarker(), 'au-marker', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
-  }
 }
 
 export interface IElementParser {

--- a/packages/jit/src/index.ts
+++ b/packages/jit/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ast';
 export * from './attribute-parser';
 export * from './attribute-pattern';
 export * from './binding-command';

--- a/packages/jit/src/index.ts
+++ b/packages/jit/src/index.ts
@@ -1,4 +1,5 @@
 export * from './attribute-parser';
+export * from './attribute-pattern';
 export * from './binding-command';
 export * from './common';
 export * from './configuration';

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -1,9 +1,10 @@
 import { Immutable, IServiceLocator, PLATFORM } from '@aurelia/kernel';
 import { BindingMode, CustomAttributeResource, CustomElementResource, DOM, HydrateTemplateController, IAttributeDefinition, IBindableDescription, IExpressionParser, IResourceDescriptions, ITemplateDefinition, TargetedInstruction } from '@aurelia/runtime';
-import { AttrSyntax, IAttributeParser } from './attribute-parser';
+import { AttrSyntax, ElementSyntax } from './ast';
+import { IAttributeParser } from './attribute-parser';
 import { BindingCommandResource,  IBindingCommand } from './binding-command';
 import { Char } from './common';
-import { ElementSyntax, IElementParser, NodeType } from './element-parser';
+import { IElementParser, NodeType } from './element-parser';
 
 export class SemanticModel {
   public readonly isSemanticModel: true;

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -131,14 +131,6 @@ describe('@attributePattern', () => {
         ['value:bind',   null,           []],
         ['value@bind',   null,           []]
       ]
-    ],
-    [
-      [
-        { pattern: 'PART.PART', symbols: '.' },
-        { pattern: '@PART',     symbols: '@' },
-        { pattern: ':PART',     symbols: ':' },
-        { pattern: 'ng-PART',   symbols: '-' }
-      ]
     ]
   ]) {
     describe(`parse [${defs.map(d => d.pattern)}]`, () => {

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -6,9 +6,9 @@ import { DI } from '@aurelia/kernel';
 describe('SyntaxInterpreter', () => {
   for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
     [
-      ['target.command'],
+      ['PART.PART'],
       [
-        ['value.bind',  'target.command', ['value', 'bind']],
+        ['value.bind',  'PART.PART', ['value', 'bind']],
         ['.bind',       null,             []],
         ['bind',        null,             ['bind']],
         ['value.',      null,             ['value']],
@@ -17,9 +17,9 @@ describe('SyntaxInterpreter', () => {
       ]
     ],
     [
-      ['target.command', 'asdf.command', 'target.asdf'],
+      ['PART.PART', 'asdf.PART', 'PART.asdf'],
       [
-        ['value.bind', 'target.command',  ['value', 'bind']],
+        ['value.bind', 'PART.PART',  ['value', 'bind']],
         ['.bind',       null,             []],
         ['bind',        null,             ['bind']],
         ['value.',      null,             ['value']],
@@ -28,10 +28,10 @@ describe('SyntaxInterpreter', () => {
       ]
     ],
     [
-      ['target.command', ':target'],
+      ['PART.PART', ':PART'],
       [
-        ['value.bind',  'target.command', ['value', 'bind']],
-        [':value',      ':target',        ['value']],
+        ['value.bind',  'PART.PART', ['value', 'bind']],
+        [':value',      ':PART',        ['value']],
         ['.bind',       null,             []],
         ['bind',        null,             ['bind']],
         ['value.',      null,             ['value']],
@@ -66,22 +66,22 @@ describe('SyntaxInterpreter', () => {
 describe('@attributePattern', () => {
   for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
     [
-      ['target.command'],
+      ['PART.PART'],
       [
-        ['value.bind',  'target.command', ['value', 'bind']]
+        ['value.bind',  'PART.PART', ['value', 'bind']]
       ]
     ],
     [
-      ['target.command', 'asdf.command', 'target.asdf'],
+      ['PART.PART', 'asdf.PART', 'PART.asdf'],
       [
-        ['value.bind', 'target.command',  ['value', 'bind']]
+        ['value.bind', 'PART.PART',  ['value', 'bind']]
       ]
     ],
     [
-      ['target.command', ':target'],
+      ['PART.PART', ':PART'],
       [
-        ['value.bind',  'target.command', ['value', 'bind']],
-        [':value',      ':target',        ['value']]
+        ['value.bind',  'PART.PART', ['value', 'bind']],
+        [':value',      ':PART',        ['value']]
       ]
     ]
   ]) {
@@ -91,7 +91,7 @@ describe('@attributePattern', () => {
           let receivedRawName: string;
           let receivedRawValue: string;
           let receivedParts: string[];
-          @attributePattern(patterns)
+          @attributePattern(...patterns)
           class ThePattern {}
           for (const pattern of patterns) {
             ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
@@ -104,14 +104,10 @@ describe('@attributePattern', () => {
           container.register(<any>ThePattern);
           const interpreter = container.get(ISyntaxInterpreter);
           const attrPattern = container.get(IAttributePattern);
-          interpreter.add(attrPattern.$patternOrPatterns);
+          interpreter.add(attrPattern.$patterns);
 
           const result = interpreter.interpret(value);
-          if (Array.isArray(attrPattern.$patternOrPatterns)) {
-            expect(attrPattern.$patternOrPatterns.indexOf(result.pattern)).to.be.gte(0);
-          } else {
-            expect(attrPattern.$patternOrPatterns).to.equal(result.pattern);
-          }
+          expect(attrPattern.$patterns.indexOf(result.pattern)).to.be.gte(0);
 
           attrPattern[result.pattern](value, 'foo', result.parts);
           expect(receivedRawName).to.equal(value);

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { SyntaxInterpreter } from '../../src/attribute-pattern';
+
+
+describe.only('@bindingSyntax', () => {
+  for (const [patterns, tests] of <[string[], [string, string][]][]>[
+    [
+      ['target.command'],
+      [
+        ['value.bind', 'target.command'],
+        ['.bind', null],
+        ['bind', null],
+        ['value.', null],
+        ['value', null],
+        ['.', null]
+      ]
+    ],
+    [
+      ['target.command', 'asdf.command', 'target.asdf'],
+      [
+        ['value.bind', 'target.command'],
+        ['.bind', null],
+        ['bind', null],
+        ['value.', null],
+        ['value', null],
+        ['.', null]
+      ]
+    ],
+    [
+      ['target.command', ':target'],
+      [
+        ['value.bind', 'target.command'],
+        [':value', ':target'],
+        ['.bind', null],
+        ['bind', null],
+        ['value.', null],
+        ['value', null],
+        ['.', null],
+        ['value:', null],
+        [':', null],
+        [':.', null],
+        [':value.', null],
+        ['.value:', null],
+        [':value.bind', null],
+        ['value.bind:', null],
+        ['value:bind', null]
+      ]
+    ]
+  ]) {
+    describe(`parse [${patterns}]`, () => {
+      for (const [value, match] of tests) {
+        it(`parse [${patterns}] -> interpret [${value}] -> match=[${match}]`, () => {
+          const sut = new SyntaxInterpreter();
+          sut.add(patterns);
+
+          const result = sut.interpret(value);
+          expect(result).to.equal(match);
+        });
+      }
+    });
+  }
+
+
+});

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -1,64 +1,125 @@
 import { expect } from 'chai';
-import { SyntaxInterpreter } from '../../src/attribute-pattern';
+import { SyntaxInterpreter, attributePattern, IAttributePattern, ISyntaxInterpreter } from '../../src/attribute-pattern';
+import { DI } from '@aurelia/kernel';
 
 
-describe('@bindingSyntax', () => {
-  for (const [patterns, tests] of <[string[], [string, string][]][]>[
+describe('SyntaxInterpreter', () => {
+  for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
     [
       ['target.command'],
       [
-        ['value.bind', 'target.command'],
-        ['.bind', null],
-        ['bind', null],
-        ['value.', null],
-        ['value', null],
-        ['.', null]
+        ['value.bind',  'target.command', ['value', 'bind']],
+        ['.bind',       null,             []],
+        ['bind',        null,             ['bind']],
+        ['value.',      null,             ['value']],
+        ['value',       null,             ['value']],
+        ['.',           null,             []]
       ]
     ],
     [
       ['target.command', 'asdf.command', 'target.asdf'],
       [
-        ['value.bind', 'target.command'],
-        ['.bind', null],
-        ['bind', null],
-        ['value.', null],
-        ['value', null],
-        ['.', null]
+        ['value.bind', 'target.command',  ['value', 'bind']],
+        ['.bind',       null,             []],
+        ['bind',        null,             ['bind']],
+        ['value.',      null,             ['value']],
+        ['value',       null,             ['value']],
+        ['.',           null,             []]
       ]
     ],
     [
       ['target.command', ':target'],
       [
-        ['value.bind', 'target.command'],
-        [':value', ':target'],
-        ['.bind', null],
-        ['bind', null],
-        ['value.', null],
-        ['value', null],
-        ['.', null],
-        ['value:', null],
-        [':', null],
-        [':.', null],
-        [':value.', null],
-        ['.value:', null],
-        [':value.bind', null],
-        ['value.bind:', null],
-        ['value:bind', null]
+        ['value.bind',  'target.command', ['value', 'bind']],
+        [':value',      ':target',        ['value']],
+        ['.bind',       null,             []],
+        ['bind',        null,             ['bind']],
+        ['value.',      null,             ['value']],
+        ['value',       null,             ['value']],
+        ['.',           null,             []],
+        ['value:',      null,             []],
+        [':',           null,             []],
+        [':.',          null,             []],
+        [':value.',     null,             []],
+        ['.value:',     null,             []],
+        [':value.bind', null,             []],
+        ['value.bind:', null,             ['value']],
+        ['value:bind',  null,             []]
       ]
     ]
   ]) {
     describe(`parse [${patterns}]`, () => {
-      for (const [value, match] of tests) {
+      for (const [value, match, values] of tests) {
         it(`parse [${patterns}] -> interpret [${value}] -> match=[${match}]`, () => {
           const sut = new SyntaxInterpreter();
           sut.add(patterns);
 
           const result = sut.interpret(value);
           expect(result.pattern).to.equal(match);
+          expect(result.parts).to.deep.equal(values);
         });
       }
     });
   }
+});
 
+describe('@attributePattern', () => {
+  for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
+    [
+      ['target.command'],
+      [
+        ['value.bind',  'target.command', ['value', 'bind']]
+      ]
+    ],
+    [
+      ['target.command', 'asdf.command', 'target.asdf'],
+      [
+        ['value.bind', 'target.command',  ['value', 'bind']]
+      ]
+    ],
+    [
+      ['target.command', ':target'],
+      [
+        ['value.bind',  'target.command', ['value', 'bind']],
+        [':value',      ':target',        ['value']]
+      ]
+    ]
+  ]) {
+    describe(`parse [${patterns}]`, () => {
+      for (const [value, match, values] of tests) {
+        it(`parse [${patterns}] -> interpret [${value}] -> match=[${match}]`, () => {
+          let receivedRawName: string;
+          let receivedRawValue: string;
+          let receivedParts: string[];
+          @attributePattern(patterns)
+          class ThePattern {}
+          for (const pattern of patterns) {
+            ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
+              receivedRawName = rawName;
+              receivedRawValue = rawValue;
+              receivedParts = parts;
+            }
+          }
+          const container = DI.createContainer();
+          container.register(<any>ThePattern);
+          const interpreter = container.get(ISyntaxInterpreter);
+          const attrPattern = container.get(IAttributePattern);
+          interpreter.add(attrPattern.$patternOrPatterns);
 
+          const result = interpreter.interpret(value);
+          if (Array.isArray(attrPattern.$patternOrPatterns)) {
+            expect(attrPattern.$patternOrPatterns.indexOf(result.pattern)).to.be.gte(0);
+          } else {
+            expect(attrPattern.$patternOrPatterns).to.equal(result.pattern);
+          }
+
+          attrPattern[result.pattern](value, 'foo', result.parts);
+          expect(receivedRawName).to.equal(value);
+          expect(receivedRawValue).to.equal('foo');
+          expect(receivedParts).to.deep.equal(result.parts);
+          expect(result.parts).to.deep.equal(values);
+        });
+      }
+    });
+  }
 });

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -54,7 +54,7 @@ describe.only('@bindingSyntax', () => {
           sut.add(patterns);
 
           const result = sut.interpret(value);
-          expect(result).to.equal(match);
+          expect(result.pattern).to.equal(match);
         });
       }
     });

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -1,99 +1,155 @@
 import { expect } from 'chai';
-import { SyntaxInterpreter, attributePattern, IAttributePattern, ISyntaxInterpreter } from '../../src/attribute-pattern';
+import { SyntaxInterpreter, attributePattern, IAttributePattern, ISyntaxInterpreter, AttributePatternDefinition } from '../../src/attribute-pattern';
 import { DI } from '@aurelia/kernel';
 
-
-describe('SyntaxInterpreter', () => {
-  for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
+describe('@attributePattern', () => {
+  for (const [defs, tests] of <[AttributePatternDefinition[], [string, string, string[]][]][]>[
     [
-      ['PART.PART'],
+      [
+        { pattern: 'PART.PART', symbols: '.' }
+      ],
       [
         ['value.bind',  'PART.PART', ['value', 'bind']],
-        ['.bind',       null,             []],
-        ['bind',        null,             ['bind']],
-        ['value.',      null,             ['value']],
-        ['value',       null,             ['value']],
-        ['.',           null,             []]
+        ['.bind',       null,        []],
+        ['bind',        null,        []],
+        ['value.',      null,        []],
+        ['value',       null,        []],
+        ['.',           null,        []]
       ]
     ],
     [
-      ['PART.PART', 'asdf.PART', 'PART.asdf'],
+      [
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: 'asdf.PART', symbols: '.' },
+        { pattern: 'PART.asdf', symbols: '.' }
+      ],
       [
         ['value.bind', 'PART.PART',  ['value', 'bind']],
-        ['.bind',       null,             []],
-        ['bind',        null,             ['bind']],
-        ['value.',      null,             ['value']],
-        ['value',       null,             ['value']],
-        ['.',           null,             []]
+        ['.bind',       null,        []],
+        ['bind',        null,        []],
+        ['value.',      null,        []],
+        ['value',       null,        []],
+        ['.',           null,        []]
       ]
     ],
     [
-      ['PART.PART', ':PART'],
       [
-        ['value.bind',  'PART.PART', ['value', 'bind']],
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: ':PART', symbols: ':' }
+      ],
+      [
+        ['value.bind',  'PART.PART',    ['value', 'bind']],
+        [':.:',         'PART.PART',    [':', ':']],
+        [':value.bind', 'PART.PART',    [':value', 'bind']],
+        ['value.bind:', 'PART.PART',    ['value', 'bind:']],
         [':value',      ':PART',        ['value']],
-        ['.bind',       null,             []],
-        ['bind',        null,             ['bind']],
-        ['value.',      null,             ['value']],
-        ['value',       null,             ['value']],
-        ['.',           null,             []],
-        ['value:',      null,             []],
-        [':',           null,             []],
-        [':.',          null,             []],
-        [':value.',     null,             []],
-        ['.value:',     null,             []],
-        [':value.bind', null,             []],
-        ['value.bind:', null,             ['value']],
-        ['value:bind',  null,             []]
-      ]
-    ]
-  ]) {
-    describe(`parse [${patterns}]`, () => {
-      for (const [value, match, values] of tests) {
-        it(`parse [${patterns}] -> interpret [${value}] -> match=[${match}]`, () => {
-          const sut = new SyntaxInterpreter();
-          sut.add(patterns);
-
-          const result = sut.interpret(value);
-          expect(result.pattern).to.equal(match);
-          expect(result.parts).to.deep.equal(values);
-        });
-      }
-    });
-  }
-});
-
-describe('@attributePattern', () => {
-  for (const [patterns, tests] of <[string[], [string, string, string[]][]][]>[
-    [
-      ['PART.PART'],
-      [
-        ['value.bind',  'PART.PART', ['value', 'bind']]
+        [':.',          ':PART',        ['.']],
+        [':value.',     ':PART',        ['value.']],
+        ['.bind',       null,           []],
+        ['bind',        null,           []],
+        ['value.',      null,           []],
+        ['value',       null,           []],
+        ['value:',      null,           []],
+        ['.',           null,           []],
+        [':',           null,           []],
+        ['::',          null,           []],
+        ['..',          null,           []],
+        ['.:',          null,           []],
+        ['.value:',     null,           []],
+        ['value:bind',  null,           []]
       ]
     ],
     [
-      ['PART.PART', 'asdf.PART', 'PART.asdf'],
       [
-        ['value.bind', 'PART.PART',  ['value', 'bind']]
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: '@PART', symbols: '@' }
+      ],
+      [
+        ['value.bind',  'PART.PART',    ['value', 'bind']],
+        ['@.@',         'PART.PART',    ['@', '@']],
+        ['@value.bind', 'PART.PART',    ['@value', 'bind']],
+        ['value.bind@', 'PART.PART',    ['value', 'bind@']],
+        ['@value',      '@PART',        ['value']],
+        ['@.',          '@PART',        ['.']],
+        ['@value.',     '@PART',        ['value.']],
+        ['.bind',       null,           []],
+        ['bind',        null,           []],
+        ['value.',      null,           []],
+        ['value',       null,           []],
+        ['value@',      null,           []],
+        ['.',           null,           []],
+        ['@',           null,           []],
+        ['@@',          null,           []],
+        ['..',          null,           []],
+        ['.@',          null,           []],
+        ['.value@',     null,           []],
+        ['value@bind',  null,           []]
       ]
     ],
     [
-      ['PART.PART', ':PART'],
       [
-        ['value.bind',  'PART.PART', ['value', 'bind']],
-        [':value',      ':PART',        ['value']]
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: '@PART', symbols: '@' },
+        { pattern: ':PART', symbols: ':' }
+      ],
+      [
+        ['value.bind',   'PART.PART',    ['value', 'bind']],
+        [':value',       ':PART',        ['value']],
+        ['@value',       '@PART',        ['value']],
+        [':.:',          'PART.PART',    [':', ':']],
+        ['@.@',          'PART.PART',    ['@', '@']],
+        [':value.bind',  'PART.PART',    [':value', 'bind']],
+        ['@value.bind',  'PART.PART',    ['@value', 'bind']],
+        ['@:value.bind', 'PART.PART',    ['@:value', 'bind']],
+        [':@value.bind', 'PART.PART',    [':@value', 'bind']],
+        ['@:value',      '@PART',        [':value']],
+        [':@value',      ':PART',        ['@value']],
+        ['value.bind:',  'PART.PART',    ['value', 'bind:']],
+        ['value.bind@',  'PART.PART',    ['value', 'bind@']],
+        [':value',       ':PART',        ['value']],
+        ['@value',       '@PART',        ['value']],
+        [':.',           ':PART',        ['.']],
+        ['@.',           '@PART',        ['.']],
+        [':value.',      ':PART',        ['value.']],
+        ['@value.',      '@PART',        ['value.']],
+        ['.bind',        null,           []],
+        ['bind',         null,           []],
+        ['value.',       null,           []],
+        ['value',        null,           []],
+        ['value:',       null,           []],
+        ['value@',       null,           []],
+        ['.',            null,           []],
+        ['..',           null,           []],
+        [':',            null,           []],
+        ['@',            null,           []],
+        ['::',           null,           []],
+        ['@@',           null,           []],
+        ['.:',           null,           []],
+        ['.@',           null,           []],
+        ['.value:',      null,           []],
+        ['.value@',      null,           []],
+        ['value:bind',   null,           []],
+        ['value@bind',   null,           []]
+      ]
+    ],
+    [
+      [
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: '@PART',     symbols: '@' },
+        { pattern: ':PART',     symbols: ':' },
+        { pattern: 'ng-PART',   symbols: '-' }
       ]
     ]
   ]) {
-    describe(`parse [${patterns}]`, () => {
+    describe(`parse [${defs.map(d => d.pattern)}]`, () => {
       for (const [value, match, values] of tests) {
-        it(`parse [${patterns}] -> interpret [${value}] -> match=[${match}]`, () => {
+        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, () => {
           let receivedRawName: string;
           let receivedRawValue: string;
           let receivedParts: string[];
-          @attributePattern(...patterns)
+          @attributePattern(...defs)
           class ThePattern {}
-          for (const pattern of patterns) {
+          for (const { pattern } of defs) {
             ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
               receivedRawName = rawName;
               receivedRawValue = rawValue;
@@ -104,15 +160,19 @@ describe('@attributePattern', () => {
           container.register(<any>ThePattern);
           const interpreter = container.get(ISyntaxInterpreter);
           const attrPattern = container.get(IAttributePattern);
-          interpreter.add(attrPattern.$patterns);
+          interpreter.add(attrPattern.$patternDefs);
 
           const result = interpreter.interpret(value);
-          expect(attrPattern.$patterns.indexOf(result.pattern)).to.be.gte(0);
+          if (match !== null) {
+            expect(attrPattern.$patternDefs.map(d => d.pattern).indexOf(result.pattern)).to.be.gte(0);
+            attrPattern[result.pattern](value, 'foo', result.parts);
+            expect(receivedRawName).to.equal(value);
+            expect(receivedRawValue).to.equal('foo');
+            expect(receivedParts).to.deep.equal(result.parts);
+          } else {
+            expect(attrPattern.$patternDefs.map(d => d.pattern).indexOf(result.pattern)).to.equal(-1);
+          }
 
-          attrPattern[result.pattern](value, 'foo', result.parts);
-          expect(receivedRawName).to.equal(value);
-          expect(receivedRawValue).to.equal('foo');
-          expect(receivedParts).to.deep.equal(result.parts);
           expect(result.parts).to.deep.equal(values);
         });
       }

--- a/packages/jit/test/unit/attribute-pattern.spec.ts
+++ b/packages/jit/test/unit/attribute-pattern.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { SyntaxInterpreter } from '../../src/attribute-pattern';
 
 
-describe.only('@bindingSyntax', () => {
+describe('@bindingSyntax', () => {
   for (const [patterns, tests] of <[string[], [string, string][]][]>[
     [
       ['target.command'],

--- a/packages/jit/test/unit/template-compiler.spec.ts
+++ b/packages/jit/test/unit/template-compiler.spec.ts
@@ -24,19 +24,26 @@ import {
   BindingIdentifier,
   IExpression,
   PrimitiveLiteral
-} from '../../../runtime/src';
+} from '../../../runtime/src/index';
 import {
   TemplateCompiler,
   BasicConfiguration,
   parseCore,
   AttributeParser,
-  ElementParser
-} from '../../src';
+  ElementParser,
+  SyntaxInterpreter,
+  DotSeparatedAttributePattern,
+  IAttributeParser
+} from '../../src/index';
 import { expect } from 'chai';
 import { createElement, eachCartesianJoinFactory, verifyBindingInstructionsEqual } from './util';
 
-const attrParser = new AttributeParser();
-const elParser = new ElementParser(attrParser);
+const c = DI.createContainer();
+c.register(<any>DotSeparatedAttributePattern);
+
+const attrParser = c.get(IAttributeParser);
+const elParser = new ElementParser(<any>attrParser);
+
 
 export function createAttribute(name: string, value: string): Attr {
   const attr = document.createAttribute(name);
@@ -52,7 +59,7 @@ describe('TemplateCompiler', () => {
 
   beforeEach(() => {
     container = DI.createContainer();
-    container.register(BasicConfiguration);
+    container.register(<any>BasicConfiguration);
     expressionParser = container.get(IExpressionParser);
     sut = new TemplateCompiler(expressionParser as any, elParser, attrParser);
     container.registerResolver(CustomAttributeResource.keyFrom('foo'), <any>{ getFactory: () => ({ Type: { description: {} } }) });

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -638,7 +638,7 @@ export class Container implements IContainer {
 
       if (resolver === undefined) {
         if (current.parent === null) {
-          resolver = this.jitRegister(key, current)
+          resolver = this.jitRegister(key, current);
           return resolver.resolve(current, this);
         }
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -137,6 +137,9 @@ export const DI = {
 
   createInterface<T = any>(friendlyName?: string): IDefaultableInterfaceSymbol<T> {
     const Key: any = function(target: Injectable, property: string, index: number): any {
+      if (target === undefined) {
+        throw Reporter.error(16, Key); // TODO: add error (trying to resolve an InterfaceSymbol that has no registrations)
+      }
       Key.friendlyName = friendlyName || 'Interface';
       (target.inject || (target.inject = []))[index] = Key;
       return target;
@@ -182,7 +185,8 @@ export const DI = {
     return function(target: any, key?: string, descriptor?: PropertyDescriptor | number): void {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         if (!target.hasOwnProperty('inject')) {
-          target.inject = DI.getDesignParamTypes(target).slice();
+          const types = DI.getDesignParamTypes(target)
+          target.inject = types.slice();
         }
 
         if (dependencies.length === 1) {
@@ -196,7 +200,8 @@ export const DI = {
         fn.inject = dependencies;
       } else { // It's a class decorator.
         if (dependencies.length === 0) {
-          target.inject = DI.getDesignParamTypes(target).slice();
+          const types = DI.getDesignParamTypes(target)
+          target.inject = types.slice();
         } else {
           target.inject = dependencies;
         }
@@ -227,7 +232,8 @@ Foo.register(container);
   // tslint:enable:jsdoc-format
   transient<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
     target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
-      return Registration.transient(target, target).register(container, target);
+      const registration = Registration.transient(target, target);
+      return registration.register(container, target);
     };
     return <T & RegisterSelf<T>>target;
   },
@@ -254,7 +260,8 @@ Foo.register(container);
   // tslint:enable:jsdoc-format
   singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
     target.register = function register(container: IContainer): IResolver<InstanceType<T>> {
-      return Registration.singleton(target, target).register(container, target);
+      const registration = Registration.singleton(target, target);
+      return registration.register(container, target);
     };
     return <T & RegisterSelf<T>>target;
   }
@@ -402,11 +409,17 @@ export class Resolver implements IResolver, IRegistration {
       case ResolverStrategy.instance:
         return this.state;
       case ResolverStrategy.singleton:
+      {
         this.strategy = ResolverStrategy.instance;
-        return this.state = handler.getFactory(this.state).construct(handler);
+        const factory = handler.getFactory(this.state);
+        return this.state = factory.construct(handler);
+      }
       case ResolverStrategy.transient:
+      {
         // Always create transients from the requesting container
-        return handler.getFactory(this.state).construct(requestor);
+        const factory = handler.getFactory(this.state);
+        return factory.construct(requestor);
+      }
       case ResolverStrategy.callback:
         return (this.state as ResolveCallback)(handler, requestor, this);
       case ResolverStrategy.array:
@@ -621,11 +634,12 @@ export class Container implements IContainer {
     let current: Container = this;
 
     while (current !== null) {
-      const resolver = current.resolvers.get(key);
+      let resolver = current.resolvers.get(key);
 
       if (resolver === undefined) {
         if (current.parent === null) {
-          return this.jitRegister(key, current).resolve(current, this);
+          resolver = this.jitRegister(key, current)
+          return resolver.resolve(current, this);
         }
 
         current = current.parent;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Introduces a new decorator `@attributePattern` that allows you to register a custom pattern for parsing attribute names.

The only special keyword is `PART` which means "match any number of characters that does not occur in the provided symbol list" ~"match any number of characters out of `-_$+abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789`". Any characters in the pattern that are not included in this list will automatically be interpreted as symbols (or part separators).~

You place this decorator on a class, with one or more patterns per decorator. Then you add methods to the class corresponding to the patterns in the decorator - those methods will be called with the interpretation result if a pattern for that class is matched.

The interpretation result is the raw name+value and an array of strings (parts). You need to return an `AttrSyntax`.

It's quite simple:

### Default aurelia syntax
```ts
@attributePattern({ pattern: 'PART.PART', symbols: '.' })
export class DotSeparatedAttributePattern {
  public ['PART.PART'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
    return new AttrSyntax(rawName, rawValue, parts[0], parts[1]);
  }
}
```

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Directly related to: https://github.com/aurelia/aurelia/issues/165
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

See [`@attributePattern({ pattern: 'PART.PART', symbols: '.' }, { pattern: 'PART.PART.PART', symbols: '.' })`](https://github.com/aurelia/aurelia/pull/296/files#diff-bda6980752cccfd5f1db2d37f30249fcR398) for what represents the current templating syntax

See [`@attributePattern({ pattern: ':PART', symbols: ':' })`](https://github.com/aurelia/aurelia/pull/296/files#diff-bda6980752cccfd5f1db2d37f30249fcR413) and [`@attributePattern({ pattern: '@PART', symbols: '@' })`](https://github.com/aurelia/aurelia/pull/296/files#diff-bda6980752cccfd5f1db2d37f30249fcR424) for the newly introduced shorthands
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Testing for the alternative syntax is not very extensive. A few basic unit tests exist to verify that the discussed use cases are supported.

Since this also replaces the previous attribute parsing logic, the test coverage for the normal dot syntax is in fact quite extensive since all the template compiler integration tests hit it.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

- Performance improvements might be needed (marked by TODO's in comments)
- Some cleanup and/or rework of the template compiler and/or binding commands might be appropriate to better utilize this new feature
- Perhaps `@bindingCommand` may be deprecated and the attribute patterns should implement a compile method (one per command, etc)?

A follow-up PR should include some finalizing touches directly pertaining to the template compiler.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
