### PR TITLE
refactor: more any to strict typing conversions

### DIFF
--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -28,7 +28,7 @@ export interface IBindingCommand {
 
 export interface IBindingCommandDefinition extends IResourceDefinition { }
 
-export interface IBindingCommandType extends IResourceType<IBindingCommandDefinition, IBindingCommand, Class<IBindingCommand, IIndexable>> { }
+export interface IBindingCommandType extends IResourceType<IBindingCommandDefinition, IBindingCommand, Class<IBindingCommand>> { }
 
 export interface IBindingCommandResource extends
   IResourceKind<IBindingCommandDefinition, IBindingCommand, Class<IBindingCommand>> { }

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -348,8 +348,9 @@ export class AttributeSymbol implements IAttributeSymbol {
       if (!this.isMultiAttrBinding) {
         for (const prop in bindables) {
           const b = bindables[prop];
+          const defaultBindingMode = definition.defaultBindingMode === undefined ? BindingMode.toView : definition.defaultBindingMode;
           this.to = b.property;
-          this.mode = (b.mode !== undefined && b.mode !== BindingMode.default) ? b.mode : (definition.defaultBindingMode || BindingMode.toView);
+          this.mode = (b.mode !== undefined && b.mode !== BindingMode.default) ? b.mode : defaultBindingMode;
           this.bindable = b as Immutable<Required<IBindableDescription>>;
           this.isBindable = this.isAttributeBindable = true;
           break;

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -623,7 +623,6 @@ export class Container implements IContainer {
       : false;
   }
 
-  // tslint:disable-next-line:no-reserved-keywords
   public get(key: any): any {
     validateKey(key);
 

--- a/packages/plugin-requirejs/src/processing.ts
+++ b/packages/plugin-requirejs/src/processing.ts
@@ -110,7 +110,6 @@ interface Require {
   nodeRequire(name: string): unknown;
 }
 
-// tslint:disable-next-line:no-reserved-keywords
 declare const require: Require;
 
 export function loadFromFile(url: string, callback: (content: string) => void, errback: (error: Error) => void): void {

--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -52,7 +52,6 @@ export class BindingContext implements IBindingContext {
     return new BindingContext(keyOrObj, value);
   }
 
-  // tslint:disable-next-line:no-reserved-keywords
   public static get(scope: IScope, name: string, ancestor: number): IBindingContext | IOverrideContext | IBindScope {
     if (scope === undefined) {
       throw Reporter.error(RuntimeError.UndefinedScope);

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -1,6 +1,7 @@
 import { IServiceLocator, Reporter } from '@aurelia/kernel';
+import { INode } from '../dom';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
-import { AccessorOrObserver, IBindingTargetObserver, IScope, LifecycleFlags } from '../observation';
+import { AccessorOrObserver, IBindingTargetObserver, IObservable, IScope, LifecycleFlags } from '../observation';
 import { ExpressionKind, ForOfStatement, hasBind, hasUnbind, IsBindingBehavior } from './ast';
 import { BindingMode } from './binding-mode';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
@@ -11,7 +12,7 @@ export interface IBinding extends IBindScope {
   readonly $scope: IScope;
 }
 
-export type IBindingTarget = any; // Node | CSSStyleDeclaration | IObservable;
+export type IBindingTarget = INode | IObservable; // Node | CSSStyleDeclaration | IObservable;
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
 const { oneTime, toView, fromView } = BindingMode;

--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -7,7 +7,6 @@ import { subscriberCollection } from './subscriber-collection';
 
 export interface ComputedOverrides {
   // Indicates that a getter doesn't need to re-calculate its dependencies after the first observation.
-  // tslint:disable-next-line:no-reserved-keywords
   static?: boolean;
 
   // Indicates that the getter of a getter/setter pair can change its value based on side-effects outside the setter.
@@ -31,7 +30,6 @@ export function createComputedObserver(
   observerLocator: IObserverLocator,
   dirtyChecker: IDirtyChecker,
   lifecycle: ILifecycle,
-  // tslint:disable-next-line:no-reserved-keywords
   instance: IObservable & { constructor: Function & ComputedLookup },
   propertyName: string,
   descriptor: PropertyDescriptor): IBindingTargetAccessor {

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,4 +1,4 @@
-import { IServiceLocator, Reporter } from '@aurelia/kernel';
+import { IIndexable, IServiceLocator, Reporter } from '@aurelia/kernel';
 import { IBindScope, ILifecycle, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
 import { IExpression } from './ast';
@@ -46,7 +46,7 @@ export class LetBinding implements IPartialConnectableBinding {
     }
 
     if (flags & LifecycleFlags.updateTargetInstance) {
-      const { target, targetProperty } = this;
+      const { target, targetProperty } = this as {target: IIndexable; targetProperty: string};
       previousValue = target[targetProperty];
       newValue = this.sourceExpression.evaluate(flags, this.$scope, this.locator);
       if (newValue !== previousValue) {
@@ -69,7 +69,7 @@ export class LetBinding implements IPartialConnectableBinding {
     this.$state |= State.isBinding;
 
     this.$scope = scope;
-    this.target = this.toViewModel ? scope.bindingContext : scope.overrideContext;
+    this.target = (this.toViewModel ? scope.bindingContext : scope.overrideContext) as IIndexable;
 
     const sourceExpression = this.sourceExpression;
     if (sourceExpression.bind) {

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -224,7 +224,6 @@ export class ObserverLocator implements IObserverLocator {
     }
 
     const descriptor = getPropertyDescriptor(obj, propertyName) as PropertyDescriptor & {
-      // tslint:disable-next-line:no-reserved-keywords
       get: PropertyDescriptor['get'] & { getObserver(obj: IObservable): IBindingTargetObserver };
     };
 

--- a/packages/runtime/src/binding/resources/attr-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/attr-binding-behavior.ts
@@ -1,4 +1,5 @@
 import { IRegistry } from '@aurelia/kernel';
+import { INode } from '../../dom';
 import { ILifecycle } from '../../lifecycle';
 import { IScope, LifecycleFlags } from '../../observation';
 import { Binding } from '../binding';
@@ -10,7 +11,7 @@ export class AttrBindingBehavior {
   public static register: IRegistry['register'];
 
   public bind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {
-    binding.targetObserver = new DataAttributeAccessor(binding.locator.get(ILifecycle), binding.target, binding.targetProperty);
+    binding.targetObserver = new DataAttributeAccessor(binding.locator.get(ILifecycle), binding.target as INode, binding.targetProperty);
   }
 
   public unbind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {

--- a/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
@@ -23,7 +23,7 @@ const unset = {};
 export function debounceCallSource(this: DebounceableBinding, newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void {
   const state = this.debounceState;
   clearTimeout(state.timeoutId);
-  state.timeoutId = setTimeout(() => this.debouncedMethod(newValue, oldValue, flags), state.delay);
+  state.timeoutId = setTimeout(() => { this.debouncedMethod(newValue, oldValue, flags); }, state.delay);
 }
 
 /*@internal*/

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -1,4 +1,4 @@
-import { DI, Immutable, Omit, PLATFORM } from '@aurelia/kernel';
+import { DI, Immutable, IRegistry, Omit, PLATFORM } from '@aurelia/kernel';
 import { ForOfStatement, Interpolation, IsBindingBehavior } from './binding/ast';
 import { BindingMode } from './binding/binding-mode';
 import { DelegationStrategy } from './binding/event-manager';
@@ -63,7 +63,7 @@ export interface ITemplateDefinition extends IResourceDefinition {
   cache?: '*' | number;
   template?: string | INode;
   instructions?: TargetedInstruction[][];
-  dependencies?: any[];
+  dependencies?: IRegistry[];
   build?: IBuildInstruction;
   surrogates?: TargetedInstruction[];
   bindables?: Record<string, IBindableDescription>;
@@ -300,7 +300,7 @@ export function buildTemplateDefinition(
   build?: IBuildInstruction | boolean | null,
   bindables?: Record<string, IBindableDescription> | null,
   instructions?: ReadonlyArray<ReadonlyArray<TargetedInstruction>> | null,
-  dependencies?: ReadonlyArray<unknown> | null,
+  dependencies?: ReadonlyArray<IRegistry> | null,
   surrogates?: ReadonlyArray<TargetedInstruction> | null,
   containerless?: boolean | null,
   shadowOptions?: { mode: 'open' | 'closed' } | null,

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -51,7 +51,6 @@ export interface IHTMLElement extends IElement {
 }
 
 export interface IInputElement extends IElement {
-  // tslint:disable-next-line:no-reserved-keywords
   readonly type: string;
   value: string;
   checked: boolean;

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -1,5 +1,5 @@
 import { IContainer, inject, IRegistry } from '@aurelia/kernel';
-import { Binding } from './binding/binding';
+import { Binding, IBindingTarget } from './binding/binding';
 import { BindingMode } from './binding/binding-mode';
 import { Call } from './binding/call';
 import { IEventManager } from './binding/event-manager';
@@ -203,7 +203,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
 
   public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IStylePropertyBindingInstruction): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
-    const bindable = new Binding(expr, (<any>target).style, instruction.to, BindingMode.toView, this.observerLocator, context);
+    const bindable = new Binding(expr, (<INode & {style: IBindingTarget}>target).style, instruction.to, BindingMode.toView, this.observerLocator, context);
     addBindable(renderable, bindable);
   }
 }
@@ -304,7 +304,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     component.$hydrate(this.renderingEngine);
 
     if (instruction.link) {
-      (component as any).link(renderable.$attachableTail);
+      (component as ICustomAttribute & { link(attachableTail: IAttach): void}).link(renderable.$attachableTail);
     }
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {

--- a/packages/runtime/src/instructions.ts
+++ b/packages/runtime/src/instructions.ts
@@ -4,8 +4,6 @@ import { DelegationStrategy } from './binding/event-manager';
 import { ICallBindingInstruction, IHydrateAttributeInstruction, IHydrateElementInstruction, IHydrateTemplateController, IInterpolationInstruction, IIteratorBindingInstruction, ILetBindingInstruction, ILetElementInstruction, IListenerBindingInstruction, IPropertyBindingInstruction, IRefBindingInstruction, ISetPropertyInstruction, IStylePropertyBindingInstruction, ITargetedInstruction, ITemplateDefinition, ITextBindingInstruction, TargetedInstruction, TargetedInstructionType } from './definitions';
 import { INode } from './dom';
 
-// tslint:disable:no-reserved-keywords | TODO: get rid of this suppression and fix the error
-
 export class TextBindingInstruction implements ITextBindingInstruction {
   public type: TargetedInstructionType.textBinding = TargetedInstructionType.textBinding;
   constructor(public from: string | Interpolation) {}

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -1,4 +1,4 @@
-import { IDisposable, IIndexable } from '@aurelia/kernel';
+import { IDisposable, IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from './lifecycle';
 
 export enum LifecycleFlags {
@@ -55,7 +55,7 @@ export interface IChangeTracker {
 /**
  * Basic interface to normalize getting/setting a value of any property on any object
  */
-export interface IAccessor<TValue = any> {
+export interface IAccessor<TValue = unknown> {
   getValue(): TValue;
   setValue(newValue: TValue, flags: LifecycleFlags): void;
 }
@@ -66,7 +66,7 @@ export interface IAccessor<TValue = any> {
 export interface IBindingTargetAccessor<
   TObj = any,
   TProp = keyof TObj,
-  TValue = any>
+  TValue = unknown>
   extends IDisposable,
           IAccessor<TValue>,
           IPropertyChangeTracker<TObj, TProp> { }
@@ -77,7 +77,7 @@ export interface IBindingTargetAccessor<
 export interface IBindingTargetObserver<
   TObj = any,
   TProp = keyof TObj,
-  TValue = any>
+  TValue = unknown>
   extends IBindingTargetAccessor<TObj, TProp, TValue>,
           ISubscribable<MutationKind.instance>,
           ISubscriberCollection<MutationKind.instance> {
@@ -94,7 +94,7 @@ export type AccessorOrObserver = IBindingTargetAccessor | IBindingTargetObserver
  * The deletedItems property contains the items (in case of an array) or keys (in case of map or set) that have been deleted.
  */
 export type IndexMap = number[] & {
-  deletedItems?: any[];
+  deletedItems?: unknown[];
 };
 
 /**
@@ -108,7 +108,7 @@ export enum MutationKind {
 /**
  * Describes a type that specifically tracks changes in an object property, or simply something that can have a getter and/or setter
  */
-export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = any> {
+export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = IIndexable | Primitive> {
   obj: TObj;
   propertyKey?: TProp;
   currentValue?: TValue;
@@ -126,7 +126,7 @@ export interface ICollectionChangeTracker<T extends Collection> extends IChangeT
 /**
  * Represents a (subscriber) function that can be called by a PropertyChangeNotifier
  */
-export type IPropertyChangeHandler<TValue = any> = (newValue: TValue, previousValue: TValue, flags: LifecycleFlags) => void;
+export type IPropertyChangeHandler<TValue = unknown> = (newValue: TValue, previousValue: TValue, flags: LifecycleFlags) => void;
 /**
  * Represents a (observer) function that can notify subscribers of mutations on a property
  */
@@ -269,7 +269,7 @@ export type PropertyObserver = IPropertyObserver<any, PropertyKey>;
 /**
  * A collection (array, set or map)
  */
-export type Collection = any[] | Set<any> | Map<any, any>;
+export type Collection = unknown[] | Set<unknown> | Map<unknown, unknown>;
 interface IObservedCollection {
   $observer?: CollectionObserver;
 }
@@ -277,15 +277,15 @@ interface IObservedCollection {
 /**
  * An array that is being observed for mutations
  */
-export interface IObservedArray<T = any> extends IObservedCollection, Array<T> { }
+export interface IObservedArray<T = unknown> extends IObservedCollection, Array<T> { }
 /**
  * A set that is being observed for mutations
  */
-export interface IObservedSet<T = any> extends IObservedCollection, Set<T> { }
+export interface IObservedSet<T = unknown> extends IObservedCollection, Set<T> { }
 /**
  * A map that is being observed for mutations
  */
-export interface IObservedMap<K = any, V = any> extends IObservedCollection, Map<K, V> { }
+export interface IObservedMap<K = unknown, V = unknown> extends IObservedCollection, Map<K, V> { }
 /**
  * A collection that is being observed for mutations
  */
@@ -300,23 +300,23 @@ export const enum CollectionKind {
 }
 
 export type LengthPropertyName<T> =
-  T extends any[] ? 'length' :
-  T extends Set<any> ? 'size' :
-  T extends Map<any, any> ? 'size' :
+  T extends unknown[] ? 'length' :
+  T extends Set<unknown> ? 'size' :
+  T extends Map<unknown, unknown> ? 'size' :
   never;
 
 export type CollectionTypeToKind<T> =
-  T extends any[] ? CollectionKind.array | CollectionKind.indexed :
-  T extends Set<any> ? CollectionKind.set | CollectionKind.keyed :
-  T extends Map<any, any> ? CollectionKind.map | CollectionKind.keyed :
+  T extends unknown[] ? CollectionKind.array | CollectionKind.indexed :
+  T extends Set<unknown> ? CollectionKind.set | CollectionKind.keyed :
+  T extends Map<unknown, unknown> ? CollectionKind.map | CollectionKind.keyed :
   never;
 
 export type CollectionKindToType<T> =
-  T extends CollectionKind.array ? any[] :
-  T extends CollectionKind.indexed ? any[] :
-  T extends CollectionKind.map ? Map<any, any> :
-  T extends CollectionKind.set ? Set<any> :
-  T extends CollectionKind.keyed ? Set<any> | Map<any, any> :
+  T extends CollectionKind.array ? unknown[] :
+  T extends CollectionKind.indexed ? unknown[] :
+  T extends CollectionKind.map ? Map<unknown, unknown> :
+  T extends CollectionKind.set ? Set<unknown> :
+  T extends CollectionKind.keyed ? Set<unknown> | Map<unknown, unknown> :
   never;
 
 export type ObservedCollectionKindToType<T> =

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -1,4 +1,4 @@
-import { Constructable, IIndexable } from '@aurelia/kernel';
+import { Constructable, IIndexable, IRegistry } from '@aurelia/kernel';
 import { buildTemplateDefinition, isTargetedInstruction, TargetedInstruction, TargetedInstructionType, TemplateDefinition } from '../definitions';
 import { DOM, INode } from '../dom';
 import { IRenderContext, IView, IViewFactory } from '../lifecycle';
@@ -21,7 +21,7 @@ export class RenderPlan {
   constructor(
     private readonly node: INode,
     private readonly instructions: TargetedInstruction[][],
-    private readonly dependencies: ReadonlyArray<any>
+    private readonly dependencies: ReadonlyArray<IRegistry>
   ) {}
 
   public get definition(): TemplateDefinition {
@@ -42,7 +42,7 @@ export class RenderPlan {
   }
 
   /*@internal*/
-  public mergeInto(parent: INode, instructions: TargetedInstruction[][], dependencies: any[]): void {
+  public mergeInto(parent: INode, instructions: TargetedInstruction[][], dependencies: IRegistry[]): void {
     DOM.appendChild(parent, this.node);
     instructions.push(...this.instructions);
     dependencies.push(...this.dependencies);
@@ -51,8 +51,8 @@ export class RenderPlan {
 
 function createElementForTag(tagName: string, props?: IIndexable, children?: ArrayLike<ChildType>): RenderPlan {
   const instructions: TargetedInstruction[] = [];
-  const allInstructions = [];
-  const dependencies = [];
+  const allInstructions: TargetedInstruction[][] = [];
+  const dependencies: IRegistry[] = [];
   const element = DOM.createElement(tagName);
   let hasInstructions = false;
 
@@ -137,7 +137,7 @@ function createElementForType(Type: ICustomElementType, props?: IIndexable, chil
   return new RenderPlan(element, allInstructions, dependencies);
 }
 
-function addChildren(parent: INode, children: ArrayLike<ChildType>, allInstructions: TargetedInstruction[][], dependencies: any[]): void {
+function addChildren(parent: INode, children: ArrayLike<ChildType>, allInstructions: TargetedInstruction[][], dependencies: IRegistry[]): void {
   for (let i = 0, ii = children.length; i < ii; ++i) {
     const current = children[i];
 

--- a/packages/runtime/src/templating/resources/compose.ts
+++ b/packages/runtime/src/templating/resources/compose.ts
@@ -45,9 +45,9 @@ export class Compose {
     };
 
     this.properties = instruction.instructions
-      .filter((x: any) => !composeProps.includes(x.to))
+      .filter((x: ITargetedInstruction & {to?: string}) => !composeProps.includes(x.to))
       .reduce(
-        (acc, item: any) => {
+        (acc, item: ITargetedInstruction & {to?: string}) => {
           if (item.to) {
             acc[item.to] = item;
           }

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -126,7 +126,7 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
 
       $lifecycle.beginBind();
       if (indexMap === null) {
-        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray<unknown> | IObservedSet<unknown> | IObservedMap<unknown, unknown> | IIndexable)) => {
+        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray | IObservedSet | IObservedMap | IIndexable)) => {
           const view = views[i];
           if (!!view.$scope && view.$scope.bindingContext[local] === item) {
             view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));
@@ -135,7 +135,7 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
           }
         });
       } else {
-        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray<unknown> | IObservedSet<unknown> | IObservedMap<unknown, unknown> | IIndexable)) => {
+        forOf.iterate(items, (arr, i, item: (string | number | boolean | IObservedArray | IObservedSet | IObservedMap | IIndexable)) => {
           const view = views[i];
           if (indexMap[i] === i && !!view.$scope) {
             view.$bind(flags, Scope.fromParent($scope, view.$scope.bindingContext));

--- a/packages/runtime/src/templating/resources/with.ts
+++ b/packages/runtime/src/templating/resources/with.ts
@@ -1,8 +1,8 @@
 import { inject, IRegistry } from '@aurelia/kernel';
 import { Scope } from '../../binding/binding-context';
 import { IRenderLocation } from '../../dom';
-import { IView, IViewFactory, State } from '../../lifecycle';
-import { LifecycleFlags } from '../../observation';
+import { IBindScope, IView, IViewFactory, State } from '../../lifecycle';
+import { IBindingContext, LifecycleFlags } from '../../observation';
 import { bindable } from '../bindable';
 import { ICustomAttribute, templateController } from '../custom-attribute';
 
@@ -12,7 +12,8 @@ export interface With extends ICustomAttribute {}
 export class With {
   public static register: IRegistry['register'];
 
-  @bindable public value: any = null;
+  // TODO: this type is incorrect (it can be any user-provided object), need to fix and double check Scope.
+  @bindable public value: IBindScope | IBindingContext = null;
 
   private currentView: IView = null;
 

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -59,13 +59,13 @@ export class View implements IView {
     this.$bind = lockedBind;
   }
 
-  public release(flags: LifecycleFlags): any {
+  public release(flags: LifecycleFlags): boolean {
     this.isFree = true;
     if (this.$state & State.isAttached) {
       return this.cache.canReturnToCache(this);
     }
 
-    return this.$unmount(flags);
+    return !!this.$unmount(flags);
   }
 }
 

--- a/tslint.json
+++ b/tslint.json
@@ -29,7 +29,7 @@
     "no-http-string": [true, "http://localhost:?.*"],
     "no-inner-html": false,
     "no-octal-literal": true,
-    "no-reserved-keywords": true,
+    "no-reserved-keywords": false, // See https://github.com/aurelia/aurelia/pull/297
     "no-string-based-set-immediate": true,
     "no-string-based-set-interval": true,
     "no-string-based-set-timeout": true,


### PR DESCRIPTION
# Pull Request

## 📖 Description

More linting fixes. This time its mostly `any` to more strict type conversions.

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

Notable changes:
- Mostly `any` conversions where I could upstream already existing types.
- ~~In `ITargetedInstruction` the `type` property will be renamed to `Type` in a future PR, but as far as I know there are no such plans for `from`, so I suppressed those warnings.~~
- Disabled the `no-reserved-keywords` linting rule, see discussion below.

## 📑 Test Plan

Depend on CircleCI.

## ⏭ Next Steps

- Check types used by Scope (https://github.com/aurelia/aurelia/pull/297#discussion_r234462754)
- Maybe undo some renames that were done just to satisfy `no-reserved-keywords`.
- And more, see #249.
