### PR TITLE
refactor: partially revert renames due to no-reserved-keywords

### DIFF
--- a/packages/debug/src/reporter.ts
+++ b/packages/debug/src/reporter.ts
@@ -9,7 +9,7 @@ const enum MessageType {
 
 interface IMessageInfo {
   message: string;
-  messageType: MessageType;
+  type: MessageType;
 }
 
 export const Reporter: typeof RuntimeReporter = {...RuntimeReporter,
@@ -17,7 +17,7 @@ export const Reporter: typeof RuntimeReporter = {...RuntimeReporter,
     const info = getMessageInfoForCode(code);
 
     // tslint:disable:no-console
-    switch (info.messageType) {
+    switch (info.type) {
       case MessageType.debug:
         console.debug(info.message, ...params);
         break;
@@ -45,162 +45,162 @@ function getMessageInfoForCode(code: number): IMessageInfo {
 
 function createInvalidCodeMessageInfo(code: number): IMessageInfo {
   return {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: `Attempted to report with unknown code ${code}.`
   };
 }
 
 const codeLookup: Record<string, IMessageInfo> = {
   0: {
-    messageType: MessageType.warn,
+    type: MessageType.warn,
     message: 'Cannot add observers to object.'
   },
   1: {
-    messageType: MessageType.warn,
+    type: MessageType.warn,
     message: 'Cannot observe property of object.'
   },
   2: {
-    messageType: MessageType.info,
+    type: MessageType.info,
     message: 'Starting application in debug mode.'
   },
   3: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Runtime expression compilation is only available when including JIT support.'
   },
   4: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid animation direction.'
   },
   5: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'key/value cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?'
   },
   6: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid resolver strategy specified.'
   },
   7: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Constructor Parameter with index cannot be null or undefined. Are you trying to inject/register something that doesn\'t exist with DI?'
   },
   8: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Self binding behavior only supports events.'
   },
   9: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:\'blur\'">'
   },
   10: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.'
   },
   11: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Only property bindings and string interpolation bindings can be signaled. Trigger, delegate and call bindings cannot be signaled.'
   },
   12: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Signal name is required.'
   },
   14: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Property cannot be assigned.'
   },
   15: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unexpected call context.'
   },
   16: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Only one child observer per content view is supported for the life of the content view.'
   },
   17: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'You can only define one default implementation for an interface.'
   },
   18: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'You cannot observe a setter only property.'
   },
   19: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Value for expression is non-repeatable.'
   },
   20: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'No template compiler found with the specified name. JIT support or a custom compiler is required.'
   },
   21: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'You cannot combine the containerless custom element option with Shadow DOM.'
   },
   22: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'A containerless custom element cannot be the root component of an application.'
   },
   30: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'There are more targets than there are target instructions.'
   },
   31: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'There are more target instructions than there are targets.'
   },
   100: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid start of expression.'
   },
   101: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unconsumed token.'
   },
   102: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Double dot and spread operators are not supported.'
   },
   103: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid member expression.'
   },
   104: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unexpected end of expression.'
   },
   105: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Expected identifier.'
   },
   106: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid BindingIdentifier at left hand side of "of".'
   },
   107: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Invalid or unsupported property definition in object literal.'
   },
   108: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unterminated quote in string literal.'
   },
   109: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unterminated template string.'
   },
   110: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Missing expected token.'
   },
   111: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unexpected character.'
   },
   150: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Left hand side of expression is not assignable.'
   },
   151: {
-    messageType: MessageType.error,
+    type: MessageType.error,
     message: 'Unexpected keyword "of"'
   }
 };

--- a/packages/runtime/src/binding/array-observer.ts
+++ b/packages/runtime/src/binding/array-observer.ts
@@ -191,12 +191,12 @@ function preSortCompare(x: IIndexable | Primitive, y: IIndexable | Primitive): n
   return 0;
 }
 
-function insertionSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, toIndex: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
   let velement, ielement, vtmp, itmp, order;
   let i, j;
-  for (i = fromIndex + 1; i < toIndex; i++) {
+  for (i = from + 1; i < to; i++) {
     velement = arr[i]; ielement = indexMap[i];
-    for (j = i - 1; j >= fromIndex; j--) {
+    for (j = i - 1; j >= from; j--) {
       vtmp = arr[j]; itmp = indexMap[j];
       order = compareFn(vtmp, velement);
       if (order > 0) {
@@ -209,7 +209,7 @@ function insertionSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: numbe
   }
 }
 
-function quickSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, toIndex: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
   let thirdIndex = 0, i = 0;
   let v0, v1, v2;
   let i0, i1, i2;
@@ -220,14 +220,14 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, t
 
   // tslint:disable-next-line:no-constant-condition
   while (true) {
-    if (toIndex - fromIndex <= 10) {
-      insertionSort(arr, indexMap, fromIndex, toIndex, compareFn);
+    if (to - from <= 10) {
+      insertionSort(arr, indexMap, from, to, compareFn);
       return;
     }
 
-    thirdIndex = fromIndex + ((toIndex - fromIndex) >> 1);
-    v0 = arr[fromIndex];       i0 = indexMap[fromIndex];
-    v1 = arr[toIndex - 1];     i1 = indexMap[toIndex - 1];
+    thirdIndex = from + ((to - from) >> 1);
+    v0 = arr[from];       i0 = indexMap[from];
+    v1 = arr[to - 1];     i1 = indexMap[to - 1];
     v2 = arr[thirdIndex]; i2 = indexMap[thirdIndex];
     c01 = compareFn(v0, v1);
     if (c01 > 0) {
@@ -249,11 +249,11 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, t
         v2 = vtmp; i2 = itmp;
       }
     }
-    arr[fromIndex] = v0;   indexMap[fromIndex] = i0;
-    arr[toIndex - 1] = v2; indexMap[toIndex - 1] = i2;
+    arr[from] = v0;   indexMap[from] = i0;
+    arr[to - 1] = v2; indexMap[to - 1] = i2;
     vpivot = v1;      ipivot = i1;
-    lowEnd = fromIndex + 1;
-    highStart = toIndex - 1;
+    lowEnd = from + 1;
+    highStart = to - 1;
     arr[thirdIndex] = arr[lowEnd]; indexMap[thirdIndex] = indexMap[lowEnd];
     arr[lowEnd] = vpivot;          indexMap[lowEnd] = ipivot;
 
@@ -283,12 +283,12 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, fromIndex: number, t
         }
       }
     }
-    if (toIndex - highStart < lowEnd - fromIndex) {
-      quickSort(arr, indexMap, highStart, toIndex, compareFn);
-      toIndex = lowEnd;
+    if (to - highStart < lowEnd - from) {
+      quickSort(arr, indexMap, highStart, to, compareFn);
+      to = lowEnd;
     } else {
-      quickSort(arr, indexMap, fromIndex, lowEnd, compareFn);
-      fromIndex = highStart;
+      quickSort(arr, indexMap, from, lowEnd, compareFn);
+      from = highStart;
     }
   }
 }

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -107,8 +107,8 @@ export type TargetedInstruction =
   ILetElementInstruction;
 
 export function isTargetedInstruction(value: { type?: string }): value is TargetedInstruction {
-  const Type = value.type;
-  return typeof Type === 'string' && instructionTypeValues.indexOf(Type) !== -1;
+  const type = value.type;
+  return typeof type === 'string' && instructionTypeValues.indexOf(type) !== -1;
 }
 
 export interface ITextBindingInstruction extends ITargetedInstruction {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Now that the decision is made to disable the `no-reserved-keywords` linting rule (See #297) it's better to revert some of the changes made just to satisfy that linting rule, when their original names better suited their purpose.

### 🎫 Issues

Part of #249, follow up to #297 and partially reverts #262 and #290.

## 👩‍💻 Reviewer Notes

Straight up renames.

Will increase the number of linting errors until #297 is merged and `no-reserved-keywords` is actually disabled.

## 📑 Test Plan

Trust in CircleCI

## ⏭ Next Steps

See #249.