### PR TITLE
refactor: fix no-floating-promises linting warnings

### DIFF
--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -131,7 +131,7 @@ export class CustomSetterObserver implements CustomSetterObserver {
 
         if (oldValue !== newValue) {
           that.oldValue = oldValue;
-          that.lifecycle.enqueueFlush(that);
+          that.lifecycle.enqueueFlush(that).catch(error => { throw error; });
 
           that.currentValue = newValue;
         }
@@ -276,7 +276,7 @@ export class GetterController {
   }
 
   public handleChange(): void {
-    this.lifecycle.enqueueFlush(this.owner);
+    this.lifecycle.enqueueFlush(this.owner).catch(error => { throw error; });
   }
 
   private unsubscribeAllDependencies(): void {

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -149,7 +149,7 @@ function callCollectionSubscribers(this: ISubscriberCollection<MutationKind.coll
       }
     }
   }
-  this.lifecycle.enqueueFlush(this);
+  this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
 }
 
 function hasSubscribers<T extends MutationKind>(this: ISubscriberCollection<T>): boolean {

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -34,7 +34,7 @@ function flush(this: BindingTargetAccessor, flags: LifecycleFlags): void {
   if (flags & LifecycleFlags.doNotUpdateDOM) {
     if (DOM.isNodeInstance(this.obj)) {
       // re-queue the change so it will still propagate on flush when it's attached again
-      this.lifecycle.enqueueFlush(this);
+      this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
       return;
     }
   }

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -1239,7 +1239,7 @@ export class CompositionCoordinator {
       this.swapTask.wait().then(() => {
         this.onSwapComplete();
         this.processNext();
-      });
+      }).catch(error => { throw error; });
     }
   }
 
@@ -1289,7 +1289,7 @@ export class AggregateLifecycleTask implements ILifecycleTask<void> {
     if (!task.done) {
       this.done = false;
       this.tasks.push(task);
-      task.wait().then(() => { this.tryComplete(); });
+      task.wait().then(() => { this.tryComplete(); }).catch(error => { throw error; });
     }
   }
 

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -482,7 +482,7 @@ export class ChildrenObserver implements Partial<IChildrenObserver> {
       this.customElement.$childrenChanged();
     }
 
-    this.lifecycle.enqueueFlush(this);
+    this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
     this.hasChanges = true;
   }
 }

--- a/packages/runtime/src/templating/resources/if.ts
+++ b/packages/runtime/src/templating/resources/if.ts
@@ -58,7 +58,7 @@ export class If {
       const view = this.updateView(flags);
       this.coordinator.compose(view, flags);
     } else {
-      this.$lifecycle.enqueueFlush(this);
+      this.$lifecycle.enqueueFlush(this).catch(error => { throw error; });
     }
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes all warnings related to the `no-floating-promises` tslint rule.

### 🎫 Issues

Part of #249.

## 👩‍💻 Reviewer Notes

The linting rule warns on every Promise-chain that does not have a `catch` at the end. So we add one where I'm just propagating the error up the stack.

## 📑 Test Plan

Trust CircleCI.

## ⏭ Next Steps

See #249.
