### PR TITLE
perf(all): shorten au-marker to au-m

### DIFF
--- a/packages/examples/dbmonster-a/app-config.ts
+++ b/packages/examples/dbmonster-a/app-config.ts
@@ -22,8 +22,8 @@ export const appConfig: ITemplateDefinition = {
           cache: "*",
           template: `
             <tr>
-              <td class="dbname"><au-marker class="au"></au-marker> </td>
-              <td class="query-count"><au-marker class="au"></au-marker> </td>
+              <td class="dbname"><au- class="au"></au-> </td>
+              <td class="query-count"><au- class="au"></au-> </td>
               <td class="au"></td>
             </tr>
           `,
@@ -38,8 +38,8 @@ export const appConfig: ITemplateDefinition = {
                   cache: "*",
                   template: `
                   <td>
-                    <au-marker class="au"></au-marker> <div class="popover left">
-                      <div class="popover-content"><au-marker class="au"></au-marker> </div>
+                    <au- class="au"></au-> <div class="popover left">
+                      <div class="popover-content"><au- class="au"></au-> </div>
                       <div class="arrow"></div>
                     </div>
                   </td>

--- a/packages/examples/dbmonster-a/app-config.ts
+++ b/packages/examples/dbmonster-a/app-config.ts
@@ -22,8 +22,8 @@ export const appConfig: ITemplateDefinition = {
           cache: "*",
           template: `
             <tr>
-              <td class="dbname"><au- class="au"></au-> </td>
-              <td class="query-count"><au- class="au"></au-> </td>
+              <td class="dbname"><au-m class="au"></au-m> </td>
+              <td class="query-count"><au-m class="au"></au-m> </td>
               <td class="au"></td>
             </tr>
           `,
@@ -38,8 +38,8 @@ export const appConfig: ITemplateDefinition = {
                   cache: "*",
                   template: `
                   <td>
-                    <au- class="au"></au-> <div class="popover left">
-                      <div class="popover-content"><au- class="au"></au-> </div>
+                    <au-m class="au"></au-m> <div class="popover left">
+                      <div class="popover-content"><au-m class="au"></au-m> </div>
                       <div class="arrow"></div>
                     </div>
                   </td>

--- a/packages/examples/test-aot/app-config.ts
+++ b/packages/examples/test-aot/app-config.ts
@@ -11,16 +11,16 @@ export const appConfig: ITemplateDefinition = {
     import1
   ],
   template: `
-    <au- class="au"></au-> <br/>
-    <au- class="au"></au-> <br/>
+    <au-m class="au"></au-m> <br/>
+    <au-m class="au"></au-m> <br/>
     <input type="text" class="au">
     <name-tag class="au">
-      <h2>Message: <au- class="au"></au-> </h2>
+      <h2>Message: <au-m class="au"></au-m> </h2>
     </name-tag>
     <input type="checkbox" class="au" />
-    <au- class="au"></au->
-    <au- class="au"></au->
-    <au- class="au"></au->
+    <au-m class="au"></au-m>
+    <au-m class="au"></au-m>
+    <au-m class="au"></au-m>
     <button class="au">Add Todo</button>
   `,
   instructions: [
@@ -78,7 +78,7 @@ export const appConfig: ITemplateDefinition = {
         type: TargetedInstructionType.hydrateTemplateController,
         res: 'if',
         def: {
-          template: `<div><au- class="au"></au-> </div>`,
+          template: `<div><au-m class="au"></au-m> </div>`,
           instructions: [
             [
               {
@@ -114,7 +114,7 @@ export const appConfig: ITemplateDefinition = {
         type: TargetedInstructionType.hydrateTemplateController,
         res: 'repeat',
         def: {
-          template: `<div><au- class="au"></au-> </div>`,
+          template: `<div><au-m class="au"></au-m> </div>`,
           instructions: [
             [
               {

--- a/packages/examples/test-aot/app-config.ts
+++ b/packages/examples/test-aot/app-config.ts
@@ -11,16 +11,16 @@ export const appConfig: ITemplateDefinition = {
     import1
   ],
   template: `
-    <au-marker class="au"></au-marker> <br/>
-    <au-marker class="au"></au-marker> <br/>
+    <au- class="au"></au-> <br/>
+    <au- class="au"></au-> <br/>
     <input type="text" class="au">
     <name-tag class="au">
-      <h2>Message: <au-marker class="au"></au-marker> </h2>
+      <h2>Message: <au- class="au"></au-> </h2>
     </name-tag>
     <input type="checkbox" class="au" />
-    <au-marker class="au"></au-marker>
-    <au-marker class="au"></au-marker>
-    <au-marker class="au"></au-marker>
+    <au- class="au"></au->
+    <au- class="au"></au->
+    <au- class="au"></au->
     <button class="au">Add Todo</button>
   `,
   instructions: [
@@ -78,7 +78,7 @@ export const appConfig: ITemplateDefinition = {
         type: TargetedInstructionType.hydrateTemplateController,
         res: 'if',
         def: {
-          template: `<div><au-marker class="au"></au-marker> </div>`,
+          template: `<div><au- class="au"></au-> </div>`,
           instructions: [
             [
               {
@@ -114,7 +114,7 @@ export const appConfig: ITemplateDefinition = {
         type: TargetedInstructionType.hydrateTemplateController,
         res: 'repeat',
         def: {
-          template: `<div><au-marker class="au"></au-marker> </div>`,
+          template: `<div><au- class="au"></au-> </div>`,
           instructions: [
             [
               {

--- a/packages/jit/src/ast.ts
+++ b/packages/jit/src/ast.ts
@@ -15,7 +15,7 @@ export class AttrSyntax {
   }
 }
 
-const marker = DOM.createElement('au-') as Element;
+const marker = DOM.createElement('au-m') as Element;
 marker.classList.add('au');
 const createMarker: () => HTMLElement = marker.cloneNode.bind(marker, false);
 
@@ -40,6 +40,6 @@ export class ElementSyntax {
   }
 
   public static createMarker(): ElementSyntax {
-    return new ElementSyntax(createMarker(), 'au-', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
+    return new ElementSyntax(createMarker(), 'au-m', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
   }
 }

--- a/packages/jit/src/ast.ts
+++ b/packages/jit/src/ast.ts
@@ -15,7 +15,7 @@ export class AttrSyntax {
   }
 }
 
-const marker = DOM.createElement('au-marker') as Element;
+const marker = DOM.createElement('au-') as Element;
 marker.classList.add('au');
 const createMarker: () => HTMLElement = marker.cloneNode.bind(marker, false);
 
@@ -40,6 +40,6 @@ export class ElementSyntax {
   }
 
   public static createMarker(): ElementSyntax {
-    return new ElementSyntax(createMarker(), 'au-marker', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
+    return new ElementSyntax(createMarker(), 'au-', null, PLATFORM.emptyArray, PLATFORM.emptyArray);
   }
 }

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -584,7 +584,7 @@ export class ElementSymbol {
     this._$content = null;
     this._isCustomElement = this._isLet = this._isSlot = this._isTemplate = false;
     this._isMarker = true;
-    this._name = 'AU-';
+    this._name = 'AU-M';
     this._node = marker.node;
     this._syntax = marker;
   }

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -584,7 +584,7 @@ export class ElementSymbol {
     this._$content = null;
     this._isCustomElement = this._isLet = this._isSlot = this._isTemplate = false;
     this._isMarker = true;
-    this._name = 'AU-MARKER';
+    this._name = 'AU-';
     this._node = marker.node;
     this._syntax = marker;
   }

--- a/packages/jit/test/unit/template-compiler.spec.ts
+++ b/packages/jit/test/unit/template-compiler.spec.ts
@@ -258,7 +258,7 @@ describe('TemplateCompiler', () => {
             `<template><el prop.bind="p"></el></template>`,
             [Prop]
           );
-          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au- class="au"></au-></template>')
+          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au-m class="au"></au-m></template>')
           const [hydratePropAttrInstruction] = instructions[0] as [HydrateTemplateController];
           expect((hydratePropAttrInstruction.def.template as HTMLTemplateElement).outerHTML).to.equal('<template><el></el></template>');
         });
@@ -275,7 +275,7 @@ describe('TemplateCompiler', () => {
             `<template><el name.bind="name" title.bind="title" prop.bind="p"></el></template>`,
             [Prop]
           );
-          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au- class="au"></au-></template>')
+          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au-m class="au"></au-m></template>')
           const [hydratePropAttrInstruction] = instructions[0] as [HydrateTemplateController];
           verifyInstructions(hydratePropAttrInstruction.instructions as any, [
             { toVerify: ['type', 'to', 'from'],
@@ -467,7 +467,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       res: target,
       def: {
         name: target,
-        template: createElement(`<template><au- class="au"></au-></template>`),
+        template: createElement(`<template><au-m class="au"></au-m></template>`),
         instructions: [[childInstr]]
       },
       instructions: createTplCtrlAttributeInstruction(attr, value),
@@ -478,7 +478,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       instructions: []
     }
     const output = {
-      template: createElement(`<div><au- class="au"></au-></div>`),
+      template: createElement(`<div><au-m class="au"></au-m></div>`),
       instructions: [[instruction]]
     }
     return [input, <any>output];
@@ -489,7 +489,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       compiledMarkup = `<${tagName}></${tagName}>`;
       instructions = []
     } else {
-      compiledMarkup = `<${tagName}><au- class="au"></au-></${tagName}>`;
+      compiledMarkup = `<${tagName}><au-m class="au"></au-m></${tagName}>`;
       instructions = [[childInstr]]
     }
     const instruction = {
@@ -509,7 +509,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       instructions: []
     }
     const output = {
-      template: createElement(finalize ? `<div><au- class="au"></au-></div>` : `<au- class="au"></au->`),
+      template: createElement(finalize ? `<div><au-m class="au"></au-m></div>` : `<au-m class="au"></au-m>`),
       instructions: [[instruction]]
     }
     return [input, <any>output];

--- a/packages/jit/test/unit/template-compiler.spec.ts
+++ b/packages/jit/test/unit/template-compiler.spec.ts
@@ -258,7 +258,7 @@ describe('TemplateCompiler', () => {
             `<template><el prop.bind="p"></el></template>`,
             [Prop]
           );
-          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au-marker class="au"></au-marker></template>')
+          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au- class="au"></au-></template>')
           const [hydratePropAttrInstruction] = instructions[0] as [HydrateTemplateController];
           expect((hydratePropAttrInstruction.def.template as HTMLTemplateElement).outerHTML).to.equal('<template><el></el></template>');
         });
@@ -275,7 +275,7 @@ describe('TemplateCompiler', () => {
             `<template><el name.bind="name" title.bind="title" prop.bind="p"></el></template>`,
             [Prop]
           );
-          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au-marker class="au"></au-marker></template>')
+          expect((template as HTMLTemplateElement).outerHTML).to.equal('<template><au- class="au"></au-></template>')
           const [hydratePropAttrInstruction] = instructions[0] as [HydrateTemplateController];
           verifyInstructions(hydratePropAttrInstruction.instructions as any, [
             { toVerify: ['type', 'to', 'from'],
@@ -467,7 +467,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       res: target,
       def: {
         name: target,
-        template: createElement(`<template><au-marker class="au"></au-marker></template>`),
+        template: createElement(`<template><au- class="au"></au-></template>`),
         instructions: [[childInstr]]
       },
       instructions: createTplCtrlAttributeInstruction(attr, value),
@@ -478,7 +478,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       instructions: []
     }
     const output = {
-      template: createElement(`<div><au-marker class="au"></au-marker></div>`),
+      template: createElement(`<div><au- class="au"></au-></div>`),
       instructions: [[instruction]]
     }
     return [input, <any>output];
@@ -489,7 +489,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       compiledMarkup = `<${tagName}></${tagName}>`;
       instructions = []
     } else {
-      compiledMarkup = `<${tagName}><au-marker class="au"></au-marker></${tagName}>`;
+      compiledMarkup = `<${tagName}><au- class="au"></au-></${tagName}>`;
       instructions = [[childInstr]]
     }
     const instruction = {
@@ -509,7 +509,7 @@ function createTemplateController(attr: string, target: string, value: string, t
       instructions: []
     }
     const output = {
-      template: createElement(finalize ? `<div><au-marker class="au"></au-marker></div>` : `<au-marker class="au"></au-marker>`),
+      template: createElement(finalize ? `<div><au- class="au"></au-></div>` : `<au- class="au"></au->`),
       instructions: [[instruction]]
     }
     return [input, <any>output];

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -282,7 +282,7 @@ export const NodeSequence = {
 /**
  * An specialized INodeSequence with optimizations for text (interpolation) bindings
  * The contract of this INodeSequence is:
- * - the previous element is an `au-marker` node
+ * - the previous element is an `au-` node
  * - text is the actual text node
  */
 export class TextNodeSequence implements INodeSequence {
@@ -346,7 +346,7 @@ export class FragmentNodeSequence implements INodeSequence {
       // will do it anyway) and store them in the target list (since the comments
       // can't be queried)
       const target = targetNodeList[i];
-      if (target.nodeName === 'AU-MARKER') {
+      if (target.nodeName === 'AU-') {
         // note the renderer will still call this method, but it will just return the
         // location if it sees it's already a location
         targets[i] = DOM.convertToRenderLocation(target);
@@ -468,7 +468,7 @@ export class NodeSequenceFactory {
         return;
       case 2:
         const target = childNodes[0];
-        if (target.nodeName === 'AU-MARKER' || target.nodeName === '#comment') {
+        if (target.nodeName === 'AU-' || target.nodeName === '#comment') {
           const text = childNodes[1];
           if (text.nodeType === TEXT_NODE && text.textContent === ' ') {
             text.textContent = '';
@@ -507,7 +507,7 @@ export class AuMarker implements INode {
   public readonly firstChild: INode;
   public readonly lastChild: INode;
   public readonly childNodes: ArrayLike<INode>;
-  public readonly nodeName: 'AU-MARKER';
+  public readonly nodeName: 'AU-';
   public readonly nodeType: typeof ELEMENT_NODE;
   public textContent: string = '';
 
@@ -521,6 +521,6 @@ export class AuMarker implements INode {
   proto.firstChild = null;
   proto.lastChild = null;
   proto.childNodes = PLATFORM.emptyArray;
-  proto.nodeName = 'AU-MARKER';
+  proto.nodeName = 'AU-';
   proto.nodeType = ELEMENT_NODE;
 })(<Writable<AuMarker>>AuMarker.prototype);

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -282,7 +282,7 @@ export const NodeSequence = {
 /**
  * An specialized INodeSequence with optimizations for text (interpolation) bindings
  * The contract of this INodeSequence is:
- * - the previous element is an `au-` node
+ * - the previous element is an `au-m` node
  * - text is the actual text node
  */
 export class TextNodeSequence implements INodeSequence {
@@ -346,7 +346,7 @@ export class FragmentNodeSequence implements INodeSequence {
       // will do it anyway) and store them in the target list (since the comments
       // can't be queried)
       const target = targetNodeList[i];
-      if (target.nodeName === 'AU-') {
+      if (target.nodeName === 'AU-M') {
         // note the renderer will still call this method, but it will just return the
         // location if it sees it's already a location
         targets[i] = DOM.convertToRenderLocation(target);
@@ -468,7 +468,7 @@ export class NodeSequenceFactory {
         return;
       case 2:
         const target = childNodes[0];
-        if (target.nodeName === 'AU-' || target.nodeName === '#comment') {
+        if (target.nodeName === 'AU-M' || target.nodeName === '#comment') {
           const text = childNodes[1];
           if (text.nodeType === TEXT_NODE && text.textContent === ' ') {
             text.textContent = '';
@@ -507,7 +507,7 @@ export class AuMarker implements INode {
   public readonly firstChild: INode;
   public readonly lastChild: INode;
   public readonly childNodes: ArrayLike<INode>;
-  public readonly nodeName: 'AU-';
+  public readonly nodeName: 'AU-M';
   public readonly nodeType: typeof ELEMENT_NODE;
   public textContent: string = '';
 
@@ -521,6 +521,6 @@ export class AuMarker implements INode {
   proto.firstChild = null;
   proto.lastChild = null;
   proto.childNodes = PLATFORM.emptyArray;
-  proto.nodeName = 'AU-';
+  proto.nodeName = 'AU-M';
   proto.nodeType = ELEMENT_NODE;
 })(<Writable<AuMarker>>AuMarker.prototype);

--- a/packages/runtime/test/unit/mock.ts
+++ b/packages/runtime/test/unit/mock.ts
@@ -225,7 +225,7 @@ export function createMockRenderContext(
 }
 
 
-const marker = document.createElement('au-');
+const marker = document.createElement('au-m');
 marker.classList.add('au');
 export const createMarker = marker.cloneNode.bind(marker, false);
 

--- a/packages/runtime/test/unit/mock.ts
+++ b/packages/runtime/test/unit/mock.ts
@@ -225,7 +225,7 @@ export function createMockRenderContext(
 }
 
 
-const marker = document.createElement('au-marker');
+const marker = document.createElement('au-');
 marker.classList.add('au');
 export const createMarker = marker.cloneNode.bind(marker, false);
 

--- a/packages/runtime/test/unit/util.ts
+++ b/packages/runtime/test/unit/util.ts
@@ -27,7 +27,7 @@ export interface IRepeaterFixture {
 
 export function createTextBindingTemplateSource(propertyName: string, oneTime?: boolean): ITemplateDefinition {
   return {
-    template: `<div><au- class="au"></au-> </div>`,
+    template: `<div><au-m class="au"></au-m> </div>`,
     instructions: [
       [
         {
@@ -119,7 +119,7 @@ export function createRepeaterTemplateSource({ elName, colName, itemName }: IRep
     name: elName,
     dependencies: [],
     template: `
-      <au- class="au"></au->
+      <au-m class="au"></au-m>
     `,
     instructions: [
       [

--- a/packages/runtime/test/unit/util.ts
+++ b/packages/runtime/test/unit/util.ts
@@ -27,7 +27,7 @@ export interface IRepeaterFixture {
 
 export function createTextBindingTemplateSource(propertyName: string, oneTime?: boolean): ITemplateDefinition {
   return {
-    template: `<div><au-marker class="au"></au-marker> </div>`,
+    template: `<div><au- class="au"></au-> </div>`,
     instructions: [
       [
         {
@@ -119,7 +119,7 @@ export function createRepeaterTemplateSource({ elName, colName, itemName }: IRep
     name: elName,
     dependencies: [],
     template: `
-      <au-marker class="au"></au-marker>
+      <au- class="au"></au->
     `,
     instructions: [
       [


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Shortens the `au-marker` element name to `au-`.

This makes templates quite a bit shorter, thereby easier to read and smaller in size (for pre-compiled templates).
Originally the idea was to rename it to `au`, but that wouldn't make it compliant with WebComponents, hence the dash. There's no rule that a custom element name cannot end with a dash, and something like `a-u` just seems very awkward.
It's a bit weird ending with a dash, but I actually quite like it. It stands out.

Wonder what others think @EisenbergEffect @bigopon ?
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

N/A
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

N/A
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Verified that a custom element with this name can be created via `customElements.define`
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

N/A
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
