### PR TITLE
refactor(kernel): linting fixes for di

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -185,7 +185,7 @@ export const DI = {
     return function(target: Injectable, key?: string, descriptor?: PropertyDescriptor | number): void {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         if (!target.hasOwnProperty('inject')) {
-          const types = DI.getDesignParamTypes(target)
+          const types = DI.getDesignParamTypes(target);
           target.inject = types.slice();
         }
 
@@ -200,7 +200,7 @@ export const DI = {
         fn.inject = dependencies;
       } else { // It's a class decorator.
         if (dependencies.length === 0) {
-          const types = DI.getDesignParamTypes(target)
+          const types = DI.getDesignParamTypes(target);
           target.inject = types.slice();
         } else {
           target.inject = dependencies;
@@ -275,7 +275,7 @@ function createResolver(
 ): (key: any) => ReturnType<typeof DI.inject> {
   return function(key: any): ReturnType<typeof DI.inject> {
     const Key = function Key(target: Injectable, property?: string, descriptor?: PropertyDescriptor | number): void {
-      return DI.inject(Key)(target, property, descriptor);
+      DI.inject(Key)(target, property, descriptor);
     };
 
     (Key as any).resolve = function(handler: IContainer, requestor: IContainer): any {

--- a/packages/runtime/src/binding/target-accessors.ts
+++ b/packages/runtime/src/binding/target-accessors.ts
@@ -4,7 +4,6 @@ import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor } from '../observation';
 import { targetObserver } from './target-observer';
 
-// tslint:disable-next-line:no-http-string
 const xlinkAttributeNS = 'http://www.w3.org/1999/xlink';
 
 export interface XLinkAttributeAccessor extends IBindingTargetAccessor<IHTMLElement, string, string> {}

--- a/tslint.json
+++ b/tslint.json
@@ -26,7 +26,7 @@
     "no-eval": true,
     "no-exec-script": true,
     "no-function-constructor-with-string-args": true,
-    "no-http-string": [true, "http://localhost:?.*"],
+    "no-http-string": [true, "http://localhost:?.*", "http://www.w3.org/1999/xlink"],
     "no-inner-html": false,
     "no-octal-literal": true,
     "no-reserved-keywords": false, // See https://github.com/aurelia/aurelia/pull/297


### PR DESCRIPTION
# Pull Request

## 📖 Description

A few linting fixes for `di`.

Edit: added a `tslint.json` tweak to globally allow usage of the `xlink` namespace and removed a corresponding suppression.

### 🎫 Issues

Part of #249 

## 👩‍💻 Reviewer Notes

Once this is merged only `kernel/src/di.ts`, `jit/src/expression-parser.ts` and `runtime/src/observation.ts` still have linting errors, excluding the `completed docs` rule, and most of them are `no-any` errors.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

See #249.