### PR TITLE
refactor: linting fixes for IIndexable

### DIFF
--- a/packages/jit/src/binding-command.ts
+++ b/packages/jit/src/binding-command.ts
@@ -1,4 +1,4 @@
-import { Class, Constructable, IContainer, IIndexable, IRegistry, Registration, Writable } from '@aurelia/kernel';
+import { Class, Constructable, IContainer, IRegistry, Registration, Writable } from '@aurelia/kernel';
 import {
   BindingType,
   CallBindingInstruction,

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -18,13 +18,7 @@ export type Class<T, C = IIndexable> = C & {
 
 export type Injectable<T = {}> = Constructable<T> & { inject?: Function[] };
 
-// Note: use of "any" here can perfectly well be replaced by "unknown" but that would also involve fixing consumers of this
-// interface since their indexed properties are now all returning "unknown" which is not assignable to anything else.
-// We are however not disabling this rule with "no-any" because it is a legitimate problem that tslint is warning us about,
-// and it should remind us of the fact that we have more work to do in making typings across the runtime more accurate.
-// For changing this "any" to "unknown", we could either resort to upcasting at the consumer side of things (less preferable because unsafe)
-// or we could simply return "unknown" at the API boundaries of consumers that return values from this object (more preferable but more work)
-export type IIndexable<T extends object = object> = T & { [key: string]: any };
+export type IIndexable<T extends object = object> = T & { [key: string]: unknown };
 
 export type ImmutableObject<T> =
     T extends [infer A1, infer B1, infer C1, infer D1, infer E1, infer F1, infer G] ? ImmutableArray<[A1, B1, C1, D1, E1, F1, G]> :

--- a/packages/runtime/src/binding/array-observer.ts
+++ b/packages/runtime/src/binding/array-observer.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from '../lifecycle';
 import { CollectionKind, ICollectionObserver, IndexMap, IObservedArray, LifecycleFlags } from '../observation';
 import { collectionObserver } from './collection-observer';
@@ -142,7 +141,7 @@ function observeReverse(this: IObservedArray): ReturnType<typeof nativeReverse> 
 
 // https://tc39.github.io/ecma262/#sec-array.prototype.sort
 // https://github.com/v8/v8/blob/master/src/js/array.js
-function observeSort(this: IObservedArray, compareFn?: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): IObservedArray {
+function observeSort(this: IObservedArray, compareFn?: (a: unknown, b: unknown) => number): IObservedArray {
   const o = this.$observer;
   if (o === undefined) {
     return nativeSort.call(this, compareFn);
@@ -168,16 +167,16 @@ function observeSort(this: IObservedArray, compareFn?: (a: IIndexable | Primitiv
 }
 
 // https://tc39.github.io/ecma262/#sec-sortcompare
-function sortCompare(x: IIndexable | Primitive, y: IIndexable | Primitive): number {
+function sortCompare(x: unknown, y: unknown): number {
   if (x === y) {
     return 0;
   }
-  x = x === null ? 'null' : x.toString();
-  y = y === null ? 'null' : y.toString();
-  return x < y ? -1 : 1;
+  x = x === null ? 'null' : (x as {}).toString();
+  y = y === null ? 'null' : (y as {}).toString();
+  return (x as {}) < (y as {}) ? -1 : 1;
 }
 
-function preSortCompare(x: IIndexable | Primitive, y: IIndexable | Primitive): number {
+function preSortCompare(x: unknown, y: unknown): number {
   if (x === undefined) {
     if (y === undefined) {
       return 0;
@@ -191,7 +190,7 @@ function preSortCompare(x: IIndexable | Primitive, y: IIndexable | Primitive): n
   return 0;
 }
 
-function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: unknown, b: unknown) => number): void {
   let velement, ielement, vtmp, itmp, order;
   let i, j;
   for (i = from + 1; i < to; i++) {
@@ -209,7 +208,7 @@ function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to
   }
 }
 
-function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: IIndexable | Primitive, b: IIndexable | Primitive) => number): void {
+function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: unknown, b: unknown) => number): void {
   let thirdIndex = 0, i = 0;
   let v0, v1, v2;
   let i0, i1, i2;

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -1,4 +1,4 @@
-import { IIndexable, IServiceLocator, Primitive } from '@aurelia/kernel';
+import { IServiceLocator } from '@aurelia/kernel';
 import { INode } from '../dom';
 import { IBindScope, State } from '../lifecycle';
 import { IAccessor, IScope, LifecycleFlags } from '../observation';
@@ -27,10 +27,10 @@ export class Call {
     this.targetObserver = observerLocator.getObserver(target, targetProperty);
   }
 
-  public callSource(args: IIndexable): Primitive | IIndexable {
+  public callSource(args: object): unknown {
     const overrideContext = this.$scope.overrideContext;
     Object.assign(overrideContext, args);
-    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator) as IIndexable;
+    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator);
 
     for (const prop in args) {
       delete overrideContext[prop];
@@ -83,7 +83,7 @@ export class Call {
     this.$state &= ~(State.isBound | State.isUnbinding);
   }
 
-  public observeProperty(obj: IIndexable, propertyName: string): void {
+  public observeProperty(obj: object, propertyName: string): void {
     return;
   }
 

--- a/packages/runtime/src/binding/dirty-checker.ts
+++ b/packages/runtime/src/binding/dirty-checker.ts
@@ -1,4 +1,4 @@
-import { DI, IIndexable, Primitive } from '@aurelia/kernel';
+import { DI } from '@aurelia/kernel';
 import { IBindingTargetAccessor, IBindingTargetObserver, IObservable, IPropertySubscriber, LifecycleFlags } from '../observation';
 import { propertyObserver } from './property-observer';
 
@@ -66,7 +66,7 @@ export interface DirtyCheckProperty extends IBindingTargetObserver { }
 @propertyObserver()
 export class DirtyCheckProperty implements DirtyCheckProperty {
   public obj: IObservable;
-  public oldValue: IIndexable | Primitive;
+  public oldValue: unknown;
   public propertyKey: string;
 
   private dirtyChecker: DirtyChecker;
@@ -82,11 +82,11 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
     return this.oldValue !== this.obj[this.propertyKey];
   }
 
-  public getValue(): IIndexable | Primitive {
+  public getValue(): unknown {
     return this.obj[this.propertyKey];
   }
 
-  public setValue(newValue: IIndexable | Primitive): void {
+  public setValue(newValue: unknown): void {
     this.obj[this.propertyKey] = newValue;
   }
 

--- a/packages/runtime/src/binding/element-observation.ts
+++ b/packages/runtime/src/binding/element-observation.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { DOM, IElement, IInputElement, INode, INodeObserver } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import {
@@ -38,14 +37,14 @@ const inputValueDefaults = {
 const handleEventFlags = LifecycleFlags.fromDOMEvent | LifecycleFlags.updateSourceExpression;
 
 export interface ValueAttributeObserver extends
-  IBindingTargetObserver<INode, string, Primitive | IIndexable> { }
+  IBindingTargetObserver<INode, string> { }
 
 @targetObserver('')
 export class ValueAttributeObserver implements ValueAttributeObserver {
   public currentFlags: LifecycleFlags;
-  public currentValue: Primitive | IIndexable;
-  public defaultValue: Primitive | IIndexable;
-  public oldValue: Primitive | IIndexable;
+  public currentValue: unknown;
+  public defaultValue: unknown;
+  public oldValue: unknown;
   public flush: () => void;
   public handler: IEventSubscriber;
   public lifecycle: ILifecycle;
@@ -74,11 +73,11 @@ export class ValueAttributeObserver implements ValueAttributeObserver {
     this.oldValue = this.currentValue = obj[propertyKey];
   }
 
-  public getValue(): Primitive | IIndexable {
+  public getValue(): unknown {
     return this.obj[this.propertyKey];
   }
 
-  public setValueCore(newValue: Primitive | IIndexable, flags: LifecycleFlags): void {
+  public setValueCore(newValue: unknown, flags: LifecycleFlags): void {
     this.obj[this.propertyKey] = newValue;
     if (flags & LifecycleFlags.fromBind) {
       return;
@@ -127,7 +126,7 @@ const defaultHandleBatchedChangeFlags = LifecycleFlags.fromFlush | LifecycleFlag
 
 interface IInternalInputElement extends IInputElement {
   matcher?: typeof defaultMatcher;
-  model?: Primitive | IIndexable;
+  model?: unknown;
   $observers?: IObserversLookup & {
     model?: SetterObserver;
     value?: ValueAttributeObserver;
@@ -135,21 +134,21 @@ interface IInternalInputElement extends IInputElement {
 }
 
 export interface CheckedObserver extends
-  IBindingTargetObserver<IInternalInputElement, string, Primitive | IIndexable>,
+  IBindingTargetObserver<IInternalInputElement, string>,
   IBatchedCollectionSubscriber,
   IPropertySubscriber { }
 
 @targetObserver()
 export class CheckedObserver implements CheckedObserver {
   public currentFlags: LifecycleFlags;
-  public currentValue: Primitive | IIndexable;
-  public defaultValue: Primitive | IIndexable;
+  public currentValue: unknown;
+  public defaultValue: unknown;
   public flush: () => void;
   public handler: IEventSubscriber;
   public lifecycle: ILifecycle;
   public obj: IInternalInputElement;
   public observerLocator: IObserverLocator;
-  public oldValue: Primitive | IIndexable;
+  public oldValue: unknown;
 
   private arrayObserver: ICollectionObserver<CollectionKind.array>;
   private valueObserver: ValueAttributeObserver | SetterObserver;
@@ -161,11 +160,11 @@ export class CheckedObserver implements CheckedObserver {
     this.observerLocator = observerLocator;
   }
 
-  public getValue(): Primitive | IIndexable {
+  public getValue(): unknown {
     return this.currentValue;
   }
 
-  public setValueCore(newValue: Primitive | IIndexable, flags: LifecycleFlags): void {
+  public setValueCore(newValue: unknown, flags: LifecycleFlags): void {
     if (!this.valueObserver) {
       this.valueObserver = this.obj['$observers'] && (this.obj['$observers'].model || this.obj['$observers'].value);
       if (this.valueObserver) {
@@ -190,7 +189,7 @@ export class CheckedObserver implements CheckedObserver {
   }
 
   // handlePropertyChange (todo: rename normal subscribe methods in target observers to batched, since that's what they really are)
-  public handleChange(newValue: Primitive | IIndexable, previousValue: Primitive | IIndexable, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     this.synchronizeElement();
     this.notify(flags);
   }
@@ -200,7 +199,7 @@ export class CheckedObserver implements CheckedObserver {
     const element = this.obj;
     const elementValue = element.hasOwnProperty('model') ? element['model'] : element.value;
     const isRadio = element.type === 'radio';
-    const matcher = element['matcher'] || ((a: Primitive | IIndexable, b: Primitive | IIndexable) => a === b);
+    const matcher = element['matcher'] || ((a: unknown, b: unknown) => a === b);
 
     if (isRadio) {
       element.checked = !!matcher(value, elementValue);
@@ -287,9 +286,7 @@ const childObserverOptions = {
   characterData: true
 };
 
-type UntypedArray = (Primitive | IIndexable)[];
-
-function defaultMatcher(a: Primitive | IIndexable, b: Primitive | IIndexable): boolean {
+function defaultMatcher(a: unknown, b: unknown): boolean {
   return a === b;
 }
 
@@ -300,22 +297,22 @@ export interface ISelectElement extends IElement {
   matcher?: typeof defaultMatcher;
 }
 export interface IOptionElement extends IElement {
-  model?: Primitive | IIndexable;
+  model?: unknown;
   selected: boolean;
   value: string;
 }
 
 export interface SelectValueObserver extends
-  IBindingTargetObserver<ISelectElement, string, Primitive | IIndexable | UntypedArray>,
+  IBindingTargetObserver<ISelectElement, string>,
   IBatchedCollectionSubscriber,
   IPropertySubscriber { }
 
 @targetObserver()
 export class SelectValueObserver implements SelectValueObserver {
-  public currentValue: Primitive | IIndexable | UntypedArray;
+  public currentValue: unknown;
   public currentFlags: LifecycleFlags;
-  public oldValue: Primitive | IIndexable | UntypedArray;
-  public defaultValue: Primitive | UntypedArray;
+  public oldValue: unknown;
+  public defaultValue: unknown;
 
   public flush: () => void;
 
@@ -329,11 +326,11 @@ export class SelectValueObserver implements SelectValueObserver {
     public observerLocator: IObserverLocator
   ) { }
 
-  public getValue(): Primitive | IIndexable | UntypedArray {
+  public getValue(): unknown {
     return this.currentValue;
   }
 
-  public setValueCore(newValue: Primitive | UntypedArray, flags: LifecycleFlags): void {
+  public setValueCore(newValue: unknown, flags: LifecycleFlags): void {
     const isArray = Array.isArray(newValue);
     if (!isArray && newValue !== null && newValue !== undefined && this.obj.multiple) {
       throw new Error('Only null or Array instances can be bound to a multi-select.');
@@ -343,7 +340,7 @@ export class SelectValueObserver implements SelectValueObserver {
       this.arrayObserver = null;
     }
     if (isArray) {
-      this.arrayObserver = this.observerLocator.getArrayObserver(<(Primitive | IIndexable)[]>newValue);
+      this.arrayObserver = this.observerLocator.getArrayObserver(<unknown[]>newValue);
       this.arrayObserver.subscribeBatched(this);
     }
     this.synchronizeOptions();
@@ -358,7 +355,7 @@ export class SelectValueObserver implements SelectValueObserver {
   }
 
   // called when a different value was assigned
-  public handleChange(newValue: Primitive | UntypedArray, previousValue: Primitive | UntypedArray, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
     this.setValue(newValue, flags);
   }
 
@@ -394,7 +391,7 @@ export class SelectValueObserver implements SelectValueObserver {
       const option = options[i];
       const optionValue = option.hasOwnProperty('model') ? option.model : option.value;
       if (isArray) {
-        option.selected = (<UntypedArray>currentValue).findIndex(item => !!matcher(optionValue, item)) !== -1;
+        option.selected = (<unknown[]>currentValue).findIndex(item => !!matcher(optionValue, item)) !== -1;
         continue;
       }
       option.selected = !!matcher(optionValue, currentValue);
@@ -434,7 +431,7 @@ export class SelectValueObserver implements SelectValueObserver {
       let option: IOptionElement;
       const matcher = obj.matcher || defaultMatcher;
       // A.1.b.i
-      const values: UntypedArray = [];
+      const values: unknown[] = [];
       while (i < len) {
         option = options[i];
         if (option.selected) {
@@ -471,7 +468,7 @@ export class SelectValueObserver implements SelectValueObserver {
     }
     // B. single select
     // B.1
-    let value: Primitive | IIndexable | UntypedArray = null;
+    let value: unknown = null;
     while (i < len) {
       const option = options[i];
       if (option.selected) {

--- a/packages/runtime/src/binding/map-observer.ts
+++ b/packages/runtime/src/binding/map-observer.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from '../lifecycle';
 import { CollectionKind, ICollectionObserver, IObservedMap, LifecycleFlags } from '../observation';
 import { nativePush, nativeSplice } from './array-observer';
@@ -13,7 +12,7 @@ export const nativeDelete = proto.delete;
 // fortunately, map/delete/clear are easy to reconstruct for the indexMap
 
 // https://tc39.github.io/ecma262/#sec-map.prototype.map
-function observeSet(this: IObservedMap, key: IIndexable | Primitive, value: IIndexable | Primitive): ReturnType<typeof nativeSet> {
+function observeSet(this: IObservedMap, key: unknown, value: unknown): ReturnType<typeof nativeSet> {
   const o = this.$observer;
   if (o === undefined) {
     return nativeSet.call(this, key, value);
@@ -63,7 +62,7 @@ function observeClear(this: IObservedMap): ReturnType<typeof nativeClear>  {
 }
 
 // https://tc39.github.io/ecma262/#sec-map.prototype.delete
-function observeDelete(this: IObservedMap, value: IIndexable | Primitive): ReturnType<typeof nativeDelete> {
+function observeDelete(this: IObservedMap, value: unknown): ReturnType<typeof nativeDelete> {
   const o = this.$observer;
   if (o === undefined) {
     return nativeDelete.call(this, value);

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -1,4 +1,4 @@
-import { DI, IIndexable, inject, Primitive, Reporter } from '@aurelia/kernel';
+import { DI, inject, Reporter } from '@aurelia/kernel';
 import { DOM, IHTMLElement, IInputElement } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import {
@@ -27,9 +27,9 @@ export interface IObserverLocator {
   getObserver(obj: IObservable, propertyName: string): AccessorOrObserver;
   getAccessor(obj: IObservable, propertyName: string): IBindingTargetAccessor;
   addAdapter(adapter: IObjectObservationAdapter): void;
-  getArrayObserver(observedArray: (IIndexable | Primitive)[]): ICollectionObserver<CollectionKind.array>;
-  getMapObserver(observedMap: Map<IIndexable | Primitive, IIndexable | Primitive>): ICollectionObserver<CollectionKind.map>;
-  getSetObserver(observedSet: Set<IIndexable | Primitive>): ICollectionObserver<CollectionKind.set>;
+  getArrayObserver(observedArray: unknown[]): ICollectionObserver<CollectionKind.array>;
+  getMapObserver(observedMap: Map<unknown, unknown>): ICollectionObserver<CollectionKind.map>;
+  getSetObserver(observedSet: Set<unknown>): ICollectionObserver<CollectionKind.set>;
 }
 
 export const IObserverLocator = DI.createInterface<IObserverLocator>()

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -57,10 +57,10 @@ export class SetterObserver implements SetterObserver {
     this.propertyKey = propertyKey;
   }
 
-  public getValue(): IIndexable | Primitive {
+  public getValue(): unknown {
     return this.currentValue;
   }
-  public setValue(newValue: IIndexable | Primitive, flags: LifecycleFlags): void {
+  public setValue(newValue: unknown, flags: LifecycleFlags): void {
     const currentValue = this.currentValue;
     if (currentValue !== newValue) {
       this.currentValue = newValue;
@@ -86,9 +86,9 @@ export interface Observer extends IPropertyObserver<IIndexable, string> {}
 export class Observer implements Observer {
   public obj: IIndexable;
   public propertyKey: string;
-  public currentValue: IIndexable | Primitive;
+  public currentValue: unknown;
 
-  private callback: (newValue: IIndexable | Primitive, oldValue: IIndexable | Primitive) => IIndexable | Primitive;
+  private callback: (newValue: unknown, oldValue: unknown) => unknown;
 
   constructor(
     instance: object,
@@ -103,11 +103,11 @@ export class Observer implements Observer {
         : noop;
   }
 
-  public getValue(): IIndexable | Primitive {
+  public getValue(): unknown {
     return this.currentValue;
   }
 
-  public setValue(newValue: IIndexable | Primitive, flags: LifecycleFlags): void {
+  public setValue(newValue: unknown, flags: LifecycleFlags): void {
     const currentValue = this.currentValue;
 
     if (currentValue !== newValue) {

--- a/packages/runtime/src/binding/set-observer.ts
+++ b/packages/runtime/src/binding/set-observer.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { ILifecycle } from '../lifecycle';
 import { CollectionKind, ICollectionObserver, IObservedSet, LifecycleFlags } from '../observation';
 import { nativePush, nativeSplice } from './array-observer';
@@ -13,7 +12,7 @@ export const nativeDelete = proto.delete;
 // fortunately, add/delete/clear are easy to reconstruct for the indexMap
 
 // https://tc39.github.io/ecma262/#sec-set.prototype.add
-function observeAdd(this: IObservedSet, value: IIndexable | Primitive): ReturnType<typeof nativeAdd> {
+function observeAdd(this: IObservedSet, value: unknown): ReturnType<typeof nativeAdd> {
   const o = this.$observer;
   if (o === undefined) {
     return nativeAdd.call(this, value);
@@ -53,7 +52,7 @@ function observeClear(this: IObservedSet): ReturnType<typeof nativeClear>  {
 }
 
 // https://tc39.github.io/ecma262/#sec-set.prototype.delete
-function observeDelete(this: IObservedSet, value: IIndexable | Primitive): ReturnType<typeof nativeDelete> {
+function observeDelete(this: IObservedSet, value: unknown): ReturnType<typeof nativeDelete> {
   const o = this.$observer;
   if (o === undefined) {
     return nativeDelete.call(this, value);

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import {
   IBatchedCollectionSubscriber, IBatchedSubscriberCollection, IndexMap, IPropertySubscriber,
   ISubscriberCollection, LifecycleFlags, MutationKind, MutationKindToBatchedSubscriber,
@@ -86,8 +85,8 @@ function removeSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>
 
 function callPropertySubscribers(
   this: ISubscriberCollection<MutationKind.instance>,
-  newValue: IIndexable | Primitive,
-  previousValue: IIndexable | Primitive,
+  newValue: unknown,
+  previousValue: unknown,
   flags: LifecycleFlags): void {
   /**
    * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this

--- a/packages/runtime/src/binding/target-accessors.ts
+++ b/packages/runtime/src/binding/target-accessors.ts
@@ -1,3 +1,4 @@
+import { IIndexable } from '@aurelia/kernel';
 import { DOM, IHTMLElement, INode } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor } from '../observation';
@@ -75,15 +76,15 @@ export class DataAttributeAccessor implements DataAttributeAccessor {
   }
 }
 
-export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElement, 'style', string | object> {}
+export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElement, 'style', string | Record<string, string>> {}
 
 @targetObserver()
 export class StyleAttributeAccessor implements StyleAttributeAccessor {
-  public currentValue: string | object;
-  public defaultValue: string | object;
+  public currentValue: string | Record<string, string>;
+  public defaultValue: string | Record<string, string>;
   public lifecycle: ILifecycle;
   public obj: IHTMLElement;
-  public oldValue: string | object;
+  public oldValue: string | Record<string, string>;
   public propertyKey: 'style';
   public styles: object;
   public version: number;
@@ -109,7 +110,7 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
     this.obj.style.setProperty(style, value, priority);
   }
 
-  public setValueCore(newValue: string | object): void {
+  public setValueCore(newValue: string | Record<string, string>): void {
     const styles = this.styles || {};
     let style;
     let version = this.version;
@@ -252,13 +253,13 @@ export class ElementPropertyAccessor implements ElementPropertyAccessor {
   }
 }
 
-export interface PropertyAccessor extends IBindingTargetAccessor<object, string> {}
+export interface PropertyAccessor extends IBindingTargetAccessor<IIndexable, string> {}
 
 export class PropertyAccessor implements PropertyAccessor {
-  public obj: object;
+  public obj: IIndexable;
   public propertyKey: string;
 
-  constructor(obj: object, propertyKey: string) {
+  constructor(obj: IIndexable, propertyKey: string) {
     this.obj = obj;
     this.propertyKey = propertyKey;
   }

--- a/packages/runtime/src/binding/target-accessors.ts
+++ b/packages/runtime/src/binding/target-accessors.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { DOM, IHTMLElement, INode } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor } from '../observation';
@@ -76,17 +75,17 @@ export class DataAttributeAccessor implements DataAttributeAccessor {
   }
 }
 
-export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElement, 'style', string | IIndexable> {}
+export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElement, 'style', string | object> {}
 
 @targetObserver()
 export class StyleAttributeAccessor implements StyleAttributeAccessor {
-  public currentValue: string | IIndexable;
-  public defaultValue: string | IIndexable;
+  public currentValue: string | object;
+  public defaultValue: string | object;
   public lifecycle: ILifecycle;
   public obj: IHTMLElement;
-  public oldValue: string | IIndexable;
+  public oldValue: string | object;
   public propertyKey: 'style';
-  public styles: IIndexable;
+  public styles: object;
   public version: number;
 
   constructor(lifecycle: ILifecycle, obj: IHTMLElement) {
@@ -110,7 +109,7 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
     this.obj.style.setProperty(style, value, priority);
   }
 
-  public setValueCore(newValue: string | IIndexable): void {
+  public setValueCore(newValue: string | object): void {
     const styles = this.styles || {};
     let style;
     let version = this.version;
@@ -167,7 +166,7 @@ export class ClassAttributeAccessor implements ClassAttributeAccessor {
   public defaultValue: string;
   public doNotCache: true;
   public lifecycle: ILifecycle;
-  public nameIndex: IIndexable;
+  public nameIndex: object;
   public obj: INode;
   public oldValue: string;
   public version: number;
@@ -230,45 +229,45 @@ ClassAttributeAccessor.prototype.doNotCache = true;
 ClassAttributeAccessor.prototype.version = 0;
 ClassAttributeAccessor.prototype.nameIndex = null;
 
-export interface ElementPropertyAccessor extends IBindingTargetAccessor<IIndexable, string, Primitive | IIndexable> {}
+export interface ElementPropertyAccessor extends IBindingTargetAccessor<object, string> {}
 
 @targetObserver('')
 export class ElementPropertyAccessor implements ElementPropertyAccessor {
   public lifecycle: ILifecycle;
-  public obj: IIndexable;
+  public obj: object;
   public propertyKey: string;
 
-  constructor(lifecycle: ILifecycle, obj: IIndexable, propertyKey: string) {
+  constructor(lifecycle: ILifecycle, obj: object, propertyKey: string) {
     this.lifecycle = lifecycle;
     this.obj = obj;
     this.propertyKey = propertyKey;
   }
 
-  public getValue(): Primitive | IIndexable {
+  public getValue(): unknown {
     return this.obj[this.propertyKey];
   }
 
-  public setValueCore(value: Primitive | IIndexable): void {
+  public setValueCore(value: unknown): void {
     this.obj[this.propertyKey] = value;
   }
 }
 
-export interface PropertyAccessor extends IBindingTargetAccessor<IIndexable, string, Primitive | IIndexable> {}
+export interface PropertyAccessor extends IBindingTargetAccessor<object, string> {}
 
 export class PropertyAccessor implements PropertyAccessor {
-  public obj: IIndexable;
+  public obj: object;
   public propertyKey: string;
 
-  constructor(obj: IIndexable, propertyKey: string) {
+  constructor(obj: object, propertyKey: string) {
     this.obj = obj;
     this.propertyKey = propertyKey;
   }
 
-  public getValue(): Primitive | IIndexable {
+  public getValue(): unknown {
     return this.obj[this.propertyKey];
   }
 
-  public setValue(value: Primitive | IIndexable): void {
+  public setValue(value: unknown): void {
     this.obj[this.propertyKey] = value;
   }
 }

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -1,4 +1,3 @@
-import { IIndexable, Primitive } from '@aurelia/kernel';
 import { DOM } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor, LifecycleFlags, MutationKind } from '../observation';
@@ -7,14 +6,14 @@ import { subscriberCollection } from './subscriber-collection';
 type BindingTargetAccessor = IBindingTargetAccessor & {
   lifecycle: ILifecycle;
   currentFlags: LifecycleFlags;
-  oldValue?: IIndexable | Primitive;
-  defaultValue: Primitive | IIndexable;
+  oldValue?: unknown;
+  defaultValue: unknown;
   $nextFlush?: BindingTargetAccessor;
   flush(flags: LifecycleFlags): void;
-  setValueCore(value: Primitive | IIndexable, flags: LifecycleFlags): void;
+  setValueCore(value: unknown, flags: LifecycleFlags): void;
 };
 
-function setValue(this: BindingTargetAccessor, newValue: Primitive | IIndexable, flags: LifecycleFlags): Promise<void> {
+function setValue(this: BindingTargetAccessor, newValue: unknown, flags: LifecycleFlags): Promise<void> {
   const currentValue = this.currentValue;
   newValue = newValue === null || newValue === undefined ? this.defaultValue : newValue;
   if (currentValue !== newValue) {
@@ -56,7 +55,7 @@ function dispose(this: BindingTargetAccessor): void {
   this.propertyKey = '';
 }
 
-export function targetObserver(defaultValue: Primitive | IIndexable = null): ClassDecorator {
+export function targetObserver(defaultValue: unknown = null): ClassDecorator {
   return function(target: Function): void {
     subscriberCollection(MutationKind.instance)(target);
     const proto = <BindingTargetAccessor>target.prototype;

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -1,4 +1,4 @@
-import { IDisposable, IIndexable, Primitive } from '@aurelia/kernel';
+import { IDisposable, IIndexable } from '@aurelia/kernel';
 import { ILifecycle } from './lifecycle';
 
 export enum LifecycleFlags {
@@ -108,7 +108,7 @@ export enum MutationKind {
 /**
  * Describes a type that specifically tracks changes in an object property, or simply something that can have a getter and/or setter
  */
-export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = IIndexable | Primitive> {
+export interface IPropertyChangeTracker<TObj extends Object, TProp = keyof TObj, TValue = unknown> {
   obj: TObj;
   propertyKey?: TProp;
   currentValue?: TValue;

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -1,5 +1,5 @@
-import { Constructable, IIndexable, IRegistry } from '@aurelia/kernel';
-import { buildTemplateDefinition, isTargetedInstruction, TargetedInstruction, TargetedInstructionType, TemplateDefinition } from '../definitions';
+import { Constructable, IRegistry } from '@aurelia/kernel';
+import { buildTemplateDefinition, isTargetedInstruction, ITargetedInstruction, TargetedInstruction, TargetedInstructionType, TemplateDefinition } from '../definitions';
 import { DOM, INode } from '../dom';
 import { IRenderContext, IView, IViewFactory } from '../lifecycle';
 import { ICustomElementType } from './custom-element';
@@ -7,7 +7,7 @@ import { IRenderingEngine, ITemplate } from './lifecycle-render';
 
 type ChildType = RenderPlan | string | INode;
 
-export function createElement(tagOrType: string | Constructable, props?: IIndexable, children?: ArrayLike<ChildType>): RenderPlan {
+export function createElement(tagOrType: string | Constructable, props?: object, children?: ArrayLike<ChildType>): RenderPlan {
   if (typeof tagOrType === 'string') {
     return createElementForTag(tagOrType, props, children);
   } else {
@@ -49,7 +49,7 @@ export class RenderPlan {
   }
 }
 
-function createElementForTag(tagName: string, props?: IIndexable, children?: ArrayLike<ChildType>): RenderPlan {
+function createElementForTag(tagName: string, props?: object, children?: ArrayLike<ChildType>): RenderPlan {
   const instructions: TargetedInstruction[] = [];
   const allInstructions: TargetedInstruction[][] = [];
   const dependencies: IRegistry[] = [];
@@ -59,11 +59,11 @@ function createElementForTag(tagName: string, props?: IIndexable, children?: Arr
   if (props) {
     Object.keys(props)
       .forEach(to => {
-        const value = props[to];
+        const value: unknown = props[to];
 
-        if (isTargetedInstruction(value)) {
+        if (isTargetedInstruction(value as ITargetedInstruction)) {
           hasInstructions = true;
-          instructions.push(value);
+          instructions.push(value as TargetedInstruction);
         } else {
           DOM.setAttribute(element, to, value);
         }
@@ -82,12 +82,12 @@ function createElementForTag(tagName: string, props?: IIndexable, children?: Arr
   return new RenderPlan(element, allInstructions, dependencies);
 }
 
-function createElementForType(Type: ICustomElementType, props?: IIndexable, children?: ArrayLike<ChildType>): RenderPlan {
+function createElementForType(Type: ICustomElementType, props?: object, children?: ArrayLike<ChildType>): RenderPlan {
   const tagName = Type.description.name;
   const instructions: TargetedInstruction[] = [];
   const allInstructions = [instructions];
-  const dependencies = [];
-  const childInstructions = [];
+  const dependencies: IRegistry[] = [];
+  const childInstructions: TargetedInstruction[] = [];
   const bindables = Type.description.bindables;
   const element = DOM.createElement(tagName);
 
@@ -106,10 +106,10 @@ function createElementForType(Type: ICustomElementType, props?: IIndexable, chil
   if (props) {
     Object.keys(props)
       .forEach(to => {
-        const value = props[to];
+        const value: unknown = props[to];
 
-        if (isTargetedInstruction(value)) {
-          childInstructions.push(value);
+        if (isTargetedInstruction(value as ITargetedInstruction)) {
+          childInstructions.push(value as TargetedInstruction);
         } else {
           const bindable = bindables[to];
 

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -9,7 +9,7 @@ type ChildType = RenderPlan | string | INode;
 
 export function createElement(tagOrType: string | Constructable, props?: object, children?: ArrayLike<ChildType>): RenderPlan {
   if (typeof tagOrType === 'string') {
-    return createElementForTag(tagOrType, props, children);
+    return createElementForTag(tagOrType, props as Record<string, string | ITargetedInstruction>, children);
   } else {
     return createElementForType(tagOrType as ICustomElementType, props, children);
   }
@@ -49,7 +49,7 @@ export class RenderPlan {
   }
 }
 
-function createElementForTag(tagName: string, props?: object, children?: ArrayLike<ChildType>): RenderPlan {
+function createElementForTag(tagName: string, props?: Record<string, string | ITargetedInstruction>, children?: ArrayLike<ChildType>): RenderPlan {
   const instructions: TargetedInstruction[] = [];
   const allInstructions: TargetedInstruction[][] = [];
   const dependencies: IRegistry[] = [];
@@ -59,7 +59,7 @@ function createElementForTag(tagName: string, props?: object, children?: ArrayLi
   if (props) {
     Object.keys(props)
       .forEach(to => {
-        const value: unknown = props[to];
+        const value = props[to];
 
         if (isTargetedInstruction(value as ITargetedInstruction)) {
           hasInstructions = true;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is a WIP.

This changes `IIndexable` from `any` to `unknown` and fixes call sites, propagating out to the API boundaries. It also switches from `IIndexable` to base `object` in a few places where we're not actually interested type-wise that it is indexable, just that it's an object. 

### 🎫 Issues

Part of #249.

## 👩‍💻 Reviewer Notes

Is this the right way to go? Especially interested in feedback from @fkleuver as he had some ideas on where he wanted to go with this, but open to feedback from all. 👍

(And all these changes are just for one `any` -> `unknown` linting warning fix 😁)

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

See #249.
