### PR TITLE
refactor: add Sonarts linting rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8065,6 +8065,12 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"immutable": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
+			"dev": true
+		},
 		"import-fresh": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -13606,6 +13612,15 @@
 						"tslib": "^1.8.1"
 					}
 				}
+			}
+		},
+		"tslint-sonarts": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/tslint-sonarts/-/tslint-sonarts-1.8.0.tgz",
+			"integrity": "sha512-tpijO5VR18e+Ny99uMNNov3Hw7diiYQ8KoJkezpHGw9hSFFrO5g2PhwdQQo7O9puhJKMIutLl9g+ICMgg+bh0w==",
+			"dev": true,
+			"requires": {
+				"immutable": "^3.8.2"
 			}
 		},
 		"tsutils": {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "validate-commit-msg": "^2.14.0",
     "webpack": "^4.25.1",

--- a/packages/aot/package.json
+++ b/packages/aot/package.json
@@ -78,6 +78,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/jit/package.json
+++ b/packages/jit/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/jit/src/expression-parser.ts
+++ b/packages/jit/src/expression-parser.ts
@@ -91,6 +91,14 @@ export function parseCore(input: string, bindingType?: BindingType): IExpression
 }
 
 /*@internal*/
+// JUSTIFICATION: This is performance-critical code which follows a subset of the well-known ES spec.
+// Knowing the spec, or parsers in general, will help with understanding this code and it is therefore not the
+// single source of information for being able to figure it out.
+// It generally does not need to change unless the spec changes or spec violations are found, or optimization
+// opportunities are found (which would likely not fix these warnings in any case).
+// It's therefore not considered to have any tangible impact on the maintainability of the code base.
+// For reference, most of the parsing logic is based on: https://tc39.github.io/ecma262/#sec-ecmascript-language-expressions
+// tslint:disable-next-line:no-big-function cognitive-complexity
 export function parse<TPrec extends Precedence, TType extends BindingType>(state: ParserState, access: Access, minPrecedence: TPrec, bindingType: TType):
   TPrec extends Precedence.Unary ? IsUnary :
   TPrec extends Precedence.Binary ? IsBinary :
@@ -183,7 +191,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
           } else if (state!.currentToken === Token.EOF) {
             throw Reporter.error(SyntaxError.ExpectedIdentifier, { state });
           }
-          continue;
         } else if (state.currentToken & Token.AccessScopeTerminal) {
           const ancestor = access & Access.Ancestor;
           result = ancestor === 0 ? $this : ancestor === 1 ? $parent : new AccessThis(ancestor);
@@ -673,6 +680,7 @@ function parseInterpolation(state: ParserState): Interpolation {
  */
 function parseTemplate(state: ParserState, access: Access, bindingType: BindingType, result: IsLeftHandSide, tagged: boolean): TaggedTemplate | Template {
   const cooked = [state.tokenValue as string];
+  // TODO: properly implement raw parts / decide whether we want this
   //const raw = [state.tokenRaw];
   consume(state, Token.TemplateContinuation);
   const expressions = [parse(state, access, Precedence.Assign, bindingType)];

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -276,6 +276,7 @@ export class AttributeSymbol implements IAttributeSymbol {
     return this._isProcessed;
   }
 
+  // TODO: Reduce complexity (currently at 60)
   constructor(
     semanticModel: SemanticModel,
     $element: ElementSymbol,

--- a/packages/jit/src/template-compiler.ts
+++ b/packages/jit/src/template-compiler.ts
@@ -116,11 +116,10 @@ export class TemplateCompiler implements ITemplateCompiler {
         // Doesn't make sense for these properties as they need to be unique
         const name = $attr.target;
         if (name !== 'id' && name !== 'part' && name !== 'replace-part') {
+          // tslint:disable-next-line:no-small-switch
           switch (name) {
             // TODO: handle simple surrogate style attribute
             case 'style':
-              attrInst = new SetAttributeInstruction($attr.rawValue, name);
-              break;
             default:
               attrInst = new SetAttributeInstruction($attr.rawValue, name);
           }
@@ -310,18 +309,15 @@ export class TemplateCompiler implements ITemplateCompiler {
           }
         }
       }
-      // plain attribute on a custom element
-      if ($attr.onCustomElement) {
-        // bindable attribute
-        if ($attr.isElementBindable) {
-          const expression = parser.parse($attr.rawValue, BindingType.Interpolation);
-          if (expression === null) {
-            // no interpolation -> make it a setProperty on the component
-            return new SetPropertyInstruction($attr.rawValue, $attr.to);
-          }
-          // interpolation -> behave like toView (e.g. foo="${someProp}")
-          return new InterpolationInstruction(expression, $attr.to);
+      // plain bindable attribute on a custom element
+      if ($attr.onCustomElement && $attr.isElementBindable) {
+        const expression = parser.parse($attr.rawValue, BindingType.Interpolation);
+        if (expression === null) {
+          // no interpolation -> make it a setProperty on the component
+          return new SetPropertyInstruction($attr.rawValue, $attr.to);
         }
+        // interpolation -> behave like toView (e.g. foo="${someProp}")
+        return new InterpolationInstruction(expression, $attr.to);
       }
       {
         // plain attribute on a normal element

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -74,6 +74,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -7,7 +7,7 @@ export interface IDisposable {
 }
 
 export type Constructable<T = {}> = {
-  // tslint:disable-next-line:no-any
+  // tslint:disable-next-line:no-any no-useless-intersection
   new(...args: unknown[]): T & any; // this is a "hack" to stop typescript from nagging about the type parameter T being unused (the parameter may be used for type inference)
 };
 

--- a/packages/plugin-parcel/package.json
+++ b/packages/plugin-parcel/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/plugin-requirejs/package.json
+++ b/packages/plugin-requirejs/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/plugin-requirejs/src/component.ts
+++ b/packages/plugin-requirejs/src/component.ts
@@ -45,10 +45,11 @@ export function write(pluginName: string, moduleName: string, writer: (content: 
     const text = buildMap[moduleName];
     const description = createTemplateDescription(text);
     const depsToLoad = processImports(description.imports, moduleName);
+    const depsToLoadMapped = depsToLoad.map(x => `"${x}"`).join(',');
 
     depsToLoad.unshift('@aurelia/runtime');
 
-    writer(`define("${pluginName}!${moduleName}", [${depsToLoad.map(x => `"${x}"`).join(',')}], function() {
+    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function() {
       var Component = arguments[0].Component;
       var templateSource = {
         name: '${kebabCase(templateImport.basename)}',

--- a/packages/plugin-requirejs/src/processing.ts
+++ b/packages/plugin-requirejs/src/processing.ts
@@ -145,6 +145,7 @@ export function trimDots(ary: string[]): void {
       // as an ID it is less than ideal. In larger point
       // releases, may be better to just kick out an error.
       if (i === 0 || (i === 1 && ary[2] === '..') || ary[i - 1] === '..') {
+        // tslint:disable-next-line:no-redundant-jump
         continue;
       } else if (i > 0) {
         ary.splice(i - 1, 2);

--- a/packages/plugin-requirejs/src/view.ts
+++ b/packages/plugin-requirejs/src/view.ts
@@ -44,9 +44,10 @@ export function write(pluginName: string, moduleName: string, writer: (content: 
     const text = buildMap[moduleName];
     const description = createTemplateDescription(text);
     const depsToLoad = processImports(description.imports, moduleName);
+    const depsToLoadMapped = depsToLoad.map(x => `"${x}"`).join(',');
     const templateImport = parseImport(moduleName);
 
-    writer(`define("${pluginName}!${moduleName}", [${depsToLoad.map(x => `"${x}"`).join(',')}], function() {
+    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function() {
       var templateSource = {
         name: '${kebabCase(templateImport.basename)}',
         template: '${escape(description.template)}',

--- a/packages/plugin-svg/package.json
+++ b/packages/plugin-svg/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -76,6 +76,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/runtime/src/binding/array-observer.ts
+++ b/packages/runtime/src/binding/array-observer.ts
@@ -24,7 +24,8 @@ function observePush(this: IObservedArray): ReturnType<typeof nativePush> {
   this.length = o.indexMap.length = len + argCount;
   let i = len;
   while (i < this.length) {
-    this[i] = arguments[i - len]; o.indexMap[i] = - 2;
+    this[i] = arguments[i - len];
+    o.indexMap[i] = - 2;
     i++;
   }
   o.callSubscribers('push', arguments, LifecycleFlags.isCollectionMutation);
@@ -127,14 +128,16 @@ function observeReverse(this: IObservedArray): ReturnType<typeof nativeReverse> 
   const len = this.length;
   const middle = (len / 2) | 0;
   let lower = 0;
+  // tslint:disable:no-statements-same-line
   while (lower !== middle) {
     const upper = len - lower - 1;
-    const lowerValue = this[lower]; const lowerIndex = o.indexMap[lower];
-    const upperValue = this[upper]; const upperIndex = o.indexMap[upper];
-    this[lower] = upperValue; o.indexMap[lower] = upperIndex;
-    this[upper] = lowerValue; o.indexMap[upper] = lowerIndex;
+    const lowerValue = this[lower];  const lowerIndex = o.indexMap[lower];
+    const upperValue = this[upper];  const upperIndex = o.indexMap[upper];
+    this[lower] = upperValue;        o.indexMap[lower] = upperIndex;
+    this[upper] = lowerValue;        o.indexMap[upper] = lowerIndex;
     lower++;
   }
+  // tslint:enable:no-statements-same-line
   o.callSubscribers('reverse', arguments, LifecycleFlags.isCollectionMutation);
   return this;
 }
@@ -194,20 +197,25 @@ function insertionSort(arr: IObservedArray, indexMap: IndexMap, from: number, to
   let velement, ielement, vtmp, itmp, order;
   let i, j;
   for (i = from + 1; i < to; i++) {
-    velement = arr[i]; ielement = indexMap[i];
+    velement = arr[i];
+    ielement = indexMap[i];
     for (j = i - 1; j >= from; j--) {
-      vtmp = arr[j]; itmp = indexMap[j];
+      vtmp = arr[j];
+      itmp = indexMap[j];
       order = compareFn(vtmp, velement);
       if (order > 0) {
-        arr[j + 1] = vtmp; indexMap[j + 1] = itmp;
+        arr[j + 1] = vtmp;
+        indexMap[j + 1] = itmp;
       } else {
         break;
       }
     }
-    arr[j + 1] = velement; indexMap[j + 1] = ielement;
+    arr[j + 1] = velement;
+    indexMap[j + 1] = ielement;
   }
 }
 
+// tslint:disable-next-line:cognitive-complexity
 function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: number, compareFn: (a: unknown, b: unknown) => number): void {
   let thirdIndex = 0, i = 0;
   let v0, v1, v2;
@@ -224,44 +232,45 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
       return;
     }
 
+    // tslint:disable:no-statements-same-line
     thirdIndex = from + ((to - from) >> 1);
-    v0 = arr[from];       i0 = indexMap[from];
-    v1 = arr[to - 1];     i1 = indexMap[to - 1];
-    v2 = arr[thirdIndex]; i2 = indexMap[thirdIndex];
+    v0 = arr[from];                i0 = indexMap[from];
+    v1 = arr[to - 1];              i1 = indexMap[to - 1];
+    v2 = arr[thirdIndex];          i2 = indexMap[thirdIndex];
     c01 = compareFn(v0, v1);
     if (c01 > 0) {
-      vtmp = v0; itmp = i0;
-      v0 = v1;   i0 = i1;
-      v1 = vtmp; i1 = itmp;
+      vtmp = v0;                   itmp = i0;
+      v0 = v1;                     i0 = i1;
+      v1 = vtmp;                   i1 = itmp;
     }
     c02 = compareFn(v0, v2);
     if (c02 >= 0) {
-      vtmp = v0; itmp = i0;
-      v0 = v2;   i0 = i2;
-      v2 = v1;   i2 = i1;
-      v1 = vtmp; i1 = itmp;
+      vtmp = v0;                   itmp = i0;
+      v0 = v2;                     i0 = i2;
+      v2 = v1;                     i2 = i1;
+      v1 = vtmp;                   i1 = itmp;
     } else {
       c12 = compareFn(v1, v2);
       if (c12 > 0) {
-        vtmp = v1; itmp = i1;
-        v1 = v2;   i1 = i2;
-        v2 = vtmp; i2 = itmp;
+        vtmp = v1;                 itmp = i1;
+        v1 = v2;                   i1 = i2;
+        v2 = vtmp;                 i2 = itmp;
       }
     }
-    arr[from] = v0;   indexMap[from] = i0;
-    arr[to - 1] = v2; indexMap[to - 1] = i2;
-    vpivot = v1;      ipivot = i1;
+    arr[from] = v0;                indexMap[from] = i0;
+    arr[to - 1] = v2;              indexMap[to - 1] = i2;
+    vpivot = v1;                   ipivot = i1;
     lowEnd = from + 1;
     highStart = to - 1;
     arr[thirdIndex] = arr[lowEnd]; indexMap[thirdIndex] = indexMap[lowEnd];
     arr[lowEnd] = vpivot;          indexMap[lowEnd] = ipivot;
 
     partition: for (i = lowEnd + 1; i < highStart; i++) {
-      velement = arr[i]; ielement = indexMap[i];
+      velement = arr[i];           ielement = indexMap[i];
       order = compareFn(velement, vpivot);
       if (order < 0) {
-        arr[i] = arr[lowEnd];   indexMap[i] = indexMap[lowEnd];
-        arr[lowEnd] = velement; indexMap[lowEnd] = ielement;
+        arr[i] = arr[lowEnd];      indexMap[i] = indexMap[lowEnd];
+        arr[lowEnd] = velement;    indexMap[lowEnd] = ielement;
         lowEnd++;
       } else if (order > 0) {
         do {
@@ -270,18 +279,20 @@ function quickSort(arr: IObservedArray, indexMap: IndexMap, from: number, to: nu
           if (highStart == i) {
             break partition;
           }
-          vtopElement = arr[highStart];          order = compareFn(vtopElement, vpivot);
+          vtopElement = arr[highStart]; order = compareFn(vtopElement, vpivot);
         } while (order > 0);
         arr[i] = arr[highStart];   indexMap[i] = indexMap[highStart];
         arr[highStart] = velement; indexMap[highStart] = ielement;
         if (order < 0) {
-          velement = arr[i];      ielement = indexMap[i];
-          arr[i] = arr[lowEnd];   indexMap[i] = indexMap[lowEnd];
-          arr[lowEnd] = velement; indexMap[lowEnd] = ielement;
+          velement = arr[i];       ielement = indexMap[i];
+          arr[i] = arr[lowEnd];    indexMap[i] = indexMap[lowEnd];
+          arr[lowEnd] = velement;  indexMap[lowEnd] = ielement;
           lowEnd++;
         }
       }
     }
+    // tslint:enable:no-statements-same-line
+
     if (to - highStart < lowEnd - from) {
       quickSort(arr, indexMap, highStart, to, compareFn);
       to = lowEnd;

--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -21,14 +21,16 @@ export class InternalObserversLookup {
   }
 }
 
+type BindingContextValue = ObservedCollection | StrictPrimitive | IIndexable;
+
 export class BindingContext implements IBindingContext {
-  [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
+  [key: string]: BindingContextValue;
 
   public readonly $synthetic: true;
 
   public $observers: ObserversLookup<IOverrideContext>;
 
-  private constructor(keyOrObj?: string | IIndexable, value?: ObservedCollection | StrictPrimitive | IIndexable) {
+  private constructor(keyOrObj?: string | IIndexable, value?: BindingContextValue) {
     this.$synthetic = true;
 
     if (keyOrObj !== undefined) {
@@ -47,8 +49,8 @@ export class BindingContext implements IBindingContext {
   }
 
   public static create(obj?: IIndexable): BindingContext;
-  public static create(key: string, value: ObservedCollection | StrictPrimitive | IIndexable): BindingContext;
-  public static create(keyOrObj?: string | IIndexable, value?: ObservedCollection | StrictPrimitive | IIndexable): BindingContext {
+  public static create(key: string, value: BindingContextValue): BindingContext;
+  public static create(keyOrObj?: string | IIndexable, value?: BindingContextValue): BindingContext {
     return new BindingContext(keyOrObj, value);
   }
 

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -12,7 +12,7 @@ export interface IBinding extends IBindScope {
   readonly $scope: IScope;
 }
 
-export type IBindingTarget = INode | IObservable; // Node | CSSStyleDeclaration | IObservable;
+export type IBindingTarget = INode | IObservable; // Can be: Node | CSSStyleDeclaration | IObservable;
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
 const { oneTime, toView, fromView } = BindingMode;
@@ -66,7 +66,7 @@ export class Binding implements IPartialConnectableBinding {
     this.sourceExpression.assign(flags | LifecycleFlags.updateSourceExpression, this.$scope, this.locator, value);
   }
 
-  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
+  public handleChange(newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }
@@ -79,7 +79,7 @@ export class Binding implements IPartialConnectableBinding {
       const targetObserver = this.targetObserver;
       const mode = this.mode;
 
-      previousValue = targetObserver.getValue();
+      const previousValue = targetObserver.getValue();
       // if the only observable is an AccessScope then we can assume the passed-in newValue is the correct and latest value
       if (sourceExpression.$kind !== ExpressionKind.AccessScope || this.observerSlots > 1) {
         newValue = sourceExpression.evaluate(flags, $scope, locator);

--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -22,7 +22,7 @@ export function computed(config: ComputedOverrides): PropertyDecorator {
 }
 
 // tslint:disable-next-line:no-typeof-undefined
-const noProxy = !(typeof Proxy !== 'undefined');
+const noProxy = typeof Proxy === 'undefined';
 const computedOverrideDefaults: ComputedOverrides = { static: false, volatile: false };
 
 /* @internal */

--- a/packages/runtime/src/binding/element-observation.ts
+++ b/packages/runtime/src/binding/element-observation.ts
@@ -2,7 +2,7 @@ import { DOM, IElement, IInputElement, INode, INodeObserver } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import {
   CollectionKind, IBatchedCollectionSubscriber, IBindingTargetObserver, ICollectionObserver,
-  IndexMap, IObserversLookup,  IPropertySubscriber, LifecycleFlags
+  IndexMap, IPropertySubscriber, LifecycleFlags, ObserversLookup
 } from '../observation';
 import { IEventSubscriber } from './event-manager';
 import { IObserverLocator } from './observer-locator';
@@ -110,11 +110,9 @@ export class ValueAttributeObserver implements ValueAttributeObserver {
 
   private flushFileChanges(): void {
     const currentValue = this.currentValue;
-    if (this.oldValue !== currentValue) {
-      if (currentValue === '') {
-        this.setValueCore(currentValue, this.currentFlags);
-        this.oldValue = this.currentValue;
-      }
+    if (this.oldValue !== currentValue && currentValue === '') {
+      this.setValueCore(currentValue, this.currentFlags);
+      this.oldValue = this.currentValue;
     }
   }
 }
@@ -127,7 +125,7 @@ const defaultHandleBatchedChangeFlags = LifecycleFlags.fromFlush | LifecycleFlag
 interface IInternalInputElement extends IInputElement {
   matcher?: typeof defaultMatcher;
   model?: unknown;
-  $observers?: IObserversLookup & {
+  $observers?: ObserversLookup & {
     model?: SetterObserver;
     value?: ValueAttributeObserver;
   };

--- a/packages/runtime/src/binding/event-manager.ts
+++ b/packages/runtime/src/binding/event-manager.ts
@@ -294,7 +294,7 @@ export class EventManager implements IEventManager {
   ): EventSubscription {
     let delegatedHandlers: Record<string, ListenerTracker> | undefined;
     let capturedHandlers: Record<string, ListenerTracker> | undefined;
-    let handlerEntry: ListenerTracker | ListenerTracker | undefined;
+    let handlerEntry: ListenerTracker | undefined;
 
     if (strategy === DelegationStrategy.bubbling) {
       delegatedHandlers = this.delegatedHandlers;

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -1,12 +1,14 @@
 import { DI, PLATFORM, Reporter } from '@aurelia/kernel';
 import { AccessMember, AccessScope, CallMember, CallScope, ExpressionKind, ForOfStatement, Interpolation, IsBindingBehavior, PrimitiveLiteral } from './ast';
 
+type BindingExpression = Interpolation | ForOfStatement | IsBindingBehavior;
+
 export interface IExpressionParser {
-  cache(expressions: Record<string, Interpolation | ForOfStatement | IsBindingBehavior>): void;
+  cache(expressions: Record<string, BindingExpression>): void;
   parse(expression: string, bindingType: BindingType.ForCommand): ForOfStatement;
   parse(expression: string, bindingType: BindingType.Interpolation): Interpolation;
   parse(expression: string, bindingType: Exclude<BindingType, BindingType.ForCommand | BindingType.Interpolation>): IsBindingBehavior;
-  parse(expression: string, bindingType: BindingType): Interpolation | ForOfStatement | IsBindingBehavior;
+  parse(expression: string, bindingType: BindingType): BindingExpression;
 }
 
 export const IExpressionParser = DI.createInterface<IExpressionParser>()
@@ -27,7 +29,7 @@ export class ExpressionParser implements IExpressionParser {
   public parse(expression: string, bindingType: BindingType.ForCommand): ForOfStatement;
   public parse(expression: string, bindingType: BindingType.Interpolation): Interpolation;
   public parse(expression: string, bindingType: Exclude<BindingType, BindingType.ForCommand | BindingType.Interpolation>): IsBindingBehavior;
-  public parse(expression: string, bindingType: BindingType): Interpolation | ForOfStatement | IsBindingBehavior {
+  public parse(expression: string, bindingType: BindingType): BindingExpression {
     switch (bindingType) {
       case BindingType.Interpolation:
       {
@@ -61,7 +63,7 @@ export class ExpressionParser implements IExpressionParser {
     }
   }
 
-  public cache(expressions: Record<string, Interpolation | ForOfStatement | IsBindingBehavior>): void {
+  public cache(expressions: Record<string, BindingExpression>): void {
     const { forOfLookup, expressionLookup, interpolationLookup } = this;
     for (const expression in expressions) {
       const expr = expressions[expression];
@@ -81,11 +83,11 @@ export class ExpressionParser implements IExpressionParser {
   private parseCore(expression: string, bindingType: BindingType.ForCommand): ForOfStatement;
   private parseCore(expression: string, bindingType: BindingType.Interpolation): Interpolation;
   private parseCore(expression: string, bindingType: Exclude<BindingType, BindingType.ForCommand | BindingType.Interpolation>): IsBindingBehavior;
-  private parseCore(expression: string, bindingType: BindingType): Interpolation | ForOfStatement | IsBindingBehavior {
+  private parseCore(expression: string, bindingType: BindingType): BindingExpression {
     try {
       const parts = expression.split('.');
       const firstPart = parts[0];
-      let current: Interpolation | ForOfStatement | IsBindingBehavior;
+      let current: BindingExpression;
 
       if (firstPart.endsWith('()')) {
         current = new CallScope(firstPart.replace('()', ''), PLATFORM.emptyArray);

--- a/packages/runtime/src/binding/interpolation-binding.ts
+++ b/packages/runtime/src/binding/interpolation-binding.ts
@@ -94,6 +94,7 @@ export class InterpolationBinding implements IPartialConnectableBinding {
 
   public targetObserver: IBindingTargetAccessor;
 
+  // tslint:disable-next-line:parameters-max-number
   constructor(sourceExpression: IExpression, interpolation: Interpolation, target: IBindingTarget, targetProperty: string, mode: BindingMode, observerLocator: IObserverLocator, locator: IServiceLocator, isFirst: boolean) {
     this.$state = State.none;
 
@@ -113,13 +114,13 @@ export class InterpolationBinding implements IPartialConnectableBinding {
     this.targetObserver.setValue(value, flags | LifecycleFlags.updateTargetInstance);
   }
 
-  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
+  public handleChange(_newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }
 
-    previousValue = this.targetObserver.getValue();
-    newValue = this.interpolation.evaluate(flags, this.$scope, this.locator);
+    const previousValue = this.targetObserver.getValue();
+    const newValue = this.interpolation.evaluate(flags, this.$scope, this.locator);
     if (newValue !== previousValue) {
       this.updateTarget(newValue, flags);
     }

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -40,15 +40,15 @@ export class LetBinding implements IPartialConnectableBinding {
     this.toViewModel = toViewModel;
   }
 
-  public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
+  public handleChange(_newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
     if (!(this.$state & State.isBound)) {
       return;
     }
 
     if (flags & LifecycleFlags.updateTargetInstance) {
       const { target, targetProperty } = this as {target: IIndexable; targetProperty: string};
-      previousValue = target[targetProperty];
-      newValue = this.sourceExpression.evaluate(flags, this.$scope, this.locator);
+      const previousValue: unknown = target[targetProperty];
+      const newValue: unknown = this.sourceExpression.evaluate(flags, this.$scope, this.locator);
       if (newValue !== previousValue) {
         target[targetProperty] = newValue;
       }

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -30,12 +30,10 @@ function setValue(this: BindingTargetAccessor, newValue: unknown, flags: Lifecyc
 }
 
 function flush(this: BindingTargetAccessor, flags: LifecycleFlags): void {
-  if (flags & LifecycleFlags.doNotUpdateDOM) {
-    if (DOM.isNodeInstance(this.obj)) {
-      // re-queue the change so it will still propagate on flush when it's attached again
-      this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
-      return;
-    }
+  if ((flags & LifecycleFlags.doNotUpdateDOM) && DOM.isNodeInstance(this.obj)) {
+    // re-queue the change so it will still propagate on flush when it's attached again
+    this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
+    return;
   }
   const currentValue = this.currentValue;
   // we're doing this check because a value could be set multiple times before a flush, and the final value could be the same as the original value

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -279,6 +279,7 @@ export function buildTemplateDefinition(
 export function buildTemplateDefinition(
   ctor: CustomElementConstructor | null,
   nameOrDef: string | Immutable<ITemplateDefinition>): TemplateDefinition;
+// tslint:disable-next-line:parameters-max-number
 export function buildTemplateDefinition(
   ctor: CustomElementConstructor | null,
   name: string | null,
@@ -292,6 +293,7 @@ export function buildTemplateDefinition(
   containerless?: boolean | null,
   shadowOptions?: { mode: 'open' | 'closed' } | null,
   hasSlots?: boolean | null): TemplateDefinition;
+  // tslint:disable-next-line:parameters-max-number // TODO: Reduce complexity (currently at 64)
 export function buildTemplateDefinition(
   ctor: CustomElementConstructor | null,
   nameOrDef: string | Immutable<ITemplateDefinition> | null,
@@ -359,10 +361,8 @@ export function buildTemplateDefinition(
   }
 
   // special handling for invocations that quack like a @customElement decorator
-  if (argLen === 2 && ctor !== null) {
-    if (typeof nameOrDef === 'string' || !('build' in nameOrDef)) {
-      def.build = buildRequired;
-    }
+  if (argLen === 2 && ctor !== null && (typeof nameOrDef === 'string' || !('build' in nameOrDef))) {
+    def.build = buildRequired;
   }
 
   return def;

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -1402,11 +1402,9 @@ export class AggregateLifecycleTask implements ILifecycleTask<void> {
         this.tasks.splice(idx, 1);
       }
     }
-    if (this.tasks.length === 0) {
-      if (this.owner !== null) {
-        this.owner.finishTask(this);
-        this.owner = null;
-      }
+    if (this.tasks.length === 0 && this.owner !== null) {
+      this.owner.finishTask(this);
+      this.owner = null;
     }
   }
 

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -366,10 +366,9 @@ export interface IScope {
   readonly overrideContext: IOverrideContext;
 }
 
+// TODO: currently unused, still need to fix the observersLookup type
 export interface IObserversLookup<TObj extends IIndexable = IIndexable, TKey extends keyof TObj =
-Exclude<keyof TObj, '$synthetic' | '$observers' | 'bindingContext' | 'overrideContext' | 'parentOverrideContext'>> {
-
-}
+  Exclude<keyof TObj, '$synthetic' | '$observers' | 'bindingContext' | 'overrideContext' | 'parentOverrideContext'>> { }
 
 export type ObserversLookup<TObj extends IIndexable = IIndexable, TKey extends keyof TObj =
   Exclude<keyof TObj, '$synthetic' | '$observers' | 'bindingContext' | 'overrideContext' | 'parentOverrideContext'>> =

--- a/packages/runtime/src/templating/lifecycle-attach.ts
+++ b/packages/runtime/src/templating/lifecycle-attach.ts
@@ -6,6 +6,7 @@ import { ICustomAttribute } from './custom-attribute';
 import { ICustomElement } from './custom-element';
 
 /*@internal*/
+// tslint:disable-next-line:no-ignored-initial-value
 export function $attachAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {
   if (this.$state & State.isAttached) {
     return;
@@ -33,6 +34,7 @@ export function $attachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
 }
 
 /*@internal*/
+// tslint:disable-next-line:no-ignored-initial-value
 export function $attachElement(this: Writable<ICustomElement>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {
   if (this.$state & State.isAttached) {
     return;
@@ -91,6 +93,7 @@ export function $attachView(this: Writable<IView>, flags: LifecycleFlags, encaps
 }
 
 /*@internal*/
+// tslint:disable-next-line:no-ignored-initial-value
 export function $detachAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags): void {
   if (this.$state & State.isAttached) {
     const lifecycle = this.$lifecycle;
@@ -115,6 +118,7 @@ export function $detachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
 }
 
 /*@internal*/
+// tslint:disable-next-line:no-ignored-initial-value
 export function $detachElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (this.$state & State.isAttached) {
     const lifecycle = this.$lifecycle;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^5.2.1",
+    "tslint-sonarts": "^1.8.0",
     "typescript": "^3.1.6",
     "webpack": "^4.25.1"
   }

--- a/tslint.json
+++ b/tslint.json
@@ -257,6 +257,15 @@
     "prefer-switch": false, // more of a style preference
     "prefer-type-cast": false,   // pick either type-cast format and use it consistently
     "return-undefined": false, // this actually affect the readability of the code
-    "space-before-function-paren": false   // turn this on if this is really your coding standard
+    "space-before-function-paren": false ,  // turn this on if this is really your coding standard
+
+  /**
+    * Sonarts rules
+    */
+    "cognitive-complexity": [true, 30],
+    "max-union-size": [true, 5],
+    "no-extra-semicolon": false,
+    "no-identical-functions": false,
+    "no-duplicate-string": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "tslint:latest",
-    "tslint-microsoft-contrib"
+    "tslint-microsoft-contrib",
+    "tslint-sonarts"
   ],
   "linterOptions": {
     "exclude": [


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is just an experiment based on a discussion with @zewa666 and @fkleuver. 

It appears that Code Climate runs the Sonarts linting rules. The problem is that we only see those issues once we've created a PR. It would be beneficial to see those issues earlier in the process, so this PR brings those rules into our own ruleset.

One of my goals was to make this PR *violation neutral*, so ~~it does not introduce new linting errors.~~ I did cheat a bit ~~though, as i suppressed a few~~ and added `// TODO: fix` style comments.

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

Notable things:
- The rule with the most violations is `cognitive-complexity`, which has a default value of 15. After a discussion with @fkleuver I set it to 30 for now and ~~suppressed~~ *marked* the higher ones with `// TODO: fix` style comments.
- I suppressed some `no-ignored-initial-value` as it doesn't like arguments named `this`.
- I disables the `no-identical-functions` and `no-duplicate-string` rules on `tslint.json` level, as fixing those would lead to less readable/maintainable code imho.

## 📑 Test Plan

Trust CircleCI and I'm curious what Code Climate says.

## ⏭ Next Steps

Decide if we want to use this, and if so, with what rule configuration.
