### PR TITLE
chore(codeclimate): disable tslint on codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -58,8 +58,7 @@ checks:
     enabled: false # default true
 plugins:
   tslint:
-    enabled: true
-    config: tslint.json
+    enabled: false
 exclude_patterns:
 # Exclude code that is not actually built and published
 # The reasoning being that dev code like tests or build scripts can be changed without having to account for backwards compatibility and thus is much easier to refactor / tidy up at a later point in time


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

The `sonarts` and `tslint-microsoft-contrib` custom tslint rules cause CodeClimate to crash. This PR disables tslint on CodeClimate following discussion around https://github.com/aurelia/aurelia/pull/310
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Follow-up to: https://github.com/aurelia/aurelia/pull/310
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

We could create an secondary tslint.json config with just the rules that CodeClimate supports, and point codeclimate.yml to that one. This isn't particularly important since we already have a lint job on CI, but it is a potential point of improvement for the future
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
