### PR TITLE
refactor: standardise on "as" type casts

### DIFF
--- a/packages/debug/src/reporter.ts
+++ b/packages/debug/src/reporter.ts
@@ -35,7 +35,7 @@ export const Reporter: typeof RuntimeReporter = {...RuntimeReporter,
   error(code: number, ...params: unknown[]): Error {
     const info = getMessageInfoForCode(code);
     const error = new Error(info.message);
-    (<Error & {data: unknown}>error).data = params;
+    (error as Error & {data: unknown}).data = params;
     return error;
   }};
 

--- a/packages/jit/src/element-parser.ts
+++ b/packages/jit/src/element-parser.ts
@@ -3,7 +3,7 @@ import { DOM, IAttr, INode } from '@aurelia/runtime';
 import { AttrSyntax, ElementSyntax } from './ast';
 import { IAttributeParser } from './attribute-parser';
 
-const domParser = <HTMLDivElement>DOM.createElement('div');
+const domParser = DOM.createElement('div') as HTMLDivElement;
 
 export const enum NodeType {
   Element = 1,
@@ -49,7 +49,7 @@ export class ElementParser implements IElementParser {
     let children: ElementSyntax[];
     let content: ElementSyntax;
     if (node.nodeName === 'TEMPLATE') {
-      content = this.parse((<HTMLTemplateElement>node).content);
+      content = this.parse((node as HTMLTemplateElement).content);
       children = PLATFORM.emptyArray as ElementSyntax[];
     } else {
       content = null;

--- a/packages/jit/src/expression-parser.ts
+++ b/packages/jit/src/expression-parser.ts
@@ -203,9 +203,9 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
     // falls through
     case Token.Identifier: // identifier
       if (bindingType & BindingType.IsIterator) {
-        result = new BindingIdentifier(<string>state.tokenValue);
+        result = new BindingIdentifier(state.tokenValue as string);
       } else {
-        result = new AccessScope(<string>state.tokenValue, access & Access.Ancestor);
+        result = new AccessScope(state.tokenValue as string, access & Access.Ancestor);
         access = Access.Scope;
       }
       state.assignable = true;
@@ -232,7 +232,7 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
       access = Access.Reset;
       break;
     case Token.TemplateTail:
-      result = new Template([<string>state.tokenValue]);
+      result = new Template([state.tokenValue as string]);
       state.assignable = false;
       nextToken(state);
       access = Access.Reset;
@@ -350,7 +350,7 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
           break;
         case Token.TemplateTail:
           state.assignable = false;
-          const strings = [<string>state.tokenValue];
+          const strings = [state.tokenValue as string];
           result = new TaggedTemplate(strings, strings, result as IsLeftHandSide);
           nextToken(state);
           break;
@@ -911,7 +911,7 @@ function decompress(lookup: (CharScanner | number)[] | null, $set: Set<number> |
     let end = compressed[i + 1];
     end = end > 0 ? end : start + 1;
     if (lookup) {
-      lookup.fill(<CharScanner | number>value, start, end);
+      lookup.fill(value as CharScanner | number, start, end);
     }
     if ($set) {
       for (let ch = start; ch < end; ch++) {
@@ -940,9 +940,9 @@ decompress(null, AsciiIdParts, codes.AsciiIdPart, true);
 // IdentifierPart lookup
 const IdParts = new Uint8Array(0xFFFF);
 // tslint:disable-next-line:no-any
-decompress(<any>IdParts, null, codes.IdStart, 1);
+decompress(IdParts as any, null, codes.IdStart, 1);
 // tslint:disable-next-line:no-any
-decompress(<any>IdParts, null, codes.Digit, 1);
+decompress(IdParts as any, null, codes.Digit, 1);
 
 type CharScanner = ((p: ParserState) => Token | null) & { notMapped?: boolean };
 

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -80,7 +80,7 @@ export class SemanticModel {
     if (existing !== undefined) {
       return existing;
     }
-    const definition = <IAttributeDefinition>this.resources.find(CustomAttributeResource, name);
+    const definition = this.resources.find(CustomAttributeResource, name) as IAttributeDefinition;
     return this.attrDefCache[name] = definition === undefined ? null : definition;
   }
 
@@ -89,7 +89,7 @@ export class SemanticModel {
     if (existing !== undefined) {
       return existing;
     }
-    const definition = <ITemplateDefinition>this.resources.find(CustomElementResource, name);
+    const definition = this.resources.find(CustomElementResource, name) as ITemplateDefinition;
     return this.elDefCache[name] = definition === undefined ? null : definition;
   }
 
@@ -385,7 +385,7 @@ export class AttributeSymbol implements IAttributeSymbol {
   public markAsProcessed(): void {
     this._isProcessed = true;
     if (this.isTemplateController) {
-      (<Element>this.$element.node).removeAttribute(this.rawName);
+      (this.$element.node as Element).removeAttribute(this.rawName);
     }
   }
 }
@@ -525,7 +525,7 @@ export class ElementSymbol {
   }
 
   public makeTarget(): void {
-    (<Element>this.node).classList.add('au');
+    (this.node as Element).classList.add('au');
   }
 
   public replaceTextNodeWithMarker(): void {
@@ -545,7 +545,7 @@ export class ElementSymbol {
     if (node.parentNode) {
       node.parentNode.replaceChild(marker.node, node);
     } else if (this.isTemplate) {
-      (<HTMLTemplateElement>node).content.appendChild(marker.node);
+      (node as HTMLTemplateElement).content.appendChild(marker.node);
     }
     this.setToMarker(marker);
   }

--- a/packages/jit/src/template-compiler.ts
+++ b/packages/jit/src/template-compiler.ts
@@ -57,7 +57,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       this.compileSurrogate(root);
     }
 
-    return <TemplateDefinition>definition;
+    return definition as TemplateDefinition;
   }
 
   private compileNode($el: ElementSymbol): ElementSymbol {
@@ -82,7 +82,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         }
         return nextSibling;
       case NodeType.Text:
-        const expression = this.exprParser.parse((<Text>$el.node).wholeText, BindingType.Interpolation);
+        const expression = this.exprParser.parse(($el.node as Text).wholeText, BindingType.Interpolation);
         if (expression === null) {
           while (($el = $el.nextSibling) && $el.node.nodeType === NodeType.Text);
           return $el;
@@ -169,7 +169,7 @@ export class TemplateCompiler implements ITemplateCompiler {
 
   private compileCustomElement($el: ElementSymbol): void {
     if ($el.$attributes.length === 0) {
-      $el.addInstructions([new HydrateElementInstruction($el.definition.name, <TargetedInstruction[]>PLATFORM.emptyArray)]);
+      $el.addInstructions([new HydrateElementInstruction($el.definition.name, PLATFORM.emptyArray as TargetedInstruction[])]);
       if ($el.definition.containerless) {
         $el.replaceNodeWithMarker();
       } else {
@@ -247,7 +247,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         letInstructions.push(new LetBindingInstruction(expr, to));
       } else if ($attr.rawName === 'to-view-model') {
         toViewModel = true;
-        (<Element>$el.node).removeAttribute('to-view-model');
+        ($el.node as Element).removeAttribute('to-view-model');
       } else {
         const expr = this.exprParser.parse($attr.rawValue, BindingType.Interpolation);
         if (expr === null) {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -94,13 +94,13 @@ export type RegisterSelf<T extends Constructable> = {
 if (!('getOwnMetadata' in Reflect)) {
   // tslint:disable-next-line:no-any
   Reflect.getOwnMetadata = function(metadataKey: any, target: Object): any {
-    return (<IIndexable>target)[metadataKey];
+    return (target as IIndexable)[metadataKey];
   };
 
   // tslint:disable-next-line:no-any
   Reflect.metadata = function(metadataKey: any, metadataValue: any): (target: Function) => void {
     return function(target: Function): void {
-      (<IIndexable>target)[metadataKey] = metadataValue;
+      (target as IIndexable)[metadataKey] = metadataValue;
     };
   };
 }
@@ -235,7 +235,7 @@ Foo.register(container);
       const registration = Registration.transient(target, target);
       return registration.register(container, target);
     };
-    return <T & RegisterSelf<T>>target;
+    return target as T & RegisterSelf<T>;
   },
 
   // tslint:disable:jsdoc-format
@@ -263,7 +263,7 @@ Foo.register(container);
       const registration = Registration.singleton(target, target);
       return registration.register(container, target);
     };
-    return <T & RegisterSelf<T>>target;
+    return target as T & RegisterSelf<T>;
   }
 };
 

--- a/packages/plugin-svg/src/svg-analyzer.ts
+++ b/packages/plugin-svg/src/svg-analyzer.ts
@@ -205,20 +205,20 @@ function createElement(html: string): Element {
   // Using very HTML-specific code here since you won't install this module
   // unless you are actually running in a browser, using HTML,
   // and dealing with browser inconsistencies.
-  const div = <HTMLElement>DOM.createElement('div');
+  const div = DOM.createElement('div') as HTMLElement;
   div.innerHTML = html;
   return div.firstElementChild;
 }
 
 if (createElement('<svg><altGlyph /></svg>').firstElementChild.nodeName === 'altglyph' && svgElements.altGlyph) {
   // handle chrome casing inconsistencies.
-  (<{altglyph?: string[]}>svgElements).altglyph = svgElements.altGlyph;
+  (svgElements as {altglyph?: string[]}).altglyph = svgElements.altGlyph;
   delete svgElements.altGlyph;
-  (<{altglyphdef?: string[]}>svgElements).altglyphdef = svgElements.altGlyphDef;
+  (svgElements as {altglyphdef?: string[]}).altglyphdef = svgElements.altGlyphDef;
   delete svgElements.altGlyphDef;
-  (<{altglyphitem?: string[]}>svgElements).altglyphitem = svgElements.altGlyphItem;
+  (svgElements as {altglyphitem?: string[]}).altglyphitem = svgElements.altGlyphItem;
   delete svgElements.altGlyphItem;
-  (<{glyphref?: string[]}>svgElements).glyphref = svgElements.glyphRef;
+  (svgElements as {glyphref?: string[]}).glyphref = svgElements.glyphRef;
   delete svgElements.glyphRef;
 }
 

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -39,11 +39,11 @@ export class Aurelia {
     const host = config.host as INode & {$au?: Aurelia | null};
     let component: ICustomElement;
     const componentOrType = config.component as ICustomElement | ICustomElementType;
-    if (CustomElementResource.isType(<ICustomElementType>componentOrType)) {
-      this.container.register(<ICustomElementType>componentOrType);
-      component = this.container.get<ICustomElement>(CustomElementResource.keyFrom((<ICustomElementType>componentOrType).description.name));
+    if (CustomElementResource.isType(componentOrType as ICustomElementType)) {
+      this.container.register(componentOrType as ICustomElementType);
+      component = this.container.get<ICustomElement>(CustomElementResource.keyFrom((componentOrType as ICustomElementType).description.name));
     } else {
-      component = <ICustomElement>componentOrType;
+      component = componentOrType as ICustomElement;
     }
 
     const startTask = () => {
@@ -95,4 +95,4 @@ export class Aurelia {
   }
 }
 
-(<{Aurelia: unknown}>PLATFORM.global).Aurelia = Aurelia;
+(PLATFORM.global as {Aurelia: unknown}).Aurelia = Aurelia;

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -235,7 +235,7 @@ export class BindingBehavior implements IExpression {
       throw Reporter.error(RuntimeError.BehaviorAlreadyApplied, this);
     }
     binding[behaviorKey] = behavior;
-    behavior.bind.apply(behavior, (<unknown[]>[flags, scope, binding]).concat(evalList(flags, scope, locator, this.args)));
+    behavior.bind.apply(behavior, ([flags, scope, binding] as unknown[]).concat(evalList(flags, scope, locator, this.args)));
   }
 
   public unbind(flags: LifecycleFlags, scope: IScope, binding: IConnectableBinding): void {
@@ -1281,10 +1281,10 @@ function isNumeric(value: unknown): value is number {
   const valueType = typeof value;
   if (valueType === 'number') return true;
   if (valueType !== 'string') return false;
-  const len = (<string>value).length;
+  const len = (value as string).length;
   if (len === 0) return false;
   for (let i = 0; i < len; ++i) {
-    const char = (<string>value).charCodeAt(i);
+    const char = (value as string).charCodeAt(i);
     if (char < 0x30 /*0*/ || char > 0x39/*9*/) {
       return false;
     }

--- a/packages/runtime/src/binding/collection-observer.ts
+++ b/packages/runtime/src/binding/collection-observer.ts
@@ -37,14 +37,14 @@ function resetIndexMapKeyed(this: ICollectionObserver<CollectionKind.keyed>): vo
 }
 
 function getLengthObserver(this: CollectionObserver): CollectionLengthObserver {
-  return this.lengthObserver === undefined ? (this.lengthObserver = new CollectionLengthObserver(<Collection&ICollectionObserver<CollectionKind>>this, this.lengthPropertyName)) : this.lengthObserver as CollectionLengthObserver;
+  return this.lengthObserver === undefined ? (this.lengthObserver = new CollectionLengthObserver(this as Collection&ICollectionObserver<CollectionKind>, this.lengthPropertyName)) : this.lengthObserver as CollectionLengthObserver;
 }
 
 export function collectionObserver(kind: CollectionKind.array | CollectionKind.set | CollectionKind.map): ClassDecorator {
   return function(target: Function): void {
     subscriberCollection(MutationKind.collection)(target);
     batchedSubscriberCollection()(target);
-    const proto = <CollectionObserver>target.prototype;
+    const proto = target.prototype as CollectionObserver;
 
     proto.$nextFlush = null;
 

--- a/packages/runtime/src/binding/element-observation.ts
+++ b/packages/runtime/src/binding/element-observation.ts
@@ -338,7 +338,7 @@ export class SelectValueObserver implements SelectValueObserver {
       this.arrayObserver = null;
     }
     if (isArray) {
-      this.arrayObserver = this.observerLocator.getArrayObserver(<unknown[]>newValue);
+      this.arrayObserver = this.observerLocator.getArrayObserver(newValue as unknown[]);
       this.arrayObserver.subscribeBatched(this);
     }
     this.synchronizeOptions();
@@ -389,7 +389,7 @@ export class SelectValueObserver implements SelectValueObserver {
       const option = options[i];
       const optionValue = option.hasOwnProperty('model') ? option.model : option.value;
       if (isArray) {
-        option.selected = (<unknown[]>currentValue).findIndex(item => !!matcher(optionValue, item)) !== -1;
+        option.selected = (currentValue as unknown[]).findIndex(item => !!matcher(optionValue, item)) !== -1;
         continue;
       }
       option.selected = !!matcher(optionValue, currentValue);

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -175,17 +175,17 @@ export class ObserverLocator implements IObserverLocator {
       }
 
       if (propertyName === 'style' || propertyName === 'css') {
-        return new StyleAttributeAccessor(this.lifecycle, <IHTMLElement>obj);
+        return new StyleAttributeAccessor(this.lifecycle, obj as IHTMLElement);
       }
 
       const tagName = obj['tagName'];
       const handler = this.eventManager.getElementHandler(obj, propertyName);
       if (propertyName === 'value' && tagName === 'SELECT') {
-        return new SelectValueObserver(this.lifecycle, <ISelectElement>obj, handler, this);
+        return new SelectValueObserver(this.lifecycle, obj as ISelectElement, handler, this);
       }
 
       if (propertyName === 'checked' && tagName === 'INPUT') {
-        return new CheckedObserver(this.lifecycle, <IInputElement>obj, handler, this);
+        return new CheckedObserver(this.lifecycle, obj as IInputElement, handler, this);
       }
 
       if (handler) {
@@ -194,7 +194,7 @@ export class ObserverLocator implements IObserverLocator {
 
       const xlinkResult = /^xlink:(.+)$/.exec(propertyName);
       if (xlinkResult) {
-        return new XLinkAttributeAccessor(this.lifecycle, <IHTMLElement>obj, propertyName, xlinkResult[1]);
+        return new XLinkAttributeAccessor(this.lifecycle, obj as IHTMLElement, propertyName, xlinkResult[1]);
       }
 
       if (propertyName === 'role'
@@ -209,17 +209,17 @@ export class ObserverLocator implements IObserverLocator {
     switch (tag) {
       case '[object Array]':
         if (propertyName === 'length') {
-          return this.getArrayObserver(<IObservedArray>obj).getLengthObserver();
+          return this.getArrayObserver(obj as IObservedArray).getLengthObserver();
         }
         return this.dirtyChecker.createProperty(obj, propertyName);
       case '[object Map]':
         if (propertyName === 'size') {
-          return this.getMapObserver(<IObservedMap>obj).getLengthObserver();
+          return this.getMapObserver(obj as IObservedMap).getLengthObserver();
         }
         return this.dirtyChecker.createProperty(obj, propertyName);
       case '[object Set]':
         if (propertyName === 'size') {
-          return this.getSetObserver(<IObservedSet>obj).getLengthObserver();
+          return this.getSetObserver(obj as IObservedSet).getLengthObserver();
         }
         return this.dirtyChecker.createProperty(obj, propertyName);
     }
@@ -252,11 +252,11 @@ export class ObserverLocator implements IObserverLocator {
 export function getCollectionObserver(lifecycle: ILifecycle, collection: IObservedMap | IObservedSet | IObservedArray): CollectionObserver {
   switch (toStringTag.call(collection)) {
     case '[object Array]':
-      return getArrayObserver(lifecycle, <IObservedArray>collection);
+      return getArrayObserver(lifecycle, collection as IObservedArray);
     case '[object Map]':
-      return getMapObserver(lifecycle, <IObservedMap>collection);
+      return getMapObserver(lifecycle, collection as IObservedMap);
     case '[object Set]':
-      return getSetObserver(lifecycle, <IObservedSet>collection);
+      return getSetObserver(lifecycle, collection as IObservedSet);
   }
   return null;
 }

--- a/packages/runtime/src/binding/property-observation.ts
+++ b/packages/runtime/src/binding/property-observation.ts
@@ -32,7 +32,7 @@ export class PrimitiveObserver implements IAccessor, ISubscribable<MutationKind.
   }
 
   private getStringLength(): number {
-    return (<string>this.obj).length;
+    return (this.obj as string).length;
   }
   private returnUndefined(): undefined {
     return undefined;

--- a/packages/runtime/src/binding/property-observer.ts
+++ b/packages/runtime/src/binding/property-observer.ts
@@ -37,7 +37,7 @@ function dispose(this: PropertyObserver): void {
 export function propertyObserver(): ClassDecorator {
   return function(target: Function): void {
     subscriberCollection(MutationKind.instance)(target);
-    const proto = <PropertyObserver>target.prototype;
+    const proto = target.prototype as PropertyObserver;
 
     proto.observing = false;
     proto.obj = null;

--- a/packages/runtime/src/binding/resources/self-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/self-binding-behavior.ts
@@ -7,7 +7,7 @@ import { Listener } from '../listener';
 
 /*@internal*/
 export function handleSelfEvent(this: SelfableBinding, event: Event): ReturnType<Listener['callSource']> {
-  const target = <INode><unknown>findOriginalEventTarget(event);
+  const target = findOriginalEventTarget(event) as unknown as INode;
 
   if (this.target !== target) {
     return;

--- a/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/update-trigger-binding-behavior.ts
@@ -36,7 +36,7 @@ export class UpdateTriggerBindingBehavior {
     }
 
     // ensure the binding's target observer has been set.
-    const targetObserver = <UpdateTriggerableObserver>this.observerLocator.getObserver(binding.target, binding.targetProperty);
+    const targetObserver = this.observerLocator.getObserver(binding.target, binding.targetProperty) as UpdateTriggerableObserver;
     if (!targetObserver.handler) {
       throw Reporter.error(10);
     }

--- a/packages/runtime/src/binding/subscriber-collection.ts
+++ b/packages/runtime/src/binding/subscriber-collection.ts
@@ -6,7 +6,7 @@ import {
 
 export function subscriberCollection<T extends MutationKind>(mutationKind: T): ClassDecorator {
   return function(target: Function): void {
-    const proto = <ISubscriberCollection<MutationKind.instance | MutationKind.collection>>target.prototype;
+    const proto = target.prototype as ISubscriberCollection<MutationKind.instance | MutationKind.collection>;
 
     proto._subscriberFlags = SubscriberFlags.None;
     proto._subscriber0 = null;
@@ -183,7 +183,7 @@ function hasSubscriber<T extends MutationKind>(this: ISubscriberCollection<T>, s
 
 export function batchedSubscriberCollection(): ClassDecorator {
   return function(target: Function): void {
-    const proto = <IBatchedSubscriberCollection<MutationKind.collection>>target.prototype;
+    const proto = target.prototype as IBatchedSubscriberCollection<MutationKind.collection>;
 
     proto._batchedSubscriberFlags = SubscriberFlags.None;
     proto._batchedSubscriber0 = null;

--- a/packages/runtime/src/binding/target-accessors.ts
+++ b/packages/runtime/src/binding/target-accessors.ts
@@ -117,7 +117,7 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
     if (newValue !== null) {
       if (newValue instanceof Object) {
         let value;
-        for (style in (<Object>newValue)) {
+        for (style in (newValue as Object)) {
           if (newValue.hasOwnProperty(style)) {
             value = newValue[style];
             style = style.replace(/([A-Z])/g, m => `-${m.toLowerCase()}`);
@@ -125,7 +125,7 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
             this._setProperty(style, value);
           }
         }
-      } else if ((<string>newValue).length) {
+      } else if ((newValue as string).length) {
         const rx = /\s*([\w\-]+)\s*:\s*((?:(?:[\w\-]+\(\s*(?:"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[\w\-]+\(\s*(?:[^"](?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^\)]*)\),?|[^\)]*)\),?|"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^;]*),?\s*)+);?/g;
         let pair;
         while ((pair = rx.exec(newValue)) !== null) {

--- a/packages/runtime/src/binding/target-observer.ts
+++ b/packages/runtime/src/binding/target-observer.ts
@@ -56,7 +56,7 @@ function dispose(this: BindingTargetAccessor): void {
 export function targetObserver(defaultValue: unknown = null): ClassDecorator {
   return function(target: Function): void {
     subscriberCollection(MutationKind.instance)(target);
-    const proto = <BindingTargetAccessor>target.prototype;
+    const proto = target.prototype as BindingTargetAccessor;
 
     proto.$nextFlush = null;
 

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -245,9 +245,9 @@ class DefaultTemplateDefinition implements Required<ITemplateDefinition> {
     this.cache = 0;
     this.build = buildNotRequired;
     this.bindables = PLATFORM.emptyObject;
-    this.instructions = <this['instructions']>PLATFORM.emptyArray;
-    this.dependencies = <this['dependencies']>PLATFORM.emptyArray;
-    this.surrogates = <this['surrogates']>PLATFORM.emptyArray;
+    this.instructions = PLATFORM.emptyArray as this['instructions'];
+    this.dependencies = PLATFORM.emptyArray as this['dependencies'];
+    this.surrogates = PLATFORM.emptyArray as this['surrogates'];
     this.containerless = false;
     this.shadowOptions = null;
     this.hasSlots = false;
@@ -318,7 +318,7 @@ export function buildTemplateDefinition(
     case 10: if (containerless !== null) def.containerless = containerless;
     case 9: if (surrogates !== null) def.surrogates = PLATFORM.toArray(surrogates);
     case 8: if (dependencies !== null) def.dependencies = PLATFORM.toArray(dependencies);
-    case 7: if (instructions !== null) def.instructions = <TargetedInstruction[][]>PLATFORM.toArray(instructions);
+    case 7: if (instructions !== null) def.instructions = PLATFORM.toArray(instructions) as TargetedInstruction[][];
     case 6: if (bindables !== null) def.bindables = { ...bindables };
     case 5: if (build !== null) def.build = build === true ? buildRequired : build === false ? buildNotRequired : { ...build };
     case 4: if (cache !== null) def.cache = cache;

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -115,50 +115,50 @@ export interface INodeObserver {
 export const DOM = {
   createDocumentFragment(markupOrNode?: string | IElement): IDocumentFragment {
     if (markupOrNode === undefined || markupOrNode === null) {
-      return <IDocumentFragment>document.createDocumentFragment();
+      return document.createDocumentFragment() as IDocumentFragment;
     }
-    if ((<IElement>markupOrNode).nodeType > 0) {
-      if ((<IElement>markupOrNode).content !== undefined) {
-        return (<IElement>markupOrNode).content;
+    if ((markupOrNode as IElement).nodeType > 0) {
+      if ((markupOrNode as IElement).content !== undefined) {
+        return (markupOrNode as IElement).content;
       }
       const fragment = document.createDocumentFragment();
-      fragment.appendChild(<any>markupOrNode);
-      return <IDocumentFragment>fragment;
+      fragment.appendChild(markupOrNode as any);
+      return fragment as IDocumentFragment;
     }
-    return DOM.createTemplate(<string>markupOrNode).content;
+    return DOM.createTemplate(markupOrNode as string).content;
   },
   createTemplate(markup?: string): IElement {
     if (markup === undefined) {
-      return <IElement>document.createElement('template');
+      return document.createElement('template') as IElement;
     }
     const template = document.createElement('template');
     template.innerHTML = markup;
-    return <IElement>template;
+    return template as IElement;
   },
   addClass(node: INode, className: string): void {
-    (<any>node).classList.add(className);
+    (node as any).classList.add(className);
   },
   addEventListener(eventName: string, subscriber: any, publisher?: INode, options?: any): void {
-    ((<any>publisher) || document).addEventListener(eventName, subscriber, options);
+    ((publisher as any) || document).addEventListener(eventName, subscriber, options);
   },
   appendChild(parent: INode, child: INode): void {
-    (<any>parent).appendChild(child);
+    (parent as any).appendChild(child);
   },
   attachShadow(host: IElement, options: ShadowRootInit): IDocumentFragment {
-    return (<any>host).attachShadow(options);
+    return (host as any).attachShadow(options);
   },
   cloneNode<T extends INode = INode>(node: T, deep?: boolean): T {
-    return (<any>node).cloneNode(deep !== false); // use true unless the caller explicitly passes in false
+    return (node as any).cloneNode(deep !== false); // use true unless the caller explicitly passes in false
   },
   convertToRenderLocation(node: INode): IRenderLocation {
     if (isRenderLocation(node)) {
       return node; // it's already a RenderLocation (converted by FragmentNodeSequence)
     }
-    if ((<any>node).parentNode === null) {
+    if ((node as any).parentNode === null) {
       throw Reporter.error(52);
     }
-    const locationEnd = <IRenderLocation>document.createComment('au-end');
-    const locationStart = <IRenderLocation>document.createComment('au-start');
+    const locationEnd = document.createComment('au-end') as IRenderLocation;
+    const locationStart = document.createComment('au-start') as IRenderLocation;
     DOM.replaceNode(locationEnd, node);
     DOM.insertBefore(locationStart, locationEnd);
     locationEnd.$start = locationStart;
@@ -166,30 +166,30 @@ export const DOM = {
     return locationEnd;
   },
   createComment(text: string): IComment {
-    return <IComment>document.createComment(text);
+    return document.createComment(text) as IComment;
   },
   createElement(name: string): IElement {
     return document.createElement(name);
   },
   createNodeObserver(target: INode, callback: MutationCallback, options: MutationObserverInit): MutationObserver {
     const observer = new MutationObserver(callback);
-    observer.observe(<any>target, options);
+    observer.observe(target as any, options);
     return observer;
   },
   createTextNode(text: string): IText {
-    return <IText>document.createTextNode(text);
+    return document.createTextNode(text) as IText;
   },
   getAttribute(node: INode, name: string): any {
-    return (<any>node).getAttribute(name);
+    return (node as any).getAttribute(name);
   },
   hasClass(node: INode, className: string): boolean {
-    return (<any>node).classList.contains(className);
+    return (node as any).classList.contains(className);
   },
   insertBefore(nodeToInsert: INode, referenceNode: INode): void {
-    (<any>referenceNode).parentNode.insertBefore(nodeToInsert, referenceNode);
+    (referenceNode as any).parentNode.insertBefore(nodeToInsert, referenceNode);
   },
   isAllWhitespace(node: INode): boolean {
-    if ((<any>node).auInterpolationTarget === true) {
+    if ((node as any).auInterpolationTarget === true) {
       return false;
     }
     const text = node.textContent;
@@ -232,32 +232,32 @@ export const DOM = {
     container.registerResolver(SVGElement, resolver);
   },
   remove(node: INodeLike): void {
-    if ((<any>node).remove) {
-      (<any>node).remove();
+    if ((node as any).remove) {
+      (node as any).remove();
     } else {
-      (<any>node).parentNode.removeChild(node);
+      (node as any).parentNode.removeChild(node);
     }
   },
   removeAttribute(node: INode, name: string): void {
-    (<any>node).removeAttribute(name);
+    (node as any).removeAttribute(name);
   },
   removeClass(node: INode, className: string): void {
-    (<any>node).classList.remove(className);
+    (node as any).classList.remove(className);
   },
   removeEventListener(eventName: string, subscriber: any, publisher?: INode, options?: any): void {
-    ((<any>publisher) || document).removeEventListener(eventName, subscriber, options);
+    ((publisher as any) || document).removeEventListener(eventName, subscriber, options);
   },
   replaceNode(newChild: INode, oldChild: INode): void {
     if (oldChild.parentNode) {
-      (<any>oldChild).parentNode.replaceChild(newChild, oldChild);
+      (oldChild as any).parentNode.replaceChild(newChild, oldChild);
     }
   },
   setAttribute(node: INode, name: string, value: any): void {
-    (<any>node).setAttribute(name, value);
+    (node as any).setAttribute(name, value);
   },
   treatAsNonWhitespace(node: INode): void {
     // see isAllWhitespace above
-    (<any>node).auInterpolationTarget = true;
+    (node as any).auInterpolationTarget = true;
   }
 };
 
@@ -303,15 +303,15 @@ export class TextNodeSequence implements INodeSequence {
   }
 
   public insertBefore(refNode: INode): void {
-    (<any>refNode).parentNode.insertBefore(this.firstChild, refNode);
+    (refNode as any).parentNode.insertBefore(this.firstChild, refNode);
   }
 
   public appendTo(parent: INode): void {
-    (<any>parent).appendChild(this.firstChild);
+    (parent as any).appendChild(this.firstChild);
   }
 
   public remove(): void {
-    (<any>this.firstChild).remove();
+    (this.firstChild as any).remove();
   }
 }
 // tslint:enable:no-any
@@ -335,7 +335,7 @@ export class FragmentNodeSequence implements INodeSequence {
   constructor(fragment: IDocumentFragment) {
     this.fragment = fragment;
     // tslint:disable-next-line:no-any
-    const targetNodeList = (<any>fragment).querySelectorAll('.au');
+    const targetNodeList = (fragment as any).querySelectorAll('.au');
     let i = 0;
     let ii = targetNodeList.length;
     const targets = this.targets = Array(ii);
@@ -375,7 +375,7 @@ export class FragmentNodeSequence implements INodeSequence {
 
   public insertBefore(refNode: IRenderLocation): void {
     // tslint:disable-next-line:no-any
-    (<any>refNode).parentNode.insertBefore(this.fragment, refNode);
+    (refNode as any).parentNode.insertBefore(this.fragment, refNode);
     // internally we could generally assume that this is an IRenderLocation,
     // but since this is also public API we still need to double check
     // (or horrible things might happen)
@@ -399,7 +399,7 @@ export class FragmentNodeSequence implements INodeSequence {
 
   public appendTo(parent: INode): void {
     // tslint:disable-next-line:no-any
-    (<any>parent).appendChild(this.fragment);
+    (parent as any).appendChild(this.fragment);
     // this can never be a RenderLocation, and if for whatever reason we moved
     // from a RenderLocation to a host, make sure "start" and "end" are null
     this.start = this.end = null;
@@ -417,7 +417,7 @@ export class FragmentNodeSequence implements INodeSequence {
       while (current !== end) {
         next = current.nextSibling;
         // tslint:disable-next-line:no-any
-        (<any>fragment).appendChild(current);
+        (fragment as any).appendChild(current);
         current = next;
       }
       this.start.$nodes = null;
@@ -433,7 +433,7 @@ export class FragmentNodeSequence implements INodeSequence {
         while (current !== null) {
           next = current.nextSibling;
           // tslint:disable-next-line:no-any
-          (<any>fragment).appendChild(current);
+          (fragment as any).appendChild(current);
 
           if (current === end) {
             break;
@@ -472,7 +472,7 @@ export class NodeSequenceFactory {
           if (text.nodeType === TEXT_NODE && text.textContent === ' ') {
             text.textContent = '';
             this.deepClone = false;
-            this.node = <ICloneableNode>text;
+            this.node = text as ICloneableNode;
             this.Type = TextNodeSequence;
             return;
           }
@@ -480,7 +480,7 @@ export class NodeSequenceFactory {
       // falls through if not returned
       default:
         this.deepClone = true;
-        this.node = <ICloneableNode>fragment;
+        this.node = fragment as ICloneableNode;
         this.Type = FragmentNodeSequence;
     }
   }
@@ -525,4 +525,4 @@ export class AuMarker implements INode {
   proto.childNodes = PLATFORM.emptyArray;
   proto.nodeName = 'AU-M';
   proto.nodeType = ELEMENT_NODE;
-})(<Writable<AuMarker>>AuMarker.prototype);
+})(AuMarker.prototype as Writable<AuMarker>);

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -18,9 +18,9 @@ import { IInstructionRenderer, instructionRenderer, IRenderer, IRenderingEngine 
 
 export function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TFrom, bindingType: BindingType): Exclude<TFrom, string> {
   if (typeof srcOrExpr === 'string') {
-    return <Exclude<TFrom, string>><unknown>parser.parse(srcOrExpr, bindingType);
+    return parser.parse(srcOrExpr, bindingType) as unknown as Exclude<TFrom, string>;
   }
-  return <Exclude<TFrom, string>>srcOrExpr;
+  return srcOrExpr as Exclude<TFrom, string>;
 }
 
 export function addBindable(renderable: IBindables, bindable: IBindScope): void {
@@ -203,7 +203,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
 
   public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IStylePropertyBindingInstruction): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
-    const bindable = new Binding(expr, (<INode & {style: IBindingTarget}>target).style, instruction.to, BindingMode.toView, this.observerLocator, context);
+    const bindable = new Binding(expr, (target as INode & {style: IBindingTarget}).style, instruction.to, BindingMode.toView, this.observerLocator, context);
     addBindable(renderable, bindable);
   }
 }
@@ -347,20 +347,20 @@ export class LetElementRenderer implements IInstructionRenderer {
 export const HtmlRenderer = {
   register(container: IContainer): void {
     container.register(
-      <IRegistry><unknown>TextBindingRenderer,
-      <IRegistry><unknown>InterpolationBindingRenderer,
-      <IRegistry><unknown>PropertyBindingRenderer,
-      <IRegistry><unknown>IteratorBindingRenderer,
-      <IRegistry><unknown>ListenerBindingRenderer,
-      <IRegistry><unknown>CallBindingRenderer,
-      <IRegistry><unknown>RefBindingRenderer,
-      <IRegistry><unknown>StylePropertyBindingRenderer,
-      <IRegistry><unknown>SetPropertyRenderer,
-      <IRegistry><unknown>SetAttributeRenderer,
-      <IRegistry><unknown>CustomElementRenderer,
-      <IRegistry><unknown>CustomAttributeRenderer,
-      <IRegistry><unknown>TemplateControllerRenderer,
-      <IRegistry><unknown>LetElementRenderer
+      TextBindingRenderer as unknown as IRegistry,
+      InterpolationBindingRenderer as unknown as IRegistry,
+      PropertyBindingRenderer as unknown as IRegistry,
+      IteratorBindingRenderer as unknown as IRegistry,
+      ListenerBindingRenderer as unknown as IRegistry,
+      CallBindingRenderer as unknown as IRegistry,
+      RefBindingRenderer as unknown as IRegistry,
+      StylePropertyBindingRenderer as unknown as IRegistry,
+      SetPropertyRenderer as unknown as IRegistry,
+      SetAttributeRenderer as unknown as IRegistry,
+      CustomElementRenderer as unknown as IRegistry,
+      CustomAttributeRenderer as unknown as IRegistry,
+      TemplateControllerRenderer as unknown as IRegistry,
+      LetElementRenderer as unknown as IRegistry
     );
   }
 };

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -714,11 +714,11 @@ export class Lifecycle implements ILifecycle {
     this.flushHead = this;
     this.flushTail = this;
 
-    this.connectHead = <IConnectableBinding><unknown>this; // this cast is safe because we know exactly which properties we'll use
-    this.connectTail = <IConnectableBinding><unknown>this;
+    this.connectHead = this as unknown as IConnectableBinding; // this cast is safe because we know exactly which properties we'll use
+    this.connectTail = this as unknown as IConnectableBinding;
 
-    this.patchHead = <IConnectableBinding><unknown>this;
-    this.patchTail = <IConnectableBinding><unknown>this;
+    this.patchHead = this as unknown as IConnectableBinding;
+    this.patchTail = this as unknown as IConnectableBinding;
 
     this.boundHead = this;
     this.boundTail = this;
@@ -879,7 +879,7 @@ export class Lifecycle implements ILifecycle {
     if (this.connectCount > 0) {
       this.connectCount = 0;
       let current = this.connectHead.$nextConnect;
-      this.connectHead = this.connectTail = <IConnectableBinding><unknown>this;
+      this.connectHead = this.connectTail = this as unknown as IConnectableBinding;
       let next: typeof current;
       do {
         current.connect(flags);
@@ -901,7 +901,7 @@ export class Lifecycle implements ILifecycle {
     while (this.patchCount > 0) {
       this.patchCount = 0;
       let current = this.patchHead.$nextPatch;
-      this.patchHead = this.patchTail = <IConnectableBinding><unknown>this;
+      this.patchHead = this.patchTail = this as unknown as IConnectableBinding;
       let next: typeof current;
       do {
         current.patch(flags);

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -81,7 +81,7 @@ function define<T>(this: ICustomAttributeResource, name: string, ctor: T): T & I
 function define<T>(this: ICustomAttributeResource, definition: IAttributeDefinition, ctor: T): T & ICustomAttributeType;
 function define<T>(this: ICustomAttributeResource, nameOrDefinition: string | IAttributeDefinition, ctor: T): T & ICustomAttributeType {
   const Type = ctor as T & Writable<ICustomAttributeType>;
-  const description = createCustomAttributeDescription(typeof nameOrDefinition === 'string' ? { name: nameOrDefinition } : nameOrDefinition, <T & ICustomAttributeType>Type);
+  const description = createCustomAttributeDescription(typeof nameOrDefinition === 'string' ? { name: nameOrDefinition } : nameOrDefinition, Type as T & ICustomAttributeType);
   const proto: Writable<ICustomAttribute> = Type.prototype;
 
   Type.kind = CustomAttributeResource;
@@ -135,7 +135,7 @@ function define<T>(this: ICustomAttributeResource, nameOrDefinition: string | IA
     proto.$nextDetached = null;
   }
 
-  return <ICustomAttributeType & T>Type;
+  return Type as ICustomAttributeType & T;
 }
 
 export const CustomAttributeResource: ICustomAttributeResource = {

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -73,7 +73,7 @@ export function useShadowDOM<T extends Constructable>(targetOrOptions?: (T & Has
 
   function useShadowDOMDecorator(target: T & HasShadowOptions): T & Required<HasShadowOptions> {
     target.shadowOptions = options;
-    return <T & Required<HasShadowOptions>>target;
+    return target as T & Required<HasShadowOptions>;
   }
 
   return typeof targetOrOptions === 'function' ? useShadowDOMDecorator(targetOrOptions) : useShadowDOMDecorator;
@@ -83,7 +83,7 @@ type HasContainerless = Pick<ITemplateDefinition, 'containerless'>;
 
 function containerlessDecorator<T extends Constructable>(target: T & HasContainerless): T & Required<HasContainerless> {
   target.containerless = true;
-  return <T & Required<HasContainerless>>target;
+  return target as T & Required<HasContainerless>;
 }
 
 /**
@@ -109,7 +109,7 @@ function define<T>(this: ICustomElementResource, nameOrDefinition: string | ITem
     throw Reporter.error(70);
   }
   const Type = (ctor === null ? class HTMLOnlyElement { /* HTML Only */ } : ctor) as T & Writable<ICustomElementType>;
-  const description = buildTemplateDefinition(<ICustomElementType><unknown>Type, nameOrDefinition);
+  const description = buildTemplateDefinition(Type as unknown as ICustomElementType, nameOrDefinition);
   const proto: Writable<ICustomElement> = Type.prototype;
 
   Type.kind = CustomElementResource;
@@ -176,14 +176,14 @@ function define<T>(this: ICustomElementResource, nameOrDefinition: string | ITem
     proto.$nextDetached = null;
   }
 
-  return <ICustomElementType & T>Type;
+  return Type as ICustomElementType & T;
 }
 
 export const CustomElementResource: ICustomElementResource = {
   name: customElementName,
   keyFrom: customElementKey,
   isType,
-  behaviorFor: <ICustomElementResource['behaviorFor']>customElementBehavior,
+  behaviorFor: customElementBehavior as ICustomElementResource['behaviorFor'],
   define
 };
 

--- a/packages/runtime/src/templating/lifecycle-attach.ts
+++ b/packages/runtime/src/templating/lifecycle-attach.ts
@@ -28,7 +28,7 @@ export function $attachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
   this.$state &= ~State.isAttaching;
 
   if (hooks & Hooks.hasAttached) {
-    lifecycle.enqueueAttached(<Required<typeof this>>this);
+    lifecycle.enqueueAttached(this as Required<typeof this>);
   }
   lifecycle.endAttach(flags);
 }
@@ -65,7 +65,7 @@ export function $attachElement(this: Writable<ICustomElement>, flags: LifecycleF
   this.$state &= ~State.isAttaching;
 
   if (hooks & Hooks.hasAttached) {
-    lifecycle.enqueueAttached(<Required<typeof this>>this);
+    lifecycle.enqueueAttached(this as Required<typeof this>);
   }
   lifecycle.endAttach(flags);
 }
@@ -111,7 +111,7 @@ export function $detachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
     this.$state &= ~(State.isAttached | State.isDetaching);
 
     if (hooks & Hooks.hasDetached) {
-      lifecycle.enqueueDetached(<Required<typeof this>>this);
+      lifecycle.enqueueDetached(this as Required<typeof this>);
     }
     lifecycle.endDetach(flags);
   }
@@ -150,7 +150,7 @@ export function $detachElement(this: Writable<ICustomElement>, flags: LifecycleF
     this.$state &= ~(State.isAttached | State.isDetaching);
 
     if (hooks & Hooks.hasDetached) {
-      lifecycle.enqueueDetached(<Required<typeof this>>this);
+      lifecycle.enqueueDetached(this as Required<typeof this>);
     }
     lifecycle.endDetach(flags);
   }

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -189,7 +189,7 @@ export class RenderingEngine implements IRenderingEngine {
 
       //If the element has a view, support Recursive Components by adding self to own view template container.
       if (found.renderContext !== null && componentType) {
-        componentType.register(<ExposedContext>found.renderContext);
+        componentType.register(found.renderContext as ExposedContext);
       }
 
       this.templateLookup.set(definition, found);
@@ -228,7 +228,7 @@ export class RenderingEngine implements IRenderingEngine {
   }
 
   private templateFromSource(definition: TemplateDefinition, parentContext?: IRenderContext): ITemplate {
-    parentContext = parentContext || <ExposedContext>this.container;
+    parentContext = parentContext || this.container as ExposedContext;
 
     if (definition && definition.template) {
       if (definition.build.required) {
@@ -239,7 +239,7 @@ export class RenderingEngine implements IRenderingEngine {
           throw Reporter.error(20, compilerName);
         }
 
-        definition = compiler.compile(<ITemplateDefinition>definition, new RuntimeCompilationResources(<ExposedContext>parentContext), ViewCompileFlags.surrogate);
+        definition = compiler.compile(definition as ITemplateDefinition, new RuntimeCompilationResources(parentContext as ExposedContext), ViewCompileFlags.surrogate);
       }
 
       return new CompiledTemplate(this, parentContext, definition);
@@ -535,8 +535,8 @@ export class CompiledTemplate implements ITemplate {
   }
 
   public render(renderable: IRenderable, host?: INode, parts?: TemplatePartDefinitions): void {
-    const nodes = (<Writable<IRenderable>>renderable).$nodes = this.factory.createNodeSequence();
-    (<Writable<IRenderable>>renderable).$context = this.renderContext;
+    const nodes = (renderable as Writable<IRenderable>).$nodes = this.factory.createNodeSequence();
+    (renderable as Writable<IRenderable>).$context = this.renderContext;
     this.renderContext.render(renderable, nodes.findTargets(), this.templateDefinition, host, parts);
   }
 }
@@ -546,8 +546,8 @@ export class CompiledTemplate implements ITemplate {
 export const noViewTemplate: ITemplate = {
   renderContext: null,
   render(renderable: IRenderable): void {
-    (<Writable<IRenderable>>renderable).$nodes = NodeSequence.empty;
-    (<Writable<IRenderable>>renderable).$context = null;
+    (renderable as Writable<IRenderable>).$nodes = NodeSequence.empty;
+    (renderable as Writable<IRenderable>).$context = null;
   }
 };
 
@@ -555,7 +555,7 @@ export const noViewTemplate: ITemplate = {
 export type ExposedContext = IRenderContext & IDisposable & IContainer;
 
 export function createRenderContext(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
-  const context = <ExposedContext>parentRenderContext.createChild();
+  const context = parentRenderContext.createChild() as ExposedContext;
   const renderableProvider = new InstanceProvider();
   const elementProvider = new InstanceProvider();
   const instructionProvider = new InstanceProvider<ITargetedInstruction>();

--- a/packages/runtime/src/templating/resources/repeat.ts
+++ b/packages/runtime/src/templating/resources/repeat.ts
@@ -49,8 +49,8 @@ export class Repeat<T extends ObservedCollection = IObservedArray> {
   public bound(flags: LifecycleFlags): void {
     let current = this.renderable.$bindableHead;
     while (current !== null) {
-      if ((<Binding>current).target === this && (<Binding>current).targetProperty === 'items') {
-        this.forOf = (<Binding>current).sourceExpression as ForOfStatement;
+      if ((current as Binding).target === this && (current as Binding).targetProperty === 'items') {
+        this.forOf = (current as Binding).sourceExpression as ForOfStatement;
         break;
       }
       current = current.$nextBind;

--- a/tslint.json
+++ b/tslint.json
@@ -244,7 +244,7 @@
     "file-header": false,  // enable this rule only if you are legally required to add a file header
     "import-blacklist": false,  // enable and configure this as you desire
     "interface-over-type-literal": false,  // there are plenty of reasons to prefer interfaces
-    "no-angle-bracket-type-assertion": false,  // pick either type-cast format and use it consistently
+    "no-angle-bracket-type-assertion": true,  // pick either type-cast format and use it consistently
     "no-inferred-empty-object-type": false,  // if the compiler is satisfied then this is probably not an issue
     "no-internal-module": false, // only enable this if you are not using internal modules
     "no-magic-numbers": false,  // by default it will find too many false positives


### PR DESCRIPTION
# Pull Request

## 📖 Description

Typescript has two ways of type assertion:
1. `variable as type`
2. `<type>variable`

In the codebase both ways are used interchangeably. For consistency it would be better to pick one and stick to it. After discussing it with @fkleuver we decided to go for the `as` style type assertion, because:
- When using TypeScript with JSX, only as-style assertions are allowed. ([Reference](https://www.typescriptlang.org/docs/handbook/basic-types.html))
- It reduces confusion when used in conjunction with Generics.

So this PR turns on the related linting rule and changes all type assertions to use the `as` style.

### 🎫 Issues

Related to #249.

## 👩‍💻 Reviewer Notes

Migration was done using the `--fix` option of `tslint`.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

See #249.
