### PR TITLE
Linting fixes

### DIFF
--- a/packages/debug/src/binding/unparser.ts
+++ b/packages/debug/src/binding/unparser.ts
@@ -32,12 +32,12 @@ export function enableImprovedExpressionDebugging(): void {
   astTypeMap.forEach(x => { adoptDebugMethods(x.type, x.name); });
 }
 
-/*@internal*/
+/** @internal */
 export function adoptDebugMethods($type: Unwrap<typeof astTypeMap>['type'], name: string): void {
   $type.prototype.toString = function(): string { return Unparser.unparse(this); };
 }
 
-/*@internal*/
+/** @internal */
 export class Unparser implements AST.IVisitor<void> {
   public text: string = '';
 
@@ -289,7 +289,7 @@ export class Unparser implements AST.IVisitor<void> {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class Serializer implements AST.IVisitor<string> {
   public static serialize(expr: AST.IExpression): string {
     const visitor = new Serializer();

--- a/packages/jit/src/attribute-parser.ts
+++ b/packages/jit/src/attribute-parser.ts
@@ -9,7 +9,7 @@ export interface IAttributeParser {
 export const IAttributeParser = DI.createInterface<IAttributeParser>()
   .withDefault(x => x.singleton(AttributeParser));
 
-/*@internal*/
+/** @internal */
 @inject(ISyntaxInterpreter, all(IAttributePattern))
 export class AttributeParser implements IAttributeParser {
   private interpreter: ISyntaxInterpreter;

--- a/packages/jit/src/attribute-pattern.ts
+++ b/packages/jit/src/attribute-pattern.ts
@@ -6,7 +6,7 @@ export interface AttributePatternDefinition {
   symbols: string;
 }
 
-/*@internal*/
+/** @internal */
 export interface ICharSpec {
   chars: string;
   repeat: boolean;
@@ -16,7 +16,7 @@ export interface ICharSpec {
   equals(other: ICharSpec): boolean;
 }
 
-/*@internal*/
+/** @internal */
 export class CharSpec implements ICharSpec {
   public chars: string;
   public repeat: boolean;
@@ -140,7 +140,7 @@ export class Interpretation {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class State {
   public charSpec: ICharSpec;
   public nextStates: State[];
@@ -217,13 +217,13 @@ export class State {
   }
 }
 
-/*@internal*/
+/** @internal */
 export interface ISegment {
   text: string;
   eachChar(callback: (spec: CharSpec) => void): void;
 }
 
-/*@internal*/
+/** @internal */
 export class StaticSegment implements ISegment {
   public text: string;
   private len: number;
@@ -246,7 +246,7 @@ export class StaticSegment implements ISegment {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class DynamicSegment implements ISegment {
   public text: string;
   private spec: CharSpec;
@@ -261,7 +261,7 @@ export class DynamicSegment implements ISegment {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class SymbolSegment implements ISegment {
   public text: string;
   private spec: CharSpec;
@@ -276,7 +276,7 @@ export class SymbolSegment implements ISegment {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class SegmentTypes {
   public statics: number;
   public dynamics: number;
@@ -298,7 +298,7 @@ export interface ISyntaxInterpreter {
 
 export const ISyntaxInterpreter = DI.createInterface<ISyntaxInterpreter>().withDefault(x => x.singleton(SyntaxInterpreter));
 
-/*@internal*/
+/** @internal */
 export class SyntaxInterpreter {
   public rootState: State;
   private initialStates: State[];

--- a/packages/jit/src/common.ts
+++ b/packages/jit/src/common.ts
@@ -1,4 +1,4 @@
-/*@internal*/
+/** @internal */
 export function unescapeCode(code: number): number {
   switch (code) {
     case Char.LowerB: return Char.Backspace;
@@ -14,7 +14,7 @@ export function unescapeCode(code: number): number {
   }
 }
 
-/*@internal*/
+/** @internal */
 export const enum Access {
   Reset                   = 0b0000000000000,
   Ancestor                = 0b0000111111111,
@@ -23,7 +23,7 @@ export const enum Access {
   Member                  = 0b0100000000000,
   Keyed                   = 0b1000000000000
 }
-/*@internal*/
+/** @internal */
 export const enum Precedence {
   Variadic                = 0b000111101,
   Assign                  = 0b000111110,
@@ -39,7 +39,7 @@ export const enum Precedence {
   Primary                 = 0b111000010,
   Unary                   = 0b111000011,
 }
-/*@internal*/
+/** @internal */
 export const enum Token {
   EOF                     = 0b110000000000_000_000000,
   ExpressionTerminal      = 0b100000000000_000_000000,
@@ -102,7 +102,7 @@ export const enum Token {
   OfKeyword               = 0b100000000101_000_101011
 }
 
-/*@internal*/
+/** @internal */
 export const enum Char {
   Null           = 0x00,
   Backspace      = 0x08,

--- a/packages/jit/src/element-parser.ts
+++ b/packages/jit/src/element-parser.ts
@@ -27,7 +27,7 @@ export interface IElementParser {
 export const IElementParser = DI.createInterface<IElementParser>()
   .withDefault(x => x.singleton(ElementParser));
 
-/*@internal*/
+/** @internal */
 @inject(IAttributeParser)
 export class ElementParser implements IElementParser {
   public attrParser: IAttributeParser;

--- a/packages/jit/src/expression-parser.ts
+++ b/packages/jit/src/expression-parser.ts
@@ -28,7 +28,7 @@ const $undefined = PrimitiveLiteral.$undefined;
 const $this = AccessThis.$this;
 const $parent = AccessThis.$parent;
 
-/*@internal*/
+/** @internal */
 export class ParserState {
   public index: number;
   public startIndex: number;
@@ -80,7 +80,7 @@ const enum SemanticError {
   UnexpectedForOf = 151
 }
 
-/*@internal*/
+/** @internal */
 export function parseCore(input: string, bindingType?: BindingType): IExpression {
   $state.input = input;
   $state.length = input.length;
@@ -89,7 +89,7 @@ export function parseCore(input: string, bindingType?: BindingType): IExpression
   return parse($state, Access.Reset, Precedence.Variadic, bindingType === undefined ? BindingType.BindCommand : bindingType);
 }
 
-/*@internal*/
+/** @internal */
 // JUSTIFICATION: This is performance-critical code which follows a subset of the well-known ES spec.
 // Knowing the spec, or parsers in general, will help with understanding this code and it is therefore not the
 // single source of information for being able to figure it out.

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -379,7 +379,7 @@ export const optional = createResolver((key: any, handler: IContainer, requestor
   }
 });
 
-/*@internal*/
+/** @internal */
 export const enum ResolverStrategy {
   instance = 0,
   singleton = 1,
@@ -389,7 +389,7 @@ export const enum ResolverStrategy {
   alias = 5
 }
 
-/*@internal*/
+/** @internal */
 export class Resolver implements IResolver, IRegistration {
   public key: any;
   public strategy: ResolverStrategy;
@@ -442,7 +442,7 @@ export class Resolver implements IResolver, IRegistration {
   }
 }
 
-/*@internal*/
+/** @internal */
 export interface IInvoker {
   invoke(container: IContainer, fn: Function, dependencies: Function[]): any;
   invokeWithDynamicDependencies(
@@ -453,7 +453,7 @@ export interface IInvoker {
   ): any;
 }
 
-/*@internal*/
+/** @internal */
 export class Factory implements IFactory {
   public Type: Function;
   private invoker: IInvoker;
@@ -500,7 +500,7 @@ export class Factory implements IFactory {
   }
 }
 
-/*@internal*/
+/** @internal */
 export interface IContainerConfiguration {
   factories?: Map<Function, IFactory>;
 }
@@ -515,7 +515,7 @@ function isRegistry(obj: IRegistry | Record<string, IRegistry>): obj is IRegistr
   return typeof obj.register === 'function';
 }
 
-/*@internal*/
+/** @internal */
 export class Container implements IContainer {
   private parent: Container | null;
   private resolvers: Map<any, IResolver>;
@@ -750,7 +750,7 @@ export const Registration = {
   }
 };
 
-/*@internal*/
+/** @internal */
 export function validateKey(key: unknown): void {
   // note: design:paramTypes which will default to Object if the param types cannot be statically analyzed by tsc
   // this check is intended to properly report on that problem - under no circumstance should Object be a valid key anyway
@@ -775,7 +775,7 @@ function buildAllResponse(resolver: IResolver, handler: IContainer, requestor: I
   return [resolver.resolve(handler, requestor)];
 }
 
-/*@internal*/
+/** @internal */
 export const classInvokers: IInvoker[] = [
   {
     invoke<T extends Constructable, K>(container: IContainer, Type: T): K {
@@ -826,13 +826,13 @@ export const classInvokers: IInvoker[] = [
   }
 ];
 
-/*@internal*/
+/** @internal */
 export const fallbackInvoker: IInvoker = {
   invoke: invokeWithDynamicDependencies as (container: IContainer, fn: Function, dependencies: Function[]) => any,
   invokeWithDynamicDependencies
 };
 
-/*@internal*/
+/** @internal */
 export function invokeWithDynamicDependencies<T extends Constructable, K>(
   container: IContainer,
   Type: T,

--- a/packages/plugin-requirejs/src/processing.ts
+++ b/packages/plugin-requirejs/src/processing.ts
@@ -23,7 +23,7 @@ export function processImports(toProcess: ITemplateImport[], relativeTo: string)
 
 const capitalMatcher = /([A-Z])/g;
 
-/*@internal*/
+/** @internal */
 export function addHyphenAndLower(char: string): string {
   return `-${char.toLowerCase()}`;
 }
@@ -131,7 +131,7 @@ export function loadFromFile(url: string, callback: (content: string) => void, e
   }
 }
 
-/*@internal*/
+/** @internal */
 export function trimDots(ary: string[]): void {
   for (let i = 0; i < ary.length; ++i) {
     const part = ary[i];

--- a/packages/plugin-requirejs/src/types.ts
+++ b/packages/plugin-requirejs/src/types.ts
@@ -3,18 +3,18 @@
 // [1] https://requirejs.org/docs/plugins.html#apiload
 // [2] https://github.com/aurelia/aurelia/pull/256
 
-/*@internal*/
+/** @internal */
 export type Require = {
   (name: string[], callback: (text: string) => void):
   void; toUrl(name: string): string;
 };
 
-/*@internal*/
+/** @internal */
 export type RequireConfig = {
   isBuild?: boolean;
 };
 
-/*@internal*/
+/** @internal */
 export type RequireOnLoad = {
   (content: string|{}): void;
   error?(error: Error): void;

--- a/packages/plugin-requirejs/src/view.ts
+++ b/packages/plugin-requirejs/src/view.ts
@@ -3,7 +3,7 @@ import { Require, RequireConfig, RequireOnLoad } from './types';
 
 const buildMap = {};
 
-/*@internal*/
+/** @internal */
 export function finishLoad(name: string, content: string, onLoad: (content: string) => void): void {
   buildMap[name] = content;
   onLoad(content);

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1292,7 +1292,7 @@ function isNumeric(value: unknown): value is number {
   return true;
 }
 
-/*@internal*/
+/** @internal */
 export const IterateForOfStatement = {
   ['[object Array]'](result: unknown[], func: (arr: Collection, index: number, item: unknown) => void): void {
     for (let i = 0, ii = result.length; i < ii; ++i) {
@@ -1330,7 +1330,7 @@ export const IterateForOfStatement = {
   }
 };
 
-/*@internal*/
+/** @internal */
 export const CountForOfStatement = {
   ['[object Array]'](result: unknown[]): number { return result.length; },
   ['[object Map]'](result: Map<unknown, unknown>): number { return result.size; },

--- a/packages/runtime/src/binding/binding-context.ts
+++ b/packages/runtime/src/binding/binding-context.ts
@@ -10,7 +10,7 @@ const enum RuntimeError {
   NilParentScope = 253
 }
 
-/*@internal*/
+/** @internal */
 export class InternalObserversLookup {
   public getOrCreate(obj: IBindingContext | IOverrideContext, key: string): PropertyObserver {
     let observer = this[key];

--- a/packages/runtime/src/binding/computed-observer.ts
+++ b/packages/runtime/src/binding/computed-observer.ts
@@ -144,7 +144,7 @@ export interface GetterObserver extends IBindingTargetObserver { }
 
 // Used when there is no setter, and the getter is dependent on other properties of the object;
 // Used when there is a setter but the value of the getter can change based on properties set outside of the setter.
-/*@internal*/
+/** @internal */
 @subscriberCollection(MutationKind.instance)
 export class GetterObserver implements GetterObserver {
   public dispose: () => void;
@@ -190,7 +190,7 @@ export class GetterObserver implements GetterObserver {
 
 GetterObserver.prototype.dispose = PLATFORM.noop;
 
-/*@internal*/
+/** @internal */
 export class GetterController {
   public value: unknown;
   public isCollecting: boolean;

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -36,7 +36,7 @@ export interface IConnectableBinding extends IPartialConnectableBinding {
   patch(flags: LifecycleFlags): void;
 }
 
-/*@internal*/
+/** @internal */
 export function addObserver(this: IConnectableBinding, observer: IBindingTargetObserver): void {
   // find the observer.
   const observerSlots = this.observerSlots === undefined ? 0 : this.observerSlots;
@@ -65,7 +65,7 @@ export function addObserver(this: IConnectableBinding, observer: IBindingTargetO
   ensureEnoughSlotNames(i);
 }
 
-/*@internal*/
+/** @internal */
 export function observeProperty(this: IConnectableBinding, obj: IIndexable, propertyName: string): void {
   const observer = this.observerLocator.getObserver(obj, propertyName) as IBindingTargetObserver;
   /* Note: we need to cast here because we can indeed get an accessor instead of an observer,
@@ -78,7 +78,7 @@ export function observeProperty(this: IConnectableBinding, obj: IIndexable, prop
   this.addObserver(observer);
 }
 
-/*@internal*/
+/** @internal */
 export function unobserve(this: IConnectableBinding, all?: boolean): void {
   const slots = this.observerSlots;
   let slotName: string;

--- a/packages/runtime/src/binding/dirty-checker.ts
+++ b/packages/runtime/src/binding/dirty-checker.ts
@@ -9,7 +9,7 @@ export interface IDirtyChecker {
 export const IDirtyChecker = DI.createInterface<IDirtyChecker>()
   .withDefault(x => x.singleton(DirtyChecker));
 
-/*@internal*/
+/** @internal */
 export class DirtyChecker {
   private checkDelay: number;
   private tracked: DirtyCheckProperty[];
@@ -62,7 +62,7 @@ export class DirtyChecker {
 
 export interface DirtyCheckProperty extends IBindingTargetObserver { }
 
-/*@internal*/
+/** @internal */
 @propertyObserver()
 export class DirtyCheckProperty implements DirtyCheckProperty {
   public obj: IObservable;

--- a/packages/runtime/src/binding/event-manager.ts
+++ b/packages/runtime/src/binding/event-manager.ts
@@ -6,7 +6,7 @@ export interface IEventWithStandardPropagation extends Event {
   standardStopPropagation?: Event['stopPropagation'];
 }
 
-/*@internal*/
+/** @internal */
 export type CompatibleEvent = {
   target?: EventTarget;
 
@@ -21,7 +21,7 @@ export type CompatibleEvent = {
 };
 
 //Note: path and deepPath are designed to handle v0 and v1 shadow dom specs respectively
-/*@internal*/
+/** @internal */
 export function findOriginalEventTarget(event: Event & CompatibleEvent): EventTarget {
   return (event.composedPath && event.composedPath()[0]) || (event.deepPath && event.deepPath()[0]) || (event.path && event.path[0]) || event.target;
 }
@@ -215,7 +215,7 @@ export interface IEventManager {
 export const IEventManager = DI.createInterface<IEventManager>()
   .withDefault(x => x.singleton(EventManager));
 
-/*@internal*/
+/** @internal */
 export class EventManager implements IEventManager {
   public elementHandlerLookup: Record<string, Record<string, string[]>> = {};
   public delegatedHandlers: Record<string, ListenerTracker> = {};

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -14,7 +14,7 @@ export interface IExpressionParser {
 export const IExpressionParser = DI.createInterface<IExpressionParser>()
   .withDefault(x => x.singleton(ExpressionParser));
 
-/*@internal*/
+/** @internal */
 export class ExpressionParser implements IExpressionParser {
   private expressionLookup: Record<string, IsBindingBehavior>;
   private forOfLookup: Record<string, ForOfStatement>;

--- a/packages/runtime/src/binding/observer-locator.ts
+++ b/packages/runtime/src/binding/observer-locator.ts
@@ -48,7 +48,7 @@ function getPropertyDescriptor(subject: object, name: string): PropertyDescripto
 }
 
 @inject(ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer)
-/*@internal*/
+/** @internal */
 export class ObserverLocator implements IObserverLocator {
   private adapters: IObjectObservationAdapter[];
   private dirtyChecker: IDirtyChecker;

--- a/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/debounce-binding-behavior.ts
@@ -19,14 +19,14 @@ export type DebounceableBinding = IBinding & {
 
 const unset = {};
 
-/*@internal*/
+/** @internal */
 export function debounceCallSource(this: DebounceableBinding, newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void {
   const state = this.debounceState;
   clearTimeout(state.timeoutId);
   state.timeoutId = setTimeout(() => { this.debouncedMethod(newValue, oldValue, flags); }, state.delay);
 }
 
-/*@internal*/
+/** @internal */
 export function debounceCall(this: DebounceableBinding, newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void {
   const state = this.debounceState;
   clearTimeout(state.timeoutId);

--- a/packages/runtime/src/binding/resources/self-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/self-binding-behavior.ts
@@ -5,7 +5,7 @@ import { bindingBehavior } from '../binding-behavior';
 import { findOriginalEventTarget } from '../event-manager';
 import { Listener } from '../listener';
 
-/*@internal*/
+/** @internal */
 export function handleSelfEvent(this: SelfableBinding, event: Event): ReturnType<Listener['callSource']> {
   const target = findOriginalEventTarget(event) as unknown as INode;
 

--- a/packages/runtime/src/binding/resources/throttle-binding-behavior.ts
+++ b/packages/runtime/src/binding/resources/throttle-binding-behavior.ts
@@ -14,7 +14,7 @@ export type ThrottleableBinding = IBinding & {
   };
 };
 
-/*@internal*/
+/** @internal */
 export function throttle(this: ThrottleableBinding, newValue: unknown): void {
   const state = this.throttleState;
   const elapsed = +new Date() - state.last;

--- a/packages/runtime/src/binding/signaler.ts
+++ b/packages/runtime/src/binding/signaler.ts
@@ -12,7 +12,7 @@ export interface ISignaler {
 
 export const ISignaler = DI.createInterface<ISignaler>().withDefault(x => x.singleton(Signaler));
 
-/*@internal*/
+/** @internal */
 export class Signaler implements ISignaler {
   public signals: Record<string, Set<IPropertySubscriber>>;
 

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -7,20 +7,20 @@ import { IResourceDefinition, ResourceDescription } from './resource';
 import { CustomElementConstructor, ICustomElement } from './templating/custom-element';
 import { ICustomElementHost } from './templating/lifecycle-render';
 
-/*@internal*/
+/** @internal */
 export const customElementName = 'custom-element';
-/*@internal*/
+/** @internal */
 export function customElementKey(name: string): string {
   return `${customElementName}:${name}`;
 }
-/*@internal*/
+/** @internal */
 export function customElementBehavior(node: ICustomElementHost): ICustomElement | null {
   return node.$customElement === undefined ? null : node.$customElement;
 }
 
-/*@internal*/
+/** @internal */
 export const customAttributeName = 'custom-attribute';
-/*@internal*/
+/** @internal */
 export function customAttributeKey(name: string): string {
   return `${customAttributeName}:${name}`;
 }
@@ -212,7 +212,7 @@ export interface ILetBindingInstruction extends ITargetedInstruction {
   to: string;
 }
 
-/*@internal*/
+/** @internal */
 export const buildRequired: IBuildInstruction = Object.freeze({
   required: true,
   compiler: 'default'

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -321,7 +321,7 @@ export class TextNodeSequence implements INodeSequence {
 // has an instance of this under the hood. Anyone who wants to create a node sequence from
 // a string of markup would also receive an instance of this.
 // CompiledTemplates create instances of FragmentNodeSequence.
-/*@internal*/
+/** @internal */
 export class FragmentNodeSequence implements INodeSequence {
   public firstChild: INode;
   public lastChild: INode;
@@ -495,7 +495,7 @@ export class NodeSequenceFactory {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class AuMarker implements INode {
   public get parentNode(): INode {
     return this.nextSibling.parentNode;

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -47,7 +47,7 @@ export function addAttachable(renderable: IAttachables, attachable: IAttach): vo
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.textBinding)
-/*@internal*/
+/** @internal */
 export class TextBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -74,7 +74,7 @@ export class TextBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.interpolation)
-/*@internal*/
+/** @internal */
 export class InterpolationBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -98,7 +98,7 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.propertyBinding)
-/*@internal*/
+/** @internal */
 export class PropertyBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -117,7 +117,7 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.iteratorBinding)
-/*@internal*/
+/** @internal */
 export class IteratorBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -136,7 +136,7 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IEventManager)
 @instructionRenderer(TargetedInstructionType.listenerBinding)
-/*@internal*/
+/** @internal */
 export class ListenerBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private eventManager: IEventManager;
@@ -155,7 +155,7 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.callBinding)
-/*@internal*/
+/** @internal */
 export class CallBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -174,7 +174,7 @@ export class CallBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser)
 @instructionRenderer(TargetedInstructionType.refBinding)
-/*@internal*/
+/** @internal */
 export class RefBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
 
@@ -191,7 +191,7 @@ export class RefBindingRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.stylePropertyBinding)
-/*@internal*/
+/** @internal */
 export class StylePropertyBindingRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;
@@ -209,7 +209,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
 }
 
 @instructionRenderer(TargetedInstructionType.setProperty)
-/*@internal*/
+/** @internal */
 export class SetPropertyRenderer implements IInstructionRenderer {
   public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: ISetPropertyInstruction): void {
     target[instruction.to] = instruction.value;
@@ -217,7 +217,7 @@ export class SetPropertyRenderer implements IInstructionRenderer {
 }
 
 @instructionRenderer(TargetedInstructionType.setAttribute)
-/*@internal*/
+/** @internal */
 export class SetAttributeRenderer implements IInstructionRenderer {
   public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: ISetAttributeInstruction): void {
     DOM.setAttribute(target, instruction.to, instruction.value);
@@ -226,7 +226,7 @@ export class SetAttributeRenderer implements IInstructionRenderer {
 
 @inject(IRenderingEngine)
 @instructionRenderer(TargetedInstructionType.hydrateElement)
-/*@internal*/
+/** @internal */
 export class CustomElementRenderer implements IInstructionRenderer {
   private renderingEngine: IRenderingEngine;
 
@@ -256,7 +256,7 @@ export class CustomElementRenderer implements IInstructionRenderer {
 
 @inject(IRenderingEngine)
 @instructionRenderer(TargetedInstructionType.hydrateAttribute)
-/*@internal*/
+/** @internal */
 export class CustomAttributeRenderer implements IInstructionRenderer {
   private renderingEngine: IRenderingEngine;
 
@@ -286,7 +286,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
 
 @inject(IRenderingEngine)
 @instructionRenderer(TargetedInstructionType.hydrateTemplateController)
-/*@internal*/
+/** @internal */
 export class TemplateControllerRenderer implements IInstructionRenderer {
   private renderingEngine: IRenderingEngine;
 
@@ -321,7 +321,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
 
 @inject(IExpressionParser, IObserverLocator)
 @instructionRenderer(TargetedInstructionType.letElement)
-/*@internal*/
+/** @internal */
 export class LetElementRenderer implements IInstructionRenderer {
   private parser: IExpressionParser;
   private observerLocator: IObserverLocator;

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -159,7 +159,7 @@ export interface ILifecycleBinding extends IHooks, IState {
 }
 
 export interface ILifecycleBound extends IHooks, IState {
-  /*@internal*/$nextBound?: ILifecycleBound;
+  /** @internal */$nextBound?: ILifecycleBound;
 
   /**
    * Called at the end of `$bind`, after this instance and its children (if any) are bound.
@@ -204,7 +204,7 @@ export interface ILifecycleUnbinding extends IHooks, IState {
 }
 
 export interface ILifecycleUnbound extends IHooks, IState {
-  /*@internal*/$nextUnbound?: ILifecycleUnbound;
+  /** @internal */$nextUnbound?: ILifecycleUnbound;
 
   /**
    * Called at the end of `$unbind`, after this instance and its children (if any) are unbound.
@@ -248,7 +248,7 @@ export interface ILifecycleAttaching extends IHooks, IState {
 }
 
 export interface ILifecycleAttached extends IHooks, IState {
-  /*@internal*/$nextAttached?: ILifecycleAttached;
+  /** @internal */$nextAttached?: ILifecycleAttached;
 
   /**
    * Called at the end of `$attach`, after this instance and its children (if any) are attached.
@@ -284,7 +284,7 @@ export interface ILifecycleDetaching extends IHooks, IState {
 }
 
 export interface ILifecycleDetached extends IHooks, IState {
-  /*@internal*/$nextDetached?: ILifecycleDetached;
+  /** @internal */$nextDetached?: ILifecycleDetached;
 
   /**
    * Called at the end of `$detach`, after this instance and its children (if any) are detached.
@@ -347,12 +347,12 @@ export interface ILifecycleDetach {
 }
 
 export interface IAttach extends ILifecycleAttach, ILifecycleDetach, ICachable {
-  /*@internal*/$nextAttach: IAttach;
-  /*@internal*/$prevAttach: IAttach;
+  /** @internal */$nextAttach: IAttach;
+  /** @internal */$prevAttach: IAttach;
 }
 
 export interface ILifecycleMount {
-  /*@internal*/$nextMount?: ILifecycleMount;
+  /** @internal */$nextMount?: ILifecycleMount;
 
   /**
    * Add the `$nodes` of this instance to the Host or RenderLocation that this instance is holding.
@@ -361,7 +361,7 @@ export interface ILifecycleMount {
 }
 
 export interface ILifecycleUnmount {
-  /*@internal*/$nextUnmount?: ILifecycleUnmount;
+  /** @internal */$nextUnmount?: ILifecycleUnmount;
 
   /**
    * Remove the `$nodes` of this instance from the Host or RenderLocation that this instance is holding, optionally returning them to a cache.
@@ -399,8 +399,8 @@ export interface ILifecycleBindScope {
 }
 
 export interface IBind extends ILifecycleBind, ILifecycleUnbind {
-  /*@internal*/$nextBind: IBindSelf | IBindScope;
-  /*@internal*/$prevBind: IBindSelf | IBindScope;
+  /** @internal */$nextBind: IBindSelf | IBindScope;
+  /** @internal */$prevBind: IBindSelf | IBindScope;
 }
 
 export interface IBindScope extends Omit<IBind, '$bind'>, ILifecycleBindScope { }
@@ -628,82 +628,82 @@ export const IFlushLifecycle = ILifecycle as InterfaceSymbol<IFlushLifecycle>;
 export const IBindLifecycle = ILifecycle as InterfaceSymbol<IBindLifecycle>;
 export const IAttachLifecycle = ILifecycle as InterfaceSymbol<IAttachLifecycle>;
 
-/*@internal*/
+/** @internal */
 export class Lifecycle implements ILifecycle {
-  /*@internal*/public bindDepth: number;
-  /*@internal*/public attachDepth: number;
-  /*@internal*/public detachDepth: number;
-  /*@internal*/public unbindDepth: number;
+  /** @internal */public bindDepth: number;
+  /** @internal */public attachDepth: number;
+  /** @internal */public detachDepth: number;
+  /** @internal */public unbindDepth: number;
 
-  /*@internal*/public flushHead: IChangeTracker;
-  /*@internal*/public flushTail: IChangeTracker;
+  /** @internal */public flushHead: IChangeTracker;
+  /** @internal */public flushTail: IChangeTracker;
 
-  /*@internal*/public connectHead: IConnectableBinding;
-  /*@internal*/public connectTail: IConnectableBinding;
+  /** @internal */public connectHead: IConnectableBinding;
+  /** @internal */public connectTail: IConnectableBinding;
 
-  /*@internal*/public patchHead: IConnectableBinding;
-  /*@internal*/public patchTail: IConnectableBinding;
+  /** @internal */public patchHead: IConnectableBinding;
+  /** @internal */public patchTail: IConnectableBinding;
 
-  /*@internal*/public boundHead: ILifecycleBound;
-  /*@internal*/public boundTail: ILifecycleBound;
+  /** @internal */public boundHead: ILifecycleBound;
+  /** @internal */public boundTail: ILifecycleBound;
 
-  /*@internal*/public mountHead: ILifecycleMount;
-  /*@internal*/public mountTail: ILifecycleMount;
+  /** @internal */public mountHead: ILifecycleMount;
+  /** @internal */public mountTail: ILifecycleMount;
 
-  /*@internal*/public attachedHead: ILifecycleAttached;
-  /*@internal*/public attachedTail: ILifecycleAttached;
+  /** @internal */public attachedHead: ILifecycleAttached;
+  /** @internal */public attachedTail: ILifecycleAttached;
 
-  /*@internal*/public unmountHead: ILifecycleUnmount;
-  /*@internal*/public unmountTail: ILifecycleUnmount;
+  /** @internal */public unmountHead: ILifecycleUnmount;
+  /** @internal */public unmountTail: ILifecycleUnmount;
 
-  /*@internal*/public detachedHead: ILifecycleDetached;
-  /*@internal*/public detachedTail: ILifecycleDetached;
+  /** @internal */public detachedHead: ILifecycleDetached;
+  /** @internal */public detachedTail: ILifecycleDetached;
 
-  /*@internal*/public unbindAfterDetachHead: ILifecycleUnbindAfterDetach;
-  /*@internal*/public unbindAfterDetachTail: ILifecycleUnbindAfterDetach;
+  /** @internal */public unbindAfterDetachHead: ILifecycleUnbindAfterDetach;
+  /** @internal */public unbindAfterDetachTail: ILifecycleUnbindAfterDetach;
 
-  /*@internal*/public unboundHead: ILifecycleUnbound;
-  /*@internal*/public unboundTail: ILifecycleUnbound;
+  /** @internal */public unboundHead: ILifecycleUnbound;
+  /** @internal */public unboundTail: ILifecycleUnbound;
 
-  /*@internal*/public flushed: Promise<void>;
-  /*@internal*/public promise: Promise<void>;
+  /** @internal */public flushed: Promise<void>;
+  /** @internal */public promise: Promise<void>;
 
-  /*@internal*/public flushCount: number;
-  /*@internal*/public connectCount: number;
-  /*@internal*/public patchCount: number;
-  /*@internal*/public boundCount: number;
-  /*@internal*/public mountCount: number;
-  /*@internal*/public attachedCount: number;
-  /*@internal*/public unmountCount: number;
-  /*@internal*/public detachedCount: number;
-  /*@internal*/public unbindAfterDetachCount: number;
-  /*@internal*/public unboundCount: number;
+  /** @internal */public flushCount: number;
+  /** @internal */public connectCount: number;
+  /** @internal */public patchCount: number;
+  /** @internal */public boundCount: number;
+  /** @internal */public mountCount: number;
+  /** @internal */public attachedCount: number;
+  /** @internal */public unmountCount: number;
+  /** @internal */public detachedCount: number;
+  /** @internal */public unbindAfterDetachCount: number;
+  /** @internal */public unboundCount: number;
 
   // These are dummy properties to make the lifecycle conform to the interfaces
   // of the components it manages. This allows the lifecycle itself to be the first link
   // in the chain and removes the need for an additional null check on each addition.
-  /*@internal*/public $nextFlush: IChangeTracker;
-  /*@internal*/public flush: IChangeTracker['flush'];
-  /*@internal*/public $nextConnect: IConnectableBinding;
-  /*@internal*/public connect: IConnectableBinding['connect'];
-  /*@internal*/public $nextPatch: IConnectableBinding;
-  /*@internal*/public patch: IConnectableBinding['patch'];
-  /*@internal*/public $nextBound: ILifecycleBound;
-  /*@internal*/public bound: ILifecycleBound['bound'];
-  /*@internal*/public $nextMount: ILifecycleMount;
-  /*@internal*/public $mount: ILifecycleMount['$mount'];
-  /*@internal*/public $nextAttached: ILifecycleAttached;
-  /*@internal*/public attached: ILifecycleAttached['attached'];
-  /*@internal*/public $nextUnmount: ILifecycleUnmount;
-  /*@internal*/public $unmount: ILifecycleUnmount['$unmount'];
-  /*@internal*/public $nextDetached: ILifecycleDetached;
-  /*@internal*/public detached: ILifecycleDetached['detached'];
-  /*@internal*/public $nextUnbindAfterDetach: ILifecycleUnbindAfterDetach;
-  /*@internal*/public $unbind: ILifecycleUnbindAfterDetach['$unbind'];
-  /*@internal*/public $nextUnbound: ILifecycleUnbound;
-  /*@internal*/public unbound: ILifecycleUnbound['unbound'];
+  /** @internal */public $nextFlush: IChangeTracker;
+  /** @internal */public flush: IChangeTracker['flush'];
+  /** @internal */public $nextConnect: IConnectableBinding;
+  /** @internal */public connect: IConnectableBinding['connect'];
+  /** @internal */public $nextPatch: IConnectableBinding;
+  /** @internal */public patch: IConnectableBinding['patch'];
+  /** @internal */public $nextBound: ILifecycleBound;
+  /** @internal */public bound: ILifecycleBound['bound'];
+  /** @internal */public $nextMount: ILifecycleMount;
+  /** @internal */public $mount: ILifecycleMount['$mount'];
+  /** @internal */public $nextAttached: ILifecycleAttached;
+  /** @internal */public attached: ILifecycleAttached['attached'];
+  /** @internal */public $nextUnmount: ILifecycleUnmount;
+  /** @internal */public $unmount: ILifecycleUnmount['$unmount'];
+  /** @internal */public $nextDetached: ILifecycleDetached;
+  /** @internal */public detached: ILifecycleDetached['detached'];
+  /** @internal */public $nextUnbindAfterDetach: ILifecycleUnbindAfterDetach;
+  /** @internal */public $unbind: ILifecycleUnbindAfterDetach['$unbind'];
+  /** @internal */public $nextUnbound: ILifecycleUnbound;
+  /** @internal */public unbound: ILifecycleUnbound['unbound'];
 
-  /*@internal*/public task: AggregateLifecycleTask | null;
+  /** @internal */public task: AggregateLifecycleTask | null;
 
   constructor() {
     this.bindDepth = 0;
@@ -1370,7 +1370,7 @@ export interface ILifecycleTask<T = unknown> {
 export class AggregateLifecycleTask implements ILifecycleTask<void> {
   public done: boolean;
 
-  /*@internal*/
+  /** @internal */
   public owner: Lifecycle;
 
   private resolve: () => void;
@@ -1463,7 +1463,7 @@ export class AggregateLifecycleTask implements ILifecycleTask<void> {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class PromiseSwap implements ILifecycleTask<IView> {
   public done: boolean;
 

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -33,7 +33,7 @@ export enum LifecycleFlags {
   doNotUpdateDOM         = 0b0100_00000000000000_000_00,
 }
 
-/*@internal*/
+/** @internal */
 export const enum SubscriberFlags {
   None            = 0,
   Subscriber0     = 0b0001,
@@ -212,11 +212,11 @@ export interface ISubscribable<T extends MutationKind> {
  * A collection of property or collection subscribers
  */
 export interface ISubscriberCollection<T extends MutationKind> extends ISubscribable<T> {
-  /*@internal*/_subscriberFlags?: SubscriberFlags;
-  /*@internal*/_subscriber0?: MutationKindToSubscriber<T>;
-  /*@internal*/_subscriber1?: MutationKindToSubscriber<T>;
-  /*@internal*/_subscriber2?: MutationKindToSubscriber<T>;
-  /*@internal*/_subscribersRest?: MutationKindToSubscriber<T>[];
+  /** @internal */_subscriberFlags?: SubscriberFlags;
+  /** @internal */_subscriber0?: MutationKindToSubscriber<T>;
+  /** @internal */_subscriber1?: MutationKindToSubscriber<T>;
+  /** @internal */_subscriber2?: MutationKindToSubscriber<T>;
+  /** @internal */_subscribersRest?: MutationKindToSubscriber<T>[];
 
   callSubscribers: MutationKindToNotifier<T>;
   hasSubscribers(): boolean;
@@ -229,16 +229,16 @@ export interface ISubscriberCollection<T extends MutationKind> extends ISubscrib
  * A collection of batched property or collection subscribers
  */
 export interface IBatchedSubscriberCollection<T extends MutationKind> extends IBatchedSubscribable<T> {
-  /*@internal*/_batchedSubscriberFlags?: SubscriberFlags;
-  /*@internal*/_batchedSubscriber0?: MutationKindToBatchedSubscriber<T>;
-  /*@internal*/_batchedSubscriber1?: MutationKindToBatchedSubscriber<T>;
-  /*@internal*/_batchedSubscriber2?: MutationKindToBatchedSubscriber<T>;
-  /*@internal*/_batchedSubscribersRest?: MutationKindToBatchedSubscriber<T>[];
+  /** @internal */_batchedSubscriberFlags?: SubscriberFlags;
+  /** @internal */_batchedSubscriber0?: MutationKindToBatchedSubscriber<T>;
+  /** @internal */_batchedSubscriber1?: MutationKindToBatchedSubscriber<T>;
+  /** @internal */_batchedSubscriber2?: MutationKindToBatchedSubscriber<T>;
+  /** @internal */_batchedSubscribersRest?: MutationKindToBatchedSubscriber<T>[];
 
-  /*@internal*/lifecycle?: ILifecycle;
+  /** @internal */lifecycle?: ILifecycle;
   callBatchedSubscribers: MutationKindToBatchedNotifier<T>;
 
-  /*@internal*/flush(flags: LifecycleFlags): void;
+  /** @internal */flush(flags: LifecycleFlags): void;
   hasBatchedSubscribers(): boolean;
   hasBatchedSubscriber(subscriber: MutationKindToBatchedSubscriber<T>): boolean;
   removeBatchedSubscriber(subscriber: MutationKindToBatchedSubscriber<T>): boolean;
@@ -258,7 +258,7 @@ export interface IPropertyObserver<TObj extends Object, TProp extends keyof TObj
   IAccessor<TObj[TProp]>,
   IPropertyChangeTracker<TObj, TProp>,
   ISubscriberCollection<MutationKind.instance> {
-  /*@internal*/observing: boolean;
+  /** @internal */observing: boolean;
 }
 
 /**

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -45,7 +45,7 @@ export class RenderPlan {
     return engine.getViewFactory(this.definition, parentContext);
   }
 
-  /*@internal*/
+  /** @internal */
   public mergeInto(parent: INode, instructions: TargetedInstruction[][], dependencies: IRegistry[]): void {
     DOM.appendChild(parent, this.node);
     instructions.push(...this.instructions);

--- a/packages/runtime/src/templating/custom-attribute.ts
+++ b/packages/runtime/src/templating/custom-attribute.ts
@@ -35,7 +35,7 @@ export interface ICustomAttributeResource extends
 
 type CustomAttributeDecorator = <T>(target: PartialCustomAttributeType<T>) => T & ICustomAttributeType;
 
-/*@internal*/
+/** @internal */
 export function registerAttribute(this: ICustomAttributeType, container: IContainer): void {
   const description = this.description;
   const resourceKey = this.kind.keyFrom(description.name);
@@ -145,7 +145,7 @@ export const CustomAttributeResource: ICustomAttributeResource = {
   define
 };
 
-/*@internal*/
+/** @internal */
 export function createCustomAttributeDescription(def: IAttributeDefinition, Type: ICustomAttributeType): ResourceDescription<IAttributeDefinition> {
   const aliases = def. aliases;
   const defaultBindingMode = def.defaultBindingMode;

--- a/packages/runtime/src/templating/custom-element.ts
+++ b/packages/runtime/src/templating/custom-element.ts
@@ -41,7 +41,7 @@ export interface ICustomElementResource extends
 
 type CustomElementDecorator = <T>(target: PartialCustomElementType<T>) => T & ICustomElementType;
 
-/*@internal*/
+/** @internal */
 export function registerElement(this: ICustomElementType, container: IContainer): void {
   const resourceKey = this.kind.keyFrom(this.description.name);
   container.register(Registration.transient(resourceKey, this));

--- a/packages/runtime/src/templating/lifecycle-attach.ts
+++ b/packages/runtime/src/templating/lifecycle-attach.ts
@@ -5,7 +5,7 @@ import { LifecycleFlags } from '../observation';
 import { ICustomAttribute } from './custom-attribute';
 import { ICustomElement } from './custom-element';
 
-/*@internal*/
+/** @internal */
 // tslint:disable-next-line:no-ignored-initial-value
 export function $attachAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {
   if (this.$state & State.isAttached) {
@@ -33,7 +33,7 @@ export function $attachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
   lifecycle.endAttach(flags);
 }
 
-/*@internal*/
+/** @internal */
 // tslint:disable-next-line:no-ignored-initial-value
 export function $attachElement(this: Writable<ICustomElement>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {
   if (this.$state & State.isAttached) {
@@ -70,7 +70,7 @@ export function $attachElement(this: Writable<ICustomElement>, flags: LifecycleF
   lifecycle.endAttach(flags);
 }
 
-/*@internal*/
+/** @internal */
 export function $attachView(this: Writable<IView>, flags: LifecycleFlags, encapsulationSource?: IEncapsulationSource): void {
   if (this.$state & State.isAttached) {
     return;
@@ -92,7 +92,7 @@ export function $attachView(this: Writable<IView>, flags: LifecycleFlags, encaps
   this.$state &= ~State.isAttaching;
 }
 
-/*@internal*/
+/** @internal */
 // tslint:disable-next-line:no-ignored-initial-value
 export function $detachAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags): void {
   if (this.$state & State.isAttached) {
@@ -117,7 +117,7 @@ export function $detachAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
   }
 }
 
-/*@internal*/
+/** @internal */
 // tslint:disable-next-line:no-ignored-initial-value
 export function $detachElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (this.$state & State.isAttached) {
@@ -156,7 +156,7 @@ export function $detachElement(this: Writable<ICustomElement>, flags: LifecycleF
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $detachView(this: Writable<IView>, flags: LifecycleFlags): void {
   if (this.$state & State.isAttached) {
     // add isDetaching flag
@@ -182,7 +182,7 @@ export function $detachView(this: Writable<IView>, flags: LifecycleFlags): void 
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $cacheAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags): void {
   flags |= LifecycleFlags.fromCache;
   if (this.$hooks & Hooks.hasCaching) {
@@ -190,7 +190,7 @@ export function $cacheAttribute(this: Writable<ICustomAttribute>, flags: Lifecyc
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $cacheElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   flags |= LifecycleFlags.fromCache;
   if (this.$hooks & Hooks.hasCaching) {
@@ -204,7 +204,7 @@ export function $cacheElement(this: Writable<ICustomElement>, flags: LifecycleFl
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $cacheView(this: Writable<IView>, flags: LifecycleFlags): void {
   flags |= LifecycleFlags.fromCache;
   let current = this.$attachableTail;
@@ -214,7 +214,7 @@ export function $cacheView(this: Writable<IView>, flags: LifecycleFlags): void {
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $mountElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (!(this.$state & State.isMounted)) {
     this.$state |= State.isMounted;
@@ -222,7 +222,7 @@ export function $mountElement(this: Writable<ICustomElement>, flags: LifecycleFl
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $unmountElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (this.$state & State.isMounted) {
     this.$state &= ~State.isMounted;
@@ -230,7 +230,7 @@ export function $unmountElement(this: Writable<ICustomElement>, flags: Lifecycle
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $mountView(this: Writable<IView>, flags: LifecycleFlags): void {
   if (!(this.$state & State.isMounted)) {
     this.$state |= State.isMounted;
@@ -238,7 +238,7 @@ export function $mountView(this: Writable<IView>, flags: LifecycleFlags): void {
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $unmountView(this: Writable<IView>, flags: LifecycleFlags): boolean {
   if (this.$state & State.isMounted) {
     this.$state &= ~State.isMounted;

--- a/packages/runtime/src/templating/lifecycle-bind.ts
+++ b/packages/runtime/src/templating/lifecycle-bind.ts
@@ -4,7 +4,7 @@ import { IScope, LifecycleFlags } from '../observation';
 import { ICustomAttribute } from './custom-attribute';
 import { ICustomElement } from './custom-element';
 
-/*@internal*/
+/** @internal */
 export function $bindAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags, scope: IScope): void {
   flags |= LifecycleFlags.fromBind;
 
@@ -39,7 +39,7 @@ export function $bindAttribute(this: Writable<ICustomAttribute>, flags: Lifecycl
   lifecycle.endBind(flags);
 }
 
-/*@internal*/
+/** @internal */
 export function $bindElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (this.$state & State.isBound) {
     return;
@@ -74,7 +74,7 @@ export function $bindElement(this: Writable<ICustomElement>, flags: LifecycleFla
   lifecycle.endBind(flags);
 }
 
-/*@internal*/
+/** @internal */
 export function $bindView(this: Writable<IView>, flags: LifecycleFlags, scope: IScope): void {
   flags |= LifecycleFlags.fromBind;
 
@@ -100,7 +100,7 @@ export function $bindView(this: Writable<IView>, flags: LifecycleFlags, scope: I
   this.$state &= ~State.isBinding;
 }
 
-/*@internal*/
+/** @internal */
 export function $unbindAttribute(this: Writable<ICustomAttribute>, flags: LifecycleFlags): void {
   if (this.$state & State.isBound) {
     const lifecycle = this.$lifecycle;
@@ -126,7 +126,7 @@ export function $unbindAttribute(this: Writable<ICustomAttribute>, flags: Lifecy
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $unbindElement(this: Writable<ICustomElement>, flags: LifecycleFlags): void {
   if (this.$state & State.isBound) {
     const lifecycle = this.$lifecycle;
@@ -158,7 +158,7 @@ export function $unbindElement(this: Writable<ICustomElement>, flags: LifecycleF
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $unbindView(this: Writable<IView>, flags: LifecycleFlags): void {
   if (this.$state & State.isBound) {
     // add isUnbinding flag

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -74,7 +74,7 @@ export interface ILifecycleRender {
   render?(host: INode, parts: Immutable<Pick<IHydrateElementInstruction, 'parts'>>): IElementTemplateProvider | void;
 }
 
-/*@internal*/
+/** @internal */
 export function $hydrateAttribute(this: Writable<ICustomAttribute>, renderingEngine: IRenderingEngine): void {
   const Type = this.constructor as ICustomAttributeType;
 
@@ -85,7 +85,7 @@ export function $hydrateAttribute(this: Writable<ICustomAttribute>, renderingEng
   }
 }
 
-/*@internal*/
+/** @internal */
 export function $hydrateElement(this: Writable<ICustomElement>, renderingEngine: IRenderingEngine, host: INode, options: IElementHydrationOptions = PLATFORM.emptyObject): void {
   const Type = this.constructor as ICustomElementType;
   const description = Type.description;
@@ -113,7 +113,7 @@ export function $hydrateElement(this: Writable<ICustomElement>, renderingEngine:
   }
 }
 
-/*@internal*/
+/** @internal */
 export const defaultShadowOptions = {
   mode: 'open' as 'open' | 'closed'
 };
@@ -152,7 +152,7 @@ export const IRenderingEngine = DI.createInterface<IRenderingEngine>()
 const defaultCompilerName = 'default';
 
 @inject(IContainer, ILifecycle, all(ITemplateCompiler))
-/*@internal*/
+/** @internal */
 export class RenderingEngine implements IRenderingEngine {
   private behaviorLookup: Map<ICustomElementType | ICustomAttributeType, RuntimeBehavior>;
   private compilers: Record<string, ITemplateCompiler>;
@@ -250,7 +250,7 @@ export class RenderingEngine implements IRenderingEngine {
 }
 const childObserverOptions = { childList: true };
 
-/*@internal*/
+/** @internal */
 export class ShadowDOMProjector implements IElementProjector {
   public host: ICustomElementHost;
   public shadowRoot: ICustomElementHost;
@@ -284,7 +284,7 @@ export class ShadowDOMProjector implements IElementProjector {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class ContainerlessProjector implements IElementProjector {
   public host: ICustomElementHost;
 
@@ -326,7 +326,7 @@ export class ContainerlessProjector implements IElementProjector {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class HostProjector implements IElementProjector {
   public host: ICustomElementHost;
 
@@ -432,7 +432,7 @@ export interface IChildrenObserver extends
   ISubscribable<MutationKind.instance>,
   ISubscriberCollection<MutationKind.instance> { }
 
-/*@internal*/
+/** @internal */
 @subscriberCollection(MutationKind.instance)
 export class ChildrenObserver implements Partial<IChildrenObserver> {
   public hasChanges: boolean;
@@ -488,7 +488,7 @@ export class ChildrenObserver implements Partial<IChildrenObserver> {
   }
 }
 
-/*@internal*/
+/** @internal */
 export function findElements(nodes: ArrayLike<INode>): ICustomElement[] {
   const components: ICustomElement[] = [];
 
@@ -520,7 +520,7 @@ export interface ITemplate {
 // TemplateCompiler either through a JIT or AOT process.
 // Essentially, CompiledTemplate wraps up the small bit of code that is needed to take a TemplateDefinition
 // and create instances of it on demand.
-/*@internal*/
+/** @internal */
 export class CompiledTemplate implements ITemplate {
   public readonly factory: INodeSequenceFactory;
   public readonly renderContext: IRenderContext;
@@ -542,7 +542,7 @@ export class CompiledTemplate implements ITemplate {
 }
 
 // This is an implementation of ITemplate that always returns a node sequence representing "no DOM" to render.
-/*@internal*/
+/** @internal */
 export const noViewTemplate: ITemplate = {
   renderContext: null,
   render(renderable: IRenderable): void {
@@ -551,7 +551,7 @@ export const noViewTemplate: ITemplate = {
   }
 };
 
-/*@internal*/
+/** @internal */
 export type ExposedContext = IRenderContext & IDisposable & IContainer;
 
 export function createRenderContext(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
@@ -605,7 +605,7 @@ export function createRenderContext(renderingEngine: IRenderingEngine, parentRen
   return context;
 }
 
-/*@internal*/
+/** @internal */
 export class InstanceProvider<T> implements IResolver {
   private instance: T | null;
 
@@ -629,7 +629,7 @@ export class InstanceProvider<T> implements IResolver {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class ViewFactoryProvider implements IResolver {
   private factory: IViewFactory | null;
   private renderingEngine: IRenderingEngine;

--- a/packages/runtime/src/templating/resources/if.ts
+++ b/packages/runtime/src/templating/resources/if.ts
@@ -75,7 +75,7 @@ export class If {
     this.coordinator.compose(view, flags);
   }
 
-  /*@internal*/
+  /** @internal */
   public updateView(flags: LifecycleFlags): IView | null {
     let view: IView | null;
 
@@ -90,7 +90,7 @@ export class If {
     return view;
   }
 
-  /*@internal*/
+  /** @internal */
   public ensureView(view: IView | null, factory: IViewFactory, flags: LifecycleFlags): IView {
     if (view === null) {
       view = factory.create();

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -6,10 +6,10 @@ import { $attachView, $cacheView, $detachView, $mountView, $unmountView } from '
 import { $bindView, $unbindView } from './lifecycle-bind';
 import { ITemplate } from './lifecycle-render';
 
-/*@internal*/
+/** @internal */
 export interface View extends IView {}
 
-/*@internal*/
+/** @internal */
 export class View implements IView {
   public $bindableHead: IBindScope;
   public $bindableTail: IBindScope;
@@ -86,7 +86,7 @@ export class View implements IView {
   }
 }
 
-/*@internal*/
+/** @internal */
 export class ViewFactory implements IViewFactory {
   public static maxCacheSize: number = 0xFFFF;
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes some parser linting errors (including the commented-out code - I changed my mind on that).

Also changes the `/*@internal*/` comments to`/** @internal */` JSDoc comments. This isn't a linting fix in itself, but it adds the `@internal` marker to intellisense which is a good thing for clarity especially in unit tests with cross-package imports.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/249
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

- Changed the null assertions `state!.currentToken` to `state.currentToken as Token` (fixes the type error as well as the tslint error)
- Removed commented-out code (I realized that a different TODO comment further up should serve as a sufficient reminder)
- Did a find-replace-all `/*@internal*/` with `/** @internal */` across the whole project
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

N/A
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

N/A, just some standalone fixes to help out @BBosman 
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
