### PR TITLE
chore(examples): update gulp semver range to reflect 4.0.0 release

### DIFF
--- a/examples/jit-aurelia-cli-ts/package.json
+++ b/examples/jit-aurelia-cli-ts/package.json
@@ -26,7 +26,7 @@
     "gulp-sourcemaps": "latest",
     "gulp-typescript": "latest",
     "gulp-watch": "latest",
-    "gulp": "next",
+    "gulp": "latest",
     "http-server": "latest",
     "minimatch": "latest",
     "rimraf": "latest",

--- a/examples/jit-browserify-ts/package.json
+++ b/examples/jit-browserify-ts/package.json
@@ -15,7 +15,7 @@
     "@types/node": "latest",
     "browser-sync": "latest",
     "browserify": "latest",
-    "gulp": "latest",
+    "gulp": "^3.9.1",
     "http-server": "latest",
     "rimraf": "latest",
     "stringify": "latest",

--- a/test/wdio/cases/dev/jit-aurelia-cli-ts/package.json
+++ b/test/wdio/cases/dev/jit-aurelia-cli-ts/package.json
@@ -27,7 +27,7 @@
     "gulp-sourcemaps": "latest",
     "gulp-typescript": "latest",
     "gulp-watch": "latest",
-    "gulp": "next",
+    "gulp": "latest",
     "http-server": "latest",
     "minimatch": "latest",
     "rimraf": "latest",

--- a/test/wdio/cases/dev/jit-browserify-ts/package.json
+++ b/test/wdio/cases/dev/jit-browserify-ts/package.json
@@ -16,7 +16,7 @@
     "@types/node": "latest",
     "browser-sync": "latest",
     "browserify": "latest",
-    "gulp": "latest",
+    "gulp": "^3.9.1",
     "http-server": "latest",
     "rimraf": "latest",
     "stringify": "latest",

--- a/test/wdio/cases/latest/jit-aurelia-cli-ts/package.json
+++ b/test/wdio/cases/latest/jit-aurelia-cli-ts/package.json
@@ -27,7 +27,7 @@
     "gulp-sourcemaps": "latest",
     "gulp-typescript": "latest",
     "gulp-watch": "latest",
-    "gulp": "next",
+    "gulp": "latest",
     "http-server": "latest",
     "minimatch": "latest",
     "rimraf": "latest",

--- a/test/wdio/cases/latest/jit-browserify-ts/package.json
+++ b/test/wdio/cases/latest/jit-browserify-ts/package.json
@@ -16,7 +16,7 @@
     "@types/node": "latest",
     "browser-sync": "latest",
     "browserify": "latest",
-    "gulp": "latest",
+    "gulp": "^3.9.1",
     "http-server": "latest",
     "rimraf": "latest",
     "stringify": "latest",

--- a/test/wdio/cases/local/jit-aurelia-cli-ts/package.json
+++ b/test/wdio/cases/local/jit-aurelia-cli-ts/package.json
@@ -27,7 +27,7 @@
     "gulp-sourcemaps": "latest",
     "gulp-typescript": "latest",
     "gulp-watch": "latest",
-    "gulp": "next",
+    "gulp": "latest",
     "http-server": "latest",
     "minimatch": "latest",
     "rimraf": "latest",

--- a/test/wdio/cases/local/jit-browserify-ts/package.json
+++ b/test/wdio/cases/local/jit-browserify-ts/package.json
@@ -16,7 +16,7 @@
     "@types/node": "latest",
     "browser-sync": "latest",
     "browserify": "latest",
-    "gulp": "latest",
+    "gulp": "^3.9.1",
     "http-server": "latest",
     "rimraf": "latest",
     "stringify": "latest",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Gulp finally published `4.0.0` to their `latest` channel, so the `next` semver tag stopped working and broke the `aurelia-cli-ts` example. In addition, the `latest` now points to `4.0.0` which breaks the browserify example. This PR fixes both issues.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Build broke
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

N/A
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

CircleCI tests should pass
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

N/A
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
