### PR TITLE
chore(all): add script to bundle only a single package

### DIFF
--- a/packages/aot/package.json
+++ b/packages/aot/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=aot --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm aot",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=debug --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm debug",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/jit/package.json
+++ b/packages/jit/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=jit --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm jit",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=kernel --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm kernel",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/plugin-parcel/package.json
+++ b/packages/plugin-parcel/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-parcel --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-parcel --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm plugin-parcel",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/plugin-requirejs/package.json
+++ b/packages/plugin-requirejs/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-requirejs --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm plugin-requirejs",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/plugin-svg/package.json
+++ b/packages/plugin-svg/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-svg --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm plugin-svg",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-webpack --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=plugin-webpack --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm plugin-webpack",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=router --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm router",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=runtime --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm runtime",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=testing --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=testing --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm testing",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -36,6 +36,7 @@
     "test:debugger": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=validation --browsers=ChromeDebugging",
     "test:debugger:verbose": "cross-env TS_NODE_PROJECT=\"../../scripts/tsconfig.json\" karma start ../../scripts/karma.conf.ts --package=validation --browsers=ChromeDebugging --reporter=mocha",
     "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm validation",
     "dev": "tsc -b -w",
     "publish:local": "npm pack"
   },

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -9,25 +9,31 @@ import project from './project';
 const log = createLogger('bundle');
 
 async function createBundle(): Promise<void> {
-  const outputs = process.argv.slice(2)[0].split(',');
+  const args = process.argv.slice(2);
+
+  const outputs = args[0].split(',');
+  const filtered = args.length > 1 ? args[1].split(',') : null;
 
   // ensure the bundles are created in the correct order of dependency
-  const packages = project.packages.slice().sort((a, b) => {
-    switch (a.name) {
-      case 'kernel':
-        return 0;
-      case 'runtime':
-        return 1;
-      case 'debug':
-      case 'jit':
-      case 'plugin-requirejs':
-      case 'plugin-svg':
-      case 'router':
-        return 2;
-      case 'aot':
-        return 3;
+  const packages = project.packages.slice()
+    .filter(p => filtered === null || filtered.indexOf(p.name) !== -1)
+    .sort((a, b) => {
+      switch (a.name) {
+        case 'kernel':
+          return 0;
+        case 'runtime':
+          return 1;
+        case 'debug':
+        case 'jit':
+        case 'plugin-requirejs':
+        case 'plugin-svg':
+        case 'router':
+          return 2;
+        case 'aot':
+          return 3;
+      }
     }
-  });
+  );
   const count = packages.length;
   let cur = 0;
   for (const pkg of packages) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This addresses some difficulties for myself, @bigopon and @jwx with regards to building test apps inside the repo using relative paths. Currently you'll have to `npm run bundle:dist` for any updates to propagate and this takes about a minute for all packages.

This PR allows you to `npm run bundle` on individual package level, making it more viable to use a local test app for developing purposes with somewhat quick iterations.

`npm run bundle:dist` only needs to be run once so the dependent bundles exist. After that, you can `npm run bundle` for example inside `packages/router` to refresh the router for the test app. No need to `npm run build` as well (but in case of any typing errors you might still want to try this though)
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

N/A
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

N/A
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Verified with the router package
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

N/A
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
