### PR TITLE
fix(template-binder): correctly traverse not-compilable node types

### DIFF
--- a/packages/jit/src/template-binder.ts
+++ b/packages/jit/src/template-binder.ts
@@ -416,19 +416,7 @@ export class TemplateBinder {
       ++i;
     }
 
-    let childNode: INode = node.content.firstChild;
-    let nextChild: INode;
-    while (childNode !== null) {
-      switch (childNode.nodeType) {
-        case NodeType.Text:
-          childNode = this.bindText(childNode as IText).nextSibling;
-          break;
-        case NodeType.Element:
-          nextChild = childNode.nextSibling;
-          this.bindManifest(this.manifest, childNode as IHTMLElement);
-          childNode = nextChild;
-      }
-    }
+    this.bindChildNodes(node);
 
     this.surrogate = surrogateSave;
     this.parentManifestRoot = parentManifestRootSave;
@@ -607,13 +595,23 @@ export class TemplateBinder {
     let nextChild: INode;
     while (childNode !== null) {
       switch (childNode.nodeType) {
-        case NodeType.Text:
-          childNode = this.bindText(childNode as IText).nextSibling;
-          break;
         case NodeType.Element:
           nextChild = childNode.nextSibling;
           this.bindManifest(this.manifest, childNode as IHTMLElement);
           childNode = nextChild;
+          break;
+        case NodeType.Text:
+          childNode = this.bindText(childNode as IText).nextSibling;
+          break;
+        case NodeType.CDATASection:
+        case NodeType.ProcessingInstruction:
+        case NodeType.Comment:
+        case NodeType.DocumentType:
+          childNode = childNode.nextSibling;
+          break;
+        case NodeType.Document:
+        case NodeType.DocumentFragment:
+          childNode = childNode.firstChild;
       }
     }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

@jwx discovered this the hard way in his router test app, but apparently I broke the compiler when there are comments. Big oops. I added traversal for all node types back in and all should work again as it did before.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

N/A
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Added traversal for other node types and reused `bindChildren` in `template-binder`
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Added a few xml-based tests to verify all node type traversals don't cause the compiler to hang or crash. This is just a bit quick-n-dirty but it does the job for now
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Add more complete tests for the different document types (html, xml, svg) that can be parsed by the browser as well as rendering for these.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
