### PR TITLE
Injectable dom

### DIFF
--- a/packages/jit/src/template-binder.ts
+++ b/packages/jit/src/template-binder.ts
@@ -1,5 +1,5 @@
-import { PLATFORM, Reporter, Tracer } from '@aurelia/kernel';
-import { BindingMode, BindingType, DOM, IExpressionParser, IHTMLElement, IHTMLTemplateElement, INode, Interpolation, IsExpressionOrStatement, IText, NodeType } from '@aurelia/runtime';
+import { PLATFORM, Tracer } from '@aurelia/kernel';
+import { BindingMode, BindingType, IDOM, IExpressionParser, IHTMLElement, IHTMLTemplateElement, INode, Interpolation, IsExpressionOrStatement, IText, NodeType } from '@aurelia/runtime';
 import { AttrSyntax } from './ast';
 import { IAttributeParser } from './attribute-parser';
 import { IBindingCommand } from './binding-command';
@@ -47,7 +47,7 @@ export class TemplateControllerSymbol {
     return this._bindings;
   }
 
-  constructor(dom: DOM, syntax: AttrSyntax, info: AttrInfo, partName: string | null) {
+  constructor(dom: IDOM, syntax: AttrSyntax, info: AttrInfo, partName: string | null) {
     this.flags = SymbolFlags.isTemplateController | SymbolFlags.hasMarker;
     this.res = info.name;
     this.partName = partName;
@@ -212,7 +212,7 @@ export class CustomElementSymbol {
     return this._parts;
   }
 
-  constructor(dom: DOM, node: IHTMLElement, info: ElementInfo) {
+  constructor(dom: IDOM, node: IHTMLElement, info: ElementInfo) {
     this.flags = SymbolFlags.isCustomElement;
     this.res = info.name;
     this.physicalNode = node;
@@ -249,7 +249,7 @@ export class LetElementSymbol {
     return this._bindings;
   }
 
-  constructor(dom: DOM, node: IHTMLElement) {
+  constructor(dom: IDOM, node: IHTMLElement) {
     this.flags = SymbolFlags.isLetElement | SymbolFlags.hasMarker;
     this.physicalNode = node;
     this.toViewModel = false;
@@ -307,7 +307,7 @@ export class TextSymbol {
   public interpolation: Interpolation;
   public marker: IHTMLElement;
 
-  constructor(dom: DOM, node: IText, interpolation: Interpolation) {
+  constructor(dom: IDOM, node: IText, interpolation: Interpolation) {
     this.flags = SymbolFlags.isText | SymbolFlags.hasMarker;
     this.physicalNode = node;
     this.interpolation = interpolation;
@@ -334,7 +334,7 @@ export type AnySymbol =
 
 const slice = Array.prototype.slice;
 
-function createMarker(dom: DOM): IHTMLElement {
+function createMarker(dom: IDOM): IHTMLElement {
   const marker = dom.createElement('au-m');
   marker.className = 'au';
   return marker as IHTMLElement;
@@ -384,7 +384,7 @@ export class TemplateBinder {
     this.partName = null;
   }
 
-  public bind(dom: DOM, node: IHTMLTemplateElement): PlainElementSymbol {
+  public bind(dom: IDOM, node: IHTMLTemplateElement): PlainElementSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bind', slice.call(arguments)); }
 
     const surrogateSave = this.surrogate;
@@ -427,7 +427,7 @@ export class TemplateBinder {
     return manifest;
   }
 
-  private bindManifest(dom: DOM, parentManifest: ElementSymbol, node: IHTMLTemplateElement | IHTMLElement): void {
+  private bindManifest(dom: IDOM, parentManifest: ElementSymbol, node: IHTMLTemplateElement | IHTMLElement): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindManifest', slice.call(arguments)); }
 
     switch (node.nodeName) {
@@ -484,7 +484,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindLetElement(dom: DOM, parentManifest: ElementSymbol, node: IHTMLElement): void {
+  private bindLetElement(dom: IDOM, parentManifest: ElementSymbol, node: IHTMLElement): void {
     const symbol = new LetElementSymbol(dom, node);
     parentManifest.childNodes.push(symbol);
 
@@ -510,7 +510,7 @@ export class TemplateBinder {
     node.parentNode.replaceChild(symbol.marker, node);
   }
 
-  private bindAttributes(dom: DOM, node: IHTMLTemplateElement | IHTMLElement, parentManifest: ElementSymbol): void {
+  private bindAttributes(dom: IDOM, node: IHTMLTemplateElement | IHTMLElement, parentManifest: ElementSymbol): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindAttributes', slice.call(arguments)); }
 
     const { parentManifestRoot, manifestRoot, manifest } = this;
@@ -582,7 +582,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindChildNodes(dom: DOM, node: IHTMLTemplateElement | IHTMLElement): void {
+  private bindChildNodes(dom: IDOM, node: IHTMLTemplateElement | IHTMLElement): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindChildNodes', slice.call(arguments)); }
 
     let childNode: INode;
@@ -618,7 +618,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindText(dom: DOM, node: IText): INode {
+  private bindText(dom: IDOM, node: IText): INode {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindText', slice.call(arguments)); }
     const interpolation = this.exprParser.parse(node.wholeText, BindingType.Interpolation);
     if (interpolation !== null) {
@@ -633,7 +633,7 @@ export class TemplateBinder {
     return node;
   }
 
-  private declareTemplateController(dom: DOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
+  private declareTemplateController(dom: IDOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.declareTemplateController', slice.call(arguments)); }
 
     let symbol: TemplateControllerSymbol;
@@ -655,7 +655,7 @@ export class TemplateBinder {
     return symbol;
   }
 
-  private bindCustomAttribute(dom: DOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): void {
+  private bindCustomAttribute(dom: IDOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindCustomAttribute', slice.call(arguments)); }
 
     const command = this.resources.getBindingCommand(attrSyntax);
@@ -679,7 +679,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindMultiAttribute(dom: DOM, symbol: ResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
+  private bindMultiAttribute(dom: IDOM, symbol: ResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindMultiAttribute', slice.call(arguments)); }
 
     const attributes = parseMultiAttributeBinding(value);
@@ -702,7 +702,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindPlainAttribute(dom: DOM, attrSyntax: AttrSyntax): void {
+  private bindPlainAttribute(dom: IDOM, attrSyntax: AttrSyntax): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindPlainAttribute', slice.call(arguments)); }
 
     if (attrSyntax.rawValue.length === 0) {
@@ -740,7 +740,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private declareReplacePart(dom: DOM, node: IHTMLTemplateElement | IHTMLElement): ReplacePartSymbol {
+  private declareReplacePart(dom: IDOM, node: IHTMLTemplateElement | IHTMLElement): ReplacePartSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.declareReplacePart', slice.call(arguments)); }
 
     const name = node.getAttribute('replace-part');
@@ -757,7 +757,7 @@ export class TemplateBinder {
   }
 }
 
-function processInterpolationText(dom: DOM, symbol: TextSymbol): void {
+function processInterpolationText(dom: IDOM, symbol: TextSymbol): void {
   const node = symbol.physicalNode;
   const parentNode = node.parentNode;
   while (node.nextSibling !== null && node.nextSibling.nodeType === NodeType.Text) {
@@ -771,7 +771,7 @@ function processInterpolationText(dom: DOM, symbol: TextSymbol): void {
  * A (temporary) standalone function that purely does the DOM processing (lifting) related to template controllers.
  * It's a first refactoring step towards separating DOM parsing/binding from mutations.
  */
-function processTemplateControllers(dom: DOM, manifestProxy: ParentNodeSymbol, manifest: ElementSymbol): void {
+function processTemplateControllers(dom: IDOM, manifestProxy: ParentNodeSymbol, manifest: ElementSymbol): void {
   const manifestNode = manifest.physicalNode;
   let current = manifestProxy as TemplateControllerSymbol;
   while ((current as ParentNodeSymbol) !== manifest) {
@@ -799,7 +799,7 @@ function processTemplateControllers(dom: DOM, manifestProxy: ParentNodeSymbol, m
   }
 }
 
-function processReplacePart(dom: DOM, replacePart: ReplacePartSymbol, manifestProxy: ParentNodeSymbol): void {
+function processReplacePart(dom: IDOM, replacePart: ReplacePartSymbol, manifestProxy: ParentNodeSymbol): void {
     let proxyNode: IHTMLElement;
     if (manifestProxy.flags & SymbolFlags.hasMarker) {
       proxyNode = (manifestProxy as SymbolWithMarker).marker;

--- a/packages/jit/src/template-binder.ts
+++ b/packages/jit/src/template-binder.ts
@@ -47,7 +47,7 @@ export class TemplateControllerSymbol {
     return this._bindings;
   }
 
-  constructor(syntax: AttrSyntax, info: AttrInfo, partName: string | null) {
+  constructor(dom: DOM, syntax: AttrSyntax, info: AttrInfo, partName: string | null) {
     this.flags = SymbolFlags.isTemplateController | SymbolFlags.hasMarker;
     this.res = info.name;
     this.partName = partName;
@@ -55,7 +55,7 @@ export class TemplateControllerSymbol {
     this.syntax = syntax;
     this.template = null;
     this.templateController = null;
-    this.marker = createMarker();
+    this.marker = createMarker(dom);
     this._bindings = null;
   }
 }
@@ -212,7 +212,7 @@ export class CustomElementSymbol {
     return this._parts;
   }
 
-  constructor(node: IHTMLElement, info: ElementInfo) {
+  constructor(dom: DOM, node: IHTMLElement, info: ElementInfo) {
     this.flags = SymbolFlags.isCustomElement;
     this.res = info.name;
     this.physicalNode = node;
@@ -221,7 +221,7 @@ export class CustomElementSymbol {
     this.templateController = null;
     if (info.containerless) {
       this.isContainerless = true;
-      this.marker = createMarker();
+      this.marker = createMarker(dom);
       this.flags |= SymbolFlags.hasMarker;
     } else {
       this.isContainerless = false;
@@ -249,11 +249,11 @@ export class LetElementSymbol {
     return this._bindings;
   }
 
-  constructor(node: IHTMLElement) {
+  constructor(dom: DOM, node: IHTMLElement) {
     this.flags = SymbolFlags.isLetElement | SymbolFlags.hasMarker;
     this.physicalNode = node;
     this.toViewModel = false;
-    this.marker = createMarker();
+    this.marker = createMarker(dom);
     this._bindings = null;
   }
 }
@@ -307,11 +307,11 @@ export class TextSymbol {
   public interpolation: Interpolation;
   public marker: IHTMLElement;
 
-  constructor(node: IText, interpolation: Interpolation) {
+  constructor(dom: DOM, node: IText, interpolation: Interpolation) {
     this.flags = SymbolFlags.isText | SymbolFlags.hasMarker;
     this.physicalNode = node;
     this.interpolation = interpolation;
-    this.marker = createMarker();
+    this.marker = createMarker(dom);
   }
 }
 
@@ -334,8 +334,8 @@ export type AnySymbol =
 
 const slice = Array.prototype.slice;
 
-function createMarker(): IHTMLElement {
-  const marker = DOM.createElement('au-m');
+function createMarker(dom: DOM): IHTMLElement {
+  const marker = dom.createElement('au-m');
   marker.className = 'au';
   return marker as IHTMLElement;
 }
@@ -384,7 +384,7 @@ export class TemplateBinder {
     this.partName = null;
   }
 
-  public bind(node: IHTMLTemplateElement): PlainElementSymbol {
+  public bind(dom: DOM, node: IHTMLTemplateElement): PlainElementSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bind', slice.call(arguments)); }
 
     const surrogateSave = this.surrogate;
@@ -406,17 +406,17 @@ export class TemplateBinder {
       }
       const attrInfo = this.resources.getAttributeInfo(attrSyntax);
       if (attrInfo === null) {
-        this.bindPlainAttribute(attrSyntax);
+        this.bindPlainAttribute(dom, attrSyntax);
       } else if (attrInfo.isTemplateController) {
         throw new Error('Cannot have template controller on surrogate element.');
         // TODO: use reporter
       } else {
-        this.bindCustomAttribute(attrSyntax, attrInfo);
+        this.bindCustomAttribute(dom, attrSyntax, attrInfo);
       }
       ++i;
     }
 
-    this.bindChildNodes(node);
+    this.bindChildNodes(dom, node);
 
     this.surrogate = surrogateSave;
     this.parentManifestRoot = parentManifestRootSave;
@@ -427,13 +427,13 @@ export class TemplateBinder {
     return manifest;
   }
 
-  private bindManifest(parentManifest: ElementSymbol, node: IHTMLTemplateElement | IHTMLElement): void {
+  private bindManifest(dom: DOM, parentManifest: ElementSymbol, node: IHTMLTemplateElement | IHTMLElement): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindManifest', slice.call(arguments)); }
 
     switch (node.nodeName) {
       case 'LET':
         // let cannot have children and has some different processing rules, so return early
-        this.bindLetElement(parentManifest, node);
+        this.bindLetElement(dom, parentManifest, node);
         if (Tracer.enabled) { Tracer.leave(); }
         return;
       case 'SLOT':
@@ -460,15 +460,15 @@ export class TemplateBinder {
     } else {
       // it's a custom element so we set the manifestRoot as well (for storing replace-parts)
       this.parentManifestRoot = this.manifestRoot;
-      manifestRoot = this.manifestRoot = this.manifest = new CustomElementSymbol(node, elementInfo);
+      manifestRoot = this.manifestRoot = this.manifest = new CustomElementSymbol(dom, node, elementInfo);
     }
 
     // lifting operations done by template controllers and replace-parts effectively unlink the nodes, so start at the bottom
-    this.bindChildNodes(node);
+    this.bindChildNodes(dom, node);
 
     // the parentManifest will receive either the direct child nodes, or the template controllers / replace-parts
     // wrapping them
-    this.bindAttributes(node, parentManifest);
+    this.bindAttributes(dom, node, parentManifest);
 
     if (manifestRoot !== undefined && manifestRoot.isContainerless) {
       node.parentNode.replaceChild(manifestRoot.marker, node);
@@ -484,8 +484,8 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindLetElement(parentManifest: ElementSymbol, node: IHTMLElement): void {
-    const symbol = new LetElementSymbol(node);
+  private bindLetElement(dom: DOM, parentManifest: ElementSymbol, node: IHTMLElement): void {
+    const symbol = new LetElementSymbol(dom, node);
     parentManifest.childNodes.push(symbol);
 
     const attributes = node.attributes;
@@ -510,7 +510,7 @@ export class TemplateBinder {
     node.parentNode.replaceChild(symbol.marker, node);
   }
 
-  private bindAttributes(node: IHTMLTemplateElement | IHTMLElement, parentManifest: ElementSymbol): void {
+  private bindAttributes(dom: DOM, node: IHTMLTemplateElement | IHTMLElement, parentManifest: ElementSymbol): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindAttributes', slice.call(arguments)); }
 
     const { parentManifestRoot, manifestRoot, manifest } = this;
@@ -519,7 +519,7 @@ export class TemplateBinder {
     // If there are template controllers, then this will be the outer-most TemplateControllerSymbol.
     let manifestProxy = manifest as ParentNodeSymbol;
 
-    const replacePart = this.declareReplacePart(node);
+    const replacePart = this.declareReplacePart(dom, node);
 
     let previousController: TemplateControllerSymbol;
     let currentController: TemplateControllerSymbol;
@@ -537,11 +537,11 @@ export class TemplateBinder {
 
       if (attrInfo === null) {
         // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-        this.bindPlainAttribute(attrSyntax);
+        this.bindPlainAttribute(dom, attrSyntax);
       } else if (attrInfo.isTemplateController) {
         // the manifest is wrapped by the inner-most template controller (if there are multiple on the same element)
         // so keep setting manifest.templateController to the latest template controller we find
-        currentController = manifest.templateController = this.declareTemplateController(attrSyntax, attrInfo);
+        currentController = manifest.templateController = this.declareTemplateController(dom, attrSyntax, attrInfo);
 
         // the proxy and the manifest are only identical when we're at the first template controller (since the controller
         // is assigned to the proxy), so this evaluates to true at most once per node
@@ -556,11 +556,11 @@ export class TemplateBinder {
         previousController = currentController;
       } else {
         // a regular custom attribute
-        this.bindCustomAttribute(attrSyntax, attrInfo);
+        this.bindCustomAttribute(dom, attrSyntax, attrInfo);
       }
     }
 
-    processTemplateControllers(manifestProxy, manifest);
+    processTemplateControllers(dom, manifestProxy, manifest);
 
     if (replacePart === null) {
       // the proxy is either the manifest itself or the outer-most controller; add it directly to the parent
@@ -576,13 +576,13 @@ export class TemplateBinder {
       const partOwner = manifest === manifestRoot ? parentManifestRoot : manifestRoot;
       partOwner.parts.push(replacePart);
 
-      processReplacePart(replacePart, manifestProxy);
+      processReplacePart(dom, replacePart, manifestProxy);
     }
 
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindChildNodes(node: IHTMLTemplateElement | IHTMLElement): void {
+  private bindChildNodes(dom: DOM, node: IHTMLTemplateElement | IHTMLElement): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindChildNodes', slice.call(arguments)); }
 
     let childNode: INode;
@@ -597,11 +597,11 @@ export class TemplateBinder {
       switch (childNode.nodeType) {
         case NodeType.Element:
           nextChild = childNode.nextSibling;
-          this.bindManifest(this.manifest, childNode as IHTMLElement);
+          this.bindManifest(dom, this.manifest, childNode as IHTMLElement);
           childNode = nextChild;
           break;
         case NodeType.Text:
-          childNode = this.bindText(childNode as IText).nextSibling;
+          childNode = this.bindText(dom, childNode as IText).nextSibling;
           break;
         case NodeType.CDATASection:
         case NodeType.ProcessingInstruction:
@@ -618,13 +618,13 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindText(node: IText): INode {
+  private bindText(dom: DOM, node: IText): INode {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindText', slice.call(arguments)); }
     const interpolation = this.exprParser.parse(node.wholeText, BindingType.Interpolation);
     if (interpolation !== null) {
-      const symbol = new TextSymbol(node, interpolation);
+      const symbol = new TextSymbol(dom, node, interpolation);
       this.manifest.childNodes.push(symbol);
-      processInterpolationText(symbol);
+      processInterpolationText(dom, symbol);
     }
     while (node.nextSibling !== null && node.nextSibling.nodeType === NodeType.Text) {
       node = node.nextSibling as IText;
@@ -633,18 +633,18 @@ export class TemplateBinder {
     return node;
   }
 
-  private declareTemplateController(attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
+  private declareTemplateController(dom: DOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.declareTemplateController', slice.call(arguments)); }
 
     let symbol: TemplateControllerSymbol;
     // dynamicOptions logic here is similar to (and explained in) bindCustomAttribute
     const command = this.resources.getBindingCommand(attrSyntax);
     if (command === null && attrInfo.hasDynamicOptions) {
-      symbol = new TemplateControllerSymbol(attrSyntax, attrInfo, this.partName);
+      symbol = new TemplateControllerSymbol(dom, attrSyntax, attrInfo, this.partName);
       this.partName = null;
-      this.bindMultiAttribute(symbol, attrInfo, attrSyntax.rawValue);
+      this.bindMultiAttribute(dom, symbol, attrInfo, attrSyntax.rawValue);
     } else {
-      symbol = new TemplateControllerSymbol(attrSyntax, attrInfo, this.partName);
+      symbol = new TemplateControllerSymbol(dom, attrSyntax, attrInfo, this.partName);
       const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
       const expr = this.exprParser.parse(attrSyntax.rawValue, bindingType);
       symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable, expr, attrSyntax.rawValue, attrSyntax.target));
@@ -655,7 +655,7 @@ export class TemplateBinder {
     return symbol;
   }
 
-  private bindCustomAttribute(attrSyntax: AttrSyntax, attrInfo: AttrInfo): void {
+  private bindCustomAttribute(dom: DOM, attrSyntax: AttrSyntax, attrInfo: AttrInfo): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindCustomAttribute', slice.call(arguments)); }
 
     const command = this.resources.getBindingCommand(attrSyntax);
@@ -664,7 +664,7 @@ export class TemplateBinder {
       // a dynamicOptions (semicolon separated binding) is only valid without a binding command;
       // the binding commands must be declared in the dynamicOptions expression itself
       symbol = new CustomAttributeSymbol(attrSyntax, attrInfo);
-      this.bindMultiAttribute(symbol, attrInfo, attrSyntax.rawValue);
+      this.bindMultiAttribute(dom, symbol, attrInfo, attrSyntax.rawValue);
     } else {
       // we've either got a command (with or without dynamicOptions, the latter maps to the first bindable),
       // or a null command but without dynamicOptions (which may be an interpolation or a normal string)
@@ -679,7 +679,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindMultiAttribute(symbol: ResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
+  private bindMultiAttribute(dom: DOM, symbol: ResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindMultiAttribute', slice.call(arguments)); }
 
     const attributes = parseMultiAttributeBinding(value);
@@ -702,7 +702,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindPlainAttribute(attrSyntax: AttrSyntax): void {
+  private bindPlainAttribute(dom: DOM, attrSyntax: AttrSyntax): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.bindPlainAttribute', slice.call(arguments)); }
 
     if (attrSyntax.rawValue.length === 0) {
@@ -740,7 +740,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private declareReplacePart(node: IHTMLTemplateElement | IHTMLElement): ReplacePartSymbol {
+  private declareReplacePart(dom: DOM, node: IHTMLTemplateElement | IHTMLElement): ReplacePartSymbol {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder.declareReplacePart', slice.call(arguments)); }
 
     const name = node.getAttribute('replace-part');
@@ -757,7 +757,7 @@ export class TemplateBinder {
   }
 }
 
-function processInterpolationText(symbol: TextSymbol): void {
+function processInterpolationText(dom: DOM, symbol: TextSymbol): void {
   const node = symbol.physicalNode;
   const parentNode = node.parentNode;
   while (node.nextSibling !== null && node.nextSibling.nodeType === NodeType.Text) {
@@ -771,7 +771,7 @@ function processInterpolationText(symbol: TextSymbol): void {
  * A (temporary) standalone function that purely does the DOM processing (lifting) related to template controllers.
  * It's a first refactoring step towards separating DOM parsing/binding from mutations.
  */
-function processTemplateControllers(manifestProxy: ParentNodeSymbol, manifest: ElementSymbol): void {
+function processTemplateControllers(dom: DOM, manifestProxy: ParentNodeSymbol, manifest: ElementSymbol): void {
   const manifestNode = manifest.physicalNode;
   let current = manifestProxy as TemplateControllerSymbol;
   while ((current as ParentNodeSymbol) !== manifest) {
@@ -787,11 +787,11 @@ function processTemplateControllers(manifestProxy: ParentNodeSymbol, manifest: E
         manifestNode.remove();
       } else {
         // the manifest is not a template element so we need to wrap it in one
-        current.physicalNode = DOM.createTemplate();
+        current.physicalNode = dom.createTemplate();
         current.physicalNode.content.appendChild(manifestNode);
       }
     } else {
-      current.physicalNode = DOM.createTemplate();
+      current.physicalNode = dom.createTemplate();
       current.physicalNode.content.appendChild(current.marker);
     }
     manifestNode.removeAttribute(current.syntax.rawName);
@@ -799,7 +799,7 @@ function processTemplateControllers(manifestProxy: ParentNodeSymbol, manifest: E
   }
 }
 
-function processReplacePart(replacePart: ReplacePartSymbol, manifestProxy: ParentNodeSymbol): void {
+function processReplacePart(dom: DOM, replacePart: ReplacePartSymbol, manifestProxy: ParentNodeSymbol): void {
     let proxyNode: IHTMLElement;
     if (manifestProxy.flags & SymbolFlags.hasMarker) {
       proxyNode = (manifestProxy as SymbolWithMarker).marker;
@@ -811,7 +811,7 @@ function processReplacePart(replacePart: ReplacePartSymbol, manifestProxy: Paren
       replacePart.physicalNode = proxyNode as IHTMLTemplateElement;
     } else {
       // otherwise wrap the replace-part in a template
-      replacePart.physicalNode = DOM.createTemplate();
+      replacePart.physicalNode = dom.createTemplate();
       replacePart.physicalNode.content.appendChild(proxyNode);
     }
 }

--- a/packages/jit/src/template-compiler.ts
+++ b/packages/jit/src/template-compiler.ts
@@ -1,6 +1,7 @@
 import { inject, IResourceDescriptions, PLATFORM } from '@aurelia/kernel';
 import {
   AttributeInstruction,
+  DOM,
   HydrateAttributeInstruction,
   HydrateElementInstruction,
   HydrateTemplateController,
@@ -76,11 +77,11 @@ export class TemplateCompiler implements ITemplateCompiler {
     this.instructionRows = null;
   }
 
-  public compile(definition: ITemplateDefinition, descriptions: IResourceDescriptions): TemplateDefinition {
+  public compile(dom: DOM, definition: ITemplateDefinition, descriptions: IResourceDescriptions): TemplateDefinition {
     const resources = new ResourceModel(descriptions);
     const binder = new TemplateBinder(resources, this.attrParser, this.exprParser);
     const template = definition.template = this.factory.createTemplate(definition.template);
-    const surrogate = binder.bind(template);
+    const surrogate = binder.bind(dom, template);
     if (definition.instructions === undefined || definition.instructions === PLATFORM.emptyArray) {
       definition.instructions = [];
     }

--- a/packages/jit/src/template-compiler.ts
+++ b/packages/jit/src/template-compiler.ts
@@ -1,11 +1,11 @@
 import { inject, IResourceDescriptions, PLATFORM } from '@aurelia/kernel';
 import {
   AttributeInstruction,
-  DOM,
   HydrateAttributeInstruction,
   HydrateElementInstruction,
   HydrateTemplateController,
   IBuildInstruction,
+  IDOM,
   IExpressionParser,
   ILetBindingInstruction,
   InstructionRow,
@@ -77,7 +77,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     this.instructionRows = null;
   }
 
-  public compile(dom: DOM, definition: ITemplateDefinition, descriptions: IResourceDescriptions): TemplateDefinition {
+  public compile(dom: IDOM, definition: ITemplateDefinition, descriptions: IResourceDescriptions): TemplateDefinition {
     const resources = new ResourceModel(descriptions);
     const binder = new TemplateBinder(resources, this.attrParser, this.exprParser);
     const template = definition.template = this.factory.createTemplate(definition.template);

--- a/packages/jit/src/template-factory.ts
+++ b/packages/jit/src/template-factory.ts
@@ -39,10 +39,12 @@ export const ITemplateFactory = DI.createInterface<ITemplateFactory>()
  * @internal
  */
 export class TemplateFactory {
+  private dom: DOM;
   private template: IHTMLTemplateElement;
 
-  constructor() {
-    this.template = DOM.createTemplate();
+  constructor(dom: DOM) {
+    this.dom = dom;
+    this.template = dom.createTemplate();
   }
 
   public createTemplate(markup: string): IHTMLTemplateElement;
@@ -56,7 +58,7 @@ export class TemplateFactory {
       // if the input is either not wrapped in a template or there is more than one node,
       // return the whole template that wraps it/them (and create a new one for the next input)
       if (node === null || node.nodeName !== 'TEMPLATE' || node.nextElementSibling !== null) {
-        this.template = DOM.createTemplate();
+        this.template = this.dom.createTemplate();
         return template;
       }
       // the node to return is both a template and the only node, so return just the node
@@ -66,7 +68,7 @@ export class TemplateFactory {
     }
     if (input.nodeName !== 'TEMPLATE') {
       // if we get one node that is not a template, wrap it in one
-      const template = DOM.createTemplate();
+      const template = this.dom.createTemplate();
       template.content.appendChild(input);
       return template;
     }

--- a/packages/jit/src/template-factory.ts
+++ b/packages/jit/src/template-factory.ts
@@ -1,5 +1,5 @@
 import { DI, inject } from '@aurelia/kernel';
-import { DOM, IElement, IHTMLTemplateElement, INode } from '@aurelia/runtime';
+import { IDOM, IElement, IHTMLTemplateElement, INode } from '@aurelia/runtime';
 
 /**
  * Utility that creates a `HTMLTemplateElement` out of string markup or an existing DOM node.
@@ -38,12 +38,12 @@ export const ITemplateFactory = DI.createInterface<ITemplateFactory>()
  *
  * @internal
  */
-@inject(DOM)
+@inject(IDOM)
 export class TemplateFactory {
-  private dom: DOM;
+  private dom: IDOM;
   private template: IHTMLTemplateElement;
 
-  constructor(dom: DOM) {
+  constructor(dom: IDOM) {
     this.dom = dom;
     this.template = dom.createTemplate();
   }

--- a/packages/jit/src/template-factory.ts
+++ b/packages/jit/src/template-factory.ts
@@ -1,4 +1,4 @@
-import { DI } from '@aurelia/kernel';
+import { DI, inject } from '@aurelia/kernel';
 import { DOM, IElement, IHTMLTemplateElement, INode } from '@aurelia/runtime';
 
 /**
@@ -38,6 +38,7 @@ export const ITemplateFactory = DI.createInterface<ITemplateFactory>()
  *
  * @internal
  */
+@inject(DOM)
 export class TemplateFactory {
   private dom: DOM;
   private template: IHTMLTemplateElement;

--- a/packages/jit/test/generated/template-compiler.mutations.basic.spec.ts
+++ b/packages/jit/test/generated/template-compiler.mutations.basic.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode, ILifecycle } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode, ILifecycle } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.mutations.basic", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.mutations.basic", function () {
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     it("works 1", function () {

--- a/packages/jit/test/generated/template-compiler.static.if-else.double.spec.ts
+++ b/packages/jit/test/generated/template-compiler.static.if-else.double.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.static.if-else.double", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.static.if-else.double", function () {
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     function verify(au, host, expected) {

--- a/packages/jit/test/generated/template-compiler.static.if-else.repeat.double.spec.ts
+++ b/packages/jit/test/generated/template-compiler.static.if-else.repeat.double.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.static.if-else.repeat.double", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.static.if-else.repeat.double", function ()
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     function verify(au, host, expected) {

--- a/packages/jit/test/generated/template-compiler.static.if-else.repeat.spec.ts
+++ b/packages/jit/test/generated/template-compiler.static.if-else.repeat.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.static.if-else.repeat", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.static.if-else.repeat", function () {
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     function verify(au, host, expected) {

--- a/packages/jit/test/generated/template-compiler.static.if-else.spec.ts
+++ b/packages/jit/test/generated/template-compiler.static.if-else.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.static.if-else", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.static.if-else", function () {
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     function verify(au, host, expected) {

--- a/packages/jit/test/generated/template-compiler.static.spec.ts
+++ b/packages/jit/test/generated/template-compiler.static.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { DI } from "../../../kernel/src/index";
-import { CustomElementResource, DOM, Aurelia, BindingMode } from "../../../runtime/src/index";
+import { CustomElementResource, Aurelia, BindingMode } from "../../../runtime/src/index";
 import { BasicConfiguration } from "../../src/index";
 
 describe("generated.template-compiler.static", function () {
@@ -8,7 +8,7 @@ describe("generated.template-compiler.static", function () {
         const container = DI.createContainer();
         container.register(BasicConfiguration);
         const au = new Aurelia(container);
-        const host = DOM.createElement("div");
+        const host = document.createElement("div");
         return { au, host };
     }
     function verify(au, host, expected) {

--- a/packages/jit/test/integration/prepare.ts
+++ b/packages/jit/test/integration/prepare.ts
@@ -1,8 +1,11 @@
 
 import { BasicConfiguration } from "../../src";
 import { expect } from "chai";
-import { valueConverter, customElement, bindable, CustomElementResource, IObserverLocator, Aurelia, Lifecycle, ILifecycle, INode, IElement } from "../../../runtime/src/index";
-import { IContainer, DI, Constructable, PLATFORM } from "../../../kernel/src/index";
+import { valueConverter, customElement, bindable, CustomElementResource, IObserverLocator, Aurelia, Lifecycle, ILifecycle, INode, IElement, DOM, IDOM } from "../../../runtime/src/index";
+import { IContainer, DI, Constructable, PLATFORM, Registration } from "../../../kernel/src/index";
+
+const dom = <any>new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 export function cleanup(): void {
   const body = document.body;
@@ -65,6 +68,7 @@ const globalResources: any[] = [
 export const TestConfiguration = {
   register(container: IContainer) {
     container.register(...globalResources);
+    container.register(domRegistration);
   }
 }
 
@@ -115,9 +119,10 @@ export function stringify(o) {
 
 export function setupAndStart(template: string, $class: Constructable | null, ...registrations: any[]) {
   const container = DI.createContainer();
+  container.register(domRegistration);
   container.register(...registrations);
-  const lifecycle = container.get(ILifecycle);
-  const observerLocator = container.get(IObserverLocator);
+  const lifecycle = container.get<ILifecycle>(ILifecycle);
+  const observerLocator = container.get<IObserverLocator>(IObserverLocator);
   container.register(TestConfiguration, BasicConfiguration)
   const host = document.createElement('app');
   document.body.appendChild(host);
@@ -129,9 +134,10 @@ export function setupAndStart(template: string, $class: Constructable | null, ..
 
 export function setup(template: string, $class: Constructable | null, ...registrations: any[]) {
   const container = DI.createContainer();
+  container.register(domRegistration);
   container.register(...registrations);
-  const lifecycle = container.get(ILifecycle);
-  const observerLocator = container.get(IObserverLocator);
+  const lifecycle = container.get<ILifecycle>(ILifecycle);
+  const observerLocator = container.get<IObserverLocator>(IObserverLocator);
   container.register(TestConfiguration, BasicConfiguration)
   const host = document.createElement('app');
   document.body.appendChild(host);

--- a/packages/jit/test/integration/template-compiler.base.ts
+++ b/packages/jit/test/integration/template-compiler.base.ts
@@ -1,16 +1,20 @@
 import { TestSuite } from "../../../../scripts/test-suite";
-import { IObserverLocator, DOM, Aurelia, ILifecycle } from '../../../runtime/src/index';;
-import { DI } from "@aurelia/kernel";
+import { IObserverLocator, DOM, Aurelia, ILifecycle, IDOM } from '../../../runtime/src/index';
+import { DI, Registration } from "../../../kernel/src/index";
 import { BasicConfiguration } from "../../src";
 import { TestConfiguration } from "./prepare";
 
-const app = DOM.createElement('app') as Node;
+const app = document.createElement('app') as Node;
 const createApp = app.cloneNode.bind(app, false);
+
+const dom = <any>new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 export const baseSuite = new TestSuite(null);
 
 baseSuite.addDataSlot('a').addData(null).setFactory(c => {
   const container = DI.createContainer();
+  container.register(domRegistration);
   container.get(IObserverLocator);
   container.register(BasicConfiguration);
   container.register(TestConfiguration);

--- a/packages/jit/test/integration/template-compiler.compose.spec.ts
+++ b/packages/jit/test/integration/template-compiler.compose.spec.ts
@@ -2,7 +2,8 @@ import { expect } from "chai";
 import { defineCustomElement } from "./prepare";
 import {
   bindable, Aurelia, ViewFactory, View, IView,
-  RenderPlan, IViewFactory, CompiledTemplate, IRenderingEngine, DOM, ILifecycle
+  RenderPlan, IViewFactory, CompiledTemplate, IRenderingEngine, DOM, ILifecycle,
+  IDOM, TemplateDefinition
 } from "../../../runtime/src/index";
 import { baseSuite } from "./template-compiler.base";
 import { IContainer } from "@aurelia/kernel";
@@ -64,7 +65,8 @@ suite.addDataSlot('f') // subject + expected text
     const msg = ctx.h = 'Hello!';
     ctx.g = 'sub';
     const engine = ctx.a.get(IRenderingEngine);
-    return engine.getViewFactory({
+    const dom = ctx.a.get(IDOM);
+    return engine.getViewFactory(dom, <TemplateDefinition>{
       template: `<template>${msg}</template>`,
       build: { required: true, compiler: 'default' }
     });
@@ -74,16 +76,18 @@ suite.addDataSlot('f') // subject + expected text
     const msg = ctx.h = 'Hello!';
     ctx.g = 'sub';
     const engine = ctx.a.get(IRenderingEngine);
-    return engine.getViewFactory({
+    const dom = ctx.a.get(IDOM);
+    return engine.getViewFactory(dom, <TemplateDefinition>{
       template: `<template>${msg}</template>`,
       build: { required: true, compiler: 'default' }
     }).create();
   })
   // RenderPlan
   .addData('06').setFactory(ctx => {
+    const dom = ctx.a.get(IDOM);
     const msg = ctx.h = 'Hello!';
     ctx.g = 'sub';
-    return new RenderPlan(<any>`<div>${msg}</div>`, [], []);
+    return new RenderPlan(dom, <any>`<div>${msg}</div>`, [], []);
   })
   // Raw Template (inline)
   .addData('07').setFactory(ctx => {

--- a/packages/jit/test/integration/template-compiler.deep-bindables.spec.ts
+++ b/packages/jit/test/integration/template-compiler.deep-bindables.spec.ts
@@ -19,9 +19,9 @@ const parentSuite = baseSuite.clone<IContainer, Aurelia, ILifecycle, IHTMLElemen
 
 parentSuite.addDataSlot('e').addData('app').setFactory(ctx => {
   const { a: container } = ctx;
-  const template = DOM.createTemplate();
-  const text = DOM.createTextNode('${$1}${$2}${$3}');
-  const fooA_el = DOM.createElement('foo-a');
+  const template = document.createElement('template');
+  const text = document.createTextNode('${$1}${$2}${$3}');
+  const fooA_el = document.createElement('foo-a');
 
   fooA_el.setAttribute('a1.bind', '$1');
   fooA_el.setAttribute('a2.bind', '$2');
@@ -37,9 +37,9 @@ parentSuite.addDataSlot('e').addData('app').setFactory(ctx => {
 });
 parentSuite.addDataSlot('f').addData('foo-a').setFactory(ctx => {
   const { a: container } = ctx;
-  const template = DOM.createElement('template');
-  const text = DOM.createTextNode('${a1}${a2}${a3}');
-  const fooB_el = DOM.createElement('foo-b');
+  const template = document.createElement('template');
+  const text = document.createTextNode('${a1}${a2}${a3}');
+  const fooB_el = document.createElement('foo-b');
 
   fooB_el.setAttribute('b1.bind', 'a1');
   fooB_el.setAttribute('b2.bind', 'a2');
@@ -62,9 +62,9 @@ parentSuite.addDataSlot('f').addData('foo-a').setFactory(ctx => {
 });
 parentSuite.addDataSlot('g').addData('foo-b').setFactory(ctx => {
   const { a: container } = ctx;
-  const template = DOM.createElement('template');
-  const text = DOM.createTextNode('${b1}${b2}${b3}');
-  const fooC_el = DOM.createElement('foo-c');
+  const template = document.createElement('template');
+  const text = document.createTextNode('${b1}${b2}${b3}');
+  const fooC_el = document.createElement('foo-c');
 
   fooC_el.setAttribute('c1.bind', 'b1');
   fooC_el.setAttribute('c2.bind', 'b2');
@@ -87,8 +87,8 @@ parentSuite.addDataSlot('g').addData('foo-b').setFactory(ctx => {
 });
 parentSuite.addDataSlot('h').addData('foo-c').setFactory(ctx => {
   const { a: container } = ctx;
-  const template = DOM.createElement('template');
-  const text = DOM.createTextNode('${c1}${c2}${c3}');
+  const template = document.createElement('template');
+  const text = document.createTextNode('${c1}${c2}${c3}');
 
   template.content.appendChild(text);
 
@@ -120,7 +120,7 @@ wrappedBasic.addActionSlot('wrap in div')
     } = ctx;
 
     for (const template of [appTemplate, fooATemplate, fooBTemplate, fooCTemplate] as IHTMLTemplateElement[]) {
-      const div = DOM.createElement('div');
+      const div = document.createElement('div');
       div.appendChild(template.content);
       template.content.appendChild(div);
     }

--- a/packages/jit/test/integration/template-compiler.kitchen-sink.spec.ts
+++ b/packages/jit/test/integration/template-compiler.kitchen-sink.spec.ts
@@ -1,11 +1,15 @@
 import { expect } from 'chai';
 import { tearDown, setupAndStart, cleanup, defineCustomElement } from './prepare';
 import { baseSuite } from './template-compiler.base';
-import { IContainer, Constructable, DI, IRegistry, Tracer, RuntimeCompilationResources } from '../../../kernel/src/index';;
-import { Aurelia, ICustomElementType, ILifecycle, CustomElementResource, DOM, ISignaler, Lifecycle, TextNodeSequence, IExpressionParser, LifecycleFlags, INodeSequence, NodeSequenceFactory, ITemplateCompiler } from '../../../runtime/src/index';
+import { IContainer, Constructable, DI, IRegistry, Tracer, RuntimeCompilationResources, Registration } from '../../../kernel/src/index';;
+import { Aurelia, ICustomElementType, ILifecycle, CustomElementResource, DOM, IDOM, ISignaler, Lifecycle, TextNodeSequence, IExpressionParser, LifecycleFlags, INodeSequence, NodeSequenceFactory, ITemplateCompiler } from '../../../runtime/src/index';
 import { BasicConfiguration, TemplateBinder, ResourceModel, IAttributeParser } from '../../src/index';
 import { enableTracing, SymbolTraceWriter, disableTracing } from '../unit/util';
 import { stringifyTemplateDefinition } from '../../src/debugging';
+
+
+const dom = <any>new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 const spec = 'template-compiler.kitchen-sink';
 
@@ -13,7 +17,7 @@ const spec = 'template-compiler.kitchen-sink';
 describe(spec, () => {
   it('startup with App type', () => {
     const component = CustomElementResource.define({ name: 'app', template: `<template>\${message}</template>` }, class { message = 'Hello!' });
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const au = new Aurelia().register(BasicConfiguration).app({ host, component }).start();
     expect(host.textContent).to.equal('Hello!');
     au.stop();
@@ -247,7 +251,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -321,7 +325,7 @@ describe(spec, () => {
     container.register(<any>Foo);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -383,7 +387,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -448,7 +452,7 @@ describe(spec, () => {
     container.register(<any>Foo);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -518,7 +522,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -584,7 +588,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -647,7 +651,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -710,7 +714,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -776,7 +780,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle);
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -824,7 +828,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle) as Lifecycle;
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -863,7 +867,7 @@ describe(spec, () => {
     const lifecycle = container.get(ILifecycle) as Lifecycle;
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -892,7 +896,7 @@ describe(spec, () => {
     }, class {
       $nodes: INodeSequence;
       render() {
-        this.$nodes = NodeSequenceFactory.createFor('foo').createNodeSequence();
+        this.$nodes = new NodeSequenceFactory(dom, 'foo').createNodeSequence();
       }
     });
 
@@ -901,7 +905,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -946,7 +950,7 @@ describe(spec, () => {
 
       const au = new Aurelia(<any>container);
 
-      const host = DOM.createElement('div');
+      const host = document.createElement('div');
       const component = new App();
 
       au.app({ host, component });
@@ -968,7 +972,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -989,7 +993,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1010,7 +1014,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1031,7 +1035,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1052,7 +1056,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1073,7 +1077,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1095,7 +1099,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1116,7 +1120,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1137,7 +1141,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1158,7 +1162,7 @@ describe(spec, () => {
 
     const au = new Aurelia(<any>container);
 
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const component = new App();
 
     au.app({ host, component });
@@ -1209,7 +1213,7 @@ describe('xml node compiler tests', () => {
       const exprParser = container.get(IExpressionParser) as IExpressionParser;
       const binder = new TemplateBinder(resources, attrParser, <any>exprParser);
 
-      const result = binder.bind(<any>fakeSurrogate);
+      const result = binder.bind(dom, <any>fakeSurrogate);
       expect(result.physicalNode).to.equal(fakeSurrogate);
     });
   }
@@ -1223,7 +1227,7 @@ describe("generated.template-compiler.static (with tracing)", function () {
       const container = DI.createContainer();
       container.register(BasicConfiguration);
       const au = new Aurelia(container);
-      const host = DOM.createElement("div");
+      const host = document.createElement("div");
       return { au, host };
   }
   function verify(au, host, expected, description) {

--- a/packages/jit/test/integration/template-compiler.repeater-custom-element.spec.ts
+++ b/packages/jit/test/integration/template-compiler.repeater-custom-element.spec.ts
@@ -199,7 +199,7 @@ describe(spec, () => {
       txt = 'a';
       $children;
     });
-    const host = DOM.createElement('div');
+    const host = document.createElement('div');
     const au = new Aurelia();
     au.register(BasicConfiguration);
     au.register(FooEl);

--- a/packages/jit/test/unit/template-factory.spec.ts
+++ b/packages/jit/test/unit/template-factory.spec.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 describe('TemplateFactory', () => {
 
   it('template-wrapped markup string', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<template><div class="au">foo</div></template>`;
 
     const expectedHTML = markup;
@@ -19,7 +19,7 @@ describe('TemplateFactory', () => {
   });
 
   it('non-template-wrapped markup string', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<div class="au">foo</div>`;
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -29,7 +29,7 @@ describe('TemplateFactory', () => {
   });
 
   it('double template-wrapped markup string', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<template><div class="au">foo</div></template>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -39,7 +39,7 @@ describe('TemplateFactory', () => {
   });
 
   it('double non-template-wrapped markup string', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<div class="au">foo</div>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -49,9 +49,11 @@ describe('TemplateFactory', () => {
   });
 
   it('template node', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<div class="au">foo</div>`;
-    const node = DOM.createTemplate(markup);
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    const node = template;
 
     const expectedHTML = `<template>${markup}</template>`
     const actualHTML = sut.createTemplate(node).outerHTML;
@@ -60,9 +62,11 @@ describe('TemplateFactory', () => {
   });
 
   it('non-template node', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<div class="au">foo</div>`;
-    const node = DOM.createTemplate(markup).content.firstElementChild;
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    const node = template.content.firstElementChild;
 
     const expectedHTML = `<template>${markup}</template>`
     const actualHTML = sut.createTemplate(node).outerHTML;
@@ -71,9 +75,11 @@ describe('TemplateFactory', () => {
   });
 
   it('template node with parent', () => {
-    const sut = new TemplateFactory();
+    const sut = new TemplateFactory(<any>new DOM(<any>document));
     const markup = `<template><div class="au">foo</div></template>`;
-    const node = DOM.createTemplate(markup).content.firstElementChild;
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    const node = template.content.firstElementChild;
 
     expect(node.parentNode).not.to.equal(null);
 

--- a/packages/plugin-svg/src/svg-analyzer.ts
+++ b/packages/plugin-svg/src/svg-analyzer.ts
@@ -205,7 +205,7 @@ function createElement(html: string): Element {
   // Using very HTML-specific code here since you won't install this module
   // unless you are actually running in a browser, using HTML,
   // and dealing with browser inconsistencies.
-  const div = DOM.createElement('div') as HTMLElement;
+  const div = document.createElement('div');
   div.innerHTML = html;
   return div.firstElementChild as Element;
 }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,4 +1,4 @@
-import { CustomElementResource, ICustomElement, ICustomElementType, INode, IRenderingEngine, LifecycleFlags } from '@aurelia/runtime';
+import { CustomElementResource, ICustomElement, ICustomElementType, IDOM, INode, IRenderingEngine, LifecycleFlags } from '@aurelia/runtime';
 import { INavigationInstruction } from './history-browser';
 import { Router } from './router';
 import { Scope } from './scope';
@@ -119,6 +119,7 @@ export class Viewport {
 
     const host: INode = this.element as INode;
     const renderingEngine = this.router.container.get(IRenderingEngine);
+    const dom = this.router.container.get(IDOM);
 
     if (this.component) {
       if (this.component.leave) {
@@ -132,7 +133,7 @@ export class Viewport {
       if (this.nextComponent.enter) {
         this.nextComponent.enter(this.nextInstruction, this.instruction);
       }
-      this.nextComponent.$hydrate(renderingEngine, host);
+      this.nextComponent.$hydrate(dom, renderingEngine, host);
       this.nextComponent.$bind(LifecycleFlags.fromStartTask | LifecycleFlags.fromBind, null);
       this.nextComponent.$attach(LifecycleFlags.fromStartTask, host);
 

--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -327,7 +327,7 @@ let setup = async (): Promise<{ au, container, host, router }> => {
   container.register(<any>ViewportCustomElement);
   container.register(Foo, Bar, Baz, Qux, Quux, Corge);
   const au = new Aurelia(<any>container);
-  const host = DOM.createElement('div');
+  const host = document.createElement('div');
   document.body.appendChild(<any>host);
   const component = new App();
   au.app({ component, host });

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -1,5 +1,5 @@
-import { DI, IContainer, IRegistry, PLATFORM, Registration, Reporter } from '@aurelia/kernel';
-import { DOM } from './dom';
+import { DI, IContainer, IRegistry, PLATFORM, Registration } from '@aurelia/kernel';
+import { DOM, IDOM } from './dom';
 import { IDocument, INode } from './dom.interfaces';
 import { LifecycleFlags } from './observation';
 import { CustomElementResource, ICustomElement, ICustomElementType } from './resources/custom-element';
@@ -8,7 +8,7 @@ import { IRenderingEngine } from './templating/lifecycle-render';
 declare var document: IDocument;
 
 export interface ISinglePageApp {
-  dom?: DOM;
+  dom?: IDOM;
   host: unknown;
   component: unknown;
 }
@@ -49,7 +49,7 @@ export class Aurelia {
     } else {
       component = componentOrType as ICustomElement;
     }
-    if (!this.container.has(DOM, false)) {
+    if (!this.container.has(IDOM, false)) {
       if (config.dom !== undefined) {
         this.useDOM(config.dom);
       } else if (host.ownerDocument !== null) {
@@ -64,7 +64,7 @@ export class Aurelia {
       if (!this.components.includes(component)) {
         this._root = component;
         this.components.push(component);
-        const dom = this.container.get(DOM);
+        const dom = this.container.get(IDOM);
         const re = this.container.get(IRenderingEngine);
         component.$hydrate(dom, re, host);
       }
@@ -111,7 +111,7 @@ export class Aurelia {
   /**
    * Use the supplied `dom` directly for this `Aurelia` instance.
    */
-  public useDOM(dom: DOM): this;
+  public useDOM(dom: IDOM): this;
   /**
    * Create a new HTML `DOM` backed by the supplied `document`.
    */
@@ -122,9 +122,9 @@ export class Aurelia {
    * If no argument is provided, uses the default global `document` variable.
    * (this will throw an error in non-browser environments).
    */
-  public useDOM(domOrDocument?: DOM | IDocument): this;
-  public useDOM(domOrDocument?: DOM | IDocument): this {
-    let dom: DOM;
+  public useDOM(domOrDocument?: IDOM | IDocument): this;
+  public useDOM(domOrDocument?: IDOM | IDocument): this {
+    let dom: IDOM;
     if (domOrDocument === undefined) {
       dom = new DOM(document);
     } else if (quacksLikeDOM(domOrDocument)) {
@@ -133,13 +133,13 @@ export class Aurelia {
       dom = new DOM(domOrDocument);
     }
     Registration
-      .instance(DOM, dom)
-      .register(this.container, DOM);
+      .instance(IDOM, dom)
+      .register(this.container, IDOM);
     return this;
   }
 }
 
-function quacksLikeDOM(potentialDOM: unknown): potentialDOM is DOM {
+function quacksLikeDOM(potentialDOM: unknown): potentialDOM is IDOM {
   return 'convertToRenderLocation' in (potentialDOM as object);
 }
 

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -1,8 +1,11 @@
 import { DI, IContainer, IRegistry, PLATFORM, Registration } from '@aurelia/kernel';
-import { INode } from './dom.interfaces';
+import { DOM } from './dom';
+import { IDocument, INode } from './dom.interfaces';
 import { LifecycleFlags } from './observation';
-import { CustomElementResource, ICustomElement, ICustomElementType } from './resources/custom-element';
+import { CustomElementResource, ICustomElement, ICustomElementType, containerless } from './resources/custom-element';
 import { IRenderingEngine } from './templating/lifecycle-render';
+
+declare var document: IDocument;
 
 export interface ISinglePageApp {
   host: unknown;
@@ -45,6 +48,8 @@ export class Aurelia {
     } else {
       component = componentOrType as ICustomElement;
     }
+    const dom = new DOM(document);
+    this.container.register(Registration.instance(DOM, dom));
 
     const startTask = () => {
       host.$au = this;
@@ -52,7 +57,7 @@ export class Aurelia {
         this._root = component;
         this.components.push(component);
         const re = this.container.get(IRenderingEngine);
-        component.$hydrate(re, host);
+        component.$hydrate(dom, re, host);
       }
 
       component.$bind(LifecycleFlags.fromStartTask | LifecycleFlags.fromBind, null);

--- a/packages/runtime/src/binding/listener.ts
+++ b/packages/runtime/src/binding/listener.ts
@@ -1,4 +1,5 @@
 import { IDisposable, IIndexable, IServiceLocator, Tracer } from '@aurelia/kernel';
+import { DOM } from '../dom';
 import { IEvent, INode } from '../dom.interfaces';
 import { IBindScope, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
@@ -11,6 +12,8 @@ const slice = Array.prototype.slice;
 
 export interface Listener extends IConnectableBinding {}
 export class Listener implements IBinding {
+  public dom: DOM;
+
   public $nextBind: IBindScope;
   public $prevBind: IBindScope;
   public $state: State;
@@ -26,7 +29,17 @@ export class Listener implements IBinding {
   private eventManager: IEventManager;
   private handler: IDisposable;
 
-  constructor(targetEvent: string, delegationStrategy: DelegationStrategy, sourceExpression: IsBindingBehavior, target: INode, preventDefault: boolean, eventManager: IEventManager, locator: IServiceLocator) {
+  constructor(
+    dom: DOM,
+    targetEvent: string,
+    delegationStrategy: DelegationStrategy,
+    sourceExpression: IsBindingBehavior,
+    target: INode,
+    preventDefault: boolean,
+    eventManager: IEventManager,
+    locator: IServiceLocator
+  ) {
+    this.dom = dom;
     this.$nextBind = null;
     this.$prevBind = null;
     this.$state = State.none;
@@ -83,6 +96,7 @@ export class Listener implements IBinding {
     }
 
     this.handler = this.eventManager.addEventListener(
+      this.dom,
       this.target,
       this.targetEvent,
       this,

--- a/packages/runtime/src/binding/listener.ts
+++ b/packages/runtime/src/binding/listener.ts
@@ -1,5 +1,5 @@
 import { IDisposable, IIndexable, IServiceLocator, Tracer } from '@aurelia/kernel';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { IEvent, INode } from '../dom.interfaces';
 import { IBindScope, State } from '../lifecycle';
 import { IScope, LifecycleFlags } from '../observation';
@@ -12,7 +12,7 @@ const slice = Array.prototype.slice;
 
 export interface Listener extends IConnectableBinding {}
 export class Listener implements IBinding {
-  public dom: DOM;
+  public dom: IDOM;
 
   public $nextBind: IBindScope;
   public $prevBind: IBindScope;
@@ -30,7 +30,7 @@ export class Listener implements IBinding {
   private handler: IDisposable;
 
   constructor(
-    dom: DOM,
+    dom: IDOM,
     targetEvent: string,
     delegationStrategy: DelegationStrategy,
     sourceExpression: IsBindingBehavior,

--- a/packages/runtime/src/dom.interfaces.ts
+++ b/packages/runtime/src/dom.interfaces.ts
@@ -78,6 +78,7 @@ export interface INode extends INodeLike, IEventTarget {
   readonly nextSibling: INode | null;
   readonly nodeName: string;
   readonly nodeType: NodeType;
+  readonly ownerDocument: IDocument | null;
   readonly parentNode: INode & IParentNode | null;
   readonly previousSibling: INode | null;
   textContent: string | null;

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -219,13 +219,15 @@ export const NodeSequence = {
  * - text is the actual text node
  */
 export class TextNodeSequence implements INodeSequence {
+  public dom: DOM;
   public firstChild: IText;
   public lastChild: IText;
   public childNodes: IText[];
 
   private targets: [INode];
 
-  constructor(text: IText) {
+  constructor(dom: DOM, text: IText) {
+    this.dom = dom;
     this.firstChild = text;
     this.lastChild = text;
     this.childNodes = [text];
@@ -257,11 +259,11 @@ export class TextNodeSequence implements INodeSequence {
 // CompiledTemplates create instances of FragmentNodeSequence.
 /** @internal */
 export class FragmentNodeSequence implements INodeSequence {
+  public dom: DOM;
   public firstChild: INode;
   public lastChild: INode;
   public childNodes: INode[];
 
-  private readonly dom: DOM;
   private end: IRenderLocation;
   private fragment: IDocumentFragment;
   private start: IRenderLocation;
@@ -420,7 +422,7 @@ export class NodeSequenceFactory implements INodeSequenceFactory {
   }
 
   public createNodeSequence(): INodeSequence {
-    return new this.Type(this.node.cloneNode(this.deepClone));
+    return new this.Type(this.dom, this.node.cloneNode(this.deepClone));
   }
 }
 

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -118,16 +118,6 @@ export class DOM {
   public getAttribute(node: IHTMLElement, name: string): string {
     return node.getAttribute(name);
   }
-  public getChildNodes(node: INode): ReadonlyArray<INode> {
-    if (node.childNodes.length) {
-      return PLATFORM.toArray(node.childNodes);
-    } else {
-      return PLATFORM.emptyArray;
-    }
-  }
-  public getParentNode(node: INode): INode {
-    return node.parentNode;
-  }
   public hasClass(node: IHTMLElement, className: string): boolean {
     return node.classList.contains(className);
   }
@@ -137,15 +127,6 @@ export class DOM {
   public insertBefore(nodeToInsert: INode, referenceNode: INode): void {
     referenceNode.parentNode.insertBefore(nodeToInsert, referenceNode);
   }
-  public isCommentNodeType(node: INode): node is IComment {
-    return node.nodeType === NodeType.Comment;
-  }
-  public isDocumentFragmentType(node: INode): node is IDocumentFragment {
-    return node.nodeType === NodeType.DocumentFragment;
-  }
-  public isElementNodeType(node: INode): node is IHTMLElement {
-    return node.nodeType === NodeType.Element;
-  }
   public isMarker(node: unknown): node is IHTMLElement {
     return (node as AuMarker).nodeName === 'AU-M';
   }
@@ -154,14 +135,6 @@ export class DOM {
   }
   public isRenderLocation(node: unknown): node is IRenderLocation {
     return (node as IComment).textContent === 'au-end';
-  }
-  public isTextNodeType(node: INode): node is IText {
-    return node.nodeType === NodeType.Text;
-  }
-  public migrateChildNodes(currentParent: INode, newParent: INode): void {
-    while (currentParent.firstChild !== null) {
-      newParent.appendChild(currentParent.firstChild);
-    }
   }
   public registerElementResolver(container: IContainer, resolver: IResolver): void {
     container.registerResolver(INode, resolver);

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -83,11 +83,11 @@ export class TextBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: ITextBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ITextBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('TextBindingRenderer.render', slice.call(arguments)); }
     const next = target.nextSibling;
-    if (DOM.isMarker(target)) {
-      DOM.remove(target);
+    if (dom.isMarker(target)) {
+      dom.remove(target);
     }
     let bindable: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
@@ -113,7 +113,7 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IInterpolationInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IInterpolationInstruction): void {
     if (Tracer.enabled) { Tracer.enter('InterpolationBindingRenderer.render', slice.call(arguments)); }
     let bindable: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
@@ -139,7 +139,7 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IPropertyBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IPropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('PropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const bindable = new Binding(expr, target, instruction.to, instruction.mode, this.observerLocator, context);
@@ -160,7 +160,7 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IIteratorBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IIteratorBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('IteratorBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
     const bindable = new Binding(expr, target, instruction.to, BindingMode.toView, this.observerLocator, context);
@@ -181,10 +181,10 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
     this.eventManager = eventManager;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IListenerBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IListenerBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('ListenerBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
-    const bindable = new Listener(instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
+    const bindable = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
     addBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
@@ -202,7 +202,7 @@ export class CallBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: ICallBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ICallBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CallBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
     const bindable = new Call(expr, target, instruction.to, this.observerLocator, context);
@@ -221,7 +221,7 @@ export class RefBindingRenderer implements IInstructionRenderer {
     this.parser = parser;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: INode, instruction: IRefBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IRefBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('RefBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
     const bindable = new Ref(expr, target, context);
@@ -242,7 +242,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: IHTMLElement, instruction: IStylePropertyBindingInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IHTMLElement, instruction: IStylePropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const bindable = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
@@ -254,7 +254,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.setProperty)
 /** @internal */
 export class SetPropertyRenderer implements IInstructionRenderer {
-  public render(context: IRenderContext, renderable: IRenderable, target: IIndexable, instruction: ISetPropertyInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IIndexable, instruction: ISetPropertyInstruction): void {
     if (Tracer.enabled) { Tracer.enter('SetPropertyRenderer.render', slice.call(arguments)); }
     target[instruction.to] = instruction.value;
     if (Tracer.enabled) { Tracer.leave(); }
@@ -264,9 +264,9 @@ export class SetPropertyRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.setAttribute)
 /** @internal */
 export class SetAttributeRenderer implements IInstructionRenderer {
-  public render(context: IRenderContext, renderable: IRenderable, target: IElement, instruction: ISetAttributeInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: ISetAttributeInstruction): void {
     if (Tracer.enabled) { Tracer.enter('SetAttributeRenderer.render', slice.call(arguments)); }
-    DOM.setAttribute(target, instruction.to, instruction.value);
+    dom.setAttribute(target as IHTMLElement, instruction.to, instruction.value);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -281,18 +281,18 @@ export class CustomElementRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: IRenderLocation, instruction: IHydrateElementInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IRenderLocation, instruction: IHydrateElementInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CustomElementRenderer.render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction, null, null, target, true);
     const component = context.get<ICustomElement>(customElementKey(instruction.res));
     const instructionRenderers = context.get(IRenderer).instructionRenderers;
     const childInstructions = instruction.instructions;
 
-    component.$hydrate(this.renderingEngine, target, instruction as IElementHydrationOptions);
+    component.$hydrate(dom, this.renderingEngine, target, instruction as IElementHydrationOptions);
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const current = childInstructions[i];
-      instructionRenderers[current.type].render(context, renderable, component, current);
+      instructionRenderers[current.type].render(dom, context, renderable, component, current);
     }
 
     addBindable(renderable, component);
@@ -313,7 +313,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateAttributeInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateAttributeInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CustomAttributeRenderer.render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction);
     const component = context.get<ICustomAttribute>(customAttributeKey(instruction.res));
@@ -324,7 +324,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const current = childInstructions[i];
-      instructionRenderers[current.type].render(context, renderable, component, current);
+      instructionRenderers[current.type].render(dom, context, renderable, component, current);
     }
 
     addBindable(renderable, component);
@@ -345,10 +345,10 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateTemplateController, parts?: TemplatePartDefinitions): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateTemplateController, parts?: TemplatePartDefinitions): void {
     if (Tracer.enabled) { Tracer.enter('TemplateControllerRenderer.render', slice.call(arguments)); }
-    const factory = this.renderingEngine.getViewFactory(instruction.def, context);
-    const operation = context.beginComponentOperation(renderable, target, instruction, factory, parts, DOM.convertToRenderLocation(target), false);
+    const factory = this.renderingEngine.getViewFactory(dom, instruction.def, context);
+    const operation = context.beginComponentOperation(renderable, target, instruction, factory, parts, dom.convertToRenderLocation(target), false);
     const component = context.get<ICustomAttribute>(customAttributeKey(instruction.res));
     const instructionRenderers = context.get(IRenderer).instructionRenderers;
     const childInstructions = instruction.instructions;
@@ -361,7 +361,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const current = childInstructions[i];
-      instructionRenderers[current.type].render(context, renderable, component, current);
+      instructionRenderers[current.type].render(dom, context, renderable, component, current);
     }
 
     addBindable(renderable, component);
@@ -384,7 +384,7 @@ export class LetElementRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateLetElementInstruction): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateLetElementInstruction): void {
     if (Tracer.enabled) { Tracer.enter('LetElementRenderer.render', slice.call(arguments)); }
     target.remove();
     const childInstructions = instruction.instructions;

--- a/packages/runtime/src/html-renderer.ts
+++ b/packages/runtime/src/html-renderer.ts
@@ -27,7 +27,7 @@ import {
   TargetedInstructionType,
   TemplatePartDefinitions
 } from './definitions';
-import { DOM } from './dom';
+import { IDOM } from './dom';
 import { IElement, IHTMLElement, INode, IRenderLocation } from './dom.interfaces';
 import { IAttach, IAttachables, IBindables, IBindScope, IRenderable, IRenderContext } from './lifecycle';
 import { IEventManager } from './observation/event-manager';
@@ -83,7 +83,7 @@ export class TextBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ITextBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ITextBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('TextBindingRenderer.render', slice.call(arguments)); }
     const next = target.nextSibling;
     if (dom.isMarker(target)) {
@@ -113,7 +113,7 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IInterpolationInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IInterpolationInstruction): void {
     if (Tracer.enabled) { Tracer.enter('InterpolationBindingRenderer.render', slice.call(arguments)); }
     let bindable: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
@@ -139,7 +139,7 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IPropertyBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IPropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('PropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const bindable = new Binding(expr, target, instruction.to, instruction.mode, this.observerLocator, context);
@@ -160,7 +160,7 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IIteratorBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IIteratorBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('IteratorBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
     const bindable = new Binding(expr, target, instruction.to, BindingMode.toView, this.observerLocator, context);
@@ -181,7 +181,7 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
     this.eventManager = eventManager;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IListenerBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IListenerBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('ListenerBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
     const bindable = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
@@ -202,7 +202,7 @@ export class CallBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ICallBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ICallBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CallBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
     const bindable = new Call(expr, target, instruction.to, this.observerLocator, context);
@@ -221,7 +221,7 @@ export class RefBindingRenderer implements IInstructionRenderer {
     this.parser = parser;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IRefBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IRefBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('RefBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
     const bindable = new Ref(expr, target, context);
@@ -242,7 +242,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IHTMLElement, instruction: IStylePropertyBindingInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IHTMLElement, instruction: IStylePropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const bindable = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
@@ -254,7 +254,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.setProperty)
 /** @internal */
 export class SetPropertyRenderer implements IInstructionRenderer {
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IIndexable, instruction: ISetPropertyInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IIndexable, instruction: ISetPropertyInstruction): void {
     if (Tracer.enabled) { Tracer.enter('SetPropertyRenderer.render', slice.call(arguments)); }
     target[instruction.to] = instruction.value;
     if (Tracer.enabled) { Tracer.leave(); }
@@ -264,7 +264,7 @@ export class SetPropertyRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.setAttribute)
 /** @internal */
 export class SetAttributeRenderer implements IInstructionRenderer {
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: ISetAttributeInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: ISetAttributeInstruction): void {
     if (Tracer.enabled) { Tracer.enter('SetAttributeRenderer.render', slice.call(arguments)); }
     dom.setAttribute(target as IHTMLElement, instruction.to, instruction.value);
     if (Tracer.enabled) { Tracer.leave(); }
@@ -281,7 +281,7 @@ export class CustomElementRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IRenderLocation, instruction: IHydrateElementInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IRenderLocation, instruction: IHydrateElementInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CustomElementRenderer.render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction, null, null, target, true);
     const component = context.get<ICustomElement>(customElementKey(instruction.res));
@@ -313,7 +313,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateAttributeInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateAttributeInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CustomAttributeRenderer.render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction);
     const component = context.get<ICustomAttribute>(customAttributeKey(instruction.res));
@@ -345,7 +345,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     this.renderingEngine = renderingEngine;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateTemplateController, parts?: TemplatePartDefinitions): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateTemplateController, parts?: TemplatePartDefinitions): void {
     if (Tracer.enabled) { Tracer.enter('TemplateControllerRenderer.render', slice.call(arguments)); }
     const factory = this.renderingEngine.getViewFactory(dom, instruction.def, context);
     const operation = context.beginComponentOperation(renderable, target, instruction, factory, parts, dom.convertToRenderLocation(target), false);
@@ -384,7 +384,7 @@ export class LetElementRenderer implements IInstructionRenderer {
     this.observerLocator = observerLocator;
   }
 
-  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateLetElementInstruction): void {
+  public render(dom: IDOM, context: IRenderContext, renderable: IRenderable, target: IElement, instruction: IHydrateLetElementInstruction): void {
     if (Tracer.enabled) { Tracer.enter('LetElementRenderer.render', slice.call(arguments)); }
     target.remove();
     const childInstructions = instruction.instructions;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,3 @@
-
-
-
 export * from './binding/ast';
 export * from './binding/binding-mode';
 export * from './binding/binding';

--- a/packages/runtime/src/observation/collection-observer.ts
+++ b/packages/runtime/src/observation/collection-observer.ts
@@ -84,6 +84,10 @@ export function collectionObserver(kind: CollectionKind.array | CollectionKind.s
 
 export interface CollectionLengthObserver extends IBindingTargetObserver<Collection, string> {}
 
+/**
+ * Temporary shortcut to let the @targetObserver decorator know that the length property is never on a DOM instance
+ * TODO: add information to the observers so they don't need to consult the DOM
+ */
 const domStub = {
   isNodeInstance(value: unknown): false {
     return false;

--- a/packages/runtime/src/observation/collection-observer.ts
+++ b/packages/runtime/src/observation/collection-observer.ts
@@ -84,8 +84,15 @@ export function collectionObserver(kind: CollectionKind.array | CollectionKind.s
 
 export interface CollectionLengthObserver extends IBindingTargetObserver<Collection, string> {}
 
+const domStub = {
+  isNodeInstance(value: unknown): false {
+    return false;
+  }
+};
+
 @targetObserver()
 export class CollectionLengthObserver implements CollectionLengthObserver, IPatch {
+  public dom: typeof domStub;
   public currentValue: number;
   public currentFlags: LifecycleFlags;
 
@@ -93,6 +100,7 @@ export class CollectionLengthObserver implements CollectionLengthObserver, IPatc
   public propertyKey: 'length' | 'size';
 
   constructor(obj: Collection, propertyKey: 'length' | 'size') {
+    this.dom = domStub;
     this.obj = obj;
     this.propertyKey = propertyKey;
 

--- a/packages/runtime/src/observation/element-observation.ts
+++ b/packages/runtime/src/observation/element-observation.ts
@@ -48,6 +48,7 @@ export interface ValueAttributeObserver extends
 
 @targetObserver('')
 export class ValueAttributeObserver implements ValueAttributeObserver {
+  public dom: DOM;
   public currentFlags: LifecycleFlags;
   public currentValue: unknown;
   public defaultValue: unknown;
@@ -58,7 +59,8 @@ export class ValueAttributeObserver implements ValueAttributeObserver {
   public obj: INode;
   public propertyKey: string;
 
-  constructor(lifecycle: ILifecycle, obj: INode, propertyKey: string, handler: IEventSubscriber) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: INode, propertyKey: string, handler: IEventSubscriber) {
+    this.dom = dom;
     this.handler = handler;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -145,6 +147,7 @@ export interface CheckedObserver extends
 
 @targetObserver()
 export class CheckedObserver implements CheckedObserver {
+  public dom: DOM;
   public currentFlags: LifecycleFlags;
   public currentValue: unknown;
   public defaultValue: unknown;
@@ -158,7 +161,8 @@ export class CheckedObserver implements CheckedObserver {
   private arrayObserver: ICollectionObserver<CollectionKind.array>;
   private valueObserver: ValueAttributeObserver | SetterObserver;
 
-  constructor(lifecycle: ILifecycle, obj: IInputElement, handler: IEventSubscriber, observerLocator: IObserverLocator) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: IInputElement, handler: IEventSubscriber, observerLocator: IObserverLocator) {
+    this.dom = dom;
     this.handler = handler;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -233,7 +237,7 @@ export class CheckedObserver implements CheckedObserver {
     let value = this.currentValue;
     const element = this.obj;
     const elementValue = element.hasOwnProperty('model') ? element['model'] : element.value;
-    let index;
+    let index: number;
     const matcher = element['matcher'] || defaultMatcher;
 
     if (element.type === 'checkbox') {
@@ -310,10 +314,16 @@ export interface SelectValueObserver extends
 
 @targetObserver()
 export class SelectValueObserver implements SelectValueObserver {
+  public dom: DOM;
   public currentValue: unknown;
   public currentFlags: LifecycleFlags;
   public oldValue: unknown;
   public defaultValue: unknown;
+
+  public lifecycle: ILifecycle;
+  public obj: ISelectElement;
+  public handler: IEventSubscriber;
+  public observerLocator: IObserverLocator;
 
   public flush: () => void;
 
@@ -321,11 +331,18 @@ export class SelectValueObserver implements SelectValueObserver {
   private nodeObserver: IMutationObserver;
 
   constructor(
-    public lifecycle: ILifecycle,
-    public obj: ISelectElement,
-    public handler: IEventSubscriber,
-    public observerLocator: IObserverLocator
-  ) { }
+    dom: DOM,
+    lifecycle: ILifecycle,
+    obj: ISelectElement,
+    handler: IEventSubscriber,
+    observerLocator: IObserverLocator
+  ) {
+    this.dom = dom;
+    this.lifecycle = lifecycle;
+    this.obj = obj;
+    this.handler = handler;
+    this.observerLocator = observerLocator;
+  }
 
   public getValue(): unknown {
     return this.currentValue;
@@ -502,7 +519,7 @@ export class SelectValueObserver implements SelectValueObserver {
   }
 
   public bind(): void {
-    this.nodeObserver = DOM.createNodeObserver(
+    this.nodeObserver = this.dom.createNodeObserver(
       this.obj,
       this.handleNodeChange.bind(this),
       childObserverOptions

--- a/packages/runtime/src/observation/element-observation.ts
+++ b/packages/runtime/src/observation/element-observation.ts
@@ -1,4 +1,4 @@
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { IHTMLInputElement, IHTMLOptionElement, IHTMLSelectElement, IMutationObserver, INode } from '../dom.interfaces';
 import { ILifecycle } from '../lifecycle';
 import {
@@ -48,7 +48,7 @@ export interface ValueAttributeObserver extends
 
 @targetObserver('')
 export class ValueAttributeObserver implements ValueAttributeObserver {
-  public dom: DOM;
+  public dom: IDOM;
   public currentFlags: LifecycleFlags;
   public currentValue: unknown;
   public defaultValue: unknown;
@@ -59,7 +59,7 @@ export class ValueAttributeObserver implements ValueAttributeObserver {
   public obj: INode;
   public propertyKey: string;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: INode, propertyKey: string, handler: IEventSubscriber) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: INode, propertyKey: string, handler: IEventSubscriber) {
     this.dom = dom;
     this.handler = handler;
     this.lifecycle = lifecycle;
@@ -147,7 +147,7 @@ export interface CheckedObserver extends
 
 @targetObserver()
 export class CheckedObserver implements CheckedObserver {
-  public dom: DOM;
+  public dom: IDOM;
   public currentFlags: LifecycleFlags;
   public currentValue: unknown;
   public defaultValue: unknown;
@@ -161,7 +161,7 @@ export class CheckedObserver implements CheckedObserver {
   private arrayObserver: ICollectionObserver<CollectionKind.array>;
   private valueObserver: ValueAttributeObserver | SetterObserver;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: IInputElement, handler: IEventSubscriber, observerLocator: IObserverLocator) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: IInputElement, handler: IEventSubscriber, observerLocator: IObserverLocator) {
     this.dom = dom;
     this.handler = handler;
     this.lifecycle = lifecycle;
@@ -314,7 +314,7 @@ export interface SelectValueObserver extends
 
 @targetObserver()
 export class SelectValueObserver implements SelectValueObserver {
-  public dom: DOM;
+  public dom: IDOM;
   public currentValue: unknown;
   public currentFlags: LifecycleFlags;
   public oldValue: unknown;
@@ -331,7 +331,7 @@ export class SelectValueObserver implements SelectValueObserver {
   private nodeObserver: IMutationObserver;
 
   constructor(
-    dom: DOM,
+    dom: IDOM,
     lifecycle: ILifecycle,
     obj: ISelectElement,
     handler: IEventSubscriber,

--- a/packages/runtime/src/observation/event-manager.ts
+++ b/packages/runtime/src/observation/event-manager.ts
@@ -1,5 +1,5 @@
 import { DI, IDisposable } from '@aurelia/kernel';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { IEventListenerOrEventListenerObject, IEventTarget, IManagedEvent, INode } from '../dom.interfaces';
 
 //Note: path and deepPath are designed to handle v0 and v1 shadow dom specs respectively
@@ -67,13 +67,13 @@ function handleDelegatedEvent(event: IManagedEvent): void {
 }
 
 export class ListenerTracker {
-  private dom: DOM;
+  private dom: IDOM;
   private capture: boolean;
   private count: number;
   private eventName: string;
   private listener: IEventListenerOrEventListenerObject;
 
-  constructor(dom: DOM, eventName: string, listener: IEventListenerOrEventListenerObject, capture: boolean) {
+  constructor(dom: IDOM, eventName: string, listener: IEventListenerOrEventListenerObject, capture: boolean) {
     this.dom = dom;
     this.capture = capture;
     this.count = 0;
@@ -129,10 +129,10 @@ export class TriggerSubscription {
   public target: INode;
   public targetEvent: string;
   public callback: IEventListenerOrEventListenerObject;
-  private dom: DOM;
+  private dom: IDOM;
 
   constructor(
-    dom: DOM,
+    dom: IDOM,
     target: INode,
     targetEvent: string,
     callback: IEventListenerOrEventListenerObject
@@ -170,12 +170,12 @@ export interface IEventSubscriber extends IDisposable {
 }
 
 export class EventSubscriber implements IEventSubscriber {
-  private readonly dom: DOM;
+  private readonly dom: IDOM;
   private readonly events: string[];
   private target: INode;
   private handler: IEventListenerOrEventListenerObject;
 
-  constructor(dom: DOM, events: string[]) {
+  constructor(dom: IDOM, events: string[]) {
     this.dom = dom;
     this.events = events;
     this.target = null;
@@ -212,8 +212,8 @@ export type EventSubscription = DelegateOrCaptureSubscription | TriggerSubscript
 
 export interface IEventManager {
   registerElementConfiguration(config: IElementConfiguration): void;
-  getElementHandler(dom: DOM, target: INode, propertyName: string): IEventSubscriber | null;
-  addEventListener(dom: DOM, target: INode, targetEvent: string, callbackOrListener: IEventListenerOrEventListenerObject, delegate: DelegationStrategy): IDisposable;
+  getElementHandler(dom: IDOM, target: INode, propertyName: string): IEventSubscriber | null;
+  addEventListener(dom: IDOM, target: INode, targetEvent: string, callbackOrListener: IEventListenerOrEventListenerObject, delegate: DelegationStrategy): IDisposable;
 }
 
 export const IEventManager = DI.createInterface<IEventManager>()
@@ -272,7 +272,7 @@ export class EventManager implements IEventManager {
     }
   }
 
-  public getElementHandler(dom: DOM, target: INode, propertyName: string): IEventSubscriber | null {
+  public getElementHandler(dom: IDOM, target: INode, propertyName: string): IEventSubscriber | null {
     const tagName = target['tagName'];
     const lookup = this.elementHandlerLookup;
 
@@ -291,7 +291,7 @@ export class EventManager implements IEventManager {
   }
 
   public addEventListener(
-    dom: DOM,
+    dom: IDOM,
     target: IEventTargetWithLookups,
     targetEvent: string,
     callbackOrListener: IEventListenerOrEventListenerObject,

--- a/packages/runtime/src/observation/event-manager.ts
+++ b/packages/runtime/src/observation/event-manager.ts
@@ -67,12 +67,14 @@ function handleDelegatedEvent(event: IManagedEvent): void {
 }
 
 export class ListenerTracker {
+  private dom: DOM;
   private capture: boolean;
   private count: number;
   private eventName: string;
   private listener: IEventListenerOrEventListenerObject;
 
-  constructor(eventName: string, listener: IEventListenerOrEventListenerObject, capture: boolean) {
+  constructor(dom: DOM, eventName: string, listener: IEventListenerOrEventListenerObject, capture: boolean) {
+    this.dom = dom;
     this.capture = capture;
     this.count = 0;
     this.eventName = eventName;
@@ -82,14 +84,14 @@ export class ListenerTracker {
   public increment(): void {
     this.count++;
     if (this.count === 1) {
-      DOM.addEventListener(this.eventName, this.listener, null, this.capture);
+      this.dom .addEventListener(this.eventName, this.listener, null, this.capture);
     }
   }
 
   public decrement(): void {
     this.count--;
     if (this.count === 0) {
-      DOM.removeEventListener(this.eventName, this.listener, null, this.capture);
+      this.dom .removeEventListener(this.eventName, this.listener, null, this.capture);
     }
   }
 }
@@ -98,12 +100,19 @@ export class ListenerTracker {
  * Enable dispose() pattern for `delegate` & `capture` commands
  */
 export class DelegateOrCaptureSubscription {
+  public entry: ListenerTracker;
+  public lookup: Record<string, IEventListenerOrEventListenerObject>;
+  public targetEvent: string;
+
   constructor(
-    public entry: ListenerTracker,
-    public lookup: Record<string, IEventListenerOrEventListenerObject>,
-    public targetEvent: string,
+    entry: ListenerTracker,
+    lookup: Record<string, IEventListenerOrEventListenerObject>,
+    targetEvent: string,
     callback: IEventListenerOrEventListenerObject
   ) {
+    this.entry = entry;
+    this.lookup = lookup;
+    this.targetEvent = targetEvent;
     lookup[targetEvent] = callback;
   }
 
@@ -117,16 +126,26 @@ export class DelegateOrCaptureSubscription {
  * Enable dispose() pattern for addEventListener for `trigger`
  */
 export class TriggerSubscription {
+  public target: INode;
+  public targetEvent: string;
+  public callback: IEventListenerOrEventListenerObject;
+  private dom: DOM;
+
   constructor(
-    public target: INode,
-    public targetEvent: string,
-    public callback: IEventListenerOrEventListenerObject
+    dom: DOM,
+    target: INode,
+    targetEvent: string,
+    callback: IEventListenerOrEventListenerObject
   ) {
-    DOM.addEventListener(targetEvent, callback, target);
+    this.dom = dom;
+    this.target = target;
+    this.targetEvent = targetEvent;
+    this.callback = callback;
+    dom.addEventListener(targetEvent, callback, target);
   }
 
   public dispose(): void {
-    DOM.removeEventListener(this.targetEvent, this.callback, this.target);
+    this.dom.removeEventListener(this.targetEvent, this.callback, this.target);
   }
 }
 
@@ -151,10 +170,13 @@ export interface IEventSubscriber extends IDisposable {
 }
 
 export class EventSubscriber implements IEventSubscriber {
+  private readonly dom: DOM;
+  private readonly events: string[];
   private target: INode;
   private handler: IEventListenerOrEventListenerObject;
 
-  constructor(private readonly events: string[]) {
+  constructor(dom: DOM, events: string[]) {
+    this.dom = dom;
     this.events = events;
     this.target = null;
     this.handler = null;
@@ -164,7 +186,7 @@ export class EventSubscriber implements IEventSubscriber {
     this.target = node;
     this.handler = callbackOrListener;
 
-    const add = DOM.addEventListener;
+    const add = this.dom.addEventListener;
     const events = this.events;
 
     for (let i = 0, ii = events.length; ii > i; ++i) {
@@ -176,7 +198,7 @@ export class EventSubscriber implements IEventSubscriber {
     const node = this.target;
     const callbackOrListener = this.handler;
     const events = this.events;
-    const remove = DOM.removeEventListener;
+    const remove = this.dom.removeEventListener;
 
     for (let i = 0, ii = events.length; ii > i; ++i) {
       remove(events[i], callbackOrListener, node);
@@ -190,8 +212,8 @@ export type EventSubscription = DelegateOrCaptureSubscription | TriggerSubscript
 
 export interface IEventManager {
   registerElementConfiguration(config: IElementConfiguration): void;
-  getElementHandler(target: INode, propertyName: string): IEventSubscriber | null;
-  addEventListener(target: INode, targetEvent: string, callbackOrListener: IEventListenerOrEventListenerObject, delegate: DelegationStrategy): IDisposable;
+  getElementHandler(dom: DOM, target: INode, propertyName: string): IEventSubscriber | null;
+  addEventListener(dom: DOM, target: INode, targetEvent: string, callbackOrListener: IEventListenerOrEventListenerObject, delegate: DelegationStrategy): IDisposable;
 }
 
 export const IEventManager = DI.createInterface<IEventManager>()
@@ -250,25 +272,26 @@ export class EventManager implements IEventManager {
     }
   }
 
-  public getElementHandler(target: INode, propertyName: string): IEventSubscriber | null {
+  public getElementHandler(dom: DOM, target: INode, propertyName: string): IEventSubscriber | null {
     const tagName = target['tagName'];
     const lookup = this.elementHandlerLookup;
 
     if (tagName) {
       if (lookup[tagName] && lookup[tagName][propertyName]) {
-        return new EventSubscriber(lookup[tagName][propertyName]);
+        return new EventSubscriber(dom, lookup[tagName][propertyName]);
       }
       if (propertyName === 'textContent' || propertyName === 'innerHTML') {
-        return new EventSubscriber(lookup['content editable'].value);
+        return new EventSubscriber(dom, lookup['content editable'].value);
       }
       if (propertyName === 'scrollTop' || propertyName === 'scrollLeft') {
-        return new EventSubscriber(lookup['scrollable element'][propertyName]);
+        return new EventSubscriber(dom, lookup['scrollable element'][propertyName]);
       }
     }
     return null;
   }
 
   public addEventListener(
+    dom: DOM,
     target: IEventTargetWithLookups,
     targetEvent: string,
     callbackOrListener: IEventListenerOrEventListenerObject,
@@ -280,18 +303,18 @@ export class EventManager implements IEventManager {
 
     if (strategy === DelegationStrategy.bubbling) {
       delegatedHandlers = this.delegatedHandlers;
-      handlerEntry = delegatedHandlers[targetEvent] || (delegatedHandlers[targetEvent] = new ListenerTracker(targetEvent, handleDelegatedEvent, false));
+      handlerEntry = delegatedHandlers[targetEvent] || (delegatedHandlers[targetEvent] = new ListenerTracker(dom, targetEvent, handleDelegatedEvent, false));
       handlerEntry.increment();
       const delegatedCallbacks = target.delegatedCallbacks || (target.delegatedCallbacks = {});
       return new DelegateOrCaptureSubscription(handlerEntry, delegatedCallbacks, targetEvent, callbackOrListener);
     }
     if (strategy === DelegationStrategy.capturing) {
       capturedHandlers = this.capturedHandlers;
-      handlerEntry = capturedHandlers[targetEvent] || (capturedHandlers[targetEvent] = new ListenerTracker(targetEvent, handleCapturedEvent, true));
+      handlerEntry = capturedHandlers[targetEvent] || (capturedHandlers[targetEvent] = new ListenerTracker(dom, targetEvent, handleCapturedEvent, true));
       handlerEntry.increment();
       const capturedCallbacks = target.capturedCallbacks || (target.capturedCallbacks = {});
       return new DelegateOrCaptureSubscription(handlerEntry, capturedCallbacks, targetEvent, callbackOrListener);
     }
-    return new TriggerSubscription(target, targetEvent, callbackOrListener);
+    return new TriggerSubscription(dom, target, targetEvent, callbackOrListener);
   }
 }

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -1,6 +1,6 @@
 import { DI, inject, Reporter } from '@aurelia/kernel';
-import { DOM } from '../dom';
-import { IElement, IHTMLElement } from '../dom.interfaces';
+import { IDOM } from '../dom';
+import { IHTMLElement } from '../dom.interfaces';
 import { ILifecycle } from '../lifecycle';
 import {
   AccessorOrObserver,
@@ -64,10 +64,10 @@ function getPropertyDescriptor(subject: object, name: string): PropertyDescripto
   return pd;
 }
 
-@inject(DOM, ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer)
+@inject(IDOM, ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer)
 /** @internal */
 export class ObserverLocator implements IObserverLocator {
-  private dom: DOM;
+  private dom: IDOM;
   private adapters: IObjectObservationAdapter[];
   private dirtyChecker: IDirtyChecker;
   private eventManager: IEventManager;
@@ -75,7 +75,7 @@ export class ObserverLocator implements IObserverLocator {
   private svgAnalyzer: ISVGAnalyzer;
 
   constructor(
-    dom: DOM,
+    dom: IDOM,
     lifecycle: ILifecycle,
     eventManager: IEventManager,
     dirtyChecker: IDirtyChecker,

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -64,7 +64,7 @@ function getPropertyDescriptor(subject: object, name: string): PropertyDescripto
   return pd;
 }
 
-@inject(ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer)
+@inject(DOM, ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer)
 /** @internal */
 export class ObserverLocator implements IObserverLocator {
   private dom: DOM;

--- a/packages/runtime/src/observation/target-accessors.ts
+++ b/packages/runtime/src/observation/target-accessors.ts
@@ -1,5 +1,5 @@
 import { IIndexable } from '@aurelia/kernel';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { IElement, IHTMLElement, INode } from '../dom.interfaces';
 import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor } from '../observation';
@@ -11,7 +11,7 @@ export interface XLinkAttributeAccessor extends IBindingTargetAccessor<IHTMLElem
 
 @targetObserver('')
 export class XLinkAttributeAccessor implements XLinkAttributeAccessor {
-  public dom: DOM;
+  public dom: IDOM;
   public attributeName: string;
   public currentValue: string;
   public defaultValue: string;
@@ -27,7 +27,7 @@ export class XLinkAttributeAccessor implements XLinkAttributeAccessor {
   // Using very HTML-specific code here since this isn't likely to get
   // called unless operating against a real HTML element.
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string, attributeName: string) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string, attributeName: string) {
     this.dom = dom;
     this.attributeName = attributeName;
     this.lifecycle = lifecycle;
@@ -51,7 +51,7 @@ export interface DataAttributeAccessor extends IBindingTargetAccessor<INode, str
 
 @targetObserver()
 export class DataAttributeAccessor implements DataAttributeAccessor {
-  public dom: DOM;
+  public dom: IDOM;
   public currentValue: string;
   public defaultValue: string;
   public lifecycle: ILifecycle;
@@ -59,7 +59,7 @@ export class DataAttributeAccessor implements DataAttributeAccessor {
   public oldValue: string;
   public propertyKey: string;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string) {
     this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -84,7 +84,7 @@ export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElem
 
 @targetObserver()
 export class StyleAttributeAccessor implements StyleAttributeAccessor {
-  public dom: DOM;
+  public dom: IDOM;
   public currentValue: string | Record<string, string>;
   public defaultValue: string | Record<string, string>;
   public lifecycle: ILifecycle;
@@ -94,7 +94,7 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
   public styles: object;
   public version: number;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: IHTMLElement) {
     this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -169,7 +169,7 @@ export interface ClassAttributeAccessor extends IBindingTargetAccessor<INode, st
 
 @targetObserver('')
 export class ClassAttributeAccessor implements ClassAttributeAccessor {
-  public dom: DOM;
+  public dom: IDOM;
   public currentValue: string;
   public defaultValue: string;
   public doNotCache: true;
@@ -179,7 +179,7 @@ export class ClassAttributeAccessor implements ClassAttributeAccessor {
   public oldValue: string;
   public version: number;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: IHTMLElement) {
     this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -242,12 +242,12 @@ export interface ElementPropertyAccessor extends IBindingTargetAccessor<object, 
 
 @targetObserver('')
 export class ElementPropertyAccessor implements ElementPropertyAccessor {
-  public dom: DOM;
+  public dom: IDOM;
   public lifecycle: ILifecycle;
   public obj: object;
   public propertyKey: string;
 
-  constructor(dom: DOM, lifecycle: ILifecycle, obj: object, propertyKey: string) {
+  constructor(dom: IDOM, lifecycle: ILifecycle, obj: object, propertyKey: string) {
     this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;

--- a/packages/runtime/src/observation/target-accessors.ts
+++ b/packages/runtime/src/observation/target-accessors.ts
@@ -11,6 +11,7 @@ export interface XLinkAttributeAccessor extends IBindingTargetAccessor<IHTMLElem
 
 @targetObserver('')
 export class XLinkAttributeAccessor implements XLinkAttributeAccessor {
+  public dom: DOM;
   public attributeName: string;
   public currentValue: string;
   public defaultValue: string;
@@ -26,7 +27,8 @@ export class XLinkAttributeAccessor implements XLinkAttributeAccessor {
   // Using very HTML-specific code here since this isn't likely to get
   // called unless operating against a real HTML element.
 
-  constructor(lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string, attributeName: string) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string, attributeName: string) {
+    this.dom = dom;
     this.attributeName = attributeName;
     this.lifecycle = lifecycle;
     this.obj = obj;
@@ -49,14 +51,16 @@ export interface DataAttributeAccessor extends IBindingTargetAccessor<INode, str
 
 @targetObserver()
 export class DataAttributeAccessor implements DataAttributeAccessor {
+  public dom: DOM;
   public currentValue: string;
   public defaultValue: string;
   public lifecycle: ILifecycle;
-  public obj: IElement;
+  public obj: IHTMLElement;
   public oldValue: string;
   public propertyKey: string;
 
-  constructor(lifecycle: ILifecycle, obj: IElement, propertyKey: string) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement, propertyKey: string) {
+    this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
     this.oldValue = this.currentValue = this.getValue();
@@ -64,14 +68,14 @@ export class DataAttributeAccessor implements DataAttributeAccessor {
   }
 
   public getValue(): string {
-    return DOM.getAttribute(this.obj, this.propertyKey);
+    return this.dom.getAttribute(this.obj, this.propertyKey);
   }
 
   public setValueCore(newValue: string): void {
     if (newValue === null) {
-      DOM.removeAttribute(this.obj, this.propertyKey);
+      this.dom.removeAttribute(this.obj, this.propertyKey);
     } else {
-      DOM.setAttribute(this.obj, this.propertyKey, newValue);
+      this.dom.setAttribute(this.obj, this.propertyKey, newValue);
     }
   }
 }
@@ -80,6 +84,7 @@ export interface StyleAttributeAccessor extends IBindingTargetAccessor<IHTMLElem
 
 @targetObserver()
 export class StyleAttributeAccessor implements StyleAttributeAccessor {
+  public dom: DOM;
   public currentValue: string | Record<string, string>;
   public defaultValue: string | Record<string, string>;
   public lifecycle: ILifecycle;
@@ -89,7 +94,8 @@ export class StyleAttributeAccessor implements StyleAttributeAccessor {
   public styles: object;
   public version: number;
 
-  constructor(lifecycle: ILifecycle, obj: IHTMLElement) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement) {
+    this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
     this.oldValue = this.currentValue = obj.style.cssText;
@@ -163,16 +169,18 @@ export interface ClassAttributeAccessor extends IBindingTargetAccessor<INode, st
 
 @targetObserver('')
 export class ClassAttributeAccessor implements ClassAttributeAccessor {
+  public dom: DOM;
   public currentValue: string;
   public defaultValue: string;
   public doNotCache: true;
   public lifecycle: ILifecycle;
   public nameIndex: object;
-  public obj: IElement;
+  public obj: IHTMLElement;
   public oldValue: string;
   public version: number;
 
-  constructor(lifecycle: ILifecycle, obj: IElement) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: IHTMLElement) {
+    this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
   }
@@ -184,8 +192,8 @@ export class ClassAttributeAccessor implements ClassAttributeAccessor {
   public setValueCore(newValue: string): void {
     const nameIndex = this.nameIndex || {};
     let version = this.version;
-    let names;
-    let name;
+    let names: string[];
+    let name: string;
 
     // Add the classes, tracking the version at which they were added.
     if (newValue.length) {
@@ -197,7 +205,7 @@ export class ClassAttributeAccessor implements ClassAttributeAccessor {
           continue;
         }
         nameIndex[name] = version;
-        DOM.addClass(node, name);
+        this.dom.addClass(node, name);
       }
     }
 
@@ -221,7 +229,7 @@ export class ClassAttributeAccessor implements ClassAttributeAccessor {
       // will be removed if they're not present in the next update.
       // Better would be do have some configurability for this behavior, allowing the user to
       // decide whether initial classes always need to be kept, always removed, or something in between
-      DOM.removeClass(this.obj, name);
+      this.dom.removeClass(this.obj, name);
     }
   }
 }
@@ -234,11 +242,13 @@ export interface ElementPropertyAccessor extends IBindingTargetAccessor<object, 
 
 @targetObserver('')
 export class ElementPropertyAccessor implements ElementPropertyAccessor {
+  public dom: DOM;
   public lifecycle: ILifecycle;
   public obj: object;
   public propertyKey: string;
 
-  constructor(lifecycle: ILifecycle, obj: object, propertyKey: string) {
+  constructor(dom: DOM, lifecycle: ILifecycle, obj: object, propertyKey: string) {
+    this.dom = dom;
     this.lifecycle = lifecycle;
     this.obj = obj;
     this.propertyKey = propertyKey;

--- a/packages/runtime/src/observation/target-observer.ts
+++ b/packages/runtime/src/observation/target-observer.ts
@@ -7,6 +7,7 @@ import { subscriberCollection } from './subscriber-collection';
 const slice = Array.prototype.slice;
 
 type BindingTargetAccessor = IBindingTargetAccessor & {
+  dom: DOM;
   lifecycle: ILifecycle;
   currentFlags: LifecycleFlags;
   oldValue?: unknown;
@@ -23,7 +24,7 @@ function setValue(this: BindingTargetAccessor, newValue: unknown, flags: Lifecyc
   if (currentValue !== newValue) {
     this.currentValue = newValue;
     if ((flags & (LifecycleFlags.fromFlush | LifecycleFlags.fromBind)) &&
-      !((flags & LifecycleFlags.doNotUpdateDOM) && DOM.isNodeInstance(this.obj))) {
+      !((flags & LifecycleFlags.doNotUpdateDOM) && this.dom.isNodeInstance(this.obj))) {
       this.setValueCore(newValue, flags);
     } else {
       this.currentFlags = flags;
@@ -37,7 +38,7 @@ function setValue(this: BindingTargetAccessor, newValue: unknown, flags: Lifecyc
 
 function flush(this: BindingTargetAccessor, flags: LifecycleFlags): void {
   if (Tracer.enabled) { Tracer.enter(`${this['constructor'].name}.flush`, slice.call(arguments)); }
-  if ((flags & LifecycleFlags.doNotUpdateDOM) && DOM.isNodeInstance(this.obj)) {
+  if ((flags & LifecycleFlags.doNotUpdateDOM) && this.dom.isNodeInstance(this.obj)) {
     // re-queue the change so it will still propagate on flush when it's attached again
     this.lifecycle.enqueueFlush(this).catch(error => { throw error; });
     if (Tracer.enabled) { Tracer.leave(); }

--- a/packages/runtime/src/observation/target-observer.ts
+++ b/packages/runtime/src/observation/target-observer.ts
@@ -1,5 +1,5 @@
 import { Tracer } from '@aurelia/kernel';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { ILifecycle } from '../lifecycle';
 import { IBindingTargetAccessor, LifecycleFlags, MutationKind } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
@@ -7,7 +7,7 @@ import { subscriberCollection } from './subscriber-collection';
 const slice = Array.prototype.slice;
 
 type BindingTargetAccessor = IBindingTargetAccessor & {
-  dom: DOM;
+  dom: IDOM;
   lifecycle: ILifecycle;
   currentFlags: LifecycleFlags;
   oldValue?: unknown;

--- a/packages/runtime/src/resources/binding-behaviors/attr.ts
+++ b/packages/runtime/src/resources/binding-behaviors/attr.ts
@@ -1,6 +1,7 @@
 import { IRegistry } from '@aurelia/kernel';
 import { Binding } from '../../binding/binding';
-import { IElement } from '../../dom.interfaces';
+import { DOM } from '../../dom';
+import { IHTMLElement } from '../../dom.interfaces';
 import { ILifecycle } from '../../lifecycle';
 import { IScope, LifecycleFlags } from '../../observation';
 import { DataAttributeAccessor } from '../../observation/target-accessors';
@@ -11,7 +12,7 @@ export class AttrBindingBehavior {
   public static register: IRegistry['register'];
 
   public bind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {
-    binding.targetObserver = new DataAttributeAccessor(binding.locator.get(ILifecycle), binding.target as IElement, binding.targetProperty);
+    binding.targetObserver = new DataAttributeAccessor(binding.locator.get(DOM), binding.locator.get(ILifecycle), binding.target as IHTMLElement, binding.targetProperty);
   }
 
   public unbind(flags: LifecycleFlags, scope: IScope, binding: Binding): void {

--- a/packages/runtime/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime/src/resources/binding-behaviors/update-trigger.ts
@@ -1,6 +1,7 @@
 import { inject, IRegistry, Reporter } from '@aurelia/kernel';
 import { Binding } from '../../binding/binding';
 import { BindingMode } from '../../binding/binding-mode';
+import { DOM } from '../../dom';
 import { IScope, LifecycleFlags } from '../../observation';
 import { CheckedObserver, SelectValueObserver, ValueAttributeObserver } from '../../observation/element-observation';
 import { EventSubscriber, IEventSubscriber } from '../../observation/event-manager';
@@ -47,7 +48,7 @@ export class UpdateTriggerBindingBehavior {
     targetObserver.originalHandler = binding.targetObserver.handler;
 
     // replace the element subscribe function with one that uses the correct events.
-    targetObserver.handler = new EventSubscriber(events);
+    targetObserver.handler = new EventSubscriber(binding.locator.get(DOM), events);
   }
 
   public unbind(flags: LifecycleFlags, scope: IScope, binding: UpdateTriggerableBinding): void {

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -16,6 +16,7 @@ import {
   ITemplateDefinition,
   TemplateDefinition
 } from '../definitions';
+import { DOM } from '../dom';
 import { INode } from '../dom.interfaces';
 import {
   Hooks,
@@ -70,7 +71,7 @@ export interface ICustomElement extends
 
   readonly $projector: IElementProjector;
   readonly $host: ICustomElementHost;
-  $hydrate(renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
+  $hydrate(dom: DOM, renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
 }
 
 export interface ICustomElementResource extends

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -16,7 +16,7 @@ import {
   ITemplateDefinition,
   TemplateDefinition
 } from '../definitions';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { INode } from '../dom.interfaces';
 import {
   Hooks,
@@ -71,7 +71,7 @@ export interface ICustomElement extends
 
   readonly $projector: IElementProjector;
   readonly $host: ICustomElementHost;
-  $hydrate(dom: DOM, renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
+  $hydrate(dom: IDOM, renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
 }
 
 export interface ICustomElementResource extends

--- a/packages/runtime/src/resources/custom-elements/compose.ts
+++ b/packages/runtime/src/resources/custom-elements/compose.ts
@@ -6,7 +6,7 @@ import {
   TargetedInstruction,
   TemplateDefinition
 } from '../../definitions';
-import { DOM } from '../../dom';
+import { IDOM } from '../../dom';
 import { CompositionCoordinator, IRenderable, IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
 import { bindable } from '../../templating/bindable';
@@ -25,21 +25,21 @@ type Subject = IViewFactory | IView | RenderPlan | Constructable | TemplateDefin
 
 export interface Compose extends ICustomElement {}
 @customElement(composeSource)
-@inject(IRenderable, ITargetedInstruction, IRenderingEngine, CompositionCoordinator)
+@inject(IDOM, IRenderable, ITargetedInstruction, IRenderingEngine, CompositionCoordinator)
 export class Compose {
   public static register: IRegistry['register'];
 
   @bindable public subject: Subject | Promise<Subject> | null;
   @bindable public composing: boolean;
 
-  private dom: DOM;
+  private dom: IDOM;
   private coordinator: CompositionCoordinator;
   private lastSubject: Subject | Promise<Subject> | null;
   private properties: Record<string, TargetedInstruction>;
   private renderable: IRenderable;
   private renderingEngine: IRenderingEngine;
 
-  constructor(dom: DOM, renderable: IRenderable, instruction: Immutable<IHydrateElementInstruction>, renderingEngine: IRenderingEngine, coordinator: CompositionCoordinator) {
+  constructor(dom: IDOM, renderable: IRenderable, instruction: Immutable<IHydrateElementInstruction>, renderingEngine: IRenderingEngine, coordinator: CompositionCoordinator) {
     this.dom = dom;
     this.subject = null;
     this.composing = false;

--- a/packages/runtime/src/resources/custom-elements/compose.ts
+++ b/packages/runtime/src/resources/custom-elements/compose.ts
@@ -6,6 +6,7 @@ import {
   TargetedInstruction,
   TemplateDefinition
 } from '../../definitions';
+import { DOM } from '../../dom';
 import { CompositionCoordinator, IRenderable, IView, IViewFactory } from '../../lifecycle';
 import { LifecycleFlags } from '../../observation';
 import { bindable } from '../../templating/bindable';
@@ -31,13 +32,15 @@ export class Compose {
   @bindable public subject: Subject | Promise<Subject> | null;
   @bindable public composing: boolean;
 
+  private dom: DOM;
   private coordinator: CompositionCoordinator;
   private lastSubject: Subject | Promise<Subject> | null;
   private properties: Record<string, TargetedInstruction>;
   private renderable: IRenderable;
   private renderingEngine: IRenderingEngine;
 
-  constructor(renderable: IRenderable, instruction: Immutable<IHydrateElementInstruction>, renderingEngine: IRenderingEngine, coordinator: CompositionCoordinator) {
+  constructor(dom: DOM, renderable: IRenderable, instruction: Immutable<IHydrateElementInstruction>, renderingEngine: IRenderingEngine, coordinator: CompositionCoordinator) {
+    this.dom = dom;
     this.subject = null;
     this.composing = false;
 
@@ -141,6 +144,7 @@ export class Compose {
 
     if ('template' in subject) { // Raw Template Definition
       return this.renderingEngine.getViewFactory(
+        this.dom,
         subject,
         this.renderable.$context
       ).create();
@@ -148,6 +152,7 @@ export class Compose {
 
     // Constructable (Custom Element Constructor)
     return createElement(
+      this.dom,
       subject,
       this.properties,
       this.$projector.children

--- a/packages/runtime/src/templating/create-element.ts
+++ b/packages/runtime/src/templating/create-element.ts
@@ -6,7 +6,7 @@ import {
   TargetedInstructionType,
   TemplateDefinition
 } from '../definitions';
-import { DOM } from '../dom';
+import { IDOM } from '../dom';
 import { INode } from '../dom.interfaces';
 import { IRenderContext, IView, IViewFactory } from '../lifecycle';
 import { ICustomElementType } from '../resources/custom-element';
@@ -14,7 +14,7 @@ import { IRenderingEngine, ITemplate } from './lifecycle-render';
 
 const slice = Array.prototype.slice;
 
-export function createElement(dom: DOM, tagOrType: string | Constructable, props?: Record<string, string | TargetedInstruction>, children?: ArrayLike<unknown>): RenderPlan {
+export function createElement(dom: IDOM, tagOrType: string | Constructable, props?: Record<string, string | TargetedInstruction>, children?: ArrayLike<unknown>): RenderPlan {
   if (typeof tagOrType === 'string') {
     return createElementForTag(dom, tagOrType, props, children);
   } else {
@@ -23,14 +23,14 @@ export function createElement(dom: DOM, tagOrType: string | Constructable, props
 }
 
 export class RenderPlan {
-  private readonly dom: DOM;
+  private readonly dom: IDOM;
   private readonly dependencies: ReadonlyArray<IRegistry>;
   private readonly instructions: TargetedInstruction[][];
   private readonly node: INode;
 
   private lazyDefinition: TemplateDefinition;
 
-  constructor(dom: DOM, node: INode, instructions: TargetedInstruction[][], dependencies: ReadonlyArray<IRegistry>) {
+  constructor(dom: IDOM, node: INode, instructions: TargetedInstruction[][], dependencies: ReadonlyArray<IRegistry>) {
     this.dom = dom;
     this.dependencies = dependencies;
     this.instructions = instructions;
@@ -62,7 +62,7 @@ export class RenderPlan {
   }
 }
 
-function createElementForTag(dom: DOM, tagName: string, props?: Record<string, string | TargetedInstruction>, children?: ArrayLike<unknown>): RenderPlan {
+function createElementForTag(dom: IDOM, tagName: string, props?: Record<string, string | TargetedInstruction>, children?: ArrayLike<unknown>): RenderPlan {
   if (Tracer.enabled) { Tracer.enter('createElementForTag', slice.call(arguments)); }
   const instructions: TargetedInstruction[] = [];
   const allInstructions: TargetedInstruction[][] = [];
@@ -97,7 +97,7 @@ function createElementForTag(dom: DOM, tagName: string, props?: Record<string, s
   return new RenderPlan(dom, element, allInstructions, dependencies);
 }
 
-function createElementForType(dom: DOM, Type: ICustomElementType, props?: object, children?: ArrayLike<unknown>): RenderPlan {
+function createElementForType(dom: IDOM, Type: ICustomElementType, props?: object, children?: ArrayLike<unknown>): RenderPlan {
   if (Tracer.enabled) { Tracer.enter('createElementForType', slice.call(arguments)); }
   const tagName = Type.description.name;
   const instructions: TargetedInstruction[] = [];
@@ -154,7 +154,7 @@ function createElementForType(dom: DOM, Type: ICustomElementType, props?: object
   return new RenderPlan(dom, element, allInstructions, dependencies);
 }
 
-function addChildren(dom: DOM, parent: INode, children: ArrayLike<unknown>, allInstructions: TargetedInstruction[][], dependencies: IRegistry[]): void {
+function addChildren(dom: IDOM, parent: INode, children: ArrayLike<unknown>, allInstructions: TargetedInstruction[][], dependencies: IRegistry[]): void {
   for (let i = 0, ii = children.length; i < ii; ++i) {
     const current = children[i];
 

--- a/packages/runtime/src/templating/lifecycle-render.ts
+++ b/packages/runtime/src/templating/lifecycle-render.ts
@@ -29,7 +29,7 @@ import {
   TemplatePartDefinitions
 } from '../definitions';
 import { DOM, INodeSequenceFactory, NodeSequence, NodeSequenceFactory } from '../dom';
-import { IElement, INode, INodeSequence, IRenderLocation } from '../dom.interfaces';
+import { IHTMLElement, INode, INodeSequence, IRenderLocation } from '../dom.interfaces';
 import { Hooks, ILifecycle, IRenderable, IRenderContext, IViewFactory } from '../lifecycle';
 import { IAccessor, IPropertySubscriber, ISubscribable, ISubscriberCollection, LifecycleFlags, MutationKind } from '../observation';
 import { Scope } from '../observation/binding-context';
@@ -43,7 +43,7 @@ const slice = Array.prototype.slice;
 
 export interface ITemplateCompiler {
   readonly name: string;
-  compile(definition: ITemplateDefinition, resources: IResourceDescriptions, viewCompileFlags?: ViewCompileFlags): TemplateDefinition;
+  compile(dom: DOM, definition: ITemplateDefinition, resources: IResourceDescriptions, viewCompileFlags?: ViewCompileFlags): TemplateDefinition;
 }
 
 export const ITemplateCompiler = DI.createInterface<ITemplateCompiler>().noDefault();
@@ -116,14 +116,14 @@ export function $hydrateAttribute(this: Writable<ICustomAttribute>, renderingEng
 }
 
 /** @internal */
-export function $hydrateElement(this: Writable<ICustomElement>, renderingEngine: IRenderingEngine, host: INode, options: IElementHydrationOptions = PLATFORM.emptyObject): void {
+export function $hydrateElement(this: Writable<ICustomElement>, dom: DOM, renderingEngine: IRenderingEngine, host: INode, options: IElementHydrationOptions = PLATFORM.emptyObject): void {
   if (Tracer.enabled) { Tracer.enter(`${this['constructor'].name}.$hydrateElement`, slice.call(arguments)); }
   const Type = this.constructor as ICustomElementType;
   const description = Type.description;
 
   this.$scope = Scope.create(this, null);
   this.$host = host;
-  this.$projector = determineProjector(this, host, description);
+  this.$projector = determineProjector(dom, this, host, description);
 
   renderingEngine.applyRuntimeBehavior(Type, this);
 
@@ -135,7 +135,7 @@ export function $hydrateElement(this: Writable<ICustomElement>, renderingEngine:
       template.render(this, host, options.parts);
     }
   } else {
-    const template = renderingEngine.getElementTemplate(description, Type);
+    const template = renderingEngine.getElementTemplate(dom, description, Type);
     template.render(this, host, options.parts);
   }
 
@@ -151,6 +151,7 @@ export const defaultShadowOptions = {
 };
 
 function determineProjector(
+  dom: DOM,
   $customElement: ICustomElement,
   host: ICustomElementHost,
   definition: TemplateDefinition
@@ -160,19 +161,19 @@ function determineProjector(
       throw Reporter.error(21);
     }
 
-    return new ShadowDOMProjector($customElement, host, definition);
+    return new ShadowDOMProjector(dom, $customElement, host, definition);
   }
 
   if (definition.containerless) {
-    return new ContainerlessProjector($customElement, host);
+    return new ContainerlessProjector(dom, $customElement, host);
   }
 
-  return new HostProjector($customElement, host);
+  return new HostProjector(dom, $customElement, host);
 }
 
 export interface IRenderingEngine {
-  getElementTemplate(definition: TemplateDefinition, componentType?: ICustomElementType): ITemplate;
-  getViewFactory(source: Immutable<ITemplateDefinition>, parentContext?: IRenderContext): IViewFactory;
+  getElementTemplate(dom: DOM, definition: TemplateDefinition, componentType?: ICustomElementType): ITemplate;
+  getViewFactory(dom: DOM, source: Immutable<ITemplateDefinition>, parentContext?: IRenderContext): IViewFactory;
 
   applyRuntimeBehavior(Type: ICustomAttributeType, instance: ICustomAttribute): void;
   applyRuntimeBehavior(Type: ICustomElementType, instance: ICustomElement): void;
@@ -209,7 +210,7 @@ export class RenderingEngine implements IRenderingEngine {
     );
   }
 
-  public getElementTemplate(definition: TemplateDefinition, componentType?: ICustomElementType): ITemplate {
+  public getElementTemplate(dom: DOM, definition: TemplateDefinition, componentType?: ICustomElementType): ITemplate {
     if (!definition) {
       return null;
     }
@@ -217,7 +218,7 @@ export class RenderingEngine implements IRenderingEngine {
     let found = this.templateLookup.get(definition);
 
     if (!found) {
-      found = this.templateFromSource(definition);
+      found = this.templateFromSource(dom, definition);
 
       //If the element has a view, support Recursive Components by adding self to own view template container.
       if (found.renderContext !== null && componentType) {
@@ -230,7 +231,7 @@ export class RenderingEngine implements IRenderingEngine {
     return found;
   }
 
-  public getViewFactory(definition: Immutable<ITemplateDefinition>, parentContext?: IRenderContext): IViewFactory {
+  public getViewFactory(dom: DOM, definition: Immutable<ITemplateDefinition>, parentContext?: IRenderContext): IViewFactory {
     if (!definition) {
       return null;
     }
@@ -239,7 +240,7 @@ export class RenderingEngine implements IRenderingEngine {
 
     if (!factory) {
       const validSource = buildTemplateDefinition(null, definition);
-      const template = this.templateFromSource(validSource, parentContext);
+      const template = this.templateFromSource(dom, validSource, parentContext);
       factory = new ViewFactory(validSource.name, template, this.lifecycle);
       factory.setCacheSize(validSource.cache, true);
       this.factoryLookup.set(definition, factory);
@@ -259,7 +260,7 @@ export class RenderingEngine implements IRenderingEngine {
     found.applyTo(instance, this.lifecycle);
   }
 
-  private templateFromSource(definition: TemplateDefinition, parentContext?: IRenderContext): ITemplate {
+  private templateFromSource(dom: DOM, definition: TemplateDefinition, parentContext?: IRenderContext): ITemplate {
     parentContext = parentContext || this.container as ExposedContext;
 
     if (definition && definition.template) {
@@ -271,10 +272,10 @@ export class RenderingEngine implements IRenderingEngine {
           throw Reporter.error(20, compilerName);
         }
 
-        definition = compiler.compile(definition as ITemplateDefinition, new RuntimeCompilationResources(parentContext as ExposedContext), ViewCompileFlags.surrogate);
+        definition = compiler.compile(dom, definition as ITemplateDefinition, new RuntimeCompilationResources(parentContext as ExposedContext), ViewCompileFlags.surrogate);
       }
 
-      return new CompiledTemplate(this, parentContext, definition);
+      return new CompiledTemplate(dom, this, parentContext, definition);
     }
 
     return noViewTemplate;
@@ -284,13 +285,15 @@ const childObserverOptions = { childList: true };
 
 /** @internal */
 export class ShadowDOMProjector implements IElementProjector {
+  public dom: DOM;
   public host: ICustomElementHost;
   public shadowRoot: ICustomElementHost;
 
-  constructor($customElement: ICustomElement, host: ICustomElementHost, definition: TemplateDefinition) {
+  constructor(dom: DOM, $customElement: ICustomElement, host: ICustomElementHost, definition: TemplateDefinition) {
+    this.dom = dom;
     this.host = host;
 
-    this.shadowRoot = DOM.attachShadow(this.host as IElement, definition.shadowOptions || defaultShadowOptions);
+    this.shadowRoot = dom.attachShadow(this.host as IHTMLElement, definition.shadowOptions || defaultShadowOptions);
     this.host.$customElement = $customElement;
     this.shadowRoot.$customElement = $customElement;
   }
@@ -300,7 +303,7 @@ export class ShadowDOMProjector implements IElementProjector {
   }
 
   public subscribeToChildrenChange(callback: () => void): void {
-    DOM.createNodeObserver(this.host, callback, childObserverOptions);
+    this.dom.createNodeObserver(this.host, callback, childObserverOptions);
   }
 
   public provideEncapsulationSource(parentEncapsulationSource: INode): INode {
@@ -322,18 +325,20 @@ export class ShadowDOMProjector implements IElementProjector {
 
 /** @internal */
 export class ContainerlessProjector implements IElementProjector {
+  public dom: DOM;
   public host: ICustomElementHost;
 
   private childNodes: ArrayLike<INode>;
 
-  constructor($customElement: ICustomElement, host: ICustomElementHost) {
+  constructor(dom: DOM, $customElement: ICustomElement, host: ICustomElementHost) {
+    this.dom = dom;
     if (host.childNodes.length) {
       this.childNodes = PLATFORM.toArray(host.childNodes);
     } else {
       this.childNodes = PLATFORM.emptyArray;
     }
 
-    this.host = DOM.convertToRenderLocation(host);
+    this.host = dom.convertToRenderLocation(host);
     this.host.$customElement = $customElement;
   }
 
@@ -368,9 +373,11 @@ export class ContainerlessProjector implements IElementProjector {
 
 /** @internal */
 export class HostProjector implements IElementProjector {
+  public dom: DOM;
   public host: ICustomElementHost;
 
-  constructor($customElement: ICustomElement, host: ICustomElementHost) {
+  constructor(dom: DOM, $customElement: ICustomElement, host: ICustomElementHost) {
+    this.dom = dom;
     this.host = host;
 
     this.host.$customElement = $customElement;
@@ -571,11 +578,11 @@ export class CompiledTemplate implements ITemplate {
 
   private templateDefinition: TemplateDefinition;
 
-  constructor(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, templateDefinition: TemplateDefinition) {
+  constructor(dom: DOM, renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, templateDefinition: TemplateDefinition) {
     this.templateDefinition = templateDefinition;
 
-    this.factory = NodeSequenceFactory.createFor(this.templateDefinition.template);
-    this.renderContext = createRenderContext(renderingEngine, parentRenderContext, this.templateDefinition.dependencies);
+    this.factory = new NodeSequenceFactory(dom, this.templateDefinition.template as string | INode);
+    this.renderContext = createRenderContext(dom, renderingEngine, parentRenderContext, this.templateDefinition.dependencies);
   }
 
   public render(renderable: IRenderable, host?: INode, parts?: TemplatePartDefinitions): void {
@@ -598,16 +605,16 @@ export const noViewTemplate: ITemplate = {
 /** @internal */
 export type ExposedContext = IRenderContext & IDisposable & IContainer;
 
-export function createRenderContext(renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
+export function createRenderContext(dom: DOM, renderingEngine: IRenderingEngine, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
   const context = parentRenderContext.createChild() as ExposedContext;
   const renderableProvider = new InstanceProvider();
   const elementProvider = new InstanceProvider();
   const instructionProvider = new InstanceProvider<ITargetedInstruction>();
-  const factoryProvider = new ViewFactoryProvider(renderingEngine);
+  const factoryProvider = new ViewFactoryProvider(dom, renderingEngine);
   const renderLocationProvider = new InstanceProvider<IRenderLocation>();
   const renderer = context.get(IRenderer);
 
-  DOM.registerElementResolver(context, elementProvider);
+  dom.registerElementResolver(context, elementProvider);
 
   context.registerResolver(IViewFactory, factoryProvider);
   context.registerResolver(IRenderable, renderableProvider);
@@ -619,7 +626,7 @@ export function createRenderContext(renderingEngine: IRenderingEngine, parentRen
   }
 
   context.render = function(this: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, templateDefinition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void {
-    renderer.render(this, renderable, targets, templateDefinition, host, parts);
+    renderer.render(dom, this, renderable, targets, templateDefinition, host, parts);
   };
 
   context.beginComponentOperation = function(renderable: IRenderable, target: INode, instruction: ITargetedInstruction, factory?: IViewFactory, parts?: TemplatePartDefinitions, location?: IRenderLocation): IDisposable {
@@ -675,11 +682,13 @@ export class InstanceProvider<T> implements IResolver {
 
 /** @internal */
 export class ViewFactoryProvider implements IResolver {
+  private dom: DOM;
   private factory: IViewFactory | null;
   private renderingEngine: IRenderingEngine;
   private replacements: TemplatePartDefinitions;
 
-  constructor(renderingEngine: IRenderingEngine) {
+  constructor(dom: DOM, renderingEngine: IRenderingEngine) {
+    this.dom = dom;
     this.renderingEngine = renderingEngine;
   }
 
@@ -698,7 +707,7 @@ export class ViewFactoryProvider implements IResolver {
     }
     const found = this.replacements[factory.name];
     if (found) {
-      return this.renderingEngine.getViewFactory(found, requestor);
+      return this.renderingEngine.getViewFactory(this.dom, found, requestor);
     }
 
     return factory;
@@ -712,7 +721,7 @@ export class ViewFactoryProvider implements IResolver {
 
 export interface IRenderer {
   instructionRenderers: Record<string, IInstructionRenderer>;
-  render(context: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, templateDefinition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void;
+  render(dom: DOM, context: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, templateDefinition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void;
 }
 
 export const IRenderer = DI.createInterface<IRenderer>().withDefault(x => x.singleton(Renderer));
@@ -722,7 +731,7 @@ export interface IInstructionTypeClassifier<TType extends string = string> {
 }
 
 export interface IInstructionRenderer<TType extends string = string> extends Partial<IInstructionTypeClassifier<TType>> {
-  render(context: IRenderContext, renderable: IRenderable, target: unknown, instruction: ITargetedInstruction, ...rest: unknown[]): void;
+  render(dom: DOM, context: IRenderContext, renderable: IRenderable, target: unknown, instruction: ITargetedInstruction, ...rest: unknown[]): void;
 }
 
 export const IInstructionRenderer = DI.createInterface<IInstructionRenderer>().noDefault();
@@ -767,7 +776,7 @@ export class Renderer implements IRenderer {
     });
   }
 
-  public render(context: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, definition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void {
+  public render(dom: DOM, context: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, definition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void {
     if (Tracer.enabled) { Tracer.enter('Renderer.render', slice.call(arguments)); }
     const targetInstructions = definition.instructions;
     const instructionRenderers = this.instructionRenderers;
@@ -785,7 +794,7 @@ export class Renderer implements IRenderer {
 
       for (let j = 0, jj = instructions.length; j < jj; ++j) {
         const current = instructions[j];
-        instructionRenderers[current.type].render(context, renderable, target, current, parts);
+        instructionRenderers[current.type].render(dom, context, renderable, target, current, parts);
       }
     }
 
@@ -794,7 +803,7 @@ export class Renderer implements IRenderer {
 
       for (let i = 0, ii = surrogateInstructions.length; i < ii; ++i) {
         const current = surrogateInstructions[i];
-        instructionRenderers[current.type].render(context, renderable, host, current, parts);
+        instructionRenderers[current.type].render(dom, context, renderable, host, current, parts);
       }
     }
     if (Tracer.enabled) { Tracer.leave(); }

--- a/packages/runtime/test/integration/attr-binding-behavior.spec.ts
+++ b/packages/runtime/test/integration/attr-binding-behavior.spec.ts
@@ -15,7 +15,7 @@ describe('AttrBindingBehavior', () => {
   let scope: IScope;
 
   beforeEach(() => {
-    target = DOM.createElement('div');
+    target = document.createElement('div');
     targetProperty = 'foo';
     sut = new AttrBindingBehavior();
     container = DI.createContainer();

--- a/packages/runtime/test/integration/binding.spec.ts
+++ b/packages/runtime/test/integration/binding.spec.ts
@@ -1,11 +1,16 @@
 import { spy, SinonSpy } from 'sinon';
-import { BindingContext, Scope, AccessMember, PrimitiveLiteral, IExpression, ExpressionKind, IBindingTargetObserver, Binding, IBindingTarget, IObserverLocator, AccessScope, BindingMode, LifecycleFlags, IScope, ILifecycle, SubscriberFlags, IPropertySubscriber, IPropertyChangeNotifier, SetterObserver, ObjectLiteral, PropertyAccessor, BindingType, State, Lifecycle } from '../../src/index';
-import { DI } from '../../../kernel/src/index';
+import { BindingContext, Scope, AccessMember, PrimitiveLiteral, DOM, IDOM, IExpression, ExpressionKind, IBindingTargetObserver, Binding, IBindingTarget, IObserverLocator, AccessScope, BindingMode, LifecycleFlags, IScope, ILifecycle, SubscriberFlags, IPropertySubscriber, IPropertyChangeNotifier, SetterObserver, ObjectLiteral, PropertyAccessor, BindingType, State, Lifecycle } from '../../src/index';
+import { DI, Registration } from '../../../kernel/src/index';
 import { createScopeForTest } from '../unit/binding/shared';
 import { expect } from 'chai';
 import { _, massSpy, massReset, massRestore, ensureNotCalled, eachCartesianJoinFactory, verifyEqual } from '../unit/util';
 import sinon from 'sinon';
 import { parse, ParserState, Access, Precedence, parseCore } from '../../../jit/src';
+
+
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 /**
  * pad a string with spaces on the right-hand side until it's the specified length
@@ -30,6 +35,7 @@ describe('Binding', () => {
 
   function setup(sourceExpression: any = dummySourceExpression, target: any = dummyTarget, targetProperty: string = dummyTargetProperty, mode: BindingMode = dummyMode) {
     const container = DI.createContainer();
+    container.register(domRegistration);
     const lifecycle = container.get(ILifecycle) as Lifecycle;
     const observerLocator = container.get(IObserverLocator);
     const sut = new Binding(sourceExpression, target, targetProperty, mode, observerLocator, <any>container);
@@ -79,6 +85,7 @@ describe('Binding', () => {
     rawExpr += args.join('+');
     const expr = parseCore(rawExpr, 0);
     const container = DI.createContainer();
+    container.register(domRegistration);
     const observerLocator = container.get(IObserverLocator);
     const lifecycle = container.get(ILifecycle) as Lifecycle;
     const target = {val: 0};

--- a/packages/runtime/test/integration/checked-observer.spec.ts
+++ b/packages/runtime/test/integration/checked-observer.spec.ts
@@ -7,12 +7,17 @@ import {
   IBindingTargetObserver,
   IPropertySubscriber,
   enableArrayObservation,
-  Lifecycle
+  Lifecycle,
+  DOM,
+  IDOM
 } from '../../src/index';
 import { createElement, _ } from '../unit/util';
 import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
-import { DI } from '../../../kernel/src/index';
+import { DI, Registration } from '../../../kernel/src/index';
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 type ObservedInputElement = HTMLInputElement & {
   $observers: Record<string, IBindingTargetObserver>;
@@ -32,6 +37,7 @@ describe('CheckedObserver', () => {
   describe('setValue() - primitive - type="checkbox"', () => {
     function setup(hasSubscriber: boolean) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
@@ -101,6 +107,7 @@ describe('CheckedObserver', () => {
   describe('handleEvent() - primitive - type="checkbox"', () => {
     function setup() {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
       const el = <ObservedInputElement>createElement(`<input type="checkbox"/>`);
@@ -153,6 +160,7 @@ describe('CheckedObserver', () => {
   describe('setValue() - primitive - type="radio"', () => {
     function setup(hasSubscriber: boolean) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
       const elA = <ObservedInputElement>createElement(`<input name="foo" type="radio" value="A"/>`);
@@ -248,6 +256,7 @@ describe('CheckedObserver', () => {
   describe('handleEvent() - primitive - type="radio"', () => {
     function setup() {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
       const elA = <ObservedInputElement>createElement(`<input name="foo" type="radio" value="A"/>`);
@@ -325,6 +334,7 @@ describe('CheckedObserver', () => {
   describe('setValue() - array - type="checkbox"', () => {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
@@ -399,6 +409,7 @@ describe('CheckedObserver', () => {
   describe('mutate collection - array - type="checkbox"', () => {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
@@ -464,6 +475,7 @@ describe('CheckedObserver', () => {
   describe('handleEvent() - array - type="checkbox"', () => {
     function setup(value: any, prop: string) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
       const el = <ObservedInputElement>createElement(`<input type="checkbox"/>`);
@@ -528,6 +540,7 @@ describe('CheckedObserver', () => {
   describe('SelectValueObserver.setValue() - array - type="checkbox"', () => {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const container = DI.createContainer();
+      container.register(domRegistration);
       const lifecycle = container.get(ILifecycle) as Lifecycle;
       const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 

--- a/packages/runtime/test/integration/repeat.spec.ts
+++ b/packages/runtime/test/integration/repeat.spec.ts
@@ -14,14 +14,17 @@ import {
   Lifecycle,
   IView,
   State,
-  ILifecycle
+  ILifecycle,
+  DOM, IDOM
 } from '../../src/index';
 import { expect } from 'chai';
 import { MockTextNodeTemplate } from '../unit/mock';
 import { eachCartesianJoinFactory } from '../../../../scripts/test-lib';
 import { createScopeForTest } from '../unit/binding/shared';
-import { DI } from '../../../kernel/src/index';
+import { DI, Registration } from '../../../kernel/src/index';
 
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 const expressions = {
   item: new AccessScope('item'),
@@ -46,12 +49,13 @@ function verifyViewBindingContexts(views: IView[], items: any[]): void {
 
 function setup<T extends ObservedCollection>() {
   const container = DI.createContainer();
+  container.register(domRegistration);
   const lifecycle = container.get(ILifecycle) as Lifecycle;
   const host = document.createElement('div');
   const location = document.createComment('au-loc');
   host.appendChild(location);
 
-  const observerLocator = new ObserverLocator(lifecycle, null, null, null);
+  const observerLocator = new ObserverLocator(dom, lifecycle, null, null, null);
   const factory = new ViewFactory(null, <any>new MockTextNodeTemplate(expressions.item, observerLocator, container), lifecycle)
   const renderable = { } as any;
   const sut = new Repeat<T>(location, renderable, factory);

--- a/packages/runtime/test/integration/select-value-observer.spec.ts
+++ b/packages/runtime/test/integration/select-value-observer.spec.ts
@@ -1,8 +1,12 @@
-import { IObserverLocator, ILifecycle, SelectValueObserver, LifecycleFlags, DOM } from '../../src/index';
+import { IObserverLocator, ILifecycle, SelectValueObserver, LifecycleFlags, DOM, IDOM } from '../../src/index';
 import { createElement, _, eachCartesianJoin, eachCartesianJoinFactory, h, verifyEqual } from '../unit/util';
 import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
-import { DI, Primitive } from '../../../kernel/src/index';
+import { DI, Primitive, Registration } from '../../../kernel/src/index';
+
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 const eventDefaults = { bubbles: true };
 
@@ -12,6 +16,7 @@ type Anything = any;
 describe('SelectValueObserver', () => {
   function createFixture(initialValue: Anything = '', options = [], multiple = false) {
     const container = DI.createContainer();
+    container.register(domRegistration);
     const observerLocator = <IObserverLocator>container.get(IObserverLocator);
     const lifecycle = container.get(ILifecycle);
     const optionElements = options.map(o => `<option value="${o}">${o}</option>`).join('\n');
@@ -56,7 +61,7 @@ describe('SelectValueObserver', () => {
         const nodeObserver = sut['nodeObserver'];
         expect(nodeObserver).not.to.be.undefined;
         expect(nodeObserver).to.be.instanceOf(
-          DOM.createNodeObserver(document.createElement('div'), () => {}, { childList: true }).constructor,
+          dom.createNodeObserver(document.createElement('div'), () => {}, { childList: true }).constructor,
           'It should have created instance from the same class with other node observer'
         );
       }
@@ -243,6 +248,7 @@ describe('SelectValueObserver', () => {
 
       function createMutiSelectSut(initialValue: Anything[], options: SelectValidChild[]) {
         const container = DI.createContainer();
+        container.register(domRegistration);
         const observerLocator = <IObserverLocator>container.get(IObserverLocator);
         // const lifecycle = <ILifecycle>container.get(ILifecycle);
         const el = select(...options);

--- a/packages/runtime/test/integration/value-attribute-observer.spec.ts
+++ b/packages/runtime/test/integration/value-attribute-observer.spec.ts
@@ -7,11 +7,16 @@ import {
   IBindingTargetObserver,
   IPropertySubscriber,
   Lifecycle,
+  DOM,
+  IDOM
 } from '../../src/index';
 import { createElement, _ } from '../unit/util';
 import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
-import { DI } from '../../../kernel/src/index';
+import { DI, Registration } from '../../../kernel/src/index';
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 describe('ValueAttributeObserver', () => {
   const eventDefaults = { bubbles: true };
@@ -35,6 +40,7 @@ describe('ValueAttributeObserver', () => {
     describe(`setValue() - type="${inputType}"`, () => {
       function setup(hasSubscriber: boolean) {
         const container = DI.createContainer();
+        container.register(domRegistration);
         const lifecycle = container.get(ILifecycle) as Lifecycle;
         const observerLocator = container.get(IObserverLocator);
 
@@ -104,6 +110,7 @@ describe('ValueAttributeObserver', () => {
     describe(`handleEvent() - type="${inputType}"`, () => {
       function setup() {
         const container = DI.createContainer();
+        container.register(domRegistration);
         const observerLocator = <IObserverLocator>container.get(IObserverLocator);
 
         const el = <HTMLInputElement>createElement(`<input type="${inputType}"/>`);

--- a/packages/runtime/test/integration/view.spec.ts
+++ b/packages/runtime/test/integration/view.spec.ts
@@ -1,5 +1,5 @@
 import { spy } from 'sinon';
-import { PLATFORM, Writable, DI } from '../../../kernel/src/index';
+import { PLATFORM, Writable, DI, Registration } from '../../../kernel/src/index';
 import {
   noViewTemplate,
   ITemplate,
@@ -23,11 +23,17 @@ import {
   State,
   ObserverLocator,
   NodeSequence,
-  INodeSequenceFactory
+  INodeSequenceFactory,
+  DOM,
+  IDOM
 } from '../../src';
 import { expect } from 'chai';
 import { eachCartesianJoin, eachCartesianJoinFactory } from '../../../../scripts/test-lib';
 import { MockTextNodeTemplate } from '../unit/mock';
+
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 class StubView {
   constructor(public cached = false) {}
@@ -165,6 +171,7 @@ describe(`View`, () => {
       [
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
           const factory = new ViewFactory('foo', noViewTemplate, lifecycle);
           factory.setCacheSize('*', true);
@@ -172,29 +179,33 @@ describe(`View`, () => {
         },
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
           const factory = new ViewFactory('foo', noViewTemplate, lifecycle);
           return [` noViewTemplate, viewFactory(cache=false)`, lifecycle, <View>factory.create(), noViewTemplate, factory, false];
         },
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
-          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(lifecycle, null, null, null), container) as any;
+          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(dom, lifecycle, null, null, null), container) as any;
           const factory = new ViewFactory('foo', <any>template, lifecycle);
           factory.setCacheSize('*', true);
           return [`textNodeTemplate, viewFactory(cache=true )`, lifecycle, <View>factory.create(), template, factory, true];
         },
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
-          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(lifecycle, null, null, null), container) as any;
+          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(dom, lifecycle, null, null, null), container) as any;
           const factory = new ViewFactory('foo', <any>template, lifecycle);
           return [`textNodeTemplate, viewFactory(cache=false)`, lifecycle, <View>factory.create(), template, factory, false];
         },
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
-          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(lifecycle, null, null, null), container) as any;
+          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(dom, lifecycle, null, null, null), container) as any;
           const factory = new ViewFactory('foo', <any>template, lifecycle);
           const child = <View>factory.create();
           const sut = <View>factory.create();
@@ -205,8 +216,9 @@ describe(`View`, () => {
         },
         () => {
           const container = DI.createContainer();
+          container.register(domRegistration);
           const lifecycle = container.get(ILifecycle) as Lifecycle;
-          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(lifecycle, null, null, null), container) as any;
+          const template = new MockTextNodeTemplate(expressions.text, new ObserverLocator(dom, lifecycle, null, null, null), container) as any;
           const factory = new ViewFactory('foo', <any>template, lifecycle);
           const child = <View>factory.create();
           const sut = <View>factory.create();

--- a/packages/runtime/test/unit/binding/ast.spec.ts
+++ b/packages/runtime/test/unit/binding/ast.spec.ts
@@ -14,12 +14,15 @@ import {
   IScope, isPureLiteral, Binding, ObserverLocator, Lifecycle,
   connects, HtmlLiteral, ArrayBindingPattern, ObjectBindingPattern,
   BindingIdentifier, ForOfStatement, Interpolation, observes, callsFunction,
-  hasAncestor, isAssignable, isLeftHandSide, isPrimary, isResource, hasBind, hasUnbind, isLiteral, ExpressionKind, ISignaler, Scope, OverrideContext
+  hasAncestor, isAssignable, isLeftHandSide, isPrimary, isResource, hasBind, hasUnbind, isLiteral, ExpressionKind, ISignaler, Scope, OverrideContext,
+  DOM
 } from '../../../src/index';
 import { expect } from 'chai';
 import { spy, SinonSpy } from 'sinon';
 import { createScopeForTest } from './shared';
 import { eachCartesianJoin, eachCartesianJoinFactory } from '../../../../../scripts/test-lib';
+
+const dom = new DOM(<any>document);
 
 const $false = PrimitiveLiteral.$false;
 const $true = PrimitiveLiteral.$true;
@@ -1926,7 +1929,7 @@ describe('BindingBehavior', () => {
 
           const mock = new MockBindingBehavior();
           const locator = new MockServiceLocator(new Map<any, any>([['binding-behavior:mock', mock]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value }, null);
@@ -1943,7 +1946,7 @@ describe('BindingBehavior', () => {
 
           const mock = new MockBindingBehavior();
           const locator = new MockServiceLocator(new Map<any, any>([['binding-behavior:mock', mock]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value, a: arg1 }, null);
@@ -1966,7 +1969,7 @@ describe('BindingBehavior', () => {
 
           const mock = new MockBindingBehavior();
           const locator = new MockServiceLocator(new Map<any, any>([['binding-behavior:mock', mock]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value, a: arg1, b: arg2, c: arg3 }, null);
@@ -2198,7 +2201,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value }, null);
@@ -2215,7 +2218,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value }, null);
@@ -2232,7 +2235,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value }, null);
@@ -2249,7 +2252,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value }, null);
@@ -2267,7 +2270,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value, a: arg1 }, null);
@@ -2291,7 +2294,7 @@ describe('ValueConverter', () => {
           const mock = new MockValueConverter(methods);
           mock['signals'] = signals;
           const locator = new MockServiceLocator(new Map<any, any>([['value-converter:mock', mock], [ISignaler, signaler]]));
-          const observerLocator = new ObserverLocator(new Lifecycle(), null, null, null);
+          const observerLocator = new ObserverLocator(dom, new Lifecycle(), null, null, null);
           const binding = new Binding(<any>expr, null, null, null, observerLocator, locator);
 
           const scope = Scope.create({ foo: value, a: arg1, b: arg2, c: arg3 }, null);

--- a/packages/runtime/test/unit/binding/call.spec.ts
+++ b/packages/runtime/test/unit/binding/call.spec.ts
@@ -1,14 +1,18 @@
 import { CallScope, BindingBehavior, ExpressionKind } from './../../../src/binding/ast';
 import { spy, SinonSpy } from 'sinon';
-import { IExpression, IObserverLocator, AccessScope, LifecycleFlags, IScope, ILifecycle, SetterObserver, Call } from '../../../src/index';
-import { DI } from '../../../../kernel/src/index';
+import { IExpression, IObserverLocator, AccessScope, LifecycleFlags, IScope, ILifecycle, SetterObserver, Call, DOM, IDOM } from '../../../src/index';
+import { DI, Registration } from '../../../../kernel/src/index';
 import { createScopeForTest } from './shared';
 import { expect } from 'chai';
 import { _, massSpy, massReset, massRestore, eachCartesianJoinFactory } from '../util';
 
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
+
 describe('Call', () => {
   function setup(sourceExpression: IExpression, target: any, targetProperty: string) {
     const container = DI.createContainer();
+    container.register(domRegistration);
     const lifecycle = container.get(ILifecycle);
     const observerLocator = container.get(IObserverLocator);
     const sut = new Call(sourceExpression, target, targetProperty, observerLocator, container);

--- a/packages/runtime/test/unit/binding/event-manager.spec.ts
+++ b/packages/runtime/test/unit/binding/event-manager.spec.ts
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { _, createElement } from '../util';
 
+const dom = new DOM(<any>document);
+
 const CAPTURING_PHASE = 1;
 const AT_TARGET = 2;
 const BUBBLING_PHASE = 3;
@@ -39,7 +41,7 @@ describe('ListenerTracker', () => {
     } else {
       listener['handleEvent'] = handler;
     }
-    const sut = new ListenerTracker(eventName, listener, capture);
+    const sut = new ListenerTracker(dom, eventName, listener, capture);
     const el = document.createElement('div');
     el.addEventListener(eventName, listener, capture);
     document.body.appendChild(el);
@@ -194,7 +196,7 @@ describe('TriggerSubscription', () => {
     });
 
     const callback = spy();
-    const sut = new TriggerSubscription(el, eventName, callback);
+    const sut = new TriggerSubscription(dom, el, eventName, callback);
 
     return { callback, sut, handler, event, el };
   }
@@ -252,7 +254,7 @@ describe('EventSubscriber', () => {
       });
     })
 
-    const sut = new EventSubscriber(eventNames);
+    const sut = new EventSubscriber(dom, eventNames);
 
     return { sut, handler, listener, events, el };
   }
@@ -396,7 +398,7 @@ describe('EventManager', () => {
           expectedEventNames = lookup[tagName][propertyName];
         }
         it(_`tagName=${tagName}, propertyName=${propertyName} returns handler with eventNames=${expectedEventNames}`, () => {
-          const handler = sut.getElementHandler(createElement(`<${tagName}></${tagName}>`), propertyName);
+          const handler = sut.getElementHandler(dom, createElement(`<${tagName}></${tagName}>`), propertyName);
           expect(handler['events']).to.deep.equal(expectedEventNames);
         })
       }
@@ -404,15 +406,15 @@ describe('EventManager', () => {
 
     it(`returns null if the target does not have a tagName`, () => {
       const text = document.createTextNode('asdf');
-      const handler = sut.getElementHandler(text, 'textContent');
+      const handler = sut.getElementHandler(dom, text, 'textContent');
       expect(handler).to.be.null;
     });
 
     it(`returns null if the property does not exist in the configuration`, () => {
       const el = createElement('<input></input>');
-      let handler = sut.getElementHandler(el, 'value');
+      let handler = sut.getElementHandler(dom, el, 'value');
       expect(handler).not.to.be.null;
-      handler = sut.getElementHandler(el, 'value1');
+      handler = sut.getElementHandler(dom, el, 'value1');
       expect(handler).to.be.null;
     });
   });
@@ -457,8 +459,8 @@ describe('EventManager', () => {
       const wrapper = document.createElement('div');
       const parentEl = document.createElement('parent-div');
       const childEl = document.createElement('child-div');
-      const parentSubscription = sut.addEventListener(parentEl, eventName, parentListener, strategy);
-      const childSubscription = sut.addEventListener(childEl, eventName, childListener, strategy);
+      const parentSubscription = sut.addEventListener(dom, parentEl, eventName, parentListener, strategy);
+      const childSubscription = sut.addEventListener(dom, childEl, eventName, childListener, strategy);
       parentEl.appendChild(childEl);
       if (shadow !== null) {
         const shadowRoot = wrapper.attachShadow(<any>{ mode: shadow });

--- a/packages/runtime/test/unit/binding/observer-locator.spec.ts
+++ b/packages/runtime/test/unit/binding/observer-locator.spec.ts
@@ -1,4 +1,4 @@
-import { ObserverLocator, ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer, DataAttributeAccessor, PrimitiveObserver, ClassAttributeAccessor, StyleAttributeAccessor, SelectValueObserver, ValueAttributeObserver, CheckedObserver, XLinkAttributeAccessor, DirtyCheckProperty, CustomSetterObserver, SetterObserver, CollectionLengthObserver, PropertyAccessor, ElementPropertyAccessor } from '../../../src/index';
+import { ObserverLocator, DOM, ILifecycle, IEventManager, IDirtyChecker, ISVGAnalyzer, DataAttributeAccessor, PrimitiveObserver, ClassAttributeAccessor, StyleAttributeAccessor, SelectValueObserver, ValueAttributeObserver, CheckedObserver, XLinkAttributeAccessor, DirtyCheckProperty, CustomSetterObserver, SetterObserver, CollectionLengthObserver, PropertyAccessor, ElementPropertyAccessor } from '../../../src/index';
 import { expect } from 'chai';
 import { DI } from '@aurelia/kernel';
 import { _, createElement } from '../util';
@@ -12,7 +12,7 @@ describe('ObserverLocator', () => {
     const em = container.get(IEventManager);
     const dc = container.get(IDirtyChecker);
     const sa = container.get(ISVGAnalyzer);
-    const sut = new ObserverLocator(lifecycle, em, dc, sa);
+    const sut = new ObserverLocator(new DOM(<any>document), lifecycle, em, dc, sa);
 
     return { sut };
   }

--- a/packages/runtime/test/unit/binding/target-observers.spec.ts
+++ b/packages/runtime/test/unit/binding/target-observers.spec.ts
@@ -1,9 +1,10 @@
-import { XLinkAttributeAccessor, DataAttributeAccessor, StyleAttributeAccessor, Lifecycle, ClassAttributeAccessor, LifecycleFlags } from "../../../src/index";
+import { XLinkAttributeAccessor, DataAttributeAccessor, StyleAttributeAccessor, Lifecycle, ClassAttributeAccessor, LifecycleFlags, DOM } from "../../../src/index";
 import { createElement, globalAttributeNames } from "../util";
 import { expect } from "chai";
 import { CSS_PROPERTIES } from "../css-properties";
 import { spy } from "sinon";
 
+const dom = new DOM(<any>document);
 
 function createSvgUseElement(name: string, value: string) {
   return createElement(`<svg>
@@ -38,7 +39,7 @@ describe('XLinkAttributeAccessor', () => {
       it(`returns ${value} for xlink:${name}`, () => {
         el = createSvgUseElement(name, value);
         lifecycle = new Lifecycle();
-        sut = new XLinkAttributeAccessor(lifecycle, el, `xlink:${name}`, name);
+        sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
         const actual = sut.getValue();
         expect(actual).to.equal(value);
       });
@@ -50,7 +51,7 @@ describe('XLinkAttributeAccessor', () => {
       it(`sets xlink:${name} to foo`, () => {
         el = createSvgUseElement(name, value);
         lifecycle = new Lifecycle();
-        sut = new XLinkAttributeAccessor(lifecycle, el, `xlink:${name}`, name);
+        sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
         sut.setValue('foo', LifecycleFlags.none);
         expect(sut.getValue()).not.to.equal('foo');
         lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -73,7 +74,7 @@ describe('DataAttributeAccessor', () => {
         it(`returns "${value}" for attribute "${name}"`, () => {
           el = createElement(`<div ${name}="${value}"></div>`);
           lifecycle = new Lifecycle();
-          sut = new DataAttributeAccessor(lifecycle, el, name);
+          sut = new DataAttributeAccessor(dom, lifecycle, el, name);
           const actual = sut.getValue();
           expect(actual).to.equal(value);
         });
@@ -88,7 +89,7 @@ describe('DataAttributeAccessor', () => {
           el = createElement(`<div></div>`);
           lifecycle = new Lifecycle();
           const expected = value !== null && value !== undefined ? `<div ${name}="${value}"></div>` : '<div></div>';
-          sut = new DataAttributeAccessor(lifecycle, el, name);
+          sut = new DataAttributeAccessor(dom, lifecycle, el, name);
           sut.setValue(value, LifecycleFlags.none);
           if (value !== null && value !== undefined) {
             expect(el.outerHTML).not.to.equal(expected);
@@ -116,7 +117,7 @@ describe('StyleAccessor', () => {
     it(`setValue - style="${rule}"`, () => {
       el = <HTMLElement>createElement('<div></div>');
       lifecycle = new Lifecycle();
-      sut = new StyleAttributeAccessor(lifecycle, el);
+      sut = new StyleAttributeAccessor(dom, lifecycle, el);
       sut._setProperty = spy();
 
       sut.setValue(rule, LifecycleFlags.none);
@@ -130,7 +131,7 @@ describe('StyleAccessor', () => {
   it(`getValue - style="display: block;"`, () => {
     el = <HTMLElement>createElement(`<div style="display: block;"></div>`);
     lifecycle = new Lifecycle();
-    sut = new StyleAttributeAccessor(lifecycle, el);
+    sut = new StyleAttributeAccessor(dom, lifecycle, el);
 
     const actual = sut.getValue();
     expect(actual).to.equal('display: block;');
@@ -158,7 +159,7 @@ describe('ClassAccessor', () => {
         el = createElement(markup);
         initialClassList = el.classList.toString();
         lifecycle = new Lifecycle();
-        sut = new ClassAttributeAccessor(lifecycle, el);
+        sut = new ClassAttributeAccessor(dom, lifecycle, el);
       });
 
       it(`setValue("${classList}") updates ${markup}`, () => {

--- a/packages/runtime/test/unit/dom.spec.ts
+++ b/packages/runtime/test/unit/dom.spec.ts
@@ -357,61 +357,61 @@ describe('DOM', () => {
     }
   });
 
-  describe('isElementNodeType', () => {
-    const nodes = [
-      document.createElement('div'),
-      document.createElement('asdf')
-    ];
-    for (const node of nodes) {
-      it(`should return true if the value is of type ${Object.prototype.toString.call(node)}`, () => {
-        const actual = DOM.isElementNodeType(node);
-        expect(actual).to.be.true;
-      });
-    }
+  // describe('isElementNodeType', () => {
+  //   const nodes = [
+  //     document.createElement('div'),
+  //     document.createElement('asdf')
+  //   ];
+  //   for (const node of nodes) {
+  //     it(`should return true if the value is of type ${Object.prototype.toString.call(node)}`, () => {
+  //       const actual = DOM.isElementNodeType(node);
+  //       expect(actual).to.be.true;
+  //     });
+  //   }
 
-    const nonNodes = [
-      document.createAttribute('asdf'),
-      document.createComment('asdf'),
-      document.createTextNode('asdf'),
-      document.createDocumentFragment(),
-      document,
-      document.doctype
-    ];
-    for (const nonNode of nonNodes) {
-      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, () => {
-        const actual = DOM.isElementNodeType(nonNode);
-        expect(actual).to.be.false;
-      });
-    }
-  });
+  //   const nonNodes = [
+  //     document.createAttribute('asdf'),
+  //     document.createComment('asdf'),
+  //     document.createTextNode('asdf'),
+  //     document.createDocumentFragment(),
+  //     document,
+  //     document.doctype
+  //   ];
+  //   for (const nonNode of nonNodes) {
+  //     it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, () => {
+  //       const actual = DOM.isElementNodeType(nonNode);
+  //       expect(actual).to.be.false;
+  //     });
+  //   }
+  // });
 
-  describe('isTextNodeType', () => {
-    const nodes = [
-      document.createTextNode('asdf')
-    ];
-    for (const node of nodes) {
-      it(`should return true if the value is of type ${Object.prototype.toString.call(node)}`, () => {
-        const actual = DOM.isTextNodeType(node);
-        expect(actual).to.be.true;
-      });
-    }
+  // describe('isTextNodeType', () => {
+  //   const nodes = [
+  //     document.createTextNode('asdf')
+  //   ];
+  //   for (const node of nodes) {
+  //     it(`should return true if the value is of type ${Object.prototype.toString.call(node)}`, () => {
+  //       const actual = DOM.isTextNodeType(node);
+  //       expect(actual).to.be.true;
+  //     });
+  //   }
 
-    const nonNodes = [
-      document.createAttribute('asdf'),
-      document.createComment('asdf'),
-      document.createElement('div'),
-      document.createElement('asdf'),
-      document.createDocumentFragment(),
-      document,
-      document.doctype
-    ];
-    for (const nonNode of nonNodes) {
-      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, () => {
-        const actual = DOM.isTextNodeType(nonNode);
-        expect(actual).to.be.false;
-      });
-    }
-  });
+  //   const nonNodes = [
+  //     document.createAttribute('asdf'),
+  //     document.createComment('asdf'),
+  //     document.createElement('div'),
+  //     document.createElement('asdf'),
+  //     document.createDocumentFragment(),
+  //     document,
+  //     document.doctype
+  //   ];
+  //   for (const nonNode of nonNodes) {
+  //     it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, () => {
+  //       const actual = DOM.isTextNodeType(nonNode);
+  //       expect(actual).to.be.false;
+  //     });
+  //   }
+  // });
 
   describe('remove', () => {
     it('should remove the childNode from its parent (non-polyfilled)', () => {

--- a/packages/runtime/test/unit/mock.ts
+++ b/packages/runtime/test/unit/mock.ts
@@ -36,7 +36,6 @@ import {
   RuntimeBehavior,
   ILifecycle,
   ITemplateDefinition,
-  IResourceType,
   IAttributeDefinition,
   ICustomAttribute,
   IRenderer,
@@ -196,6 +195,7 @@ const expressions = {
 
 export class MockIfTextNodeTemplate {
   constructor(
+    public dom: any,
     public sourceExpression: any,
     public observerLocator: any,
     public lifecycle: any,
@@ -205,7 +205,7 @@ export class MockIfTextNodeTemplate {
   public render(renderable: Partial<IRenderable>, host?: INode, parts?: TemplatePartDefinitions): void {
     const nodes = (<Writable<IRenderable>>renderable).$nodes = MockNodeSequence.createRenderLocation();
 
-    const observerLocator = new ObserverLocator(this.lifecycle, null, null, null);
+    const observerLocator = new ObserverLocator(dom, this.lifecycle, null, null, null);
     const factory = new ViewFactory(null, <any>new MockTextNodeTemplate(expressions.if, observerLocator, this.container), this.lifecycle);
 
     const sut = new If(factory, nodes.firstChild, new CompositionCoordinator(this.lifecycle));
@@ -224,6 +224,7 @@ export class MockIfTextNodeTemplate {
 
 export class MockIfElseTextNodeTemplate {
   constructor(
+    public dom: any,
     public sourceExpression: any,
     public observerLocator: any,
     public lifecycle: any,
@@ -233,7 +234,7 @@ export class MockIfElseTextNodeTemplate {
   public render(renderable: Partial<IRenderable>, host?: INode, parts?: TemplatePartDefinitions): void {
     const ifNodes = (<Writable<IRenderable>>renderable).$nodes = MockNodeSequence.createRenderLocation();
 
-    const observerLocator = new ObserverLocator(this.lifecycle, null, null, null);
+    const observerLocator = new ObserverLocator(this.dom, this.lifecycle, null, null, null);
     const ifFactory = new ViewFactory(null, <any>new MockTextNodeTemplate(expressions.if, observerLocator, this.container), this.lifecycle);
 
     const ifSut = new If(ifFactory, ifNodes.firstChild, new CompositionCoordinator(this.lifecycle));

--- a/packages/runtime/test/unit/templating/create-element.spec.ts
+++ b/packages/runtime/test/unit/templating/create-element.spec.ts
@@ -1,13 +1,16 @@
-import { HydrateElementInstruction } from '../../../../jit/src';
 import { expect } from 'chai';
 import { eachCartesianJoinFactory, eachCartesianJoin, createElement, _ } from '../util';
-import { TargetedInstruction, INode, ICustomElementType, CustomElementResource, TargetedInstructionType, createElement as sut, RenderPlan  } from '../../../src';
+import { Registration } from '../../../../kernel/src/index';
+import { TargetedInstruction, INode, ICustomElementType, CustomElementResource, TargetedInstructionType, createElement as sut, RenderPlan, HydrateElementInstruction, IDOM, DOM } from '../../../src/index';
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 describe(`createElement() creates element based on tag`, () => {
   eachCartesianJoin([['div', 'template']], (tag: string) => {
     describe(`tag=${tag}`, () => {
       it(`translates raw object properties to attributes`, () => {
-        const actual = sut(tag, { title: 'asdf', foo: 'bar' });
+        const actual = sut(dom, tag, { title: 'asdf', foo: 'bar' });
 
         const node = actual['node'] as Element;
 
@@ -20,7 +23,7 @@ describe(`createElement() creates element based on tag`, () => {
 
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
         it(`can handle ${str} props`, () => {
-          const actual = sut(tag, props);
+          const actual = sut(dom, tag, props);
 
           const node = actual['node'] as Element;
 
@@ -31,7 +34,7 @@ describe(`createElement() creates element based on tag`, () => {
 
       eachCartesianJoin([['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']], t => {
         it(`understands targeted instruction type=${t}`, () => {
-          const actual = sut(tag, { prop: { type: t }});
+          const actual = sut(dom, tag, { prop: { type: t }});
 
           const instruction = actual['instructions'][0][0] as TargetedInstruction;
           const node = actual['node'] as Element;
@@ -51,12 +54,12 @@ describe(`createElement() creates element based on tag`, () => {
         ],
         <(($1: [Array<RenderPlan | string | INode>, string]) => [Array<RenderPlan | string | INode>, string])[]>[
           ([children, expected]) => [children, expected],
-          ([children, expected]) => [[sut('div', null, ['baz']), ...children], `baz${expected}`],
-          ([children, expected]) => [[sut('div', null, [createElement('<div>baz</div>')]), ...children], `baz${expected}`]
+          ([children, expected]) => [[sut(dom, 'div', null, ['baz']), ...children], `baz${expected}`],
+          ([children, expected]) => [[sut(dom, 'div', null, [createElement('<div>baz</div>')]), ...children], `baz${expected}`]
         ]
       ], ($1, [children, expected]) => {
         it(_`adds children (${children})`, () => {
-          const actual = sut(tag, null, children);
+          const actual = sut(dom, tag, null, children);
 
           const node = actual['node'] as Element;
 
@@ -81,7 +84,7 @@ describe(`createElement() creates element based on type`, () => {
     describe(_`type=${createType()}`, () => {
       it(`translates raw object properties to attributes`, () => {
         const type = createType();
-        const actual = sut(type, { title: 'asdf', foo: 'bar' });
+        const actual = sut(dom, type, { title: 'asdf', foo: 'bar' });
 
         const node = actual['node'] as Element;
         const instruction = (<any>actual['instructions'][0][0]) as HydrateElementInstruction
@@ -110,7 +113,7 @@ describe(`createElement() creates element based on type`, () => {
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
         it(`can handle ${str} props`, () => {
           const type = createType();
-          const actual = sut(type, props);
+          const actual = sut(dom, type, props);
 
           const node = actual['node'] as Element;
           const instruction = (<any>actual['instructions'][0][0]) as HydrateElementInstruction
@@ -125,7 +128,7 @@ describe(`createElement() creates element based on type`, () => {
       eachCartesianJoin([['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']], t => {
         it(`understands targeted instruction type=${t}`, () => {
           const type = createType();
-          const actual = sut(type, { prop: { type: t }});
+          const actual = sut(dom, type, { prop: { type: t }});
 
           const node = actual['node'] as Element;
           const instruction = (<any>actual['instructions'][0][0]) as HydrateElementInstruction
@@ -148,13 +151,13 @@ describe(`createElement() creates element based on type`, () => {
         ],
         <(($1: [Array<RenderPlan | string | INode>, string]) => [Array<RenderPlan | string | INode>, string])[]>[
           ([children, expected]) => [children, expected],
-          ([children, expected]) => [[sut('div', null, ['baz']), ...children], `baz${expected}`],
-          ([children, expected]) => [[sut('div', null, [createElement('<div>baz</div>')]), ...children], `baz${expected}`]
+          ([children, expected]) => [[sut(dom, 'div', null, ['baz']), ...children], `baz${expected}`],
+          ([children, expected]) => [[sut(dom, 'div', null, [createElement('<div>baz</div>')]), ...children], `baz${expected}`]
         ]
       ], ($1, [children, expected]) => {
         it(_`adds children (${children})`, () => {
           const type = createType();
-          const actual = sut(type, null, children);
+          const actual = sut(dom, type, null, children);
 
           const node = actual['node'] as Element;
           const instruction = (<any>actual['instructions'][0][0]) as HydrateElementInstruction

--- a/packages/runtime/test/unit/templating/custom-element.$hydrate.spec.ts
+++ b/packages/runtime/test/unit/templating/custom-element.$hydrate.spec.ts
@@ -1,7 +1,9 @@
-import { Hooks, INode,  ICustomElementType, IRenderingEngine, ITemplate, RuntimeBehavior } from '../../../src/index';
+import { Hooks, INode,  ICustomElementType, IRenderingEngine, ITemplate, RuntimeBehavior, DOM } from '../../../src/index';
 import { expect } from 'chai';
 import { eachCartesianJoin } from '../util';
 import { CustomElement, createCustomElement } from './custom-element._builder';
+
+const dom = new DOM(<any>document);
 
 describe('@customElement', () => {
 
@@ -68,7 +70,7 @@ describe('@customElement', () => {
         let host: INode = <any>{};
 
         // Act
-        sut.$hydrate(renderingEngine, host);
+        sut.$hydrate(dom, renderingEngine, host);
 
         // Assert
         expect(sut).to.not.have.$state.isAttached('sut.$isAttached');

--- a/packages/runtime/test/unit/templating/custom-element.projector.spec.ts
+++ b/packages/runtime/test/unit/templating/custom-element.projector.spec.ts
@@ -1,7 +1,9 @@
-import { customElement, useShadowDOM, noViewTemplate, ICustomElement, ShadowDOMProjector, containerless, ContainerlessProjector, HostProjector } from '../../../src';
+import { customElement, useShadowDOM, noViewTemplate, ICustomElement, ShadowDOMProjector, containerless, ContainerlessProjector, HostProjector, DOM } from '../../../src';
 import { MockRenderingEngine } from '../mock';
 import { expect } from 'chai';
 import { PLATFORM } from '@aurelia/kernel';
+
+const dom = new DOM(<any>document);
 
 describe(`determineProjector`, () => {
   it(`@useShadowDOM yields ShadowDOMProjector`, () => {
@@ -15,7 +17,7 @@ describe(`determineProjector`, () => {
     const host = document.createElement('div');
 
     const sut = new Foo() as ICustomElement;
-    sut.$hydrate(<any>renderingEngine, host);
+    sut.$hydrate(dom, <any>renderingEngine, host);
 
     expect(sut.$projector).to.be.instanceof(ShadowDOMProjector);
     expect(sut.$projector['shadowRoot']).to.be.instanceof(Node);
@@ -36,7 +38,7 @@ describe(`determineProjector`, () => {
     const host = document.createElement('div');
 
     const sut = new Foo() as ICustomElement;
-    sut.$hydrate(<any>renderingEngine, host);
+    sut.$hydrate(dom, <any>renderingEngine, host);
 
     expect(sut.$projector).to.be.instanceof(ShadowDOMProjector);
     expect(sut.$projector['shadowRoot']).to.be.instanceof(Node);
@@ -59,7 +61,7 @@ describe(`determineProjector`, () => {
     parent.appendChild(host);
 
     const sut = new Foo() as ICustomElement;
-    sut.$hydrate(<any>renderingEngine, host);
+    sut.$hydrate(dom, <any>renderingEngine, host);
 
     expect(sut.$projector).to.be.instanceof(ContainerlessProjector);
     expect(sut.$projector['childNodes'].length).to.equal(0);
@@ -87,7 +89,7 @@ describe(`determineProjector`, () => {
     host.appendChild(child);
 
     const sut = new Foo() as ICustomElement;
-    sut.$hydrate(<any>renderingEngine, host);
+    sut.$hydrate(dom, <any>renderingEngine, host);
 
     expect(sut.$projector).to.be.instanceof(ContainerlessProjector);
     expect(sut.$projector['childNodes'][0]).to.equal(child);
@@ -109,7 +111,7 @@ describe(`determineProjector`, () => {
     });
     const host = document.createElement('div');
     const sut = new Foo() as ICustomElement;
-    sut.$hydrate(<any>renderingEngine, host);
+    sut.$hydrate(dom, <any>renderingEngine, host);
     expect(host['$customElement']).to.equal(sut);
     expect(sut.$projector).to.be.instanceof(HostProjector);
     expect(sut.$projector.children).to.equal(PLATFORM.emptyArray);
@@ -126,7 +128,7 @@ describe(`determineProjector`, () => {
     });
     const host = document.createElement('div');
     const sut = new Foo() as ICustomElement;
-    expect(() => sut.$hydrate(<any>renderingEngine, host)).to.throw(/21/);
+    expect(() => sut.$hydrate(dom, <any>renderingEngine, host)).to.throw(/21/);
   });
 
   it(`@containerless + hasSlots throws`, () => {
@@ -141,7 +143,7 @@ describe(`determineProjector`, () => {
     });
     const host = document.createElement('div');
     const sut = new Foo() as ICustomElement;
-    expect(() => sut.$hydrate(<any>renderingEngine, host)).to.throw(/21/);
+    expect(() => sut.$hydrate(dom, <any>renderingEngine, host)).to.throw(/21/);
   });
 });
 describe('ShadowDOMProjector', () => {

--- a/packages/runtime/test/unit/templating/fakes/view-fake.ts
+++ b/packages/runtime/test/unit/templating/fakes/view-fake.ts
@@ -7,7 +7,6 @@ import {
   IRenderContext,
   IBindScope,
   IAttach,
-  DOM,
   INodeSequence,
   IRenderLocation,
   ILifecycle,
@@ -15,8 +14,11 @@ import {
   NodeSequenceFactory,
   State,
   IMountable,
-  ILifecycleUnbind
+  ILifecycleUnbind,
+  DOM
 } from "../../../../src/index";
+
+const dom = new DOM(<any>document);
 
 export class ViewFake implements IView {
   public $bindableHead: IBindScope = null;
@@ -46,7 +48,7 @@ export class ViewFake implements IView {
   public cache: IViewFactory;
 
   constructor(public $lifecycle: Lifecycle) {
-    this.$nodes = NodeSequenceFactory.createFor('<div>Fake View</div>').createNodeSequence();
+    this.$nodes = new NodeSequenceFactory(dom, '<div>Fake View</div>').createNodeSequence();
   }
 
   public lockScope(scope: IScope): void {

--- a/packages/runtime/test/unit/templating/renderer.spec.ts
+++ b/packages/runtime/test/unit/templating/renderer.spec.ts
@@ -42,7 +42,8 @@ import {
   LetBindingInstruction,
   LetElementInstruction,
   HtmlRenderer,
-  IRenderer
+  IRenderer,
+  IDOM
 } from '../../../src/index';
 import { expect } from 'chai';
 import { _, createElement } from '../util';
@@ -52,9 +53,14 @@ import {
 import { DI, Registration } from '../../../../kernel/src/index';
 import { spy, SinonSpy } from 'sinon';
 
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
+
 describe('Renderer', () => {
   function setup() {
     const container = DI.createContainer();
+    container.register(domRegistration);
     container.register(<any>HtmlRenderer)
     ParserRegistration.register(<any>container);
     const renderable = <IRenderable>{ $bindablesHead: null, $bindableTail: null, $attachableHead: null, $attachableTail: null };
@@ -93,7 +99,7 @@ describe('Renderer', () => {
       it(_`instruction=${instruction}`, () => {
         const { sut, renderable, target, placeholder, wrapper, renderContext } = setup();
 
-        sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+        sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
         expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
         expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -118,7 +124,7 @@ describe('Renderer', () => {
           it(_`instruction=${instruction}`, () => {
             const { sut, renderable, target, wrapper, renderContext } = setup();
 
-            sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+            sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
             expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
             expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -143,7 +149,7 @@ describe('Renderer', () => {
           it(_`instruction=${instruction}`, () => {
             const { sut, renderable, target, wrapper, renderContext } = setup();
 
-            sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+            sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
             expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
             expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -168,7 +174,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
           expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -189,7 +195,7 @@ describe('Renderer', () => {
       it(_`instruction=${instruction}`, () => {
         const { sut, renderable, target, wrapper, renderContext } = setup();
 
-        sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+        sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
         expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
         expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -209,7 +215,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
           expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
@@ -232,7 +238,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderable.$bindableHead).to.equal(undefined, 'renderable.$bindableHead');
           expect(target[to]).to.equal(value);
@@ -250,7 +256,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderable.$bindableHead).to.equal(undefined, 'renderable.$bindableHead');
           expect(target.getAttribute(to)).to.equal(value + '');
@@ -268,7 +274,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderContext.beginComponentOperation).to.have.been.calledWith(renderable, target, instruction, null, null, target, true);
           expect(renderContext.get).to.have.been.calledWith(`custom-element:${res}`);
@@ -289,7 +295,7 @@ describe('Renderer', () => {
         it(_`instruction=${instruction}`, () => {
           const { sut, renderable, target, wrapper, renderContext, renderingEngine } = setup();
 
-          sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+          sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
           expect(renderContext.beginComponentOperation).to.have.been.calledWith(renderable, target, instruction);
           expect(renderContext.get).to.have.been.calledWith(`custom-attribute:${res}`);
@@ -321,7 +327,7 @@ describe('Renderer', () => {
           it(_`instruction=${instruction}`, () => {
             const { sut, renderable, target, wrapper, renderContext } = setup();
 
-            sut.instructionRenderers[instruction.type].render(renderContext, renderable, target, instruction);
+            sut.instructionRenderers[instruction.type].render(dom, renderContext, renderable, target, instruction);
 
             expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
             expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);

--- a/packages/runtime/test/unit/templating/resources/compose.spec.ts
+++ b/packages/runtime/test/unit/templating/resources/compose.spec.ts
@@ -1,7 +1,9 @@
 import { expect } from 'chai';
 import { hydrateCustomElement } from '../behavior-assistance';
-import { DOM, IViewFactory, customElement, ITemplateDefinition, LifecycleFlags, IAttach, Lifecycle, RenderPlan, Compose, CustomElementResource } from '../../../../src/index';
+import { DOM, IViewFactory, customElement, ITemplateDefinition, LifecycleFlags, IAttach, Lifecycle, RenderPlan, Compose, CustomElementResource, IDOM } from '../../../../src/index';
 import { ViewFactoryFake } from '../fakes/view-factory-fake';
+
+const dom = new DOM(<any>document);
 
 describe('The "compose" custom element', () => {
   // this is not ideal (same instance will be reused for multiple loops) but probably fine
@@ -271,7 +273,8 @@ describe('The "compose" custom element', () => {
 
   function createPotentialRenderable(lifecycle: Lifecycle): RenderPlan {
     return new RenderPlan(
-      DOM.createElement('div'),
+      dom,
+      document.createElement('div'),
       [],
       []
     );

--- a/packages/runtime/test/unit/templating/resources/if.spec.ts
+++ b/packages/runtime/test/unit/templating/resources/if.spec.ts
@@ -18,13 +18,18 @@ import {
   Lifecycle,
   ILifecycle,
   State,
+  DOM,
+  IDOM,
   CompositionCoordinator
 } from '../../../../src/index';
 import { MockTextNodeTemplate } from '../../mock';
 import { eachCartesianJoinFactory } from '../../../../../../scripts/test-lib';
 import { createScopeForTest } from '../../binding/shared';
 import { expect } from 'chai';
-import { DI, Writable } from '../../../../../kernel/src/index';
+import { DI, Writable, Registration } from '../../../../../kernel/src/index';
+
+const dom = new DOM(<any>document);
+const domRegistration = Registration.instance(IDOM, dom);
 
 describe('The "if" template controller', () => {
   it("renders its view when the value is true", () => {
@@ -184,7 +189,7 @@ function setup() {
   const ifLoc = document.createComment('au-loc');
   host.appendChild(ifLoc);
 
-  const observerLocator = new ObserverLocator(lifecycle, null, null, null);
+  const observerLocator = new ObserverLocator(dom, lifecycle, null, null, null);
   const ifFactory = new ViewFactory(null, <any>new MockTextNodeTemplate(expressions.if, observerLocator, container), lifecycle);
   const elseFactory = new ViewFactory(null, <any>new MockTextNodeTemplate(expressions.else, observerLocator, container), lifecycle);
 

--- a/packages/runtime/test/unit/templating/template.spec.ts
+++ b/packages/runtime/test/unit/templating/template.spec.ts
@@ -9,11 +9,13 @@ import {
   ITargetedInstruction,
   IRenderLocation,
   INode,
+  DOM
 
 } from '../../../src';
 import { expect } from 'chai';
 import { createElement } from '../util';
 
+const dom = new DOM(<any>document);
 
 describe(`CompiledTemplate`, () => {
   describe(`constructor`, () => {
@@ -25,7 +27,7 @@ describe(`CompiledTemplate`, () => {
       const renderer = new Renderer([]);
       const renderingEngine = new MockRenderingEngine(null, viewFactory, renderer, null);
       const container = new Container();
-      const sut = new CompiledTemplate(renderingEngine, container as any, def as any);
+      const sut = new CompiledTemplate(dom, renderingEngine, container as any, def as any);
 
       expect(sut.renderContext['parent']).to.equal(container);
 

--- a/scripts/generate-tests/template-compiler.mutations.ts
+++ b/scripts/generate-tests/template-compiler.mutations.ts
@@ -232,7 +232,7 @@ function generateAndEmit(): void {
     const nodes = [
       $$import('chai', 'expect'),
       $$import('../../../kernel/src/index', 'DI'),
-      $$import('../../../runtime/src/index', 'CustomElementResource', 'DOM', 'Aurelia', 'BindingMode', 'ILifecycle'),
+      $$import('../../../runtime/src/index', 'CustomElementResource', 'Aurelia', 'BindingMode', 'ILifecycle'),
       $$import('../../src/index', 'BasicConfiguration'),
       null,
       $$functionExpr('describe', [
@@ -244,7 +244,7 @@ function generateAndEmit(): void {
               $$const('container', $call('DI.createContainer')),
               $$call('container.register', ['BasicConfiguration']),
               $$new('au', 'Aurelia', ['container']),
-              $$const('host', $call('DOM.createElement', [$expression('div')])),
+              $$const('host', $call('document.createElement', [$expression('div')])),
               $$return({ au: 'au', host: 'host' })
             ],
             []

--- a/scripts/generate-tests/template-compiler.static.ts
+++ b/scripts/generate-tests/template-compiler.static.ts
@@ -874,7 +874,7 @@ function generateAndEmit(): void {
     const nodes = [
       $$import('chai', 'expect'),
       $$import('../../../kernel/src/index', 'DI'),
-      $$import('../../../runtime/src/index', 'CustomElementResource', 'DOM', 'Aurelia', 'BindingMode'),
+      $$import('../../../runtime/src/index', 'CustomElementResource', 'Aurelia', 'BindingMode'),
       $$import('../../src/index', 'BasicConfiguration'),
       null,
       $$functionExpr('describe', [
@@ -886,7 +886,7 @@ function generateAndEmit(): void {
               $$const('container', $call('DI.createContainer')),
               $$call('container.register', ['BasicConfiguration']),
               $$new('au', 'Aurelia', ['container']),
-              $$const('host', $call('DOM.createElement', [$expression('div')])),
+              $$const('host', $call('document.createElement', [$expression('div')])),
               $$return({ au: 'au', host: 'host' })
             ],
             []

--- a/scripts/test-lib.ts
+++ b/scripts/test-lib.ts
@@ -176,7 +176,7 @@ export function jsonStringify(o: any): string {
 }
 
 export function htmlStringify(node: Node): string {
-  if (node.textContent.length || node instanceof Text || node instanceof Comment) {
+  if ((node.textContent !== null && node.textContent.length) || node instanceof Text || node instanceof Comment) {
     return node.textContent.replace(newline, '');
   }
   if (node instanceof Element) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR changes the `DOM` object from a global object into an instantiable/injectable class exposed via a runtime-agnostic interface.

It lays an important part of the groundwork for the integrations that @bigopon has been working on. Since it's actually passed in as an argument to `$hydrate` and the renderers, it doesn't have to be an app-wide singleton. This way it would theoretically support "mixed mode".

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/87
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

There are a few places where `DOM` is actually injected via the constructor (these are all "downstream" relative to renderer entry points):
- [jit/template-factory.ts](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-160a8450d772650d8f0db236c7b67f84R47)
- [runtime/listener.ts](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-488b8209c39a6d427a52d7dc1446850dR42)
- [TextNodeSequence](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-0bbea5c3a3b006ddb3de803b5136bd53R234), [FragmentNodeSequence](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-0bbea5c3a3b006ddb3de803b5136bd53R277) and [NodeSequenceFactory](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-0bbea5c3a3b006ddb3de803b5136bd53R402)
- [ValueAttributeObserver](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-b4c6602170637f535c2488ca53c94bb3R63), [CheckedObserver](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-b4c6602170637f535c2488ca53c94bb3R165) and [SelectValueObserver](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-b4c6602170637f535c2488ca53c94bb3R340)
- [ListenerTracker](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-6fcda4949fc0764460dc5b1849a75ef1R77), [TriggerSubscription](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-6fcda4949fc0764460dc5b1849a75ef1R140) and [EventSubscriber](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-6fcda4949fc0764460dc5b1849a75ef1R179)
- [ObserverLocator](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-41934ef11565bd232010c1e170bb633bR84)
- [all target-accessors](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-aa3cb57ac85d4149a1f96a4c39055092R2)
- [compose](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-82bc89e92f5f475c2beb3fa9d66bded6R43)
- [create-element](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-e6fb80990de0b9e649914dd1ebd82af2R34)
- [all 3 projectors](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-117be0ce9c8def64f526bc8f79eb0a4aR154)
- [ViewFactoryProvider](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-117be0ce9c8def64f526bc8f79eb0a4aR691)

The DOM needs to be injected in those places because otherwise it would need to be passed around via every single lifecycle (in the case of the observers this wouldn't even be possible).

- There is an extra (preliminary, I suppose) API on `Aurelia` that allows the user to specify either the `DOM` or `document` [here](https://github.com/aurelia/aurelia/compare/injectable-dom?expand=1#diff-0bcdaa7de1d39a267573c522d86a0850R126). If none is provided, it defaults to the `host.ownerDocument` on the provided `host` during `app()`. If that property does not exist, it defaults to the global `document`.

- All input parameters on the `IDOM` interface that are DOM-specific are of type `unknown`. These can be made generic in a later iteration to provide end users with better type checking, but it might be better to expose alternative (runtime-specific) interfaces for those specific runtimes instead. I've tried generic in another branch, it gets a bit messy. For now this ensures that every kind of runtime can work without causing typing hell.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Just ensure all existing tests pass for now.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

- Also make output parameter types of `IDOM` of type `unknown` and do the necessary casting in various places (or use generics, not sure yet)
- Completely eliminate all direct method calls on `node` instances and use `dom` everywhere instead, so that we can rely on `DOM` as the single aspect of variation between runtimes.
- Extract html-specific observers etc out into `runtime-html`
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
