### PR TITLE
Fix local deps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,14 +32,16 @@
       },
       "args": [
         "${workspaceRoot}/packages/runtime/test/setup-node.ts",
-        "${workspaceRoot}/packages/runtime/test/**/if.spec.ts", // remember to change this to the file you want to debug (and you may need to remove this comment as well for VS Code's json parser)
+        "${workspaceRoot}/packages/runtime/test/**/custom-element.dependencies.spec.ts", // remember to change this to the file you want to debug (and you may need to remove this comment as well for VS Code's json parser)
         "-c",
         "-R",
         "progress",
         "-r",
+        "source-map-support/register",
+        "-r",
         "ts-node/register",
         "-r",
-        "source-map-support/register",
+        "esm",
         "--recursive",
         "--globals",
         "expect",

--- a/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
+++ b/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
@@ -1224,6 +1224,39 @@ describe('xml node compiler tests', () => {
   }
 });
 
+describe('dependency injection', () => {
+
+  it('register local dependencies ', () => {
+    const Foo = CustomElementResource.define(
+      {
+        name: 'foo',
+        template: 'bar'
+      },
+      null
+    );
+    const App = CustomElementResource.define(
+      {
+        name: 'app',
+        template: '<foo></foo>',
+        dependencies: [Foo]
+      },
+      null
+    );
+
+    const container = HTMLJitConfiguration.createContainer();
+    const au = new Aurelia(container);
+
+    const host = document.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    expect(host.textContent).to.equal('bar');
+  });
+});
+
 describe('generated.template-compiler.static (with tracing)', function () {
   function setup() {
       enableTracing();

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -2,6 +2,7 @@
 import { Constructable, IIndexable, Injectable, Primitive } from './interfaces';
 import { PLATFORM } from './platform';
 import { Reporter, Tracer } from './reporter';
+import { IResourceType } from './resource';
 
 const slice = Array.prototype.slice;
 
@@ -508,6 +509,7 @@ export class Factory implements IFactory {
 /** @internal */
 export interface IContainerConfiguration {
   factories?: Map<Function, IFactory>;
+  resourceLookup?: Record<string, IResourceType<unknown, unknown>>;
 }
 
 const containerResolver: IResolver = {
@@ -526,12 +528,14 @@ export class Container implements IContainer {
   private resolvers: Map<any, IResolver>;
   private factories: Map<Function, IFactory>;
   private configuration: IContainerConfiguration;
+  private resourceLookup: Record<string, IResolver>;
 
   constructor(configuration: IContainerConfiguration = {}) {
     this.parent = null;
     this.resolvers = new Map<any, IResolver>();
     this.configuration = configuration;
     this.factories = configuration.factories || (configuration.factories = new Map());
+    this.resourceLookup = configuration.resourceLookup || (configuration.resourceLookup = Object.create(null));
     this.resolvers.set(IContainer, containerResolver);
   }
 
@@ -565,6 +569,9 @@ export class Container implements IContainer {
 
     if (result === undefined) {
       resolvers.set(key, resolver);
+      if (typeof key === 'string') {
+        this.resourceLookup[key] = resolver;
+      }
     } else if (result instanceof Resolver && result.strategy === ResolverStrategy.array) {
       result.state.push(resolver);
     } else {
@@ -691,7 +698,9 @@ export class Container implements IContainer {
   }
 
   public createChild(): IContainer {
-    const child = new Container(this.configuration);
+    const config = this.configuration;
+    const childConfig = { factories: config.factories, resourceLookup: { ...config.resourceLookup } };
+    const child = new Container(childConfig);
     child.parent = this;
     return child;
   }

--- a/packages/kernel/test/di.spec.ts
+++ b/packages/kernel/test/di.spec.ts
@@ -1051,9 +1051,17 @@ describe(`The Container class`, () => {
   });
 
   describe(`createChild()`, () => {
-    it(`creates a child with same config and sut as parent`, () => {
+    it(`creates a child with same config and sut as parent, and copies over the resourceLookup`, () => {
+      const obj = {};
+      Registration.instance('foo', obj).register(sut, 'foo');
+      expect(sut['resourceLookup'].foo.state).to.equal(obj);
+      expect(sut['configuration'].resourceLookup.foo.state).to.equal(obj);
       const actual = sut.createChild();
-      expect(actual['configuration']).to.equal(sut['configuration']);
+      expect(actual['configuration']).not.to.equal(sut['configuration']);
+      expect(actual['configuration'].factories).to.equal(sut['configuration'].factories);
+      expect(actual['configuration'].resourceLookup).not.to.equal(sut['configuration'].resourceLookup);
+      expect(actual['configuration'].resourceLookup).to.deep.equal(sut['configuration'].resourceLookup);
+      expect(actual['configuration'].resourceLookup.foo.state).to.equal(obj);
       expect(actual['parent']).to.equal(sut);
       expect(sut['parent']).to.equal(null);
     });

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -136,7 +136,7 @@ export class Viewport {
       if (this.nextComponent.enter) {
         this.nextComponent.enter(this.nextInstruction, this.instruction);
       }
-      this.nextComponent.$hydrate(dom, projectorLocator, renderingEngine, host);
+      this.nextComponent.$hydrate(dom, projectorLocator, renderingEngine, host, null);
       this.nextComponent.$bind(LifecycleFlags.fromStartTask | LifecycleFlags.fromBind, null);
       this.nextComponent.$attach(LifecycleFlags.fromStartTask);
 

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -52,7 +52,7 @@ export class RenderPlan<T extends INode = Node> {
   }
 
   public getElementTemplate(engine: IRenderingEngine, Type?: ICustomElementType<T>): ITemplate<T> {
-    return engine.getElementTemplate(this.dom, this.definition, Type);
+    return engine.getElementTemplate(this.dom, this.definition, null, Type);
   }
 
   public createView(engine: IRenderingEngine, parentContext?: IRenderContext): IView {

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -1,7 +1,7 @@
 import { DI, IContainer, IRegistry, PLATFORM, Registration } from '@aurelia/kernel';
 import { IDOM, INode } from './dom';
 import { LifecycleFlags } from './observation';
-import { IRenderingEngine } from './rendering-engine';
+import { ExposedContext, IRenderingEngine } from './rendering-engine';
 import { CustomElementResource, ICustomElement, ICustomElementType, IProjectorLocator } from './resources/custom-element';
 
 export interface ISinglePageApp<THost extends INode = INode> {
@@ -56,7 +56,7 @@ export class Aurelia {
         this.components.push(component);
         const re = this.container.get(IRenderingEngine);
         const pl = this.container.get(IProjectorLocator);
-        component.$hydrate(dom, pl, re, host);
+        component.$hydrate(dom, pl, re, host, this.container as ExposedContext);
       }
 
       component.$bind(LifecycleFlags.fromStartTask | LifecycleFlags.fromBind, null);

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -192,7 +192,7 @@ export class CustomElementRenderer implements IInstructionRenderer {
     const projectorLocator = context.get(IProjectorLocator);
     const childInstructions = instruction.instructions;
 
-    component.$hydrate(dom, projectorLocator, this.renderingEngine, target, instruction as IElementHydrationOptions);
+    component.$hydrate(dom, projectorLocator, this.renderingEngine, target, context, instruction as IElementHydrationOptions);
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const current = childInstructions[i];

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -88,11 +88,11 @@ export class CompiledTemplate<T extends INode = INode> implements ITemplate {
 
   private definition: TemplateDefinition;
 
-  constructor(dom: IDOM<T>, definition: TemplateDefinition, factory: INodeSequenceFactory<T>, parentRenderContext: IRenderContext<T>) {
+  constructor(dom: IDOM<T>, definition: TemplateDefinition, factory: INodeSequenceFactory<T>, renderContext: IRenderContext<T>) {
     this.dom = dom;
     this.definition = definition;
     this.factory = factory;
-    this.renderContext = createRenderContext(dom, parentRenderContext, definition.dependencies);
+    this.renderContext = renderContext;
   }
 
   public render(renderable: IRenderable<T>, host?: T, parts?: TemplatePartDefinitions): void {
@@ -127,14 +127,32 @@ export const IInstructionRenderer = DI.createInterface<IInstructionRenderer>('II
 
 export interface IRenderer {
   instructionRenderers: Record<string, IInstructionRenderer>;
-  render(dom: IDOM, context: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, templateDefinition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void;
+  render(
+    dom: IDOM,
+    context: IRenderContext,
+    renderable: IRenderable,
+    targets: ArrayLike<INode>,
+    templateDefinition: TemplateDefinition,
+    host?: INode,
+    parts?: TemplatePartDefinitions
+  ): void;
 }
 
 export const IRenderer = DI.createInterface<IRenderer>('IRenderer').noDefault();
 
 export interface IRenderingEngine {
-  getElementTemplate<T extends INode = INode>(dom: IDOM<T>, definition: TemplateDefinition, componentType?: ICustomElementType<T>): ITemplate<T>;
-  getViewFactory<T extends INode = INode>(dom: IDOM<T>, source: Immutable<ITemplateDefinition>, parentContext?: IRenderContext<T>): IViewFactory<T>;
+  getElementTemplate<T extends INode = INode>(
+    dom: IDOM<T>,
+    definition: TemplateDefinition,
+    parentContext: IRenderContext<T> | null,
+    componentType: ICustomElementType<T> | null
+  ): ITemplate<T>;
+
+  getViewFactory<T extends INode = INode>(
+    dom: IDOM<T>,
+    source: Immutable<ITemplateDefinition>,
+    parentContext: IRenderContext<T> | null
+  ): IViewFactory<T>;
 
   applyRuntimeBehavior<T extends INode = INode>(Type: ICustomAttributeType<T>, instance: ICustomAttribute<T>): void;
   applyRuntimeBehavior<T extends INode = INode>(Type: ICustomElementType<T>, instance: ICustomElement<T>): void;
@@ -171,7 +189,12 @@ export class RenderingEngine implements IRenderingEngine {
     );
   }
 
-  public getElementTemplate<T extends INode = INode>(dom: IDOM<T>, definition: TemplateDefinition, componentType?: ICustomElementType<T>): ITemplate<T> {
+  public getElementTemplate<T extends INode = INode>(
+    dom: IDOM<T>,
+    definition: TemplateDefinition,
+    parentContext: IRenderContext<T> | null,
+    componentType: ICustomElementType<T> | null
+  ): ITemplate<T> {
     if (!definition) {
       return null;
     }
@@ -179,12 +202,7 @@ export class RenderingEngine implements IRenderingEngine {
     let found = this.templateLookup.get(definition);
 
     if (!found) {
-      found = this.templateFromSource(dom, definition);
-
-      //If the element has a view, support Recursive Components by adding self to own view template container.
-      if (found.renderContext !== null && componentType) {
-        componentType.register(found.renderContext as ExposedContext);
-      }
+      found = this.templateFromSource(dom, definition, parentContext, componentType);
 
       this.templateLookup.set(definition, found);
     }
@@ -192,7 +210,11 @@ export class RenderingEngine implements IRenderingEngine {
     return found as ITemplate<T>;
   }
 
-  public getViewFactory<T extends INode = INode>(dom: IDOM<T>, definition: Immutable<ITemplateDefinition>, parentContext?: IRenderContext<T>): IViewFactory<T> {
+  public getViewFactory<T extends INode = INode>(
+    dom: IDOM<T>,
+    definition: Immutable<ITemplateDefinition>,
+    parentContext: IRenderContext<T> | null
+  ): IViewFactory<T> {
     if (!definition) {
       return null;
     }
@@ -201,7 +223,7 @@ export class RenderingEngine implements IRenderingEngine {
 
     if (!factory) {
       const validSource = buildTemplateDefinition(null, definition);
-      const template = this.templateFromSource(dom, validSource, parentContext);
+      const template = this.templateFromSource(dom, validSource, parentContext, null);
       factory = new ViewFactory(validSource.name, template, this.lifecycle);
       factory.setCacheSize(validSource.cache, true);
       this.viewFactoryLookup.set(definition, factory);
@@ -221,29 +243,43 @@ export class RenderingEngine implements IRenderingEngine {
     found.applyTo(instance, this.lifecycle);
   }
 
-  private templateFromSource(dom: IDOM, definition: TemplateDefinition, parentContext?: IRenderContext): ITemplate {
-    parentContext = parentContext || this.container as ExposedContext;
+  private templateFromSource(
+    dom: IDOM,
+    definition: TemplateDefinition,
+    parentContext: IRenderContext | null,
+    componentType: ICustomElementType | null
+  ): ITemplate {
+    if (parentContext === null) {
+      parentContext = this.container as ExposedContext;
+    }
 
-    if (definition && definition.template) {
+    if (definition.template !== null) {
+      const renderContext = createRenderContext(dom, parentContext, definition.dependencies, componentType) as ExposedContext;
+
       if (definition.build.required) {
         const compilerName = definition.build.compiler || defaultCompilerName;
         const compiler = this.compilers[compilerName];
 
-        if (!compiler) {
+        if (compiler === undefined) {
           throw Reporter.error(20, compilerName);
         }
 
-        definition = compiler.compile(dom, definition as ITemplateDefinition, new RuntimeCompilationResources(parentContext as ExposedContext), ViewCompileFlags.surrogate);
+        definition = compiler.compile(dom, definition as ITemplateDefinition, new RuntimeCompilationResources(renderContext), ViewCompileFlags.surrogate);
       }
 
-      return this.templateFactory.create(parentContext, definition);
+      return this.templateFactory.create(renderContext, definition);
     }
 
     return noViewTemplate;
   }
 }
 
-export function createRenderContext(dom: IDOM, parentRenderContext: IRenderContext, dependencies: ImmutableArray<IRegistry>): IRenderContext {
+export function createRenderContext(
+  dom: IDOM,
+  parentRenderContext: IRenderContext,
+  dependencies: ImmutableArray<IRegistry>,
+  componentType: ICustomElementType | null
+): IRenderContext {
   const context = parentRenderContext.createChild() as ExposedContext;
   const renderableProvider = new InstanceProvider();
   const elementProvider = new InstanceProvider();
@@ -263,11 +299,16 @@ export function createRenderContext(dom: IDOM, parentRenderContext: IRenderConte
     context.register(...dependencies);
   }
 
+  //If the element has a view, support Recursive Components by adding self to own view template container.
+  if (componentType) {
+    componentType.register(context);
+  }
+
   context.render = function(this: IRenderContext, renderable: IRenderable, targets: ArrayLike<INode>, templateDefinition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void {
     renderer.render(dom, this, renderable, targets, templateDefinition, host, parts);
   };
 
-  context.beginComponentOperation = function(renderable: IRenderable, target: INode, instruction: ITargetedInstruction, factory?: IViewFactory, parts?: TemplatePartDefinitions, location?: IRenderLocation): IDisposable {
+  context.beginComponentOperation = function(renderable: IRenderable, target: INode, instruction: ITargetedInstruction, factory: IViewFactory | null, parts?: TemplatePartDefinitions, location?: IRenderLocation): IDisposable {
     renderableProvider.prepare(renderable);
     elementProvider.prepare(target);
     instructionProvider.prepare(instruction);

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -26,7 +26,8 @@ import {
   ILifecycleHooks,
   ILifecycleUnbindAfterDetach,
   IMountable,
-  IRenderable
+  IRenderable,
+  IRenderContext
 } from '../lifecycle';
 import { IChangeTracker } from '../observation';
 import { IRenderingEngine } from '../rendering-engine';
@@ -89,7 +90,15 @@ export interface ICustomElement<T extends INode = INode> extends
 
   readonly $projector: IElementProjector;
   readonly $host: CustomElementHost;
-  $hydrate(dom: IDOM, projectorLocator: IProjectorLocator, renderingEngine: IRenderingEngine, host: INode, options?: IElementHydrationOptions): void;
+
+  $hydrate(
+    dom: IDOM,
+    projectorLocator: IProjectorLocator,
+    renderingEngine: IRenderingEngine,
+    host: INode,
+    parentContext: IRenderContext | null,
+    options?: IElementHydrationOptions
+  ): void;
 }
 
 export interface ICustomElementResource<T extends INode = INode> extends

--- a/packages/runtime/test/resources/custom-element.dependencies.spec.ts
+++ b/packages/runtime/test/resources/custom-element.dependencies.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from 'chai';
+import { CustomElementResource } from '../../src/index';
+import { AuDOMConfiguration, AuNode, AuDOM, AuDOMTest } from '../au-dom';
+
+describe('CustomElementResource', () => {
+  describe(`define`, () => {
+    it(`creates a new class when applied to null`, () => {
+      const { au, container, lifecycle, host } = AuDOMTest.setup();
+
+      const fooDef = AuDOMTest.createTextDefinition('msg', 'foo');
+      const Foo = CustomElementResource.define(fooDef, class { public msg = 'asdf'; });
+
+      //@ts-ignore
+      const barDef = AuDOMTest.createElementDefinition([[AuDOMTest.createElementInstruction('foo', [['msg', 'msg']])]], 'bar');
+      barDef.dependencies = [Foo];
+      const Bar = CustomElementResource.define(barDef, class { public msg = 'ssss'; });
+
+      au.app({ host, component: new Bar() });
+      au.start();
+      expect(host.textContent).to.equal('asdf');
+    });
+  });
+});

--- a/packages/runtime/test/resources/custom-element.dependencies.spec.ts
+++ b/packages/runtime/test/resources/custom-element.dependencies.spec.ts
@@ -1,23 +1,23 @@
 import { expect } from 'chai';
 import { CustomElementResource } from '../../src/index';
-import { AuDOMConfiguration, AuNode, AuDOM, AuDOMTest } from '../au-dom';
+import { AuDOMTest } from '../au-dom';
 
 describe('CustomElementResource', () => {
   describe(`define`, () => {
-    it(`creates a new class when applied to null`, () => {
-      const { au, container, lifecycle, host } = AuDOMTest.setup();
+    it(`registers local dependencies`, () => {
+      const { au, host } = AuDOMTest.setup();
 
       const fooDef = AuDOMTest.createTextDefinition('msg', 'foo');
-      const Foo = CustomElementResource.define(fooDef, class { public msg = 'asdf'; });
+      const Foo = CustomElementResource.define(fooDef, class { public msg = 'asdf1'; });
 
       //@ts-ignore
       const barDef = AuDOMTest.createElementDefinition([[AuDOMTest.createElementInstruction('foo', [['msg', 'msg']])]], 'bar');
       barDef.dependencies = [Foo];
-      const Bar = CustomElementResource.define(barDef, class { public msg = 'ssss'; });
+      const Bar = CustomElementResource.define(barDef, class { public msg = 'asdf2'; });
 
       au.app({ host, component: new Bar() });
       au.start();
-      expect(host.textContent).to.equal('asdf');
+      expect(host.textContent).to.equal('asdf2');
     });
   });
 });

--- a/packages/runtime/test/template.spec.ts
+++ b/packages/runtime/test/template.spec.ts
@@ -1,21 +1,77 @@
-import { IContainer, Registration } from '@aurelia/kernel';
+import {
+  IContainer,
+  Registration
+} from '@aurelia/kernel';
 import { expect } from 'chai';
 import {
   CompiledTemplate,
+  createRenderContext,
   IDOM,
   INode,
   IRenderable,
   IRenderLocation,
   ITargetedInstruction,
   IViewFactory,
+  RuntimeConfiguration,
   TemplateDefinition
 } from '../src/index';
 import { ViewFactory } from '../src/templating/view';
-import { AuDOM, AuDOMConfiguration, AuNode, AuNodeSequenceFactory } from './au-dom';
+import {
+  AuDOM,
+  AuDOMConfiguration,
+  AuNode,
+  AuNodeSequenceFactory
+} from './au-dom';
+
+describe('createRenderContext', () => {
+  it('properly initializes a renderContext', () => {
+    const parent = AuDOMConfiguration.createContainer();
+
+    class Foo {}
+    class Bar {public static register(container: IContainer) { container.register(Registration.singleton(Bar, Bar)); }}
+    const sut = createRenderContext(new AuDOM(), parent as any, [Foo as any, Bar], null);
+    const viewFactory = new ViewFactory(null, null, null);
+
+    expect(sut['parent']).to.equal(parent);
+
+    expect(sut.has(IViewFactory, false)).to.equal(true);
+    expect(sut.has(IRenderable, false)).to.equal(true);
+    expect(sut.has(ITargetedInstruction, false)).to.equal(true);
+    expect(sut.has(IRenderLocation, false)).to.equal(true);
+    expect(sut.has(Foo, false)).to.equal(false);
+    expect(sut.has(Bar, false)).to.equal(true);
+    expect(sut.has(INode, false)).to.equal(true);
+    expect(sut.has(AuNode, false)).to.equal(true);
+
+    expect(typeof sut.render).to.equal('function');
+    expect(typeof sut.beginComponentOperation).to.equal('function');
+    expect(typeof sut['dispose']).to.equal('function');
+
+    expect(() => sut.get(IViewFactory)).to.throw(/50/);
+    expect(sut.get(IRenderable)).to.equal(null);
+    expect(sut.get(ITargetedInstruction)).to.equal(null);
+    expect(sut.get(IRenderLocation)).to.equal(null);
+
+    const renderable = {} as any;
+    const target = {} as any;
+    const instruction = {} as any;
+    const parts = {} as any;
+    const location = {} as any;
+
+    sut.beginComponentOperation(renderable, target, instruction, viewFactory as any, parts, location);
+
+    expect(() => sut.get(IViewFactory)).to.throw(/51/);
+    expect(sut.get(IRenderable)).to.equal(renderable);
+    expect(sut.get(INode)).to.equal(target);
+    expect(sut.get(AuNode)).to.equal(target);
+    expect(sut.get(ITargetedInstruction)).to.equal(instruction);
+    expect(sut.get(IRenderLocation)).to.equal(location);
+  });
+});
 
 describe(`CompiledTemplate`, () => {
   describe(`constructor`, () => {
-    it(`creates a new renderContext and createNodeSequence function`, () => {
+    it(`creates a new createNodeSequence function`, () => {
       class Foo {}
       class Bar {public static register(container: IContainer) { container.register(Registration.singleton(Bar, Bar)); }}
       const container = AuDOMConfiguration.createContainer();
@@ -23,43 +79,7 @@ describe(`CompiledTemplate`, () => {
       const templateNode = AuNode.createTemplate().appendChild(AuNode.createText('foo'));
       const nsFactory = new AuNodeSequenceFactory(dom, templateNode);
       const def = { template: templateNode, dependencies: [Foo, Bar] } as unknown as TemplateDefinition;
-      const viewFactory = new ViewFactory(null, null, null);
       const sut = new CompiledTemplate(dom, def, nsFactory, container as any);
-
-      expect(sut.renderContext['parent']).to.equal(container);
-
-      expect(sut.renderContext.has(IViewFactory, false)).to.equal(true);
-      expect(sut.renderContext.has(IRenderable, false)).to.equal(true);
-      expect(sut.renderContext.has(ITargetedInstruction, false)).to.equal(true);
-      expect(sut.renderContext.has(IRenderLocation, false)).to.equal(true);
-      expect(sut.renderContext.has(Foo, false)).to.equal(false);
-      expect(sut.renderContext.has(Bar, false)).to.equal(true);
-      expect(sut.renderContext.has(INode, false)).to.equal(true);
-      expect(sut.renderContext.has(AuNode, false)).to.equal(true);
-
-      expect(typeof sut.renderContext.render).to.equal('function');
-      expect(typeof sut.renderContext.beginComponentOperation).to.equal('function');
-      expect(typeof sut.renderContext['dispose']).to.equal('function');
-
-      expect(() => sut.renderContext.get(IViewFactory)).to.throw(/50/);
-      expect(sut.renderContext.get(IRenderable)).to.equal(null);
-      expect(sut.renderContext.get(ITargetedInstruction)).to.equal(null);
-      expect(sut.renderContext.get(IRenderLocation)).to.equal(null);
-
-      const renderable = {} as any;
-      const target = {} as any;
-      const instruction = {} as any;
-      const parts = {} as any;
-      const location = {} as any;
-
-      sut.renderContext.beginComponentOperation(renderable, target, instruction, viewFactory as any, parts, location);
-
-      expect(() => sut.renderContext.get(IViewFactory)).to.throw(/51/);
-      expect(sut.renderContext.get(IRenderable)).to.equal(renderable);
-      expect(sut.renderContext.get(INode)).to.equal(target);
-      expect(sut.renderContext.get(AuNode)).to.equal(target);
-      expect(sut.renderContext.get(ITargetedInstruction)).to.equal(instruction);
-      expect(sut.renderContext.get(IRenderLocation)).to.equal(location);
 
       const nodes = sut.factory.createNodeSequence();
       expect(nodes.childNodes[0].textContent).to.equal('foo');

--- a/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
@@ -72,7 +72,8 @@ describe('@customElement', () => {
           {} as any,
           { getElementProjector() { return null; }} as any,
           renderingEngine,
-          host
+          host,
+          null
         );
 
         // Assert


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR fixes locally registered dependencies in jit mode (and a small bit of test cleanup).

- `createRenderContext` is called [much earlier](https://github.com/aurelia/aurelia/compare/fix-local-deps?expand=1#diff-b12a454f7d84dd07c94592e2fb3b0a30R257) and is also passed into the template compiler so that the resources are available throughout. 
- the render context becomes a mandatory argument in a couple places where it was optional before (but it may be `null`), making the parameters a bit more visible. 
- render context is also passed via `hydrate` now so that you actually get a proper container tree representing the resource tree, instead of only sibling containers based on the root like it was before
- A special `resourceLookup` object is added to the container where any resolvers with string keys are stored. This lookup is cloned into child containers so that the resource model in the template compiler doesn't need to traverse up the container tree

Not necessarily an ideal implementation, a bit hacky/leaky from the perspective of `RuntimeCompilationResources`. But I would really have to sit down for this to come up with something better, and I think other things are a bit higher priority than getting this "proper" right now. So we may need to revisit this bit in the future.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Registering resources via the decorator didn't work
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

I believe this PR is small enough (for a change.. :) ) that looking at the files would give a pretty good picture. Besides the irrelevant test cleanup, of course.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

There is one very lonely little test: https://github.com/aurelia/aurelia/compare/fix-local-deps?expand=1#diff-af2b863bb67c21ecaf1b2faf0ad4eb3eR1227
Again, this needs to be more thorough (especially since all kinds of pesky situations can arise from even the smallest flaw in the container) but all else seems to work, so leaving it be for now. Kernel tests need to be improved overall anyway.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

With relation to this issue, add a few hundred edge case tests and see where that leads in terms of fixes/improvements. I don't necessarily want to redesign this over theoretical issues, but actually prove that there are issues via tests. I'm hoping @EisenbergEffect can help me with some examples and cases in the future here.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
