### PR TITLE
refactor: make unknown the default for InterfaceSymbol

### DIFF
--- a/packages/jit-html/src/template-compiler.ts
+++ b/packages/jit-html/src/template-compiler.ts
@@ -60,7 +60,7 @@ const { enter, leave } = Profiler.createTimer('TemplateCompiler');
  * @internal
  */
 export class TemplateCompiler implements ITemplateCompiler {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ITemplateElementFactory, IAttributeParser, IExpressionParser];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ITemplateElementFactory, IAttributeParser, IExpressionParser];
 
   private readonly factory: ITemplateElementFactory;
   private readonly attrParser: IAttributeParser;

--- a/packages/jit-html/src/template-element-factory.ts
+++ b/packages/jit-html/src/template-element-factory.ts
@@ -43,7 +43,7 @@ const { enter, leave } = Profiler.createTimer('TemplateElementFactory');
  * @internal
  */
 export class HTMLTemplateElementFactory implements ITemplateElementFactory {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IDOM];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IDOM];
 
   private readonly dom: IDOM;
   private template: HTMLTemplateElement;

--- a/packages/jit/src/attribute-parser.ts
+++ b/packages/jit/src/attribute-parser.ts
@@ -12,7 +12,7 @@ const { enter, leave } = Profiler.createTimer('AttributeParser');
 
 /** @internal */
 export class AttributeParser implements IAttributeParser {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ISyntaxInterpreter, all(IAttributePattern)];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ISyntaxInterpreter, all(IAttributePattern)];
 
   private readonly interpreter: ISyntaxInterpreter;
   private readonly cache: Record<string, Interpretation>;

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -62,9 +62,9 @@ export type Class<T, C = IIndexable> = C & {
   new(...args: unknown[]): T;
 };
 
-export type InterfaceSymbol<T> = (target: Injectable<T>, property: string, index: number) => any;
+export type InterfaceSymbol<T = unknown> = (target: Injectable<T>, property: string, index: number) => any;
 
-export type Injectable<T = {}> = Constructable<T> & { inject?: (InterfaceSymbol<unknown>|Constructable)[] };
+export type Injectable<T = {}> = Constructable<T> & { inject?: (InterfaceSymbol|Constructable)[] };
 
 export type IIndexable<T extends object = object> = T & { [key: string]: unknown };
 

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -4,7 +4,7 @@ import { Router } from '../router';
 import { IViewportOptions, Viewport } from '../viewport';
 
 export class ViewportCustomElement {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>|Constructable> = [Router, INode];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol|Constructable> = [Router, INode];
 
   @bindable public name: string;
   @bindable public scope: boolean;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -46,7 +46,7 @@ export interface IRouteSeparators {
 }
 
 export class Router {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IContainer];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IContainer];
 
   public viewports: Record<string, Viewport> = {};
 

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -30,7 +30,7 @@ const slice = Array.prototype.slice;
 @instructionRenderer(HTMLTargetedInstructionType.textBinding)
 /** @internal */
 export class TextBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -62,7 +62,7 @@ export class TextBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(HTMLTargetedInstructionType.listenerBinding)
 /** @internal */
 export class ListenerBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IEventManager];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IEventManager];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -97,7 +97,7 @@ export class SetAttributeRenderer implements IInstructionRenderer {
 @instructionRenderer(HTMLTargetedInstructionType.stylePropertyBinding)
 /** @internal */
 export class StylePropertyBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -71,7 +71,7 @@ const overrideProps = (function (o: Record<string, boolean>): typeof o {
 })(Object.create(null));
 
 export class TargetObserverLocator implements ITargetObserverLocator {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IDOM];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IDOM];
 
   private readonly dom: IDOM;
 
@@ -134,7 +134,7 @@ export class TargetObserverLocator implements ITargetObserverLocator {
 }
 
 export class TargetAccessorLocator implements ITargetAccessorLocator {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IDOM];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IDOM];
 
   private readonly dom: IDOM;
 

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -18,7 +18,7 @@ export type UpdateTriggerableBinding = Binding & {
 };
 
 export class UpdateTriggerBindingBehavior {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IObserverLocator];
 
   public static register: IRegistry['register'];
 

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -32,7 +32,7 @@ export type MaybeSubjectPromise<T> = Subject<T> | Promise<Subject<T>> | null;
 
 export interface Compose<T extends INode = Node> extends ICustomElement<T> {}
 export class Compose<T extends INode = Node> implements Compose<T> {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>|Constructable> = [IDOM, IRenderable, ITargetedInstruction, IRenderingEngine, CompositionCoordinator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol|Constructable> = [IDOM, IRenderable, ITargetedInstruction, IRenderingEngine, CompositionCoordinator];
 
   public static readonly register: IRegistry['register'];
   public static readonly kind: ICustomElementResource<Node>;

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -1297,7 +1297,7 @@ export class Lifecycle implements ILifecycle {
 }
 
 export class CompositionCoordinator {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ILifecycle];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ILifecycle];
 
   public readonly $lifecycle: ILifecycle;
 

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -66,7 +66,7 @@ function getPropertyDescriptor(subject: object, name: string): PropertyDescripto
 
 /** @internal */
 export class ObserverLocator implements IObserverLocator {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ILifecycle, IDirtyChecker, ITargetObserverLocator, ITargetAccessorLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ILifecycle, IDirtyChecker, ITargetObserverLocator, ITargetAccessorLocator];
 
   private readonly adapters: IObjectObservationAdapter[];
   private readonly dirtyChecker: IDirtyChecker;

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -86,7 +86,7 @@ export function instructionRenderer<TType extends string>(instructionType: TType
 
 /* @internal */
 export class Renderer implements IRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [all(IInstructionRenderer)];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [all(IInstructionRenderer)];
 
   public instructionRenderers: Record<InstructionTypeName, IInstructionRenderer>;
 
@@ -183,7 +183,7 @@ export class SetPropertyRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.hydrateElement)
 /** @internal */
 export class CustomElementRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IRenderingEngine];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IRenderingEngine];
   public static readonly register: IRegistry['register'];
 
   private readonly renderingEngine: IRenderingEngine;
@@ -218,7 +218,7 @@ export class CustomElementRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.hydrateAttribute)
 /** @internal */
 export class CustomAttributeRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IRenderingEngine];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IRenderingEngine];
   public static readonly register: IRegistry['register'];
 
   private readonly renderingEngine: IRenderingEngine;
@@ -252,7 +252,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.hydrateTemplateController)
 /** @internal */
 export class TemplateControllerRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IRenderingEngine];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IRenderingEngine];
   public static readonly register: IRegistry['register'];
 
   private readonly renderingEngine: IRenderingEngine;
@@ -291,7 +291,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.hydrateLetElement)
 /** @internal */
 export class LetElementRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -320,7 +320,7 @@ export class LetElementRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.callBinding)
 /** @internal */
 export class CallBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -343,7 +343,7 @@ export class CallBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.refBinding)
 /** @internal */
 export class RefBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -364,7 +364,7 @@ export class RefBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.interpolation)
 /** @internal */
 export class InterpolationBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -392,7 +392,7 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.propertyBinding)
 /** @internal */
 export class PropertyBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;
@@ -415,7 +415,7 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
 @instructionRenderer(TargetedInstructionType.iteratorBinding)
 /** @internal */
 export class IteratorBindingRenderer implements IInstructionRenderer {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IExpressionParser, IObserverLocator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
   public static readonly register: IRegistry['register'];
 
   private readonly parser: IExpressionParser;

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -163,7 +163,7 @@ export const IRenderingEngine = DI.createInterface<IRenderingEngine>('IRendering
 
 /** @internal */
 export class RenderingEngine implements IRenderingEngine {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IContainer, ITemplateFactory, ILifecycle, all(ITemplateCompiler)];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IContainer, ITemplateFactory, ILifecycle, all(ITemplateCompiler)];
 
   private readonly behaviorLookup: Map<ICustomElementType | ICustomAttributeType, RuntimeBehavior>;
   private readonly compilers: Record<string, ITemplateCompiler>;

--- a/packages/runtime/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime/src/resources/binding-behaviors/signals.ts
@@ -9,7 +9,7 @@ export type SignalableBinding = Binding & {
 };
 
 export class SignalBindingBehavior {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ISignaler];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ISignaler];
 
   public static register: IRegistry['register'];
 

--- a/packages/runtime/src/resources/custom-attributes/if.ts
+++ b/packages/runtime/src/resources/custom-attributes/if.ts
@@ -8,7 +8,7 @@ import { CustomAttributeResource, ICustomAttribute, ICustomAttributeResource } f
 
 export interface If<T extends INode = INode> extends ICustomAttribute<T> {}
 export class If<T extends INode = INode> implements If<T> {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>|Constructable> = [IViewFactory, IRenderLocation, CompositionCoordinator];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol|Constructable> = [IViewFactory, IRenderLocation, CompositionCoordinator];
 
   public static readonly register: IRegistry['register'];
   public static readonly bindables: IAttributeDefinition['bindables'];
@@ -113,7 +113,7 @@ CustomAttributeResource.define({ name: 'if', isTemplateController: true }, If);
 
 export interface Else<T extends INode = INode> extends ICustomAttribute<T> {}
 export class Else<T extends INode = INode> implements Else<T> {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IViewFactory];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IViewFactory];
 
   public static readonly register: IRegistry['register'];
   public static readonly bindables: IAttributeDefinition['bindables'];

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -13,7 +13,7 @@ import { CustomAttributeResource, ICustomAttribute, ICustomAttributeResource } f
 
 export interface Repeat<C extends ObservedCollection, T extends INode = INode> extends ICustomAttribute<T>, IBatchedCollectionSubscriber {}
 export class Repeat<C extends ObservedCollection = IObservedArray, T extends INode = INode> implements Repeat<C, T> {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IRenderLocation, IRenderable, IViewFactory];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IRenderLocation, IRenderable, IViewFactory];
 
   public static readonly register: IRegistry['register'];
   public static readonly bindables: IAttributeDefinition['bindables'];

--- a/packages/runtime/src/resources/custom-attributes/replaceable.ts
+++ b/packages/runtime/src/resources/custom-attributes/replaceable.ts
@@ -7,7 +7,7 @@ import { CustomAttributeResource, ICustomAttribute, ICustomAttributeResource } f
 
 export interface Replaceable<T extends INode = INode> extends ICustomAttribute<T> {}
 export class Replaceable<T extends INode = INode> implements Replaceable<T> {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IViewFactory, IRenderLocation];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IViewFactory, IRenderLocation];
 
   public static readonly register: IRegistry['register'];
   public static readonly bindables: IAttributeDefinition['bindables'];

--- a/packages/runtime/src/resources/custom-attributes/with.ts
+++ b/packages/runtime/src/resources/custom-attributes/with.ts
@@ -9,7 +9,7 @@ import { CustomAttributeResource, ICustomAttribute, ICustomAttributeResource } f
 
 export interface With<T extends INode = INode> extends ICustomAttribute<T> {}
 export class With<T extends INode = INode> implements With<T>  {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [IViewFactory, IRenderLocation];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IViewFactory, IRenderLocation];
 
   public static readonly register: IRegistry['register'];
   public static readonly bindables: IAttributeDefinition['bindables'];

--- a/packages/runtime/src/resources/value-converters/sanitize.ts
+++ b/packages/runtime/src/resources/value-converters/sanitize.ts
@@ -22,7 +22,7 @@ export const ISanitizer = DI.createInterface<ISanitizer>('ISanitizer').withDefau
  * Simple html sanitization converter to preserve whitelisted elements and attributes on a bound property containing html.
  */
 export class SanitizeValueConverter {
-  public static readonly inject: ReadonlyArray<InterfaceSymbol<unknown>> = [ISanitizer];
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [ISanitizer];
 
   public static register: IRegistry['register'];
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

As mentioned in https://github.com/aurelia/aurelia/pull/366#issuecomment-454895508 by @fkleuver.

> A nice follow up might be to give `InterfaceSymbol` the `unknown` type argument as a default, so the whole thing doesn't need to be written out in full everywhere.

### 🎫 Issues

Follow up to #366.

## 👩‍💻 Reviewer Notes

n/a

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a
