### PR TITLE
feat(kernel): port EventAggregator to vNext

### DIFF
--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -66,10 +66,6 @@ export class EventAggregator {
     this.messageHandlers = [];
   }
 
-  public static register(container: IContainer): IResolver<EventAggregator> {
-    return Registration.singleton(EventAggregator, this).register(container);
-  }
-
   /**
    * Publishes a message.
    * @param channel The channel to publish to.

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -49,6 +49,11 @@ export interface Subscription {
   dispose(): void;
 }
 
+/**
+ * Enables loosely coupled publish/subscribe messaging.
+ * @param data The optional data published on the channel.
+ * @param event The event that triggered the callback. Only available on channel based messaging.
+ */
 export type EventAggregatorCallback = (data?: unknown, event?: string) => unknown;
 
 /**
@@ -74,25 +79,27 @@ export class EventAggregator {
 
   /**
    * Publishes a message.
-   * @param event The event or channel to publish to.
+   * @param channelOrType The event or channel to publish to.
    * @param data The data to publish on the channel.
    */
-  public publish(event: string | InstanceType<Constructable>, data?: unknown): void {
+  public publish(channel: string, data?: unknown): void;
+  public publish(type: InstanceType<Constructable>, data?: unknown): void;
+  public publish(channelOrType: string | InstanceType<Constructable>, data?: unknown): void {
     let subscribers: (EventAggregatorCallback | Handler)[];
     let i: number;
 
-    if (!event) {
+    if (!channelOrType) {
       throw new Error('Event was invalid.');
     }
 
-    if (typeof event === 'string') {
-      subscribers = this.eventLookup[event];
+    if (typeof channelOrType === 'string') {
+      subscribers = this.eventLookup[channelOrType];
       if (subscribers) {
         subscribers = subscribers.slice();
         i = subscribers.length;
 
         while (i--) {
-          invokeCallback(subscribers[i] as EventAggregatorCallback, data, event);
+          invokeCallback(subscribers[i] as EventAggregatorCallback, data, channelOrType);
         }
       }
     } else {
@@ -100,29 +107,31 @@ export class EventAggregator {
       i = subscribers.length;
 
       while (i--) {
-        invokeHandler(subscribers[i] as Handler, event);
+        invokeHandler(subscribers[i] as Handler, channelOrType);
       }
     }
   }
 
   /**
    * Subscribes to a message channel or message type.
-   * @param event The event channel or event data type.
+   * @param channelOrType The event channel or event data type.
    * @param callback The callback to be invoked when the specified message is published.
    */
-  public subscribe(event: string | Constructable, callback: EventAggregatorCallback): Subscription {
+  public subscribe(channel: string, callback: EventAggregatorCallback): Subscription;
+  public subscribe(type: Constructable, callback: EventAggregatorCallback): Subscription;
+  public subscribe(channelOrType: string | Constructable, callback: EventAggregatorCallback): Subscription {
     let handler: EventAggregatorCallback | Handler;
-    let subscribers;
+    let subscribers: (EventAggregatorCallback | Handler)[];
 
-    if (!event) {
+    if (!channelOrType) {
       throw new Error('Event channel/type was invalid.');
     }
 
-    if (typeof event === 'string') {
+    if (typeof channelOrType === 'string') {
       handler = callback;
-      subscribers = this.eventLookup[event] || (this.eventLookup[event] = []);
+      subscribers = this.eventLookup[channelOrType] || (this.eventLookup[channelOrType] = []);
     } else {
-      handler = new Handler(event, callback);
+      handler = new Handler(channelOrType, callback);
       subscribers = this.messageHandlers;
     }
 
@@ -140,13 +149,15 @@ export class EventAggregator {
 
   /**
    * Subscribes to a message channel or message type, then disposes the subscription automatically after the first message is received.
-   * @param event The event channel or event data type.
+   * @param channelOrType The event channel or event data type.
    * @param callback The callback to be invoked when the specified message is published.
    */
-  public subscribeOnce(event: string | Constructable, callback: EventAggregatorCallback): Subscription {
-    const sub = this.subscribe(event, (a, b) => {
+  public subscribeOnce(channel: string, callback: EventAggregatorCallback): Subscription;
+  public subscribeOnce(type: Constructable, callback: EventAggregatorCallback): Subscription;
+  public subscribeOnce(channelOrType: string | Constructable, callback: EventAggregatorCallback): Subscription {
+    const sub = this.subscribe(channelOrType as Constructable, (data, event) => {
       sub.dispose();
-      return callback(a, b);
+      return callback(data, event);
     });
 
     return sub;

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -74,20 +74,19 @@ export class EventAggregator {
   public publish(channel: string, data?: unknown): void;
   /**
    * Publishes a message.
-   * @param channelOrType The event to publish to.
-   * @param data The data to publish on the channel.
+   * @param instance The instance to publish to.
    */
-  public publish(type: InstanceType<Constructable>): void;
-  public publish(channelOrType: string | InstanceType<Constructable>, data?: unknown): void {
+  public publish(instance: InstanceType<Constructable>): void;
+  public publish(channelOrInstance: string | InstanceType<Constructable>, data?: unknown): void {
     let subscribers: (EventAggregatorCallback | Handler)[];
     let i: number;
 
-    if (!channelOrType) {
+    if (!channelOrInstance) {
       throw Reporter.error(0); // TODO: create error code for 'Event was invalid.'
     }
 
-    if (typeof channelOrType === 'string') {
-      const channel: string = channelOrType;
+    if (typeof channelOrInstance === 'string') {
+      const channel: string = channelOrInstance;
       subscribers = this.eventLookup[channel];
       if (subscribers) {
         subscribers = subscribers.slice();
@@ -98,25 +97,25 @@ export class EventAggregator {
         }
       }
     } else {
-      const type: InstanceType<Constructable> = channelOrType;
+      const instance: InstanceType<Constructable> = channelOrInstance;
       subscribers = this.messageHandlers.slice();
       i = subscribers.length;
 
       while (i--) {
-        invokeHandler(subscribers[i] as Handler, type);
+        invokeHandler(subscribers[i] as Handler, instance);
       }
     }
   }
 
   /**
    * Subscribes to a message channel.
-   * @param channelOrType The event channel.
+   * @param channel The event channel.
    * @param callback The callback to be invoked when the specified message is published.
    */
   public subscribe<T>(channel: string, callback: EventAggregatorCallback<T>): IDisposable;
   /**
    * Subscribes to a message type.
-   * @param channelOrType The event data type.
+   * @param type The event data type.
    * @param callback The callback to be invoked when the specified message is published.
    */
   public subscribe<T extends Constructable>(type: T, callback: EventAggregatorCallback<InstanceType<T>>): IDisposable;

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -1,0 +1,150 @@
+import { IContainer, IResolver, Registration } from './di';
+import { Constructable } from './interfaces';
+import { Reporter } from './reporter';
+
+/**
+ * Represents a handler for an EventAggregator event.
+ */
+class Handler {
+  public messageType: Constructable;
+  public callback: EventAggregatorCallback;
+
+  constructor(messageType: Constructable, callback: EventAggregatorCallback) {
+    this.messageType = messageType;
+    this.callback = callback;
+  }
+
+  public handle(message: InstanceType<Constructable>): void {
+    if (message instanceof this.messageType) {
+      this.callback.call(null, message);
+    }
+  }
+}
+
+function invokeCallback(callback: EventAggregatorCallback, data: unknown, event: string): void {
+  try {
+    callback(data, event);
+  } catch (e) {
+    Reporter.error(0, e); // TODO: create error code
+  }
+}
+
+function invokeHandler(handler: Handler, data: InstanceType<Constructable>): void {
+  try {
+    handler.handle(data);
+  } catch (e) {
+    Reporter.error(0, e); // TODO: create error code
+  }
+}
+
+/**
+ * Represents a disposable subscription to an EventAggregator event.
+ */
+export interface Subscription {
+  /**
+   * Disposes the subscription.
+   */
+  dispose(): void;
+}
+
+export type EventAggregatorCallback = (data?: unknown, event?: string) => unknown;
+
+/**
+ * Enables loosely coupled publish/subscribe messaging.
+ */
+export class EventAggregator {
+  public eventLookup: Record<string, EventAggregatorCallback[]>;
+  public messageHandlers: Handler[];
+
+  /**
+   * Creates an instance of the EventAggregator class.
+   */
+  constructor() {
+    this.eventLookup = {};
+    this.messageHandlers = [];
+  }
+
+  public static register(container: IContainer): IResolver<EventAggregator> {
+    return Registration.singleton(EventAggregator, this).register(container);
+  }
+
+  /**
+   * Publishes a message.
+   * @param event The event or channel to publish to.
+   * @param data The data to publish on the channel.
+   */
+  public publish(event: string | InstanceType<Constructable>, data?: unknown): void {
+    let subscribers: (EventAggregatorCallback | Handler)[];
+    let i: number;
+
+    if (!event) {
+      throw new Error('Event was invalid.');
+    }
+
+    if (typeof event === 'string') {
+      subscribers = this.eventLookup[event];
+      if (subscribers) {
+        subscribers = subscribers.slice();
+        i = subscribers.length;
+
+        while (i--) {
+          invokeCallback(subscribers[i] as EventAggregatorCallback, data, event);
+        }
+      }
+    } else {
+      subscribers = this.messageHandlers.slice();
+      i = subscribers.length;
+
+      while (i--) {
+        invokeHandler(subscribers[i] as Handler, event);
+      }
+    }
+  }
+
+  /**
+   * Subscribes to a message channel or message type.
+   * @param event The event channel or event data type.
+   * @param callback The callback to be invoked when the specified message is published.
+   */
+  public subscribe(event: string | Constructable, callback: EventAggregatorCallback): Subscription {
+    let handler: EventAggregatorCallback | Handler;
+    let subscribers;
+
+    if (!event) {
+      throw new Error('Event channel/type was invalid.');
+    }
+
+    if (typeof event === 'string') {
+      handler = callback;
+      subscribers = this.eventLookup[event] || (this.eventLookup[event] = []);
+    } else {
+      handler = new Handler(event, callback);
+      subscribers = this.messageHandlers;
+    }
+
+    subscribers.push(handler);
+
+    return {
+      dispose(): void {
+        const idx = subscribers.indexOf(handler);
+        if (idx !== -1) {
+          subscribers.splice(idx, 1);
+        }
+      }
+    };
+  }
+
+  /**
+   * Subscribes to a message channel or message type, then disposes the subscription automatically after the first message is received.
+   * @param event The event channel or event data type.
+   * @param callback The callback to be invoked when the specified message is published.
+   */
+  public subscribeOnce(event: string | Constructable, callback: EventAggregatorCallback): Subscription {
+    const sub = this.subscribe(event, (a, b) => {
+      sub.dispose();
+      return callback(a, b);
+    });
+
+    return sub;
+  }
+}

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -89,7 +89,7 @@ export class EventAggregator {
     let i: number;
 
     if (!channelOrType) {
-      throw new Error('Event was invalid.');
+      throw Reporter.error(0); // TODO: create error code for 'Event was invalid.'
     }
 
     if (typeof channelOrType === 'string') {
@@ -124,7 +124,7 @@ export class EventAggregator {
     let subscribers: (EventAggregatorCallback | Handler)[];
 
     if (!channelOrType) {
-      throw new Error('Event channel/type was invalid.');
+      throw Reporter.error(0); // TODO: create error code for 'Event channel/type was invalid.'
     }
 
     if (typeof channelOrType === 'string') {

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -1,5 +1,5 @@
 import { IContainer, IResolver, Registration } from './di';
-import { Constructable } from './interfaces';
+import { Constructable, IDisposable } from './interfaces';
 import { Reporter } from './reporter';
 
 /**
@@ -39,15 +39,8 @@ function invokeHandler(handler: Handler, data: InstanceType<Constructable>): voi
   }
 }
 
-/**
- * Represents a disposable subscription to an EventAggregator event.
- */
-export interface Subscription {
-  /**
-   * Disposes the subscription.
-   */
-  dispose(): void;
-}
+// TODO: move this to a v1-compat package
+export interface Subscription extends IDisposable {}
 
 /**
  * Enables loosely coupled publish/subscribe messaging.
@@ -83,7 +76,7 @@ export class EventAggregator {
    * @param data The data to publish on the channel.
    */
   public publish(channel: string, data?: unknown): void;
-  public publish(type: InstanceType<Constructable>, data?: unknown): void;
+  public publish(type: InstanceType<Constructable>): void;
   public publish(channelOrType: string | InstanceType<Constructable>, data?: unknown): void {
     let subscribers: (EventAggregatorCallback | Handler)[];
     let i: number;
@@ -117,9 +110,9 @@ export class EventAggregator {
    * @param channelOrType The event channel or event data type.
    * @param callback The callback to be invoked when the specified message is published.
    */
-  public subscribe(channel: string, callback: EventAggregatorCallback): Subscription;
-  public subscribe(type: Constructable, callback: EventAggregatorCallback): Subscription;
-  public subscribe(channelOrType: string | Constructable, callback: EventAggregatorCallback): Subscription {
+  public subscribe(channel: string, callback: EventAggregatorCallback): IDisposable;
+  public subscribe(type: Constructable, callback: EventAggregatorCallback): IDisposable;
+  public subscribe(channelOrType: string | Constructable, callback: EventAggregatorCallback): IDisposable {
     let handler: EventAggregatorCallback | Handler;
     let subscribers: (EventAggregatorCallback | Handler)[];
 
@@ -152,9 +145,9 @@ export class EventAggregator {
    * @param channelOrType The event channel or event data type.
    * @param callback The callback to be invoked when the specified message is published.
    */
-  public subscribeOnce(channel: string, callback: EventAggregatorCallback): Subscription;
-  public subscribeOnce(type: Constructable, callback: EventAggregatorCallback): Subscription;
-  public subscribeOnce(channelOrType: string | Constructable, callback: EventAggregatorCallback): Subscription {
+  public subscribeOnce(channel: string, callback: EventAggregatorCallback): IDisposable;
+  public subscribeOnce(type: Constructable, callback: EventAggregatorCallback): IDisposable;
+  public subscribeOnce(channelOrType: string | Constructable, callback: EventAggregatorCallback): IDisposable {
     const sub = this.subscribe(channelOrType as Constructable, (data, event) => {
       sub.dispose();
       return callback(data, event);

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -6,8 +6,10 @@ import { Reporter } from './reporter';
  * Represents a handler for an EventAggregator event.
  */
 class Handler {
-  public messageType: Constructable;
-  public callback: EventAggregatorCallback;
+  /** @internal */
+  public readonly messageType: Constructable;
+  /** @internal */
+  public readonly callback: EventAggregatorCallback;
 
   constructor(messageType: Constructable, callback: EventAggregatorCallback) {
     this.messageType = messageType;
@@ -53,8 +55,10 @@ export type EventAggregatorCallback = (data?: unknown, event?: string) => unknow
  * Enables loosely coupled publish/subscribe messaging.
  */
 export class EventAggregator {
-  public eventLookup: Record<string, EventAggregatorCallback[]>;
-  public messageHandlers: Handler[];
+  /** @internal */
+  public readonly eventLookup: Record<string, EventAggregatorCallback[]>;
+  /** @internal */
+  public readonly messageHandlers: Handler[];
 
   /**
    * Creates an instance of the EventAggregator class.

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -75,3 +75,8 @@ export {
   ResourcePartDescription,
   RuntimeCompilationResources
 } from './resource';
+export {
+  EventAggregator,
+  EventAggregatorCallback,
+  Subscription
+} from './eventaggregator';

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -77,6 +77,5 @@ export {
 } from './resource';
 export {
   EventAggregator,
-  EventAggregatorCallback,
-  Subscription
+  EventAggregatorCallback
 } from './eventaggregator';

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -1,0 +1,421 @@
+import { expect } from 'chai';
+import { EventAggregator } from '../src/index';
+
+describe('event aggregator', () => {
+
+  describe('subscribe', () => {
+
+    describe('string events', () => {
+
+      it('should not remove another callback when execute called twice', () => {
+        const ea = new EventAggregator();
+        let data = 0;
+
+        const subscription = ea.subscribe('dinner', function() { return; });
+        ea.subscribe('dinner', function() { data = 1; });
+
+        subscription.dispose();
+        subscription.dispose();
+
+        ea.publish('dinner');
+
+        expect(data).to.equal(1);
+      });
+
+      it('adds event with callback to the eventLookup object', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribe('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+      });
+
+      it('adds multiple callbacks the same event', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribe('dinner', callback);
+
+        const callback2 = function() { return; };
+        ea.subscribe('dinner', callback2);
+
+        expect(ea.eventLookup.dinner.length).to.equal(2);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+        expect(ea.eventLookup.dinner[1]).to.equal(callback2);
+      });
+
+      it('removes the callback after execution', () => {
+        const ea = new EventAggregator();
+
+        const callback = function() { return; };
+        const subscription = ea.subscribe('dinner', callback);
+
+        const callback2 = function() { return; };
+        const subscription2 = ea.subscribe('dinner', callback2);
+
+        expect(ea.eventLookup.dinner.length).to.equal(2);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+        expect(ea.eventLookup.dinner[1]).to.equal(callback2);
+
+        subscription.dispose();
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback2);
+
+        subscription2.dispose();
+        expect(ea.eventLookup.dinner.length).to.equal(0);
+      });
+
+      it('will respond to an event any time it is published', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribe('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+
+        ea.publish('dinner');
+        ea.publish('dinner');
+        ea.publish('dinner');
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+      });
+
+      it('will pass published data to the callback function', () => {
+        const ea = new EventAggregator();
+        let data = null;
+        const callback = function(d) { data = d; };
+        ea.subscribe('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0]).to.equal(callback);
+
+        ea.publish('dinner', { foo: 'bar' });
+        expect(data.foo).to.equal('bar');
+      });
+
+    });
+
+    describe('handler events', () => {
+
+      it('should not remove another handler when execute called twice', () => {
+        const ea = new EventAggregator();
+        let data = 0;
+
+        const subscription = ea.subscribe(DinnerEvent, function() { return; });
+        ea.subscribe(AnotherDinnerEvent, function() { data = 1; });
+
+        subscription.dispose();
+        subscription.dispose();
+
+        ea.publish(new AnotherDinnerEvent(''));
+
+        expect(data).to.equal(1);
+      });
+
+      it('adds handler with messageType and callback to the messageHandlers array', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribe(DinnerEvent, callback);
+
+        expect(ea.messageHandlers.length).to.equal(1);
+        expect(ea.messageHandlers[0].messageType).to.equal(DinnerEvent);
+        expect(ea.messageHandlers[0].callback).to.equal(callback);
+      });
+
+      it('removes the handler after execution', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        const subscription = ea.subscribe(DinnerEvent, callback);
+
+        expect(ea.messageHandlers.length).to.equal(1);
+        subscription.dispose();
+        expect(ea.messageHandlers.length).to.equal(0);
+      });
+
+    });
+
+  });
+
+  describe('subscribeOnce', () => {
+
+    describe('string events', () => {
+
+      it('adds event with an anynomous function that will execute the callback to the eventLookup object', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribeOnce('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+      });
+
+      it('adds multiple callbacks the same event', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        ea.subscribeOnce('dinner', callback);
+
+        const callback2 = function() { return; };
+        ea.subscribeOnce('dinner', callback2);
+
+        expect(ea.eventLookup.dinner.length).to.equal(2);
+        expect(ea.eventLookup.dinner[0] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+        expect(ea.eventLookup.dinner[1] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[1] === 'function').to.equal(true);
+      });
+
+      it('removes the callback after execution', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        const subscription = ea.subscribeOnce('dinner', callback);
+
+        const callback2 = function() { return; };
+        const subscription2 = ea.subscribeOnce('dinner', callback2);
+
+        expect(ea.eventLookup.dinner.length).to.equal(2);
+        expect(ea.eventLookup.dinner[0] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+        expect(ea.eventLookup.dinner[1] === callback2).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[1] === 'function').to.equal(true);
+
+        subscription.dispose();
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+
+        subscription2.dispose();
+        expect(ea.eventLookup.dinner.length).to.equal(0);
+      });
+
+      it('will respond to an event only once', () => {
+        const ea = new EventAggregator();
+        let data = null;
+
+        const callback = function() { data = 'something'; };
+        ea.subscribeOnce('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+
+        ea.publish('dinner');
+        expect(data).to.equal('something');
+
+        expect(ea.eventLookup.dinner.length).to.equal(0);
+
+        data = null;
+        ea.publish('dinner');
+        expect(data).to.equal(null);
+      });
+
+      it('will pass published data to the callback function', () => {
+        const ea = new EventAggregator();
+
+        let data = null;
+        const callback = function(d) { data = d; };
+        ea.subscribeOnce('dinner', callback);
+
+        expect(ea.eventLookup.dinner.length).to.equal(1);
+        expect(ea.eventLookup.dinner[0] === callback).to.equal(false);
+        expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
+
+        ea.publish('dinner', { foo: 'bar' });
+        expect(data.foo).to.equal('bar');
+
+        data = null;
+        ea.publish('dinner');
+        expect(data).to.equal(null);
+      });
+    });
+
+    describe('handler events', () => {
+
+      it('adds handler with messageType and callback to the messageHandlers array', () => {
+        const ea = new EventAggregator();
+
+        const callback = function() { return; };
+        ea.subscribeOnce(DinnerEvent, callback);
+
+        expect(ea.messageHandlers.length).to.equal(1);
+        expect(ea.messageHandlers[0].messageType).to.equal(DinnerEvent);
+        expect(ea.messageHandlers[0].callback === callback).to.equal(false);
+        expect(typeof ea.messageHandlers[0].callback === 'function').to.equal(true);
+
+      });
+
+      it('removes the handler after execution', () => {
+        const ea = new EventAggregator();
+        const callback = function() { return; };
+        const subscription = ea.subscribeOnce(DinnerEvent, callback);
+
+        expect(ea.messageHandlers.length).to.equal(1);
+        subscription.dispose();
+        expect(ea.messageHandlers.length).to.equal(0);
+      });
+
+    });
+
+  });
+
+  describe('publish', () => {
+
+    describe('string events', () => {
+
+      it('calls the callback functions for the event', () => {
+        const ea = new EventAggregator();
+
+        let someData: unknown, someData2: unknown;
+
+        const callback = function(cbData: unknown) {
+          someData = cbData;
+        };
+        ea.subscribe('dinner', callback);
+
+        const callback2 = function(cbData: unknown) {
+          someData2 = cbData;
+        };
+        ea.subscribe('dinner', callback2);
+
+        const data = {foo: 'bar'};
+        ea.publish('dinner', data);
+
+        expect(someData).to.equal(data);
+        expect(someData2).to.equal(data);
+      });
+
+      it('does not call the callback functions if subscriber does not exist', () => {
+        const ea = new EventAggregator();
+
+        let someData: unknown;
+
+        const callback = function(data: unknown) {
+          someData = data;
+        };
+        ea.subscribe('dinner', callback);
+
+        ea.publish('garbage', {});
+
+        expect(someData).to.be.undefined;
+      });
+
+      it('handles errors in subscriber callbacks', () => {
+        const ea = new EventAggregator();
+
+        let someMessage: unknown;
+
+        const crash = function() {
+          throw new Error('oops');
+        };
+
+        const callback = function(message) {
+          someMessage = message;
+        };
+
+        const data = {foo: 'bar'};
+
+        ea.subscribe('dinner', crash);
+        ea.subscribe('dinner', callback);
+        ea.subscribe('dinner', crash);
+
+        ea.publish('dinner', data);
+
+        expect(someMessage).to.be.equal(data);
+      });
+
+    });
+
+    describe('handler events', () => {
+
+      it('calls the callback functions for the event', () => {
+        const ea = new EventAggregator();
+
+        let someMessage: { message: string };
+
+        const callback = function(message) {
+          someMessage = message;
+        };
+        ea.subscribe(DinnerEvent, callback);
+
+        const americanDinner = new DinnerEvent('Cajun chicken');
+        ea.publish(americanDinner);
+
+        expect(someMessage.message).to.equal('Cajun chicken');
+
+        const swedishDinner = new DinnerEvent('Meatballs');
+        ea.publish(swedishDinner);
+
+        expect(someMessage.message).to.equal('Meatballs');
+      });
+
+      it('does not call the callback funtions if message is not an instance of the messageType', () => {
+        const ea = new EventAggregator();
+
+        let someMessage: unknown;
+
+        const callback = function(message) {
+          someMessage = message;
+        };
+        ea.subscribe(DinnerEvent, callback);
+
+        ea.publish(new DrinkingEvent());
+
+        expect(someMessage).to.be.undefined;
+      });
+
+      it('handles errors in subscriber callbacks', () => {
+        const ea = new EventAggregator();
+
+        let someMessage: { message: unknown };
+
+        const crash = function() {
+          throw new Error('oops');
+        };
+
+        const callback = function(message) {
+          someMessage = message;
+        };
+
+        const data = { foo: 'bar' };
+
+        ea.subscribe(DinnerEvent, crash);
+        ea.subscribe(DinnerEvent, callback);
+
+        ea.publish(new DinnerEvent(data));
+
+        expect(someMessage.message).to.equal(data);
+      });
+
+    });
+
+  });
+
+});
+
+class DinnerEvent {
+  private readonly _message: unknown;
+
+  constructor(message: unknown) {
+    this._message = message;
+  }
+
+  get message(): unknown {
+    return this._message;
+  }
+}
+
+class AnotherDinnerEvent {
+  private readonly _message: unknown;
+
+  constructor(message: unknown) {
+    this._message = message;
+  }
+
+  get message(): unknown {
+    return this._message;
+  }
+}
+
+class DrinkingEvent {}

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -1,7 +1,21 @@
 import { expect } from 'chai';
-import { EventAggregator } from '../src/index';
+import { DI, EventAggregator } from '../src/index';
 
 describe('event aggregator', () => {
+
+  describe('register', () => {
+
+    it('registers the EventAggregator as singleton', () => {
+      const Type = EventAggregator;
+      const container = DI.createContainer();
+
+      Type.register(container);
+
+      const resolved1 = container.get(EventAggregator);
+      const resolved2 = container.get(EventAggregator);
+      expect(resolved1).to.equal(resolved2);
+    });
+  });
 
   describe('subscribe', () => {
 

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -3,20 +3,6 @@ import { DI, EventAggregator } from '../src/index';
 
 describe('event aggregator', () => {
 
-  describe('register', () => {
-
-    it('registers the EventAggregator as singleton', () => {
-      const Type = EventAggregator;
-      const container = DI.createContainer();
-
-      Type.register(container);
-
-      const resolved1 = container.get(EventAggregator);
-      const resolved2 = container.get(EventAggregator);
-      expect(resolved1).to.equal(resolved2);
-    });
-  });
-
   describe('subscribe', () => {
 
     describe('string events', () => {

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -136,6 +136,16 @@ describe('event aggregator', () => {
 
     });
 
+    describe('invalid events', () => {
+      const ea = new EventAggregator();
+      const callback = function() { return; };
+
+      it('throws if channelOrType is undefined', () => {
+        expect(() => { ea.subscribe(undefined, callback); }).to.throw('Code 0');
+      });
+
+    });
+
   });
 
   describe('subscribeOnce', () => {
@@ -386,6 +396,15 @@ describe('event aggregator', () => {
         ea.publish(new DinnerEvent(data));
 
         expect(someMessage.message).to.equal(data);
+      });
+
+    });
+
+    describe('invalid events', () => {
+      const ea = new EventAggregator();
+
+      it('throws if channelOrType is undefined', () => {
+        expect(() => { ea.publish(undefined, {}); }).to.throw('Code 0');
       });
 
     });


### PR DESCRIPTION
# Pull Request

## 📖 Description

Ports EventAggregator over from vCurrent. Basic port of both `src` and `test`, with linting and typing changes applied.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Notable changes:
- ~~Added a `static register` method for registration with DI, with test.~~
- Made the callback signature explicit `(data?: unknown, event?: string) => unknown` (was `Function`) and generic and gave it its own type `EventAggregatorCallback<T>` for ease of use and readability.
- You can subscribe by channel (`string`) or type (`Constructable`, was `any`) and added function overloads (with generics) to make the API clearer.
- Dropped the `aurelia-logger` dependency and switched to `Reporter` for logging/throwing errors.
- Added some missing tests to increase coverage.
- Many cosmetic linting fixes (almost all spacing related).

## 📑 Test Plan

CircleCI.

## ⏭ Next Steps

Decide if we want to make the EventAggregator it's own `@aurelia/eventaggregator` package, and if so, extract it from `@aurelia/kernel`.