### PR TITLE
CI: fix test result report

### DIFF
--- a/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
+++ b/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
@@ -1169,7 +1169,8 @@ describe('xml node compiler tests', () => {
   ];
 
   for (const markup of markups) {
-    it(markup, () => {
+    const escaped = markup.replace(/\b/g, '\\b').replace(/\t/g, '\\t').replace(/\n/g, '\\n').replace(/\v/g, '\\v').replace(/\f/g, '\\f').replace(/\r/g, '\\r');
+    it(escaped, () => {
       const ctx = TestContext.createHTMLTestContext();
       const parser = new ctx.DOMParser();
       const doc = parser.parseFromString(markup, 'application/xml');

--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -112,7 +112,7 @@ export default function(config: IKarmaConfig): void {
     mime: {
       'text/x-typescript': ['ts']
     },
-    reporters: [process.env.CI ? 'junit' : config.reporter || 'progress'],
+    reporters: ['junit', config.reporter || 'progress'],
     webpackMiddleware: {
       stats: {
         colors: true,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Somewhere along the line CircleCI stopped being able to parse the generated `test-results.xml` making it impossible to see which tests failed on CI (you only see that *something* failed and have to run them all locally to find out which).

This PR is solely intended to fix that problem.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
