### PR TITLE
lifecycle refactor step 1/?

### DIFF
--- a/packages/jit-html/test/integration/template-compiler.custom-elements.spec.ts
+++ b/packages/jit-html/test/integration/template-compiler.custom-elements.spec.ts
@@ -202,25 +202,23 @@ describe('template-compiler.custom-elements', () => {
 
       switch (i) {
         case 0: // root component -> foo1
-          cur = current.$bindableHead;
+          cur = current.$earlyBindableHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SetterObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
           cur = cur.$nextBind;
-          expect(cur).to.be.instanceof(childCtor);
-
-          cur = cur.$nextBind;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
-
           expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
-          current = cur.$prevBind;
+
+          cur = current = current.$bindableHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
           break;
         case 1: // foo1 -> foo2
-          cur = current.$bindableHead;
+          cur = current.$earlyBindableHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
@@ -233,19 +231,18 @@ describe('template-compiler.custom-elements', () => {
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
           cur = cur.$nextBind;
-          expect(cur).to.be.instanceof(childCtor);
-
-          cur = cur.$nextBind;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
           expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
-          current = cur.$prevBind;
+
+          cur = current = current.$bindableHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
           break;
         case 2:
         case 3:
         case 4: // foo2 -> foo3-5
-          cur = current.$bindableHead;
+          cur = current.$earlyBindableHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
@@ -256,16 +253,15 @@ describe('template-compiler.custom-elements', () => {
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
-
-          cur = cur.$nextBind;
-          expect(cur).to.be.instanceof(childCtor);
 
           cur = cur.$nextBind;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
           expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
-          current = cur.$prevBind;
+
+          cur = current = current.$bindableHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
       }
 
       i++;

--- a/packages/jit-html/test/integration/template-compiler.custom-elements.spec.ts
+++ b/packages/jit-html/test/integration/template-compiler.custom-elements.spec.ts
@@ -196,72 +196,72 @@ describe('template-compiler.custom-elements', () => {
     let cur: any;
     while (i < 5) {
       const childCtor = customElementCtors[i];
-      expect(current.$attachableHead).to.be.a('object');
-      expect(current.$attachableHead).to.equal(current.$attachableTail);
-      expect(current.$attachableHead).to.be.instanceof(childCtor);
+      expect(current.$componentHead).to.be.a('object');
+      expect(current.$componentHead).to.equal(current.$componentTail);
+      expect(current.$componentHead).to.be.instanceof(childCtor);
 
       switch (i) {
         case 0: // root component -> foo1
-          cur = current.$earlyBindableHead;
+          cur = current.$bindingHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SetterObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
-          cur = cur.$nextBind;
+          cur = cur.$nextBinding;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
-          expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
+          expect(cur.$nextBinding).to.equal(null, 'cur.$nextBinding');
 
-          cur = current = current.$bindableHead;
-          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
+          cur = current = current.$componentHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$componentHead ${i}`);
           break;
         case 1: // foo1 -> foo2
-          cur = current.$earlyBindableHead;
+          cur = current.$bindingHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
-          cur = cur.$nextBind;
+          cur = cur.$nextBinding;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SetterObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
-          cur = cur.$nextBind;
+          cur = cur.$nextBinding;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
-          expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
+          expect(cur.$nextBinding).to.equal(null, 'cur.$nextBinding');
 
-          cur = current = current.$bindableHead;
-          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
+          cur = current = current.$componentHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$componentHead ${i}`);
           break;
         case 2:
         case 3:
         case 4: // foo2 -> foo3-5
-          cur = current.$earlyBindableHead;
+          cur = current.$bindingHead;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
-          cur = cur.$nextBind;
+          cur = cur.$nextBinding;
           expect(cur).to.be.instanceof(Binding);
           expect(cur._observer0).be.instanceof(SelfObserver);
           expect(cur._observer1).to.equal(undefined);
           expect(cur.targetObserver).to.be.instanceof(PropertyAccessor);
 
-          cur = cur.$nextBind;
+          cur = cur.$nextBinding;
           expect(cur).to.be.instanceof(InterpolationBinding);
           expect(cur.target.nodeName).to.equal('#text');
           expect(cur.targetObserver).to.be.instanceof(ElementPropertyAccessor);
-          expect(cur.$nextBind).to.equal(null, 'cur.$nextBind');
+          expect(cur.$nextBinding).to.equal(null, 'cur.$nextBinding');
 
-          cur = current = current.$bindableHead;
-          expect(cur).to.be.instanceof(childCtor, `cur.$bindableHead ${i}`);
+          cur = current = current.$componentHead;
+          expect(cur).to.be.instanceof(childCtor, `cur.$componentHead ${i}`);
       }
 
       i++;

--- a/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
+++ b/packages/jit-html/test/integration/template-compiler.kitchen-sink.spec.ts
@@ -1492,7 +1492,7 @@ describe('generated.template-compiler.static (with tracing)', function () {
 //         const binding = new Binding(new AccessScope(ifPropName), text, 'textContent', BindingMode.toView, observerLocator, container);
 
 //         (renderable as Writable<typeof renderable>).$nodes = nodes;
-//         addBindable(renderable, binding);
+//         addBinding(renderable, binding);
 //       }
 //     };
 
@@ -1507,7 +1507,7 @@ describe('generated.template-compiler.static (with tracing)', function () {
 //         const binding = new Binding(new AccessScope(elsePropName), text, 'textContent', BindingMode.toView, observerLocator, container);
 
 //         (renderable as Writable<typeof renderable>).$nodes = nodes;
-//         addBindable(renderable, binding);
+//         addBinding(renderable, binding);
 //       }
 //     };
 

--- a/packages/jit-html/test/util.ts
+++ b/packages/jit-html/test/util.ts
@@ -25,7 +25,7 @@ export function getVisibleText(au, host) {
 }
 
 function $getVisibleText(root, context) {
-  let current = root.$attachableHead;
+  let current = root.$componentHead;
   while (current) {
     if (current.$projector && current.$projector.shadowRoot) {
       context.text += current.$projector.shadowRoot.textContent;
@@ -39,7 +39,7 @@ function $getVisibleText(root, context) {
         $getVisibleText(view, context);
       }
     }
-    current = current.$nextAttach;
+    current = current.$nextComponent;
   }
 }
 

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -4,7 +4,6 @@ import {
   hasBind,
   hasUnbind,
   IBinding,
-  IBindScope,
   IConnectableBinding,
   IDOM,
   IsBindingBehavior,
@@ -20,8 +19,8 @@ export interface Listener extends IConnectableBinding {}
 export class Listener implements IBinding {
   public dom: IDOM;
 
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $scope: IScope;
 
@@ -47,8 +46,8 @@ export class Listener implements IBinding {
     locator: IServiceLocator
   ) {
     this.dom = dom;
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
 
     this.delegationStrategy = delegationStrategy;

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -1,6 +1,6 @@
 import { InterfaceSymbol, IRegistry, Tracer } from '@aurelia/kernel';
 import {
-  addBindable,
+  addEarlyBindable,
   Binding,
   BindingMode,
   BindingType,
@@ -55,7 +55,7 @@ export class TextBindingRenderer implements IInstructionRenderer {
     } else {
       bindable = new InterpolationBinding(expr.firstExpression, expr, next, 'textContent', BindingMode.toView, this.observerLocator, context, true);
     }
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -78,7 +78,7 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('ListenerBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
     const bindable = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -113,7 +113,7 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const bindable = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -1,6 +1,6 @@
 import { InterfaceSymbol, IRegistry, Tracer } from '@aurelia/kernel';
 import {
-  addEarlyBindable,
+  addBinding,
   Binding,
   BindingMode,
   BindingType,
@@ -48,14 +48,14 @@ export class TextBindingRenderer implements IInstructionRenderer {
     if (dom.isMarker(target)) {
       dom.remove(target);
     }
-    let bindable: MultiInterpolationBinding | InterpolationBinding;
+    let binding: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
     if (expr.isMulti) {
-      bindable = new MultiInterpolationBinding(this.observerLocator, expr, next, 'textContent', BindingMode.toView, context);
+      binding = new MultiInterpolationBinding(this.observerLocator, expr, next, 'textContent', BindingMode.toView, context);
     } else {
-      bindable = new InterpolationBinding(expr.firstExpression, expr, next, 'textContent', BindingMode.toView, this.observerLocator, context, true);
+      binding = new InterpolationBinding(expr.firstExpression, expr, next, 'textContent', BindingMode.toView, this.observerLocator, context, true);
     }
-    addEarlyBindable(renderable, bindable);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -77,8 +77,8 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: HTMLElement, instruction: IListenerBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('ListenerBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
-    const bindable = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -112,8 +112,8 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: HTMLElement, instruction: IStylePropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
-    const bindable = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -16,8 +16,7 @@ import {
   IViewFactory,
   LifecycleFlags,
   TargetedInstruction,
-  TemplateDefinition,
-  ICustomElementType
+  TemplateDefinition
 } from '@aurelia/runtime';
 import { createElement, RenderPlan } from '../../create-element';
 
@@ -25,21 +24,6 @@ const composeSource: ITemplateDefinition = {
   name: 'au-compose',
   containerless: true
 };
-
-
-export interface IViewportComponent<T extends INode = INode> {
-  viewport?: string;
-  component: string | Partial<ICustomElementType<T>>;
-}
-
-export interface Books extends ICustomElement<HTMLElement> {}
-export class Books implements Books {
-}
-
-const viewport: IViewportComponent = {
-  component: Books
-}
-
 
 const composeProps = ['subject', 'composing'];
 

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -16,7 +16,8 @@ import {
   IViewFactory,
   LifecycleFlags,
   TargetedInstruction,
-  TemplateDefinition
+  TemplateDefinition,
+  ICustomElementType
 } from '@aurelia/runtime';
 import { createElement, RenderPlan } from '../../create-element';
 
@@ -24,6 +25,21 @@ const composeSource: ITemplateDefinition = {
   name: 'au-compose',
   containerless: true
 };
+
+
+export interface IViewportComponent<T extends INode = INode> {
+  viewport?: string;
+  component: string | Partial<ICustomElementType<T>>;
+}
+
+export interface Books extends ICustomElement<HTMLElement> {}
+export class Books implements Books {
+}
+
+const viewport: IViewportComponent = {
+  component: Books
+}
+
 
 const composeProps = ['subject', 'composing'];
 

--- a/packages/runtime-html/test/_doubles/fake-view.ts
+++ b/packages/runtime-html/test/_doubles/fake-view.ts
@@ -17,6 +17,9 @@ import { NodeSequenceFactory } from '../../src/dom';
 import { HTMLTestContext } from '../util';
 
 export class FakeView implements IView {
+  public $earlyBindableHead: IBindScope;
+  public $earlyBindableTail: IBindScope;
+
   public $bindableHead: IBindScope;
   public $bindableTail: IBindScope;
 
@@ -45,6 +48,9 @@ export class FakeView implements IView {
   public readonly $lifecycle: ILifecycle;
 
   constructor(ctx: HTMLTestContext) {
+    this.$earlyBindableHead = null;
+    this.$earlyBindableTail = null;
+
     this.$bindableHead = null;
     this.$bindableTail = null;
 

--- a/packages/runtime-html/test/_doubles/fake-view.ts
+++ b/packages/runtime-html/test/_doubles/fake-view.ts
@@ -1,8 +1,7 @@
 import {
-  IAttach,
-  IBindScope,
+  IBinding,
+  IComponent,
   ILifecycle,
-  ILifecycleUnbind,
   IMountable,
   INodeSequence,
   IRenderContext,
@@ -17,25 +16,22 @@ import { NodeSequenceFactory } from '../../src/dom';
 import { HTMLTestContext } from '../util';
 
 export class FakeView implements IView {
-  public $earlyBindableHead: IBindScope;
-  public $earlyBindableTail: IBindScope;
+  public $bindingHead: IBinding;
+  public $bindingTail: IBinding;
 
-  public $bindableHead: IBindScope;
-  public $bindableTail: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
 
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $componentHead: IComponent;
+  public $componentTail: IComponent;
 
-  public $attachableHead: IAttach;
-  public $attachableTail: IAttach;
-
-  public $nextAttach: IAttach;
-  public $prevAttach: IAttach;
+  public $nextComponent: IComponent;
+  public $prevComponent: IComponent;
 
   public $nextMount: IMountable;
   public $nextUnmount: IMountable;
 
-  public $nextUnbindAfterDetach: ILifecycleUnbind;
+  public $nextUnbindAfterDetach: IComponent;
 
   public $state: State;
   public $scope: IScope;
@@ -48,20 +44,20 @@ export class FakeView implements IView {
   public readonly $lifecycle: ILifecycle;
 
   constructor(ctx: HTMLTestContext) {
-    this.$earlyBindableHead = null;
-    this.$earlyBindableTail = null;
+    this.$bindingHead = null;
+    this.$bindingTail = null;
 
-    this.$bindableHead = null;
-    this.$bindableTail = null;
+    this.$componentHead = null;
+    this.$componentTail = null;
 
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
 
-    this.$attachableHead = null;
-    this.$attachableTail = null;
+    this.$componentHead = null;
+    this.$componentTail = null;
 
-    this.$nextAttach = null;
-    this.$prevAttach = null;
+    this.$nextComponent = null;
+    this.$prevComponent = null;
 
     this.$nextMount = null;
     this.$nextUnmount = null;

--- a/packages/runtime-html/test/mock.ts
+++ b/packages/runtime-html/test/mock.ts
@@ -9,8 +9,8 @@ import {
 import {
   AccessMember,
   AccessScope,
-  addAttachable,
-  addBindable,
+  addBinding,
+  addComponent,
   Binding,
   BindingMode,
   CompositionCoordinator,
@@ -168,7 +168,7 @@ export class MockTextNodeTemplate {
 
   public render(renderable: Partial<IRenderable>, host?: INode, parts?: TemplatePartDefinitions): void {
     const nodes = (renderable as Writable<IRenderable>).$nodes = new MockTextNodeSequence(undefined);
-    addBindable(renderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
+    addBinding(renderable as IRenderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
   }
 }
 
@@ -199,11 +199,10 @@ export class MockIfTextNodeTemplate {
     (sut as any)['$scope'] = null;
 
     const behavior = RuntimeBehavior.create(If as any);
-    behavior.applyTo(sut, this.lifecycle);
+    behavior.applyTo(LifecycleFlags.none, sut, this.lifecycle);
 
-    addAttachable(renderable, sut);
-    addBindable(renderable, new Binding(this.sourceExpression, sut, 'value', BindingMode.toView, this.observerLocator, this.container));
-    addBindable(renderable, sut);
+    addComponent(renderable as IRenderable, sut);
+    addBinding(renderable as IRenderable, new Binding(this.sourceExpression, sut, 'value', BindingMode.toView, this.observerLocator, this.container));
   }
 }
 
@@ -230,29 +229,27 @@ export class MockIfElseTextNodeTemplate {
     (ifSut as any)['$scope'] = null;
 
     const ifBehavior = RuntimeBehavior.create(If as any);
-    ifBehavior.applyTo(ifSut, this.lifecycle);
+    ifBehavior.applyTo(LifecycleFlags.none, ifSut, this.lifecycle);
 
-    addAttachable(renderable, ifSut);
-    addBindable(renderable, new Binding(this.sourceExpression, ifSut, 'value', BindingMode.toView, this.observerLocator, this.container));
-    addBindable(renderable, ifSut);
+    addComponent(renderable as IRenderable, ifSut);
+    addBinding(renderable as IRenderable, new Binding(this.sourceExpression, ifSut, 'value', BindingMode.toView, this.observerLocator, this.container));
 
     const elseFactory = new ViewFactory(null, new MockTextNodeTemplate(expressions.else, observerLocator, this.container) as any, this.lifecycle);
 
     //@ts-ignore
     const elseSut = new Else(elseFactory);
 
-    elseSut.link(renderable.$attachableTail as any);
+    elseSut.link(renderable.$componentTail as any);
 
     (elseSut as any)['$isAttached'] = false;
     (elseSut as any)['$state'] = State.none;
     (elseSut as any)['$scope'] = null;
 
     const elseBehavior = RuntimeBehavior.create(Else as any);
-    elseBehavior.applyTo(elseSut as any, this.lifecycle);
+    elseBehavior.applyTo(LifecycleFlags.none, elseSut as any, this.lifecycle);
 
-    addAttachable(renderable, elseSut as any);
-    addBindable(renderable, new Binding(this.sourceExpression, elseSut, 'value', BindingMode.toView, this.observerLocator, this.container));
-    addBindable(renderable, elseSut as any);
+    addComponent(renderable as IRenderable, elseSut as any);
+    addBinding(renderable as IRenderable, new Binding(this.sourceExpression, elseSut, 'value', BindingMode.toView, this.observerLocator, this.container));
   }
 }
 
@@ -285,9 +282,9 @@ export class MockRenderingEngine implements IRenderingEngine {
     return this.renderer;
   }
 
-  public applyRuntimeBehavior(type: IResourceType<IAttributeDefinition, ICustomAttribute>, instance: ICustomAttribute): void;
-  public applyRuntimeBehavior(type: ICustomElementType, instance: ICustomElement): void;
-  public applyRuntimeBehavior(type: any, instance: any) {
+  public applyRuntimeBehavior(flags: LifecycleFlags, type: IResourceType<IAttributeDefinition, ICustomAttribute>, instance: ICustomAttribute): void;
+  public applyRuntimeBehavior(flags: LifecycleFlags, type: ICustomElementType, instance: ICustomElement): void;
+  public applyRuntimeBehavior(flags: LifecycleFlags, type: any, instance: any) {
     this.trace(`applyRuntimeBehavior`, type, instance);
     this.runtimeBehaviorApplicator(type, instance);
   }

--- a/packages/runtime-html/test/renderer.spec.ts
+++ b/packages/runtime-html/test/renderer.spec.ts
@@ -31,7 +31,7 @@ describe('Renderer', () => {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, container } = ctx;
     IExpressionParserRegistration.register(container);
-    const renderable: IRenderable = { $bindableHead: null, $bindableTail: null, $attachableHead: null, $attachableTail: null, $context: null, $nodes: null, $scope: null };
+    const renderable: IRenderable = { $earlyBindableHead: null, $earlyBindableTail: null, $bindableHead: null, $bindableTail: null, $attachableHead: null, $attachableTail: null, $context: null, $nodes: null, $scope: null };
     container.register(Registration.instance(IRenderable, renderable));
     const wrapper = ctx.createElementFromMarkup('<div><au-target class="au"></au-target> </div>');
     dom.appendChild(ctx.doc.body, wrapper);
@@ -73,9 +73,11 @@ describe('Renderer', () => {
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-        expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-        expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-        const bindable = renderable.$bindableHead as InterpolationBinding;
+        expect(renderable.$bindableHead).to.equal(null);
+        expect(renderable.$bindableTail).to.equal(null);
+        expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+        expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+        const bindable = renderable.$earlyBindableHead as InterpolationBinding;
         expect(bindable.target).to.equal(placeholder);
         expect(bindable.interpolation['expressions'][0]['name']).to.equal('foo');
         expect(bindable.interpolation['parts'][0]).to.equal('');
@@ -98,9 +100,11 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-            const bindable = renderable.$bindableHead as Listener;
+            expect(renderable.$bindableHead).to.equal(null);
+            expect(renderable.$bindableTail).to.equal(null);
+            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+            const bindable = renderable.$earlyBindableHead as Listener;
             expect(bindable.target).to.equal(target);
             expect(bindable.sourceExpression['name']).to.equal('foo');
             expect(bindable.delegationStrategy).to.equal(instruction.strategy);
@@ -123,9 +127,11 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-          expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-          const bindable = renderable.$bindableHead as InterpolationBinding;
+          expect(renderable.$bindableHead).to.equal(null);
+          expect(renderable.$bindableTail).to.equal(null);
+          expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+          expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+          const bindable = renderable.$earlyBindableHead as InterpolationBinding;
           expect(bindable.target).to.equal(target.style);
           expect(bindable.sourceExpression['name']).to.equal('foo');
           expect(bindable.mode).to.equal(BindingMode.toView);
@@ -146,7 +152,10 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null, 'renderable.$bindableHead');
+          expect(renderable.$bindableHead).to.equal(null);
+          expect(renderable.$bindableTail).to.equal(null);
+          expect(renderable.$earlyBindableHead).to.equal(null);
+          expect(renderable.$earlyBindableTail).to.equal(null);
           expect(target.getAttribute(to)).to.equal(`${value}`);
 
           tearDown({ ctx, wrapper });

--- a/packages/runtime-html/test/renderer.spec.ts
+++ b/packages/runtime-html/test/renderer.spec.ts
@@ -31,7 +31,7 @@ describe('Renderer', () => {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, container } = ctx;
     IExpressionParserRegistration.register(container);
-    const renderable: IRenderable = { $earlyBindableHead: null, $earlyBindableTail: null, $bindableHead: null, $bindableTail: null, $attachableHead: null, $attachableTail: null, $context: null, $nodes: null, $scope: null };
+    const renderable: IRenderable = { $bindingHead: null, $bindingTail: null, $componentHead: null, $componentTail: null, $context: null, $nodes: null, $scope: null };
     container.register(Registration.instance(IRenderable, renderable));
     const wrapper = ctx.createElementFromMarkup('<div><au-target class="au"></au-target> </div>');
     dom.appendChild(ctx.doc.body, wrapper);
@@ -73,11 +73,11 @@ describe('Renderer', () => {
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-        expect(renderable.$bindableHead).to.equal(null);
-        expect(renderable.$bindableTail).to.equal(null);
-        expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-        expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-        const bindable = renderable.$earlyBindableHead as InterpolationBinding;
+        expect(renderable.$componentHead).to.equal(null);
+        expect(renderable.$componentTail).to.equal(null);
+        expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+        expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+        const bindable = renderable.$bindingHead as InterpolationBinding;
         expect(bindable.target).to.equal(placeholder);
         expect(bindable.interpolation['expressions'][0]['name']).to.equal('foo');
         expect(bindable.interpolation['parts'][0]).to.equal('');
@@ -100,11 +100,11 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$bindableHead).to.equal(null);
-            expect(renderable.$bindableTail).to.equal(null);
-            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-            const bindable = renderable.$earlyBindableHead as Listener;
+            expect(renderable.$componentHead).to.equal(null);
+            expect(renderable.$componentTail).to.equal(null);
+            expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+            expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+            const bindable = renderable.$bindingHead as Listener;
             expect(bindable.target).to.equal(target);
             expect(bindable.sourceExpression['name']).to.equal('foo');
             expect(bindable.delegationStrategy).to.equal(instruction.strategy);
@@ -127,11 +127,11 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null);
-          expect(renderable.$bindableTail).to.equal(null);
-          expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-          expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-          const bindable = renderable.$earlyBindableHead as InterpolationBinding;
+          expect(renderable.$componentHead).to.equal(null);
+          expect(renderable.$componentTail).to.equal(null);
+          expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+          expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+          const bindable = renderable.$bindingHead as InterpolationBinding;
           expect(bindable.target).to.equal(target.style);
           expect(bindable.sourceExpression['name']).to.equal('foo');
           expect(bindable.mode).to.equal(BindingMode.toView);
@@ -152,10 +152,10 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null);
-          expect(renderable.$bindableTail).to.equal(null);
-          expect(renderable.$earlyBindableHead).to.equal(null);
-          expect(renderable.$earlyBindableTail).to.equal(null);
+          expect(renderable.$componentHead).to.equal(null);
+          expect(renderable.$componentTail).to.equal(null);
+          expect(renderable.$bindingHead).to.equal(null);
+          expect(renderable.$bindingTail).to.equal(null);
           expect(target.getAttribute(to)).to.equal(`${value}`);
 
           tearDown({ ctx, wrapper });

--- a/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
+++ b/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
@@ -1,4 +1,4 @@
-import { CustomElementResource, IAttach, ITemplateDefinition, IViewFactory, LifecycleFlags } from '@aurelia/runtime';
+import { CustomElementResource, IComponent, ITemplateDefinition, IViewFactory, LifecycleFlags } from '@aurelia/runtime';
 import { expect } from 'chai';
 import { Compose, RenderPlan } from '../../../src/index';
 import { FakeViewFactory } from '../../_doubles/fake-view-factory';
@@ -276,13 +276,13 @@ describe('The "compose" custom element', () => {
     return compose['coordinator']['currentView'];
   }
 
-  function runAttachLifecycle(ctx: HTMLTestContext, item: IAttach) {
+  function runAttachLifecycle(ctx: HTMLTestContext, item: IComponent) {
     ctx.lifecycle.beginAttach();
     item.$attach(LifecycleFlags.none);
     ctx.lifecycle.endAttach(LifecycleFlags.none);
   }
 
-  function runDetachLifecycle(ctx: HTMLTestContext, item: IAttach) {
+  function runDetachLifecycle(ctx: HTMLTestContext, item: IComponent) {
     ctx.lifecycle.beginDetach();
     item.$detach(LifecycleFlags.none);
     ctx.lifecycle.endDetach(LifecycleFlags.none);

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -47,7 +47,7 @@ import {
   UnaryOperator
 } from '../ast';
 import { ExpressionKind, LifecycleFlags } from '../flags';
-import { IBindScope } from '../lifecycle';
+import { IBinding } from '../lifecycle';
 import { Collection, IBindingContext, IOverrideContext, IScope, ObservedCollection } from '../observation';
 import { BindingContext } from '../observation/binding-context';
 import { ISignaler } from '../observation/signaler';
@@ -414,7 +414,7 @@ export class AccessScope implements IAccessScopeExpression {
     this.ancestor = ancestor;
   }
 
-  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): IBindingContext | IBindScope | IOverrideContext {
+  public evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator): IBindingContext | IBinding | IOverrideContext {
     const name = this.name;
     return BindingContext.get(scope, name, this.ancestor, flags)[name];
   }

--- a/packages/runtime/src/binding/binding.ts
+++ b/packages/runtime/src/binding/binding.ts
@@ -1,18 +1,13 @@
 import { IServiceLocator, Reporter, Tracer } from '@aurelia/kernel';
 import { IForOfStatement, IsBindingBehavior } from '../ast';
 import { BindingMode, ExpressionKind, LifecycleFlags, State } from '../flags';
-import { IBindScope, ILifecycle } from '../lifecycle';
+import { IBinding, ILifecycle } from '../lifecycle';
 import { AccessorOrObserver, IBindingTargetObserver, IObservable, IScope } from '../observation';
 import { IObserverLocator } from '../observation/observer-locator';
 import { hasBind, hasUnbind } from './ast';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 
 const slice = Array.prototype.slice;
-
-export interface IBinding extends IBindScope {
-  readonly locator: IServiceLocator;
-  readonly $scope: IScope;
-}
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
 const { oneTime, toView, fromView } = BindingMode;
@@ -24,8 +19,8 @@ export interface Binding extends IConnectableBinding {}
 
 @connectable()
 export class Binding implements IPartialConnectableBinding {
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $lifecycle: ILifecycle;
   public $nextConnect: IConnectableBinding;
@@ -44,8 +39,8 @@ export class Binding implements IPartialConnectableBinding {
   public persistentFlags: LifecycleFlags;
 
   constructor(sourceExpression: IsBindingBehavior | IForOfStatement, target: IObservable, targetProperty: string, mode: BindingMode, observerLocator: IObserverLocator, locator: IServiceLocator) {
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
     this.$lifecycle = locator.get(ILifecycle);
     this.$nextConnect = null;

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -1,7 +1,7 @@
 import { IServiceLocator, Tracer } from '@aurelia/kernel';
 import { IsBindingBehavior } from '../ast';
 import { LifecycleFlags, State } from '../flags';
-import { IBindScope } from '../lifecycle';
+import { IBinding } from '../lifecycle';
 import { IAccessor, IBindingContext, IObservable, IScope } from '../observation';
 import { IObserverLocator } from '../observation/observer-locator';
 import { hasBind, hasUnbind } from './ast';
@@ -11,8 +11,8 @@ const slice = Array.prototype.slice;
 
 export interface Call extends IConnectableBinding {}
 export class Call {
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $scope: IScope;
 
@@ -21,8 +21,8 @@ export class Call {
   public targetObserver: IAccessor;
 
   constructor(sourceExpression: IsBindingBehavior, target: IObservable | IBindingContext, targetProperty: string, observerLocator: IObserverLocator, locator: IServiceLocator) {
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
 
     this.locator = locator;

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -1,9 +1,9 @@
 import { Class, IIndexable, Tracer } from '@aurelia/kernel';
 import { IConnectable } from '../ast';
 import { LifecycleFlags } from '../flags';
+import { IBinding } from '../lifecycle';
 import { IBindingTargetObserver, IPropertySubscriber, ISubscribable, MutationKind } from '../observation';
 import { IObserverLocator } from '../observation/observer-locator';
-import { IBinding } from './binding';
 
 // TODO: add connect-queue (or something similar) back in when everything else is working, to improve startup time
 

--- a/packages/runtime/src/binding/interpolation-binding.ts
+++ b/packages/runtime/src/binding/interpolation-binding.ts
@@ -1,17 +1,16 @@
 import { IServiceLocator } from '@aurelia/kernel';
 import { IExpression, IInterpolationExpression } from '../ast';
 import { BindingMode, LifecycleFlags, State } from '../flags';
-import { IBindScope } from '../lifecycle';
+import { IBinding } from '../lifecycle';
 import { IBindingTargetAccessor, IObservable, IScope } from '../observation';
 import { IObserverLocator } from '../observation/observer-locator';
-import { IBinding } from './binding';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
 
 const { toView, oneTime } = BindingMode;
 
 export class MultiInterpolationBinding implements IBinding {
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $scope: IScope;
 
@@ -24,8 +23,8 @@ export class MultiInterpolationBinding implements IBinding {
   public targetProperty: string;
 
   constructor(observerLocator: IObserverLocator, interpolation: IInterpolationExpression, target: IObservable, targetProperty: string, mode: BindingMode, locator: IServiceLocator) {
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
     this.$scope = null;
 

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -1,7 +1,7 @@
 import { IIndexable, IServiceLocator, Reporter, Tracer } from '@aurelia/kernel';
 import { IExpression } from '../ast';
 import { LifecycleFlags, State } from '../flags';
-import { IBindScope, ILifecycle } from '../lifecycle';
+import { IBinding, ILifecycle } from '../lifecycle';
 import { IObservable, IScope } from '../observation';
 import { IObserverLocator } from '../observation/observer-locator';
 import { connectable, IConnectableBinding, IPartialConnectableBinding } from './connectable';
@@ -12,8 +12,8 @@ export interface LetBinding extends IConnectableBinding {}
 
 @connectable()
 export class LetBinding implements IPartialConnectableBinding {
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $lifecycle: ILifecycle;
   public $scope: IScope;
@@ -27,8 +27,8 @@ export class LetBinding implements IPartialConnectableBinding {
   private readonly toViewModel: boolean;
 
   constructor(sourceExpression: IExpression, targetProperty: string, observerLocator: IObserverLocator, locator: IServiceLocator, toViewModel: boolean = false) {
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
     this.$lifecycle = locator.get(ILifecycle);
     this.$scope = null;

--- a/packages/runtime/src/binding/ref.ts
+++ b/packages/runtime/src/binding/ref.ts
@@ -1,18 +1,17 @@
 import { IIndexable, IServiceLocator, Tracer } from '@aurelia/kernel';
 import { IsBindingBehavior } from '../ast';
 import { LifecycleFlags, State } from '../flags';
-import { IBindScope } from '../lifecycle';
+import { IBinding } from '../lifecycle';
 import { IObservable, IScope } from '../observation';
 import { hasBind, hasUnbind } from './ast';
-import { IBinding } from './binding';
 import { IConnectableBinding } from './connectable';
 
 const slice = Array.prototype.slice;
 
 export interface Ref extends IConnectableBinding {}
 export class Ref implements IBinding {
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
   public $state: State;
   public $scope: IScope;
 
@@ -21,8 +20,8 @@ export class Ref implements IBinding {
   public target: IObservable;
 
   constructor(sourceExpression: IsBindingBehavior, target: IObservable, locator: IServiceLocator) {
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
     this.$state = State.none;
 
     this.locator = locator;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -89,7 +89,6 @@ export {
   UnaryOperator
 } from './ast';
 export {
-  IBinding,
   Binding
 } from './binding/binding';
 export {
@@ -370,22 +369,13 @@ export {
 export {
   AggregateLifecycleTask,
   CompositionCoordinator,
-  IAttach,
-  IBind,
-  IBindScope,
-  ICachable,
+  IComponent,
+  IBinding,
   IHooks,
   ILifecycle,
-  ILifecycleAttach,
-  ILifecycleBind,
-  ILifecycleBindScope,
-  ILifecycleCache,
-  ILifecycleDetach,
   ILifecycleHooks,
   ILifecycleMount,
   ILifecycleTask,
-  ILifecycleUnbind,
-  ILifecycleUnbindAfterDetach,
   ILifecycleUnmount,
   IMountable,
   IRenderable,
@@ -443,9 +433,8 @@ export {
 export {
   instructionRenderer,
   ensureExpression,
-  addAttachable,
-  addBindable,
-  addEarlyBindable
+  addComponent,
+  addBinding
 } from './renderer';
 export {
   CompiledTemplate,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -444,7 +444,8 @@ export {
   instructionRenderer,
   ensureExpression,
   addAttachable,
-  addBindable
+  addBindable,
+  addEarlyBindable
 } from './renderer';
 export {
   CompiledTemplate,

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -33,7 +33,14 @@ export interface IState {
  */
 export interface IRenderable<T extends INode = INode> extends IState {
   /**
-   * The Bindings, Views, CustomElements, CustomAttributes and other bindable components that belong to this instance.
+   * The Bindings that belong to this instance and need to be bound before the `binding()` hook is invoked.
+   */
+  $earlyBindableHead?: IBindScope;
+  $earlyBindableTail?: IBindScope;
+
+  /**
+   * The Views, CustomElements, CustomAttributes and other bindable components that belong to this instance
+   * and should be invoked after the `binding()` hook of this instance but before the `bound()` lifecycle starts.
    */
   $bindableHead?: IBindScope;
   $bindableTail?: IBindScope;

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -6,7 +6,6 @@ import {
   InterfaceSymbol,
   IResolver,
   IServiceLocator,
-  Omit,
   PLATFORM,
   Registration,
   Tracer
@@ -28,28 +27,31 @@ export interface IState {
   $lifecycle?: ILifecycle;
 }
 
+export interface IBinding {
+  readonly $nextBinding: IBinding | null;
+  readonly $prevBinding: IBinding | null;
+  readonly locator: IServiceLocator;
+  readonly $scope: IScope | null;
+  readonly $state: State;
+  $bind(flags: LifecycleFlags, scope: IScope): void;
+  $unbind(flags: LifecycleFlags): void;
+}
+
 /**
  * An object containing the necessary information to render something for display.
  */
 export interface IRenderable<T extends INode = INode> extends IState {
   /**
-   * The Bindings that belong to this instance and need to be bound before the `binding()` hook is invoked.
+   * The Bindings that belong to this instance.
    */
-  $earlyBindableHead?: IBindScope;
-  $earlyBindableTail?: IBindScope;
+  $bindingHead?: IBinding;
+  $bindingTail?: IBinding;
 
   /**
-   * The Views, CustomElements, CustomAttributes and other bindable components that belong to this instance
-   * and should be invoked after the `binding()` hook of this instance but before the `bound()` lifecycle starts.
+   * The Views, CustomElements, CustomAttributes and other components that are children of this instance.
    */
-  $bindableHead?: IBindScope;
-  $bindableTail?: IBindScope;
-
-  /**
-   * The Views, CustomElements, CustomAttributes and other attachable components that belong to this instance.
-   */
-  $attachableHead?: IAttach;
-  $attachableTail?: IAttach;
+  $componentHead?: IComponent;
+  $componentTail?: IComponent;
 
   /**
    * The (dependency) context of this instance.
@@ -81,7 +83,7 @@ export interface IRenderContext<T extends INode = INode> extends IServiceLocator
   beginComponentOperation(renderable: IRenderable<T>, target: object, instruction: Immutable<ITargetedInstruction>, factory?: IViewFactory<T>, parts?: TemplatePartDefinitions, location?: IRenderLocation<T>, locationIsContainer?: boolean): IDisposable;
 }
 
-export interface IView<T extends INode = INode> extends IBindScope, IRenderable<T>, IAttach, IMountable {
+export interface IView<T extends INode = INode> extends IRenderable<T>, IComponent, IMountable {
   readonly cache: IViewCache<T>;
   readonly isFree: boolean;
   readonly location: IRenderLocation<T>;
@@ -306,23 +308,15 @@ export interface ILifecycleHooks extends IHooks, IState {
   caching?(flags: LifecycleFlags): void;
 }
 
-export interface ILifecycleCache {
-  $cache(flags: LifecycleFlags): void;
-}
-
-export interface ICachable extends ILifecycleCache { }
-
-export interface ILifecycleAttach {
+export interface IComponent {
+  readonly $nextComponent: IComponent | null;
+  readonly $prevComponent: IComponent | null;
+  $nextUnbindAfterDetach: IComponent | null;
+  $bind(flags: LifecycleFlags, scope?: IScope): void;
+  $unbind(flags: LifecycleFlags): void;
   $attach(flags: LifecycleFlags): void;
-}
-
-export interface ILifecycleDetach {
   $detach(flags: LifecycleFlags): void;
-}
-
-export interface IAttach extends ILifecycleAttach, ILifecycleDetach, ICachable {
-  /** @internal */$nextAttach: IAttach;
-  /** @internal */$prevAttach: IAttach;
+  $cache(flags: LifecycleFlags): void;
 }
 
 export interface ILifecycleMount {
@@ -347,32 +341,6 @@ export interface ILifecycleUnmount {
   $unmount(flags: LifecycleFlags): boolean | void;
 }
 export interface IMountable extends ILifecycleMount, ILifecycleUnmount { }
-
-export interface ILifecycleUnbind {
-  $state?: State;
-  $unbind(flags: LifecycleFlags): void;
-}
-
-export interface ILifecycleUnbindAfterDetach extends ILifecycleUnbind {
-  $nextUnbindAfterDetach?: ILifecycleUnbindAfterDetach;
-}
-
-export interface ILifecycleBind {
-  $state?: State;
-  $bind(flags: LifecycleFlags, scope?: IScope): void;
-}
-
-export interface ILifecycleBindScope {
-  $state?: State;
-  $bind(flags: LifecycleFlags, scope: IScope): void;
-}
-
-export interface IBind extends ILifecycleBind, ILifecycleUnbind {
-  /** @internal */$nextBind: IBindScope;
-  /** @internal */$prevBind: IBindScope;
-}
-
-export interface IBindScope extends Omit<IBind, '$bind'>, ILifecycleBindScope { }
 
 const marker = Object.freeze(Object.create(null));
 
@@ -575,7 +543,7 @@ export interface ILifecycle {
    * This method is idempotent; adding the same item more than once has the same effect as
    * adding it once.
    */
-  enqueueUnbindAfterDetach(requestor: ILifecycleUnbind): void;
+  enqueueUnbindAfterDetach(requestor: IComponent): void;
 
   /**
    * Close / shrink a detach batch for invoking queued `$unmount` and `detached` callbacks.
@@ -625,8 +593,8 @@ export class Lifecycle implements ILifecycle {
   /** @internal */public detachedHead: ILifecycleHooks;
   /** @internal */public detachedTail: ILifecycleHooks;
 
-  /** @internal */public unbindAfterDetachHead: ILifecycleUnbindAfterDetach;
-  /** @internal */public unbindAfterDetachTail: ILifecycleUnbindAfterDetach;
+  /** @internal */public unbindAfterDetachHead: IComponent;
+  /** @internal */public unbindAfterDetachTail: IComponent;
 
   /** @internal */public unboundHead: ILifecycleHooks;
   /** @internal */public unboundTail: ILifecycleHooks;
@@ -664,8 +632,8 @@ export class Lifecycle implements ILifecycle {
   /** @internal */public $unmount: ILifecycleUnmount['$unmount'];
   /** @internal */public $nextDetached: ILifecycleHooks;
   /** @internal */public detached: ILifecycleHooks['detached'];
-  /** @internal */public $nextUnbindAfterDetach: ILifecycleUnbindAfterDetach;
-  /** @internal */public $unbind: ILifecycleUnbindAfterDetach['$unbind'];
+  /** @internal */public $nextUnbindAfterDetach: IComponent;
+  /** @internal */public $unbind: IComponent['$unbind'];
   /** @internal */public $nextUnbound: ILifecycleHooks;
   /** @internal */public unbound: ILifecycleHooks['unbound'];
 
@@ -701,8 +669,8 @@ export class Lifecycle implements ILifecycle {
     this.detachedHead = this; //LOL
     this.detachedTail = this;
 
-    this.unbindAfterDetachHead = this;
-    this.unbindAfterDetachTail = this;
+    this.unbindAfterDetachHead = this as unknown as IComponent;
+    this.unbindAfterDetachTail = this as unknown as IComponent;
 
     this.unboundHead = this;
     this.unboundTail = this;
@@ -1147,7 +1115,7 @@ export class Lifecycle implements ILifecycle {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  public enqueueUnbindAfterDetach(requestor: ILifecycleUnbindAfterDetach): void {
+  public enqueueUnbindAfterDetach(requestor: IComponent): void {
     if (Tracer.enabled) { Tracer.enter('Lifecycle.enqueueUnbindAfterDetach', slice.call(arguments)); }
     // This method is idempotent; adding the same item more than once has the same effect as
     // adding it once.
@@ -1216,7 +1184,7 @@ export class Lifecycle implements ILifecycle {
       this.beginUnbind();
       this.unbindAfterDetachCount = 0;
       let currentUnbind = this.unbindAfterDetachHead.$nextUnbindAfterDetach;
-      this.unbindAfterDetachHead = this.unbindAfterDetachTail = this;
+      this.unbindAfterDetachHead = this.unbindAfterDetachTail = this as unknown as IComponent;
       let nextUnbind: typeof currentUnbind;
 
       do {

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -1,6 +1,6 @@
 import { IIndexable, Reporter, StrictPrimitive, Tracer } from '@aurelia/kernel';
 import { LifecycleFlags } from '../flags';
-import { IBindScope } from '../lifecycle';
+import { IBinding } from '../lifecycle';
 import {
   IBindingContext,
   IOverrideContext,
@@ -87,7 +87,7 @@ export class BindingContext implements IBindingContext {
     return bc;
   }
 
-  public static get(scope: IScope, name: string, ancestor: number, flags: LifecycleFlags): IBindingContext | IOverrideContext | IBindScope {
+  public static get(scope: IScope, name: string, ancestor: number, flags: LifecycleFlags): IBindingContext | IOverrideContext | IBinding {
     if (Tracer.enabled) { Tracer.enter('BindingContext.get', slice.call(arguments)); }
     if (scope === undefined) {
       throw Reporter.error(RuntimeError.UndefinedScope);
@@ -159,13 +159,13 @@ export class BindingContext implements IBindingContext {
 }
 
 export class Scope implements IScope {
-  public bindingContext: IBindingContext | IBindScope;
+  public bindingContext: IBindingContext | IBinding;
   public overrideContext: IOverrideContext;
   // parentScope is strictly internal API and mainly for replaceable template controller.
   // NOT intended for regular scope traversal!
   /** @internal */public readonly parentScope: IScope | null;
 
-  private constructor(bindingContext: IBindingContext | IBindScope, overrideContext: IOverrideContext) {
+  private constructor(bindingContext: IBindingContext | IBinding, overrideContext: IOverrideContext) {
     this.bindingContext = bindingContext;
     this.overrideContext = overrideContext;
     this.parentScope = null;
@@ -178,7 +178,7 @@ export class Scope implements IScope {
    * or when you simply want to prevent binding expressions from traversing up the scope.
    * @param bc The `BindingContext` to back the `Scope` with.
    */
-  public static create(flags: LifecycleFlags, bc: IBindingContext | IBindScope): Scope;
+  public static create(flags: LifecycleFlags, bc: IBindingContext | IBinding): Scope;
   /**
    * Create a new `Scope` backed by the provided `BindingContext` and `OverrideContext`.
    *
@@ -188,7 +188,7 @@ export class Scope implements IScope {
    * during binding, it will traverse up via the `parentOverrideContext` of the `OverrideContext` until
    * it finds the property.
    */
-  public static create(flags: LifecycleFlags, bc: IBindingContext | IBindScope, oc: IOverrideContext): Scope;
+  public static create(flags: LifecycleFlags, bc: IBindingContext | IBinding, oc: IOverrideContext): Scope;
   /**
    * Create a new `Scope` backed by the provided `BindingContext` and `OverrideContext`.
    *
@@ -198,8 +198,8 @@ export class Scope implements IScope {
    * @param bc The `BindingContext` to back the `Scope` with.
    * @param oc null. This overload is functionally equivalent to not passing this argument at all.
    */
-  public static create(flags: LifecycleFlags, bc: IBindingContext | IBindScope, oc: null): Scope;
-  public static create(flags: LifecycleFlags, bc: IBindingContext | IBindScope, oc?: IOverrideContext | null): Scope {
+  public static create(flags: LifecycleFlags, bc: IBindingContext | IBinding, oc: null): Scope;
+  public static create(flags: LifecycleFlags, bc: IBindingContext | IBinding, oc?: IOverrideContext | null): Scope {
     if (Tracer.enabled) { Tracer.enter('Scope.create', slice.call(arguments)); }
     if (Tracer.enabled) { Tracer.leave(); }
     return new Scope(bc, oc === null || oc === undefined ? OverrideContext.create(flags, bc, oc) : oc);
@@ -214,7 +214,7 @@ export class Scope implements IScope {
     return new Scope(oc.bindingContext, oc);
   }
 
-  public static fromParent(flags: LifecycleFlags, ps: IScope | null, bc: IBindingContext | IBindScope): Scope {
+  public static fromParent(flags: LifecycleFlags, ps: IScope | null, bc: IBindingContext | IBinding): Scope {
     if (Tracer.enabled) { Tracer.enter('Scope.fromParent', slice.call(arguments)); }
     if (ps === null || ps === undefined) {
       throw Reporter.error(RuntimeError.NilParentScope);
@@ -228,16 +228,16 @@ export class OverrideContext implements IOverrideContext {
   [key: string]: ObservedCollection | StrictPrimitive | IIndexable;
 
   public readonly $synthetic: true;
-  public bindingContext: IBindingContext | IBindScope;
+  public bindingContext: IBindingContext | IBinding;
   public parentOverrideContext: IOverrideContext | null;
 
-  private constructor(bindingContext: IBindingContext | IBindScope, parentOverrideContext: IOverrideContext | null) {
+  private constructor(bindingContext: IBindingContext | IBinding, parentOverrideContext: IOverrideContext | null) {
     this.$synthetic = true;
     this.bindingContext = bindingContext;
     this.parentOverrideContext = parentOverrideContext;
   }
 
-  public static create(flags: LifecycleFlags, bc: IBindingContext | IBindScope, poc: IOverrideContext | null): OverrideContext {
+  public static create(flags: LifecycleFlags, bc: IBindingContext | IBinding, poc: IOverrideContext | null): OverrideContext {
     if (Tracer.enabled) { Tracer.enter('OverrideContext.create', slice.call(arguments)); }
     if (Tracer.enabled) { Tracer.leave(); }
     return new OverrideContext(bc, poc === undefined ? null : poc);

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -7,7 +7,8 @@ import {
   IResolver,
   Registration,
   Reporter,
-  Tracer
+  Tracer,
+  Writable
 } from '@aurelia/kernel';
 import { Binding } from './binding/binding';
 import { Call } from './binding/call';
@@ -37,10 +38,10 @@ import {
 import { IDOM, INode } from './dom';
 import { BindingMode, LifecycleFlags } from './flags';
 import {
-  IAttach,
-  IBindScope,
+  IComponent,
   IRenderable,
   IRenderContext,
+  IBinding,
 } from './lifecycle';
 import { IObserverLocator } from './observation/observer-locator';
 import {
@@ -140,42 +141,29 @@ export function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TF
   return srcOrExpr as Exclude<TFrom, string>;
 }
 
-export function addEarlyBindable(renderable: IRenderable, bindable: IBindScope): void {
-  if (Tracer.enabled) { Tracer.enter('addEarlyBindable', slice.call(arguments)); }
-  bindable.$prevBind = renderable.$earlyBindableTail;
-  bindable.$nextBind = null;
-  if (renderable.$earlyBindableTail === null) {
-    renderable.$earlyBindableHead = bindable;
+export function addBinding(renderable: IRenderable, binding: IBinding): void {
+  if (Tracer.enabled) { Tracer.enter('addBinding', slice.call(arguments)); }
+  (binding as Writable<IBinding>).$prevBinding = renderable.$bindingTail;
+  (binding as Writable<IBinding>).$nextBinding = null;
+  if (renderable.$bindingTail === null) {
+    renderable.$bindingHead = binding;
   } else {
-    renderable.$earlyBindableTail.$nextBind = bindable;
+    (renderable.$bindingTail as Writable<IBinding>).$nextBinding = binding;
   }
-  renderable.$earlyBindableTail = bindable;
+  renderable.$bindingTail = binding;
   if (Tracer.enabled) { Tracer.leave(); }
 }
 
-export function addBindable(renderable: IRenderable, bindable: IBindScope): void {
-  if (Tracer.enabled) { Tracer.enter('addBindable', slice.call(arguments)); }
-  bindable.$prevBind = renderable.$bindableTail;
-  bindable.$nextBind = null;
-  if (renderable.$bindableTail === null) {
-    renderable.$bindableHead = bindable;
+export function addComponent(renderable: IRenderable, component: IComponent): void {
+  if (Tracer.enabled) { Tracer.enter('addComponent', slice.call(arguments)); }
+  (component as Writable<IComponent>).$prevComponent = renderable.$componentTail;
+  (component as Writable<IComponent>).$nextComponent = null;
+  if (renderable.$componentTail === null) {
+    renderable.$componentHead = component;
   } else {
-    renderable.$bindableTail.$nextBind = bindable;
+    (renderable.$componentTail as Writable<IComponent>).$nextComponent = component;
   }
-  renderable.$bindableTail = bindable;
-  if (Tracer.enabled) { Tracer.leave(); }
-}
-
-export function addAttachable(renderable: IRenderable, attachable: IAttach): void {
-  if (Tracer.enabled) { Tracer.enter('addAttachable', slice.call(arguments)); }
-  attachable.$prevAttach = renderable.$attachableTail;
-  attachable.$nextAttach = null;
-  if (renderable.$attachableTail === null) {
-    renderable.$attachableHead = attachable;
-  } else {
-    renderable.$attachableTail.$nextAttach = attachable;
-  }
-  renderable.$attachableTail = attachable;
+  renderable.$componentTail = component;
   if (Tracer.enabled) { Tracer.leave(); }
 }
 
@@ -218,8 +206,7 @@ export class CustomElementRenderer implements IInstructionRenderer {
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
-    addBindable(renderable, component);
-    addAttachable(renderable, component);
+    addComponent(renderable, component);
 
     operation.dispose();
     if (Tracer.enabled) { Tracer.leave(); }
@@ -252,8 +239,7 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
-    addBindable(renderable, component);
-    addAttachable(renderable, component);
+    addComponent(renderable, component);
 
     operation.dispose();
     if (Tracer.enabled) { Tracer.leave(); }
@@ -283,7 +269,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     component.$hydrate(flags, this.renderingEngine);
 
     if (instruction.link) {
-      (component as ICustomAttribute & { link(attachableTail: IAttach): void}).link(renderable.$attachableTail);
+      (component as ICustomAttribute & { link(componentTail: IComponent): void}).link(renderable.$componentTail);
     }
 
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
@@ -291,8 +277,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
-    addBindable(renderable, component);
-    addAttachable(renderable, component);
+    addComponent(renderable, component);
 
     operation.dispose();
     if (Tracer.enabled) { Tracer.leave(); }
@@ -321,8 +306,8 @@ export class LetElementRenderer implements IInstructionRenderer {
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       const childInstruction = childInstructions[i];
       const expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
-      const bindable = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
-      addEarlyBindable(renderable, bindable);
+      const binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
+      addBinding(renderable, binding);
     }
     if (Tracer.enabled) { Tracer.leave(); }
   }
@@ -345,8 +330,8 @@ export class CallBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: ICallBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('CallBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
-    const bindable = new Call(expr, target, instruction.to, this.observerLocator, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Call(expr, target, instruction.to, this.observerLocator, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -366,8 +351,8 @@ export class RefBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IRefBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('RefBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
-    const bindable = new Ref(expr, target, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Ref(expr, target, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -388,14 +373,14 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IInterpolationInstruction): void {
     if (Tracer.enabled) { Tracer.enter('InterpolationBindingRenderer.render', slice.call(arguments)); }
-    let bindable: MultiInterpolationBinding | InterpolationBinding;
+    let binding: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
     if (expr.isMulti) {
-      bindable = new MultiInterpolationBinding(this.observerLocator, expr, target, instruction.to, BindingMode.toView, context);
+      binding = new MultiInterpolationBinding(this.observerLocator, expr, target, instruction.to, BindingMode.toView, context);
     } else {
-      bindable = new InterpolationBinding(expr.firstExpression, expr, target, instruction.to, BindingMode.toView, this.observerLocator, context, true);
+      binding = new InterpolationBinding(expr.firstExpression, expr, target, instruction.to, BindingMode.toView, this.observerLocator, context, true);
     }
-    addEarlyBindable(renderable, bindable);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -417,8 +402,8 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IPropertyBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('PropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
-    const bindable = new Binding(expr, target, instruction.to, instruction.mode, this.observerLocator, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Binding(expr, target, instruction.to, instruction.mode, this.observerLocator, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -440,8 +425,8 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: INode, instruction: IIteratorBindingInstruction): void {
     if (Tracer.enabled) { Tracer.enter('IteratorBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
-    const bindable = new Binding(expr, target, instruction.to, BindingMode.toView, this.observerLocator, context);
-    addEarlyBindable(renderable, bindable);
+    const binding = new Binding(expr, target, instruction.to, BindingMode.toView, this.observerLocator, context);
+    addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -140,6 +140,19 @@ export function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TF
   return srcOrExpr as Exclude<TFrom, string>;
 }
 
+export function addEarlyBindable(renderable: IRenderable, bindable: IBindScope): void {
+  if (Tracer.enabled) { Tracer.enter('addEarlyBindable', slice.call(arguments)); }
+  bindable.$prevBind = renderable.$earlyBindableTail;
+  bindable.$nextBind = null;
+  if (renderable.$earlyBindableTail === null) {
+    renderable.$earlyBindableHead = bindable;
+  } else {
+    renderable.$earlyBindableTail.$nextBind = bindable;
+  }
+  renderable.$earlyBindableTail = bindable;
+  if (Tracer.enabled) { Tracer.leave(); }
+}
+
 export function addBindable(renderable: IRenderable, bindable: IBindScope): void {
   if (Tracer.enabled) { Tracer.enter('addBindable', slice.call(arguments)); }
   bindable.$prevBind = renderable.$bindableTail;
@@ -309,7 +322,7 @@ export class LetElementRenderer implements IInstructionRenderer {
       const childInstruction = childInstructions[i];
       const expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
       const bindable = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
-      addBindable(renderable, bindable);
+      addEarlyBindable(renderable, bindable);
     }
     if (Tracer.enabled) { Tracer.leave(); }
   }
@@ -333,7 +346,7 @@ export class CallBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('CallBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
     const bindable = new Call(expr, target, instruction.to, this.observerLocator, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -354,7 +367,7 @@ export class RefBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('RefBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
     const bindable = new Ref(expr, target, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -382,7 +395,7 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
     } else {
       bindable = new InterpolationBinding(expr.firstExpression, expr, target, instruction.to, BindingMode.toView, this.observerLocator, context, true);
     }
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -405,7 +418,7 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('PropertyBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const bindable = new Binding(expr, target, instruction.to, instruction.mode, this.observerLocator, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }
@@ -428,7 +441,7 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('IteratorBindingRenderer.render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
     const bindable = new Binding(expr, target, instruction.to, BindingMode.toView, this.observerLocator, context);
-    addBindable(renderable, bindable);
+    addEarlyBindable(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/src/resources/binding-behavior.ts
+++ b/packages/runtime/src/resources/binding-behavior.ts
@@ -8,8 +8,8 @@ import {
   Registration,
   Writable
 } from '@aurelia/kernel';
-import { IBinding } from '../binding/binding';
 import { LifecycleFlags } from '../flags';
+import { IBinding } from '../lifecycle';
 import { IScope } from '../observation';
 
 export interface IBindingBehavior {

--- a/packages/runtime/src/resources/binding-behaviors/debounce.ts
+++ b/packages/runtime/src/resources/binding-behaviors/debounce.ts
@@ -1,6 +1,7 @@
 import { IRegistry, PLATFORM } from '@aurelia/kernel';
-import { Binding, IBinding } from '../../binding/binding';
+import { Binding } from '../../binding/binding';
 import { BindingMode, LifecycleFlags } from '../../flags';
+import { IBinding } from '../../lifecycle';
 import { IScope } from '../../observation';
 import { BindingBehaviorResource } from '../binding-behavior';
 

--- a/packages/runtime/src/resources/binding-behaviors/throttle.ts
+++ b/packages/runtime/src/resources/binding-behaviors/throttle.ts
@@ -1,6 +1,7 @@
 import { IRegistry, PLATFORM } from '@aurelia/kernel';
-import { Binding, IBinding } from '../../binding/binding';
+import { Binding } from '../../binding/binding';
 import { BindingMode, LifecycleFlags } from '../../flags';
+import { IBinding } from '../../lifecycle';
 import { IScope } from '../../observation';
 import { BindingBehaviorResource } from '../binding-behavior';
 

--- a/packages/runtime/src/resources/custom-attribute.ts
+++ b/packages/runtime/src/resources/custom-attribute.ts
@@ -19,10 +19,9 @@ import {
 import { INode } from '../dom';
 import { BindingMode, Hooks, LifecycleFlags } from '../flags';
 import {
-  IAttach,
-  IBindScope,
+  IBinding,
+  IComponent,
   ILifecycleHooks,
-  ILifecycleUnbindAfterDetach,
   IRenderable
 } from '../lifecycle';
 import { IChangeTracker } from '../observation';
@@ -49,9 +48,7 @@ export interface ICustomAttributeType<T extends INode = INode> extends
 export interface ICustomAttribute<T extends INode = INode> extends
   Partial<IChangeTracker>,
   ILifecycleHooks,
-  IBindScope,
-  ILifecycleUnbindAfterDetach,
-  IAttach,
+  IComponent,
   IRenderable<T> {
 
   $hydrate(flags: LifecycleFlags, renderingEngine: IRenderingEngine): void;
@@ -142,10 +139,8 @@ function define<T extends Constructable>(this: ICustomAttributeResource, nameOrD
   proto.$unbind = $unbindAttribute;
   proto.$cache = $cacheAttribute;
 
-  proto.$prevBind = null;
-  proto.$nextBind = null;
-  proto.$prevAttach = null;
-  proto.$nextAttach = null;
+  proto.$prevComponent = null;
+  proto.$nextComponent = null;
 
   proto.$nextUnbindAfterDetach = null;
 

--- a/packages/runtime/src/resources/custom-attributes/if.ts
+++ b/packages/runtime/src/resources/custom-attributes/if.ts
@@ -1,7 +1,7 @@
 import { Constructable, InterfaceSymbol, IRegistry } from '@aurelia/kernel';
 import { AttributeDefinition, IAttributeDefinition } from '../../definitions';
 import { INode, IRenderLocation } from '../../dom';
-import { LifecycleFlags } from '../../flags';
+import { LifecycleFlags, State } from '../../flags';
 import { CompositionCoordinator, IView, IViewFactory } from '../../lifecycle';
 import { ProxyObserver } from '../../observation/proxy-observer';
 import { bindable } from '../../templating/bindable';
@@ -71,14 +71,16 @@ export class If<T extends INode = INode> implements If<T> {
   }
 
   public valueChanged(newValue: boolean, oldValue: boolean, flags: LifecycleFlags): void {
-    if (ProxyObserver.isProxy(this)) {
-      flags |= LifecycleFlags.useProxies;
-    }
-    if (flags & LifecycleFlags.fromFlush) {
-      const view = this.updateView(flags);
-      this.coordinator.compose(view, flags);
-    } else {
-      this.$lifecycle.enqueueFlush(this).catch(error => { throw error; });
+    if (this.$state & (State.isBound | State.isBinding)) {
+      if (ProxyObserver.isProxy(this)) {
+        flags |= LifecycleFlags.useProxies;
+      }
+      if (flags & LifecycleFlags.fromFlush) {
+        const view = this.updateView(flags);
+        this.coordinator.compose(view, flags);
+      } else {
+        this.$lifecycle.enqueueFlush(this).catch(error => { throw error; });
+      }
     }
   }
 

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -51,13 +51,13 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
 
   public binding(flags: LifecycleFlags): void {
     this.checkCollectionObserver(flags);
-    let current = this.renderable.$earlyBindableHead as Binding;
+    let current = this.renderable.$bindingHead as Binding;
     while (current !== null) {
       if (ProxyObserver.getRawIfProxy(current.target) === ProxyObserver.getRawIfProxy(this) && current.targetProperty === 'items') {
         this.forOf = current.sourceExpression as ForOfStatement;
         break;
       }
-      current = current.$nextBind as Binding;
+      current = current.$nextBinding as Binding;
     }
     this.local = this.forOf.declaration.evaluate(flags, this.$scope, null) as string;
 

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -51,10 +51,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
 
   public binding(flags: LifecycleFlags): void {
     this.checkCollectionObserver(flags);
-  }
-
-  public bound(flags: LifecycleFlags): void {
-    let current = this.renderable.$bindableHead as Binding;
+    let current = this.renderable.$earlyBindableHead as Binding;
     while (current !== null) {
       if (ProxyObserver.getRawIfProxy(current.target) === ProxyObserver.getRawIfProxy(this) && current.targetProperty === 'items') {
         this.forOf = current.sourceExpression as ForOfStatement;
@@ -85,7 +82,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
     }
   }
 
-  public unbound(flags: LifecycleFlags): void {
+  public unbinding(flags: LifecycleFlags): void {
     this.checkCollectionObserver(flags);
 
     const { views } = this;
@@ -113,7 +110,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
       flags |= LifecycleFlags.useProxies;
     }
     const { views, $lifecycle } = this;
-    if (this.$state & State.isBound) {
+    if (this.$state & (State.isBound | State.isBinding)) {
       const { local, $scope, factory, forOf, items } = this;
       const oldLength = views.length;
       const newLength = forOf.count(items);
@@ -165,7 +162,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
       $lifecycle.endBind(flags);
     }
 
-    if (this.$state & State.isAttached) {
+    if (this.$state & (State.isAttached | State.isAttaching)) {
       const { location } = this;
       $lifecycle.beginAttach();
       if (indexMap === null) {

--- a/packages/runtime/src/resources/custom-attributes/with.ts
+++ b/packages/runtime/src/resources/custom-attributes/with.ts
@@ -35,7 +35,7 @@ export class With<T extends INode = INode> implements With<T>  {
   }
 
   public valueChanged(this: With): void {
-    if (this.$state & State.isBound) {
+    if (this.$state & (State.isBound | State.isBinding)) {
       this.bindChild(LifecycleFlags.fromBindableHandler);
     }
   }

--- a/packages/runtime/src/resources/custom-attributes/with.ts
+++ b/packages/runtime/src/resources/custom-attributes/with.ts
@@ -2,7 +2,7 @@ import { InterfaceSymbol, IRegistry } from '@aurelia/kernel';
 import { AttributeDefinition, IAttributeDefinition } from '../../definitions';
 import { INode, IRenderLocation } from '../../dom';
 import { LifecycleFlags, State } from '../../flags';
-import { IBindScope, IView, IViewFactory } from '../../lifecycle';
+import { IBinding, IView, IViewFactory } from '../../lifecycle';
 import { IBindingContext } from '../../observation';
 import { Scope } from '../../observation/binding-context';
 import { bindable } from '../../templating/bindable';
@@ -18,7 +18,7 @@ export class With<T extends INode = INode> implements With<T>  {
   public static readonly description: AttributeDefinition;
 
   // TODO: this type is incorrect (it can be any user-provided object), need to fix and double check Scope.
-  @bindable public value: IBindScope | IBindingContext;
+  @bindable public value: IBinding | IBindingContext;
 
   private readonly currentView: IView<T>;
   private readonly factory: IViewFactory<T>;

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -159,6 +159,8 @@ function define<T extends Constructable>(this: ICustomElementResource, nameOrDef
   proto.$scope = null;
   proto.$hooks = 0;
 
+  proto.$earlyBindableHead = null;
+  proto.$earlyBindableTail = null;
   proto.$bindableHead = null;
   proto.$bindableTail = null;
   proto.$attachableHead = null;

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -21,10 +21,8 @@ import {
 import { IDOM, INode, INodeSequence, IRenderLocation } from '../dom';
 import { Hooks, LifecycleFlags } from '../flags';
 import {
-  IAttach,
-  IBind,
+  IComponent,
   ILifecycleHooks,
-  ILifecycleUnbindAfterDetach,
   IMountable,
   IRenderable,
   IRenderContext
@@ -83,9 +81,7 @@ export interface ICustomElement<T extends INode = INode> extends
   Partial<IChangeTracker>,
   ILifecycleHooks,
   ILifecycleRender,
-  IBind,
-  ILifecycleUnbindAfterDetach,
-  IAttach,
+  IComponent,
   IMountable,
   IRenderable<T> {
 
@@ -149,22 +145,18 @@ function define<T extends Constructable>(this: ICustomElementResource, nameOrDef
   proto.$unbind = $unbindElement;
   proto.$cache = $cacheElement;
 
-  proto.$prevBind = null;
-  proto.$nextBind = null;
-  proto.$prevAttach = null;
-  proto.$nextAttach = null;
+  proto.$prevComponent = null;
+  proto.$nextComponent = null;
 
   proto.$nextUnbindAfterDetach = null;
 
   proto.$scope = null;
   proto.$hooks = 0;
 
-  proto.$earlyBindableHead = null;
-  proto.$earlyBindableTail = null;
-  proto.$bindableHead = null;
-  proto.$bindableTail = null;
-  proto.$attachableHead = null;
-  proto.$attachableTail = null;
+  proto.$bindingHead = null;
+  proto.$bindingTail = null;
+  proto.$componentHead = null;
+  proto.$componentTail = null;
 
   proto.$mount = $mountElement;
   proto.$unmount = $unmountElement;

--- a/packages/runtime/src/templating/lifecycle-attach.ts
+++ b/packages/runtime/src/templating/lifecycle-attach.ts
@@ -1,9 +1,9 @@
 import { Profiler, Tracer, Writable } from '@aurelia/kernel';
 import { Hooks, LifecycleFlags, State } from '../flags';
-import { IAttach, ILifecycleHooks, IMountable, IRenderable, IView } from '../lifecycle';
+import { IComponent, ILifecycleHooks, IMountable, IRenderable, IView } from '../lifecycle';
 import { ICustomElement } from '../resources/custom-element';
 
-interface IAttachable extends IRenderable, ILifecycleHooks, IAttach { }
+interface IAttachable extends IRenderable, ILifecycleHooks, IComponent { }
 
 const slice = Array.prototype.slice;
 
@@ -65,10 +65,10 @@ export function $attachElement(this: Writable<IAttachable & IMountable>, flags: 
     this.attaching(flags);
   }
 
-  let current = this.$attachableHead;
+  let current = this.$componentHead;
   while (current !== null) {
     current.$attach(flags);
-    current = current.$nextAttach;
+    current = current.$nextComponent;
   }
 
   lifecycle.enqueueMount(this);
@@ -96,10 +96,10 @@ export function $attachView(this: Writable<IAttachable & IMountable>, flags: Lif
   this.$state |= State.isAttaching;
   flags |= LifecycleFlags.fromAttach;
 
-  let current = this.$attachableHead;
+  let current = this.$componentHead;
   while (current !== null) {
     current.$attach(flags);
-    current = current.$nextAttach;
+    current = current.$nextComponent;
   }
 
   this.$lifecycle.enqueueMount(this);
@@ -161,10 +161,10 @@ export function $detachElement(this: Writable<IAttachable & IMountable>, flags: 
       this.detaching(flags);
     }
 
-    let current = this.$attachableTail;
+    let current = this.$componentTail;
     while (current !== null) {
       current.$detach(flags);
-      current = current.$prevAttach;
+      current = current.$prevComponent;
     }
 
     // remove isAttached and isDetaching flags
@@ -194,10 +194,10 @@ export function $detachView(this: Writable<IAttachable & IMountable>, flags: Lif
       flags |= LifecycleFlags.parentUnmountQueued;
     }
 
-    let current = this.$attachableTail;
+    let current = this.$componentTail;
     while (current !== null) {
       current.$detach(flags);
-      current = current.$prevAttach;
+      current = current.$prevComponent;
     }
 
     // remove isAttached and isDetaching flags
@@ -224,10 +224,10 @@ export function $cacheElement(this: Writable<IAttachable>, flags: LifecycleFlags
     this.caching(flags);
   }
 
-  let current = this.$attachableTail;
+  let current = this.$componentTail;
   while (current !== null) {
     current.$cache(flags);
-    current = current.$prevAttach;
+    current = current.$prevComponent;
   }
   if (Tracer.enabled) { Tracer.leave(); }
 }
@@ -236,10 +236,10 @@ export function $cacheElement(this: Writable<IAttachable>, flags: LifecycleFlags
 export function $cacheView(this: Writable<IAttachable>, flags: LifecycleFlags): void {
   if (Tracer.enabled) { Tracer.enter(`${this['constructor'].name}.$cacheView`, slice.call(arguments)); }
   flags |= LifecycleFlags.fromCache;
-  let current = this.$attachableTail;
+  let current = this.$componentTail;
   while (current !== null) {
     current.$cache(flags);
-    current = current.$prevAttach;
+    current = current.$prevComponent;
   }
 }
 

--- a/packages/runtime/src/templating/lifecycle-bind.ts
+++ b/packages/runtime/src/templating/lifecycle-bind.ts
@@ -78,11 +78,17 @@ export function $bindElement(this: Writable<IBindable>, flags: LifecycleFlags, p
     lifecycle.enqueueBound(this);
   }
 
+  let current = this.$earlyBindableHead;
+  while (current !== null) {
+    current.$bind(flags, scope);
+    current = current.$nextBind;
+  }
+
   if (hooks & Hooks.hasBinding) {
     this.binding(flags);
   }
 
-  let current = this.$bindableHead;
+  current = this.$bindableHead;
   while (current !== null) {
     current.$bind(flags, scope);
     current = current.$nextBind;
@@ -114,7 +120,14 @@ export function $bindView(this: Writable<IBindable>, flags: LifecycleFlags, scop
   this.$state |= State.isBinding;
 
   this.$scope = scope;
-  let current = this.$bindableHead;
+
+  let current = this.$earlyBindableHead;
+  while (current !== null) {
+    current.$bind(flags, scope);
+    current = current.$nextBind;
+  }
+
+  current = this.$bindableHead;
   while (current !== null) {
     current.$bind(flags, scope);
     current = current.$nextBind;
@@ -170,11 +183,17 @@ export function $unbindElement(this: Writable<IBindable>, flags: LifecycleFlags)
       lifecycle.enqueueUnbound(this);
     }
 
+    let current = this.$earlyBindableTail;
+    while (current !== null) {
+      current.$unbind(flags);
+      current = current.$prevBind;
+    }
+
     if (hooks & Hooks.hasUnbinding) {
       this.unbinding(flags);
     }
 
-    let current = this.$bindableTail;
+    current = this.$bindableTail;
     while (current !== null) {
       current.$unbind(flags);
       current = current.$prevBind;
@@ -199,7 +218,13 @@ export function $unbindView(this: Writable<IBindable>, flags: LifecycleFlags): v
 
     flags |= LifecycleFlags.fromUnbind;
 
-    let current = this.$bindableTail;
+    let current = this.$earlyBindableTail;
+    while (current !== null) {
+      current.$unbind(flags);
+      current = current.$prevBind;
+    }
+
+    current = this.$bindableTail;
     while (current !== null) {
       current.$unbind(flags);
       current = current.$prevBind;

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -2,10 +2,9 @@ import { Reporter, Tracer } from '@aurelia/kernel';
 import { INode, INodeSequence, IRenderLocation } from '../dom';
 import { LifecycleFlags, State } from '../flags';
 import {
-  IAttach,
-  IBindScope,
+  IBinding,
+  IComponent,
   ILifecycle,
-  ILifecycleUnbind,
   IMountable,
   IRenderContext,
   IView,
@@ -15,7 +14,7 @@ import {
 import { IScope } from '../observation';
 import { ITemplate } from '../rendering-engine';
 import { $attachView, $cacheView, $detachView, $mountView, $unmountView } from './lifecycle-attach';
-import { $bindView, $unbindView } from './lifecycle-bind';
+import { $bindView, $lockedBind, $lockedUnbind, $unbindView } from './lifecycle-bind';
 
 const slice = Array.prototype.slice;
 
@@ -24,25 +23,19 @@ export interface View<T extends INode = INode> extends IView<T> {}
 
 /** @internal */
 export class View<T extends INode = INode> implements IView<T> {
-  public $earlyBindableHead: IBindScope;
-  public $earlyBindableTail: IBindScope;
+  public $bindingHead: IBinding;
+  public $bindingTail: IBinding;
 
-  public $bindableHead: IBindScope;
-  public $bindableTail: IBindScope;
+  public $componentHead: IComponent;
+  public $componentTail: IComponent;
 
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
-
-  public $attachableHead: IAttach;
-  public $attachableTail: IAttach;
-
-  public $nextAttach: IAttach;
-  public $prevAttach: IAttach;
+  public $nextComponent: IComponent;
+  public $prevComponent: IComponent;
 
   public $nextMount: IMountable;
   public $nextUnmount: IMountable;
 
-  public $nextUnbindAfterDetach: ILifecycleUnbind;
+  public $nextUnbindAfterDetach: IComponent;
 
   public $state: State;
   public $scope: IScope;
@@ -55,20 +48,17 @@ export class View<T extends INode = INode> implements IView<T> {
   public readonly $lifecycle: ILifecycle;
 
   constructor($lifecycle: ILifecycle, cache: IViewCache<T>) {
-    this.$earlyBindableHead = null;
-    this.$earlyBindableTail = null;
+    this.$bindingHead = null;
+    this.$bindingTail = null;
 
-    this.$bindableHead = null;
-    this.$bindableTail = null;
+    this.$componentHead = null;
+    this.$componentTail = null;
 
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$componentHead = null;
+    this.$componentTail = null;
 
-    this.$attachableHead = null;
-    this.$attachableTail = null;
-
-    this.$nextAttach = null;
-    this.$prevAttach = null;
+    this.$nextComponent = null;
+    this.$prevComponent = null;
 
     this.$nextMount = null;
     this.$nextUnmount = null;
@@ -122,8 +112,8 @@ export class View<T extends INode = INode> implements IView<T> {
   public lockScope(scope: IScope): void {
     if (Tracer.enabled) { Tracer.enter('View.lockScope', slice.call(arguments)); }
     this.$scope = scope;
-    this.$bind = lockedBind;
-    this.$unbind = lockedUnbind;
+    this.$bind = $lockedBind;
+    this.$unbind = $lockedUnbind;
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
@@ -204,45 +194,6 @@ export class ViewFactory<T extends INode = INode> implements IViewFactory<T> {
     }
     return view;
   }
-}
-
-function lockedBind<T extends INode = INode>(this: View<T>, flags: LifecycleFlags): void {
-  if (Tracer.enabled) { Tracer.enter(`View.lockedBind`, slice.call(arguments)); }
-  if (this.$state & State.isBound) {
-    if (Tracer.enabled) { Tracer.leave(); }
-    return;
-  }
-
-  flags |= LifecycleFlags.fromBind;
-  const lockedScope = this.$scope;
-  let current = this.$bindableHead;
-  while (current !== null) {
-    current.$bind(flags, lockedScope);
-    current = current.$nextBind;
-  }
-
-  this.$state |= State.isBound;
-  if (Tracer.enabled) { Tracer.leave(); }
-}
-
-function lockedUnbind<T extends INode = INode>(this: IView<T>, flags: LifecycleFlags): void {
-  if (Tracer.enabled) { Tracer.enter(`View.lockedUnbind`, slice.call(arguments)); }
-  if (this.$state & State.isBound) {
-    // add isUnbinding flag
-    this.$state |= State.isUnbinding;
-
-    flags |= LifecycleFlags.fromUnbind;
-
-    let current = this.$bindableTail;
-    while (current !== null) {
-      current.$unbind(flags);
-      current = current.$prevBind;
-    }
-
-    // remove isBound and isUnbinding flags
-    this.$state &= ~(State.isBound | State.isUnbinding);
-  }
-  if (Tracer.enabled) { Tracer.leave(); }
 }
 
 ((proto: IView): void => {

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -24,6 +24,9 @@ export interface View<T extends INode = INode> extends IView<T> {}
 
 /** @internal */
 export class View<T extends INode = INode> implements IView<T> {
+  public $earlyBindableHead: IBindScope;
+  public $earlyBindableTail: IBindScope;
+
   public $bindableHead: IBindScope;
   public $bindableTail: IBindScope;
 
@@ -52,6 +55,9 @@ export class View<T extends INode = INode> implements IView<T> {
   public readonly $lifecycle: ILifecycle;
 
   constructor($lifecycle: ILifecycle, cache: IViewCache<T>) {
+    this.$earlyBindableHead = null;
+    this.$earlyBindableTail = null;
+
     this.$bindableHead = null;
     this.$bindableTail = null;
 

--- a/packages/runtime/test/_doubles/fake-renderable.ts
+++ b/packages/runtime/test/_doubles/fake-renderable.ts
@@ -5,21 +5,17 @@ export class FakeRenderable implements IRenderable {
   public $nodes: IRenderable['$nodes'] = null;
   public $lifecycle: IRenderable['$lifecycle'] = null;
 
-  public $prevBind: ICustomElement['$prevBind'] = null;
-  public $nextBind: ICustomElement['$nextBind'] = null;
-  public $prevAttach: ICustomElement['$prevAttach'] = null;
-  public $nextAttach: ICustomElement['$nextAttach'] = null;
+  public $prevComponent: ICustomElement['$prevComponent'] = null;
+  public $nextComponent: ICustomElement['$nextComponent'] = null;
 
   public $scope: ICustomElement['$scope'] = null;
   public $hooks: ICustomElement['$hooks'] = 0;
   public $state: ICustomElement['$state'] = 0;
 
-  public $earlyBindableHead: ICustomElement['$earlyBindableHead'] = null;
-  public $earlyBindableTail: ICustomElement['$earlyBindableTail'] = null;
-  public $bindableHead: ICustomElement['$bindableHead'] = null;
-  public $bindableTail: ICustomElement['$bindableTail'] = null;
-  public $attachableHead: ICustomElement['$attachableHead'] = null;
-  public $attachableTail: ICustomElement['$attachableTail'] = null;
+  public $bindingHead: ICustomElement['$bindingHead'] = null;
+  public $bindingTail: ICustomElement['$bindingTail'] = null;
+  public $componentHead: ICustomElement['$componentHead'] = null;
+  public $componentTail: ICustomElement['$componentTail'] = null;
 
   public $nextMount: ICustomElement['$nextMount'] = null;
   public $nextUnmount: ICustomElement['$nextUnmount'] = null;

--- a/packages/runtime/test/_doubles/fake-renderable.ts
+++ b/packages/runtime/test/_doubles/fake-renderable.ts
@@ -14,6 +14,8 @@ export class FakeRenderable implements IRenderable {
   public $hooks: ICustomElement['$hooks'] = 0;
   public $state: ICustomElement['$state'] = 0;
 
+  public $earlyBindableHead: ICustomElement['$earlyBindableHead'] = null;
+  public $earlyBindableTail: ICustomElement['$earlyBindableTail'] = null;
   public $bindableHead: ICustomElement['$bindableHead'] = null;
   public $bindableTail: ICustomElement['$bindableTail'] = null;
   public $attachableHead: ICustomElement['$attachableHead'] = null;

--- a/packages/runtime/test/_doubles/fake-view.ts
+++ b/packages/runtime/test/_doubles/fake-view.ts
@@ -1,8 +1,7 @@
 import {
-  IAttach,
-  IBindScope,
+  IBinding,
+  IComponent,
   ILifecycle,
-  ILifecycleUnbind,
   IMountable,
   INodeSequence,
   IRenderContext,
@@ -16,25 +15,22 @@ import {
 import { AuDOM, AuNode, AuNodeSequence } from '../au-dom';
 
 export class FakeView implements IView<AuNode> {
-  public $earlyBindableHead: IBindScope;
-  public $earlyBindableTail: IBindScope;
+  public $bindingHead: IBinding;
+  public $bindingTail: IBinding;
 
-  public $bindableHead: IBindScope;
-  public $bindableTail: IBindScope;
+  public $nextBinding: IBinding;
+  public $prevBinding: IBinding;
 
-  public $nextBind: IBindScope;
-  public $prevBind: IBindScope;
+  public $componentHead: IComponent;
+  public $componentTail: IComponent;
 
-  public $attachableHead: IAttach;
-  public $attachableTail: IAttach;
-
-  public $nextAttach: IAttach;
-  public $prevAttach: IAttach;
+  public $nextComponent: IComponent;
+  public $prevComponent: IComponent;
 
   public $nextMount: IMountable;
   public $nextUnmount: IMountable;
 
-  public $nextUnbindAfterDetach: ILifecycleUnbind;
+  public $nextUnbindAfterDetach: IComponent;
 
   public $state: State;
   public $scope: IScope;
@@ -47,20 +43,17 @@ export class FakeView implements IView<AuNode> {
   public readonly $lifecycle: ILifecycle;
 
   constructor($lifecycle: ILifecycle) {
-    this.$earlyBindableHead = null;
-    this.$earlyBindableTail = null;
+    this.$bindingHead = null;
+    this.$bindingTail = null;
 
-    this.$bindableHead = null;
-    this.$bindableTail = null;
+    this.$nextBinding = null;
+    this.$prevBinding = null;
 
-    this.$nextBind = null;
-    this.$prevBind = null;
+    this.$componentHead = null;
+    this.$componentTail = null;
 
-    this.$attachableHead = null;
-    this.$attachableTail = null;
-
-    this.$nextAttach = null;
-    this.$prevAttach = null;
+    this.$nextComponent = null;
+    this.$prevComponent = null;
 
     this.$nextMount = null;
     this.$nextUnmount = null;

--- a/packages/runtime/test/_doubles/fake-view.ts
+++ b/packages/runtime/test/_doubles/fake-view.ts
@@ -16,6 +16,9 @@ import {
 import { AuDOM, AuNode, AuNodeSequence } from '../au-dom';
 
 export class FakeView implements IView<AuNode> {
+  public $earlyBindableHead: IBindScope;
+  public $earlyBindableTail: IBindScope;
+
   public $bindableHead: IBindScope;
   public $bindableTail: IBindScope;
 
@@ -44,6 +47,9 @@ export class FakeView implements IView<AuNode> {
   public readonly $lifecycle: ILifecycle;
 
   constructor($lifecycle: ILifecycle) {
+    this.$earlyBindableHead = null;
+    this.$earlyBindableTail = null;
+
     this.$bindableHead = null;
     this.$bindableTail = null;
 

--- a/packages/runtime/test/au-dom.ts
+++ b/packages/runtime/test/au-dom.ts
@@ -13,7 +13,7 @@ import {
 } from '../../jit/src/index';
 import { TargetedInstruction } from '../dist';
 import {
-  addBindable,
+  addBinding,
   Aurelia,
   BasicConfiguration,
   Binding,
@@ -600,7 +600,7 @@ export class AuTextRenderer implements IInstructionRenderer {
       realTarget = target;
     }
     const bindable = new Binding(instruction.from, realTarget, 'textContent', BindingMode.toView, this.observerLocator, context);
-    addBindable(renderable, bindable);
+    addBinding(renderable, bindable);
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/test/renderer.spec.ts
+++ b/packages/runtime/test/renderer.spec.ts
@@ -34,7 +34,17 @@ describe('Renderer', () => {
     const container = AuDOMConfiguration.createContainer();
     IExpressionParserRegistration.register(container as any);
     const dom = container.get(IDOM);
-    const renderable: IRenderable = { $bindableHead: null, $bindableTail: null, $attachableHead: null, $attachableTail: null, $context: null, $nodes: null, $scope: null };
+    const renderable: IRenderable = {
+      $earlyBindableHead: null,
+      $earlyBindableTail: null,
+      $bindableHead: null,
+      $bindableTail: null,
+      $attachableHead: null,
+      $attachableTail: null,
+      $context: null,
+      $nodes: null,
+      $scope: null
+    };
     container.register(Registration.instance(IRenderable, renderable));
     const target = AuNode.createMarker();
 
@@ -71,9 +81,11 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-            const bindable = renderable.$bindableHead as InterpolationBinding;
+            expect(renderable.$bindableHead).to.equal(null);
+            expect(renderable.$bindableTail).to.equal(null);
+            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+            const bindable = renderable.$earlyBindableHead as InterpolationBinding;
             expect(bindable.target).to.equal(target);
             expect(bindable.sourceExpression['name']).to.equal('foo');
             expect(bindable.mode).to.equal(instruction.mode);
@@ -93,9 +105,11 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-          expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-          const bindable = renderable.$bindableHead as InterpolationBinding;
+          expect(renderable.$bindableHead).to.equal(null);
+          expect(renderable.$bindableTail).to.equal(null);
+          expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+          expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+          const bindable = renderable.$earlyBindableHead as InterpolationBinding;
           expect(bindable.targetObserver['obj']).to.equal(target);
           expect(bindable.targetObserver['propertyKey']).to.equal(to);
           expect(bindable.sourceExpression['name']).to.equal('foo');
@@ -112,9 +126,11 @@ describe('Renderer', () => {
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-        expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-        expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-        const bindable = renderable.$bindableHead as InterpolationBinding;
+        expect(renderable.$bindableHead).to.equal(null);
+        expect(renderable.$bindableTail).to.equal(null);
+        expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+        expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+        const bindable = renderable.$earlyBindableHead as InterpolationBinding;
         expect(bindable.target).to.equal(target);
         expect(bindable.sourceExpression['name']).to.equal('foo');
       });
@@ -130,7 +146,10 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null, 'renderable.$bindableHead');
+          expect(renderable.$bindableHead).to.equal(null);
+          expect(renderable.$bindableTail).to.equal(null);
+          expect(renderable.$earlyBindableHead).to.equal(null);
+          expect(renderable.$earlyBindableTail).to.equal(null);
           expect(target[to]).to.equal(value);
         });
       }
@@ -171,6 +190,8 @@ describe('Renderer', () => {
           if (instructions.length) {
             expect(component.foo).to.equal('bar');
           }
+          expect(renderable.$earlyBindableHead).to.equal(null);
+          expect(renderable.$earlyBindableTail).to.equal(null);
           expect(renderable.$bindableHead).to.equal(component);
           expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
           expect(renderable.$attachableHead).to.equal(component);
@@ -195,8 +216,10 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$bindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
+            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
+            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
+            expect(renderable.$bindableHead).to.equal(null);
+            expect(renderable.$bindableTail).to.equal(null);
           });
         }
       }

--- a/packages/runtime/test/renderer.spec.ts
+++ b/packages/runtime/test/renderer.spec.ts
@@ -35,12 +35,10 @@ describe('Renderer', () => {
     IExpressionParserRegistration.register(container as any);
     const dom = container.get(IDOM);
     const renderable: IRenderable = {
-      $earlyBindableHead: null,
-      $earlyBindableTail: null,
-      $bindableHead: null,
-      $bindableTail: null,
-      $attachableHead: null,
-      $attachableTail: null,
+      $bindingHead: null,
+      $bindingTail: null,
+      $componentHead: null,
+      $componentTail: null,
       $context: null,
       $nodes: null,
       $scope: null
@@ -81,11 +79,11 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$bindableHead).to.equal(null);
-            expect(renderable.$bindableTail).to.equal(null);
-            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-            const bindable = renderable.$earlyBindableHead as InterpolationBinding;
+            expect(renderable.$componentHead).to.equal(null);
+            expect(renderable.$componentTail).to.equal(null);
+            expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+            expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+            const bindable = renderable.$bindingHead as InterpolationBinding;
             expect(bindable.target).to.equal(target);
             expect(bindable.sourceExpression['name']).to.equal('foo');
             expect(bindable.mode).to.equal(instruction.mode);
@@ -105,11 +103,11 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null);
-          expect(renderable.$bindableTail).to.equal(null);
-          expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-          expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-          const bindable = renderable.$earlyBindableHead as InterpolationBinding;
+          expect(renderable.$componentHead).to.equal(null);
+          expect(renderable.$componentTail).to.equal(null);
+          expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+          expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+          const bindable = renderable.$bindingHead as InterpolationBinding;
           expect(bindable.targetObserver['obj']).to.equal(target);
           expect(bindable.targetObserver['propertyKey']).to.equal(to);
           expect(bindable.sourceExpression['name']).to.equal('foo');
@@ -126,11 +124,11 @@ describe('Renderer', () => {
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-        expect(renderable.$bindableHead).to.equal(null);
-        expect(renderable.$bindableTail).to.equal(null);
-        expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-        expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-        const bindable = renderable.$earlyBindableHead as InterpolationBinding;
+        expect(renderable.$componentHead).to.equal(null);
+        expect(renderable.$componentTail).to.equal(null);
+        expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+        expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+        const bindable = renderable.$bindingHead as InterpolationBinding;
         expect(bindable.target).to.equal(target);
         expect(bindable.sourceExpression['name']).to.equal('foo');
       });
@@ -146,10 +144,10 @@ describe('Renderer', () => {
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-          expect(renderable.$bindableHead).to.equal(null);
-          expect(renderable.$bindableTail).to.equal(null);
-          expect(renderable.$earlyBindableHead).to.equal(null);
-          expect(renderable.$earlyBindableTail).to.equal(null);
+          expect(renderable.$componentHead).to.equal(null);
+          expect(renderable.$componentTail).to.equal(null);
+          expect(renderable.$bindingHead).to.equal(null);
+          expect(renderable.$bindingTail).to.equal(null);
           expect(target[to]).to.equal(value);
         });
       }
@@ -190,12 +188,12 @@ describe('Renderer', () => {
           if (instructions.length) {
             expect(component.foo).to.equal('bar');
           }
-          expect(renderable.$earlyBindableHead).to.equal(null);
-          expect(renderable.$earlyBindableTail).to.equal(null);
-          expect(renderable.$bindableHead).to.equal(component);
-          expect(renderable.$bindableHead).to.equal(renderable.$bindableTail);
-          expect(renderable.$attachableHead).to.equal(component);
-          expect(renderable.$attachableHead).to.equal(renderable.$attachableTail);
+          expect(renderable.$bindingHead).to.equal(null);
+          expect(renderable.$bindingTail).to.equal(null);
+          expect(renderable.$componentHead).to.equal(component);
+          expect(renderable.$componentHead).to.equal(renderable.$componentTail);
+          expect(renderable.$componentHead).to.equal(component);
+          expect(renderable.$componentHead).to.equal(renderable.$componentTail);
         });
       }
     }
@@ -216,10 +214,10 @@ describe('Renderer', () => {
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
 
-            expect(renderable.$earlyBindableHead).to.be.a('object', 'renderable.$bindableHead');
-            expect(renderable.$earlyBindableHead).to.equal(renderable.$earlyBindableTail);
-            expect(renderable.$bindableHead).to.equal(null);
-            expect(renderable.$bindableTail).to.equal(null);
+            expect(renderable.$bindingHead).to.be.a('object', 'renderable.$componentHead');
+            expect(renderable.$bindingHead).to.equal(renderable.$bindingTail);
+            expect(renderable.$componentHead).to.equal(null);
+            expect(renderable.$componentTail).to.equal(null);
           });
         }
       }

--- a/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../../scripts/test-lib';
 import {
   AccessScope,
-  addBindable,
+  addBinding,
   Binding,
   BindingContext,
   BindingMode,
@@ -193,7 +193,7 @@ describe(`If/Else`, () => {
           binding.persistentFlags |= baseFlags;
 
           (renderable as Writable<typeof renderable>).$nodes = nodes;
-          addBindable(renderable, binding);
+          addBinding(renderable, binding);
         }
       };
 
@@ -209,7 +209,7 @@ describe(`If/Else`, () => {
           binding.persistentFlags |= baseFlags;
 
           (renderable as Writable<typeof renderable>).$nodes = nodes;
-          addBindable(renderable, binding);
+          addBinding(renderable, binding);
         }
       };
 

--- a/packages/runtime/test/resources/custom-attributes/if.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import {
   Else,
-  IAttach,
+  IComponent,
   If,
   IView,
   LifecycleFlags
@@ -132,13 +132,13 @@ describe('The "if" template controller', () => {
     return ifAttr['coordinator']['currentView'] as IView<AuNode>;
   }
 
-  function runAttachLifecycle(lifecycle: Lifecycle, item: IAttach) {
+  function runAttachLifecycle(lifecycle: Lifecycle, item: IComponent) {
     lifecycle.beginAttach();
     item.$attach(LifecycleFlags.none);
     lifecycle.endAttach(LifecycleFlags.none);
   }
 
-  function runDetachLifecycle(lifecycle: Lifecycle, item: IAttach) {
+  function runDetachLifecycle(lifecycle: Lifecycle, item: IComponent) {
     lifecycle.beginDetach();
     item.$detach(LifecycleFlags.none);
     lifecycle.endDetach(LifecycleFlags.none);

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
@@ -74,7 +74,7 @@
 //   const factory = new ViewFactory(null, new MockIfElseTextNodeTemplate(dom, expressions.show, observerLocator, lifecycle, container) as any, lifecycle);
 //   const renderable = { } as any;
 //   const sut = new Repeat<T>(location, renderable, factory);
-//   renderable.$bindableHead = renderable.$bindableTail = new Binding(expressions.items, sut, 'items', BindingMode.toView, null, container as any);
+//   renderable.$componentHead = renderable.$componentTail = new Binding(expressions.items, sut, 'items', BindingMode.toView, null, container as any);
 //   sut.$state = 0;
 //   sut.$scope = null;
 //   const behavior = RuntimeBehavior.create(Repeat as any, sut);

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
@@ -55,7 +55,7 @@
 //   const factory = new ViewFactory(null, new MockTextNodeTemplate(expressions.item, observerLocator, container) as any, lifecycle);
 //   const renderable = { } as any;
 //   const sut = new Repeat<T>(location, renderable, factory);
-//   renderable.$bindableHead = renderable.$bindableTail = new Binding(expressions.items, sut, 'items', BindingMode.toView, null, container as any);
+//   renderable.$componentHead = renderable.$componentTail = new Binding(expressions.items, sut, 'items', BindingMode.toView, null, container as any);
 //   sut.$state = 0;
 //   sut.$scope = null;
 //   const behavior = RuntimeBehavior.create(Repeat as any, sut);

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
@@ -5,7 +5,7 @@ import {
 } from '../../../../../scripts/test-lib';
 import {
   AccessScope,
-  addBindable,
+  addBinding,
   Binding,
   BindingContext,
   BindingIdentifier,
@@ -307,7 +307,7 @@ describe(`Repeat`, () => {
           binding.persistentFlags |= baseFlags;
 
           (itemRenderable as Writable<typeof itemRenderable>).$nodes = nodes;
-          addBindable(itemRenderable, itemBinding);
+          addBinding(itemRenderable, itemBinding);
         }
       };
 
@@ -319,7 +319,7 @@ describe(`Repeat`, () => {
         sourceExpression: new ForOfStatement(new BindingIdentifier('item'), new AccessScope('items'))
       } as any;
       const renderable: IRenderable<AuNode> = {
-        $earlyBindableHead: binding
+        $bindingHead: binding
       } as any;
       let sut: Repeat<IObservedArray, AuNode>;
       if (useProxies) {

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
@@ -319,7 +319,7 @@ describe(`Repeat`, () => {
         sourceExpression: new ForOfStatement(new BindingIdentifier('item'), new AccessScope('items'))
       } as any;
       const renderable: IRenderable<AuNode> = {
-        $bindableHead: binding
+        $earlyBindableHead: binding
       } as any;
       let sut: Repeat<IObservedArray, AuNode>;
       if (useProxies) {

--- a/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
+++ b/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
@@ -2,7 +2,7 @@ import { Constructable, IContainer, Overwrite, Registration } from '@aurelia/ker
 import { expect } from 'chai';
 import {
   CustomAttributeResource,
-  IAttach,
+  IComponent,
   ICustomAttribute,
   ICustomAttributeType,
   IDOM,
@@ -94,13 +94,13 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(unbindCalled).to.equal(true);
   });
 
-  function runAttachLifecycle(lifecycle: Lifecycle, item: IAttach) {
+  function runAttachLifecycle(lifecycle: Lifecycle, item: IComponent) {
     lifecycle.beginAttach();
     item.$attach(LF.none);
     lifecycle.endAttach(LF.none);
   }
 
-  function runDetachLifecycle(lifecycle: Lifecycle, item: IAttach) {
+  function runDetachLifecycle(lifecycle: Lifecycle, item: IComponent) {
     lifecycle.beginDetach();
     item.$detach(LF.none);
     lifecycle.endDetach(LF.none);

--- a/packages/runtime/test/template.spec.ts
+++ b/packages/runtime/test/template.spec.ts
@@ -31,25 +31,25 @@ describe('createRenderContext', () => {
     const sut = createRenderContext(new AuDOM(), parent as any, [Foo as any, Bar], null);
     const viewFactory = new ViewFactory(null, null, null);
 
-    expect(sut['parent']).to.equal(parent);
+    expect(sut['parent']).to.equal(parent, `sut['parent']`);
 
-    expect(sut.has(IViewFactory, false)).to.equal(true);
-    expect(sut.has(IRenderable, false)).to.equal(true);
-    expect(sut.has(ITargetedInstruction, false)).to.equal(true);
-    expect(sut.has(IRenderLocation, false)).to.equal(true);
-    expect(sut.has(Foo, false)).to.equal(false);
-    expect(sut.has(Bar, false)).to.equal(true);
-    expect(sut.has(INode, false)).to.equal(true);
-    expect(sut.has(AuNode, false)).to.equal(true);
+    expect(sut.has(IViewFactory, false)).to.equal(true, `sut.has(IViewFactory, false)`);
+    expect(sut.has(IRenderable, false)).to.equal(true, `sut.has(IRenderable, false)`);
+    expect(sut.has(ITargetedInstruction, false)).to.equal(true, `sut.has(ITargetedInstruction, false)`);
+    expect(sut.has(IRenderLocation, false)).to.equal(true, `sut.has(IRenderLocation, false)`);
+    expect(sut.has(Foo, false)).to.equal(true, `sut.has(Foo, false)`);
+    expect(sut.has(Bar, false)).to.equal(true, `sut.has(Bar, false)`);
+    expect(sut.has(INode, false)).to.equal(true, `sut.has(INode, false)`);
+    expect(sut.has(AuNode, false)).to.equal(true, `sut.has(AuNode, false)`);
 
-    expect(typeof sut.render).to.equal('function');
-    expect(typeof sut.beginComponentOperation).to.equal('function');
-    expect(typeof sut['dispose']).to.equal('function');
+    expect(typeof sut.render).to.equal('function', `typeof sut.render`);
+    expect(typeof sut.beginComponentOperation).to.equal('function', `typeof sut.beginComponentOperation`);
+    expect(typeof sut['dispose']).to.equal('function', `typeof sut['dispose']`);
 
     expect(() => sut.get(IViewFactory)).to.throw(/50/);
-    expect(sut.get(IRenderable)).to.equal(null);
-    expect(sut.get(ITargetedInstruction)).to.equal(null);
-    expect(sut.get(IRenderLocation)).to.equal(null);
+    expect(sut.get(IRenderable)).to.equal(null, `sut.get(IRenderable)`);
+    expect(sut.get(ITargetedInstruction)).to.equal(null, `sut.get(ITargetedInstruction)`);
+    expect(sut.get(IRenderLocation)).to.equal(null, `sut.get(IRenderLocation)`);
 
     const renderable = {} as any;
     const target = {} as any;
@@ -60,11 +60,11 @@ describe('createRenderContext', () => {
     sut.beginComponentOperation(renderable, target, instruction, viewFactory as any, parts, location);
 
     expect(() => sut.get(IViewFactory)).to.throw(/51/);
-    expect(sut.get(IRenderable)).to.equal(renderable);
-    expect(sut.get(INode)).to.equal(target);
-    expect(sut.get(AuNode)).to.equal(target);
-    expect(sut.get(ITargetedInstruction)).to.equal(instruction);
-    expect(sut.get(IRenderLocation)).to.equal(location);
+    expect(sut.get(IRenderable)).to.equal(renderable, `sut.get(IRenderable)`);
+    expect(sut.get(INode)).to.equal(target, `sut.get(INode)`);
+    expect(sut.get(AuNode)).to.equal(target, `sut.get(AuNode)`);
+    expect(sut.get(ITargetedInstruction)).to.equal(instruction, `sut.get(ITargetedInstruction)`);
+    expect(sut.get(IRenderLocation)).to.equal(location, `sut.get(IRenderLocation)`);
   });
 });
 
@@ -81,7 +81,7 @@ describe(`CompiledTemplate`, () => {
       const sut = new CompiledTemplate(dom, def, nsFactory, container as any);
 
       const nodes = sut.factory.createNodeSequence();
-      expect(nodes.childNodes[0].textContent).to.equal('foo');
+      expect(nodes.childNodes[0].textContent).to.equal('foo', `nodes.childNodes[0].textContent`);
     });
   });
 });

--- a/packages/runtime/test/templating/custom-element.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$attach.spec.ts
@@ -65,9 +65,9 @@ describe('@customElement', () => {
         const initState = sut.$state;
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
-        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
-        sut.$bindableHead = sut.$bindableTail = null;
-        sut.$attachableHead = sut.$attachableTail = null;
+        sut.$bindingHead = sut.$bindingTail = null;
+        sut.$componentHead = sut.$componentTail = null;
+        sut.$componentHead = sut.$componentTail = null;
         propsSpec.setProps(sut);
         const hooks = hooksSpec.getHooks();
         sut.$hooks = hooks;
@@ -157,9 +157,9 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
-        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
-        sut.$bindableHead = sut.$bindableTail = null;
-        sut.$attachableHead = sut.$attachableTail = null;
+        sut.$bindingHead = sut.$bindingTail = null;
+        sut.$componentHead = sut.$componentTail = null;
+        sut.$componentHead = sut.$componentTail = null;
         propsSpec.setProps(sut);
         const hooks = hooksSpec.getHooks();
         sut.$hooks = hooks;
@@ -213,9 +213,9 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
-        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
-        sut.$bindableHead = sut.$bindableTail = null;
-        sut.$attachableHead = sut.$attachableTail = null;
+        sut.$bindingHead = sut.$bindingTail = null;
+        sut.$componentHead = sut.$componentTail = null;
+        sut.$componentHead = sut.$componentTail = null;
         const hooks = hooksSpec.getHooks();
         sut.$hooks = hooks;
 

--- a/packages/runtime/test/templating/custom-element.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$attach.spec.ts
@@ -65,6 +65,7 @@ describe('@customElement', () => {
         const initState = sut.$state;
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
+        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
         sut.$bindableHead = sut.$bindableTail = null;
         sut.$attachableHead = sut.$attachableTail = null;
         propsSpec.setProps(sut);
@@ -156,6 +157,7 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
+        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
         sut.$bindableHead = sut.$bindableTail = null;
         sut.$attachableHead = sut.$attachableTail = null;
         propsSpec.setProps(sut);
@@ -211,6 +213,7 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
         sut.$scope = Scope.create(LF.none, sut, null);
+        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
         sut.$bindableHead = sut.$bindableTail = null;
         sut.$attachableHead = sut.$attachableTail = null;
         const hooks = hooksSpec.getHooks();

--- a/packages/runtime/test/templating/custom-element.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$bind.spec.ts
@@ -113,6 +113,7 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
         sut.$scope = Scope.create(LF.none, sut, null);
+        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
         sut.$bindableHead = sut.$bindableTail = null;
         sut.$attachableHead = sut.$attachableTail = null;
         sut.$hooks = hooksSpec.getHooks();
@@ -221,6 +222,7 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
         sut.$scope = Scope.create(LF.none, sut, null);
+        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
         sut.$bindableHead = sut.$bindableTail = null;
         sut.$attachableHead = sut.$attachableTail = null;
         sut.$hooks = hooksSpec.getHooks();

--- a/packages/runtime/test/templating/custom-element.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$bind.spec.ts
@@ -113,9 +113,9 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
         sut.$scope = Scope.create(LF.none, sut, null);
-        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
-        sut.$bindableHead = sut.$bindableTail = null;
-        sut.$attachableHead = sut.$attachableTail = null;
+        sut.$bindingHead = sut.$bindingTail = null;
+        sut.$componentHead = sut.$componentTail = null;
+        sut.$componentHead = sut.$componentTail = null;
         sut.$hooks = hooksSpec.getHooks();
         const expectedFlags = flagsSpec.getExpectedFlags();
         const flags = flagsSpec.getFlags();
@@ -222,9 +222,9 @@ describe('@customElement', () => {
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
         sut.$scope = Scope.create(LF.none, sut, null);
-        sut.$earlyBindableHead = sut.$earlyBindableTail = null;
-        sut.$bindableHead = sut.$bindableTail = null;
-        sut.$attachableHead = sut.$attachableTail = null;
+        sut.$bindingHead = sut.$bindingTail = null;
+        sut.$componentHead = sut.$componentTail = null;
+        sut.$componentHead = sut.$componentTail = null;
         sut.$hooks = hooksSpec.getHooks();
         const expectedFlags = flagsSpec.getExpectedFlags();
         const flags = flagsSpec.getFlags();

--- a/packages/runtime/test/templating/view.spec.ts
+++ b/packages/runtime/test/templating/view.spec.ts
@@ -7,8 +7,8 @@ import {
 } from '../../../../scripts/test-lib';
 import {
   AccessScope,
-  addAttachable,
-  addBindable,
+  addBinding,
+  addComponent,
   Binding,
   BindingContext,
   BindingMode,
@@ -145,7 +145,7 @@ describe(`ViewFactory`, () => {
 
 // public render(renderable: Partial<IRenderable>, host?: INode, parts?: TemplatePartDefinitions): void {
 //   const nodes = (<Writable<IRenderable>>renderable).$nodes = new MockTextNodeSequence();
-//   addBindable(renderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
+//   addBinding(renderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
 // }
 describe('View', () => {
   function runBindLifecycle(lifecycle: ILifecycle, view: IView<AuNode>, flags: LF, scope: IScope): void {
@@ -411,7 +411,7 @@ describe('View', () => {
           const binding = new Binding(new AccessScope(propName), text, 'textContent', BindingMode.oneTime, observerLocator, container);
 
           (renderable as Writable<typeof renderable>).$nodes = nodes;
-          addBindable(renderable, binding);
+          addBinding(renderable, binding);
         }
       };
       const childFactory = new ViewFactory<AuNode>('child', childTemplate, lifecycle);
@@ -430,13 +430,12 @@ describe('View', () => {
           const binding = new Binding(new AccessScope(propName), text, 'textContent', BindingMode.oneTime, observerLocator, container);
 
           (renderable as Writable<typeof renderable>).$nodes = nodes;
-          addBindable(renderable, binding);
+          addBinding(renderable, binding);
 
           for (let i = 0; i < childCount; ++i) {
             const child = childSuts[i] = childFactory.create();
             child.hold(childLocs[i]);
-            addBindable(renderable, child);
-            addAttachable(renderable, child);
+            addComponent(renderable, child);
           }
         }
       };


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Main purpose of this PR is to allow the repeater (and any other resources) to bind its child views during the `binding()` hook instead of during `bound()` in order to keep the timings of the different kinds of binding-related operations closer to each other.

To accomplish this, I adjusted the rendering process to put bindings in a separate list from bindable components. Those bindings are then bound before the `binding()` hook is invoked, so that within the `binding()` hook you can safely assume the component itself to already be in a "bound" state. Child components are still going to be bound *after* the `binding()` hook, so that you can also safely assume all parent components to both be in a bound state and to have had their `binding()` hooks already invoked.

On the side, I also added a register recursion guard to the container's `register()` method and added an `isClass` check so that if you pass in a regular class without a static `register` method, it's automatically registered as a singleton (consistent with vCurrent). This is to fix a test that decided to fail suddenly.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

- `$bindableHead`/`Tail`, ... and `$attachableHead`/`Tail` linked lists are merged into `$componentHead`/`Tail`. These are always used together anyway.
- Bindings are stored in `$bindingHead`/`Tail` so they can be invoked separately (earlier)
- Standalone lifecycle hook interfaces for binding and attaching merged into `IComponent`, removing about 10 exported interfaces and simplifying the API

A lot more little details to get this all to work but the changes all boil down to merging bindable/attachable into component, and adding bindings to the renderables separately.

This all appears to have resulted in a performance gain of around 3-4%

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

- No functionality removed or added, so existing tests passing should be sufficient
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Further optimize/unify lifecycle related types where it makes sense, before proceeding with the task-related work
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
