### PR TITLE
perf(all): pre-declare variables used in loops

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -564,16 +564,23 @@ export class Container implements IContainer {
       // Most likely cause is trying to register a plain object that does not have a
       // register method and is not a class constructor
     }
+    let current: IRegistry | Record<string, IRegistry>;
+    let keys: string[];
+    let value: IRegistry;
+    let j: number;
+    let jj: number;
     for (let i = 0, ii = params.length; i < ii; ++i) {
-      const current = params[i] as IRegistry | Record<string, IRegistry>;
+      current = params[i] as IRegistry | Record<string, IRegistry>;
       if (isRegistry(current)) {
         current.register(this);
       } else if (isClass(current)) {
         Registration.singleton(current, current).register(this);
       } else {
-        const keys = Object.keys(current);
-        for (let j = 0, jj = keys.length; j < jj; ++j) {
-          const value = current[keys[j]];
+        keys = Object.keys(current);
+        j = 0;
+        jj = keys.length;
+        for (; j < jj; ++j) {
+          value = current[keys[j]];
           // note: we could remove this if-branch and call this.register directly
           // - the extra check is just a perf tweak to create fewer unnecessary arrays by the spread operator
           if (isRegistry(value)) {
@@ -636,9 +643,10 @@ export class Container implements IContainer {
     }
 
     let current: Container = this;
+    let resolver: IResolver;
 
     while (current !== null) {
-      const resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
+      resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
 
       if (resolver === undefined) {
         if (current.parent === null) {
@@ -672,9 +680,10 @@ export class Container implements IContainer {
     }
 
     let current: Container = this;
+    let resolver: IResolver;
 
     while (current !== null) {
-      let resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
+      resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
 
       if (resolver === undefined) {
         if (current.parent === null) {
@@ -695,9 +704,10 @@ export class Container implements IContainer {
     validateKey(key);
 
     let current: Container | null = this;
+    let resolver: IResolver;
 
     while (current !== null) {
-      const resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
+      resolver = current.resolvers.get(key as InterfaceSymbol<IContainer>);
 
       if (resolver === undefined) {
         if (this.parent === null) {

--- a/packages/plugin-svg/src/svg-analyzer.ts
+++ b/packages/plugin-svg/src/svg-analyzer.ts
@@ -214,13 +214,13 @@ function createElement(html: string): Element {
 if (createElement('<svg><altGlyph /></svg>').firstElementChild.nodeName === 'altglyph' && svgElements.altGlyph) {
   // handle chrome casing inconsistencies.
   (svgElements as {altglyph?: string[]}).altglyph = svgElements.altGlyph;
-  delete svgElements.altGlyph;
+  Reflect.deleteProperty(svgElements, 'altGlyph');
   (svgElements as {altglyphdef?: string[]}).altglyphdef = svgElements.altGlyphDef;
-  delete svgElements.altGlyphDef;
+  Reflect.deleteProperty(svgElements, 'altGlyphDef');
   (svgElements as {altglyphitem?: string[]}).altglyphitem = svgElements.altGlyphItem;
-  delete svgElements.altGlyphItem;
+  Reflect.deleteProperty(svgElements, 'altGlyphItem');
   (svgElements as {glyphref?: string[]}).glyphref = svgElements.glyphRef;
-  delete svgElements.glyphRef;
+  Reflect.deleteProperty(svgElements, 'glyphRef');
 }
 
 export function register(container: IContainer): void {

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -67,7 +67,7 @@ export class Listener implements IBinding {
 
     const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator);
 
-    delete overrideContext.$event;
+    Reflect.deleteProperty(overrideContext, '$event');
 
     if (result !== true && this.preventDefault) {
       event.preventDefault();

--- a/packages/runtime-html/test/observation/observer-locator.spec.ts
+++ b/packages/runtime-html/test/observation/observer-locator.spec.ts
@@ -240,7 +240,7 @@ describe('ObserverLocator', () => {
                       if (hasOverrides) {
                         obj.constructor['computed'] = { isVolatile };
                       }
-                      Object.defineProperty(obj, 'foo', descriptor);
+                      Reflect.defineProperty(obj, 'foo', descriptor);
                       if (hasSetter && configurable && !hasGetter && !(hasAdapterObserver && adapterIsDefined)) {
                         expect(() => sut.getObserver(LF.none, obj, 'foo')).to.throw(/18/);
                       } else {
@@ -334,7 +334,7 @@ describe('ObserverLocator', () => {
     const obj = {};
     const write = Reporter.write;
     Reporter.write = spy();
-    Object.defineProperty(obj, '$observers', { value: undefined });
+    Reflect.defineProperty(obj, '$observers', { value: undefined });
     sut.getObserver(LF.none, obj, 'foo');
     expect(Reporter.write).to.have.been.calledWith(0);
     Reporter.write = write;

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -37,8 +37,7 @@ export class Call {
     const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator);
 
     for (const prop in args) {
-      // tslint:disable-next-line:no-dynamic-delete
-      delete overrideContext[prop];
+      Reflect.deleteProperty(overrideContext, prop);
     }
 
     if (Tracer.enabled) { Tracer.leave(); }
@@ -60,9 +59,8 @@ export class Call {
 
     this.$scope = scope;
 
-    const sourceExpression = this.sourceExpression;
-    if (hasBind(sourceExpression)) {
-      sourceExpression.bind(flags, scope, this);
+    if (hasBind(this.sourceExpression)) {
+      this.sourceExpression.bind(flags, scope, this);
     }
 
     this.targetObserver.setValue($args => this.callSource($args), flags);
@@ -82,9 +80,8 @@ export class Call {
     // add isUnbinding flag
     this.$state |= State.isUnbinding;
 
-    const sourceExpression = this.sourceExpression;
-    if (hasUnbind(sourceExpression)) {
-      sourceExpression.unbind(flags, this.$scope, this);
+    if (hasUnbind(this.sourceExpression)) {
+      this.sourceExpression.unbind(flags, this.$scope, this);
     }
 
     this.$scope = null;

--- a/packages/runtime/src/binding/ref.ts
+++ b/packages/runtime/src/binding/ref.ts
@@ -44,9 +44,8 @@ export class Ref implements IBinding {
 
     this.$scope = scope;
 
-    const sourceExpression = this.sourceExpression;
-    if (hasBind(sourceExpression)) {
-      sourceExpression.bind(flags, scope, this);
+    if (hasBind(this.sourceExpression)) {
+      this.sourceExpression.bind(flags, scope, this);
     }
 
     this.sourceExpression.assign(flags, this.$scope, this.locator, this.target);

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -342,7 +342,7 @@ const descriptorProps = {
   configurable: true
 };
 
-const def = Object.defineProperty;
+const def = Reflect.defineProperty;
 
 for (const method of methods) {
   def(observe[method], 'observing', { value: true, writable: false, configurable: false, enumerable: false });

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -25,12 +25,11 @@ const enum RuntimeError {
 export class InternalObserversLookup {
   public getOrCreate(flags: LifecycleFlags, obj: IBindingContext | IOverrideContext, key: string): PropertyObserver {
     if (Tracer.enabled) { Tracer.enter('InternalObserversLookup.getOrCreate', slice.call(arguments)); }
-    let observer = this[key];
-    if (observer === undefined) {
-      observer = this[key] = new SetterObserver(flags, obj, key);
+    if (this[key] === undefined) {
+      this[key] = new SetterObserver(flags, obj, key);
     }
     if (Tracer.enabled) { Tracer.leave(); }
-    return observer;
+    return this[key];
   }
 }
 
@@ -149,12 +148,11 @@ export class BindingContext implements IBindingContext {
 
   public getObservers(flags: LifecycleFlags): ObserversLookup<IOverrideContext> {
     if (Tracer.enabled) { Tracer.enter('BindingContext.getObservers', slice.call(arguments)); }
-    let observers = this.$observers;
-    if (observers === undefined) {
-      this.$observers = observers = new InternalObserversLookup() as ObserversLookup<IOverrideContext>;
+    if (this.$observers === undefined) {
+      this.$observers = new InternalObserversLookup() as ObserversLookup<IOverrideContext>;
     }
     if (Tracer.enabled) { Tracer.leave(); }
-    return observers;
+    return this.$observers;
   }
 }
 
@@ -245,11 +243,10 @@ export class OverrideContext implements IOverrideContext {
 
   public getObservers(): ObserversLookup<IOverrideContext> {
     if (Tracer.enabled) { Tracer.enter('OverrideContext.getObservers', slice.call(arguments)); }
-    let observers = this.$observers;
-    if (observers === undefined) {
-      this.$observers = observers = new InternalObserversLookup();
+    if (this.$observers === undefined) {
+      this.$observers = new InternalObserversLookup();
     }
     if (Tracer.enabled) { Tracer.leave(); }
-    return observers as ObserversLookup<IOverrideContext>;
+    return this.$observers as ObserversLookup<IOverrideContext>;
   }
 }

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -111,7 +111,7 @@ const descriptorProps = {
   configurable: true
 };
 
-const def = Object.defineProperty;
+const def = Reflect.defineProperty;
 
 for (const method of methods) {
   def(observe[method], 'observing', { value: true, writable: false, configurable: false, enumerable: false });

--- a/packages/runtime/src/observation/property-observer.ts
+++ b/packages/runtime/src/observation/property-observer.ts
@@ -29,8 +29,7 @@ function subscribe(this: PropertyObserver, subscriber: IPropertySubscriber): voi
 }
 
 function dispose(this: PropertyObserver): void {
-  // tslint:disable-next-line:no-dynamic-delete
-  delete this.obj[this.propertyKey];
+  Reflect.deleteProperty(this.obj, this.propertyKey);
   this.obj = null;
   this.propertyKey = null;
   this.currentValue = null;

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -101,7 +101,7 @@ const descriptorProps = {
   configurable: true
 };
 
-const def = Object.defineProperty;
+const def = Reflect.defineProperty;
 
 for (const method of methods) {
   def(observe[method], 'observing', { value: true, writable: false, configurable: false, enumerable: false });

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -2,6 +2,7 @@ import {
   all,
   Class,
   IContainer,
+  ImmutableArray,
   InterfaceSymbol,
   IRegistry,
   IResolver,
@@ -10,6 +11,7 @@ import {
   Tracer,
   Writable
 } from '@aurelia/kernel';
+import { AnyBindingExpression } from './ast';
 import { Binding } from './binding/binding';
 import { Call } from './binding/call';
 import { BindingType, IExpressionParser } from './binding/expression-parser';
@@ -27,10 +29,12 @@ import {
   IHydrateTemplateController,
   IInterpolationInstruction,
   IIteratorBindingInstruction,
+  ILetBindingInstruction,
   InstructionTypeName,
   IPropertyBindingInstruction,
   IRefBindingInstruction,
   ISetPropertyInstruction,
+  ITargetedInstruction,
   TargetedInstructionType,
   TemplateDefinition,
   TemplatePartDefinitions
@@ -112,12 +116,15 @@ export class Renderer implements IRenderer {
         throw Reporter.error(31);
       }
     }
+    let instructions: ImmutableArray<ITargetedInstruction>;
+    let target: INode;
+    let current: ITargetedInstruction;
     for (let i = 0, ii = targets.length; i < ii; ++i) {
-      const instructions = targetInstructions[i];
-      const target = targets[i];
+      instructions = targetInstructions[i];
+      target = targets[i];
 
       for (let j = 0, jj = instructions.length; j < jj; ++j) {
-        const current = instructions[j];
+        current = instructions[j];
         instructionRenderers[current.type].render(flags, dom, context, renderable, target, current, parts);
       }
     }
@@ -126,7 +133,7 @@ export class Renderer implements IRenderer {
       const surrogateInstructions = definition.surrogates;
 
       for (let i = 0, ii = surrogateInstructions.length; i < ii; ++i) {
-        const current = surrogateInstructions[i];
+        current = surrogateInstructions[i];
         instructionRenderers[current.type].render(flags, dom, context, renderable, host, current, parts);
       }
     }
@@ -193,8 +200,9 @@ export class CustomElementRenderer implements IInstructionRenderer {
 
     component.$hydrate(flags, context, target, instruction as IElementHydrationOptions);
 
+    let current: ITargetedInstruction;
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
-      const current = childInstructions[i];
+      current = childInstructions[i];
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
@@ -219,8 +227,9 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
 
     component.$hydrate(flags, context);
 
+    let current: ITargetedInstruction;
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
-      const current = childInstructions[i];
+      current = childInstructions[i];
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
@@ -257,8 +266,9 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
       (component as ICustomAttribute & { link(componentTail: IComponent): void}).link(renderable.$componentTail);
     }
 
+    let current: ITargetedInstruction;
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
-      const current = childInstructions[i];
+      current = childInstructions[i];
       instructionRenderers[current.type].render(flags, dom, context, renderable, component, current);
     }
 
@@ -288,10 +298,14 @@ export class LetElementRenderer implements IInstructionRenderer {
     dom.remove(target);
     const childInstructions = instruction.instructions;
     const toViewModel = instruction.toViewModel;
+
+    let childInstruction: ILetBindingInstruction;
+    let expr: AnyBindingExpression;
+    let binding: LetBinding;
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
-      const childInstruction = childInstructions[i];
-      const expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
-      const binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
+      childInstruction = childInstructions[i];
+      expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
+      binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
       addBinding(renderable, binding);
     }
     if (Tracer.enabled) { Tracer.leave(); }

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -74,8 +74,9 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
 
   public attaching(flags: LifecycleFlags): void {
     const { views, location } = this;
+    let view: IView;
     for (let i = 0, ii = views.length; i < ii; ++i) {
-      const view = views[i];
+      view = views[i];
       view.hold(location);
       view.$attach(flags);
     }
@@ -83,8 +84,9 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
 
   public detaching(flags: LifecycleFlags): void {
     const { views } = this;
+    let view: IView;
     for (let i = 0, ii = views.length; i < ii; ++i) {
-      const view = views[i];
+      view = views[i];
       view.$detach(flags);
       view.release(flags);
     }
@@ -94,8 +96,9 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
     this.checkCollectionObserver(flags);
 
     const { views } = this;
+    let view: IView;
     for (let i = 0, ii = views.length; i < ii; ++i) {
-      const view = views[i];
+      view = views[i];
       view.$unbind(flags);
     }
   }
@@ -128,6 +131,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
       flags |= LifecycleFlags.useProxies;
     }
     const { views, $lifecycle } = this;
+    let view: IView;
     if (this.$state & (State.isBound | State.isBinding)) {
       const { local, $scope, factory, forOf, items } = this;
       const oldLength = views.length;
@@ -139,13 +143,15 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
         }
       } else if (newLength < oldLength) {
         $lifecycle.beginDetach();
-        for (let i = newLength, view = views[i]; i < oldLength; view = views[++i]) {
+        for (let i = newLength; i < oldLength; ++i) {
+          view = views[i];
           view.release(flags);
           view.$detach(flags);
         }
         $lifecycle.endDetach(flags);
         $lifecycle.beginUnbind();
-        for (let i = newLength, view = views[i]; i < oldLength; view = views[++i]) {
+        for (let i = newLength; i < oldLength; ++i) {
+          view = views[i];
           view.$unbind(flags);
         }
         $lifecycle.endUnbind(flags);
@@ -160,7 +166,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
       $lifecycle.beginBind();
       if (indexMap === null) {
         forOf.iterate(items, (arr, i, item: (string | number | boolean | ObservedCollection | IIndexable)) => {
-          const view = views[i];
+          view = views[i];
           if (!!view.$scope && view.$scope.bindingContext[local] === item) {
             view.$bind(flags, Scope.fromParent(flags, $scope, view.$scope.bindingContext));
           } else {
@@ -169,7 +175,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
         });
       } else {
         forOf.iterate(items, (arr, i, item: (string | number | boolean | ObservedCollection | IIndexable)) => {
-          const view = views[i];
+          view = views[i];
           if (!!view.$scope && (indexMap[i] === i || view.$scope.bindingContext[local] === item)) {
             view.$bind(flags, Scope.fromParent(flags, $scope, view.$scope.bindingContext));
           } else {
@@ -185,14 +191,14 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
       $lifecycle.beginAttach();
       if (indexMap === null) {
         for (let i = 0, ii = views.length; i < ii; ++i) {
-          const view = views[i];
+          view = views[i];
           view.hold(location);
           view.$attach(flags);
         }
       } else {
         for (let i = 0, ii = views.length; i < ii; ++i) {
           if (indexMap[i] !== i) {
-            const view = views[i];
+            view = views[i];
             view.hold(location);
             view.$attach(flags);
           }
@@ -317,7 +323,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
           $mount(): void {
             let next = location;
             let j = seqLen - 1;
-            let i = indexMap.length - 1;
+            i = indexMap.length - 1;
             for (; i >= 0; --i) {
               if (indexMap[i] === -2) {
                 view = views[i];

--- a/packages/runtime/test/observation/observer-locator.spec.ts
+++ b/packages/runtime/test/observation/observer-locator.spec.ts
@@ -210,7 +210,7 @@
 //                       obj.constructor['computed'] = { isVolatile };
 //                     }
 //                     it(_`getObserver() - descriptor=${descriptor}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, () => {
-//                       Object.defineProperty(obj, 'foo', descriptor);
+//                       Reflect.defineProperty(obj, 'foo', descriptor);
 //                       if (hasSetter && configurable && !hasGetter && !(hasAdapterObserver && adapterIsDefined)) {
 //                         expect(() => sut.getObserver(obj, 'foo')).to.throw(/18/);
 //                       } else {
@@ -296,7 +296,7 @@
 //     const obj = {};
 //     const write = Reporter.write;
 //     Reporter.write = spy();
-//     Object.defineProperty(obj, '$observers', { value: undefined })
+//     Reflect.defineProperty(obj, '$observers', { value: undefined })
 //     sut.getObserver(obj, 'foo');
 //     expect(Reporter.write).to.have.been.calledWith(0);
 //     Reporter.write = write;

--- a/packages/runtime/test/observation/proxy-observer.spec.ts
+++ b/packages/runtime/test/observation/proxy-observer.spec.ts
@@ -125,9 +125,7 @@ describe('ProxyObserver', function() {
         expect(proxyCallCount).to.equal(prevCallCount, 'callCount #4');
       }
 
-      // (it's the point of the test)
-      // tslint:disable-next-line:no-dynamic-delete
-      delete observer.proxy[name];
+      Reflect.deleteProperty(observer.proxy, name);
 
       if (value !== undefined) {
         expect(callCount).to.equal(++prevCallCount, 'callCount #5');


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Just a quick in-between PR to make a few small tweaks across the project that needed to happen for a while
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

- Replaced `delete obj.property` with `Reflect.deleteProperty(obj, property)` for consistency
- Pre-declare variables with `let` instead of declaring them with `const` on each iteration in loops
- Replace `Object.defineProperty` with `Reflect.defineProperty` for consistency
- Eliminate a few locally declared variables where they wouldn't have any perf benefit
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
