### PR TITLE
chore: set default linting severity to "error"

### DIFF
--- a/packages/fetch-client/src/retry-interceptor.ts
+++ b/packages/fetch-client/src/retry-interceptor.ts
@@ -89,6 +89,7 @@ export class RetryInterceptor implements Interceptor {
           if (doRetry) {
             retryConfig.counter++;
             const delay = calculateDelay(retryConfig);
+            // tslint:disable-next-line:no-string-based-set-timeout
             return new Promise(resolve => PLATFORM.global.setTimeout(resolve, !isNaN(delay) ? delay : 0))
               .then(() => {
                 const newRequest = requestClone.clone();

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -323,7 +323,6 @@ export class FragmentNodeSequence implements INodeSequence {
   }
 
   public insertBefore(refNode: IRenderLocation & Comment): void {
-    // tslint:disable-next-line:no-any
     refNode.parentNode.insertBefore(this.fragment, refNode);
     // internally we could generally assume that this is an IRenderLocation,
     // but since this is also public API we still need to double check

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -33,7 +33,7 @@ export class InternalObserversLookup {
   }
 }
 
-type BindingContextValue = ObservedCollection | StrictPrimitive | IIndexable;
+export type BindingContextValue = ObservedCollection | StrictPrimitive | IIndexable;
 
 export class BindingContext implements IBindingContext {
   [key: string]: BindingContextValue;

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -1,4 +1,4 @@
-import { IIndexable, InterfaceSymbol, IRegistry } from '@aurelia/kernel';
+import { InterfaceSymbol, IRegistry } from '@aurelia/kernel';
 import { ForOfStatement } from '../../binding/ast';
 import { Binding } from '../../binding/binding';
 import { AttributeDefinition, IAttributeDefinition } from '../../definitions';
@@ -6,7 +6,7 @@ import { INode, IRenderLocation } from '../../dom';
 import { LifecycleFlags, State } from '../../flags';
 import { IMountableComponent, IRenderable, IView, IViewFactory } from '../../lifecycle';
 import { CollectionObserver, IBatchedCollectionSubscriber, IndexMap, IObservedArray, IScope, ObservedCollection } from '../../observation';
-import { BindingContext, Scope } from '../../observation/binding-context';
+import { BindingContext, BindingContextValue, Scope } from '../../observation/binding-context';
 import { getCollectionObserver } from '../../observation/observer-locator';
 import { ProxyObserver } from '../../observation/proxy-observer';
 import { bindable } from '../../templating/bindable';
@@ -166,7 +166,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
 
       $lifecycle.beginBind();
       if (indexMap === null) {
-        forOf.iterate(flags, items, (arr, i, item: (string | number | boolean | ObservedCollection | IIndexable)) => {
+        forOf.iterate(flags, items, (arr, i, item: BindingContextValue) => {
           view = views[i];
           if (!!view.$scope && view.$scope.bindingContext[local] === item) {
             view.$bind(flags, Scope.fromParent(flags, $scope, view.$scope.bindingContext));
@@ -175,7 +175,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
           }
         });
       } else {
-        forOf.iterate(flags, items, (arr, i, item: (string | number | boolean | ObservedCollection | IIndexable)) => {
+        forOf.iterate(flags, items, (arr, i, item: BindingContextValue) => {
           view = views[i];
           if (!!view.$scope && (indexMap[i] === i || view.$scope.bindingContext[local] === item)) {
             view.$bind(flags, Scope.fromParent(flags, $scope, view.$scope.bindingContext));
@@ -234,7 +234,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
         views = this.views = Array(newLen);
 
         $lifecycle.beginBind();
-        forOf.iterate(flags, items, (arr, i, item: (string | number | boolean | ObservedCollection | IIndexable)) => {
+        forOf.iterate(flags, items, (arr, i, item: BindingContextValue) => {
           view = views[i] = factory.create(flags);
           view.$bind(flags, Scope.fromParent(flags, $scope, BindingContext.create(flags, local, item)));
         });

--- a/packages/runtime/src/templating/lifecycle-bind.ts
+++ b/packages/runtime/src/templating/lifecycle-bind.ts
@@ -233,7 +233,7 @@ export function $unbindElement(this: Writable<IBindable>, flags: LifecycleFlags)
       binding = binding.$prevBinding;
     }
 
-    // tslind:disable-next-line:no-unnecessary-type-assertion // this is a false positive
+    // tslint:disable-next-line:no-unnecessary-type-assertion // this is a false positive
     (this.$scope as Writable<IScope>).parentScope = null;
 
     // remove isBound and isUnbinding flags

--- a/tslint.json
+++ b/tslint.json
@@ -295,6 +295,7 @@
     "max-union-size": [true, 5],
     "no-extra-semicolon": false,
     "no-identical-functions": false,
-    "no-duplicate-string": false
+    "no-duplicate-string": false,
+    "no-useless-cast": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,7 @@
       "**/examples/**"
     ]
   },
-  "defaultSeverity": "warning",
+  "defaultSeverity": "error",
   "rules": {
   /**
     * Security Rules. The following rules should be turned on because they find security issues

--- a/tslint.json
+++ b/tslint.json
@@ -175,7 +175,7 @@
     "no-unnecessary-field-initialization": true,
     "no-unnecessary-local-variable": true,
     "no-unnecessary-qualifier": true,
-    "no-unnecessary-type-assertion": true,
+    "no-unnecessary-type-assertion": { "severity": "warning" }, // Gives false positives on CircleCI, so keep them as warning for now
     "no-unsupported-browser-code": true,
     "no-useless-files": true,
     "no-var-keyword": true,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Mark linting violations instead of errors, fix some straggler violations, disable `no-useless-cast linting rule` linting rule and mark `no-unnecessary-type-assertion` as warning for now to appease CircleCI.

### 🎫 Issues

Resolves: #249 

## 👩‍💻 Reviewer Notes

- Set default severity to `error`
- Disabled `no-useless-cast linting rule` linting rule as its similar to `no-unnecessary-type-assertion`.
- Marked `no-unnecessary-type-assertion` as `warning` as it triggers false positives on CircleCI and added a TODO comment to fix that issue.
- Fixed a few straggler linting errors.

## 📑 Test Plan

CircleCI
## ⏭ Next Steps

- A few rules are still marked as `warning`, eventually these violations need to be fixed and the rules set to the default severity as well.