### PR TITLE
DOM binding fix and misc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9283,6 +9283,15 @@
         "xmlbuilder": "8.2.2"
       }
     },
+    "karma-min-reporter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-min-reporter/-/karma-min-reporter-0.1.0.tgz",
+      "integrity": "sha1-RJykbylfHC687NthAtA/0gNhn2o=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.0"
+      }
+    },
     "karma-mocha": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "karma-coverage-istanbul-reporter": "^2.0.4",
     "karma-firefox-launcher": "^1.1.0",
     "karma-junit-reporter": "^1.2.0",
+    "karma-min-reporter": "^0.1.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-source-map-support": "^1.3.0",

--- a/packages/jit-html-browser/test/setup.ts
+++ b/packages/jit-html-browser/test/setup.ts
@@ -24,5 +24,5 @@ TestContext.createHTMLTestContext = createHTMLTestContext;
 
 chai.use(sinonChai);
 
-const testContext = require.context('../../jit-html/test', true, /\.spec\.ts$/);
+const testContext = require.context('../../jit-html/test', true, /binding-commands\.spec\.ts$/);
 testContext.keys().forEach(testContext);

--- a/packages/jit-html-browser/test/setup.ts
+++ b/packages/jit-html-browser/test/setup.ts
@@ -24,5 +24,5 @@ TestContext.createHTMLTestContext = createHTMLTestContext;
 
 chai.use(sinonChai);
 
-const testContext = require.context('../../jit-html/test', true, /binding-commands\.spec\.ts$/);
+const testContext = require.context('../../jit-html/test', true, /\.spec\.ts$/);
 testContext.keys().forEach(testContext);

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -102,7 +102,7 @@ export class TemplateBinder {
       }
       const attrInfo = this.resources.getAttributeInfo(attrSyntax);
       if (attrInfo === null) {
-        this.bindPlainAttribute(attrSyntax);
+        this.bindPlainAttribute(attrSyntax, attr);
       } else if (attrInfo.isTemplateController) {
         if (Profiler.enabled) { leave(); }
         throw new Error('Cannot have template controller on surrogate element.');
@@ -239,7 +239,7 @@ export class TemplateBinder {
 
       if (attrInfo === null) {
         // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-        this.bindPlainAttribute(attrSyntax);
+        this.bindPlainAttribute(attrSyntax, attr);
       } else if (attrInfo.isTemplateController) {
         // the manifest is wrapped by the inner-most template controller (if there are multiple on the same element)
         // so keep setting manifest.templateController to the latest template controller we find
@@ -404,7 +404,7 @@ export class TemplateBinder {
     if (Tracer.enabled) { Tracer.leave(); }
   }
 
-  private bindPlainAttribute(attrSyntax: AttrSyntax): void {
+  private bindPlainAttribute(attrSyntax: AttrSyntax, attr: Attr): void {
     if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindPlainAttribute', slice.call(arguments)); }
 
     if (attrSyntax.rawValue.length === 0) {
@@ -437,6 +437,11 @@ export class TemplateBinder {
       // any attributes, even if they are plain (no command/interpolation etc), should be added if they
       // are on the surrogate element
       manifest.attributes.push(new PlainAttributeSymbol(attrSyntax, command, expr));
+    }
+
+    if (command === null && expr !== null) {
+      // if it's an interpolation, clear the attribute value
+      attr.value = '';
     }
 
     if (Tracer.enabled) { Tracer.leave(); }

--- a/packages/jit-html/test/integration/binding-commands.spec.ts
+++ b/packages/jit-html/test/integration/binding-commands.spec.ts
@@ -64,7 +64,7 @@ describe('binding-commands', () => {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div class="\${foo}"></div></template>`, null);
     component.foo = 'foo bar';
     lifecycle.processFlushQueue(LF.none);
-    expect((host.firstElementChild as HTMLElement).classList.toString()).to.equal('\${foo} au foo bar'); // TODO: fix this
+    expect((host.firstElementChild as HTMLElement).classList.toString()).to.equal('au foo bar');
     tearDown(au, lifecycle, host);
   });
 

--- a/packages/jit-html/test/integration/html-attributes.spec.ts
+++ b/packages/jit-html/test/integration/html-attributes.spec.ts
@@ -1,0 +1,180 @@
+import { InjectArray } from '@aurelia/kernel';
+import { Aurelia, CustomElementResource as CE, ICustomElement, INode, LifecycleFlags as LF } from '@aurelia/runtime';
+import { expect } from 'chai';
+import { TestContext } from '../util';
+import { eachCartesianJoin } from './util';
+
+interface IThing {
+  enabled?: boolean;
+}
+type VM<T> = T & ICustomElement<Node> & {
+  el: Element;
+  parent?: VM<T>;
+};
+interface Spec {
+  t: string;
+}
+
+describe('html attribute', function() {
+  function setup() {
+    const ctx = TestContext.createHTMLTestContext();
+
+    const host = ctx.createElement('div');
+    const au = new Aurelia(ctx.container);
+    return { ctx, host, au };
+  }
+
+  describe('class', function () {
+    describe('on a surrogate', function () {
+      interface ThingSpec extends Spec {
+        createThing(): IThing;
+      }
+      interface ExpressionSpec extends Spec {
+        expression: string;
+        getExpectedClassNames(thing: IThing): string[];
+      }
+
+      const thingSpecs: ThingSpec[] = [
+        { t: '1', createThing() { return { enabled: false }; } },
+        { t: '2', createThing() { return { enabled: true  }; } },
+        { t: '3', createThing() { return {                }; } }
+      ];
+      const expressionSpecs: ExpressionSpec[] = [
+        {
+          t: '1',
+          expression: '${thing.enabled?\'class-1\':\'\'}',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-1'] : ['au'];
+          }
+        },
+        {
+          t: '2',
+          expression: '${thing.enabled?\'class-1\':\'class-2\'}',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-1'] : ['au', 'class-2'];
+          }
+        },
+        {
+          t: '3',
+          expression: '${thing.enabled?\'class-1\':\'\'} class-3',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-3', 'class-1'] : ['au', 'class-3'];
+          }
+        },
+        {
+          t: '4',
+          expression: '${thing.enabled?\'class-1\':\'class-2\'} class-3',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-3', 'class-1'] : ['au', 'class-2', 'class-3'];
+          }
+        },
+        {
+          t: '5',
+          expression: 'class-0 ${thing.enabled?\'class-1\':\'\'}',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-0', 'class-1'] : ['au', 'class-0'];
+          }
+        },
+        {
+          t: '6',
+          expression: 'class-0 ${thing.enabled?\'class-1\':\'class-2\'}',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-0', 'class-1'] : ['au', 'class-0', 'class-2'];
+          }
+        },
+        {
+          t: '7',
+          expression: 'class-0 ${thing.enabled?\'class-1\':\'\'} class-3',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-0', 'class-3', 'class-1'] : ['au', 'class-0', 'class-3'];
+          }
+        },
+        {
+          t: '8',
+          expression: 'class-0 ${thing.enabled?\'class-1\':\'class-2\'} class-3',
+          getExpectedClassNames(thing: IThing) {
+            return thing && thing.enabled ? ['au', 'class-0', 'class-3', 'class-1'] : ['au', 'class-0', 'class-2', 'class-3'];
+          }
+        },
+      ];
+
+      eachCartesianJoin(
+        [thingSpecs, thingSpecs, thingSpecs, thingSpecs, expressionSpecs],
+        function (thingSpec1, thingSpec2, thingSpec3, thingSpec4, expressionSpec) {
+          it(`${thingSpec1.t} ${thingSpec2.t} ${thingSpec3.t} ${thingSpec4.t} ${expressionSpec.t}`, function() {
+            const { createThing: createThing1 } = thingSpec1;
+            const { createThing: createThing2 } = thingSpec2;
+            const { createThing: createThing3 } = thingSpec3;
+            const { createThing: createThing4 } = thingSpec4;
+            const { expression, getExpectedClassNames } = expressionSpec;
+
+            const thing1 = createThing1();
+            const thing2 = createThing2();
+            const thing3 = createThing3();
+            const thing4 = createThing4();
+
+            const { host, au } = setup();
+            // verify that the assertions inside change handler / lifecycles were actually performed
+            let assertionCount = 0;
+
+            const component = CE.define(
+              {
+                name: 'app',
+                template: `<foo parent.bind="$this"></foo>`,
+                dependencies: [
+                  CE.define(
+                    {
+                      name: 'foo',
+                      template: `<template class="${expression}"></template>`,
+                      bindables: ['thing', 'parent']
+                    },
+                    class {
+                      public static readonly inject: InjectArray = [INode];
+                      public thing: IThing;
+                      constructor(public el: Element) {
+                        this.thing = thing1;
+                      }
+
+                      public attached(): void {
+                        this.thing = thing2;
+                        this.thing = thing3;
+                        this.thing = thing4;
+                      }
+
+                      public thingChanged(this: VM<this>, newValue: IThing, oldValue: IThing): void {
+                        this.verifyClassName(oldValue);
+                        this.$lifecycle.processFlushQueue(LF.none);
+                        this.verifyClassName(newValue);
+                      }
+
+                      private verifyClassName(this: VM<this>, thing: IThing): void {
+                        const actualClassNames: string[] = [];
+                        this.el.classList.forEach(c => { actualClassNames.push(c); });
+                        const expectedClassNames = getExpectedClassNames(thing);
+                        expect(actualClassNames.length, `actualClassNames.length #${++assertionCount}`).to.equal(expectedClassNames.length);
+                        for (const expectedClassName of expectedClassNames) {
+                          expect(actualClassNames, `actualClassNames #${++assertionCount}`).to.include(expectedClassName);
+                        }
+                      }
+                    }
+                  )
+                ]
+              },
+              class {
+                public static readonly inject: InjectArray = [INode];
+                constructor(public el: Element) {}
+              }
+            );
+
+            au.app({ host, component });
+            au.start();
+
+            expect(assertionCount, 'assertionCount').to.be.gte(12);
+
+            au.stop();
+          });
+        }
+      );
+    });
+  });
+});

--- a/packages/jit-html/test/unit/template-compiler.spec.ts
+++ b/packages/jit-html/test/unit/template-compiler.spec.ts
@@ -519,7 +519,7 @@ function createCustomElement(ctx: HTMLTestContext, tagName: string, finalize: bo
     instructions: childInstructions,
     parts: PLATFORM.emptyObject
   };
-  const attributeMarkup = attributes.map(a => `${a[0]}="${a[1]}"`).join(' ');
+  const attributeMarkup = attributes.map(a => `${a[0]}="${a[1].replace(/\$\{.*\}/, '')}"`).join(' ');
   const rawMarkup = `<${tagName} ${attributeMarkup}>${(childInput && childInput.template) || ''}</${tagName}>`;
   const input = {
     template: finalize ? `<div>${rawMarkup}</div>` : rawMarkup,

--- a/packages/jit-html/test/unit/template-compiler.spec.ts
+++ b/packages/jit-html/test/unit/template-compiler.spec.ts
@@ -519,13 +519,13 @@ function createCustomElement(ctx: HTMLTestContext, tagName: string, finalize: bo
     instructions: childInstructions,
     parts: PLATFORM.emptyObject
   };
-  const attributeMarkup = attributes.map(a => `${a[0]}="${a[1].replace(/\$\{.*\}/, '')}"`).join(' ');
+  const attributeMarkup = attributes.map(a => `${a[0]}="${a[1]}"`).join(' ');
   const rawMarkup = `<${tagName} ${attributeMarkup}>${(childInput && childInput.template) || ''}</${tagName}>`;
   const input = {
     template: finalize ? `<div>${rawMarkup}</div>` : rawMarkup,
     instructions: []
   };
-  const outputMarkup = ctx.createElementFromMarkup(`<${tagName} ${attributeMarkup}>${(childOutput && childOutput.template.outerHTML) || ''}</${tagName}>`);
+  const outputMarkup = ctx.createElementFromMarkup(`<${tagName} ${attributeMarkup.replace(/\$\{.*\}/, '')}>${(childOutput && childOutput.template.outerHTML) || ''}</${tagName}>`);
   outputMarkup.classList.add('au');
   const output = {
     template: finalize ? ctx.createElementFromMarkup(`<template><div>${outputMarkup.outerHTML}</div></template>`) : outputMarkup,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -30,6 +30,7 @@ export {
   Immutable,
   ImmutableArray,
   ImmutableObject,
+  InjectArray,
   Injectable,
   InterfaceSymbol,
   IPerformance,

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -86,6 +86,8 @@ export type ConstructableClass<T, C = IIndexable> = C & {
 
 export type InterfaceSymbol<T = unknown> = (target: Injectable<T>, property: string, index: number) => any;
 
+export type InjectArray = ReadonlyArray<InterfaceSymbol | Constructable | string>;
+
 export type Injectable<T = {}> = Constructable<T> & { inject?: (InterfaceSymbol|Constructable)[] };
 
 export type IIndexable<T extends object = object> = T & { [key: string]: unknown };

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -46,6 +46,7 @@ export class Aurelia {
 
     const domInitializer = this.container.get(IDOMInitializer);
     domInitializer.initialize(config);
+    Registration.instance(INode, host).register(this.container);
 
     const startFlags = LifecycleFlags.fromStartTask | config.strategy;
     const stopFlags = LifecycleFlags.fromStopTask | config.strategy;

--- a/packages/runtime/src/observation/self-observer.ts
+++ b/packages/runtime/src/observation/self-observer.ts
@@ -57,7 +57,7 @@ export class SelfObserver implements SelfObserver {
         const oldValue = this.currentValue;
         flags |= this.persistentFlags;
         this.currentValue = newValue;
-        this.callSubscribers(newValue, oldValue, flags);
+        this.callSubscribers(newValue, oldValue, flags | LifecycleFlags.allowPublishRoundtrip);
         if (this.callback !== null) {
           this.callback.call(this.obj, newValue, oldValue, flags);
         }

--- a/packages/runtime/src/observation/self-observer.ts
+++ b/packages/runtime/src/observation/self-observer.ts
@@ -33,7 +33,7 @@ export class SelfObserver implements SelfObserver {
     }
     this.propertyKey = propertyName;
     this.currentValue = this.obj[propertyName];
-    this.callback = this.obj[cbName] || null;
+    this.callback = this.obj[cbName] === undefined ? null : this.obj[cbName];
     if (flags & LifecycleFlags.patchStrategy) {
       this.getValue = this.getValueDirect;
     }

--- a/packages/runtime/src/observation/self-observer.ts
+++ b/packages/runtime/src/observation/self-observer.ts
@@ -23,7 +23,7 @@ export class SelfObserver implements SelfObserver {
     propertyName: string,
     cbName: string
   ) {
-    if (Tracer.enabled) { Tracer.enter('cbName', 'constructor', slice.call(arguments)); }
+    if (Tracer.enabled) { Tracer.enter('SelfObserver', 'constructor', slice.call(arguments)); }
     this.persistentFlags = flags & LifecycleFlags.persistentBindingFlags;
     if (ProxyObserver.isProxy(instance)) {
       instance.$observer.subscribe(this, propertyName);

--- a/packages/runtime/src/observation/target-observer.ts
+++ b/packages/runtime/src/observation/target-observer.ts
@@ -22,6 +22,7 @@ function setValue(this: BindingTargetAccessor, newValue: unknown, flags: Lifecyc
   const currentValue = this.currentValue;
   newValue = newValue === null || newValue === undefined ? this.defaultValue : newValue;
   if (currentValue !== newValue) {
+    this.oldValue = this.currentValue;
     this.currentValue = newValue;
     if ((flags & (LifecycleFlags.fromFlush | LifecycleFlags.fromBind)) &&
       !(this.isDOMObserver && (flags & LifecycleFlags.doNotUpdateDOM))) {

--- a/packages/runtime/test/observation/property-observation.spec.ts
+++ b/packages/runtime/test/observation/property-observation.spec.ts
@@ -169,7 +169,7 @@ describe('Observer', () => {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new SelfObserver(LF.none, {}, 'a', 'aChanged');
-      expect(observer['aChanged']).to.equal(null);
+      expect(observer['callback']).to.equal(null);
     });
   });
 });

--- a/packages/runtime/test/observation/property-observation.spec.ts
+++ b/packages/runtime/test/observation/property-observation.spec.ts
@@ -165,11 +165,11 @@ describe('SetterObserver', () => {
 
 describe('Observer', () => {
 
-  it('use noop function as default callback', () => {
+  it('initializes the default callback to null', () => {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new SelfObserver(LF.none, {}, 'a', 'aChanged');
-      expect(observer['callback'](value, undefined)).to.equal(undefined);
+      expect(observer['aChanged']).to.equal(null);
     });
   });
 });

--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -102,7 +102,7 @@ export default function(config: IKarmaConfig): void {
     mime: {
       'text/x-typescript': ['ts']
     },
-    reporters: ['junit', config.reporter || 'progress'],
+    reporters: ['junit', config.reporter || 'min'],
     webpackMiddleware: {
       stats: {
         colors: true,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Fixes #423 (oldValue was not stored in the target observer so it never recognized the difference between an initial value and an empty string set as the next value)
- Adds `InjectArray` as a shorthand type for `ReadonlyArray<InterfaceSymbol | Constructable | string>`
- Register the app host as `INode` so it can be injected into the root component
- Removes coercion from change handler in SelfObserver and moves the callback to after `callSubscribers`, so updates are actually already propagated and/or queued when the callback is invoked and you can work with the results
- Fixes #421 by removing interpolations from attribute values during compilation
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

- Fixes #423 
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Changes probably speak for themselves :)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

- Added ~2k tests to verify the various combinations of class binding initialization and updates
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

- Add more of these kinds of tests
- Look at the other bug reports :)
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
