### PR TITLE
switch from arrow to function expr in tests

### DIFF
--- a/packages/aot/test/unit/index.spec.ts
+++ b/packages/aot/test/unit/index.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { placeholder } from '../../src/index';
 
-describe('index', function() {
-  it('placeholder should be null', function() {
+describe('index', function () {
+  it('placeholder should be null', function () {
     expect(placeholder).to.equal(null);
   });
 });

--- a/packages/aot/test/unit/index.spec.ts
+++ b/packages/aot/test/unit/index.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { placeholder } from '../../src/index';
 
-describe('index', () => {
-  it('placeholder should be null', () => {
+describe('index', function() {
+  it('placeholder should be null', function() {
     expect(placeholder).to.equal(null);
   });
 });

--- a/packages/debug/src/binding/unparser.ts
+++ b/packages/debug/src/binding/unparser.ts
@@ -34,7 +34,7 @@ export function enableImprovedExpressionDebugging(): void {
 
 /** @internal */
 export function adoptDebugMethods($type: Unwrap<typeof astTypeMap>['type'], name: string): void {
-  $type.prototype.toString = function(): string { return Unparser.unparse(this); };
+  $type.prototype.toString = function (): string { return Unparser.unparse(this); };
 }
 
 /** @internal */

--- a/packages/debug/test/unit/dummy.spec.ts
+++ b/packages/debug/test/unit/dummy.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-describe('true', () => {
-  it('should be true', () => {
+describe('true', function() {
+  it('should be true', function() {
     expect(true).to.equal(true);
   });
 });

--- a/packages/debug/test/unit/dummy.spec.ts
+++ b/packages/debug/test/unit/dummy.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-describe('true', function() {
-  it('should be true', function() {
+describe('true', function () {
+  it('should be true', function () {
     expect(true).to.equal(true);
   });
 });

--- a/packages/fetch-client/test/unit/http-client.spec.ts
+++ b/packages/fetch-client/test/unit/http-client.spec.ts
@@ -8,30 +8,30 @@ import { Interceptor } from '../../src/interfaces';
 import { retryStrategy } from '../../src/retry-interceptor';
 import { json } from '../../src/util';
 
-describe('HttpClient', function() {
+describe('HttpClient', function () {
   let ctx: HTMLTestContext;
   let originalFetch: (input: string | Request, init?: RequestInit) => Promise<Response>;
   let client: HttpClient;
   let fetch: SinonStub;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
     originalFetch = ctx.dom.window.fetch;
     client = ctx.container.get(HttpClient);
     fetch = ctx.dom.window.fetch = stub();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     fetch = ctx.dom.window.fetch = originalFetch as SinonStub;
   });
 
-  it('errors on missing fetch implementation', function() {
+  it('errors on missing fetch implementation', function () {
     ctx.dom.window.fetch = undefined;
     expect(() => new HttpClient(ctx.dom)).to.throw();
   });
 
-  describe('configure', function() {
-    it('accepts plain objects', function() {
+  describe('configure', function () {
+    it('accepts plain objects', function () {
       const defaults = {};
       client.configure(defaults);
 
@@ -39,7 +39,7 @@ describe('HttpClient', function() {
       expect(client.defaults).to.equal(defaults);
     });
 
-    it('accepts configuration callbacks', function() {
+    it('accepts configuration callbacks', function () {
       const defaults = { foo: true };
       const baseUrl = '/test';
       const interceptor = {};
@@ -59,7 +59,7 @@ describe('HttpClient', function() {
       expect(client.interceptors.indexOf(interceptor)).to.equal(0);
     });
 
-    it('accepts configuration override', function() {
+    it('accepts configuration override', function () {
       const defaults = { foo: true };
 
       client.configure(config => config.withDefaults(defaults as RequestInit));
@@ -71,25 +71,25 @@ describe('HttpClient', function() {
       });
     });
 
-    it('rejects invalid configs', function() {
+    it('rejects invalid configs', function () {
       expect(() => client.configure(1 as RequestInit)).to.throw();
     });
 
-    it('applies standard configuration', function() {
+    it('applies standard configuration', function () {
       client.configure(config => config.useStandardConfiguration());
 
       expect(client.defaults.credentials).to.equal('same-origin');
       expect(client.interceptors.length).to.equal(1);
     });
 
-    it('rejects error responses', function() {
+    it('rejects error responses', function () {
       client.configure(config => config.rejectErrorResponses());
 
       expect(client.interceptors.length).to.equal(1);
     });
   });
 
-  describe('fetch', function() {
+  describe('fetch', function () {
     it('makes requests with string inputs', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -228,7 +228,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('get', function() {
+  describe('get', function () {
     it('passes-through to fetch', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -247,7 +247,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('post', function() {
+  describe('post', function () {
     it('sets method to POST and body of request and calls fetch', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -266,7 +266,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('put', function() {
+  describe('put', function () {
     it('sets method to PUT and body of request and calls fetch', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -285,7 +285,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('patch', function() {
+  describe('patch', function () {
     it('sets method to PATCH and body of request and calls fetch', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -304,7 +304,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('delete', function() {
+  describe('delete', function () {
     it('sets method to DELETE and body of request and calls fetch', function(done) {
       fetch.returns(emptyResponse(200));
 
@@ -323,7 +323,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('interceptors', function() {
+  describe('interceptors', function () {
 
     it('run on request', function(done) {
       fetch.returns(emptyResponse(200));
@@ -519,7 +519,7 @@ describe('HttpClient', function() {
         }).catch(() => { done('Unexpected catch'); });
     });
 
-    describe('rejectErrorResponses', function() {
+    describe('rejectErrorResponses', function () {
       it('can reject error responses', function(done) {
         const response = new Response(null, { status: 500 });
         fetch.returns(Promise.resolve(response));
@@ -551,7 +551,7 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('default request parameters', function() {
+  describe('default request parameters', function () {
 
     it('applies baseUrl to requests', function(done) {
       fetch.returns(emptyResponse(200));
@@ -705,10 +705,10 @@ describe('HttpClient', function() {
     });
   });
 
-  describe('retry', function() {
+  describe('retry', function () {
     this.timeout(10000);
 
-    it('fails if multiple RetryInterceptors are defined', function() {
+    it('fails if multiple RetryInterceptors are defined', function () {
       const configure = () => {
         client.configure(config => config.withRetry().withRetry());
       };
@@ -716,7 +716,7 @@ describe('HttpClient', function() {
       expect(configure).to.throw('Only one RetryInterceptor is allowed.');
     });
 
-    it('fails if RetryInterceptor is not last interceptor defined', function() {
+    it('fails if RetryInterceptor is not last interceptor defined', function () {
       const configure = () => {
         client.configure(config => config.withRetry().rejectErrorResponses());
       };
@@ -992,7 +992,7 @@ describe('HttpClient', function() {
     // });
   });
 
-  describe('isRequesting', function() {
+  describe('isRequesting', function () {
     it('is set to true when starting a request', function(done) {
       fetch.returns(emptyResponse(200));
 

--- a/packages/fetch-client/test/unit/util.spec.ts
+++ b/packages/fetch-client/test/unit/util.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { json } from '../../src/util';
 
-describe('util', function() {
-  describe('json', function() {
-    it('returns valid JSON', function() {
+describe('util', function () {
+  describe('json', function () {
+    it('returns valid JSON', function () {
       const data = { test: 'data' };
       const result = JSON.parse(json(data));
       expect(data).to.deep.equal(result);

--- a/packages/fetch-client/test/unit/util.spec.ts
+++ b/packages/fetch-client/test/unit/util.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { json } from '../../src/util';
 
-describe('util', () => {
-  describe('json', () => {
-    it('returns valid JSON', () => {
+describe('util', function() {
+  describe('json', function() {
+    it('returns valid JSON', function() {
       const data = { test: 'data' };
       const result = JSON.parse(json(data));
       expect(data).to.deep.equal(result);

--- a/packages/jit-html/test/integration/binding-commands.spec.ts
+++ b/packages/jit-html/test/integration/binding-commands.spec.ts
@@ -7,15 +7,15 @@ import { TestConfiguration } from './resources';
 import { setupAndStart, setupWithDocumentAndStart, tearDown } from './util';
 
 // TemplateCompiler - Binding Commands integration
-describe('binding-commands', () => {
+describe('binding-commands', function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // textBinding - interpolation
-  it('01.', () => {
+  it('01.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template>\${message}</template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -24,7 +24,7 @@ describe('binding-commands', () => {
   });
 
   // textBinding - interpolation with template
-  it('02.', () => {
+  it('02.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template>\${\`\${message}\`}</template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -33,7 +33,7 @@ describe('binding-commands', () => {
   });
 
   // styleBinding - bind
-  it('03.', () => {
+  it('03.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div style.bind="foo"></div></template>`, null);
     component.foo = 'color: green;';
     lifecycle.processFlushQueue(LF.none);
@@ -42,7 +42,7 @@ describe('binding-commands', () => {
   });
 
   // styleBinding - interpolation
-  it('04.', () => {
+  it('04.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div style="\${foo}"></div></template>`, null);
     component.foo = 'color: green;';
     lifecycle.processFlushQueue(LF.none);
@@ -51,7 +51,7 @@ describe('binding-commands', () => {
   });
 
   // classBinding - bind
-  it('05.', () => {
+  it('05.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div class.bind="foo"></div></template>`, null);
     component.foo = 'foo bar';
     lifecycle.processFlushQueue(LF.none);
@@ -60,7 +60,7 @@ describe('binding-commands', () => {
   });
 
   // classBinding - interpolation
-  it('06.', () => {
+  it('06.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div class="\${foo}"></div></template>`, null);
     component.foo = 'foo bar';
     lifecycle.processFlushQueue(LF.none);
@@ -69,7 +69,7 @@ describe('binding-commands', () => {
   });
 
   // oneTimeBinding - input.value
-  it('07.', () => {
+  it('07.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -78,7 +78,7 @@ describe('binding-commands', () => {
   });
 
   // toViewBinding - input.value
-  it('08.', () => {
+  it('08.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.to-view="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -87,7 +87,7 @@ describe('binding-commands', () => {
   });
 
   // fromViewBinding - input.value
-  it('09.', () => {
+  it('09.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.from-view="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -99,7 +99,7 @@ describe('binding-commands', () => {
   });
 
   // twoWayBinding - input.value
-  it('10.', () => {
+  it('10.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.two-way="message"></template>`, null);
     host.firstChild['value'] = 'hello!';
     expect(component.message).to.equal(undefined);
@@ -109,7 +109,7 @@ describe('binding-commands', () => {
   });
 
   // twoWayBinding - input.value - jsonValueConverter
-  it('11.', () => {
+  it('11.', function() {
     ctx.container.register(TestConfiguration);
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.two-way="message | json"></template>`, null);
     expect(component.message).to.equal(undefined);
@@ -125,7 +125,7 @@ describe('binding-commands', () => {
   });
 
   // oneTimeBindingBehavior - input.value
-  it('12.', () => {
+  it('12.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.to-view="message & oneTime"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -134,7 +134,7 @@ describe('binding-commands', () => {
   });
 
   // toViewBindingBehavior - input.value
-  it('13.', () => {
+  it('13.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & toView"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -143,7 +143,7 @@ describe('binding-commands', () => {
   });
 
   // fromViewBindingBehavior - input.value
-  it('14.', () => {
+  it('14.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & fromView"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -155,7 +155,7 @@ describe('binding-commands', () => {
   });
 
   // twoWayBindingBehavior - input.value
-  it('15.', () => {
+  it('15.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & twoWay"></template>`, null);
     expect(component.message).to.equal(undefined);
     host.firstChild['value'] = 'hello!';
@@ -166,7 +166,7 @@ describe('binding-commands', () => {
   });
 
   // toViewBinding - input checkbox
-  it('16.', () => {
+  it('16.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input checked.to-view="checked" type="checkbox"></template>`, null);
     expect(host.firstChild['checked']).to.equal(false);
     component.checked = true;
@@ -177,7 +177,7 @@ describe('binding-commands', () => {
   });
 
   // twoWayBinding - input checkbox
-  it('17.', () => {
+  it('17.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input checked.two-way="checked" type="checkbox"></template>`, null);
     expect(component.checked).to.equal(undefined);
     host.firstChild['checked'] = true;
@@ -188,7 +188,7 @@ describe('binding-commands', () => {
   });
 
   // trigger - button
-  it('18.', () => {
+  it('18.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><button click.trigger="doStuff()"></button></template>`, null);
     component.doStuff = spy();
     host.firstChild.dispatchEvent(new ctx.CustomEvent('click'));
@@ -197,7 +197,7 @@ describe('binding-commands', () => {
   });
 
   // delegate - button
-  it('19.', () => {
+  it('19.', function() {
     const { au, lifecycle, host, component } = setupWithDocumentAndStart(ctx, `<template><button click.delegate="doStuff()"></button></template>`, null);
     try {
       component.doStuff = spy();
@@ -211,7 +211,7 @@ describe('binding-commands', () => {
   });
 
   // capture - button
-  it('20.', () => {
+  it('20.', function() {
     const { au, lifecycle, host, component } = setupWithDocumentAndStart(ctx, `<template><button click.capture="doStuff()"></button></template>`, null);
     try {
       component.doStuff = spy();

--- a/packages/jit-html/test/integration/binding-commands.spec.ts
+++ b/packages/jit-html/test/integration/binding-commands.spec.ts
@@ -7,15 +7,15 @@ import { TestConfiguration } from './resources';
 import { setupAndStart, setupWithDocumentAndStart, tearDown } from './util';
 
 // TemplateCompiler - Binding Commands integration
-describe('binding-commands', function() {
+describe('binding-commands', function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // textBinding - interpolation
-  it('01.', function() {
+  it('01.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template>\${message}</template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -24,7 +24,7 @@ describe('binding-commands', function() {
   });
 
   // textBinding - interpolation with template
-  it('02.', function() {
+  it('02.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template>\${\`\${message}\`}</template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -33,7 +33,7 @@ describe('binding-commands', function() {
   });
 
   // styleBinding - bind
-  it('03.', function() {
+  it('03.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div style.bind="foo"></div></template>`, null);
     component.foo = 'color: green;';
     lifecycle.processFlushQueue(LF.none);
@@ -42,7 +42,7 @@ describe('binding-commands', function() {
   });
 
   // styleBinding - interpolation
-  it('04.', function() {
+  it('04.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div style="\${foo}"></div></template>`, null);
     component.foo = 'color: green;';
     lifecycle.processFlushQueue(LF.none);
@@ -51,7 +51,7 @@ describe('binding-commands', function() {
   });
 
   // classBinding - bind
-  it('05.', function() {
+  it('05.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div class.bind="foo"></div></template>`, null);
     component.foo = 'foo bar';
     lifecycle.processFlushQueue(LF.none);
@@ -60,7 +60,7 @@ describe('binding-commands', function() {
   });
 
   // classBinding - interpolation
-  it('06.', function() {
+  it('06.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div class="\${foo}"></div></template>`, null);
     component.foo = 'foo bar';
     lifecycle.processFlushQueue(LF.none);
@@ -69,7 +69,7 @@ describe('binding-commands', function() {
   });
 
   // oneTimeBinding - input.value
-  it('07.', function() {
+  it('07.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -78,7 +78,7 @@ describe('binding-commands', function() {
   });
 
   // toViewBinding - input.value
-  it('08.', function() {
+  it('08.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.to-view="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -87,7 +87,7 @@ describe('binding-commands', function() {
   });
 
   // fromViewBinding - input.value
-  it('09.', function() {
+  it('09.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.from-view="message"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -99,7 +99,7 @@ describe('binding-commands', function() {
   });
 
   // twoWayBinding - input.value
-  it('10.', function() {
+  it('10.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.two-way="message"></template>`, null);
     host.firstChild['value'] = 'hello!';
     expect(component.message).to.equal(undefined);
@@ -109,7 +109,7 @@ describe('binding-commands', function() {
   });
 
   // twoWayBinding - input.value - jsonValueConverter
-  it('11.', function() {
+  it('11.', function () {
     ctx.container.register(TestConfiguration);
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.two-way="message | json"></template>`, null);
     expect(component.message).to.equal(undefined);
@@ -125,7 +125,7 @@ describe('binding-commands', function() {
   });
 
   // oneTimeBindingBehavior - input.value
-  it('12.', function() {
+  it('12.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.to-view="message & oneTime"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -134,7 +134,7 @@ describe('binding-commands', function() {
   });
 
   // toViewBindingBehavior - input.value
-  it('13.', function() {
+  it('13.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & toView"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -143,7 +143,7 @@ describe('binding-commands', function() {
   });
 
   // fromViewBindingBehavior - input.value
-  it('14.', function() {
+  it('14.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & fromView"></template>`, null);
     component.message = 'hello!';
     lifecycle.processFlushQueue(LF.none);
@@ -155,7 +155,7 @@ describe('binding-commands', function() {
   });
 
   // twoWayBindingBehavior - input.value
-  it('15.', function() {
+  it('15.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.one-time="message & twoWay"></template>`, null);
     expect(component.message).to.equal(undefined);
     host.firstChild['value'] = 'hello!';
@@ -166,7 +166,7 @@ describe('binding-commands', function() {
   });
 
   // toViewBinding - input checkbox
-  it('16.', function() {
+  it('16.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input checked.to-view="checked" type="checkbox"></template>`, null);
     expect(host.firstChild['checked']).to.equal(false);
     component.checked = true;
@@ -177,7 +177,7 @@ describe('binding-commands', function() {
   });
 
   // twoWayBinding - input checkbox
-  it('17.', function() {
+  it('17.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input checked.two-way="checked" type="checkbox"></template>`, null);
     expect(component.checked).to.equal(undefined);
     host.firstChild['checked'] = true;
@@ -188,7 +188,7 @@ describe('binding-commands', function() {
   });
 
   // trigger - button
-  it('18.', function() {
+  it('18.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><button click.trigger="doStuff()"></button></template>`, null);
     component.doStuff = spy();
     host.firstChild.dispatchEvent(new ctx.CustomEvent('click'));
@@ -197,7 +197,7 @@ describe('binding-commands', function() {
   });
 
   // delegate - button
-  it('19.', function() {
+  it('19.', function () {
     const { au, lifecycle, host, component } = setupWithDocumentAndStart(ctx, `<template><button click.delegate="doStuff()"></button></template>`, null);
     try {
       component.doStuff = spy();
@@ -211,7 +211,7 @@ describe('binding-commands', function() {
   });
 
   // capture - button
-  it('20.', function() {
+  it('20.', function () {
     const { au, lifecycle, host, component } = setupWithDocumentAndStart(ctx, `<template><button click.capture="doStuff()"></button></template>`, null);
     try {
       component.doStuff = spy();

--- a/packages/jit-html/test/integration/binding-resources.spec.ts
+++ b/packages/jit-html/test/integration/binding-resources.spec.ts
@@ -3,10 +3,10 @@ import { HTMLTestContext, TestContext } from '../util';
 import { setupAndStart, tearDown } from './util';
 
 // TemplateCompiler - Binding Resources integration
-describe('binding-resources', function() {
+describe('binding-resources', function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 

--- a/packages/jit-html/test/integration/binding-resources.spec.ts
+++ b/packages/jit-html/test/integration/binding-resources.spec.ts
@@ -3,10 +3,10 @@ import { HTMLTestContext, TestContext } from '../util';
 import { setupAndStart, tearDown } from './util';
 
 // TemplateCompiler - Binding Resources integration
-describe('binding-resources', () => {
+describe('binding-resources', function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 

--- a/packages/jit-html/test/integration/compose.spec.ts
+++ b/packages/jit-html/test/integration/compose.spec.ts
@@ -16,7 +16,7 @@ import { trimFull } from './util';
 const build = { required: true, compiler: 'default' };
 const spec = 'compose';
 
-describe(spec, () => {
+describe(spec, function() {
   function setup(): SpecContext {
     const ctx = TestContext.createHTMLTestContext();
     const { container, dom, lifecycle, observerLocator, renderingEngine: re } = ctx;
@@ -148,7 +148,7 @@ describe(spec, () => {
     const { createSubject, expectedText } = subjectSpec;
     const { template } = templateSpec;
 
-    it(`verify au-compose behavior - subjectSpec ${subjectSpec.t}, templateSpec ${templateSpec.t}`, async () => {
+    it(`verify au-compose behavior - subjectSpec ${subjectSpec.t}, templateSpec ${templateSpec.t}`, async function() {
       const ctx = setup();
       const subject = createSubject(ctx);
       const { au, host, lifecycle } = ctx;

--- a/packages/jit-html/test/integration/compose.spec.ts
+++ b/packages/jit-html/test/integration/compose.spec.ts
@@ -16,7 +16,7 @@ import { trimFull } from './util';
 const build = { required: true, compiler: 'default' };
 const spec = 'compose';
 
-describe(spec, function() {
+describe(spec, function () {
   function setup(): SpecContext {
     const ctx = TestContext.createHTMLTestContext();
     const { container, dom, lifecycle, observerLocator, renderingEngine: re } = ctx;
@@ -148,7 +148,7 @@ describe(spec, function() {
     const { createSubject, expectedText } = subjectSpec;
     const { template } = templateSpec;
 
-    it(`verify au-compose behavior - subjectSpec ${subjectSpec.t}, templateSpec ${templateSpec.t}`, async function() {
+    it(`verify au-compose behavior - subjectSpec ${subjectSpec.t}, templateSpec ${templateSpec.t}`, async function () {
       const ctx = setup();
       const subject = createSubject(ctx);
       const { au, host, lifecycle } = ctx;

--- a/packages/jit-html/test/integration/custom-elements.spec.ts
+++ b/packages/jit-html/test/integration/custom-elements.spec.ts
@@ -17,15 +17,15 @@ import { TestConfiguration } from './resources';
 import { setupAndStart, tearDown } from './util';
 
 // TemplateCompiler - custom element integration
-describe('custom-elements', function() {
+describe('custom-elements', function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // custom elements
-  it('01.', function() {
+  it('01.', function () {
     ctx.container.register(TestConfiguration);
     const { au, lifecycle, host } = setupAndStart(ctx, `<template><name-tag name="bigopon"></name-tag></template>`, null);
 
@@ -35,10 +35,10 @@ describe('custom-elements', function() {
   });
 
   //[as-element]
-  describe('02.', function() {
+  describe('02.', function () {
 
     //works with custom element with [as-element]
-    it('01.', function() {
+    it('01.', function () {
       ctx.container.register(TestConfiguration);
       const { au, lifecycle, host } = setupAndStart(ctx, `<template><div as-element="name-tag" name="bigopon"></div></template>`, null);
 
@@ -48,7 +48,7 @@ describe('custom-elements', function() {
     });
 
     //ignores tag name
-    it('02.', function() {
+    it('02.', function () {
       ctx.container.register(TestConfiguration);
       const { au, lifecycle, host } = setupAndStart(ctx, `<template><name-tag as-element="div" name="bigopon">Fred</name-tag></template>`, null);
 
@@ -59,7 +59,7 @@ describe('custom-elements', function() {
   });
 
   //<let/>
-  it('03.', function() {
+  it('03.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, '<template><let full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', null);
     expect(host.textContent).to.equal('undefined undefined');
 
@@ -76,7 +76,7 @@ describe('custom-elements', function() {
   });
 
   //<let [to-view-model] />
-  it('04.', function() {
+  it('04.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, '<template><let to-view-model full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', null);
     component.firstName = 'bi';
     expect(component.fullName).to.equal('bi undefined');
@@ -88,7 +88,7 @@ describe('custom-elements', function() {
   });
 
   //initial values propagate through multiple nested custom elements connected via bindables
-  it('05.', function() {
+  it('05.', function () {
     let boundCalls = 0;
 
     @customElement({ name: 'foo1', template: `<template><foo2 value.bind="value" value2.bind="value1"></foo2>\${value}</template>` })

--- a/packages/jit-html/test/integration/custom-elements.spec.ts
+++ b/packages/jit-html/test/integration/custom-elements.spec.ts
@@ -17,15 +17,15 @@ import { TestConfiguration } from './resources';
 import { setupAndStart, tearDown } from './util';
 
 // TemplateCompiler - custom element integration
-describe('custom-elements', () => {
+describe('custom-elements', function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // custom elements
-  it('01.', () => {
+  it('01.', function() {
     ctx.container.register(TestConfiguration);
     const { au, lifecycle, host } = setupAndStart(ctx, `<template><name-tag name="bigopon"></name-tag></template>`, null);
 
@@ -35,10 +35,10 @@ describe('custom-elements', () => {
   });
 
   //[as-element]
-  describe('02.', () => {
+  describe('02.', function() {
 
     //works with custom element with [as-element]
-    it('01.', () => {
+    it('01.', function() {
       ctx.container.register(TestConfiguration);
       const { au, lifecycle, host } = setupAndStart(ctx, `<template><div as-element="name-tag" name="bigopon"></div></template>`, null);
 
@@ -48,7 +48,7 @@ describe('custom-elements', () => {
     });
 
     //ignores tag name
-    it('02.', () => {
+    it('02.', function() {
       ctx.container.register(TestConfiguration);
       const { au, lifecycle, host } = setupAndStart(ctx, `<template><name-tag as-element="div" name="bigopon">Fred</name-tag></template>`, null);
 
@@ -59,7 +59,7 @@ describe('custom-elements', () => {
   });
 
   //<let/>
-  it('03.', () => {
+  it('03.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, '<template><let full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', null);
     expect(host.textContent).to.equal('undefined undefined');
 
@@ -76,7 +76,7 @@ describe('custom-elements', () => {
   });
 
   //<let [to-view-model] />
-  it('04.', () => {
+  it('04.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, '<template><let to-view-model full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', null);
     component.firstName = 'bi';
     expect(component.fullName).to.equal('bi undefined');
@@ -88,7 +88,7 @@ describe('custom-elements', () => {
   });
 
   //initial values propagate through multiple nested custom elements connected via bindables
-  it('05.', () => {
+  it('05.', function() {
     let boundCalls = 0;
 
     @customElement({ name: 'foo1', template: `<template><foo2 value.bind="value" value2.bind="value1"></foo2>\${value}</template>` })

--- a/packages/jit-html/test/integration/deep-bindables.spec.ts
+++ b/packages/jit-html/test/integration/deep-bindables.spec.ts
@@ -32,7 +32,7 @@ describe(spec, function () {
     BindingStrategy.keyed | BindingStrategy.patch,
     BindingStrategy.keyed | BindingStrategy.proxies
   ]) {
-    it(`strategy=${stringifyLifecycleFlags(strategy)}`, function() {
+    it(`strategy=${stringifyLifecycleFlags(strategy)}`, function () {
       const bb = (strategy & BindingStrategy.keyed) > 0 ? ' & keyed' : '';
       this.timeout(30000);
       let num = 0;
@@ -164,7 +164,7 @@ describe(spec, function () {
     BindingStrategy.keyed | BindingStrategy.patch,
     BindingStrategy.keyed | BindingStrategy.proxies
   ]) {
-    it(`profile, strategy=${stringifyLifecycleFlags(strategy)}`, function() {
+    it(`profile, strategy=${stringifyLifecycleFlags(strategy)}`, function () {
       const bb = (strategy & BindingStrategy.keyed) > 0 ? ' & keyed' : '';
       this.timeout(30000);
       const { au, host } = setup();
@@ -226,7 +226,7 @@ describe(spec, function () {
 
 // TODO: replace these tests with cartesian loop and remove these comments
 
-  // it('works 2', function() {
+  // it('works 2', function () {
   //   this.timeout(30000);
   //   let count = 100000;
   //   const { ctx, container, lifecycle, au, host } = setup();

--- a/packages/jit-html/test/integration/di-registrations.spec.ts
+++ b/packages/jit-html/test/integration/di-registrations.spec.ts
@@ -14,7 +14,7 @@ import {
 import { expect } from 'chai';
 import { TestContext } from '../util';
 
-describe('DI', function() {
+describe('DI', function () {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
     const container = ctx.container;
@@ -24,9 +24,9 @@ describe('DI', function() {
     return { ctx, container, au, host };
   }
 
-  describe('can render locally registered types', function() {
+  describe('can render locally registered types', function () {
 
-    it('from within the type in which it was registered', function() {
+    it('from within the type in which it was registered', function () {
       const { au, host } = setup();
 
       const Foo = CustomElementResource.define(
@@ -53,7 +53,7 @@ describe('DI', function() {
       expect(host.textContent).to.equal('foo');
     });
 
-    it('from within a child type of the type in which is was registered', function() {
+    it('from within a child type of the type in which is was registered', function () {
       const { au, host } = setup();
 
       const Bar = CustomElementResource.define(
@@ -88,7 +88,7 @@ describe('DI', function() {
       expect(host.textContent).to.equal('foobar');
     });
 
-    it('from within a grandchild type of the type in which is was registered', function() {
+    it('from within a grandchild type of the type in which is was registered', function () {
       const { au, host } = setup();
 
       const Baz = CustomElementResource.define(
@@ -131,7 +131,7 @@ describe('DI', function() {
       expect(host.textContent).to.equal('foobarbaz');
     });
 
-    it('from within a type whose child has registered it, which is a parent via recursion', function() {
+    it('from within a type whose child has registered it, which is a parent via recursion', function () {
       const { au, host } = setup();
 
       const Bar = CustomElementResource.define(
@@ -178,9 +178,9 @@ describe('DI', function() {
     });
   });
 
-  describe('can resolve locally registered types', function() {
+  describe('can resolve locally registered types', function () {
 
-    it('from within the type in which it was registered', function() {
+    it('from within the type in which it was registered', function () {
       const { au, host } = setup();
 
       const Foo = CustomElementResource.define(
@@ -223,7 +223,7 @@ describe('DI', function() {
       expect(host.textContent).to.equal('fooapp');
     });
 
-    it('from within a child type of the type in which is was registered', function() {
+    it('from within a child type of the type in which is was registered', function () {
       const { au, host } = setup();
 
       const Bar = CustomElementResource.define(
@@ -275,7 +275,7 @@ describe('DI', function() {
       expect(host.textContent).to.equal('appbarfoo');
     });
 
-    it('from within a grandchild type of the type in which is was registered', function() {
+    it('from within a grandchild type of the type in which is was registered', function () {
       const { au, host } = setup();
 
       const Baz = CustomElementResource.define(

--- a/packages/jit-html/test/integration/hooks.spec.ts
+++ b/packages/jit-html/test/integration/hooks.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { TestContext } from '../util';
 
 describe('hooks', function () {
-  it('test', function() {
+  it('test', function () {
     const rows: any[] = [
       {
         show: true,
@@ -268,7 +268,7 @@ describe('hooks', function () {
 
   });
 
-  it('attached task awaited indirectly', async function() {
+  it('attached task awaited indirectly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -327,7 +327,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task awaited directly', async function() {
+  it('attached task awaited directly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -391,7 +391,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task (triple then) awaited indirectly', async function() {
+  it('attached task (triple then) awaited indirectly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -458,7 +458,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task (triple then) awaited directly', async function() {
+  it('attached task (triple then) awaited directly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -522,7 +522,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('detached task awaited indirectly', async function() {
+  it('detached task awaited indirectly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -583,7 +583,7 @@ describe('hooks', function () {
 
   });
 
-  it('detached task awaited directly', async function() {
+  it('detached task awaited directly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -644,7 +644,7 @@ describe('hooks', function () {
 
   });
 
-  it('detached task (triple then) awaited indirectly', async function() {
+  it('detached task (triple then) awaited indirectly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -708,7 +708,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('detached task (triple then) awaited directly', async function() {
+  it('detached task (triple then) awaited directly', async function () {
 
     const Foo = CustomElementResource.define({
       name: 'foo',

--- a/packages/jit-html/test/integration/hooks.spec.ts
+++ b/packages/jit-html/test/integration/hooks.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { TestContext } from '../util';
 
 describe('hooks', function () {
-  it('test', () => {
+  it('test', function() {
     const rows: any[] = [
       {
         show: true,
@@ -268,7 +268,7 @@ describe('hooks', function () {
 
   });
 
-  it('attached task awaited indirectly', async () => {
+  it('attached task awaited indirectly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -327,7 +327,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task awaited directly', async () => {
+  it('attached task awaited directly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -391,7 +391,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task (triple then) awaited indirectly', async () => {
+  it('attached task (triple then) awaited indirectly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -458,7 +458,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('attached task (triple then) awaited directly', async () => {
+  it('attached task (triple then) awaited directly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -522,7 +522,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('detached task awaited indirectly', async () => {
+  it('detached task awaited indirectly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -583,7 +583,7 @@ describe('hooks', function () {
 
   });
 
-  it('detached task awaited directly', async () => {
+  it('detached task awaited directly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -644,7 +644,7 @@ describe('hooks', function () {
 
   });
 
-  it('detached task (triple then) awaited indirectly', async () => {
+  it('detached task (triple then) awaited indirectly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',
@@ -708,7 +708,7 @@ describe('hooks', function () {
     expect(host.textContent).to.equal('');
   });
 
-  it('detached task (triple then) awaited directly', async () => {
+  it('detached task (triple then) awaited directly', async function() {
 
     const Foo = CustomElementResource.define({
       name: 'foo',

--- a/packages/jit-html/test/integration/html-attributes.spec.ts
+++ b/packages/jit-html/test/integration/html-attributes.spec.ts
@@ -15,7 +15,7 @@ interface Spec {
   t: string;
 }
 
-describe('html attribute', function() {
+describe('html attribute', function () {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
 
@@ -118,7 +118,7 @@ describe('html attribute', function() {
       eachCartesianJoin(
         [thingSpecs, thingSpecs, thingSpecs, thingSpecs, expressionSpecs, elementSpecs],
         function (thingSpec1, thingSpec2, thingSpec3, thingSpec4, expressionSpec, elementSpec) {
-          it(`thingSpec1 ${thingSpec1.t}, thingSpec2 ${thingSpec2.t}, thingSpec3 ${thingSpec3.t}, thingSpec4 ${thingSpec4.t}, expressionSpec ${expressionSpec.t}, elementSpec ${elementSpec.t}`, function() {
+          it(`thingSpec1 ${thingSpec1.t}, thingSpec2 ${thingSpec2.t}, thingSpec3 ${thingSpec3.t}, thingSpec4 ${thingSpec4.t}, expressionSpec ${expressionSpec.t}, elementSpec ${elementSpec.t}`, function () {
             const { createThing: createThing1 } = thingSpec1;
             const { createThing: createThing2 } = thingSpec2;
             const { createThing: createThing3 } = thingSpec3;

--- a/packages/jit-html/test/integration/if-else.spec.ts
+++ b/packages/jit-html/test/integration/if-else.spec.ts
@@ -11,15 +11,15 @@ import {
 const spec = 'if-else';
 
 // TemplateCompiler - if/else integration
-describe(spec, function() {
+describe(spec, function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 
   //if - shows and hides
-  it('01.', function() {
+  it('01.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div if.bind="foo">bar</div></template>`, null);
     component.foo = true;
     lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -31,7 +31,7 @@ describe(spec, function() {
   });
 
   //if - shows and hides - toggles else
-  it('02.', function() {
+  it('02.', function () {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div if.bind="foo">bar</div><div else>baz</div></template>`, null);
     component.foo = true;
     lifecycle.processFlushQueue(LifecycleFlags.none);

--- a/packages/jit-html/test/integration/if-else.spec.ts
+++ b/packages/jit-html/test/integration/if-else.spec.ts
@@ -11,15 +11,15 @@ import {
 const spec = 'if-else';
 
 // TemplateCompiler - if/else integration
-describe(spec, () => {
+describe(spec, function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 
   //if - shows and hides
-  it('01.', () => {
+  it('01.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div if.bind="foo">bar</div></template>`, null);
     component.foo = true;
     lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -31,7 +31,7 @@ describe(spec, () => {
   });
 
   //if - shows and hides - toggles else
-  it('02.', () => {
+  it('02.', function() {
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><div if.bind="foo">bar</div><div else>baz</div></template>`, null);
     component.foo = true;
     lifecycle.processFlushQueue(LifecycleFlags.none);

--- a/packages/jit-html/test/integration/kitchen-sink.spec.ts
+++ b/packages/jit-html/test/integration/kitchen-sink.spec.ts
@@ -15,8 +15,8 @@ import { TestContext } from '../util';
 const spec = 'kitchen-sink';
 
 // TemplateCompiler - integration with various different parts
-describe(spec, () => {
-  it('startup with App type', () => {
+describe(spec, function() {
+  it('startup with App type', function() {
     const ctx = TestContext.createHTMLTestContext();
     const component = CustomElementResource.define({ name: 'app', template: `<template>\${message}</template>` }, class { public message = 'Hello!'; });
     const host = ctx.createElement('div');
@@ -30,7 +30,7 @@ describe(spec, () => {
     expect(host.textContent).to.equal('');
   });
 
-  it('signaler', async () => {
+  it('signaler', async function() {
 
     const items = [0, 1, 2];
     const App = CustomElementResource.define({
@@ -66,7 +66,7 @@ describe(spec, () => {
 
   });
 
-  it('signaler + oneTime', async () => {
+  it('signaler + oneTime', async function() {
 
     const items = [0, 1, 2];
     const App = CustomElementResource.define({
@@ -102,7 +102,7 @@ describe(spec, () => {
 
   });
 
-  it('render hook', async () => {
+  it('render hook', async function() {
 
     const ctx = TestContext.createHTMLTestContext();
     const App = CustomElementResource.define({
@@ -129,7 +129,7 @@ describe(spec, () => {
   });
 });
 
-describe('xml node compiler tests', () => {
+describe('xml node compiler tests', function() {
   // TODO: add some content assertions and verify different kinds of xml compilation
   // (for now these tests are just to ensure the binder doesn't hang or crash when given "unusual" node types)
   const markups = [
@@ -157,7 +157,7 @@ describe('xml node compiler tests', () => {
 
   for (const markup of markups) {
     const escaped = markup.replace(/\b/g, '\\b').replace(/\t/g, '\\t').replace(/\n/g, '\\n').replace(/\v/g, '\\v').replace(/\f/g, '\\f').replace(/\r/g, '\\r');
-    it(escaped, () => {
+    it(escaped, function() {
       const ctx = TestContext.createHTMLTestContext();
       const parser = new ctx.DOMParser();
       const doc = parser.parseFromString(markup, 'application/xml');
@@ -176,9 +176,9 @@ describe('xml node compiler tests', () => {
   }
 });
 
-describe('dependency injection', () => {
+describe('dependency injection', function() {
 
-  it('register local dependencies ', () => {
+  it('register local dependencies ', function() {
     const Foo = CustomElementResource.define(
       {
         name: 'foo',

--- a/packages/jit-html/test/integration/kitchen-sink.spec.ts
+++ b/packages/jit-html/test/integration/kitchen-sink.spec.ts
@@ -15,8 +15,8 @@ import { TestContext } from '../util';
 const spec = 'kitchen-sink';
 
 // TemplateCompiler - integration with various different parts
-describe(spec, function() {
-  it('startup with App type', function() {
+describe(spec, function () {
+  it('startup with App type', function () {
     const ctx = TestContext.createHTMLTestContext();
     const component = CustomElementResource.define({ name: 'app', template: `<template>\${message}</template>` }, class { public message = 'Hello!'; });
     const host = ctx.createElement('div');
@@ -30,7 +30,7 @@ describe(spec, function() {
     expect(host.textContent).to.equal('');
   });
 
-  it('signaler', async function() {
+  it('signaler', async function () {
 
     const items = [0, 1, 2];
     const App = CustomElementResource.define({
@@ -66,7 +66,7 @@ describe(spec, function() {
 
   });
 
-  it('signaler + oneTime', async function() {
+  it('signaler + oneTime', async function () {
 
     const items = [0, 1, 2];
     const App = CustomElementResource.define({
@@ -102,7 +102,7 @@ describe(spec, function() {
 
   });
 
-  it('render hook', async function() {
+  it('render hook', async function () {
 
     const ctx = TestContext.createHTMLTestContext();
     const App = CustomElementResource.define({
@@ -129,7 +129,7 @@ describe(spec, function() {
   });
 });
 
-describe('xml node compiler tests', function() {
+describe('xml node compiler tests', function () {
   // TODO: add some content assertions and verify different kinds of xml compilation
   // (for now these tests are just to ensure the binder doesn't hang or crash when given "unusual" node types)
   const markups = [
@@ -157,7 +157,7 @@ describe('xml node compiler tests', function() {
 
   for (const markup of markups) {
     const escaped = markup.replace(/\b/g, '\\b').replace(/\t/g, '\\t').replace(/\n/g, '\\n').replace(/\v/g, '\\v').replace(/\f/g, '\\f').replace(/\r/g, '\\r');
-    it(escaped, function() {
+    it(escaped, function () {
       const ctx = TestContext.createHTMLTestContext();
       const parser = new ctx.DOMParser();
       const doc = parser.parseFromString(markup, 'application/xml');
@@ -176,9 +176,9 @@ describe('xml node compiler tests', function() {
   }
 });
 
-describe('dependency injection', function() {
+describe('dependency injection', function () {
 
-  it('register local dependencies ', function() {
+  it('register local dependencies ', function () {
     const Foo = CustomElementResource.define(
       {
         name: 'foo',

--- a/packages/jit-html/test/integration/repeater-custom-element.spec.ts
+++ b/packages/jit-html/test/integration/repeater-custom-element.spec.ts
@@ -15,15 +15,15 @@ import {
 
 const spec = 'repeater-custom-element';
 
-describe(spec, function() {
+describe(spec, function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // repeater with custom element
-  it('103.', function() {
+  it('103.', function () {
     @customElement({ name: 'foo', template: '<template>a</template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count"></foo></template>`, null, Foo);
@@ -37,7 +37,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property
-  it('104.', function() {
+  it('104.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="theText" repeat.for="i of count"></foo></template>`, class {
@@ -54,7 +54,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property
-  it('105.', function() {
+  it('105.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="text" repeat.for="i of count"></foo></template>`, class {
@@ -71,7 +71,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed, undefined property
-  it('106.', function() {
+  it('106.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -87,7 +87,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed, undefined property
-  it('107.', function() {
+  it('107.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count" text.bind="text"></foo></template>`, null, Foo);
@@ -102,7 +102,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed
-  it('108.', function() {
+  it('108.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -118,7 +118,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed
-  it('109.', function() {
+  it('109.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -134,7 +134,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element with repeater
-  it('110.', function() {
+  it('110.', function () {
     @customElement({ name: 'foo', template: '<template><div repeat.for="item of todos">${item}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" todos.bind="todos"></foo></template>`, null, Foo);
@@ -157,7 +157,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element with repeater, nested arrays
-  it('111.', function() {
+  it('111.', function () {
     @customElement({ name: 'foo', template: '<template><div repeat.for="innerTodos of todos"><div repeat.for="item of innerTodos">${item}</div></div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" todos.bind="todos"></foo></template>`, null, Foo);
@@ -180,7 +180,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element and children observer
-  it('112.', async function() {
+  it('112.', async function () {
     this.timeout(10000);
     let childrenCount = 0;
     let childrenChangedCount = 0;
@@ -246,7 +246,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element
-  it('203.', function() {
+  it('203.', function () {
     @customElement({ name: 'foo', template: '<template>a</template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed"></foo></template>`, null, Foo);
@@ -260,7 +260,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property
-  it('204.', function() {
+  it('204.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="theText" repeat.for="i of count & keyed"></foo></template>`, class {
@@ -277,7 +277,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property
-  it('205.', function() {
+  it('205.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="text" repeat.for="i of count & keyed"></foo></template>`, class {
@@ -294,7 +294,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed, undefined property
-  it('206.', function() {
+  it('206.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -310,7 +310,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed, undefined property
-  it('207.', function() {
+  it('207.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="text"></foo></template>`, null, Foo);
@@ -325,7 +325,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed
-  it('208.', function() {
+  it('208.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -341,7 +341,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed
-  it('209.', function() {
+  it('209.', function () {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -357,7 +357,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element with repeater
-  it('210.', function() {
+  it('210.', function () {
     @customElement({ name: 'foo', template: '<template><div repeat.for="item of todos & keyed">${item}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" todos.bind="todos"></foo></template>`, null, Foo);
@@ -380,7 +380,7 @@ describe(spec, function() {
   });
 
   // repeater with custom element with repeater, nested arrays
-  it('211.', function() {
+  it('211.', function () {
     @customElement({ name: 'foo', template: '<template><div repeat.for="innerTodos of todos & keyed"><div repeat.for="item of innerTodos & keyed">${item}</div></div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" todos.bind="todos"></foo></template>`, null, Foo);
@@ -404,7 +404,7 @@ describe(spec, function() {
 
   // TODO: figure out why repeater in keyed mode gives different numbers
   // // repeater with custom element and children observer
-  // it('212.', async function() {
+  // it('212.', async function () {
   //   this.timeout(10000);
   //   let childrenCount = 0;
   //   let childrenChangedCount = 0;

--- a/packages/jit-html/test/integration/repeater-custom-element.spec.ts
+++ b/packages/jit-html/test/integration/repeater-custom-element.spec.ts
@@ -15,15 +15,15 @@ import {
 
 const spec = 'repeater-custom-element';
 
-describe(spec, () => {
+describe(spec, function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 
   // repeater with custom element
-  it('103.', () => {
+  it('103.', function() {
     @customElement({ name: 'foo', template: '<template>a</template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count"></foo></template>`, null, Foo);
@@ -37,7 +37,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property
-  it('104.', () => {
+  it('104.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="theText" repeat.for="i of count"></foo></template>`, class {
@@ -54,7 +54,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property
-  it('105.', () => {
+  it('105.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="text" repeat.for="i of count"></foo></template>`, class {
@@ -71,7 +71,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed, undefined property
-  it('106.', () => {
+  it('106.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -87,7 +87,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed, undefined property
-  it('107.', () => {
+  it('107.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count" text.bind="text"></foo></template>`, null, Foo);
@@ -102,7 +102,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed
-  it('108.', () => {
+  it('108.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -118,7 +118,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed
-  it('109.', () => {
+  it('109.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" text.bind="theText"></foo></template>`, null, Foo);
@@ -134,7 +134,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element with repeater
-  it('110.', () => {
+  it('110.', function() {
     @customElement({ name: 'foo', template: '<template><div repeat.for="item of todos">${item}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" todos.bind="todos"></foo></template>`, null, Foo);
@@ -157,7 +157,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element with repeater, nested arrays
-  it('111.', () => {
+  it('111.', function() {
     @customElement({ name: 'foo', template: '<template><div repeat.for="innerTodos of todos"><div repeat.for="item of innerTodos">${item}</div></div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count" todos.bind="todos"></foo></template>`, null, Foo);
@@ -246,7 +246,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element
-  it('203.', () => {
+  it('203.', function() {
     @customElement({ name: 'foo', template: '<template>a</template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed"></foo></template>`, null, Foo);
@@ -260,7 +260,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property
-  it('204.', () => {
+  it('204.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="theText" repeat.for="i of count & keyed"></foo></template>`, class {
@@ -277,7 +277,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property
-  it('205.', () => {
+  it('205.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo text.bind="text" repeat.for="i of count & keyed"></foo></template>`, class {
@@ -294,7 +294,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed, undefined property
-  it('206.', () => {
+  it('206.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -310,7 +310,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed, undefined property
-  it('207.', () => {
+  it('207.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text: string; }
     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="text"></foo></template>`, null, Foo);
@@ -325,7 +325,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with different name than outer property, reversed
-  it('208.', () => {
+  it('208.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -341,7 +341,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element + inner bindable with same name as outer property, reversed
-  it('209.', () => {
+  it('209.', function() {
     @customElement({ name: 'foo', template: '<template><div>${text}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public text; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" text.bind="theText"></foo></template>`, null, Foo);
@@ -357,7 +357,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element with repeater
-  it('210.', () => {
+  it('210.', function() {
     @customElement({ name: 'foo', template: '<template><div repeat.for="item of todos & keyed">${item}</div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" todos.bind="todos"></foo></template>`, null, Foo);
@@ -380,7 +380,7 @@ describe(spec, () => {
   });
 
   // repeater with custom element with repeater, nested arrays
-  it('211.', () => {
+  it('211.', function() {
     @customElement({ name: 'foo', template: '<template><div repeat.for="innerTodos of todos & keyed"><div repeat.for="item of innerTodos & keyed">${item}</div></div></template>', instructions: [], build: { required: true, compiler: 'default' } })
     class Foo { @bindable public todos: any[]; }
     const { au, lifecycle, host, component } = setup(ctx, `<template><foo repeat.for="i of count & keyed" todos.bind="todos"></foo></template>`, null, Foo);

--- a/packages/jit-html/test/integration/repeater-if-else.spec.ts
+++ b/packages/jit-html/test/integration/repeater-if-else.spec.ts
@@ -13,7 +13,7 @@ import { trimFull } from './util';
 
 const spec = 'repeater-if-else';
 
-describe(spec, function() {
+describe(spec, function () {
 
   type Comp = { items: any[]; display: boolean; $patch(flags: LifecycleFlags): void };
   interface Spec {
@@ -582,7 +582,7 @@ describe(spec, function() {
     [strategySpecs, behaviorsSpecs, ceTemplateSpecs, appTemplateSpecs, itemsSpecs, countSpecs, mutationSpecs],
     (strategySpec, behaviorsSpec, ceTemplateSpec, appTemplateSpec, itemsSpec, countSpec, mutationSpec) => {
 
-    it(`strategySpec ${strategySpec.t}, behaviorsSpec ${behaviorsSpec.t}, ceTemplateSpec ${ceTemplateSpec.t}, appTemplateSpec ${appTemplateSpec.t}, itemsSpec ${itemsSpec.t}, countSpec ${countSpec.t}, mutationSpec ${mutationSpec.t}`, function() {
+    it(`strategySpec ${strategySpec.t}, behaviorsSpec ${behaviorsSpec.t}, ceTemplateSpec ${ceTemplateSpec.t}, appTemplateSpec ${appTemplateSpec.t}, itemsSpec ${itemsSpec.t}, countSpec ${countSpec.t}, mutationSpec ${mutationSpec.t}`, function () {
       const { strategy } = strategySpec;
       const { behaviors } = behaviorsSpec;
       const { createCETemplate } = ceTemplateSpec;

--- a/packages/jit-html/test/integration/repeater.spec.ts
+++ b/packages/jit-html/test/integration/repeater.spec.ts
@@ -6,7 +6,7 @@ import { TestConfiguration } from './resources';
 
 const spec = 'repeater';
 
-describe(spec, function() {
+describe(spec, function () {
     interface Spec {
       t: string;
     }
@@ -254,7 +254,7 @@ describe(spec, function() {
     ];
 
     eachCartesianJoin([bindSpecs, templateSpecs], (bindSpec, templateSpec) => {
-      it(`bindSpec ${bindSpec.t}, templateSpec ${templateSpec.t}`, function() {
+      it(`bindSpec ${bindSpec.t}, templateSpec ${templateSpec.t}`, function () {
         const { forof, item, expected, initialize } = bindSpec;
         const { createTemplate } = templateSpec;
 

--- a/packages/jit-html/test/integration/replaceable.spec.ts
+++ b/packages/jit-html/test/integration/replaceable.spec.ts
@@ -27,7 +27,7 @@ describe('replaceable', function() {
       `43`.repeat(2)
     ]
   ]) {
-    it(`replaceable - ${title}`, () => {
+    it(`replaceable - ${title}`, function() {
 
       const App = CustomElementResource.define({ name: 'app', template: `<template><foo>${appMarkup}</foo></template>` }, class {});
       const Foo = CustomElementResource.define({ name: 'foo', template: `<template>${ceMarkup}</template>` }, class {});
@@ -48,7 +48,7 @@ describe('replaceable', function() {
     });
   }
 
-  it(`replaceable - bind to target scope`, () => {
+  it(`replaceable - bind to target scope`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { public baz = 'abc'; });
@@ -68,7 +68,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable - bind to parent scope`, () => {
+  it(`replaceable - bind to parent scope`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class {});
@@ -88,7 +88,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - bind to target scope`, () => {
+  it(`replaceable/template - bind to target scope`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -108,7 +108,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - bind to parent scope`, () => {
+  it(`replaceable/template - bind to parent scope`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
@@ -128,7 +128,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - uses last on name conflict`, () => {
+  it(`replaceable/template - uses last on name conflict`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${qux}</template><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
@@ -148,7 +148,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - same part multiple times`, () => {
+  it(`replaceable/template - same part multiple times`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -169,7 +169,7 @@ describe('replaceable', function() {
   });
 
   // TODO: fix this scenario
-  xit(`replaceable/template - parent template controller`, () => {
+  xit(`replaceable/template - parent template controller`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template if.bind="true"><template replace-part="bar">\${baz}</template></template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -189,7 +189,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling lefthand side template controller`, () => {
+  it(`replaceable/template - sibling lefthand side template controller`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template if.bind="true" replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -209,7 +209,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling righthand side template controller`, () => {
+  it(`replaceable/template - sibling righthand side template controller`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar" if.bind="true">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -229,7 +229,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling if/else with conflicting part names`, () => {
+  it(`replaceable/template - sibling if/else with conflicting part names`, function() {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar" if.bind="true">\${baz}</template></foo><foo><template replace-part="bar" if.bind="false">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });

--- a/packages/jit-html/test/integration/replaceable.spec.ts
+++ b/packages/jit-html/test/integration/replaceable.spec.ts
@@ -2,7 +2,7 @@ import { Aurelia, CustomElementResource } from '@aurelia/runtime';
 import { expect } from 'chai';
 import { TestContext } from '../util';
 
-describe('replaceable', function() {
+describe('replaceable', function () {
   for (const [title, appMarkup, ceMarkup, , , , , , expected] of [
     [
       `single, static`,
@@ -27,7 +27,7 @@ describe('replaceable', function() {
       `43`.repeat(2)
     ]
   ]) {
-    it(`replaceable - ${title}`, function() {
+    it(`replaceable - ${title}`, function () {
 
       const App = CustomElementResource.define({ name: 'app', template: `<template><foo>${appMarkup}</foo></template>` }, class {});
       const Foo = CustomElementResource.define({ name: 'foo', template: `<template>${ceMarkup}</template>` }, class {});
@@ -48,7 +48,7 @@ describe('replaceable', function() {
     });
   }
 
-  it(`replaceable - bind to target scope`, function() {
+  it(`replaceable - bind to target scope`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { public baz = 'abc'; });
@@ -68,7 +68,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable - bind to parent scope`, function() {
+  it(`replaceable - bind to parent scope`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class {});
@@ -88,7 +88,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - bind to target scope`, function() {
+  it(`replaceable/template - bind to target scope`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -108,7 +108,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - bind to parent scope`, function() {
+  it(`replaceable/template - bind to parent scope`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
@@ -128,7 +128,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - uses last on name conflict`, function() {
+  it(`replaceable/template - uses last on name conflict`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${qux}</template><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
@@ -148,7 +148,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - same part multiple times`, function() {
+  it(`replaceable/template - same part multiple times`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -169,7 +169,7 @@ describe('replaceable', function() {
   });
 
   // TODO: fix this scenario
-  xit(`replaceable/template - parent template controller`, function() {
+  xit(`replaceable/template - parent template controller`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template if.bind="true"><template replace-part="bar">\${baz}</template></template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -189,7 +189,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling lefthand side template controller`, function() {
+  it(`replaceable/template - sibling lefthand side template controller`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template if.bind="true" replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -209,7 +209,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling righthand side template controller`, function() {
+  it(`replaceable/template - sibling righthand side template controller`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar" if.bind="true">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });
@@ -229,7 +229,7 @@ describe('replaceable', function() {
 
   });
 
-  it(`replaceable/template - sibling if/else with conflicting part names`, function() {
+  it(`replaceable/template - sibling if/else with conflicting part names`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><template replace-part="bar" if.bind="true">\${baz}</template></foo><foo><template replace-part="bar" if.bind="false">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElementResource.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { public baz = 'abc'; });

--- a/packages/jit-html/test/integration/select.spec.ts
+++ b/packages/jit-html/test/integration/select.spec.ts
@@ -11,18 +11,18 @@ import {
 } from './util';
 
 // TemplateCompiler - <select/> Integration
-describe('select', () => {
+describe('select', function() {
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
   });
 
   //<select/> - single
-  describe('01.', () => {
+  describe('01.', function() {
 
     //works with multiple toView bindings
-    it('01.', () => {
+    it('01.', function() {
       const { au, lifecycle, host, observerLocator, component } = setup(
         ctx,
         `<template>
@@ -72,7 +72,7 @@ describe('select', () => {
     });
 
     //works with mixed of multiple binding: twoWay + toView
-    it('02.', () => {
+    it('02.', function() {
       const { au, lifecycle, host, observerLocator, component } = setup(
         ctx,
         `<template>
@@ -130,10 +130,10 @@ describe('select', () => {
   });
 
   //<select/> - multiple
-  describe('02.', () => {
+  describe('02.', function() {
 
     //works with multiple toView bindings without pre-selection
-    it('01.', () => {
+    it('01.', function() {
       const { au, lifecycle, host, observerLocator, component } = setupAndStart(
         ctx,
         `<template>
@@ -191,7 +191,7 @@ describe('select', () => {
     });
 
     //works with mixed of two-way + to-view bindings with pre-selection
-    it('02.', () => {
+    it('02.', function() {
       const { au, lifecycle, host, observerLocator, component } = setupAndStart(
         ctx,
         `<template>
@@ -260,7 +260,7 @@ describe('select', () => {
   });
 
   //toViewBinding - select single
-  it('03.', () => {
+  it('03.', function() {
     const { au, lifecycle, host, component } = setupAndStart(
       ctx,
       template(ctx.doc, null,
@@ -281,7 +281,7 @@ describe('select', () => {
   });
 
   //twoWayBinding - select single
-  it('04.', () => {
+  it('04.', function() {
     const { au, lifecycle, host, component } = setupAndStart(
       ctx,
       h(ctx.doc, 'template',

--- a/packages/jit-html/test/integration/select.spec.ts
+++ b/packages/jit-html/test/integration/select.spec.ts
@@ -11,18 +11,18 @@ import {
 } from './util';
 
 // TemplateCompiler - <select/> Integration
-describe('select', function() {
+describe('select', function () {
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
   });
 
   //<select/> - single
-  describe('01.', function() {
+  describe('01.', function () {
 
     //works with multiple toView bindings
-    it('01.', function() {
+    it('01.', function () {
       const { au, lifecycle, host, observerLocator, component } = setup(
         ctx,
         `<template>
@@ -72,7 +72,7 @@ describe('select', function() {
     });
 
     //works with mixed of multiple binding: twoWay + toView
-    it('02.', function() {
+    it('02.', function () {
       const { au, lifecycle, host, observerLocator, component } = setup(
         ctx,
         `<template>
@@ -130,10 +130,10 @@ describe('select', function() {
   });
 
   //<select/> - multiple
-  describe('02.', function() {
+  describe('02.', function () {
 
     //works with multiple toView bindings without pre-selection
-    it('01.', function() {
+    it('01.', function () {
       const { au, lifecycle, host, observerLocator, component } = setupAndStart(
         ctx,
         `<template>
@@ -191,7 +191,7 @@ describe('select', function() {
     });
 
     //works with mixed of two-way + to-view bindings with pre-selection
-    it('02.', function() {
+    it('02.', function () {
       const { au, lifecycle, host, observerLocator, component } = setupAndStart(
         ctx,
         `<template>
@@ -260,7 +260,7 @@ describe('select', function() {
   });
 
   //toViewBinding - select single
-  it('03.', function() {
+  it('03.', function () {
     const { au, lifecycle, host, component } = setupAndStart(
       ctx,
       template(ctx.doc, null,
@@ -281,7 +281,7 @@ describe('select', function() {
   });
 
   //twoWayBinding - select single
-  it('04.', function() {
+  it('04.', function () {
     const { au, lifecycle, host, component } = setupAndStart(
       ctx,
       h(ctx.doc, 'template',

--- a/packages/jit-html/test/unit/template-compiler.spec.ts
+++ b/packages/jit-html/test/unit/template-compiler.spec.ts
@@ -41,14 +41,14 @@ export function createAttribute(name: string, value: string): Attr {
   return attr;
 }
 
-describe('TemplateCompiler', function() {
+describe('TemplateCompiler', function () {
   let ctx: HTMLTestContext;
   let sut: ITemplateCompiler;
   let resources: IResourceDescriptions;
   let container: IContainer;
   let dom: IDOM;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
     container = ctx.container;
     sut = ctx.templateCompiler;
@@ -57,20 +57,20 @@ describe('TemplateCompiler', function() {
     dom = ctx.dom;
   });
 
-  describe('compileElement()', function() {
+  describe('compileElement()', function () {
 
-    it('set hasSlots to true <slot/>', function() {
+    it('set hasSlots to true <slot/>', function () {
       const definition = compileWith('<template><slot></slot></template>', []);
       expect(definition.hasSlots).to.equal(true);
 
       // test this with nested slot inside template controller
     });
 
-    describe('with custom element', function() {
+    describe('with custom element', function () {
 
-      describe('compiles surrogate', function() {
+      describe('compiles surrogate', function () {
 
-        it('compiles surrogate', function() {
+        it('compiles surrogate', function () {
           const { instructions, surrogates } = compileWith(
             `<template class="h-100"></template>`,
             []
@@ -81,7 +81,7 @@ describe('TemplateCompiler', function() {
           ]);
         });
 
-        it('compiles surrogate with binding expression', function() {
+        it('compiles surrogate with binding expression', function () {
           const { instructions, surrogates } = compileWith(
             `<template class.bind="base"></template>`,
             []
@@ -92,7 +92,7 @@ describe('TemplateCompiler', function() {
           ],                 'surrogate');
         });
 
-        it('compiles surrogate with interpolation expression', function() {
+        it('compiles surrogate with interpolation expression', function () {
           const { instructions, surrogates } = compileWith(
             `<template class="h-100 \${base}"></template>`,
             []
@@ -103,7 +103,7 @@ describe('TemplateCompiler', function() {
           ],                 'surrogate');
         });
 
-        it('throws on attributes that require to be unique', function() {
+        it('throws on attributes that require to be unique', function () {
           const attrs = ['id', 'part', 'replace-part'];
           attrs.forEach(attr => {
             expect(() => compileWith(
@@ -114,7 +114,7 @@ describe('TemplateCompiler', function() {
         });
       });
 
-      it('understands attr precendence: custom attr > element prop', function() {
+      it('understands attr precendence: custom attr > element prop', function () {
         @customElement('el')
         class El {
           @bindable() public prop1: string;
@@ -147,7 +147,7 @@ describe('TemplateCompiler', function() {
         verifyInstructions(rootInstructions, expectedRootInstructions);
       });
 
-      it('distinguishs element properties / normal attributes', function() {
+      it('distinguishs element properties / normal attributes', function () {
         @customElement('el')
         class El {
 
@@ -173,7 +173,7 @@ describe('TemplateCompiler', function() {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      it('understands element property casing', function() {
+      it('understands element property casing', function () {
         @customElement('el')
         class El {
 
@@ -195,7 +195,7 @@ describe('TemplateCompiler', function() {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      it('understands binding commands', function() {
+      it('understands binding commands', function () {
         @customElement('el')
         class El {
           @bindable({ mode: BindingMode.twoWay }) public propProp1: string;
@@ -231,8 +231,8 @@ describe('TemplateCompiler', function() {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      describe('with template controller', function() {
-        it('compiles', function() {
+      describe('with template controller', function () {
+        it('compiles', function () {
           @customAttribute({
             name: 'prop',
             isTemplateController: true
@@ -249,7 +249,7 @@ describe('TemplateCompiler', function() {
           expect((hydratePropAttrInstruction.def.template as HTMLTemplateElement).outerHTML).to.equal('<template><el></el></template>');
         });
 
-        it('moves attrbiutes instructions before the template controller into it', function() {
+        it('moves attrbiutes instructions before the template controller into it', function () {
           @customAttribute({
             name: 'prop',
             isTemplateController: true
@@ -275,8 +275,8 @@ describe('TemplateCompiler', function() {
           ]);
         });
 
-        describe('[as-element]', function() {
-          it('understands [as-element]', function() {
+        describe('[as-element]', function () {
+          it('understands [as-element]', function () {
             @customElement('not-div')
             class NotDiv {}
             const { instructions } = compileWith('<template><div as-element="not-div"></div></template>', [NotDiv]);
@@ -286,13 +286,13 @@ describe('TemplateCompiler', function() {
             ]);
           });
 
-          it('does not throw when element is not found', function() {
+          it('does not throw when element is not found', function () {
             const { instructions } = compileWith('<template><div as-element="not-div"></div></template>');
             expect(instructions.length).to.equal(0);
           });
 
-          describe('with template controller', function() {
-            it('compiles', function() {
+          describe('with template controller', function () {
+            it('compiles', function () {
               @customElement('not-div')
               class NotDiv {}
               const { instructions } = compileWith(
@@ -320,19 +320,19 @@ describe('TemplateCompiler', function() {
         });
       });
 
-      describe('<let/> element', function() {
+      describe('<let/> element', function () {
 
-        it('compiles', function() {
+        it('compiles', function () {
           const { instructions } = compileWith(`<template><let></let></template>`);
           expect(instructions.length).to.equal(1);
         });
 
-        it('does not generate instructions when there is no bindings', function() {
+        it('does not generate instructions when there is no bindings', function () {
           const { instructions } = compileWith(`<template><let></let></template>`);
           expect((instructions[0][0]).instructions.length).to.equal(0);
         });
 
-        it('ignores custom element resource', function() {
+        it('ignores custom element resource', function () {
           @customElement('let')
           class Let {}
 
@@ -345,7 +345,7 @@ describe('TemplateCompiler', function() {
           ]);
         });
 
-        it('compiles with attributes', function() {
+        it('compiles with attributes', function () {
           const { instructions } = compileWith(`<let a.bind="b" c="\${d}"></let>`);
           verifyInstructions((instructions[0][0]).instructions, [
             { toVerify: ['type', 'to', 'srcOrExp'],
@@ -355,13 +355,13 @@ describe('TemplateCompiler', function() {
           ]);
         });
 
-        describe('[to-view-model]', function() {
-          it('understands [to-view-model]', function() {
+        describe('[to-view-model]', function () {
+          it('understands [to-view-model]', function () {
             const { instructions } = compileWith(`<template><let to-view-model></let></template>`);
             expect((instructions[0][0]).toViewModel).to.equal(true);
           });
 
-          it('ignores [to-view-model] order', function() {
+          it('ignores [to-view-model] order', function () {
             let instructions = compileWith(`<template><let a.bind="a" to-view-model></let></template>`).instructions[0];
             verifyInstructions(instructions, [
               { toVerify: ['type', 'toViewModel'], type: TT.hydrateLetElement, toViewModel: true }
@@ -618,7 +618,7 @@ type CTCResult = [ITemplateDefinition, ITemplateDefinition];
 
 type Bindables = { [pdName: string]: IBindableDescription };
 
-describe(`TemplateCompiler - combinations`, function() {
+describe(`TemplateCompiler - combinations`, function () {
   function setup(ctx: HTMLTestContext, ...globals: IRegistry[]) {
     const container = ctx.container;
     container.register(...globals);
@@ -628,7 +628,7 @@ describe(`TemplateCompiler - combinations`, function() {
     return { container, dom, sut, resources };
   }
 
-  describe('plain attributes', function() {
+  describe('plain attributes', function () {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -657,7 +657,7 @@ describe(`TemplateCompiler - combinations`, function() {
     ],                       (ctx, [el], $2, [n1, v1, i1]) => {
       const markup = `<${el} ${n1}="${v1}"></${el}>`;
 
-      it(markup, function() {
+      it(markup, function () {
         const input = { template: markup, instructions: [], surrogates: [] };
         const expected = { template: ctx.createElementFromMarkup(`<template><${el} ${n1}="${v1}" class="au"></${el}></template>`), instructions: [[i1]], surrogates: [] };
 
@@ -671,7 +671,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('custom attributes', function() {
+  describe('custom attributes', function () {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -714,7 +714,7 @@ describe(`TemplateCompiler - combinations`, function() {
       const def = { name: PLATFORM.camelCase(attr), defaultBindingMode, bindables };
       const markup = `<div ${name}="${value}"></div>`;
 
-      it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, function() {
+      it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, function () {
         const input = { template: markup, instructions: [], surrogates: [] };
         const instruction = { type: TT.hydrateAttribute, res: def.name, instructions: [childInstruction] };
         const expected = { template: ctx.createElementFromMarkup(`<template><div ${name}="${value}" class="au"></div></template>`), instructions: [[instruction]], surrogates: [] };
@@ -730,7 +730,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('custom attributes with multiple bindings', function() {
+  describe('custom attributes with multiple bindings', function () {
 
     eachCartesianJoinFactory([
       [
@@ -767,7 +767,7 @@ describe(`TemplateCompiler - combinations`, function() {
         // TODO: test fallback to attribute name when no matching binding exists (or throw if we don't want to support this)
       ] as ((ctx: HTMLTestContext, $1: string, $2: string, $3: Bindables, $4: [string, string]) => [IBindableDescription, string])[]
     ],                       (ctx, pdName, pdProp, bindables, [cmd, attrValue], [bindableDescription, attrName]) => {
-      it(`div - pdName=${pdName}  pdProp=${pdProp}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function() {
+      it(`div - pdName=${pdName}  pdProp=${pdProp}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function () {
 
         const { sut, resources, dom  } = setup(
           ctx,
@@ -808,7 +808,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('nested template controllers (one per element)', function() {
+  describe('nested template controllers (one per element)', function () {
 
     eachCartesianJoinFactory([
       [
@@ -848,7 +848,7 @@ describe(`TemplateCompiler - combinations`, function() {
       ] as ((ctx: HTMLTestContext, $1: CTCResult, $2: CTCResult, $3: CTCResult) => CTCResult)[]
     ],                       (ctx, $1, $2, $3, [input, output]) => {
 
-      it(`${input.template}`, function() {
+      it(`${input.template}`, function () {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -870,7 +870,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('nested template controllers (multiple per element)', function() {
+  describe('nested template controllers (multiple per element)', function () {
 
     eachCartesianJoinFactory([
       [
@@ -909,7 +909,7 @@ describe(`TemplateCompiler - combinations`, function() {
       ] as ((ctx: HTMLTestContext, $1: CTCResult, $2: CTCResult, $3: CTCResult, $4: CTCResult) => CTCResult)[]
     ],                       (ctx, $1, $2, $3, $4, [input, output]) => {
 
-      it(`${input.template}`, function() {
+      it(`${input.template}`, function () {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -932,7 +932,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('sibling template controllers', function() {
+  describe('sibling template controllers', function () {
 
     eachCartesianJoinFactory([
       [
@@ -970,7 +970,7 @@ describe(`TemplateCompiler - combinations`, function() {
         instructions: []
       };
 
-      it(`${input.template}`, function() {
+      it(`${input.template}`, function () {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -1001,7 +1001,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('attributes on custom elements', function() {
+  describe('attributes on custom elements', function () {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -1043,7 +1043,7 @@ describe(`TemplateCompiler - combinations`, function() {
         (ctx) => `''`
       ] as ((ctx: HTMLTestContext) => string)[]
     ],                       (ctx, pdName, pdProp, pdAttr, bindables, [cmd, attrValue], [bindableDescription, attrName]) => {
-      it(`customElement - pdName=${pdName}  pdProp=${pdProp}  pdAttr=${pdAttr}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function() {
+      it(`customElement - pdName=${pdName}  pdProp=${pdProp}  pdAttr=${pdAttr}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function () {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -1087,7 +1087,7 @@ describe(`TemplateCompiler - combinations`, function() {
     });
   });
 
-  describe('custom elements', function() {
+  describe('custom elements', function () {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -1109,7 +1109,7 @@ describe(`TemplateCompiler - combinations`, function() {
       // ]
     //], ($1, $2, [input, output]) => {
     ],                       (ctx, [input, output]) => {
-      it(`${input.template}`, function() {
+      it(`${input.template}`, function () {
 
         const { sut, resources, dom } = setup(
           ctx,

--- a/packages/jit-html/test/unit/template-compiler.spec.ts
+++ b/packages/jit-html/test/unit/template-compiler.spec.ts
@@ -41,14 +41,14 @@ export function createAttribute(name: string, value: string): Attr {
   return attr;
 }
 
-describe('TemplateCompiler', () => {
+describe('TemplateCompiler', function() {
   let ctx: HTMLTestContext;
   let sut: ITemplateCompiler;
   let resources: IResourceDescriptions;
   let container: IContainer;
   let dom: IDOM;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
     container = ctx.container;
     sut = ctx.templateCompiler;
@@ -57,20 +57,20 @@ describe('TemplateCompiler', () => {
     dom = ctx.dom;
   });
 
-  describe('compileElement()', () => {
+  describe('compileElement()', function() {
 
-    it('set hasSlots to true <slot/>', () => {
+    it('set hasSlots to true <slot/>', function() {
       const definition = compileWith('<template><slot></slot></template>', []);
       expect(definition.hasSlots).to.equal(true);
 
       // test this with nested slot inside template controller
     });
 
-    describe('with custom element', () => {
+    describe('with custom element', function() {
 
-      describe('compiles surrogate', () => {
+      describe('compiles surrogate', function() {
 
-        it('compiles surrogate', () => {
+        it('compiles surrogate', function() {
           const { instructions, surrogates } = compileWith(
             `<template class="h-100"></template>`,
             []
@@ -81,7 +81,7 @@ describe('TemplateCompiler', () => {
           ]);
         });
 
-        it('compiles surrogate with binding expression', () => {
+        it('compiles surrogate with binding expression', function() {
           const { instructions, surrogates } = compileWith(
             `<template class.bind="base"></template>`,
             []
@@ -92,7 +92,7 @@ describe('TemplateCompiler', () => {
           ],                 'surrogate');
         });
 
-        it('compiles surrogate with interpolation expression', () => {
+        it('compiles surrogate with interpolation expression', function() {
           const { instructions, surrogates } = compileWith(
             `<template class="h-100 \${base}"></template>`,
             []
@@ -103,7 +103,7 @@ describe('TemplateCompiler', () => {
           ],                 'surrogate');
         });
 
-        it('throws on attributes that require to be unique', () => {
+        it('throws on attributes that require to be unique', function() {
           const attrs = ['id', 'part', 'replace-part'];
           attrs.forEach(attr => {
             expect(() => compileWith(
@@ -114,7 +114,7 @@ describe('TemplateCompiler', () => {
         });
       });
 
-      it('understands attr precendence: custom attr > element prop', () => {
+      it('understands attr precendence: custom attr > element prop', function() {
         @customElement('el')
         class El {
           @bindable() public prop1: string;
@@ -147,7 +147,7 @@ describe('TemplateCompiler', () => {
         verifyInstructions(rootInstructions, expectedRootInstructions);
       });
 
-      it('distinguishs element properties / normal attributes', () => {
+      it('distinguishs element properties / normal attributes', function() {
         @customElement('el')
         class El {
 
@@ -173,7 +173,7 @@ describe('TemplateCompiler', () => {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      it('understands element property casing', () => {
+      it('understands element property casing', function() {
         @customElement('el')
         class El {
 
@@ -195,7 +195,7 @@ describe('TemplateCompiler', () => {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      it('understands binding commands', () => {
+      it('understands binding commands', function() {
         @customElement('el')
         class El {
           @bindable({ mode: BindingMode.twoWay }) public propProp1: string;
@@ -231,8 +231,8 @@ describe('TemplateCompiler', () => {
         verifyInstructions(rootInstructions[0].instructions, expectedElInstructions);
       });
 
-      describe('with template controller', () => {
-        it('compiles', () => {
+      describe('with template controller', function() {
+        it('compiles', function() {
           @customAttribute({
             name: 'prop',
             isTemplateController: true
@@ -249,7 +249,7 @@ describe('TemplateCompiler', () => {
           expect((hydratePropAttrInstruction.def.template as HTMLTemplateElement).outerHTML).to.equal('<template><el></el></template>');
         });
 
-        it('moves attrbiutes instructions before the template controller into it', () => {
+        it('moves attrbiutes instructions before the template controller into it', function() {
           @customAttribute({
             name: 'prop',
             isTemplateController: true
@@ -275,8 +275,8 @@ describe('TemplateCompiler', () => {
           ]);
         });
 
-        describe('[as-element]', () => {
-          it('understands [as-element]', () => {
+        describe('[as-element]', function() {
+          it('understands [as-element]', function() {
             @customElement('not-div')
             class NotDiv {}
             const { instructions } = compileWith('<template><div as-element="not-div"></div></template>', [NotDiv]);
@@ -286,13 +286,13 @@ describe('TemplateCompiler', () => {
             ]);
           });
 
-          it('does not throw when element is not found', () => {
+          it('does not throw when element is not found', function() {
             const { instructions } = compileWith('<template><div as-element="not-div"></div></template>');
             expect(instructions.length).to.equal(0);
           });
 
-          describe('with template controller', () => {
-            it('compiles', () => {
+          describe('with template controller', function() {
+            it('compiles', function() {
               @customElement('not-div')
               class NotDiv {}
               const { instructions } = compileWith(
@@ -320,19 +320,19 @@ describe('TemplateCompiler', () => {
         });
       });
 
-      describe('<let/> element', () => {
+      describe('<let/> element', function() {
 
-        it('compiles', () => {
+        it('compiles', function() {
           const { instructions } = compileWith(`<template><let></let></template>`);
           expect(instructions.length).to.equal(1);
         });
 
-        it('does not generate instructions when there is no bindings', () => {
+        it('does not generate instructions when there is no bindings', function() {
           const { instructions } = compileWith(`<template><let></let></template>`);
           expect((instructions[0][0]).instructions.length).to.equal(0);
         });
 
-        it('ignores custom element resource', () => {
+        it('ignores custom element resource', function() {
           @customElement('let')
           class Let {}
 
@@ -345,7 +345,7 @@ describe('TemplateCompiler', () => {
           ]);
         });
 
-        it('compiles with attributes', () => {
+        it('compiles with attributes', function() {
           const { instructions } = compileWith(`<let a.bind="b" c="\${d}"></let>`);
           verifyInstructions((instructions[0][0]).instructions, [
             { toVerify: ['type', 'to', 'srcOrExp'],
@@ -355,13 +355,13 @@ describe('TemplateCompiler', () => {
           ]);
         });
 
-        describe('[to-view-model]', () => {
-          it('understands [to-view-model]', () => {
+        describe('[to-view-model]', function() {
+          it('understands [to-view-model]', function() {
             const { instructions } = compileWith(`<template><let to-view-model></let></template>`);
             expect((instructions[0][0]).toViewModel).to.equal(true);
           });
 
-          it('ignores [to-view-model] order', () => {
+          it('ignores [to-view-model] order', function() {
             let instructions = compileWith(`<template><let a.bind="a" to-view-model></let></template>`).instructions[0];
             verifyInstructions(instructions, [
               { toVerify: ['type', 'toViewModel'], type: TT.hydrateLetElement, toViewModel: true }
@@ -618,7 +618,7 @@ type CTCResult = [ITemplateDefinition, ITemplateDefinition];
 
 type Bindables = { [pdName: string]: IBindableDescription };
 
-describe(`TemplateCompiler - combinations`, () => {
+describe(`TemplateCompiler - combinations`, function() {
   function setup(ctx: HTMLTestContext, ...globals: IRegistry[]) {
     const container = ctx.container;
     container.register(...globals);
@@ -628,7 +628,7 @@ describe(`TemplateCompiler - combinations`, () => {
     return { container, dom, sut, resources };
   }
 
-  describe('plain attributes', () => {
+  describe('plain attributes', function() {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -657,7 +657,7 @@ describe(`TemplateCompiler - combinations`, () => {
     ],                       (ctx, [el], $2, [n1, v1, i1]) => {
       const markup = `<${el} ${n1}="${v1}"></${el}>`;
 
-      it(markup, () => {
+      it(markup, function() {
         const input = { template: markup, instructions: [], surrogates: [] };
         const expected = { template: ctx.createElementFromMarkup(`<template><${el} ${n1}="${v1}" class="au"></${el}></template>`), instructions: [[i1]], surrogates: [] };
 
@@ -671,7 +671,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('custom attributes', () => {
+  describe('custom attributes', function() {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -714,7 +714,7 @@ describe(`TemplateCompiler - combinations`, () => {
       const def = { name: PLATFORM.camelCase(attr), defaultBindingMode, bindables };
       const markup = `<div ${name}="${value}"></div>`;
 
-      it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, () => {
+      it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, function() {
         const input = { template: markup, instructions: [], surrogates: [] };
         const instruction = { type: TT.hydrateAttribute, res: def.name, instructions: [childInstruction] };
         const expected = { template: ctx.createElementFromMarkup(`<template><div ${name}="${value}" class="au"></div></template>`), instructions: [[instruction]], surrogates: [] };
@@ -730,7 +730,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('custom attributes with multiple bindings', () => {
+  describe('custom attributes with multiple bindings', function() {
 
     eachCartesianJoinFactory([
       [
@@ -767,7 +767,7 @@ describe(`TemplateCompiler - combinations`, () => {
         // TODO: test fallback to attribute name when no matching binding exists (or throw if we don't want to support this)
       ] as ((ctx: HTMLTestContext, $1: string, $2: string, $3: Bindables, $4: [string, string]) => [IBindableDescription, string])[]
     ],                       (ctx, pdName, pdProp, bindables, [cmd, attrValue], [bindableDescription, attrName]) => {
-      it(`div - pdName=${pdName}  pdProp=${pdProp}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, () => {
+      it(`div - pdName=${pdName}  pdProp=${pdProp}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function() {
 
         const { sut, resources, dom  } = setup(
           ctx,
@@ -808,7 +808,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('nested template controllers (one per element)', () => {
+  describe('nested template controllers (one per element)', function() {
 
     eachCartesianJoinFactory([
       [
@@ -848,7 +848,7 @@ describe(`TemplateCompiler - combinations`, () => {
       ] as ((ctx: HTMLTestContext, $1: CTCResult, $2: CTCResult, $3: CTCResult) => CTCResult)[]
     ],                       (ctx, $1, $2, $3, [input, output]) => {
 
-      it(`${input.template}`, () => {
+      it(`${input.template}`, function() {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -870,7 +870,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('nested template controllers (multiple per element)', () => {
+  describe('nested template controllers (multiple per element)', function() {
 
     eachCartesianJoinFactory([
       [
@@ -909,7 +909,7 @@ describe(`TemplateCompiler - combinations`, () => {
       ] as ((ctx: HTMLTestContext, $1: CTCResult, $2: CTCResult, $3: CTCResult, $4: CTCResult) => CTCResult)[]
     ],                       (ctx, $1, $2, $3, $4, [input, output]) => {
 
-      it(`${input.template}`, () => {
+      it(`${input.template}`, function() {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -932,7 +932,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('sibling template controllers', () => {
+  describe('sibling template controllers', function() {
 
     eachCartesianJoinFactory([
       [
@@ -970,7 +970,7 @@ describe(`TemplateCompiler - combinations`, () => {
         instructions: []
       };
 
-      it(`${input.template}`, () => {
+      it(`${input.template}`, function() {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -1001,7 +1001,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('attributes on custom elements', () => {
+  describe('attributes on custom elements', function() {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -1043,7 +1043,7 @@ describe(`TemplateCompiler - combinations`, () => {
         (ctx) => `''`
       ] as ((ctx: HTMLTestContext) => string)[]
     ],                       (ctx, pdName, pdProp, pdAttr, bindables, [cmd, attrValue], [bindableDescription, attrName]) => {
-      it(`customElement - pdName=${pdName}  pdProp=${pdProp}  pdAttr=${pdAttr}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, () => {
+      it(`customElement - pdName=${pdName}  pdProp=${pdProp}  pdAttr=${pdAttr}  cmd=${cmd}  attrName=${attrName}  attrValue="${attrValue}"`, function() {
 
         const { sut, resources, dom } = setup(
           ctx,
@@ -1087,7 +1087,7 @@ describe(`TemplateCompiler - combinations`, () => {
     });
   });
 
-  describe('custom elements', () => {
+  describe('custom elements', function() {
     eachCartesianJoinFactory([
       [
         TestContext.createHTMLTestContext
@@ -1109,7 +1109,7 @@ describe(`TemplateCompiler - combinations`, () => {
       // ]
     //], ($1, $2, [input, output]) => {
     ],                       (ctx, [input, output]) => {
-      it(`${input.template}`, () => {
+      it(`${input.template}`, function() {
 
         const { sut, resources, dom } = setup(
           ctx,

--- a/packages/jit-html/test/unit/template-element-factory.spec.ts
+++ b/packages/jit-html/test/unit/template-element-factory.spec.ts
@@ -3,16 +3,16 @@ import { expect } from 'chai';
 import { HTMLTemplateElementFactory, ITemplateElementFactory } from '../../src/template-element-factory';
 import { HTMLTestContext, TestContext } from '../util';
 
-describe('HTMLTemplateElementFactory', () => {
+describe('HTMLTemplateElementFactory', function() {
   let sut: HTMLTemplateElementFactory;
   let ctx: HTMLTestContext;
 
-  beforeEach(() => {
+  beforeEach(function() {
     ctx = TestContext.createHTMLTestContext();
     sut = new HTMLTemplateElementFactory(ctx.dom);
   });
 
-  it('template-wrapped markup string', () => {
+  it('template-wrapped markup string', function() {
     const markup = `<template><div class="au">foo</div></template>`;
 
     const expectedHTML = markup;
@@ -21,7 +21,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('non-template-wrapped markup string', () => {
+  it('non-template-wrapped markup string', function() {
     const markup = `<div class="au">foo</div>`;
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -30,7 +30,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('double template-wrapped markup string', () => {
+  it('double template-wrapped markup string', function() {
     const markup = `<template><div class="au">foo</div></template>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -39,7 +39,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('double non-template-wrapped markup string', () => {
+  it('double non-template-wrapped markup string', function() {
     const markup = `<div class="au">foo</div>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -48,7 +48,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('template node', () => {
+  it('template node', function() {
     const markup = `<div class="au">foo</div>`;
     const template = ctx.createElement('template');
     template.innerHTML = markup;
@@ -60,7 +60,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('non-template node', () => {
+  it('non-template node', function() {
     const markup = `<div class="au">foo</div>`;
     const template = ctx.createElement('template') as HTMLTemplateElement;
     template.innerHTML = markup;
@@ -72,7 +72,7 @@ describe('HTMLTemplateElementFactory', () => {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('template node with parent', () => {
+  it('template node with parent', function() {
     const markup = `<template><div class="au">foo</div></template>`;
     const template = ctx.createElement('template') as HTMLTemplateElement;
     template.innerHTML = markup;

--- a/packages/jit-html/test/unit/template-element-factory.spec.ts
+++ b/packages/jit-html/test/unit/template-element-factory.spec.ts
@@ -3,16 +3,16 @@ import { expect } from 'chai';
 import { HTMLTemplateElementFactory, ITemplateElementFactory } from '../../src/template-element-factory';
 import { HTMLTestContext, TestContext } from '../util';
 
-describe('HTMLTemplateElementFactory', function() {
+describe('HTMLTemplateElementFactory', function () {
   let sut: HTMLTemplateElementFactory;
   let ctx: HTMLTestContext;
 
-  beforeEach(function() {
+  beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
     sut = new HTMLTemplateElementFactory(ctx.dom);
   });
 
-  it('template-wrapped markup string', function() {
+  it('template-wrapped markup string', function () {
     const markup = `<template><div class="au">foo</div></template>`;
 
     const expectedHTML = markup;
@@ -21,7 +21,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('non-template-wrapped markup string', function() {
+  it('non-template-wrapped markup string', function () {
     const markup = `<div class="au">foo</div>`;
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -30,7 +30,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('double template-wrapped markup string', function() {
+  it('double template-wrapped markup string', function () {
     const markup = `<template><div class="au">foo</div></template>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -39,7 +39,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('double non-template-wrapped markup string', function() {
+  it('double non-template-wrapped markup string', function () {
     const markup = `<div class="au">foo</div>`.repeat(2);
 
     const expectedHTML = `<template>${markup}</template>`;
@@ -48,7 +48,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('template node', function() {
+  it('template node', function () {
     const markup = `<div class="au">foo</div>`;
     const template = ctx.createElement('template');
     template.innerHTML = markup;
@@ -60,7 +60,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('non-template node', function() {
+  it('non-template node', function () {
     const markup = `<div class="au">foo</div>`;
     const template = ctx.createElement('template') as HTMLTemplateElement;
     template.innerHTML = markup;
@@ -72,7 +72,7 @@ describe('HTMLTemplateElementFactory', function() {
     expect(actualHTML).to.equal(expectedHTML);
   });
 
-  it('template node with parent', function() {
+  it('template node with parent', function () {
     const markup = `<template><div class="au">foo</div></template>`;
     const template = ctx.createElement('template') as HTMLTemplateElement;
     template.innerHTML = markup;

--- a/packages/jit/test/attribute-pattern.spec.ts
+++ b/packages/jit/test/attribute-pattern.spec.ts
@@ -7,7 +7,7 @@ import {
   ISyntaxInterpreter
 } from '../src/index';
 
-describe('@attributePattern', () => {
+describe('@attributePattern', function() {
   for (const [defs, tests] of [
     [
       [
@@ -138,9 +138,9 @@ describe('@attributePattern', () => {
       ]
     ]
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
-    describe(`parse [${defs.map(d => d.pattern)}]`, () => {
+    describe(`parse [${defs.map(d => d.pattern)}]`, function() {
       for (const [value, match, values] of tests) {
-        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, () => {
+        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function() {
           let receivedRawName: string;
           let receivedRawValue: string;
           let receivedParts: string[];

--- a/packages/jit/test/attribute-pattern.spec.ts
+++ b/packages/jit/test/attribute-pattern.spec.ts
@@ -7,7 +7,7 @@ import {
   ISyntaxInterpreter
 } from '../src/index';
 
-describe('@attributePattern', function() {
+describe('@attributePattern', function () {
   for (const [defs, tests] of [
     [
       [
@@ -138,9 +138,9 @@ describe('@attributePattern', function() {
       ]
     ]
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
-    describe(`parse [${defs.map(d => d.pattern)}]`, function() {
+    describe(`parse [${defs.map(d => d.pattern)}]`, function () {
       for (const [value, match, values] of tests) {
-        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function() {
+        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
           let receivedRawName: string;
           let receivedRawValue: string;
           let receivedParts: string[];

--- a/packages/jit/test/expression-parser.spec.ts
+++ b/packages/jit/test/expression-parser.spec.ts
@@ -148,7 +148,7 @@ function verifyResultOrError(expr: string, expected: any, expectedMsg?: string, 
 
 // Note: we could loop through all generated tests by picking SimpleIsBindingBehaviorList and ComplexIsBindingBehaviorList,
 // but we're separating them out to make the test suites more granular for debugging and reporting purposes
-describe('ExpressionParser', () => {
+describe('ExpressionParser', function() {
 
   // #region Simple lists
 
@@ -432,218 +432,218 @@ describe('ExpressionParser', () => {
     BindingType.CaptureCommand,
     BindingType.CallCommand
   ] as any[]) {
-    describe(bindingTypeToString(bindingType), () => {
-      describe('parse AccessThisList', () => {
+    describe(bindingTypeToString(bindingType), function() {
+      describe('parse AccessThisList', function() {
         for (const [input, expected] of AccessThisList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse AccessScopeList', () => {
+      describe('parse AccessScopeList', function() {
         for (const [input, expected] of AccessScopeList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleStringLiteralList', () => {
+      describe('parse SimpleStringLiteralList', function() {
         for (const [input, expected] of SimpleStringLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleNumberLiteralList', () => {
+      describe('parse SimpleNumberLiteralList', function() {
         for (const [input, expected] of SimpleNumberLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse KeywordPrimitiveLiteralList', () => {
+      describe('parse KeywordPrimitiveLiteralList', function() {
         for (const [input, expected] of KeywordPrimitiveLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleArrayLiteralList', () => {
+      describe('parse SimpleArrayLiteralList', function() {
         for (const [input, expected] of SimpleArrayLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleObjectLiteralList', () => {
+      describe('parse SimpleObjectLiteralList', function() {
         for (const [input, expected] of SimpleObjectLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleTemplateLiteralList', () => {
+      describe('parse SimpleTemplateLiteralList', function() {
         for (const [input, expected] of SimpleTemplateLiteralList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleParenthesizedList', () => {
+      describe('parse SimpleParenthesizedList', function() {
         for (const [input, expected] of SimpleParenthesizedList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAccessKeyedList', () => {
+      describe('parse SimpleAccessKeyedList', function() {
         for (const [input, expected] of SimpleAccessKeyedList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAccessMemberList', () => {
+      describe('parse SimpleAccessMemberList', function() {
         for (const [input, expected] of SimpleAccessMemberList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleTaggedTemplateList', () => {
+      describe('parse SimpleTaggedTemplateList', function() {
         for (const [input, expected] of SimpleTaggedTemplateList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallFunctionList', () => {
+      describe('parse SimpleCallFunctionList', function() {
         for (const [input, expected] of SimpleCallFunctionList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallScopeList', () => {
+      describe('parse SimpleCallScopeList', function() {
         for (const [input, expected] of SimpleCallScopeList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallMemberList', () => {
+      describe('parse SimpleCallMemberList', function() {
         for (const [input, expected] of SimpleCallMemberList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleUnaryList', () => {
+      describe('parse SimpleUnaryList', function() {
         for (const [input, expected] of SimpleUnaryList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleMultiplicativeList', () => {
+      describe('parse SimpleMultiplicativeList', function() {
         for (const [input, expected] of SimpleMultiplicativeList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAdditiveList', () => {
+      describe('parse SimpleAdditiveList', function() {
         for (const [input, expected] of SimpleAdditiveList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleRelationalList', () => {
+      describe('parse SimpleRelationalList', function() {
         for (const [input, expected] of SimpleRelationalList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleEqualityList', () => {
+      describe('parse SimpleEqualityList', function() {
         for (const [input, expected] of SimpleEqualityList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleLogicalANDList', () => {
+      describe('parse SimpleLogicalANDList', function() {
         for (const [input, expected] of SimpleLogicalANDList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleLogicalORList', () => {
+      describe('parse SimpleLogicalORList', function() {
         for (const [input, expected] of SimpleLogicalORList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleConditionalList', () => {
+      describe('parse SimpleConditionalList', function() {
         for (const [input, expected] of SimpleConditionalList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAssignList', () => {
+      describe('parse SimpleAssignList', function() {
         for (const [input, expected] of SimpleAssignList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleValueConverterList', () => {
+      describe('parse SimpleValueConverterList', function() {
         for (const [input, expected] of SimpleValueConverterList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleBindingBehaviorList', () => {
+      describe('parse SimpleBindingBehaviorList', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Unary', () => {
+      describe('parse SimpleBindingBehaviorList with Precedence.Unary', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Unary, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -663,9 +663,9 @@ describe('ExpressionParser', () => {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Binary', () => {
+      describe('parse SimpleBindingBehaviorList with Precedence.Binary', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Binary, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -687,9 +687,9 @@ describe('ExpressionParser', () => {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Conditional', () => {
+      describe('parse SimpleBindingBehaviorList with Precedence.Conditional', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Conditional, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -713,9 +713,9 @@ describe('ExpressionParser', () => {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Assign', () => {
+      describe('parse SimpleBindingBehaviorList with Precedence.Assign', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Assign, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -741,9 +741,9 @@ describe('ExpressionParser', () => {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Variadic', () => {
+      describe('parse SimpleBindingBehaviorList with Precedence.Variadic', function() {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, () => {
+          it(input, function() {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Variadic, bindingType);
             verifyASTEqual(result, expected);
@@ -799,9 +799,9 @@ describe('ExpressionParser', () => {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexStringLiteralList', () => {
+  describe('parse ComplexStringLiteralList', function() {
     for (const [input, expected] of ComplexStringLiteralList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -819,9 +819,9 @@ describe('ExpressionParser', () => {
     ['90071992547409929007199254740992.9007199254740992',                 new PrimitiveLiteral(90071992547409929007199254740992.9007199254740992)],
     ['90071992547409929007199254740992.90071992547409929007199254740992', new PrimitiveLiteral(90071992547409929007199254740992.90071992547409929007199254740992)]
   ];
-  describe('parse ComplexNumberList', () => {
+  describe('parse ComplexNumberList', function() {
     for (const [input, expected] of ComplexNumberList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -858,9 +858,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`\`\${${input}}\${${input}}\``, new Template(['', '', ''], [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexTemplateLiteralList', () => {
+  describe('parse ComplexTemplateLiteralList', function() {
     for (const [input, expected] of ComplexTemplateLiteralList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -892,9 +892,9 @@ describe('ExpressionParser', () => {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexArrayLiteralList', () => {
+  describe('parse ComplexArrayLiteralList', function() {
     for (const [input, expected] of ComplexArrayLiteralList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -935,9 +935,9 @@ describe('ExpressionParser', () => {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexObjectLiteralList', () => {
+  describe('parse ComplexObjectLiteralList', function() {
     for (const [input, expected] of ComplexObjectLiteralList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -947,9 +947,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a[${input}]`, new AccessKeyed($a, expr)] as [string, any])
   ];
-  describe('parse ComplexAccessKeyedList', () => {
+  describe('parse ComplexAccessKeyedList', function() {
     for (const [input, expected] of ComplexAccessKeyedList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -967,9 +967,9 @@ describe('ExpressionParser', () => {
       [`of`]]
       .map(([input]) => [`a.${input}`, new AccessMember($a, input)] as [string, any])
   ];
-  describe('parse ComplexAccessMemberList', () => {
+  describe('parse ComplexAccessMemberList', function() {
     for (const [input, expected] of ComplexAccessMemberList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1004,9 +1004,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a\`\${${input}}\${${input}}\``, new TaggedTemplate(['', '', ''], ['', '', ''], $a, [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexTaggedTemplateList', () => {
+  describe('parse ComplexTaggedTemplateList', function() {
     for (const [input, expected] of ComplexTaggedTemplateList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1018,9 +1018,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`$this(${input},${input})`, new CallFunction($this, [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallFunctionList', () => {
+  describe('parse ComplexCallFunctionList', function() {
     for (const [input, expected] of ComplexCallFunctionList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1032,9 +1032,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a(${input},${input})`, new CallScope('a', [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallScopeList', () => {
+  describe('parse ComplexCallScopeList', function() {
     for (const [input, expected] of ComplexCallScopeList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1046,9 +1046,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a.b(${input},${input})`, new CallMember($a, 'b', [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallMemberList', () => {
+  describe('parse ComplexCallMemberList', function() {
     for (const [input, expected] of ComplexCallMemberList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1066,9 +1066,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsLeftHandSideList
       .map(([input, expr]) => [`typeof ${input}`, new Unary('typeof', expr)] as [string, any])
   ];
-  describe('parse ComplexUnaryList', () => {
+  describe('parse ComplexUnaryList', function() {
     for (const [input, expected] of ComplexUnaryList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1090,9 +1090,9 @@ describe('ExpressionParser', () => {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexMultiplicativeList', () => {
+  describe('parse ComplexMultiplicativeList', function() {
     for (const [input, expected] of ComplexMultiplicativeList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1112,9 +1112,9 @@ describe('ExpressionParser', () => {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexAdditiveList', () => {
+  describe('parse ComplexAdditiveList', function() {
     for (const [input, expected] of ComplexAdditiveList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1134,9 +1134,9 @@ describe('ExpressionParser', () => {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexRelationalList', () => {
+  describe('parse ComplexRelationalList', function() {
     for (const [input, expected] of ComplexRelationalList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1156,9 +1156,9 @@ describe('ExpressionParser', () => {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexEqualityList', () => {
+  describe('parse ComplexEqualityList', function() {
     for (const [input, expected] of ComplexEqualityList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1176,9 +1176,9 @@ describe('ExpressionParser', () => {
       .map(([i1, e1]) => SimpleLogicalANDList.map(([i2, e2]) => [`${i1}&&${i2}`, new Binary(e1.operation, e1.left, new Binary(e2.operation, new Binary('&&', e1.right, e2.left), e2.right))]) as [string, any][])
       .reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexLogicalANDList', () => {
+  describe('parse ComplexLogicalANDList', function() {
     for (const [input, expected] of ComplexLogicalANDList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1196,9 +1196,9 @@ describe('ExpressionParser', () => {
       .map(([i1, e1]) => SimpleLogicalORList.map(([i2, e2]) => [`${i1}||${i2}`, new Conditional(e1.condition, e1.yes, new Binary(e2.operation, new Binary('||', e1.no, e2.left), e2.right))]) as [string, any][])
       .reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexLogicalORList', () => {
+  describe('parse ComplexLogicalORList', function() {
     for (const [input, expected] of ComplexLogicalORList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1210,9 +1210,9 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList.map(([i1, e1]) => [`0?${i1}:1`, new Conditional($num0, e1, $num1)] as [string, any]),
     ...SimpleConditionalList.map(([i1, e1]) => [`${i1}?0:1`, new Conditional(e1.condition, e1.yes, new Conditional(e1.no, $num0, $num1))] as [string, any])
   ];
-  describe('parse ComplexConditionalList', () => {
+  describe('parse ComplexConditionalList', function() {
     for (const [input, expected] of ComplexConditionalList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1226,9 +1226,9 @@ describe('ExpressionParser', () => {
     ...SimpleAccessKeyedList.map(([i1, e1]) => [`${i1}=a`, new Assign(e1, $a)] as [string, any]),
     ...SimpleAssignList.map(([i1, e1]) => [`${i1}=c`, new Assign(e1.target, new Assign(e1.value, $c))] as [string, any])
   ];
-  describe('parse ComplexAssignList', () => {
+  describe('parse ComplexAssignList', function() {
     for (const [input, expected] of ComplexAssignList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1245,9 +1245,9 @@ describe('ExpressionParser', () => {
     ...AccessScopeList.map(([i1, e1]) => [`${i1}|a:${i1}:${i1}:${i1}|b|c:${i1}:${i1}:${i1}`, new ValueConverter(new ValueConverter(new ValueConverter(e1, 'a', [e1, e1, e1]), 'b', []), 'c', [e1, e1, e1])] as [string, any]),
     ...AccessScopeList.map(([i1, e1]) => [`${i1}|a:${i1}:${i1}:${i1}|b:${i1}:${i1}:${i1}|c`, new ValueConverter(new ValueConverter(new ValueConverter(e1, 'a', [e1, e1, e1]), 'b', [e1, e1, e1]), 'c', [])] as [string, any])
   ];
-  describe('parse ComplexValueConverterList', () => {
+  describe('parse ComplexValueConverterList', function() {
     for (const [input, expected] of ComplexValueConverterList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1264,9 +1264,9 @@ describe('ExpressionParser', () => {
     ...AccessScopeList.map(([i1, e1]) => [`${i1}&a:${i1}:${i1}:${i1}&b&c:${i1}:${i1}:${i1}`, new BindingBehavior(new BindingBehavior(new BindingBehavior(e1, 'a', [e1, e1, e1]), 'b', []), 'c', [e1, e1, e1])] as [string, any]),
     ...AccessScopeList.map(([i1, e1]) => [`${i1}&a:${i1}:${i1}:${i1}&b:${i1}:${i1}:${i1}&c`, new BindingBehavior(new BindingBehavior(new BindingBehavior(e1, 'a', [e1, e1, e1]), 'b', [e1, e1, e1]), 'c', [])] as [string, any])
   ];
-  describe('parse ComplexBindingBehaviorList', () => {
+  describe('parse ComplexBindingBehaviorList', function() {
     for (const [input, expected] of ComplexBindingBehaviorList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1275,7 +1275,7 @@ describe('ExpressionParser', () => {
   // #endregion
 
   // https://tc39.github.io/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation
-  describe('parse ForOfStatement', () => {
+  describe('parse ForOfStatement', function() {
     const SimpleForDeclarations: [string, any][] = [
       [`a`,           new BindingIdentifier('a')],
       [`{}`,          new ObjectBindingPattern([], [])],
@@ -1323,7 +1323,7 @@ describe('ExpressionParser', () => {
     ];
 
     for (const [input, expected] of ForOfStatements) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input, BindingType.ForCommand as any), expected);
       });
     }
@@ -1362,53 +1362,53 @@ describe('ExpressionParser', () => {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`\${${input}}\${${input}}`, new Interpolation(['', '', ''], [expr, expr])] as [string, any])
   ];
-  describe('parse Interpolation', () => {
+  describe('parse Interpolation', function() {
     for (const [input, expected] of InterpolationList) {
-      it(input, () => {
+      it(input, function() {
         verifyASTEqual(parseExpression(input, BindingType.Interpolation as any), expected);
       });
     }
   });
 
-  describe('parse unicode IdentifierStart', () => {
+  describe('parse unicode IdentifierStart', function() {
     for (const char of latin1IdentifierStartChars) {
-      it(char, () => {
+      it(char, function() {
         verifyASTEqual(parseExpression(char), new AccessScope(char, 0));
       });
     }
   });
 
-  describe('parse unicode IdentifierPart', () => {
+  describe('parse unicode IdentifierPart', function() {
     for (const char of latin1IdentifierPartChars) {
-      it(char, () => {
+      it(char, function() {
         const identifier = `$${char}`;
         verifyASTEqual(parseExpression(identifier), new AccessScope(identifier, 0));
       });
     }
   });
 
-  describe('Errors', () => {
+  describe('Errors', function() {
     for (const input of [
       ')', '}', ']', '%', '*',
       ',', '/', ':', '>', '<',
       '=', '?', 'of', 'instanceof', 'in', ' '
     ]) {
-      it(`throw Code 100 (InvalidExpressionStart) on "${input}"`, () => {
+      it(`throw Code 100 (InvalidExpressionStart) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 100');
       });
     }
 
     for (const input of ['..', '...', '..a', '...a', '..1', '...1', '.a.', '.a..']) {
-      it(`throw Code 101 (UnconsumedToken) on "${input}"`, () => {
+      it(`throw Code 101 (UnconsumedToken) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 101');
       });
     }
-    it(`throw Code 101 (UnconsumedToken) on "$this!"`, () => {
+    it(`throw Code 101 (UnconsumedToken) on "$this!"`, function() {
       verifyResultOrError(`$this!`, null, 'Code 101');
     });
     for (const [input] of SimpleIsAssignList) {
       for (const op of [')', ']', '}']) {
-        it(`throw Code 110 (MissingExpectedToken) on "${input}${op}"`, () => {
+        it(`throw Code 110 (MissingExpectedToken) on "${input}${op}"`, function() {
           verifyResultOrError(`${input}${op}`, null, 'Code 101');
         });
       }
@@ -1418,7 +1418,7 @@ describe('ExpressionParser', () => {
       for (const middle of ['..', '...']) {
         for (const end of ['', 'bar', '$parent']) {
           const expr = `${start}${middle}${end}`;
-          it(`throw Code 102 (DoubleDot) on "${expr}"`, () => {
+          it(`throw Code 102 (DoubleDot) on "${expr}"`, function() {
             verifyResultOrError(expr, null, 'Code 102');
           });
         }
@@ -1426,19 +1426,19 @@ describe('ExpressionParser', () => {
     }
 
     for (const nonTerminal of ['!', ' of', ' typeof', '=']) {
-      it(`throw Code 103 (InvalidMemberExpression) on "$parent${nonTerminal}"`, () => {
+      it(`throw Code 103 (InvalidMemberExpression) on "$parent${nonTerminal}"`, function() {
         verifyResultOrError(`$parent${nonTerminal}`, null, 'Code 103');
       });
     }
 
     for (const op of ['!', '(', '+', '-', '.', '[', 'typeof']) {
-      it(`throw Code 104 (UnexpectedEndOfExpression) on "${op}"`, () => {
+      it(`throw Code 104 (UnexpectedEndOfExpression) on "${op}"`, function() {
         verifyResultOrError(op, null, 'Code 104');
       });
     }
 
     for (const [input, expr] of SimpleIsLeftHandSideList) {
-      it(`throw Code 105 (ExpectedIdentifier) on "${input}."`, () => {
+      it(`throw Code 105 (ExpectedIdentifier) on "${input}."`, function() {
         if (typeof expr['value'] !== 'number' || input.includes('.')) { // only non-float numbers are allowed to end on a dot
           verifyResultOrError(`${input}.`, null, 'Code 105');
         } else {
@@ -1449,90 +1449,90 @@ describe('ExpressionParser', () => {
 
     for (const [input] of SimpleIsNativeLeftHandSideList) {
       for (const dots of ['..', '...']) {
-        it(`throw Code 105 (ExpectedIdentifier) on "${input}${dots}"`, () => {
+        it(`throw Code 105 (ExpectedIdentifier) on "${input}${dots}"`, function() {
           verifyResultOrError(`${input}${dots}`, null, 'Code 105');
         });
       }
     }
     for (const input of ['.1.', '.1..']) {
-      it(`throw Code 105 (ExpectedIdentifier) on "${input}"`, () => {
+      it(`throw Code 105 (ExpectedIdentifier) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 105');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList) {
-      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, () => {
+      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 106', BindingType.ForCommand);
       });
     }
     for (const [input] of [
       [`a`, new BindingIdentifier('a')]
     ] as [string, any][]) {
-      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, () => {
+      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 106', BindingType.ForCommand);
       });
     }
 
     for (const input of ['{', '{[]}', '{[}', '{[a]}', '{[a}', '{{', '{(']) {
-      it(`throw Code 107 (InvalidObjectLiteralPropertyDefinition) on "${input}"`, () => {
+      it(`throw Code 107 (InvalidObjectLiteralPropertyDefinition) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 107');
       });
     }
 
     for (const input of ['"', '\'']) {
-      it(`throw Code 108 (UnterminatedQuote) on "${input}"`, () => {
+      it(`throw Code 108 (UnterminatedQuote) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 108');
       });
     }
 
     for (const input of ['`', '` ', '`${a}']) {
-      it(`throw Code 109 (UnterminatedTemplate) on "${input}"`, () => {
+      it(`throw Code 109 (UnterminatedTemplate) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 109');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
       for (const op of ['(', '[']) {
-        it(`throw Code 110 (MissingExpectedToken) on "${op}${input}"`, () => {
+        it(`throw Code 110 (MissingExpectedToken) on "${op}${input}"`, function() {
           verifyResultOrError(`${op}${input}`, null, 'Code 110');
         });
       }
     }
     for (const [input] of SimpleIsConditionalList) {
-      it(`throw Code 110 (MissingExpectedToken) on "${input}?${input}"`, () => {
+      it(`throw Code 110 (MissingExpectedToken) on "${input}?${input}"`, function() {
         verifyResultOrError(`${input}?${input}`, null, 'Code 110');
       });
     }
     for (const [input] of AccessScopeList) {
-      it(`throw Code 110 (MissingExpectedToken) on "{${input}"`, () => {
+      it(`throw Code 110 (MissingExpectedToken) on "{${input}"`, function() {
         verifyResultOrError(`{${input}`, null, 'Code 110');
       });
     }
     for (const [input] of SimpleStringLiteralList) {
-      it(`throw Code 110 (MissingExpectedToken) on "{${input}}"`, () => {
+      it(`throw Code 110 (MissingExpectedToken) on "{${input}}"`, function() {
         verifyResultOrError(`{${input}}`, null, 'Code 110');
       });
     }
     for (const input of ['{24}', '{24, 24}', '{\'\'}', '{a.b}', '{a[b]}', '{a()}']) {
-      it(`throw Code 110 (MissingExpectedToken) on "${input}"`, () => {
+      it(`throw Code 110 (MissingExpectedToken) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 110');
       });
     }
 
     for (const input of ['#', ';', '@', '^', '~', '\\', 'foo;']) {
-      it(`throw Code 111 (UnexpectedCharacter) on "${input}"`, () => {
+      it(`throw Code 111 (UnexpectedCharacter) on "${input}"`, function() {
         verifyResultOrError(input, null, 'Code 111');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
-      it(`throw Code 112 (MissingValueConverter) on "${input}|"`, () => {
+      it(`throw Code 112 (MissingValueConverter) on "${input}|"`, function() {
         verifyResultOrError(`${input}|`, null, 'Code 112');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
-      it(`throw Code 113 (MissingBindingBehavior) on "${input}&"`, () => {
+      it(`throw Code 113 (MissingBindingBehavior) on "${input}&"`, function() {
         verifyResultOrError(`${input}&`, null, 'Code 113');
       });
     }
@@ -1542,21 +1542,21 @@ describe('ExpressionParser', () => {
       ...SimpleLiteralList,
       ...SimpleUnaryList
     ]) {
-      it(`throw Code 150 (NotAssignable) on "${input}=a"`, () => {
+      it(`throw Code 150 (NotAssignable) on "${input}=a"`, function() {
         verifyResultOrError(`${input}=a`, null, 'Code 150');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList.filter(([, e]) => !e.ancestor)) {
-      it(`throw Code 151 (UnexpectedForOf) on "${input} of"`, () => {
+      it(`throw Code 151 (UnexpectedForOf) on "${input} of"`, function() {
         verifyResultOrError(`${input} of`, null, 'Code 151');
       });
     }
   });
 
-  describe('unknown unicode IdentifierPart', () => {
+  describe('unknown unicode IdentifierPart', function() {
     for (const char of otherBMPIdentifierPartChars) {
-      it(char, () => {
+      it(char, function() {
         const identifier = `$${char}`;
         verifyResultOrError(identifier, null, codes.UnexpectedCharacter);
       });

--- a/packages/jit/test/expression-parser.spec.ts
+++ b/packages/jit/test/expression-parser.spec.ts
@@ -148,7 +148,7 @@ function verifyResultOrError(expr: string, expected: any, expectedMsg?: string, 
 
 // Note: we could loop through all generated tests by picking SimpleIsBindingBehaviorList and ComplexIsBindingBehaviorList,
 // but we're separating them out to make the test suites more granular for debugging and reporting purposes
-describe('ExpressionParser', function() {
+describe('ExpressionParser', function () {
 
   // #region Simple lists
 
@@ -432,218 +432,218 @@ describe('ExpressionParser', function() {
     BindingType.CaptureCommand,
     BindingType.CallCommand
   ] as any[]) {
-    describe(bindingTypeToString(bindingType), function() {
-      describe('parse AccessThisList', function() {
+    describe(bindingTypeToString(bindingType), function () {
+      describe('parse AccessThisList', function () {
         for (const [input, expected] of AccessThisList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse AccessScopeList', function() {
+      describe('parse AccessScopeList', function () {
         for (const [input, expected] of AccessScopeList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleStringLiteralList', function() {
+      describe('parse SimpleStringLiteralList', function () {
         for (const [input, expected] of SimpleStringLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleNumberLiteralList', function() {
+      describe('parse SimpleNumberLiteralList', function () {
         for (const [input, expected] of SimpleNumberLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse KeywordPrimitiveLiteralList', function() {
+      describe('parse KeywordPrimitiveLiteralList', function () {
         for (const [input, expected] of KeywordPrimitiveLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleArrayLiteralList', function() {
+      describe('parse SimpleArrayLiteralList', function () {
         for (const [input, expected] of SimpleArrayLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleObjectLiteralList', function() {
+      describe('parse SimpleObjectLiteralList', function () {
         for (const [input, expected] of SimpleObjectLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleTemplateLiteralList', function() {
+      describe('parse SimpleTemplateLiteralList', function () {
         for (const [input, expected] of SimpleTemplateLiteralList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleParenthesizedList', function() {
+      describe('parse SimpleParenthesizedList', function () {
         for (const [input, expected] of SimpleParenthesizedList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAccessKeyedList', function() {
+      describe('parse SimpleAccessKeyedList', function () {
         for (const [input, expected] of SimpleAccessKeyedList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAccessMemberList', function() {
+      describe('parse SimpleAccessMemberList', function () {
         for (const [input, expected] of SimpleAccessMemberList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleTaggedTemplateList', function() {
+      describe('parse SimpleTaggedTemplateList', function () {
         for (const [input, expected] of SimpleTaggedTemplateList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallFunctionList', function() {
+      describe('parse SimpleCallFunctionList', function () {
         for (const [input, expected] of SimpleCallFunctionList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallScopeList', function() {
+      describe('parse SimpleCallScopeList', function () {
         for (const [input, expected] of SimpleCallScopeList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleCallMemberList', function() {
+      describe('parse SimpleCallMemberList', function () {
         for (const [input, expected] of SimpleCallMemberList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleUnaryList', function() {
+      describe('parse SimpleUnaryList', function () {
         for (const [input, expected] of SimpleUnaryList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleMultiplicativeList', function() {
+      describe('parse SimpleMultiplicativeList', function () {
         for (const [input, expected] of SimpleMultiplicativeList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAdditiveList', function() {
+      describe('parse SimpleAdditiveList', function () {
         for (const [input, expected] of SimpleAdditiveList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleRelationalList', function() {
+      describe('parse SimpleRelationalList', function () {
         for (const [input, expected] of SimpleRelationalList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleEqualityList', function() {
+      describe('parse SimpleEqualityList', function () {
         for (const [input, expected] of SimpleEqualityList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleLogicalANDList', function() {
+      describe('parse SimpleLogicalANDList', function () {
         for (const [input, expected] of SimpleLogicalANDList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleLogicalORList', function() {
+      describe('parse SimpleLogicalORList', function () {
         for (const [input, expected] of SimpleLogicalORList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleConditionalList', function() {
+      describe('parse SimpleConditionalList', function () {
         for (const [input, expected] of SimpleConditionalList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleAssignList', function() {
+      describe('parse SimpleAssignList', function () {
         for (const [input, expected] of SimpleAssignList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleValueConverterList', function() {
+      describe('parse SimpleValueConverterList', function () {
         for (const [input, expected] of SimpleValueConverterList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleBindingBehaviorList', function() {
+      describe('parse SimpleBindingBehaviorList', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             verifyResultOrError(input, expected, null, bindingType);
           });
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Unary', function() {
+      describe('parse SimpleBindingBehaviorList with Precedence.Unary', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Unary, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -663,9 +663,9 @@ describe('ExpressionParser', function() {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Binary', function() {
+      describe('parse SimpleBindingBehaviorList with Precedence.Binary', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Binary, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -687,9 +687,9 @@ describe('ExpressionParser', function() {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Conditional', function() {
+      describe('parse SimpleBindingBehaviorList with Precedence.Conditional', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Conditional, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -713,9 +713,9 @@ describe('ExpressionParser', function() {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Assign', function() {
+      describe('parse SimpleBindingBehaviorList with Precedence.Assign', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Assign, bindingType);
             if ((result.$kind & ExpressionKind.IsPrimary) > 0 ||
@@ -741,9 +741,9 @@ describe('ExpressionParser', function() {
         }
       });
 
-      describe('parse SimpleBindingBehaviorList with Precedence.Variadic', function() {
+      describe('parse SimpleBindingBehaviorList with Precedence.Variadic', function () {
         for (const [input, expected] of SimpleBindingBehaviorList) {
-          it(input, function() {
+          it(input, function () {
             const state = new ParserState(input);
             const result = parse(state, Access.Reset, Precedence.Variadic, bindingType);
             verifyASTEqual(result, expected);
@@ -799,9 +799,9 @@ describe('ExpressionParser', function() {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexStringLiteralList', function() {
+  describe('parse ComplexStringLiteralList', function () {
     for (const [input, expected] of ComplexStringLiteralList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -819,9 +819,9 @@ describe('ExpressionParser', function() {
     ['90071992547409929007199254740992.9007199254740992',                 new PrimitiveLiteral(90071992547409929007199254740992.9007199254740992)],
     ['90071992547409929007199254740992.90071992547409929007199254740992', new PrimitiveLiteral(90071992547409929007199254740992.90071992547409929007199254740992)]
   ];
-  describe('parse ComplexNumberList', function() {
+  describe('parse ComplexNumberList', function () {
     for (const [input, expected] of ComplexNumberList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -858,9 +858,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`\`\${${input}}\${${input}}\``, new Template(['', '', ''], [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexTemplateLiteralList', function() {
+  describe('parse ComplexTemplateLiteralList', function () {
     for (const [input, expected] of ComplexTemplateLiteralList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -892,9 +892,9 @@ describe('ExpressionParser', function() {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexArrayLiteralList', function() {
+  describe('parse ComplexArrayLiteralList', function () {
     for (const [input, expected] of ComplexArrayLiteralList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -935,9 +935,9 @@ describe('ExpressionParser', function() {
     ] as [string, any][])
     .reduce((acc, cur) => acc.concat(cur))
   ];
-  describe('parse ComplexObjectLiteralList', function() {
+  describe('parse ComplexObjectLiteralList', function () {
     for (const [input, expected] of ComplexObjectLiteralList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -947,9 +947,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a[${input}]`, new AccessKeyed($a, expr)] as [string, any])
   ];
-  describe('parse ComplexAccessKeyedList', function() {
+  describe('parse ComplexAccessKeyedList', function () {
     for (const [input, expected] of ComplexAccessKeyedList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -967,9 +967,9 @@ describe('ExpressionParser', function() {
       [`of`]]
       .map(([input]) => [`a.${input}`, new AccessMember($a, input)] as [string, any])
   ];
-  describe('parse ComplexAccessMemberList', function() {
+  describe('parse ComplexAccessMemberList', function () {
     for (const [input, expected] of ComplexAccessMemberList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1004,9 +1004,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a\`\${${input}}\${${input}}\``, new TaggedTemplate(['', '', ''], ['', '', ''], $a, [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexTaggedTemplateList', function() {
+  describe('parse ComplexTaggedTemplateList', function () {
     for (const [input, expected] of ComplexTaggedTemplateList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1018,9 +1018,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`$this(${input},${input})`, new CallFunction($this, [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallFunctionList', function() {
+  describe('parse ComplexCallFunctionList', function () {
     for (const [input, expected] of ComplexCallFunctionList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1032,9 +1032,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a(${input},${input})`, new CallScope('a', [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallScopeList', function() {
+  describe('parse ComplexCallScopeList', function () {
     for (const [input, expected] of ComplexCallScopeList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1046,9 +1046,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`a.b(${input},${input})`, new CallMember($a, 'b', [expr, expr])] as [string, any])
   ];
-  describe('parse ComplexCallMemberList', function() {
+  describe('parse ComplexCallMemberList', function () {
     for (const [input, expected] of ComplexCallMemberList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1066,9 +1066,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsLeftHandSideList
       .map(([input, expr]) => [`typeof ${input}`, new Unary('typeof', expr)] as [string, any])
   ];
-  describe('parse ComplexUnaryList', function() {
+  describe('parse ComplexUnaryList', function () {
     for (const [input, expected] of ComplexUnaryList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1090,9 +1090,9 @@ describe('ExpressionParser', function() {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexMultiplicativeList', function() {
+  describe('parse ComplexMultiplicativeList', function () {
     for (const [input, expected] of ComplexMultiplicativeList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1112,9 +1112,9 @@ describe('ExpressionParser', function() {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexAdditiveList', function() {
+  describe('parse ComplexAdditiveList', function () {
     for (const [input, expected] of ComplexAdditiveList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1134,9 +1134,9 @@ describe('ExpressionParser', function() {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexRelationalList', function() {
+  describe('parse ComplexRelationalList', function () {
     for (const [input, expected] of ComplexRelationalList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1156,9 +1156,9 @@ describe('ExpressionParser', function() {
         .reduce((a, b) => a.concat(b))
     ] as [string, any][]).reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexEqualityList', function() {
+  describe('parse ComplexEqualityList', function () {
     for (const [input, expected] of ComplexEqualityList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1176,9 +1176,9 @@ describe('ExpressionParser', function() {
       .map(([i1, e1]) => SimpleLogicalANDList.map(([i2, e2]) => [`${i1}&&${i2}`, new Binary(e1.operation, e1.left, new Binary(e2.operation, new Binary('&&', e1.right, e2.left), e2.right))]) as [string, any][])
       .reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexLogicalANDList', function() {
+  describe('parse ComplexLogicalANDList', function () {
     for (const [input, expected] of ComplexLogicalANDList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1196,9 +1196,9 @@ describe('ExpressionParser', function() {
       .map(([i1, e1]) => SimpleLogicalORList.map(([i2, e2]) => [`${i1}||${i2}`, new Conditional(e1.condition, e1.yes, new Binary(e2.operation, new Binary('||', e1.no, e2.left), e2.right))]) as [string, any][])
       .reduce((a, b) => a.concat(b))
   ];
-  describe('parse ComplexLogicalORList', function() {
+  describe('parse ComplexLogicalORList', function () {
     for (const [input, expected] of ComplexLogicalORList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1210,9 +1210,9 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList.map(([i1, e1]) => [`0?${i1}:1`, new Conditional($num0, e1, $num1)] as [string, any]),
     ...SimpleConditionalList.map(([i1, e1]) => [`${i1}?0:1`, new Conditional(e1.condition, e1.yes, new Conditional(e1.no, $num0, $num1))] as [string, any])
   ];
-  describe('parse ComplexConditionalList', function() {
+  describe('parse ComplexConditionalList', function () {
     for (const [input, expected] of ComplexConditionalList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1226,9 +1226,9 @@ describe('ExpressionParser', function() {
     ...SimpleAccessKeyedList.map(([i1, e1]) => [`${i1}=a`, new Assign(e1, $a)] as [string, any]),
     ...SimpleAssignList.map(([i1, e1]) => [`${i1}=c`, new Assign(e1.target, new Assign(e1.value, $c))] as [string, any])
   ];
-  describe('parse ComplexAssignList', function() {
+  describe('parse ComplexAssignList', function () {
     for (const [input, expected] of ComplexAssignList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1245,9 +1245,9 @@ describe('ExpressionParser', function() {
     ...AccessScopeList.map(([i1, e1]) => [`${i1}|a:${i1}:${i1}:${i1}|b|c:${i1}:${i1}:${i1}`, new ValueConverter(new ValueConverter(new ValueConverter(e1, 'a', [e1, e1, e1]), 'b', []), 'c', [e1, e1, e1])] as [string, any]),
     ...AccessScopeList.map(([i1, e1]) => [`${i1}|a:${i1}:${i1}:${i1}|b:${i1}:${i1}:${i1}|c`, new ValueConverter(new ValueConverter(new ValueConverter(e1, 'a', [e1, e1, e1]), 'b', [e1, e1, e1]), 'c', [])] as [string, any])
   ];
-  describe('parse ComplexValueConverterList', function() {
+  describe('parse ComplexValueConverterList', function () {
     for (const [input, expected] of ComplexValueConverterList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1264,9 +1264,9 @@ describe('ExpressionParser', function() {
     ...AccessScopeList.map(([i1, e1]) => [`${i1}&a:${i1}:${i1}:${i1}&b&c:${i1}:${i1}:${i1}`, new BindingBehavior(new BindingBehavior(new BindingBehavior(e1, 'a', [e1, e1, e1]), 'b', []), 'c', [e1, e1, e1])] as [string, any]),
     ...AccessScopeList.map(([i1, e1]) => [`${i1}&a:${i1}:${i1}:${i1}&b:${i1}:${i1}:${i1}&c`, new BindingBehavior(new BindingBehavior(new BindingBehavior(e1, 'a', [e1, e1, e1]), 'b', [e1, e1, e1]), 'c', [])] as [string, any])
   ];
-  describe('parse ComplexBindingBehaviorList', function() {
+  describe('parse ComplexBindingBehaviorList', function () {
     for (const [input, expected] of ComplexBindingBehaviorList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input), expected);
       });
     }
@@ -1275,7 +1275,7 @@ describe('ExpressionParser', function() {
   // #endregion
 
   // https://tc39.github.io/ecma262/#sec-runtime-semantics-iteratordestructuringassignmentevaluation
-  describe('parse ForOfStatement', function() {
+  describe('parse ForOfStatement', function () {
     const SimpleForDeclarations: [string, any][] = [
       [`a`,           new BindingIdentifier('a')],
       [`{}`,          new ObjectBindingPattern([], [])],
@@ -1323,7 +1323,7 @@ describe('ExpressionParser', function() {
     ];
 
     for (const [input, expected] of ForOfStatements) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input, BindingType.ForCommand as any), expected);
       });
     }
@@ -1362,53 +1362,53 @@ describe('ExpressionParser', function() {
     ...SimpleIsAssignList
       .map(([input, expr]) => [`\${${input}}\${${input}}`, new Interpolation(['', '', ''], [expr, expr])] as [string, any])
   ];
-  describe('parse Interpolation', function() {
+  describe('parse Interpolation', function () {
     for (const [input, expected] of InterpolationList) {
-      it(input, function() {
+      it(input, function () {
         verifyASTEqual(parseExpression(input, BindingType.Interpolation as any), expected);
       });
     }
   });
 
-  describe('parse unicode IdentifierStart', function() {
+  describe('parse unicode IdentifierStart', function () {
     for (const char of latin1IdentifierStartChars) {
-      it(char, function() {
+      it(char, function () {
         verifyASTEqual(parseExpression(char), new AccessScope(char, 0));
       });
     }
   });
 
-  describe('parse unicode IdentifierPart', function() {
+  describe('parse unicode IdentifierPart', function () {
     for (const char of latin1IdentifierPartChars) {
-      it(char, function() {
+      it(char, function () {
         const identifier = `$${char}`;
         verifyASTEqual(parseExpression(identifier), new AccessScope(identifier, 0));
       });
     }
   });
 
-  describe('Errors', function() {
+  describe('Errors', function () {
     for (const input of [
       ')', '}', ']', '%', '*',
       ',', '/', ':', '>', '<',
       '=', '?', 'of', 'instanceof', 'in', ' '
     ]) {
-      it(`throw Code 100 (InvalidExpressionStart) on "${input}"`, function() {
+      it(`throw Code 100 (InvalidExpressionStart) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 100');
       });
     }
 
     for (const input of ['..', '...', '..a', '...a', '..1', '...1', '.a.', '.a..']) {
-      it(`throw Code 101 (UnconsumedToken) on "${input}"`, function() {
+      it(`throw Code 101 (UnconsumedToken) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 101');
       });
     }
-    it(`throw Code 101 (UnconsumedToken) on "$this!"`, function() {
+    it(`throw Code 101 (UnconsumedToken) on "$this!"`, function () {
       verifyResultOrError(`$this!`, null, 'Code 101');
     });
     for (const [input] of SimpleIsAssignList) {
       for (const op of [')', ']', '}']) {
-        it(`throw Code 110 (MissingExpectedToken) on "${input}${op}"`, function() {
+        it(`throw Code 110 (MissingExpectedToken) on "${input}${op}"`, function () {
           verifyResultOrError(`${input}${op}`, null, 'Code 101');
         });
       }
@@ -1418,7 +1418,7 @@ describe('ExpressionParser', function() {
       for (const middle of ['..', '...']) {
         for (const end of ['', 'bar', '$parent']) {
           const expr = `${start}${middle}${end}`;
-          it(`throw Code 102 (DoubleDot) on "${expr}"`, function() {
+          it(`throw Code 102 (DoubleDot) on "${expr}"`, function () {
             verifyResultOrError(expr, null, 'Code 102');
           });
         }
@@ -1426,19 +1426,19 @@ describe('ExpressionParser', function() {
     }
 
     for (const nonTerminal of ['!', ' of', ' typeof', '=']) {
-      it(`throw Code 103 (InvalidMemberExpression) on "$parent${nonTerminal}"`, function() {
+      it(`throw Code 103 (InvalidMemberExpression) on "$parent${nonTerminal}"`, function () {
         verifyResultOrError(`$parent${nonTerminal}`, null, 'Code 103');
       });
     }
 
     for (const op of ['!', '(', '+', '-', '.', '[', 'typeof']) {
-      it(`throw Code 104 (UnexpectedEndOfExpression) on "${op}"`, function() {
+      it(`throw Code 104 (UnexpectedEndOfExpression) on "${op}"`, function () {
         verifyResultOrError(op, null, 'Code 104');
       });
     }
 
     for (const [input, expr] of SimpleIsLeftHandSideList) {
-      it(`throw Code 105 (ExpectedIdentifier) on "${input}."`, function() {
+      it(`throw Code 105 (ExpectedIdentifier) on "${input}."`, function () {
         if (typeof expr['value'] !== 'number' || input.includes('.')) { // only non-float numbers are allowed to end on a dot
           verifyResultOrError(`${input}.`, null, 'Code 105');
         } else {
@@ -1449,90 +1449,90 @@ describe('ExpressionParser', function() {
 
     for (const [input] of SimpleIsNativeLeftHandSideList) {
       for (const dots of ['..', '...']) {
-        it(`throw Code 105 (ExpectedIdentifier) on "${input}${dots}"`, function() {
+        it(`throw Code 105 (ExpectedIdentifier) on "${input}${dots}"`, function () {
           verifyResultOrError(`${input}${dots}`, null, 'Code 105');
         });
       }
     }
     for (const input of ['.1.', '.1..']) {
-      it(`throw Code 105 (ExpectedIdentifier) on "${input}"`, function() {
+      it(`throw Code 105 (ExpectedIdentifier) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 105');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList) {
-      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function() {
+      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 106', BindingType.ForCommand);
       });
     }
     for (const [input] of [
       [`a`, new BindingIdentifier('a')]
     ] as [string, any][]) {
-      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function() {
+      it(`throw Code 106 (InvalidForDeclaration) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 106', BindingType.ForCommand);
       });
     }
 
     for (const input of ['{', '{[]}', '{[}', '{[a]}', '{[a}', '{{', '{(']) {
-      it(`throw Code 107 (InvalidObjectLiteralPropertyDefinition) on "${input}"`, function() {
+      it(`throw Code 107 (InvalidObjectLiteralPropertyDefinition) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 107');
       });
     }
 
     for (const input of ['"', '\'']) {
-      it(`throw Code 108 (UnterminatedQuote) on "${input}"`, function() {
+      it(`throw Code 108 (UnterminatedQuote) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 108');
       });
     }
 
     for (const input of ['`', '` ', '`${a}']) {
-      it(`throw Code 109 (UnterminatedTemplate) on "${input}"`, function() {
+      it(`throw Code 109 (UnterminatedTemplate) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 109');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
       for (const op of ['(', '[']) {
-        it(`throw Code 110 (MissingExpectedToken) on "${op}${input}"`, function() {
+        it(`throw Code 110 (MissingExpectedToken) on "${op}${input}"`, function () {
           verifyResultOrError(`${op}${input}`, null, 'Code 110');
         });
       }
     }
     for (const [input] of SimpleIsConditionalList) {
-      it(`throw Code 110 (MissingExpectedToken) on "${input}?${input}"`, function() {
+      it(`throw Code 110 (MissingExpectedToken) on "${input}?${input}"`, function () {
         verifyResultOrError(`${input}?${input}`, null, 'Code 110');
       });
     }
     for (const [input] of AccessScopeList) {
-      it(`throw Code 110 (MissingExpectedToken) on "{${input}"`, function() {
+      it(`throw Code 110 (MissingExpectedToken) on "{${input}"`, function () {
         verifyResultOrError(`{${input}`, null, 'Code 110');
       });
     }
     for (const [input] of SimpleStringLiteralList) {
-      it(`throw Code 110 (MissingExpectedToken) on "{${input}}"`, function() {
+      it(`throw Code 110 (MissingExpectedToken) on "{${input}}"`, function () {
         verifyResultOrError(`{${input}}`, null, 'Code 110');
       });
     }
     for (const input of ['{24}', '{24, 24}', '{\'\'}', '{a.b}', '{a[b]}', '{a()}']) {
-      it(`throw Code 110 (MissingExpectedToken) on "${input}"`, function() {
+      it(`throw Code 110 (MissingExpectedToken) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 110');
       });
     }
 
     for (const input of ['#', ';', '@', '^', '~', '\\', 'foo;']) {
-      it(`throw Code 111 (UnexpectedCharacter) on "${input}"`, function() {
+      it(`throw Code 111 (UnexpectedCharacter) on "${input}"`, function () {
         verifyResultOrError(input, null, 'Code 111');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
-      it(`throw Code 112 (MissingValueConverter) on "${input}|"`, function() {
+      it(`throw Code 112 (MissingValueConverter) on "${input}|"`, function () {
         verifyResultOrError(`${input}|`, null, 'Code 112');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
-      it(`throw Code 113 (MissingBindingBehavior) on "${input}&"`, function() {
+      it(`throw Code 113 (MissingBindingBehavior) on "${input}&"`, function () {
         verifyResultOrError(`${input}&`, null, 'Code 113');
       });
     }
@@ -1542,21 +1542,21 @@ describe('ExpressionParser', function() {
       ...SimpleLiteralList,
       ...SimpleUnaryList
     ]) {
-      it(`throw Code 150 (NotAssignable) on "${input}=a"`, function() {
+      it(`throw Code 150 (NotAssignable) on "${input}=a"`, function () {
         verifyResultOrError(`${input}=a`, null, 'Code 150');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList.filter(([, e]) => !e.ancestor)) {
-      it(`throw Code 151 (UnexpectedForOf) on "${input} of"`, function() {
+      it(`throw Code 151 (UnexpectedForOf) on "${input} of"`, function () {
         verifyResultOrError(`${input} of`, null, 'Code 151');
       });
     }
   });
 
-  describe('unknown unicode IdentifierPart', function() {
+  describe('unknown unicode IdentifierPart', function () {
     for (const char of otherBMPIdentifierPartChars) {
-      it(char, function() {
+      it(char, function () {
         const identifier = `$${char}`;
         verifyResultOrError(identifier, null, codes.UnexpectedCharacter);
       });

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -158,12 +158,12 @@ export const DI = {
     };
     Interface.friendlyName = friendlyName || 'Interface';
 
-    Interface.noDefault = function(): InterfaceSymbol<T> {
+    Interface.noDefault = function (): InterfaceSymbol<T> {
       return Interface;
     };
 
     Interface.withDefault = function(configure: (builder: IResolverBuilder<T>) => IResolver): InterfaceSymbol<T> {
-      Interface.withDefault = function(): InterfaceSymbol<T> {
+      Interface.withDefault = function (): InterfaceSymbol<T> {
         throw Reporter.error(17, Interface);
       };
 

--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -8,7 +8,7 @@ declare var self: IWindowOrWorkerGlobalScope;
 declare var window: IWindowOrWorkerGlobalScope;
 declare function setTimeout(handler: (...args: unknown[]) => void, timeout: number): unknown;
 
-const $global: IWindowOrWorkerGlobalScope = (function(): IWindowOrWorkerGlobalScope {
+const $global: IWindowOrWorkerGlobalScope = (function (): IWindowOrWorkerGlobalScope {
   // https://github.com/Microsoft/tslint-microsoft-contrib/issues/415
   // tslint:disable:no-typeof-undefined
   if (typeof global !== 'undefined') {
@@ -33,7 +33,7 @@ const $global: IWindowOrWorkerGlobalScope = (function(): IWindowOrWorkerGlobalSc
 })();
 
 // performance.now polyfill for non-browser envs based on https://github.com/myrne/performance-now
-const $now = (function(): () => number {
+const $now = (function (): () => number {
   let getNanoSeconds: () => number;
   let hrtime: (time?: [number, number]) => [number, number];
   let moduleLoadTime: number;
@@ -42,15 +42,15 @@ const $now = (function(): () => number {
 
   if (($global.performance !== undefined && $global.performance !== null) && $global.performance.now) {
     const $performance = $global.performance;
-    return function(): number {
+    return function (): number {
       return $performance.now();
     };
   } else if (($global.process !== undefined && $global.process !== null) && $global.process.hrtime) {
-    const now = function(): number {
+    const now = function (): number {
       return (getNanoSeconds() - nodeLoadTime) / 1e6;
     };
     hrtime = $global.process.hrtime;
-    getNanoSeconds = function(): number {
+    getNanoSeconds = function (): number {
       let hr: [number, number];
       hr = hrtime();
       return hr[0] * 1e9 + hr[1];
@@ -73,7 +73,7 @@ const {
   $getEntriesByType,
   $clearMarks,
   $clearMeasures
-} = (function(): {
+} = (function (): {
   $mark: IWindowOrWorkerGlobalScope['performance']['mark'];
   $measure: IWindowOrWorkerGlobalScope['performance']['measure'];
   $getEntriesByName: IWindowOrWorkerGlobalScope['performance']['getEntriesByName'];
@@ -195,7 +195,7 @@ const {
 })();
 
 // RAF polyfill for non-browser envs from https://github.com/chrisdickinson/raf/blob/master/index.js
-const { $raf, $caf } = (function(): { $raf(callback: (time: number) => void): number; $caf(handle: number): void } {
+const { $raf, $caf } = (function (): { $raf(callback: (time: number) => void): number; $caf(handle: number): void } {
   const vendors = ['moz', 'webkit'];
   const suffix = 'AnimationFrame';
   let raf: (callback: (time: number) => void) => number = $global[`request${suffix}`];
@@ -221,7 +221,7 @@ const { $raf, $caf } = (function(): { $raf(callback: (time: number) => void): nu
         next = Math.max(0, frameDuration - (_now - last));
         last = next + _now;
         setTimeout(
-          function(): void {
+          function (): void {
             const cp = queue.slice(0);
             // Clear queue here to prevent callbacks from appending listeners to the current frame's queue
             queue.length = 0;
@@ -230,7 +230,7 @@ const { $raf, $caf } = (function(): { $raf(callback: (time: number) => void): nu
                 try {
                   cp[i].callback(last);
                 } catch (e) {
-                  setTimeout(function(): void { throw e; }, 0);
+                  setTimeout(function (): void { throw e; }, 0);
                 }
               }
             }
@@ -258,7 +258,7 @@ const { $raf, $caf } = (function(): { $raf(callback: (time: number) => void): nu
   const $$raf = function(callback: (time: number) => void): number {
     return raf.call($global, callback);
   };
-  $$raf.cancel = function(): void {
+  $$raf.cancel = function (): void {
     caf.apply($global, arguments);
   };
   $global.requestAnimationFrame = raf;

--- a/packages/kernel/src/profiler.ts
+++ b/packages/kernel/src/profiler.ts
@@ -12,7 +12,7 @@ export interface IProfile {
   totalCount: number;
 }
 
-export const Profiler = (function(): {
+export const Profiler = (function (): {
   createTimer: typeof createTimer;
   enable: typeof enable;
   disable: typeof disable;

--- a/packages/kernel/test/di.integration.spec.ts
+++ b/packages/kernel/test/di.integration.spec.ts
@@ -8,7 +8,7 @@ import {
   Registration
 } from '../src/index';
 
-describe('DI.createInterface() -> container.get()', () => {
+describe('DI.createInterface() -> container.get()', function() {
   let container: IContainer;
 
   interface ITransient {}
@@ -31,7 +31,7 @@ describe('DI.createInterface() -> container.get()', () => {
 
   let get: ReturnType<typeof spy>;
 
-  beforeEach(() => {
+  beforeEach(function() {
     container = DI.createContainer();
     ITransient = DI.createInterface<ITransient>().withDefault(x => x.transient(Transient));
     ISingleton = DI.createInterface<ISingleton>().withDefault(x => x.singleton(Singleton));
@@ -42,12 +42,12 @@ describe('DI.createInterface() -> container.get()', () => {
     get = spy(container, 'get');
   });
 
-  afterEach(() => {
+  afterEach(function() {
     get.restore();
   });
 
-  describe('leaf', () => {
-    it(`transient registration returns a new instance each time`, () => {
+  describe('leaf', function() {
+    it(`transient registration returns a new instance each time`, function() {
       const actual1 = container.get(ITransient);
       expect(actual1).to.be.instanceof(Transient);
 
@@ -59,7 +59,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`singleton registration returns the same instance each time`, () => {
+    it(`singleton registration returns the same instance each time`, function() {
       const actual1 = container.get(ISingleton);
       expect(actual1).to.be.instanceof(Singleton);
 
@@ -71,7 +71,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`instance registration returns the same instance each time`, () => {
+    it(`instance registration returns the same instance each time`, function() {
       const actual1 = container.get(IInstance);
       expect(actual1).to.be.instanceof(Instance);
 
@@ -84,7 +84,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`callback registration is invoked each time`, () => {
+    it(`callback registration is invoked each time`, function() {
       const actual1 = container.get(ICallback);
       expect(actual1).to.be.instanceof(Callback);
 
@@ -98,7 +98,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, () => {
+    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function() {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ITransient));
 
@@ -111,7 +111,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, () => {
+    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function() {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ISingleton));
 
@@ -124,7 +124,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).to.equal(actual2);
     });
 
-    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, () => {
+    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function() {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(IInstance));
 
@@ -139,7 +139,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
 
     // TODO: make test work
-    it(`InterfaceSymbol alias to callback registration is invoked each time`, () => {
+    it(`InterfaceSymbol alias to callback registration is invoked each time`, function() {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ICallback));
 
@@ -154,7 +154,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`string alias to transient registration returns a new instance each time`, () => {
+    it(`string alias to transient registration returns a new instance each time`, function() {
       container.register(Registration.alias(ITransient, 'alias'));
 
       const actual1 = container.get('alias');
@@ -166,7 +166,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`string alias to singleton registration returns the same instance each time`, () => {
+    it(`string alias to singleton registration returns the same instance each time`, function() {
       container.register(Registration.alias(ISingleton, 'alias'));
 
       const actual1 = container.get('alias');
@@ -178,7 +178,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual1).to.equal(actual2);
     });
 
-    it(`string alias to instance registration returns the same instance each time`, () => {
+    it(`string alias to instance registration returns the same instance each time`, function() {
       container.register(Registration.alias(IInstance, 'alias'));
 
       const actual1 = container.get('alias');
@@ -191,7 +191,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(actual2).to.equal(instance);
     });
 
-    it(`string alias to callback registration is invoked each time`, () => {
+    it(`string alias to callback registration is invoked each time`, function() {
       container.register(Registration.alias(ICallback, 'alias'));
 
       const actual1 = container.get('alias');
@@ -206,7 +206,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
   });
 
-  describe('parent without inject decorator', () => {
+  describe('parent without inject decorator', function() {
     function decorator(): ClassDecorator { return (target: any) => target; }
     interface IParent { dep: any; }
     let IParent: InterfaceSymbol<IParent>;
@@ -215,7 +215,7 @@ describe('DI.createInterface() -> container.get()', () => {
       IParent = DI.createInterface<IParent>().withDefault(x => x.transient(cls));
     }
 
-    it(`transient child registration throws`, () => {
+    it(`transient child registration throws`, function() {
       @decorator()
       class Parent implements IParent { constructor(public dep: ITransient) {} }
       register(Parent);
@@ -223,7 +223,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`singleton child registration throws`, () => {
+    it(`singleton child registration throws`, function() {
       @decorator()
       class Parent implements IParent { constructor(public dep: ISingleton) {} }
       register(Parent);
@@ -231,7 +231,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`instance child registration throws`, () => {
+    it(`instance child registration throws`, function() {
       @decorator()
       class Parent implements IParent { constructor(public dep: IInstance) {} }
       register(Parent);
@@ -239,7 +239,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`callback child registration throws`, () => {
+    it(`callback child registration throws`, function() {
       @decorator()
       class Parent implements IParent { constructor(public dep: ICallback) {} }
       register(Parent);
@@ -248,7 +248,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
   });
 
-  describe('transient parent', () => {
+  describe('transient parent', function() {
     interface ITransientParent { dep: any; }
     let ITransientParent: InterfaceSymbol<ITransientParent>;
 
@@ -256,7 +256,7 @@ describe('DI.createInterface() -> container.get()', () => {
       ITransientParent = DI.createInterface<ITransientParent>().withDefault(x => x.transient(cls));
     }
 
-    it(`transient child registration returns a new instance each time`, () => {
+    it(`transient child registration returns a new instance each time`, function() {
       @inject(ITransient)
       class TransientParent implements ITransientParent { constructor(public dep: ITransient) {} }
       register(TransientParent);
@@ -276,7 +276,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`singleton child registration returns the same instance each time`, () => {
+    it(`singleton child registration returns the same instance each time`, function() {
       @inject(ISingleton)
       class TransientParent implements ITransientParent { constructor(public dep: ISingleton) {} }
       register(TransientParent);
@@ -296,7 +296,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`instance child registration returns the same instance each time`, () => {
+    it(`instance child registration returns the same instance each time`, function() {
       @inject(IInstance)
       class TransientParent implements ITransientParent { constructor(public dep: IInstance) {} }
       register(TransientParent);
@@ -316,7 +316,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`callback child registration is invoked each time`, () => {
+    it(`callback child registration is invoked each time`, function() {
       @inject(ICallback)
       class TransientParent implements ITransientParent { constructor(public dep: ICallback) {} }
       register(TransientParent);
@@ -338,7 +338,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
   });
 
-  describe('singleton parent', () => {
+  describe('singleton parent', function() {
     interface ISingletonParent { dep: any; }
     let ISingletonParent: InterfaceSymbol<ISingletonParent>;
 
@@ -346,7 +346,7 @@ describe('DI.createInterface() -> container.get()', () => {
       ISingletonParent = DI.createInterface<ISingletonParent>().withDefault(x => x.singleton(cls));
     }
 
-    it(`transient child registration is reused by the singleton parent`, () => {
+    it(`transient child registration is reused by the singleton parent`, function() {
       @inject(ITransient)
       class SingletonParent implements ISingletonParent { constructor(public dep: ITransient) {} }
       register(SingletonParent);
@@ -366,7 +366,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`singleton registration is reused by the singleton parent`, () => {
+    it(`singleton registration is reused by the singleton parent`, function() {
       @inject(ISingleton)
       class SingletonParent implements ISingletonParent { constructor(public dep: ISingleton) {} }
       register(SingletonParent);
@@ -386,7 +386,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`instance registration is reused by the singleton parent`, () => {
+    it(`instance registration is reused by the singleton parent`, function() {
       @inject(IInstance)
       class SingletonParent implements ISingletonParent { constructor(public dep: IInstance) {} }
       register(SingletonParent);
@@ -406,7 +406,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`callback registration is reused by the singleton parent`, () => {
+    it(`callback registration is reused by the singleton parent`, function() {
       @inject(ICallback)
       class SingletonParent implements ISingletonParent { constructor(public dep: ICallback) {} }
       register(SingletonParent);
@@ -428,7 +428,7 @@ describe('DI.createInterface() -> container.get()', () => {
     });
   });
 
-  describe('instance parent', () => {
+  describe('instance parent', function() {
     interface IInstanceParent { dep: any; }
     let IInstanceParent: InterfaceSymbol<IInstanceParent>;
     let instanceParent: IInstanceParent;
@@ -439,7 +439,7 @@ describe('DI.createInterface() -> container.get()', () => {
       IInstanceParent = DI.createInterface<IInstanceParent>().withDefault(x => x.instance(instanceParent));
     }
 
-    it(`transient registration is reused by the instance parent`, () => {
+    it(`transient registration is reused by the instance parent`, function() {
       @inject(ITransient)
       class InstanceParent implements IInstanceParent { constructor(public dep: ITransient) {} }
       register(InstanceParent);
@@ -459,7 +459,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`singleton registration is reused by the instance parent`, () => {
+    it(`singleton registration is reused by the instance parent`, function() {
       @inject(ISingleton)
       class InstanceParent implements IInstanceParent { constructor(public dep: ISingleton) {} }
       register(InstanceParent);
@@ -479,7 +479,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`instance registration is reused by the instance parent`, () => {
+    it(`instance registration is reused by the instance parent`, function() {
       @inject(IInstance)
       class InstanceParent implements IInstanceParent { constructor(public dep: IInstance) {} }
       register(InstanceParent);
@@ -499,7 +499,7 @@ describe('DI.createInterface() -> container.get()', () => {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`callback registration is reused by the instance parent`, () => {
+    it(`callback registration is reused by the instance parent`, function() {
       @inject(ICallback)
       class InstanceParent implements IInstanceParent { constructor(public dep: ICallback) {} }
       register(InstanceParent);

--- a/packages/kernel/test/di.integration.spec.ts
+++ b/packages/kernel/test/di.integration.spec.ts
@@ -8,7 +8,7 @@ import {
   Registration
 } from '../src/index';
 
-describe('DI.createInterface() -> container.get()', function() {
+describe('DI.createInterface() -> container.get()', function () {
   let container: IContainer;
 
   interface ITransient {}
@@ -31,7 +31,7 @@ describe('DI.createInterface() -> container.get()', function() {
 
   let get: ReturnType<typeof spy>;
 
-  beforeEach(function() {
+  beforeEach(function () {
     container = DI.createContainer();
     ITransient = DI.createInterface<ITransient>().withDefault(x => x.transient(Transient));
     ISingleton = DI.createInterface<ISingleton>().withDefault(x => x.singleton(Singleton));
@@ -42,12 +42,12 @@ describe('DI.createInterface() -> container.get()', function() {
     get = spy(container, 'get');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     get.restore();
   });
 
-  describe('leaf', function() {
-    it(`transient registration returns a new instance each time`, function() {
+  describe('leaf', function () {
+    it(`transient registration returns a new instance each time`, function () {
       const actual1 = container.get(ITransient);
       expect(actual1).to.be.instanceof(Transient);
 
@@ -59,7 +59,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`singleton registration returns the same instance each time`, function() {
+    it(`singleton registration returns the same instance each time`, function () {
       const actual1 = container.get(ISingleton);
       expect(actual1).to.be.instanceof(Singleton);
 
@@ -71,7 +71,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`instance registration returns the same instance each time`, function() {
+    it(`instance registration returns the same instance each time`, function () {
       const actual1 = container.get(IInstance);
       expect(actual1).to.be.instanceof(Instance);
 
@@ -84,7 +84,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`callback registration is invoked each time`, function() {
+    it(`callback registration is invoked each time`, function () {
       const actual1 = container.get(ICallback);
       expect(actual1).to.be.instanceof(Callback);
 
@@ -98,7 +98,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function() {
+    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function () {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ITransient));
 
@@ -111,7 +111,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function() {
+    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function () {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ISingleton));
 
@@ -124,7 +124,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual1).to.equal(actual2);
     });
 
-    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function() {
+    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function () {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(IInstance));
 
@@ -139,7 +139,7 @@ describe('DI.createInterface() -> container.get()', function() {
     });
 
     // TODO: make test work
-    it(`InterfaceSymbol alias to callback registration is invoked each time`, function() {
+    it(`InterfaceSymbol alias to callback registration is invoked each time`, function () {
       interface IAlias {}
       const IAlias = DI.createInterface<IAlias>().withDefault(x => x.aliasTo(ICallback));
 
@@ -154,7 +154,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`string alias to transient registration returns a new instance each time`, function() {
+    it(`string alias to transient registration returns a new instance each time`, function () {
       container.register(Registration.alias(ITransient, 'alias'));
 
       const actual1 = container.get('alias');
@@ -166,7 +166,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual1).not.to.equal(actual2);
     });
 
-    it(`string alias to singleton registration returns the same instance each time`, function() {
+    it(`string alias to singleton registration returns the same instance each time`, function () {
       container.register(Registration.alias(ISingleton, 'alias'));
 
       const actual1 = container.get('alias');
@@ -178,7 +178,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual1).to.equal(actual2);
     });
 
-    it(`string alias to instance registration returns the same instance each time`, function() {
+    it(`string alias to instance registration returns the same instance each time`, function () {
       container.register(Registration.alias(IInstance, 'alias'));
 
       const actual1 = container.get('alias');
@@ -191,7 +191,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(actual2).to.equal(instance);
     });
 
-    it(`string alias to callback registration is invoked each time`, function() {
+    it(`string alias to callback registration is invoked each time`, function () {
       container.register(Registration.alias(ICallback, 'alias'));
 
       const actual1 = container.get('alias');
@@ -206,7 +206,7 @@ describe('DI.createInterface() -> container.get()', function() {
     });
   });
 
-  describe('parent without inject decorator', function() {
+  describe('parent without inject decorator', function () {
     function decorator(): ClassDecorator { return (target: any) => target; }
     interface IParent { dep: any; }
     let IParent: InterfaceSymbol<IParent>;
@@ -215,7 +215,7 @@ describe('DI.createInterface() -> container.get()', function() {
       IParent = DI.createInterface<IParent>().withDefault(x => x.transient(cls));
     }
 
-    it(`transient child registration throws`, function() {
+    it(`transient child registration throws`, function () {
       @decorator()
       class Parent implements IParent { constructor(public dep: ITransient) {} }
       register(Parent);
@@ -223,7 +223,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`singleton child registration throws`, function() {
+    it(`singleton child registration throws`, function () {
       @decorator()
       class Parent implements IParent { constructor(public dep: ISingleton) {} }
       register(Parent);
@@ -231,7 +231,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`instance child registration throws`, function() {
+    it(`instance child registration throws`, function () {
       @decorator()
       class Parent implements IParent { constructor(public dep: IInstance) {} }
       register(Parent);
@@ -239,7 +239,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(() => container.get(IParent)).to.throw(/5/);
     });
 
-    it(`callback child registration throws`, function() {
+    it(`callback child registration throws`, function () {
       @decorator()
       class Parent implements IParent { constructor(public dep: ICallback) {} }
       register(Parent);
@@ -248,7 +248,7 @@ describe('DI.createInterface() -> container.get()', function() {
     });
   });
 
-  describe('transient parent', function() {
+  describe('transient parent', function () {
     interface ITransientParent { dep: any; }
     let ITransientParent: InterfaceSymbol<ITransientParent>;
 
@@ -256,7 +256,7 @@ describe('DI.createInterface() -> container.get()', function() {
       ITransientParent = DI.createInterface<ITransientParent>().withDefault(x => x.transient(cls));
     }
 
-    it(`transient child registration returns a new instance each time`, function() {
+    it(`transient child registration returns a new instance each time`, function () {
       @inject(ITransient)
       class TransientParent implements ITransientParent { constructor(public dep: ITransient) {} }
       register(TransientParent);
@@ -276,7 +276,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`singleton child registration returns the same instance each time`, function() {
+    it(`singleton child registration returns the same instance each time`, function () {
       @inject(ISingleton)
       class TransientParent implements ITransientParent { constructor(public dep: ISingleton) {} }
       register(TransientParent);
@@ -296,7 +296,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`instance child registration returns the same instance each time`, function() {
+    it(`instance child registration returns the same instance each time`, function () {
       @inject(IInstance)
       class TransientParent implements ITransientParent { constructor(public dep: IInstance) {} }
       register(TransientParent);
@@ -316,7 +316,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(4);
     });
 
-    it(`callback child registration is invoked each time`, function() {
+    it(`callback child registration is invoked each time`, function () {
       @inject(ICallback)
       class TransientParent implements ITransientParent { constructor(public dep: ICallback) {} }
       register(TransientParent);
@@ -338,7 +338,7 @@ describe('DI.createInterface() -> container.get()', function() {
     });
   });
 
-  describe('singleton parent', function() {
+  describe('singleton parent', function () {
     interface ISingletonParent { dep: any; }
     let ISingletonParent: InterfaceSymbol<ISingletonParent>;
 
@@ -346,7 +346,7 @@ describe('DI.createInterface() -> container.get()', function() {
       ISingletonParent = DI.createInterface<ISingletonParent>().withDefault(x => x.singleton(cls));
     }
 
-    it(`transient child registration is reused by the singleton parent`, function() {
+    it(`transient child registration is reused by the singleton parent`, function () {
       @inject(ITransient)
       class SingletonParent implements ISingletonParent { constructor(public dep: ITransient) {} }
       register(SingletonParent);
@@ -366,7 +366,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`singleton registration is reused by the singleton parent`, function() {
+    it(`singleton registration is reused by the singleton parent`, function () {
       @inject(ISingleton)
       class SingletonParent implements ISingletonParent { constructor(public dep: ISingleton) {} }
       register(SingletonParent);
@@ -386,7 +386,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`instance registration is reused by the singleton parent`, function() {
+    it(`instance registration is reused by the singleton parent`, function () {
       @inject(IInstance)
       class SingletonParent implements ISingletonParent { constructor(public dep: IInstance) {} }
       register(SingletonParent);
@@ -406,7 +406,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(3);
     });
 
-    it(`callback registration is reused by the singleton parent`, function() {
+    it(`callback registration is reused by the singleton parent`, function () {
       @inject(ICallback)
       class SingletonParent implements ISingletonParent { constructor(public dep: ICallback) {} }
       register(SingletonParent);
@@ -428,7 +428,7 @@ describe('DI.createInterface() -> container.get()', function() {
     });
   });
 
-  describe('instance parent', function() {
+  describe('instance parent', function () {
     interface IInstanceParent { dep: any; }
     let IInstanceParent: InterfaceSymbol<IInstanceParent>;
     let instanceParent: IInstanceParent;
@@ -439,7 +439,7 @@ describe('DI.createInterface() -> container.get()', function() {
       IInstanceParent = DI.createInterface<IInstanceParent>().withDefault(x => x.instance(instanceParent));
     }
 
-    it(`transient registration is reused by the instance parent`, function() {
+    it(`transient registration is reused by the instance parent`, function () {
       @inject(ITransient)
       class InstanceParent implements IInstanceParent { constructor(public dep: ITransient) {} }
       register(InstanceParent);
@@ -459,7 +459,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`singleton registration is reused by the instance parent`, function() {
+    it(`singleton registration is reused by the instance parent`, function () {
       @inject(ISingleton)
       class InstanceParent implements IInstanceParent { constructor(public dep: ISingleton) {} }
       register(InstanceParent);
@@ -479,7 +479,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`instance registration is reused by the instance parent`, function() {
+    it(`instance registration is reused by the instance parent`, function () {
       @inject(IInstance)
       class InstanceParent implements IInstanceParent { constructor(public dep: IInstance) {} }
       register(InstanceParent);
@@ -499,7 +499,7 @@ describe('DI.createInterface() -> container.get()', function() {
       expect(get.getCalls().length).to.equal(2);
     });
 
-    it(`callback registration is reused by the instance parent`, function() {
+    it(`callback registration is reused by the instance parent`, function () {
       @inject(ICallback)
       class InstanceParent implements IInstanceParent { constructor(public dep: ICallback) {} }
       register(InstanceParent);

--- a/packages/kernel/test/di.spec.ts
+++ b/packages/kernel/test/di.spec.ts
@@ -39,45 +39,45 @@ function assertIsMutableArray(arr: any[], length: number): void {
 
 function decorator(): ClassDecorator { return (target: any) => target; }
 
-describe(`The DI object`, function() {
-  describe(`createContainer()`, function() {
-    it(`returns an instance of Container`, function() {
+describe(`The DI object`, function () {
+  describe(`createContainer()`, function () {
+    it(`returns an instance of Container`, function () {
       const actual = DI.createContainer();
       expect(actual).to.be.instanceof(Container);
     });
 
-    it(`returns a new container every time`, function() {
+    it(`returns a new container every time`, function () {
       expect(DI.createContainer()).not.to.equal(DI.createContainer());
     });
   });
 
-  describe(`getDesignParamTypes()`, function() {
-    it(`returns PLATFORM.emptyArray if the class has no constructor or decorators`, function() {
+  describe(`getDesignParamTypes()`, function () {
+    it(`returns PLATFORM.emptyArray if the class has no constructor or decorators`, function () {
       class Foo {}
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
-    it(`returns PLATFORM.emptyArray if the class has a decorator but no constructor`, function() {
+    it(`returns PLATFORM.emptyArray if the class has a decorator but no constructor`, function () {
       @decorator()
       class Foo {}
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has no constructor args or decorators`, function() {
+    it(`returns PLATFORM.emptyArray if the class has no constructor args or decorators`, function () {
       class Foo { constructor() { return; } }
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has constructor args but no decorators`, function() {
+    it(`returns PLATFORM.emptyArray if the class has constructor args but no decorators`, function () {
       class Bar {}
       class Foo { constructor(public bar: Bar) {} }
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has constructor args and the decorator is applied via a function call`, function() {
+    it(`returns PLATFORM.emptyArray if the class has constructor args and the decorator is applied via a function call`, function () {
       class Bar {}
       class Foo { constructor(public bar: Bar) {} }
       decorator()(Foo);
@@ -85,7 +85,7 @@ describe(`The DI object`, function() {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class is declared as an anonymous variable, even if it has ctor args and decorator is applied properly`, function() {
+    it(`returns PLATFORM.emptyArray if the class is declared as an anonymous variable, even if it has ctor args and decorator is applied properly`, function () {
       class Bar {}
       // @ts-ignore
       @decorator()
@@ -94,7 +94,7 @@ describe(`The DI object`, function() {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class is declared as a named variable, even if it has ctor args and decorator is applied properly`, function() {
+    it(`returns PLATFORM.emptyArray if the class is declared as a named variable, even if it has ctor args and decorator is applied properly`, function () {
       class Bar {}
       // @ts-ignore
       @decorator()
@@ -103,16 +103,16 @@ describe(`The DI object`, function() {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    describe(`returns an empty array if the class has a decorator but no constructor args`, function() {
+    describe(`returns an empty array if the class has a decorator but no constructor args`, function () {
       @decorator()
       class Foo { constructor() { return; } }
 
-      it(_`${Foo}`, function() {
+      it(_`${Foo}`, function () {
         const actual = DI.getDesignParamTypes(Foo);
         assertIsMutableArray(actual, 0);
       });
 
-      it(_`${class {}}`, function() {
+      it(_`${class {}}`, function () {
         let cls;
         function anonDecorator(): ClassDecorator { return (target: any) => cls = target; }
         // @ts-ignore
@@ -123,11 +123,11 @@ describe(`The DI object`, function() {
       });
     });
 
-    describe(`falls back to Object for declarations that cannot be statically analyzed`, function() {
+    describe(`falls back to Object for declarations that cannot be statically analyzed`, function () {
       interface ArgCtor {}
       for (const argCtor of [
         class Bar {},
-        function() { return; },
+        function () { return; },
         () => { return; },
         class {},
         {},
@@ -139,7 +139,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooDecoratorInvocation { constructor(public arg: ArgCtor) {} }
 
-        it(_`${FooDecoratorInvocation} { constructor(${argCtor}) }`, function() {
+        it(_`${FooDecoratorInvocation} { constructor(${argCtor}) }`, function () {
           const actual = DI.getDesignParamTypes(FooDecoratorInvocation);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -148,7 +148,7 @@ describe(`The DI object`, function() {
         @(decorator as any)
         class FooDecoratorNonInvocation { constructor(public arg: ArgCtor) {} }
 
-        it(_`${FooDecoratorNonInvocation} { constructor(${argCtor}) }`, function() {
+        it(_`${FooDecoratorNonInvocation} { constructor(${argCtor}) }`, function () {
           const actual = DI.getDesignParamTypes(FooDecoratorInvocation);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -156,7 +156,7 @@ describe(`The DI object`, function() {
       }
     });
 
-    describe(`falls back to Object for mismatched declarations`, function() {
+    describe(`falls back to Object for mismatched declarations`, function () {
 
       // Technically we're testing TypeScript here, but it's still useful to have an in-place fixture to validate our assumptions
       // And also to have an alert mechanism for when the functionality in TypeScript changes, without having to read the changelogs
@@ -180,10 +180,10 @@ describe(`The DI object`, function() {
       const AnonClassInterface: AnonClassInterface = class {};
 
       interface VarFunc {}
-      const VarFunc = function() { return; };
+      const VarFunc = function () { return; };
 
       interface VarFuncInterface {}
-      const VarFuncInterface: VarFuncInterface = function() { return; };
+      const VarFuncInterface: VarFuncInterface = function () { return; };
 
       interface Func {}
       // tslint:disable-next-line:no-empty
@@ -195,12 +195,12 @@ describe(`The DI object`, function() {
       interface ArrowInterface {}
       const ArrowInterface: ArrowInterface = () => { return; };
 
-      describe(`decorator invocation`, function() {
+      describe(`decorator invocation`, function () {
         @decorator()
         class FooBar { constructor(public arg: Bar) {} }
 
         // Note: this is a negative assertion meant to make it easier to compare this describe with the one below
-        it(_`NOT ${FooBar} { constructor(public ${Bar}) }`, function() {
+        it(_`NOT ${FooBar} { constructor(public ${Bar}) }`, function () {
           const actual = DI.getDesignParamTypes(FooBar);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Bar);
@@ -210,7 +210,7 @@ describe(`The DI object`, function() {
         class FooAnonClass { constructor(public arg: AnonClass) {} }
 
         // Note: this is a negative assertion meant to make it easier to compare this describe with the one below
-        it(_`NOT ${FooAnonClass} { constructor(public ${AnonClass}) }`, function() {
+        it(_`NOT ${FooAnonClass} { constructor(public ${AnonClass}) }`, function () {
           const actual = DI.getDesignParamTypes(FooAnonClass);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(AnonClass);
@@ -220,7 +220,7 @@ describe(`The DI object`, function() {
         class FooAnonClassInterface { constructor(public arg: AnonClassInterface) {} }
 
         // this one is particularly interesting..
-        it(_`${FooAnonClassInterface} { constructor(public ${AnonClassInterface}) }`, function() {
+        it(_`${FooAnonClassInterface} { constructor(public ${AnonClassInterface}) }`, function () {
           const actual = DI.getDesignParamTypes(FooAnonClassInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -229,7 +229,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooVarFunc { constructor(public arg: VarFunc) {} }
 
-        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function() {
+        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function () {
           const actual = DI.getDesignParamTypes(FooVarFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -238,7 +238,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooVarFuncInterface { constructor(public arg: VarFuncInterface) {} }
 
-        it(_`${FooVarFuncInterface} { constructor(public ${VarFuncInterface}) }`, function() {
+        it(_`${FooVarFuncInterface} { constructor(public ${VarFuncInterface}) }`, function () {
           const actual = DI.getDesignParamTypes(FooVarFuncInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -247,7 +247,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooFunc { constructor(public arg: Func) {} }
 
-        it(_`${FooFunc} { constructor(public ${Func}) }`, function() {
+        it(_`${FooFunc} { constructor(public ${Func}) }`, function () {
           const actual = DI.getDesignParamTypes(FooFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -256,7 +256,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooArrow { constructor(public arg: Arrow) {} }
 
-        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function() {
+        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function () {
           const actual = DI.getDesignParamTypes(FooArrow);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -265,7 +265,7 @@ describe(`The DI object`, function() {
         @decorator()
         class FooArrowInterface { constructor(public arg: ArrowInterface) {} }
 
-        it(_`${FooArrowInterface} { constructor(public ${ArrowInterface}) }`, function() {
+        it(_`${FooArrowInterface} { constructor(public ${ArrowInterface}) }`, function () {
           const actual = DI.getDesignParamTypes(FooArrowInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -273,23 +273,23 @@ describe(`The DI object`, function() {
       });
     });
 
-    describe(`returns the correct types for valid declarations`, function() {
+    describe(`returns the correct types for valid declarations`, function () {
       class Bar {}
 
       const AnonClass = class {};
 
-      const VarFunc = function() { return; };
+      const VarFunc = function () { return; };
 
       // tslint:disable-next-line:no-empty
       function Func() {}
 
       const Arrow = () => { return; };
 
-      describe(`decorator invocation`, function() {
+      describe(`decorator invocation`, function () {
         @decorator()
         class FooBar { constructor(public arg: Bar) {} }
 
-        it(_`${FooBar} { constructor(public ${Bar}) }`, function() {
+        it(_`${FooBar} { constructor(public ${Bar}) }`, function () {
           const actual = DI.getDesignParamTypes(FooBar);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Bar);
@@ -299,7 +299,7 @@ describe(`The DI object`, function() {
         // @ts-ignore
         class FooAnonClass { constructor(public arg: AnonClass) {} }
 
-        it(_`${FooAnonClass} { constructor(public ${AnonClass}) }`, function() {
+        it(_`${FooAnonClass} { constructor(public ${AnonClass}) }`, function () {
           const actual = DI.getDesignParamTypes(FooAnonClass);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(AnonClass);
@@ -309,7 +309,7 @@ describe(`The DI object`, function() {
         // @ts-ignore
         class FooVarFunc { constructor(public arg: VarFunc) {} }
 
-        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function() {
+        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function () {
           const actual = DI.getDesignParamTypes(FooVarFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(VarFunc);
@@ -319,7 +319,7 @@ describe(`The DI object`, function() {
         // @ts-ignore
         class FooFunc { constructor(public arg: Func) {} }
 
-        it(_`${FooFunc} { constructor(public ${Func}) }`, function() {
+        it(_`${FooFunc} { constructor(public ${Func}) }`, function () {
           const actual = DI.getDesignParamTypes(FooFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Func);
@@ -329,7 +329,7 @@ describe(`The DI object`, function() {
         // @ts-ignore
         class FooArrow { constructor(public arg: Arrow) {} }
 
-        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function() {
+        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function () {
           const actual = DI.getDesignParamTypes(FooArrow);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Arrow);
@@ -338,17 +338,17 @@ describe(`The DI object`, function() {
     });
   });
 
-  describe(`getDependencies()`, function() {
+  describe(`getDependencies()`, function () {
     let getDesignParamTypes: ReturnType<typeof spy>;
 
-    beforeEach(function() {
+    beforeEach(function () {
       getDesignParamTypes = spy(DI, 'getDesignParamTypes');
     });
-    afterEach(function() {
+    afterEach(function () {
       getDesignParamTypes.restore();
     });
 
-    it(`uses getDesignParamTypes() if the static inject property does not exist`, function() {
+    it(`uses getDesignParamTypes() if the static inject property does not exist`, function () {
       class Bar {}
       @decorator()
       class Foo { constructor(bar: Bar) { return; } }
@@ -357,7 +357,7 @@ describe(`The DI object`, function() {
       expect(actual).to.deep.equal([Bar]);
     });
 
-    it(`uses getDesignParamTypes() if the static inject property is undefined`, function() {
+    it(`uses getDesignParamTypes() if the static inject property is undefined`, function () {
       class Bar {}
       @decorator()
       class Foo { public static inject; constructor(bar: Bar) { return; } }
@@ -366,7 +366,7 @@ describe(`The DI object`, function() {
       expect(actual).to.deep.equal([Bar]);
     });
 
-    it(`throws when inject is not an array`, function() {
+    it(`throws when inject is not an array`, function () {
       class Bar {}
       class Foo { public static inject = Bar; }
       expect(() => DI.getDependencies(Foo)).to.throw();
@@ -380,7 +380,7 @@ describe(`The DI object`, function() {
       [null],
       [42]
     ]) {
-      it(_`returns a copy of the inject array ${deps}`, function() {
+      it(_`returns a copy of the inject array ${deps}`, function () {
         class Foo { public static inject = deps.slice(); }
         const actual = DI.getDependencies(Foo);
         expect(getDesignParamTypes).not.to.have.been.called;
@@ -396,7 +396,7 @@ describe(`The DI object`, function() {
       [null],
       [42]
     ]) {
-      it(_`traverses the 2-layer prototype chain for inject array ${deps}`, function() {
+      it(_`traverses the 2-layer prototype chain for inject array ${deps}`, function () {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { public static inject = deps.slice(); }
         const actual = DI.getDependencies(Bar);
@@ -406,7 +406,7 @@ describe(`The DI object`, function() {
         expect(actual).not.to.equal(Bar.inject);
       });
 
-      it(_`traverses the 3-layer prototype chain for inject array ${deps}`, function() {
+      it(_`traverses the 3-layer prototype chain for inject array ${deps}`, function () {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { public static inject = deps.slice(); }
         class Baz extends Bar { public static inject = deps.slice(); }
@@ -418,7 +418,7 @@ describe(`The DI object`, function() {
         expect(actual).not.to.equal(Baz.inject);
       });
 
-      it(_`traverses the 1-layer + 2-layer prototype chain (with gap) for inject array ${deps}`, function() {
+      it(_`traverses the 1-layer + 2-layer prototype chain (with gap) for inject array ${deps}`, function () {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { }
         class Baz extends Bar { public static inject = deps.slice(); }
@@ -434,39 +434,39 @@ describe(`The DI object`, function() {
 
   });
 
-  describe(`createInterface()`, function() {
-    it(`returns a function that has withDefault and noDefault functions`, function() {
+  describe(`createInterface()`, function () {
+    it(`returns a function that has withDefault and noDefault functions`, function () {
       const sut = DI.createInterface();
       expect(typeof sut).to.equal('function');
       expect(typeof sut.withDefault).to.equal('function');
       expect(typeof sut.noDefault).to.equal('function');
     });
 
-    it(`noDefault returns self`, function() {
+    it(`noDefault returns self`, function () {
       const sut = DI.createInterface();
       expect(sut.noDefault()).to.equal(sut);
     });
 
-    it(`withDefault returns self with modified withDefault that throws`, function() {
+    it(`withDefault returns self with modified withDefault that throws`, function () {
       const sut = DI.createInterface();
       const sut2 = sut.withDefault(null as any);
       expect(sut).to.equal(sut2);
       expect(() => sut.withDefault(null as any)).to.throw;
     });
 
-    describe(`withDefault returns self with register function that registers the appropriate resolver`, function() {
+    describe(`withDefault returns self with register function that registers the appropriate resolver`, function () {
       let sut: IDefaultableInterfaceSymbol<any>;
       let container: IContainer;
 
       let registerResolver: ReturnType<typeof spy>;
 
-      beforeEach(function() {
+      beforeEach(function () {
         sut = DI.createInterface();
         container = new Container();
         registerResolver = spy(container, 'registerResolver');
       });
 
-      afterEach(function() {
+      afterEach(function () {
         registerResolver.restore();
       });
 
@@ -474,69 +474,69 @@ describe(`The DI object`, function() {
         return match(val => val.key === key && val.strategy === strategy && val.state === state);
       }
 
-      it(`instance without key`, function() {
+      it(`instance without key`, function () {
         const value = {};
         sut.withDefault(builder => builder.instance(value));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.instance, value));
       });
 
-      it(`instance with key`, function() {
+      it(`instance with key`, function () {
         const value = {};
         sut.withDefault(builder => builder.instance(value));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.instance, value));
       });
 
-      it(`singleton without key`, function() {
+      it(`singleton without key`, function () {
         class Foo {}
         sut.withDefault(builder => builder.singleton(Foo));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.singleton, Foo));
       });
 
-      it(`singleton with key`, function() {
+      it(`singleton with key`, function () {
         class Foo {}
         sut.withDefault(builder => builder.singleton(Foo));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.singleton, Foo));
       });
 
-      it(`transient without key`, function() {
+      it(`transient without key`, function () {
         class Foo {}
         sut.withDefault(builder => builder.transient(Foo));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.transient, Foo));
       });
 
-      it(`transient with key`, function() {
+      it(`transient with key`, function () {
         class Foo {}
         sut.withDefault(builder => builder.transient(Foo));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.transient, Foo));
       });
 
-      it(`callback without key`, function() {
+      it(`callback without key`, function () {
         const callback = () => { return; };
         sut.withDefault(builder => builder.callback(callback));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.callback, callback));
       });
 
-      it(`callback with key`, function() {
+      it(`callback with key`, function () {
         const callback = () => { return; };
         sut.withDefault(builder => builder.callback(callback));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.callback, callback));
       });
 
-      it(`aliasTo without key`, function() {
+      it(`aliasTo without key`, function () {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.alias, 'key2'));
       });
 
-      it(`aliasTo with key`, function() {
+      it(`aliasTo with key`, function () {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (sut as any).register(container, 'key1');
         expect(registerResolver).to.have.been.calledWith('key1', matchResolver('key1', ResolverStrategy.alias, 'key2'));
@@ -545,38 +545,38 @@ describe(`The DI object`, function() {
   });
 });
 
-describe(`The inject decorator`, function() {
+describe(`The inject decorator`, function () {
   class Dep1 {}
   class Dep2 {}
   class Dep3 {}
 
-  it(`can decorate classes with explicit dependencies`, function() {
+  it(`can decorate classes with explicit dependencies`, function () {
     @inject(Dep1, Dep2, Dep3)
     class Foo {}
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate classes with implicit dependencies`, function() {
+  it(`can decorate classes with implicit dependencies`, function () {
     @inject()
     class Foo { constructor(dep1: Dep1, dep2: Dep2, dep3: Dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate constructor parameters explicitly`, function() {
+  it(`can decorate constructor parameters explicitly`, function () {
     class Foo { constructor(@inject(Dep1)dep1, @inject(Dep2)dep2, @inject(Dep3)dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate constructor parameters implicitly`, function() {
+  it(`can decorate constructor parameters implicitly`, function () {
     class Foo { constructor(@inject() dep1: Dep1, @inject() dep2: Dep2, @inject() dep3: Dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate properties explicitly`, function() {
+  it(`can decorate properties explicitly`, function () {
     // @ts-ignore
     class Foo { @inject(Dep1)public dep1; @inject(Dep2)public dep2; @inject(Dep3)public dep3; }
 
@@ -585,7 +585,7 @@ describe(`The inject decorator`, function() {
     expect(Foo['inject'].dep3).to.equal(Dep3);
   });
 
-  it(`cannot decorate properties implicitly`, function() {
+  it(`cannot decorate properties implicitly`, function () {
     // @ts-ignore
     class Foo { @inject()public dep1: Dep1; @inject()public dep2: Dep2; @inject()public dep3: Dep3; }
 
@@ -595,8 +595,8 @@ describe(`The inject decorator`, function() {
   });
 });
 
-describe(`The transient decorator`, function() {
-  it(`works as a plain decorator`, function() {
+describe(`The transient decorator`, function () {
+  it(`works as a plain decorator`, function () {
     @transient
     class Foo {}
 
@@ -610,7 +610,7 @@ describe(`The transient decorator`, function() {
     expect(foo1).not.to.equal(foo2);
   });
 
-  it(`works as an invocation`, function() {
+  it(`works as an invocation`, function () {
     @transient()
     class Foo {}
 
@@ -625,8 +625,8 @@ describe(`The transient decorator`, function() {
   });
 });
 
-describe(`The singleton decorator`, function() {
-  it(`works as a plain decorator`, function() {
+describe(`The singleton decorator`, function () {
+  it(`works as a plain decorator`, function () {
     @singleton
     class Foo {}
 
@@ -640,7 +640,7 @@ describe(`The singleton decorator`, function() {
     expect(foo1).to.equal(foo2);
   });
 
-  it(`works as an invocation`, function() {
+  it(`works as an invocation`, function () {
     @singleton()
     class Foo {}
 
@@ -655,42 +655,42 @@ describe(`The singleton decorator`, function() {
   });
 });
 
-describe(`The Resolver class`, function() {
+describe(`The Resolver class`, function () {
   let container: IContainer;
   let registerResolver: ReturnType<typeof spy>;
 
-  beforeEach(function() {
+  beforeEach(function () {
     container = new Container();
     registerResolver = spy(container, 'registerResolver');
   });
 
-  afterEach(function() {
+  afterEach(function () {
     registerResolver.restore();
   });
 
-  describe(`register()`, function() {
-    it(`registers the resolver to the container with the provided key`, function() {
+  describe(`register()`, function () {
+    it(`registers the resolver to the container with the provided key`, function () {
       const sut = new Resolver('foo', 0, null);
       sut.register(container, 'bar');
       expect(registerResolver).to.have.been.calledWith('bar', sut);
     });
 
-    it(`registers the resolver to the container with its own`, function() {
+    it(`registers the resolver to the container with its own`, function () {
       const sut = new Resolver('foo', 0, null);
       sut.register(container);
       expect(registerResolver).to.have.been.calledWith('foo', sut);
     });
   });
 
-  describe(`resolve()`, function() {
-    it(`instance - returns state`, function() {
+  describe(`resolve()`, function () {
+    it(`instance - returns state`, function () {
       const state = {};
       const sut = new Resolver('foo', ResolverStrategy.instance, state);
       const actual = sut.resolve(container, container);
       expect(actual).to.equal(state);
     });
 
-    it(`singleton - returns an instance of the type and sets strategy to instance`, function() {
+    it(`singleton - returns an instance of the type and sets strategy to instance`, function () {
       class Foo {}
       const sut = new Resolver('foo', ResolverStrategy.singleton, Foo);
       const actual = sut.resolve(container, container);
@@ -700,7 +700,7 @@ describe(`The Resolver class`, function() {
       expect(actual2).to.equal(actual);
     });
 
-    it(`transient - always returns a new instance of the type`, function() {
+    it(`transient - always returns a new instance of the type`, function () {
       class Foo {}
       const sut = new Resolver('foo', ResolverStrategy.transient, Foo);
       const actual1 = sut.resolve(container, container);
@@ -711,21 +711,21 @@ describe(`The Resolver class`, function() {
       expect(actual2).not.to.equal(actual1);
     });
 
-    it(`array - calls resolve() on the first item in the state array`, function() {
+    it(`array - calls resolve() on the first item in the state array`, function () {
       const resolver = { resolve: spy() };
       const sut = new Resolver('foo', ResolverStrategy.array, [resolver]);
       sut.resolve(container, container);
       expect(resolver.resolve).to.have.been.calledWith(container, container);
     });
 
-    it(`throws for unknown strategy`, function() {
+    it(`throws for unknown strategy`, function () {
       const sut = new Resolver('foo', -1, null);
       expect(() => sut.resolve(container, container)).to.throw(/6/);
     });
   });
 
-  describe(`getFactory()`, function() {
-    it(`returns a new singleton Factory if it does not exist`, function() {
+  describe(`getFactory()`, function () {
+    it(`returns a new singleton Factory if it does not exist`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.singleton, Foo);
       const actual = sut.getFactory(container);
@@ -733,7 +733,7 @@ describe(`The Resolver class`, function() {
       expect(actual.Type).to.equal(Foo);
     });
 
-    it(`returns a new transient Factory if it does not exist`, function() {
+    it(`returns a new transient Factory if it does not exist`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.transient, Foo);
       const actual = sut.getFactory(container);
@@ -741,28 +741,28 @@ describe(`The Resolver class`, function() {
       expect(actual.Type).to.equal(Foo);
     });
 
-    it(`returns a null for instance strategy`, function() {
+    it(`returns a null for instance strategy`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.instance, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for array strategy`, function() {
+    it(`returns a null for array strategy`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.array, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for alias strategy`, function() {
+    it(`returns a null for alias strategy`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.alias, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for callback strategy`, function() {
+    it(`returns a null for callback strategy`, function () {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.callback, Foo);
       const actual = sut.getFactory(container);
@@ -771,11 +771,11 @@ describe(`The Resolver class`, function() {
   });
 });
 
-describe(`The Factory class`, function() {
+describe(`The Factory class`, function () {
 
-  describe(`create()`, function() {
+  describe(`create()`, function () {
     for (const count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-      it(`returns a new Factory with ${count} deps`, function() {
+      it(`returns a new Factory with ${count} deps`, function () {
         class Bar {}
         class Foo {public static inject = Array(count).map(c => Bar); }
         const actual = Factory.create(Foo);
@@ -792,11 +792,11 @@ describe(`The Factory class`, function() {
     }
   });
 
-  describe(`construct()`, function() {
+  describe(`construct()`, function () {
     for (const staticCount of [0, 1, 2, 3, 4, 5, 6, 7]) {
       for (const dynamicCount of [0, 1, 2]) {
         const container = new Container();
-        it(`instantiates a type with ${staticCount} static deps and ${dynamicCount} dynamic deps`, function() {
+        it(`instantiates a type with ${staticCount} static deps and ${dynamicCount} dynamic deps`, function () {
           class Bar {}
           class Foo {public static inject = Array(staticCount).fill(Bar); public args: any[]; constructor(...args: any[]) {this.args = args; }}
           const sut = Factory.create(Foo);
@@ -815,8 +815,8 @@ describe(`The Factory class`, function() {
     }
   });
 
-  describe(`registerTransformer()`, function() {
-    it(`registers the transformer`, function() {
+  describe(`registerTransformer()`, function () {
+    it(`registers the transformer`, function () {
       const container = new Container();
       class Foo {public bar; public baz; }
       const sut = Factory.create(Foo);
@@ -833,95 +833,95 @@ describe(`The Factory class`, function() {
 
 });
 
-describe(`The Container class`, function() {
+describe(`The Container class`, function () {
   let sut: IContainer;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sut = new Container();
   });
 
-  describe(`register()`, function() {
+  describe(`register()`, function () {
     let register: ReturnType<typeof spy>;
 
-    beforeEach(function() {
+    beforeEach(function () {
       register = spy();
     });
 
-    it(_`calls register() on {register}`, function() {
+    it(_`calls register() on {register}`, function () {
       sut.register({register});
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on {register},{register}`, function() {
+    it(_`calls register() on {register},{register}`, function () {
       sut.register({register}, {register});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{register}]`, function() {
+    it(_`calls register() on [{register},{register}]`, function () {
       sut.register([{register}, {register}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on {foo:{register}}`, function() {
+    it(_`calls register() on {foo:{register}}`, function () {
       sut.register({foo: {register}});
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on {foo:{register}},{foo:{register}}`, function() {
+    it(_`calls register() on {foo:{register}},{foo:{register}}`, function () {
       sut.register({foo: {register}}, {foo: {register}});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{foo:{register}},{foo:{register}}]`, function() {
+    it(_`calls register() on [{foo:{register}},{foo:{register}}]`, function () {
       sut.register([{foo: {register}}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on {register},{foo:{register}}`, function() {
+    it(_`calls register() on {register},{foo:{register}}`, function () {
       sut.register({register}, {foo: {register}});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{foo:{register}}]`, function() {
+    it(_`calls register() on [{register},{foo:{register}}]`, function () {
       sut.register([{register}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{}]`, function() {
+    it(_`calls register() on [{register},{}]`, function () {
       sut.register([{register}, {}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{},{register}]`, function() {
+    it(_`calls register() on [{},{register}]`, function () {
       sut.register([{}, {register}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{foo:{register}},{foo:{}}]`, function() {
+    it(_`calls register() on [{foo:{register}},{foo:{}}]`, function () {
       sut.register([{foo: {register}}, {foo: {}}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{foo:{}},{foo:{register}}]`, function() {
+    it(_`calls register() on [{foo:{}},{foo:{register}}]`, function () {
       sut.register([{foo: {}}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
   });
 
-  describe(`registerResolver()`, function() {
+  describe(`registerResolver()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, function() {
+      it(_`throws on invalid key ${key}`, function () {
         expect(() => sut.registerResolver(key, null as any)).to.throw(/5/);
       });
     }
 
-    it(`registers the resolver if it does not exist yet`, function() {
+    it(`registers the resolver if it does not exist yet`, function () {
       const key = {};
       const resolver = new Resolver(key, ResolverStrategy.instance, {});
       sut.registerResolver(key, resolver);
@@ -929,7 +929,7 @@ describe(`The Container class`, function() {
       expect(actual).to.equal(resolver);
     });
 
-    it(`changes to array resolver if the key already exists`, function() {
+    it(`changes to array resolver if the key already exists`, function () {
       const key = {};
       const resolver1 = new Resolver(key, ResolverStrategy.instance, {});
       const resolver2 = new Resolver(key, ResolverStrategy.instance, {});
@@ -946,7 +946,7 @@ describe(`The Container class`, function() {
       expect(actual2['state'][1]).to.equal(resolver2);
     });
 
-    it(`appends to the array resolver if the key already exists more than once`, function() {
+    it(`appends to the array resolver if the key already exists more than once`, function () {
       const key = {};
       const resolver1 = new Resolver(key, ResolverStrategy.instance, {});
       const resolver2 = new Resolver(key, ResolverStrategy.instance, {});
@@ -962,67 +962,67 @@ describe(`The Container class`, function() {
     });
   });
 
-  describe(`registerTransformer()`, function() {
+  describe(`registerTransformer()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, function() {
+      it(_`throws on invalid key ${key}`, function () {
         expect(() => sut.registerTransformer(key, null as any)).to.throw(/5/);
       });
     }
 
-    it(`registers the transformer if it does not exist yet`, function() {
+    it(`registers the transformer if it does not exist yet`, function () {
 
     });
 
-    it(`reuses the existing transformer if it exists`, function() {
+    it(`reuses the existing transformer if it exists`, function () {
 
     });
   });
 
-  describe(`getResolver()`, function() {
+  describe(`getResolver()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, function() {
+      it(_`throws on invalid key ${key}`, function () {
         expect(() => sut.getResolver(key, null as any)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`has()`, function() {
+  describe(`has()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`returns false for non-existing key ${key}`, function() {
+      it(_`returns false for non-existing key ${key}`, function () {
         expect(sut.has(key as any, false)).to.equal(false);
       });
     }
-    it(`returns true for existing key`, function() {
+    it(`returns true for existing key`, function () {
       const key = {};
       sut.registerResolver(key, new Resolver(key, ResolverStrategy.instance, {}));
       expect(sut.has(key as any, false)).to.equal(true);
     });
   });
 
-  describe(`get()`, function() {
+  describe(`get()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, function() {
+      it(_`throws on invalid key ${key}`, function () {
         expect(() => sut.get(key)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`getAll()`, function() {
+  describe(`getAll()`, function () {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, function() {
+      it(_`throws on invalid key ${key}`, function () {
         expect(() => sut.getAll(key)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`getFactory()`, function() {
+  describe(`getFactory()`, function () {
     for (const count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
       sut = new Container(); // ensure the state is reset (beforeEach doesn't know about loops)
 
-      it(`returns a new Factory with ${count} deps if it does not exist`, function() {
+      it(`returns a new Factory with ${count} deps if it does not exist`, function () {
         class Bar {}
         class Foo {public static inject = Array(count).map(c => Bar); }
         const actual = sut.getFactory(Foo);
@@ -1038,7 +1038,7 @@ describe(`The Container class`, function() {
       });
     }
 
-    it(`reuses the existing factory if it already exists`, function() {
+    it(`reuses the existing factory if it already exists`, function () {
       const create = spy(Factory, 'create');
       class Foo {}
       const actual = sut.getFactory(Foo);
@@ -1050,8 +1050,8 @@ describe(`The Container class`, function() {
     });
   });
 
-  describe(`createChild()`, function() {
-    it(`creates a child with same config and sut as parent, and copies over the resourceLookup`, function() {
+  describe(`createChild()`, function () {
+    it(`creates a child with same config and sut as parent, and copies over the resourceLookup`, function () {
       const obj = {};
       Registration.instance('foo', obj).register(sut, 'foo');
       expect(sut['resourceLookup'].foo.state).to.equal(obj);
@@ -1068,15 +1068,15 @@ describe(`The Container class`, function() {
 
   });
 
-  describe(`jitRegister()`, function() {
+  describe(`jitRegister()`, function () {
 
   });
 
 });
 
-describe(`The Registration object`, function() {
+describe(`The Registration object`, function () {
 
-  it(`instance() returns the correct resolver`, function() {
+  it(`instance() returns the correct resolver`, function () {
     const value = {};
     const actual = Registration.instance('key', value);
     expect(actual['key']).to.equal('key');
@@ -1084,7 +1084,7 @@ describe(`The Registration object`, function() {
     expect(actual['state']).to.equal(value);
   });
 
-  it(`singleton() returns the correct resolver`, function() {
+  it(`singleton() returns the correct resolver`, function () {
     class Foo {}
     const actual = Registration.singleton('key', Foo);
     expect(actual['key']).to.equal('key');
@@ -1092,7 +1092,7 @@ describe(`The Registration object`, function() {
     expect(actual['state']).to.equal(Foo);
   });
 
-  it(`transient() returns the correct resolver`, function() {
+  it(`transient() returns the correct resolver`, function () {
     class Foo {}
     const actual = Registration.transient('key', Foo);
     expect(actual['key']).to.equal('key');
@@ -1100,7 +1100,7 @@ describe(`The Registration object`, function() {
     expect(actual['state']).to.equal(Foo);
   });
 
-  it(`callback() returns the correct resolver`, function() {
+  it(`callback() returns the correct resolver`, function () {
     const callback = () => { return; };
     const actual = Registration.callback('key', callback);
     expect(actual['key']).to.equal('key');
@@ -1108,7 +1108,7 @@ describe(`The Registration object`, function() {
     expect(actual['state']).to.equal(callback);
   });
 
-  it(`alias() returns the correct resolver`, function() {
+  it(`alias() returns the correct resolver`, function () {
     const actual = Registration.alias('key', 'key2');
     expect(actual['key']).to.equal('key2');
     expect(actual['strategy']).to.equal(ResolverStrategy.alias);
@@ -1116,7 +1116,7 @@ describe(`The Registration object`, function() {
   });
 });
 
-describe(`The classInvokers object`, function() {
+describe(`The classInvokers object`, function () {
   const container = { get(t) {
     return new t();
   } } as any as IContainer;
@@ -1129,25 +1129,25 @@ describe(`The classInvokers object`, function() {
   class Dep5 {}
   class Dep6 {}
 
-  it(`invoke() handles 0 deps`, function() {
+  it(`invoke() handles 0 deps`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[0].invoke(container, Foo, []);
     expect(actual.args.length).to.equal(0);
   });
 
-  it(`invoke() handles 1 dep`, function() {
+  it(`invoke() handles 1 dep`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[1].invoke(container, Foo, [Dep1]);
     expect(actual.args.length).to.equal(1);
     expect(actual.args[0]).to.be.instanceof(Dep1);
   });
 
-  it(`invoke() handles 2 deps`, function() {
+  it(`invoke() handles 2 deps`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[2].invoke(container, Foo, [Dep1, Dep2]);
     expect(actual.args.length).to.equal(2);
     expect(actual.args[0]).to.be.instanceof(Dep1);
     expect(actual.args[1]).to.be.instanceof(Dep2);
   });
 
-  it(`invoke() handles 3 deps`, function() {
+  it(`invoke() handles 3 deps`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[3].invoke(container, Foo, [Dep1, Dep2, Dep3]);
     expect(actual.args.length).to.equal(3);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1155,7 +1155,7 @@ describe(`The classInvokers object`, function() {
     expect(actual.args[2]).to.be.instanceof(Dep3);
   });
 
-  it(`invoke() handles 4 deps`, function() {
+  it(`invoke() handles 4 deps`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[4].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4]);
     expect(actual.args.length).to.equal(4);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1164,7 +1164,7 @@ describe(`The classInvokers object`, function() {
     expect(actual.args[3]).to.be.instanceof(Dep4);
   });
 
-  it(`invoke() handles 5 deps`, function() {
+  it(`invoke() handles 5 deps`, function () {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[5].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4, Dep5]);
     expect(actual.args.length).to.equal(5);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1174,13 +1174,13 @@ describe(`The classInvokers object`, function() {
     expect(actual.args[4]).to.be.instanceof(Dep5);
   });
 
-  it(`invoke() does not handle 6 deps`, function() {
+  it(`invoke() does not handle 6 deps`, function () {
     expect(() => classInvokers[6].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4, Dep5, Dep6])).to.throw(/undefined/);
   });
 
 });
 
-describe(`The invokeWithDynamicDependencies function`, function() {
+describe(`The invokeWithDynamicDependencies function`, function () {
   const container = { get(t) {
     return `static${t}`;
   } } as any as IContainer;
@@ -1188,44 +1188,44 @@ describe(`The invokeWithDynamicDependencies function`, function() {
 
   const deps = [class Dep1 {}, class Dep2 {}, class Dep3 {}];
 
-  it(_`throws when staticDeps is null`, function() {
+  it(_`throws when staticDeps is null`, function () {
     expect(() => invokeWithDynamicDependencies(container, Foo, null, [])).to.throw();
   });
 
-  it(_`throws when any of the staticDeps is null`, function() {
+  it(_`throws when any of the staticDeps is null`, function () {
     expect(() => invokeWithDynamicDependencies(container, Foo, [null], [])).to.throw(/7/);
   });
 
-  it(_`throws when any of the staticDeps is undefined`, function() {
+  it(_`throws when any of the staticDeps is undefined`, function () {
     expect(() => invokeWithDynamicDependencies(container, Foo, [undefined], [])).to.throw(/7/);
   });
 
-  it(_`throws when staticDeps is undefined`, function() {
+  it(_`throws when staticDeps is undefined`, function () {
     expect(() => invokeWithDynamicDependencies(container, Foo, undefined, [])).to.throw();
   });
 
-  it(_`handles staticDeps is ${deps}`, function() {
+  it(_`handles staticDeps is ${deps}`, function () {
     const actual = invokeWithDynamicDependencies(container, Foo, deps, []) as Foo;
     expect(actual.args).to.deep.equal(deps.map(d => `static${d}`));
   });
 
-  it(`handles dynamicDeps is null`, function() {
+  it(`handles dynamicDeps is null`, function () {
     const actual = invokeWithDynamicDependencies(container, Foo, [], null) as Foo;
     expect(actual.args.length).to.equal(1);
     expect(actual.args[0]).to.equal(null);
   });
 
-  it(`handles dynamicDeps is undefined`, function() {
+  it(`handles dynamicDeps is undefined`, function () {
     const actual = invokeWithDynamicDependencies(container, Foo, [], undefined) as Foo;
     expect(actual.args.length).to.equal(0);
   });
 
-  it(_`handles dynamicDeps is ${deps}`, function() {
+  it(_`handles dynamicDeps is ${deps}`, function () {
     const actual = invokeWithDynamicDependencies(container, Foo, [], deps) as Foo;
     expect(actual.args).to.deep.equal(deps);
   });
 
-  it(_`handles staticDeps is ${deps} and dynamicDeps is ${deps}`, function() {
+  it(_`handles staticDeps is ${deps} and dynamicDeps is ${deps}`, function () {
     const actual = invokeWithDynamicDependencies(container, Foo, deps, deps) as Foo;
     expect(actual.args[0]).to.equal(`static${deps[0]}`);
     expect(actual.args[1]).to.equal(`static${deps[1]}`);

--- a/packages/kernel/test/di.spec.ts
+++ b/packages/kernel/test/di.spec.ts
@@ -39,45 +39,45 @@ function assertIsMutableArray(arr: any[], length: number): void {
 
 function decorator(): ClassDecorator { return (target: any) => target; }
 
-describe(`The DI object`, () => {
-  describe(`createContainer()`, () => {
-    it(`returns an instance of Container`, () => {
+describe(`The DI object`, function() {
+  describe(`createContainer()`, function() {
+    it(`returns an instance of Container`, function() {
       const actual = DI.createContainer();
       expect(actual).to.be.instanceof(Container);
     });
 
-    it(`returns a new container every time`, () => {
+    it(`returns a new container every time`, function() {
       expect(DI.createContainer()).not.to.equal(DI.createContainer());
     });
   });
 
-  describe(`getDesignParamTypes()`, () => {
-    it(`returns PLATFORM.emptyArray if the class has no constructor or decorators`, () => {
+  describe(`getDesignParamTypes()`, function() {
+    it(`returns PLATFORM.emptyArray if the class has no constructor or decorators`, function() {
       class Foo {}
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
-    it(`returns PLATFORM.emptyArray if the class has a decorator but no constructor`, () => {
+    it(`returns PLATFORM.emptyArray if the class has a decorator but no constructor`, function() {
       @decorator()
       class Foo {}
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has no constructor args or decorators`, () => {
+    it(`returns PLATFORM.emptyArray if the class has no constructor args or decorators`, function() {
       class Foo { constructor() { return; } }
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has constructor args but no decorators`, () => {
+    it(`returns PLATFORM.emptyArray if the class has constructor args but no decorators`, function() {
       class Bar {}
       class Foo { constructor(public bar: Bar) {} }
       const actual = DI.getDesignParamTypes(Foo);
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class has constructor args and the decorator is applied via a function call`, () => {
+    it(`returns PLATFORM.emptyArray if the class has constructor args and the decorator is applied via a function call`, function() {
       class Bar {}
       class Foo { constructor(public bar: Bar) {} }
       decorator()(Foo);
@@ -85,7 +85,7 @@ describe(`The DI object`, () => {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class is declared as an anonymous variable, even if it has ctor args and decorator is applied properly`, () => {
+    it(`returns PLATFORM.emptyArray if the class is declared as an anonymous variable, even if it has ctor args and decorator is applied properly`, function() {
       class Bar {}
       // @ts-ignore
       @decorator()
@@ -94,7 +94,7 @@ describe(`The DI object`, () => {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    it(`returns PLATFORM.emptyArray if the class is declared as a named variable, even if it has ctor args and decorator is applied properly`, () => {
+    it(`returns PLATFORM.emptyArray if the class is declared as a named variable, even if it has ctor args and decorator is applied properly`, function() {
       class Bar {}
       // @ts-ignore
       @decorator()
@@ -103,16 +103,16 @@ describe(`The DI object`, () => {
       expect(actual).to.equal(PLATFORM.emptyArray);
     });
 
-    describe(`returns an empty array if the class has a decorator but no constructor args`, () => {
+    describe(`returns an empty array if the class has a decorator but no constructor args`, function() {
       @decorator()
       class Foo { constructor() { return; } }
 
-      it(_`${Foo}`, () => {
+      it(_`${Foo}`, function() {
         const actual = DI.getDesignParamTypes(Foo);
         assertIsMutableArray(actual, 0);
       });
 
-      it(_`${class {}}`, () => {
+      it(_`${class {}}`, function() {
         let cls;
         function anonDecorator(): ClassDecorator { return (target: any) => cls = target; }
         // @ts-ignore
@@ -123,7 +123,7 @@ describe(`The DI object`, () => {
       });
     });
 
-    describe(`falls back to Object for declarations that cannot be statically analyzed`, () => {
+    describe(`falls back to Object for declarations that cannot be statically analyzed`, function() {
       interface ArgCtor {}
       for (const argCtor of [
         class Bar {},
@@ -139,7 +139,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooDecoratorInvocation { constructor(public arg: ArgCtor) {} }
 
-        it(_`${FooDecoratorInvocation} { constructor(${argCtor}) }`, () => {
+        it(_`${FooDecoratorInvocation} { constructor(${argCtor}) }`, function() {
           const actual = DI.getDesignParamTypes(FooDecoratorInvocation);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -148,7 +148,7 @@ describe(`The DI object`, () => {
         @(decorator as any)
         class FooDecoratorNonInvocation { constructor(public arg: ArgCtor) {} }
 
-        it(_`${FooDecoratorNonInvocation} { constructor(${argCtor}) }`, () => {
+        it(_`${FooDecoratorNonInvocation} { constructor(${argCtor}) }`, function() {
           const actual = DI.getDesignParamTypes(FooDecoratorInvocation);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -156,7 +156,7 @@ describe(`The DI object`, () => {
       }
     });
 
-    describe(`falls back to Object for mismatched declarations`, () => {
+    describe(`falls back to Object for mismatched declarations`, function() {
 
       // Technically we're testing TypeScript here, but it's still useful to have an in-place fixture to validate our assumptions
       // And also to have an alert mechanism for when the functionality in TypeScript changes, without having to read the changelogs
@@ -195,12 +195,12 @@ describe(`The DI object`, () => {
       interface ArrowInterface {}
       const ArrowInterface: ArrowInterface = () => { return; };
 
-      describe(`decorator invocation`, () => {
+      describe(`decorator invocation`, function() {
         @decorator()
         class FooBar { constructor(public arg: Bar) {} }
 
         // Note: this is a negative assertion meant to make it easier to compare this describe with the one below
-        it(_`NOT ${FooBar} { constructor(public ${Bar}) }`, () => {
+        it(_`NOT ${FooBar} { constructor(public ${Bar}) }`, function() {
           const actual = DI.getDesignParamTypes(FooBar);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Bar);
@@ -210,7 +210,7 @@ describe(`The DI object`, () => {
         class FooAnonClass { constructor(public arg: AnonClass) {} }
 
         // Note: this is a negative assertion meant to make it easier to compare this describe with the one below
-        it(_`NOT ${FooAnonClass} { constructor(public ${AnonClass}) }`, () => {
+        it(_`NOT ${FooAnonClass} { constructor(public ${AnonClass}) }`, function() {
           const actual = DI.getDesignParamTypes(FooAnonClass);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(AnonClass);
@@ -220,7 +220,7 @@ describe(`The DI object`, () => {
         class FooAnonClassInterface { constructor(public arg: AnonClassInterface) {} }
 
         // this one is particularly interesting..
-        it(_`${FooAnonClassInterface} { constructor(public ${AnonClassInterface}) }`, () => {
+        it(_`${FooAnonClassInterface} { constructor(public ${AnonClassInterface}) }`, function() {
           const actual = DI.getDesignParamTypes(FooAnonClassInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -229,7 +229,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooVarFunc { constructor(public arg: VarFunc) {} }
 
-        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, () => {
+        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function() {
           const actual = DI.getDesignParamTypes(FooVarFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -238,7 +238,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooVarFuncInterface { constructor(public arg: VarFuncInterface) {} }
 
-        it(_`${FooVarFuncInterface} { constructor(public ${VarFuncInterface}) }`, () => {
+        it(_`${FooVarFuncInterface} { constructor(public ${VarFuncInterface}) }`, function() {
           const actual = DI.getDesignParamTypes(FooVarFuncInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -247,7 +247,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooFunc { constructor(public arg: Func) {} }
 
-        it(_`${FooFunc} { constructor(public ${Func}) }`, () => {
+        it(_`${FooFunc} { constructor(public ${Func}) }`, function() {
           const actual = DI.getDesignParamTypes(FooFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -256,7 +256,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooArrow { constructor(public arg: Arrow) {} }
 
-        it(_`${FooArrow} { constructor(public ${Arrow}) }`, () => {
+        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function() {
           const actual = DI.getDesignParamTypes(FooArrow);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -265,7 +265,7 @@ describe(`The DI object`, () => {
         @decorator()
         class FooArrowInterface { constructor(public arg: ArrowInterface) {} }
 
-        it(_`${FooArrowInterface} { constructor(public ${ArrowInterface}) }`, () => {
+        it(_`${FooArrowInterface} { constructor(public ${ArrowInterface}) }`, function() {
           const actual = DI.getDesignParamTypes(FooArrowInterface);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Object);
@@ -273,7 +273,7 @@ describe(`The DI object`, () => {
       });
     });
 
-    describe(`returns the correct types for valid declarations`, () => {
+    describe(`returns the correct types for valid declarations`, function() {
       class Bar {}
 
       const AnonClass = class {};
@@ -285,11 +285,11 @@ describe(`The DI object`, () => {
 
       const Arrow = () => { return; };
 
-      describe(`decorator invocation`, () => {
+      describe(`decorator invocation`, function() {
         @decorator()
         class FooBar { constructor(public arg: Bar) {} }
 
-        it(_`${FooBar} { constructor(public ${Bar}) }`, () => {
+        it(_`${FooBar} { constructor(public ${Bar}) }`, function() {
           const actual = DI.getDesignParamTypes(FooBar);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Bar);
@@ -299,7 +299,7 @@ describe(`The DI object`, () => {
         // @ts-ignore
         class FooAnonClass { constructor(public arg: AnonClass) {} }
 
-        it(_`${FooAnonClass} { constructor(public ${AnonClass}) }`, () => {
+        it(_`${FooAnonClass} { constructor(public ${AnonClass}) }`, function() {
           const actual = DI.getDesignParamTypes(FooAnonClass);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(AnonClass);
@@ -309,7 +309,7 @@ describe(`The DI object`, () => {
         // @ts-ignore
         class FooVarFunc { constructor(public arg: VarFunc) {} }
 
-        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, () => {
+        it(_`${FooVarFunc} { constructor(public ${VarFunc}) }`, function() {
           const actual = DI.getDesignParamTypes(FooVarFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(VarFunc);
@@ -319,7 +319,7 @@ describe(`The DI object`, () => {
         // @ts-ignore
         class FooFunc { constructor(public arg: Func) {} }
 
-        it(_`${FooFunc} { constructor(public ${Func}) }`, () => {
+        it(_`${FooFunc} { constructor(public ${Func}) }`, function() {
           const actual = DI.getDesignParamTypes(FooFunc);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Func);
@@ -329,7 +329,7 @@ describe(`The DI object`, () => {
         // @ts-ignore
         class FooArrow { constructor(public arg: Arrow) {} }
 
-        it(_`${FooArrow} { constructor(public ${Arrow}) }`, () => {
+        it(_`${FooArrow} { constructor(public ${Arrow}) }`, function() {
           const actual = DI.getDesignParamTypes(FooArrow);
           assertIsMutableArray(actual, 1);
           expect(actual[0]).to.equal(Arrow);
@@ -338,17 +338,17 @@ describe(`The DI object`, () => {
     });
   });
 
-  describe(`getDependencies()`, () => {
+  describe(`getDependencies()`, function() {
     let getDesignParamTypes: ReturnType<typeof spy>;
 
-    beforeEach(() => {
+    beforeEach(function() {
       getDesignParamTypes = spy(DI, 'getDesignParamTypes');
     });
-    afterEach(() => {
+    afterEach(function() {
       getDesignParamTypes.restore();
     });
 
-    it(`uses getDesignParamTypes() if the static inject property does not exist`, () => {
+    it(`uses getDesignParamTypes() if the static inject property does not exist`, function() {
       class Bar {}
       @decorator()
       class Foo { constructor(bar: Bar) { return; } }
@@ -357,7 +357,7 @@ describe(`The DI object`, () => {
       expect(actual).to.deep.equal([Bar]);
     });
 
-    it(`uses getDesignParamTypes() if the static inject property is undefined`, () => {
+    it(`uses getDesignParamTypes() if the static inject property is undefined`, function() {
       class Bar {}
       @decorator()
       class Foo { public static inject; constructor(bar: Bar) { return; } }
@@ -366,7 +366,7 @@ describe(`The DI object`, () => {
       expect(actual).to.deep.equal([Bar]);
     });
 
-    it(`throws when inject is not an array`, () => {
+    it(`throws when inject is not an array`, function() {
       class Bar {}
       class Foo { public static inject = Bar; }
       expect(() => DI.getDependencies(Foo)).to.throw();
@@ -380,7 +380,7 @@ describe(`The DI object`, () => {
       [null],
       [42]
     ]) {
-      it(_`returns a copy of the inject array ${deps}`, () => {
+      it(_`returns a copy of the inject array ${deps}`, function() {
         class Foo { public static inject = deps.slice(); }
         const actual = DI.getDependencies(Foo);
         expect(getDesignParamTypes).not.to.have.been.called;
@@ -396,7 +396,7 @@ describe(`The DI object`, () => {
       [null],
       [42]
     ]) {
-      it(_`traverses the 2-layer prototype chain for inject array ${deps}`, () => {
+      it(_`traverses the 2-layer prototype chain for inject array ${deps}`, function() {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { public static inject = deps.slice(); }
         const actual = DI.getDependencies(Bar);
@@ -406,7 +406,7 @@ describe(`The DI object`, () => {
         expect(actual).not.to.equal(Bar.inject);
       });
 
-      it(_`traverses the 3-layer prototype chain for inject array ${deps}`, () => {
+      it(_`traverses the 3-layer prototype chain for inject array ${deps}`, function() {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { public static inject = deps.slice(); }
         class Baz extends Bar { public static inject = deps.slice(); }
@@ -418,7 +418,7 @@ describe(`The DI object`, () => {
         expect(actual).not.to.equal(Baz.inject);
       });
 
-      it(_`traverses the 1-layer + 2-layer prototype chain (with gap) for inject array ${deps}`, () => {
+      it(_`traverses the 1-layer + 2-layer prototype chain (with gap) for inject array ${deps}`, function() {
         class Foo { public static inject = deps.slice(); }
         class Bar extends Foo { }
         class Baz extends Bar { public static inject = deps.slice(); }
@@ -434,39 +434,39 @@ describe(`The DI object`, () => {
 
   });
 
-  describe(`createInterface()`, () => {
-    it(`returns a function that has withDefault and noDefault functions`, () => {
+  describe(`createInterface()`, function() {
+    it(`returns a function that has withDefault and noDefault functions`, function() {
       const sut = DI.createInterface();
       expect(typeof sut).to.equal('function');
       expect(typeof sut.withDefault).to.equal('function');
       expect(typeof sut.noDefault).to.equal('function');
     });
 
-    it(`noDefault returns self`, () => {
+    it(`noDefault returns self`, function() {
       const sut = DI.createInterface();
       expect(sut.noDefault()).to.equal(sut);
     });
 
-    it(`withDefault returns self with modified withDefault that throws`, () => {
+    it(`withDefault returns self with modified withDefault that throws`, function() {
       const sut = DI.createInterface();
       const sut2 = sut.withDefault(null as any);
       expect(sut).to.equal(sut2);
       expect(() => sut.withDefault(null as any)).to.throw;
     });
 
-    describe(`withDefault returns self with register function that registers the appropriate resolver`, () => {
+    describe(`withDefault returns self with register function that registers the appropriate resolver`, function() {
       let sut: IDefaultableInterfaceSymbol<any>;
       let container: IContainer;
 
       let registerResolver: ReturnType<typeof spy>;
 
-      beforeEach(() => {
+      beforeEach(function() {
         sut = DI.createInterface();
         container = new Container();
         registerResolver = spy(container, 'registerResolver');
       });
 
-      afterEach(() => {
+      afterEach(function() {
         registerResolver.restore();
       });
 
@@ -474,69 +474,69 @@ describe(`The DI object`, () => {
         return match(val => val.key === key && val.strategy === strategy && val.state === state);
       }
 
-      it(`instance without key`, () => {
+      it(`instance without key`, function() {
         const value = {};
         sut.withDefault(builder => builder.instance(value));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.instance, value));
       });
 
-      it(`instance with key`, () => {
+      it(`instance with key`, function() {
         const value = {};
         sut.withDefault(builder => builder.instance(value));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.instance, value));
       });
 
-      it(`singleton without key`, () => {
+      it(`singleton without key`, function() {
         class Foo {}
         sut.withDefault(builder => builder.singleton(Foo));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.singleton, Foo));
       });
 
-      it(`singleton with key`, () => {
+      it(`singleton with key`, function() {
         class Foo {}
         sut.withDefault(builder => builder.singleton(Foo));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.singleton, Foo));
       });
 
-      it(`transient without key`, () => {
+      it(`transient without key`, function() {
         class Foo {}
         sut.withDefault(builder => builder.transient(Foo));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.transient, Foo));
       });
 
-      it(`transient with key`, () => {
+      it(`transient with key`, function() {
         class Foo {}
         sut.withDefault(builder => builder.transient(Foo));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.transient, Foo));
       });
 
-      it(`callback without key`, () => {
+      it(`callback without key`, function() {
         const callback = () => { return; };
         sut.withDefault(builder => builder.callback(callback));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.callback, callback));
       });
 
-      it(`callback with key`, () => {
+      it(`callback with key`, function() {
         const callback = () => { return; };
         sut.withDefault(builder => builder.callback(callback));
         (sut as any).register(container, 'key');
         expect(registerResolver).to.have.been.calledWith('key', matchResolver('key', ResolverStrategy.callback, callback));
       });
 
-      it(`aliasTo without key`, () => {
+      it(`aliasTo without key`, function() {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (sut as any).register(container);
         expect(registerResolver).to.have.been.calledWith(sut, matchResolver(sut, ResolverStrategy.alias, 'key2'));
       });
 
-      it(`aliasTo with key`, () => {
+      it(`aliasTo with key`, function() {
         sut.withDefault(builder => builder.aliasTo('key2'));
         (sut as any).register(container, 'key1');
         expect(registerResolver).to.have.been.calledWith('key1', matchResolver('key1', ResolverStrategy.alias, 'key2'));
@@ -545,38 +545,38 @@ describe(`The DI object`, () => {
   });
 });
 
-describe(`The inject decorator`, () => {
+describe(`The inject decorator`, function() {
   class Dep1 {}
   class Dep2 {}
   class Dep3 {}
 
-  it(`can decorate classes with explicit dependencies`, () => {
+  it(`can decorate classes with explicit dependencies`, function() {
     @inject(Dep1, Dep2, Dep3)
     class Foo {}
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate classes with implicit dependencies`, () => {
+  it(`can decorate classes with implicit dependencies`, function() {
     @inject()
     class Foo { constructor(dep1: Dep1, dep2: Dep2, dep3: Dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate constructor parameters explicitly`, () => {
+  it(`can decorate constructor parameters explicitly`, function() {
     class Foo { constructor(@inject(Dep1)dep1, @inject(Dep2)dep2, @inject(Dep3)dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate constructor parameters implicitly`, () => {
+  it(`can decorate constructor parameters implicitly`, function() {
     class Foo { constructor(@inject() dep1: Dep1, @inject() dep2: Dep2, @inject() dep3: Dep3) { return; } }
 
     expect(Foo['inject']).to.deep.equal([Dep1, Dep2, Dep3]);
   });
 
-  it(`can decorate properties explicitly`, () => {
+  it(`can decorate properties explicitly`, function() {
     // @ts-ignore
     class Foo { @inject(Dep1)public dep1; @inject(Dep2)public dep2; @inject(Dep3)public dep3; }
 
@@ -585,7 +585,7 @@ describe(`The inject decorator`, () => {
     expect(Foo['inject'].dep3).to.equal(Dep3);
   });
 
-  it(`cannot decorate properties implicitly`, () => {
+  it(`cannot decorate properties implicitly`, function() {
     // @ts-ignore
     class Foo { @inject()public dep1: Dep1; @inject()public dep2: Dep2; @inject()public dep3: Dep3; }
 
@@ -595,8 +595,8 @@ describe(`The inject decorator`, () => {
   });
 });
 
-describe(`The transient decorator`, () => {
-  it(`works as a plain decorator`, () => {
+describe(`The transient decorator`, function() {
+  it(`works as a plain decorator`, function() {
     @transient
     class Foo {}
 
@@ -610,7 +610,7 @@ describe(`The transient decorator`, () => {
     expect(foo1).not.to.equal(foo2);
   });
 
-  it(`works as an invocation`, () => {
+  it(`works as an invocation`, function() {
     @transient()
     class Foo {}
 
@@ -625,8 +625,8 @@ describe(`The transient decorator`, () => {
   });
 });
 
-describe(`The singleton decorator`, () => {
-  it(`works as a plain decorator`, () => {
+describe(`The singleton decorator`, function() {
+  it(`works as a plain decorator`, function() {
     @singleton
     class Foo {}
 
@@ -640,7 +640,7 @@ describe(`The singleton decorator`, () => {
     expect(foo1).to.equal(foo2);
   });
 
-  it(`works as an invocation`, () => {
+  it(`works as an invocation`, function() {
     @singleton()
     class Foo {}
 
@@ -655,42 +655,42 @@ describe(`The singleton decorator`, () => {
   });
 });
 
-describe(`The Resolver class`, () => {
+describe(`The Resolver class`, function() {
   let container: IContainer;
   let registerResolver: ReturnType<typeof spy>;
 
-  beforeEach(() => {
+  beforeEach(function() {
     container = new Container();
     registerResolver = spy(container, 'registerResolver');
   });
 
-  afterEach(() => {
+  afterEach(function() {
     registerResolver.restore();
   });
 
-  describe(`register()`, () => {
-    it(`registers the resolver to the container with the provided key`, () => {
+  describe(`register()`, function() {
+    it(`registers the resolver to the container with the provided key`, function() {
       const sut = new Resolver('foo', 0, null);
       sut.register(container, 'bar');
       expect(registerResolver).to.have.been.calledWith('bar', sut);
     });
 
-    it(`registers the resolver to the container with its own`, () => {
+    it(`registers the resolver to the container with its own`, function() {
       const sut = new Resolver('foo', 0, null);
       sut.register(container);
       expect(registerResolver).to.have.been.calledWith('foo', sut);
     });
   });
 
-  describe(`resolve()`, () => {
-    it(`instance - returns state`, () => {
+  describe(`resolve()`, function() {
+    it(`instance - returns state`, function() {
       const state = {};
       const sut = new Resolver('foo', ResolverStrategy.instance, state);
       const actual = sut.resolve(container, container);
       expect(actual).to.equal(state);
     });
 
-    it(`singleton - returns an instance of the type and sets strategy to instance`, () => {
+    it(`singleton - returns an instance of the type and sets strategy to instance`, function() {
       class Foo {}
       const sut = new Resolver('foo', ResolverStrategy.singleton, Foo);
       const actual = sut.resolve(container, container);
@@ -700,7 +700,7 @@ describe(`The Resolver class`, () => {
       expect(actual2).to.equal(actual);
     });
 
-    it(`transient - always returns a new instance of the type`, () => {
+    it(`transient - always returns a new instance of the type`, function() {
       class Foo {}
       const sut = new Resolver('foo', ResolverStrategy.transient, Foo);
       const actual1 = sut.resolve(container, container);
@@ -711,21 +711,21 @@ describe(`The Resolver class`, () => {
       expect(actual2).not.to.equal(actual1);
     });
 
-    it(`array - calls resolve() on the first item in the state array`, () => {
+    it(`array - calls resolve() on the first item in the state array`, function() {
       const resolver = { resolve: spy() };
       const sut = new Resolver('foo', ResolverStrategy.array, [resolver]);
       sut.resolve(container, container);
       expect(resolver.resolve).to.have.been.calledWith(container, container);
     });
 
-    it(`throws for unknown strategy`, () => {
+    it(`throws for unknown strategy`, function() {
       const sut = new Resolver('foo', -1, null);
       expect(() => sut.resolve(container, container)).to.throw(/6/);
     });
   });
 
-  describe(`getFactory()`, () => {
-    it(`returns a new singleton Factory if it does not exist`, () => {
+  describe(`getFactory()`, function() {
+    it(`returns a new singleton Factory if it does not exist`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.singleton, Foo);
       const actual = sut.getFactory(container);
@@ -733,7 +733,7 @@ describe(`The Resolver class`, () => {
       expect(actual.Type).to.equal(Foo);
     });
 
-    it(`returns a new transient Factory if it does not exist`, () => {
+    it(`returns a new transient Factory if it does not exist`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.transient, Foo);
       const actual = sut.getFactory(container);
@@ -741,28 +741,28 @@ describe(`The Resolver class`, () => {
       expect(actual.Type).to.equal(Foo);
     });
 
-    it(`returns a null for instance strategy`, () => {
+    it(`returns a null for instance strategy`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.instance, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for array strategy`, () => {
+    it(`returns a null for array strategy`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.array, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for alias strategy`, () => {
+    it(`returns a null for alias strategy`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.alias, Foo);
       const actual = sut.getFactory(container);
       expect(actual).to.equal(null);
     });
 
-    it(`returns a null for callback strategy`, () => {
+    it(`returns a null for callback strategy`, function() {
       class Foo {}
       const sut = new Resolver(Foo, ResolverStrategy.callback, Foo);
       const actual = sut.getFactory(container);
@@ -771,11 +771,11 @@ describe(`The Resolver class`, () => {
   });
 });
 
-describe(`The Factory class`, () => {
+describe(`The Factory class`, function() {
 
-  describe(`create()`, () => {
+  describe(`create()`, function() {
     for (const count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
-      it(`returns a new Factory with ${count} deps`, () => {
+      it(`returns a new Factory with ${count} deps`, function() {
         class Bar {}
         class Foo {public static inject = Array(count).map(c => Bar); }
         const actual = Factory.create(Foo);
@@ -792,11 +792,11 @@ describe(`The Factory class`, () => {
     }
   });
 
-  describe(`construct()`, () => {
+  describe(`construct()`, function() {
     for (const staticCount of [0, 1, 2, 3, 4, 5, 6, 7]) {
       for (const dynamicCount of [0, 1, 2]) {
         const container = new Container();
-        it(`instantiates a type with ${staticCount} static deps and ${dynamicCount} dynamic deps`, () => {
+        it(`instantiates a type with ${staticCount} static deps and ${dynamicCount} dynamic deps`, function() {
           class Bar {}
           class Foo {public static inject = Array(staticCount).fill(Bar); public args: any[]; constructor(...args: any[]) {this.args = args; }}
           const sut = Factory.create(Foo);
@@ -815,8 +815,8 @@ describe(`The Factory class`, () => {
     }
   });
 
-  describe(`registerTransformer()`, () => {
-    it(`registers the transformer`, () => {
+  describe(`registerTransformer()`, function() {
+    it(`registers the transformer`, function() {
       const container = new Container();
       class Foo {public bar; public baz; }
       const sut = Factory.create(Foo);
@@ -833,95 +833,95 @@ describe(`The Factory class`, () => {
 
 });
 
-describe(`The Container class`, () => {
+describe(`The Container class`, function() {
   let sut: IContainer;
 
-  beforeEach(() => {
+  beforeEach(function() {
     sut = new Container();
   });
 
-  describe(`register()`, () => {
+  describe(`register()`, function() {
     let register: ReturnType<typeof spy>;
 
-    beforeEach(() => {
+    beforeEach(function() {
       register = spy();
     });
 
-    it(_`calls register() on {register}`, () => {
+    it(_`calls register() on {register}`, function() {
       sut.register({register});
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on {register},{register}`, () => {
+    it(_`calls register() on {register},{register}`, function() {
       sut.register({register}, {register});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{register}]`, () => {
+    it(_`calls register() on [{register},{register}]`, function() {
       sut.register([{register}, {register}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on {foo:{register}}`, () => {
+    it(_`calls register() on {foo:{register}}`, function() {
       sut.register({foo: {register}});
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on {foo:{register}},{foo:{register}}`, () => {
+    it(_`calls register() on {foo:{register}},{foo:{register}}`, function() {
       sut.register({foo: {register}}, {foo: {register}});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{foo:{register}},{foo:{register}}]`, () => {
+    it(_`calls register() on [{foo:{register}},{foo:{register}}]`, function() {
       sut.register([{foo: {register}}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on {register},{foo:{register}}`, () => {
+    it(_`calls register() on {register},{foo:{register}}`, function() {
       sut.register({register}, {foo: {register}});
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{foo:{register}}]`, () => {
+    it(_`calls register() on [{register},{foo:{register}}]`, function() {
       sut.register([{register}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
       expect(register.getCalls().length).to.equal(2);
     });
 
-    it(_`calls register() on [{register},{}]`, () => {
+    it(_`calls register() on [{register},{}]`, function() {
       sut.register([{register}, {}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{},{register}]`, () => {
+    it(_`calls register() on [{},{register}]`, function() {
       sut.register([{}, {register}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{foo:{register}},{foo:{}}]`, () => {
+    it(_`calls register() on [{foo:{register}},{foo:{}}]`, function() {
       sut.register([{foo: {register}}, {foo: {}}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
 
-    it(_`calls register() on [{foo:{}},{foo:{register}}]`, () => {
+    it(_`calls register() on [{foo:{}},{foo:{register}}]`, function() {
       sut.register([{foo: {}}, {foo: {register}}] as any);
       expect(register).to.have.been.calledWith(sut);
     });
   });
 
-  describe(`registerResolver()`, () => {
+  describe(`registerResolver()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, () => {
+      it(_`throws on invalid key ${key}`, function() {
         expect(() => sut.registerResolver(key, null as any)).to.throw(/5/);
       });
     }
 
-    it(`registers the resolver if it does not exist yet`, () => {
+    it(`registers the resolver if it does not exist yet`, function() {
       const key = {};
       const resolver = new Resolver(key, ResolverStrategy.instance, {});
       sut.registerResolver(key, resolver);
@@ -929,7 +929,7 @@ describe(`The Container class`, () => {
       expect(actual).to.equal(resolver);
     });
 
-    it(`changes to array resolver if the key already exists`, () => {
+    it(`changes to array resolver if the key already exists`, function() {
       const key = {};
       const resolver1 = new Resolver(key, ResolverStrategy.instance, {});
       const resolver2 = new Resolver(key, ResolverStrategy.instance, {});
@@ -946,7 +946,7 @@ describe(`The Container class`, () => {
       expect(actual2['state'][1]).to.equal(resolver2);
     });
 
-    it(`appends to the array resolver if the key already exists more than once`, () => {
+    it(`appends to the array resolver if the key already exists more than once`, function() {
       const key = {};
       const resolver1 = new Resolver(key, ResolverStrategy.instance, {});
       const resolver2 = new Resolver(key, ResolverStrategy.instance, {});
@@ -962,67 +962,67 @@ describe(`The Container class`, () => {
     });
   });
 
-  describe(`registerTransformer()`, () => {
+  describe(`registerTransformer()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, () => {
+      it(_`throws on invalid key ${key}`, function() {
         expect(() => sut.registerTransformer(key, null as any)).to.throw(/5/);
       });
     }
 
-    it(`registers the transformer if it does not exist yet`, () => {
+    it(`registers the transformer if it does not exist yet`, function() {
 
     });
 
-    it(`reuses the existing transformer if it exists`, () => {
+    it(`reuses the existing transformer if it exists`, function() {
 
     });
   });
 
-  describe(`getResolver()`, () => {
+  describe(`getResolver()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, () => {
+      it(_`throws on invalid key ${key}`, function() {
         expect(() => sut.getResolver(key, null as any)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`has()`, () => {
+  describe(`has()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`returns false for non-existing key ${key}`, () => {
+      it(_`returns false for non-existing key ${key}`, function() {
         expect(sut.has(key as any, false)).to.equal(false);
       });
     }
-    it(`returns true for existing key`, () => {
+    it(`returns true for existing key`, function() {
       const key = {};
       sut.registerResolver(key, new Resolver(key, ResolverStrategy.instance, {}));
       expect(sut.has(key as any, false)).to.equal(true);
     });
   });
 
-  describe(`get()`, () => {
+  describe(`get()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, () => {
+      it(_`throws on invalid key ${key}`, function() {
         expect(() => sut.get(key)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`getAll()`, () => {
+  describe(`getAll()`, function() {
     for (const key of [null, undefined, Object]) {
-      it(_`throws on invalid key ${key}`, () => {
+      it(_`throws on invalid key ${key}`, function() {
         expect(() => sut.getAll(key)).to.throw(/5/);
       });
     }
 
   });
 
-  describe(`getFactory()`, () => {
+  describe(`getFactory()`, function() {
     for (const count of [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]) {
       sut = new Container(); // ensure the state is reset (beforeEach doesn't know about loops)
 
-      it(`returns a new Factory with ${count} deps if it does not exist`, () => {
+      it(`returns a new Factory with ${count} deps if it does not exist`, function() {
         class Bar {}
         class Foo {public static inject = Array(count).map(c => Bar); }
         const actual = sut.getFactory(Foo);
@@ -1038,7 +1038,7 @@ describe(`The Container class`, () => {
       });
     }
 
-    it(`reuses the existing factory if it already exists`, () => {
+    it(`reuses the existing factory if it already exists`, function() {
       const create = spy(Factory, 'create');
       class Foo {}
       const actual = sut.getFactory(Foo);
@@ -1050,8 +1050,8 @@ describe(`The Container class`, () => {
     });
   });
 
-  describe(`createChild()`, () => {
-    it(`creates a child with same config and sut as parent, and copies over the resourceLookup`, () => {
+  describe(`createChild()`, function() {
+    it(`creates a child with same config and sut as parent, and copies over the resourceLookup`, function() {
       const obj = {};
       Registration.instance('foo', obj).register(sut, 'foo');
       expect(sut['resourceLookup'].foo.state).to.equal(obj);
@@ -1068,15 +1068,15 @@ describe(`The Container class`, () => {
 
   });
 
-  describe(`jitRegister()`, () => {
+  describe(`jitRegister()`, function() {
 
   });
 
 });
 
-describe(`The Registration object`, () => {
+describe(`The Registration object`, function() {
 
-  it(`instance() returns the correct resolver`, () => {
+  it(`instance() returns the correct resolver`, function() {
     const value = {};
     const actual = Registration.instance('key', value);
     expect(actual['key']).to.equal('key');
@@ -1084,7 +1084,7 @@ describe(`The Registration object`, () => {
     expect(actual['state']).to.equal(value);
   });
 
-  it(`singleton() returns the correct resolver`, () => {
+  it(`singleton() returns the correct resolver`, function() {
     class Foo {}
     const actual = Registration.singleton('key', Foo);
     expect(actual['key']).to.equal('key');
@@ -1092,7 +1092,7 @@ describe(`The Registration object`, () => {
     expect(actual['state']).to.equal(Foo);
   });
 
-  it(`transient() returns the correct resolver`, () => {
+  it(`transient() returns the correct resolver`, function() {
     class Foo {}
     const actual = Registration.transient('key', Foo);
     expect(actual['key']).to.equal('key');
@@ -1100,7 +1100,7 @@ describe(`The Registration object`, () => {
     expect(actual['state']).to.equal(Foo);
   });
 
-  it(`callback() returns the correct resolver`, () => {
+  it(`callback() returns the correct resolver`, function() {
     const callback = () => { return; };
     const actual = Registration.callback('key', callback);
     expect(actual['key']).to.equal('key');
@@ -1108,7 +1108,7 @@ describe(`The Registration object`, () => {
     expect(actual['state']).to.equal(callback);
   });
 
-  it(`alias() returns the correct resolver`, () => {
+  it(`alias() returns the correct resolver`, function() {
     const actual = Registration.alias('key', 'key2');
     expect(actual['key']).to.equal('key2');
     expect(actual['strategy']).to.equal(ResolverStrategy.alias);
@@ -1116,7 +1116,7 @@ describe(`The Registration object`, () => {
   });
 });
 
-describe(`The classInvokers object`, () => {
+describe(`The classInvokers object`, function() {
   const container = { get(t) {
     return new t();
   } } as any as IContainer;
@@ -1129,25 +1129,25 @@ describe(`The classInvokers object`, () => {
   class Dep5 {}
   class Dep6 {}
 
-  it(`invoke() handles 0 deps`, () => {
+  it(`invoke() handles 0 deps`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[0].invoke(container, Foo, []);
     expect(actual.args.length).to.equal(0);
   });
 
-  it(`invoke() handles 1 dep`, () => {
+  it(`invoke() handles 1 dep`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[1].invoke(container, Foo, [Dep1]);
     expect(actual.args.length).to.equal(1);
     expect(actual.args[0]).to.be.instanceof(Dep1);
   });
 
-  it(`invoke() handles 2 deps`, () => {
+  it(`invoke() handles 2 deps`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[2].invoke(container, Foo, [Dep1, Dep2]);
     expect(actual.args.length).to.equal(2);
     expect(actual.args[0]).to.be.instanceof(Dep1);
     expect(actual.args[1]).to.be.instanceof(Dep2);
   });
 
-  it(`invoke() handles 3 deps`, () => {
+  it(`invoke() handles 3 deps`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[3].invoke(container, Foo, [Dep1, Dep2, Dep3]);
     expect(actual.args.length).to.equal(3);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1155,7 +1155,7 @@ describe(`The classInvokers object`, () => {
     expect(actual.args[2]).to.be.instanceof(Dep3);
   });
 
-  it(`invoke() handles 4 deps`, () => {
+  it(`invoke() handles 4 deps`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[4].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4]);
     expect(actual.args.length).to.equal(4);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1164,7 +1164,7 @@ describe(`The classInvokers object`, () => {
     expect(actual.args[3]).to.be.instanceof(Dep4);
   });
 
-  it(`invoke() handles 5 deps`, () => {
+  it(`invoke() handles 5 deps`, function() {
     const actual: InstanceType<Constructable<Foo>> = classInvokers[5].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4, Dep5]);
     expect(actual.args.length).to.equal(5);
     expect(actual.args[0]).to.be.instanceof(Dep1);
@@ -1174,13 +1174,13 @@ describe(`The classInvokers object`, () => {
     expect(actual.args[4]).to.be.instanceof(Dep5);
   });
 
-  it(`invoke() does not handle 6 deps`, () => {
+  it(`invoke() does not handle 6 deps`, function() {
     expect(() => classInvokers[6].invoke(container, Foo, [Dep1, Dep2, Dep3, Dep4, Dep5, Dep6])).to.throw(/undefined/);
   });
 
 });
 
-describe(`The invokeWithDynamicDependencies function`, () => {
+describe(`The invokeWithDynamicDependencies function`, function() {
   const container = { get(t) {
     return `static${t}`;
   } } as any as IContainer;
@@ -1188,44 +1188,44 @@ describe(`The invokeWithDynamicDependencies function`, () => {
 
   const deps = [class Dep1 {}, class Dep2 {}, class Dep3 {}];
 
-  it(_`throws when staticDeps is null`, () => {
+  it(_`throws when staticDeps is null`, function() {
     expect(() => invokeWithDynamicDependencies(container, Foo, null, [])).to.throw();
   });
 
-  it(_`throws when any of the staticDeps is null`, () => {
+  it(_`throws when any of the staticDeps is null`, function() {
     expect(() => invokeWithDynamicDependencies(container, Foo, [null], [])).to.throw(/7/);
   });
 
-  it(_`throws when any of the staticDeps is undefined`, () => {
+  it(_`throws when any of the staticDeps is undefined`, function() {
     expect(() => invokeWithDynamicDependencies(container, Foo, [undefined], [])).to.throw(/7/);
   });
 
-  it(_`throws when staticDeps is undefined`, () => {
+  it(_`throws when staticDeps is undefined`, function() {
     expect(() => invokeWithDynamicDependencies(container, Foo, undefined, [])).to.throw();
   });
 
-  it(_`handles staticDeps is ${deps}`, () => {
+  it(_`handles staticDeps is ${deps}`, function() {
     const actual = invokeWithDynamicDependencies(container, Foo, deps, []) as Foo;
     expect(actual.args).to.deep.equal(deps.map(d => `static${d}`));
   });
 
-  it(`handles dynamicDeps is null`, () => {
+  it(`handles dynamicDeps is null`, function() {
     const actual = invokeWithDynamicDependencies(container, Foo, [], null) as Foo;
     expect(actual.args.length).to.equal(1);
     expect(actual.args[0]).to.equal(null);
   });
 
-  it(`handles dynamicDeps is undefined`, () => {
+  it(`handles dynamicDeps is undefined`, function() {
     const actual = invokeWithDynamicDependencies(container, Foo, [], undefined) as Foo;
     expect(actual.args.length).to.equal(0);
   });
 
-  it(_`handles dynamicDeps is ${deps}`, () => {
+  it(_`handles dynamicDeps is ${deps}`, function() {
     const actual = invokeWithDynamicDependencies(container, Foo, [], deps) as Foo;
     expect(actual.args).to.deep.equal(deps);
   });
 
-  it(_`handles staticDeps is ${deps} and dynamicDeps is ${deps}`, () => {
+  it(_`handles staticDeps is ${deps} and dynamicDeps is ${deps}`, function() {
     const actual = invokeWithDynamicDependencies(container, Foo, deps, deps) as Foo;
     expect(actual.args[0]).to.equal(`static${deps[0]}`);
     expect(actual.args[1]).to.equal(`static${deps[1]}`);

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -1,18 +1,18 @@
 import { expect } from 'chai';
 import { DI, EventAggregator } from '../src/index';
 
-describe('event aggregator', function() {
+describe('event aggregator', function () {
 
-  describe('subscribe', function() {
+  describe('subscribe', function () {
 
-    describe('string events', function() {
+    describe('string events', function () {
 
-      it('should not remove another callback when execute called twice', function() {
+      it('should not remove another callback when execute called twice', function () {
         const ea = new EventAggregator();
         let data = 0;
 
-        const subscription = ea.subscribe('dinner', function() { return; });
-        ea.subscribe('dinner', function() { data = 1; });
+        const subscription = ea.subscribe('dinner', function () { return; });
+        ea.subscribe('dinner', function () { data = 1; });
 
         subscription.dispose();
         subscription.dispose();
@@ -22,21 +22,21 @@ describe('event aggregator', function() {
         expect(data).to.equal(1);
       });
 
-      it('adds event with callback to the eventLookup object', function() {
+      it('adds event with callback to the eventLookup object', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribe('dinner', callback);
 
         expect(ea.eventLookup.dinner.length).to.equal(1);
         expect(ea.eventLookup.dinner[0]).to.equal(callback);
       });
 
-      it('adds multiple callbacks the same event', function() {
+      it('adds multiple callbacks the same event', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribe('dinner', callback);
 
-        const callback2 = function() { return; };
+        const callback2 = function () { return; };
         ea.subscribe('dinner', callback2);
 
         expect(ea.eventLookup.dinner.length).to.equal(2);
@@ -44,13 +44,13 @@ describe('event aggregator', function() {
         expect(ea.eventLookup.dinner[1]).to.equal(callback2);
       });
 
-      it('removes the callback after execution', function() {
+      it('removes the callback after execution', function () {
         const ea = new EventAggregator();
 
-        const callback = function() { return; };
+        const callback = function () { return; };
         const subscription = ea.subscribe('dinner', callback);
 
-        const callback2 = function() { return; };
+        const callback2 = function () { return; };
         const subscription2 = ea.subscribe('dinner', callback2);
 
         expect(ea.eventLookup.dinner.length).to.equal(2);
@@ -66,9 +66,9 @@ describe('event aggregator', function() {
         expect(ea.eventLookup.dinner.length).to.equal(0);
       });
 
-      it('will respond to an event any time it is published', function() {
+      it('will respond to an event any time it is published', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribe('dinner', callback);
 
         expect(ea.eventLookup.dinner.length).to.equal(1);
@@ -82,7 +82,7 @@ describe('event aggregator', function() {
         expect(ea.eventLookup.dinner[0]).to.equal(callback);
       });
 
-      it('will pass published data to the callback function', function() {
+      it('will pass published data to the callback function', function () {
         const ea = new EventAggregator();
         let data = null;
         const callback = function(d) { data = d; };
@@ -97,14 +97,14 @@ describe('event aggregator', function() {
 
     });
 
-    describe('handler events', function() {
+    describe('handler events', function () {
 
-      it('should not remove another handler when execute called twice', function() {
+      it('should not remove another handler when execute called twice', function () {
         const ea = new EventAggregator();
         let data = 0;
 
-        const subscription = ea.subscribe(DinnerEvent, function() { return; });
-        ea.subscribe(AnotherDinnerEvent, function() { data = 1; });
+        const subscription = ea.subscribe(DinnerEvent, function () { return; });
+        ea.subscribe(AnotherDinnerEvent, function () { data = 1; });
 
         subscription.dispose();
         subscription.dispose();
@@ -114,9 +114,9 @@ describe('event aggregator', function() {
         expect(data).to.equal(1);
       });
 
-      it('adds handler with messageType and callback to the messageHandlers array', function() {
+      it('adds handler with messageType and callback to the messageHandlers array', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribe(DinnerEvent, callback);
 
         expect(ea.messageHandlers.length).to.equal(1);
@@ -124,9 +124,9 @@ describe('event aggregator', function() {
         expect(ea.messageHandlers[0].callback).to.equal(callback);
       });
 
-      it('removes the handler after execution', function() {
+      it('removes the handler after execution', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         const subscription = ea.subscribe(DinnerEvent, callback);
 
         expect(ea.messageHandlers.length).to.equal(1);
@@ -136,11 +136,11 @@ describe('event aggregator', function() {
 
     });
 
-    describe('invalid events', function() {
+    describe('invalid events', function () {
       const ea = new EventAggregator();
-      const callback = function() { return; };
+      const callback = function () { return; };
 
-      it('throws if channelOrType is undefined', function() {
+      it('throws if channelOrType is undefined', function () {
         expect(() => { ea.subscribe(undefined, callback); }).to.throw('Code 0');
       });
 
@@ -148,13 +148,13 @@ describe('event aggregator', function() {
 
   });
 
-  describe('subscribeOnce', function() {
+  describe('subscribeOnce', function () {
 
-    describe('string events', function() {
+    describe('string events', function () {
 
-      it('adds event with an anynomous function that will execute the callback to the eventLookup object', function() {
+      it('adds event with an anynomous function that will execute the callback to the eventLookup object', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribeOnce('dinner', callback);
 
         expect(ea.eventLookup.dinner.length).to.equal(1);
@@ -162,12 +162,12 @@ describe('event aggregator', function() {
         expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
       });
 
-      it('adds multiple callbacks the same event', function() {
+      it('adds multiple callbacks the same event', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribeOnce('dinner', callback);
 
-        const callback2 = function() { return; };
+        const callback2 = function () { return; };
         ea.subscribeOnce('dinner', callback2);
 
         expect(ea.eventLookup.dinner.length).to.equal(2);
@@ -177,12 +177,12 @@ describe('event aggregator', function() {
         expect(typeof ea.eventLookup.dinner[1] === 'function').to.equal(true);
       });
 
-      it('removes the callback after execution', function() {
+      it('removes the callback after execution', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         const subscription = ea.subscribeOnce('dinner', callback);
 
-        const callback2 = function() { return; };
+        const callback2 = function () { return; };
         const subscription2 = ea.subscribeOnce('dinner', callback2);
 
         expect(ea.eventLookup.dinner.length).to.equal(2);
@@ -200,11 +200,11 @@ describe('event aggregator', function() {
         expect(ea.eventLookup.dinner.length).to.equal(0);
       });
 
-      it('will respond to an event only once', function() {
+      it('will respond to an event only once', function () {
         const ea = new EventAggregator();
         let data = null;
 
-        const callback = function() { data = 'something'; };
+        const callback = function () { data = 'something'; };
         ea.subscribeOnce('dinner', callback);
 
         expect(ea.eventLookup.dinner.length).to.equal(1);
@@ -221,7 +221,7 @@ describe('event aggregator', function() {
         expect(data).to.equal(null);
       });
 
-      it('will pass published data to the callback function', function() {
+      it('will pass published data to the callback function', function () {
         const ea = new EventAggregator();
 
         let data = null;
@@ -241,12 +241,12 @@ describe('event aggregator', function() {
       });
     });
 
-    describe('handler events', function() {
+    describe('handler events', function () {
 
-      it('adds handler with messageType and callback to the messageHandlers array', function() {
+      it('adds handler with messageType and callback to the messageHandlers array', function () {
         const ea = new EventAggregator();
 
-        const callback = function() { return; };
+        const callback = function () { return; };
         ea.subscribeOnce(DinnerEvent, callback);
 
         expect(ea.messageHandlers.length).to.equal(1);
@@ -256,9 +256,9 @@ describe('event aggregator', function() {
 
       });
 
-      it('removes the handler after execution', function() {
+      it('removes the handler after execution', function () {
         const ea = new EventAggregator();
-        const callback = function() { return; };
+        const callback = function () { return; };
         const subscription = ea.subscribeOnce(DinnerEvent, callback);
 
         expect(ea.messageHandlers.length).to.equal(1);
@@ -270,11 +270,11 @@ describe('event aggregator', function() {
 
   });
 
-  describe('publish', function() {
+  describe('publish', function () {
 
-    describe('string events', function() {
+    describe('string events', function () {
 
-      it('calls the callback functions for the event', function() {
+      it('calls the callback functions for the event', function () {
         const ea = new EventAggregator();
 
         let someData: unknown, someData2: unknown;
@@ -296,7 +296,7 @@ describe('event aggregator', function() {
         expect(someData2).to.equal(data);
       });
 
-      it('does not call the callback functions if subscriber does not exist', function() {
+      it('does not call the callback functions if subscriber does not exist', function () {
         const ea = new EventAggregator();
 
         let someData: unknown;
@@ -311,12 +311,12 @@ describe('event aggregator', function() {
         expect(someData).to.be.undefined;
       });
 
-      it('handles errors in subscriber callbacks', function() {
+      it('handles errors in subscriber callbacks', function () {
         const ea = new EventAggregator();
 
         let someMessage: unknown;
 
-        const crash = function() {
+        const crash = function () {
           throw new Error('oops');
         };
 
@@ -337,9 +337,9 @@ describe('event aggregator', function() {
 
     });
 
-    describe('handler events', function() {
+    describe('handler events', function () {
 
-      it('calls the callback functions for the event', function() {
+      it('calls the callback functions for the event', function () {
         const ea = new EventAggregator();
 
         let someMessage: { message: string };
@@ -360,7 +360,7 @@ describe('event aggregator', function() {
         expect(someMessage.message).to.equal('Meatballs');
       });
 
-      it('does not call the callback funtions if message is not an instance of the messageType', function() {
+      it('does not call the callback funtions if message is not an instance of the messageType', function () {
         const ea = new EventAggregator();
 
         let someMessage: unknown;
@@ -375,12 +375,12 @@ describe('event aggregator', function() {
         expect(someMessage).to.be.undefined;
       });
 
-      it('handles errors in subscriber callbacks', function() {
+      it('handles errors in subscriber callbacks', function () {
         const ea = new EventAggregator();
 
         let someMessage: { message: unknown };
 
-        const crash = function() {
+        const crash = function () {
           throw new Error('oops');
         };
 
@@ -400,10 +400,10 @@ describe('event aggregator', function() {
 
     });
 
-    describe('invalid events', function() {
+    describe('invalid events', function () {
       const ea = new EventAggregator();
 
-      it('throws if channelOrType is undefined', function() {
+      it('throws if channelOrType is undefined', function () {
         expect(() => { ea.publish(undefined, {}); }).to.throw('Code 0');
       });
 

--- a/packages/kernel/test/eventaggregator.spec.ts
+++ b/packages/kernel/test/eventaggregator.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { DI, EventAggregator } from '../src/index';
 
-describe('event aggregator', () => {
+describe('event aggregator', function() {
 
-  describe('subscribe', () => {
+  describe('subscribe', function() {
 
-    describe('string events', () => {
+    describe('string events', function() {
 
-      it('should not remove another callback when execute called twice', () => {
+      it('should not remove another callback when execute called twice', function() {
         const ea = new EventAggregator();
         let data = 0;
 
@@ -22,7 +22,7 @@ describe('event aggregator', () => {
         expect(data).to.equal(1);
       });
 
-      it('adds event with callback to the eventLookup object', () => {
+      it('adds event with callback to the eventLookup object', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribe('dinner', callback);
@@ -31,7 +31,7 @@ describe('event aggregator', () => {
         expect(ea.eventLookup.dinner[0]).to.equal(callback);
       });
 
-      it('adds multiple callbacks the same event', () => {
+      it('adds multiple callbacks the same event', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribe('dinner', callback);
@@ -44,7 +44,7 @@ describe('event aggregator', () => {
         expect(ea.eventLookup.dinner[1]).to.equal(callback2);
       });
 
-      it('removes the callback after execution', () => {
+      it('removes the callback after execution', function() {
         const ea = new EventAggregator();
 
         const callback = function() { return; };
@@ -66,7 +66,7 @@ describe('event aggregator', () => {
         expect(ea.eventLookup.dinner.length).to.equal(0);
       });
 
-      it('will respond to an event any time it is published', () => {
+      it('will respond to an event any time it is published', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribe('dinner', callback);
@@ -82,7 +82,7 @@ describe('event aggregator', () => {
         expect(ea.eventLookup.dinner[0]).to.equal(callback);
       });
 
-      it('will pass published data to the callback function', () => {
+      it('will pass published data to the callback function', function() {
         const ea = new EventAggregator();
         let data = null;
         const callback = function(d) { data = d; };
@@ -97,9 +97,9 @@ describe('event aggregator', () => {
 
     });
 
-    describe('handler events', () => {
+    describe('handler events', function() {
 
-      it('should not remove another handler when execute called twice', () => {
+      it('should not remove another handler when execute called twice', function() {
         const ea = new EventAggregator();
         let data = 0;
 
@@ -114,7 +114,7 @@ describe('event aggregator', () => {
         expect(data).to.equal(1);
       });
 
-      it('adds handler with messageType and callback to the messageHandlers array', () => {
+      it('adds handler with messageType and callback to the messageHandlers array', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribe(DinnerEvent, callback);
@@ -124,7 +124,7 @@ describe('event aggregator', () => {
         expect(ea.messageHandlers[0].callback).to.equal(callback);
       });
 
-      it('removes the handler after execution', () => {
+      it('removes the handler after execution', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         const subscription = ea.subscribe(DinnerEvent, callback);
@@ -136,11 +136,11 @@ describe('event aggregator', () => {
 
     });
 
-    describe('invalid events', () => {
+    describe('invalid events', function() {
       const ea = new EventAggregator();
       const callback = function() { return; };
 
-      it('throws if channelOrType is undefined', () => {
+      it('throws if channelOrType is undefined', function() {
         expect(() => { ea.subscribe(undefined, callback); }).to.throw('Code 0');
       });
 
@@ -148,11 +148,11 @@ describe('event aggregator', () => {
 
   });
 
-  describe('subscribeOnce', () => {
+  describe('subscribeOnce', function() {
 
-    describe('string events', () => {
+    describe('string events', function() {
 
-      it('adds event with an anynomous function that will execute the callback to the eventLookup object', () => {
+      it('adds event with an anynomous function that will execute the callback to the eventLookup object', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribeOnce('dinner', callback);
@@ -162,7 +162,7 @@ describe('event aggregator', () => {
         expect(typeof ea.eventLookup.dinner[0] === 'function').to.equal(true);
       });
 
-      it('adds multiple callbacks the same event', () => {
+      it('adds multiple callbacks the same event', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         ea.subscribeOnce('dinner', callback);
@@ -177,7 +177,7 @@ describe('event aggregator', () => {
         expect(typeof ea.eventLookup.dinner[1] === 'function').to.equal(true);
       });
 
-      it('removes the callback after execution', () => {
+      it('removes the callback after execution', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         const subscription = ea.subscribeOnce('dinner', callback);
@@ -200,7 +200,7 @@ describe('event aggregator', () => {
         expect(ea.eventLookup.dinner.length).to.equal(0);
       });
 
-      it('will respond to an event only once', () => {
+      it('will respond to an event only once', function() {
         const ea = new EventAggregator();
         let data = null;
 
@@ -221,7 +221,7 @@ describe('event aggregator', () => {
         expect(data).to.equal(null);
       });
 
-      it('will pass published data to the callback function', () => {
+      it('will pass published data to the callback function', function() {
         const ea = new EventAggregator();
 
         let data = null;
@@ -241,9 +241,9 @@ describe('event aggregator', () => {
       });
     });
 
-    describe('handler events', () => {
+    describe('handler events', function() {
 
-      it('adds handler with messageType and callback to the messageHandlers array', () => {
+      it('adds handler with messageType and callback to the messageHandlers array', function() {
         const ea = new EventAggregator();
 
         const callback = function() { return; };
@@ -256,7 +256,7 @@ describe('event aggregator', () => {
 
       });
 
-      it('removes the handler after execution', () => {
+      it('removes the handler after execution', function() {
         const ea = new EventAggregator();
         const callback = function() { return; };
         const subscription = ea.subscribeOnce(DinnerEvent, callback);
@@ -270,11 +270,11 @@ describe('event aggregator', () => {
 
   });
 
-  describe('publish', () => {
+  describe('publish', function() {
 
-    describe('string events', () => {
+    describe('string events', function() {
 
-      it('calls the callback functions for the event', () => {
+      it('calls the callback functions for the event', function() {
         const ea = new EventAggregator();
 
         let someData: unknown, someData2: unknown;
@@ -296,7 +296,7 @@ describe('event aggregator', () => {
         expect(someData2).to.equal(data);
       });
 
-      it('does not call the callback functions if subscriber does not exist', () => {
+      it('does not call the callback functions if subscriber does not exist', function() {
         const ea = new EventAggregator();
 
         let someData: unknown;
@@ -311,7 +311,7 @@ describe('event aggregator', () => {
         expect(someData).to.be.undefined;
       });
 
-      it('handles errors in subscriber callbacks', () => {
+      it('handles errors in subscriber callbacks', function() {
         const ea = new EventAggregator();
 
         let someMessage: unknown;
@@ -337,9 +337,9 @@ describe('event aggregator', () => {
 
     });
 
-    describe('handler events', () => {
+    describe('handler events', function() {
 
-      it('calls the callback functions for the event', () => {
+      it('calls the callback functions for the event', function() {
         const ea = new EventAggregator();
 
         let someMessage: { message: string };
@@ -360,7 +360,7 @@ describe('event aggregator', () => {
         expect(someMessage.message).to.equal('Meatballs');
       });
 
-      it('does not call the callback funtions if message is not an instance of the messageType', () => {
+      it('does not call the callback funtions if message is not an instance of the messageType', function() {
         const ea = new EventAggregator();
 
         let someMessage: unknown;
@@ -375,7 +375,7 @@ describe('event aggregator', () => {
         expect(someMessage).to.be.undefined;
       });
 
-      it('handles errors in subscriber callbacks', () => {
+      it('handles errors in subscriber callbacks', function() {
         const ea = new EventAggregator();
 
         let someMessage: { message: unknown };
@@ -400,10 +400,10 @@ describe('event aggregator', () => {
 
     });
 
-    describe('invalid events', () => {
+    describe('invalid events', function() {
       const ea = new EventAggregator();
 
-      it('throws if channelOrType is undefined', () => {
+      it('throws if channelOrType is undefined', function() {
         expect(() => { ea.publish(undefined, {}); }).to.throw('Code 0');
       });
 

--- a/packages/kernel/test/path.spec.ts
+++ b/packages/kernel/test/path.spec.ts
@@ -1,36 +1,36 @@
 import { expect } from 'chai';
 import { buildQueryString, join, parseQueryString, relativeToFile } from '../src/index';
 
-describe('relativeToFile', () => {
-  it('can make a dot path relative to a simple file', () => {
+describe('relativeToFile', function() {
+  it('can make a dot path relative to a simple file', function() {
     const file = 'some/file.html';
     const path = './other/module';
 
     expect(relativeToFile(path, file)).to.equal('some/other/module');
   });
 
-  it('can make a dot path relative to an absolute file', () => {
+  it('can make a dot path relative to an absolute file', function() {
     const file = 'http://aurelia.io/some/file.html';
     const path = './other/module';
 
     expect(relativeToFile(path, file)).to.equal('http://aurelia.io/some/other/module');
   });
 
-  it('can make a double dot path relative to an absolute file', () => {
+  it('can make a double dot path relative to an absolute file', function() {
     const file = 'http://aurelia.io/some/file.html';
     const path = '../other/module';
 
     expect(relativeToFile(path, file)).to.equal('http://aurelia.io/other/module');
   });
 
-  it('returns path if null file provided', () => {
+  it('returns path if null file provided', function() {
     const file = null;
     const path = 'module';
 
     expect(relativeToFile(path, file)).to.equal('module');
   });
 
-  it('returns path if empty file provided', () => {
+  it('returns path if empty file provided', function() {
     const file = '';
     const path = 'module';
 
@@ -38,169 +38,169 @@ describe('relativeToFile', () => {
   });
 });
 
-describe('join', () => {
-  it('can combine two simple paths', () => {
+describe('join', function() {
+  it('can combine two simple paths', function() {
     const path1 = 'one';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('one/two');
   });
 
-  it('can combine an absolute path and a simple path', () => {
+  it('can combine an absolute path and a simple path', function() {
     const path1 = '/one';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('/one/two');
   });
 
-  it('can combine an absolute path and a simple path with slash', () => {
+  it('can combine an absolute path and a simple path with slash', function() {
     const path1 = '/one';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('/one/two');
   });
 
-  it('can combine a single slash and a simple path', () => {
+  it('can combine a single slash and a simple path', function() {
     const path1 = '/';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('/two');
   });
 
-  it('can combine a single slash and a simple path with slash', () => {
+  it('can combine a single slash and a simple path with slash', function() {
     const path1 = '/';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('/two');
   });
 
-  it('can combine an absolute path with protocol and a simple path', () => {
+  it('can combine an absolute path with protocol and a simple path', function() {
     const path1 = 'http://aurelia.io';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine an absolute path with protocol and a simple path with slash', () => {
+  it('can combine an absolute path with protocol and a simple path with slash', function() {
     const path1 = 'http://aurelia.io';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine an absolute path and a simple path with a dot', () => {
+  it('can combine an absolute path and a simple path with a dot', function() {
     const path1 = 'http://aurelia.io';
     const path2 = './two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine a simple path and a relative path', () => {
+  it('can combine a simple path and a relative path', function() {
     const path1 = 'one';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('can combine an absolute path and a relative path', () => {
+  it('can combine an absolute path and a relative path', function() {
     const path1 = 'http://aurelia.io/somewhere';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path', () => {
+  it('can combine a protocol independent path and a simple path', function() {
     const path1 = '//aurelia.io';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path with slash', () => {
+  it('can combine a protocol independent path and a simple path with slash', function() {
     const path1 = '//aurelia.io';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path with a dot', () => {
+  it('can combine a protocol independent path and a simple path with a dot', function() {
     const path1 = '//aurelia.io';
     const path2 = './two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a relative path', () => {
+  it('can combine a protocol independent path and a relative path', function() {
     const path1 = '//aurelia.io/somewhere';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a complex path and a relative path', () => {
+  it('can combine a complex path and a relative path', function() {
     const path1 = 'one/three';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('one/two');
   });
 
-  it('returns path2 if path1 null', () => {
+  it('returns path2 if path1 null', function() {
     const path1 = null;
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('returns path2 if path1 empty', () => {
+  it('returns path2 if path1 empty', function() {
     const path1 = '';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('returns path1 if path2 null', () => {
+  it('returns path1 if path2 null', function() {
     const path1 = 'one';
     const path2 = null;
 
     expect(join(path1, path2)).to.equal('one');
   });
 
-  it('returns path1 if path2 empty', () => {
+  it('returns path1 if path2 empty', function() {
     const path1 = 'one';
     const path2 = '';
 
     expect(join(path1, path2)).to.equal('one');
   });
 
-  it('should respect a trailing slash', () => {
+  it('should respect a trailing slash', function() {
     const path1 = 'one/';
     const path2 = 'two/';
 
     expect(join(path1, path2)).to.equal('one/two/');
   });
 
-  it('should respect file:/// protocol with three slashes (empty host)', () => {
+  it('should respect file:/// protocol with three slashes (empty host)', function() {
     const path1 = 'file:///one';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('file:///one/two');
   });
 
-  it('should respect file:// protocol with two slashes (host given)', () => {
+  it('should respect file:// protocol with two slashes (host given)', function() {
     const path1 = 'file://localhost:8080';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('file://localhost:8080/two');
   });
 
-  it('should allow scheme-relative URL that uses colons in the path', () => {
+  it('should allow scheme-relative URL that uses colons in the path', function() {
     const path1 = '//localhost/one:/';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('//localhost/one:/two');
   });
 
-  it('should not add more than two leading slashes to http:// protocol', () => {
+  it('should not add more than two leading slashes to http:// protocol', function() {
     const path1 = 'http:///';
     const path2 = '/two';
 
@@ -208,8 +208,8 @@ describe('join', () => {
   });
 });
 
-describe('query strings', () => {
-  it('should build query strings', () => {
+describe('query strings', function() {
+  it('should build query strings', function() {
     const gen = buildQueryString;
 
     expect(gen()).to.equal('');
@@ -244,7 +244,7 @@ describe('query strings', () => {
     expect(gen({a: ['c', 'd', {f: 'g'}]}, true)).to.equal('a=c&a=d&a=%5Bobject%20Object%5D');
   });
 
-  it('should parse query strings', () => {
+  it('should parse query strings', function() {
     const parse = parseQueryString;
 
     expect(parse('')).to.deep.equal({});

--- a/packages/kernel/test/path.spec.ts
+++ b/packages/kernel/test/path.spec.ts
@@ -1,36 +1,36 @@
 import { expect } from 'chai';
 import { buildQueryString, join, parseQueryString, relativeToFile } from '../src/index';
 
-describe('relativeToFile', function() {
-  it('can make a dot path relative to a simple file', function() {
+describe('relativeToFile', function () {
+  it('can make a dot path relative to a simple file', function () {
     const file = 'some/file.html';
     const path = './other/module';
 
     expect(relativeToFile(path, file)).to.equal('some/other/module');
   });
 
-  it('can make a dot path relative to an absolute file', function() {
+  it('can make a dot path relative to an absolute file', function () {
     const file = 'http://aurelia.io/some/file.html';
     const path = './other/module';
 
     expect(relativeToFile(path, file)).to.equal('http://aurelia.io/some/other/module');
   });
 
-  it('can make a double dot path relative to an absolute file', function() {
+  it('can make a double dot path relative to an absolute file', function () {
     const file = 'http://aurelia.io/some/file.html';
     const path = '../other/module';
 
     expect(relativeToFile(path, file)).to.equal('http://aurelia.io/other/module');
   });
 
-  it('returns path if null file provided', function() {
+  it('returns path if null file provided', function () {
     const file = null;
     const path = 'module';
 
     expect(relativeToFile(path, file)).to.equal('module');
   });
 
-  it('returns path if empty file provided', function() {
+  it('returns path if empty file provided', function () {
     const file = '';
     const path = 'module';
 
@@ -38,169 +38,169 @@ describe('relativeToFile', function() {
   });
 });
 
-describe('join', function() {
-  it('can combine two simple paths', function() {
+describe('join', function () {
+  it('can combine two simple paths', function () {
     const path1 = 'one';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('one/two');
   });
 
-  it('can combine an absolute path and a simple path', function() {
+  it('can combine an absolute path and a simple path', function () {
     const path1 = '/one';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('/one/two');
   });
 
-  it('can combine an absolute path and a simple path with slash', function() {
+  it('can combine an absolute path and a simple path with slash', function () {
     const path1 = '/one';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('/one/two');
   });
 
-  it('can combine a single slash and a simple path', function() {
+  it('can combine a single slash and a simple path', function () {
     const path1 = '/';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('/two');
   });
 
-  it('can combine a single slash and a simple path with slash', function() {
+  it('can combine a single slash and a simple path with slash', function () {
     const path1 = '/';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('/two');
   });
 
-  it('can combine an absolute path with protocol and a simple path', function() {
+  it('can combine an absolute path with protocol and a simple path', function () {
     const path1 = 'http://aurelia.io';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine an absolute path with protocol and a simple path with slash', function() {
+  it('can combine an absolute path with protocol and a simple path with slash', function () {
     const path1 = 'http://aurelia.io';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine an absolute path and a simple path with a dot', function() {
+  it('can combine an absolute path and a simple path with a dot', function () {
     const path1 = 'http://aurelia.io';
     const path2 = './two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine a simple path and a relative path', function() {
+  it('can combine a simple path and a relative path', function () {
     const path1 = 'one';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('can combine an absolute path and a relative path', function() {
+  it('can combine an absolute path and a relative path', function () {
     const path1 = 'http://aurelia.io/somewhere';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('http://aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path', function() {
+  it('can combine a protocol independent path and a simple path', function () {
     const path1 = '//aurelia.io';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path with slash', function() {
+  it('can combine a protocol independent path and a simple path with slash', function () {
     const path1 = '//aurelia.io';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a simple path with a dot', function() {
+  it('can combine a protocol independent path and a simple path with a dot', function () {
     const path1 = '//aurelia.io';
     const path2 = './two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a protocol independent path and a relative path', function() {
+  it('can combine a protocol independent path and a relative path', function () {
     const path1 = '//aurelia.io/somewhere';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('//aurelia.io/two');
   });
 
-  it('can combine a complex path and a relative path', function() {
+  it('can combine a complex path and a relative path', function () {
     const path1 = 'one/three';
     const path2 = '../two';
 
     expect(join(path1, path2)).to.equal('one/two');
   });
 
-  it('returns path2 if path1 null', function() {
+  it('returns path2 if path1 null', function () {
     const path1 = null;
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('returns path2 if path1 empty', function() {
+  it('returns path2 if path1 empty', function () {
     const path1 = '';
     const path2 = 'two';
 
     expect(join(path1, path2)).to.equal('two');
   });
 
-  it('returns path1 if path2 null', function() {
+  it('returns path1 if path2 null', function () {
     const path1 = 'one';
     const path2 = null;
 
     expect(join(path1, path2)).to.equal('one');
   });
 
-  it('returns path1 if path2 empty', function() {
+  it('returns path1 if path2 empty', function () {
     const path1 = 'one';
     const path2 = '';
 
     expect(join(path1, path2)).to.equal('one');
   });
 
-  it('should respect a trailing slash', function() {
+  it('should respect a trailing slash', function () {
     const path1 = 'one/';
     const path2 = 'two/';
 
     expect(join(path1, path2)).to.equal('one/two/');
   });
 
-  it('should respect file:/// protocol with three slashes (empty host)', function() {
+  it('should respect file:/// protocol with three slashes (empty host)', function () {
     const path1 = 'file:///one';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('file:///one/two');
   });
 
-  it('should respect file:// protocol with two slashes (host given)', function() {
+  it('should respect file:// protocol with two slashes (host given)', function () {
     const path1 = 'file://localhost:8080';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('file://localhost:8080/two');
   });
 
-  it('should allow scheme-relative URL that uses colons in the path', function() {
+  it('should allow scheme-relative URL that uses colons in the path', function () {
     const path1 = '//localhost/one:/';
     const path2 = '/two';
 
     expect(join(path1, path2)).to.equal('//localhost/one:/two');
   });
 
-  it('should not add more than two leading slashes to http:// protocol', function() {
+  it('should not add more than two leading slashes to http:// protocol', function () {
     const path1 = 'http:///';
     const path2 = '/two';
 
@@ -208,8 +208,8 @@ describe('join', function() {
   });
 });
 
-describe('query strings', function() {
-  it('should build query strings', function() {
+describe('query strings', function () {
+  it('should build query strings', function () {
     const gen = buildQueryString;
 
     expect(gen()).to.equal('');
@@ -244,7 +244,7 @@ describe('query strings', function() {
     expect(gen({a: ['c', 'd', {f: 'g'}]}, true)).to.equal('a=c&a=d&a=%5Bobject%20Object%5D');
   });
 
-  it('should parse query strings', function() {
+  it('should parse query strings', function () {
     const parse = parseQueryString;
 
     expect(parse('')).to.deep.equal({});

--- a/packages/kernel/test/platform.spec.ts
+++ b/packages/kernel/test/platform.spec.ts
@@ -6,28 +6,28 @@ import { _ } from './util';
 
 const toString = Object.prototype.toString;
 
-describe(`The PLATFORM object`, function() {
+describe(`The PLATFORM object`, function () {
   if (typeof global !== 'undefined') {
-    it(`global references global`, function() {
+    it(`global references global`, function () {
       expect(PLATFORM.global).to.equal(global);
     });
   }
   // @ts-ignore
   if (typeof self !== 'undefined') {
-    it(`global references self`, function() {
+    it(`global references self`, function () {
       // @ts-ignore
       expect(PLATFORM.global).to.equal(self);
     });
   }
   // @ts-ignore
   if (typeof window !== 'undefined') {
-    it(`global references window`, function() {
+    it(`global references window`, function () {
       // @ts-ignore
       expect(PLATFORM.global).to.equal(window);
     });
   }
 
-  it(`now() returns a timestamp`, async function() {
+  it(`now() returns a timestamp`, async function () {
     const $1 = PLATFORM.now();
 
     await Promise.resolve();
@@ -65,7 +65,7 @@ describe(`The PLATFORM object`, function() {
     }).catch(error => { throw error; });
   });
 
-  describe(`camelCase()`, function() {
+  describe(`camelCase()`, function () {
     for (const sep of ['.', '_', '-']) {
       for (const count of [1, 2]) {
         for (const prepend of [true, false]) {
@@ -82,7 +82,7 @@ describe(`The PLATFORM object`, function() {
               let input = [foo, bar, baz].join(actualSep);
               if (prepend) input = actualSep + input;
               if (append) input += actualSep;
-              it(`${input} -> ${expected}`, function() {
+              it(`${input} -> ${expected}`, function () {
                 const actual = PLATFORM.camelCase(input);
                 expect(actual).to.equal(expected);
                 expect(PLATFORM.camelCase(input)).to.equal(actual); // verify via code coverage report that cache is being hit
@@ -94,7 +94,7 @@ describe(`The PLATFORM object`, function() {
     }
   });
 
-  describe(`kebabCase()`, function() {
+  describe(`kebabCase()`, function () {
     for (const [input, expected] of [
       ['FooBarBaz', 'foo-bar-baz'],
       ['fooBarBaz', 'foo-bar-baz'],
@@ -102,7 +102,7 @@ describe(`The PLATFORM object`, function() {
       ['FOOBARBAZ', 'f-o-o-b-a-r-b-a-z'],
       ['fOObARbAZ', 'f-o-ob-a-rb-a-z']
     ]) {
-      it(`${input} -> ${expected}`, function() {
+      it(`${input} -> ${expected}`, function () {
         const actual = PLATFORM.kebabCase(input);
         expect(actual).to.equal(expected);
         expect(PLATFORM.kebabCase(input)).to.equal(actual); // verify via code coverage report that cache is being hit
@@ -110,12 +110,12 @@ describe(`The PLATFORM object`, function() {
     }
   });
 
-  describe(`toArray()`, function() {
+  describe(`toArray()`, function () {
     for (const input of [
       [1, 2, 3, 4, 5],
       { length: 5, [1]: 1, [2]: 2, [3]: 3, [4]: 4, [5]: 5 }
     ] as ArrayLike<any>[]) {
-      it(_`converts ${input} to array`, function() {
+      it(_`converts ${input} to array`, function () {
         const expected = Array.from(input);
         const actual = PLATFORM.toArray(input);
         expect(typeof expected).to.equal(typeof actual);

--- a/packages/kernel/test/platform.spec.ts
+++ b/packages/kernel/test/platform.spec.ts
@@ -6,28 +6,28 @@ import { _ } from './util';
 
 const toString = Object.prototype.toString;
 
-describe(`The PLATFORM object`, () => {
+describe(`The PLATFORM object`, function() {
   if (typeof global !== 'undefined') {
-    it(`global references global`, () => {
+    it(`global references global`, function() {
       expect(PLATFORM.global).to.equal(global);
     });
   }
   // @ts-ignore
   if (typeof self !== 'undefined') {
-    it(`global references self`, () => {
+    it(`global references self`, function() {
       // @ts-ignore
       expect(PLATFORM.global).to.equal(self);
     });
   }
   // @ts-ignore
   if (typeof window !== 'undefined') {
-    it(`global references window`, () => {
+    it(`global references window`, function() {
       // @ts-ignore
       expect(PLATFORM.global).to.equal(window);
     });
   }
 
-  it(`now() returns a timestamp`, async () => {
+  it(`now() returns a timestamp`, async function() {
     const $1 = PLATFORM.now();
 
     await Promise.resolve();
@@ -65,7 +65,7 @@ describe(`The PLATFORM object`, () => {
     }).catch(error => { throw error; });
   });
 
-  describe(`camelCase()`, () => {
+  describe(`camelCase()`, function() {
     for (const sep of ['.', '_', '-']) {
       for (const count of [1, 2]) {
         for (const prepend of [true, false]) {
@@ -82,7 +82,7 @@ describe(`The PLATFORM object`, () => {
               let input = [foo, bar, baz].join(actualSep);
               if (prepend) input = actualSep + input;
               if (append) input += actualSep;
-              it(`${input} -> ${expected}`, () => {
+              it(`${input} -> ${expected}`, function() {
                 const actual = PLATFORM.camelCase(input);
                 expect(actual).to.equal(expected);
                 expect(PLATFORM.camelCase(input)).to.equal(actual); // verify via code coverage report that cache is being hit
@@ -94,7 +94,7 @@ describe(`The PLATFORM object`, () => {
     }
   });
 
-  describe(`kebabCase()`, () => {
+  describe(`kebabCase()`, function() {
     for (const [input, expected] of [
       ['FooBarBaz', 'foo-bar-baz'],
       ['fooBarBaz', 'foo-bar-baz'],
@@ -102,7 +102,7 @@ describe(`The PLATFORM object`, () => {
       ['FOOBARBAZ', 'f-o-o-b-a-r-b-a-z'],
       ['fOObARbAZ', 'f-o-ob-a-rb-a-z']
     ]) {
-      it(`${input} -> ${expected}`, () => {
+      it(`${input} -> ${expected}`, function() {
         const actual = PLATFORM.kebabCase(input);
         expect(actual).to.equal(expected);
         expect(PLATFORM.kebabCase(input)).to.equal(actual); // verify via code coverage report that cache is being hit
@@ -110,12 +110,12 @@ describe(`The PLATFORM object`, () => {
     }
   });
 
-  describe(`toArray()`, () => {
+  describe(`toArray()`, function() {
     for (const input of [
       [1, 2, 3, 4, 5],
       { length: 5, [1]: 1, [2]: 2, [3]: 3, [4]: 4, [5]: 5 }
     ] as ArrayLike<any>[]) {
-      it(_`converts ${input} to array`, () => {
+      it(_`converts ${input} to array`, function() {
         const expected = Array.from(input);
         const actual = PLATFORM.toArray(input);
         expect(typeof expected).to.equal(typeof actual);

--- a/packages/kernel/test/reporter.spec.ts
+++ b/packages/kernel/test/reporter.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { Reporter } from '../src/index';
 
-describe('The default Reporter', function() {
-  it('creates an Error with a minimal message upon request', function() {
+describe('The default Reporter', function () {
+  it('creates an Error with a minimal message upon request', function () {
     const code = 42;
     const error = Reporter.error(code);
     expect(error.message).to.equal(`Code ${code}`);

--- a/packages/kernel/test/reporter.spec.ts
+++ b/packages/kernel/test/reporter.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { Reporter } from '../src/index';
 
-describe('The default Reporter', () => {
-  it('creates an Error with a minimal message upon request', () => {
+describe('The default Reporter', function() {
+  it('creates an Error with a minimal message upon request', function() {
     const code = 42;
     const error = Reporter.error(code);
     expect(error.message).to.equal(`Code ${code}`);

--- a/packages/kernel/test/resource.spec.ts
+++ b/packages/kernel/test/resource.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { Container } from '../src/di';
 import { RuntimeCompilationResources } from '../src/index';
 
-describe('RuntimeCompilationResources', function() {
+describe('RuntimeCompilationResources', function () {
 
-  it('does not register while finding resource', function() {
+  it('does not register while finding resource', function () {
     const container = new Container();
     const resources = new RuntimeCompilationResources(container as any);
 

--- a/packages/kernel/test/resource.spec.ts
+++ b/packages/kernel/test/resource.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { Container } from '../src/di';
 import { RuntimeCompilationResources } from '../src/index';
 
-describe('RuntimeCompilationResources', () => {
+describe('RuntimeCompilationResources', function() {
 
-  it('does not register while finding resource', () => {
+  it('does not register while finding resource', function() {
     const container = new Container();
     const resources = new RuntimeCompilationResources(container as any);
 

--- a/packages/plugin-requirejs/src/component.ts
+++ b/packages/plugin-requirejs/src/component.ts
@@ -21,7 +21,7 @@ export function load(name: string, req: Require, onLoad: RequireOnLoad, config: 
       const description = createTemplateDescription(text);
       const depsToLoad = processImports(description.imports, name);
 
-      req(depsToLoad, function(): void {
+      req(depsToLoad, function (): void {
         const templateImport = parseImport(name);
         const templateSource = {
           name: kebabCase(templateImport.basename),
@@ -49,7 +49,7 @@ export function write(pluginName: string, moduleName: string, writer: (content: 
 
     depsToLoad.unshift('@aurelia/runtime');
 
-    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function() {
+    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function () {
       var Component = arguments[0].Component;
       var templateSource = {
         name: '${kebabCase(templateImport.basename)}',

--- a/packages/plugin-requirejs/src/view.ts
+++ b/packages/plugin-requirejs/src/view.ts
@@ -22,7 +22,7 @@ export function load(name: string, req: Require, onLoad: RequireOnLoad, config: 
       const depsToLoad = processImports(description.imports, name);
       const templateImport = parseImport(name);
 
-      req(depsToLoad, function(): void {
+      req(depsToLoad, function (): void {
         const templateSource = {
           name: kebabCase(templateImport.basename),
           template: description.template,
@@ -47,7 +47,7 @@ export function write(pluginName: string, moduleName: string, writer: (content: 
     const depsToLoadMapped = depsToLoad.map(x => `"${x}"`).join(',');
     const templateImport = parseImport(moduleName);
 
-    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function() {
+    writer(`define("${pluginName}!${moduleName}", [${depsToLoadMapped}], function () {
       var templateSource = {
         name: '${kebabCase(templateImport.basename)}',
         template: '${escape(description.template)}',

--- a/packages/router/test/unit/history-browser.spec.ts
+++ b/packages/router/test/unit/history-browser.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { HistoryBrowser } from '../../src/index';
 
-describe('HistoryBrowser', () => {
-  it('can be created', () => {
+describe('HistoryBrowser', function() {
+  it('can be created', function() {
     new HistoryBrowser();
   });
 });

--- a/packages/router/test/unit/history-browser.spec.ts
+++ b/packages/router/test/unit/history-browser.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 import { HistoryBrowser } from '../../src/index';
 
-describe('HistoryBrowser', function() {
-  it('can be created', function() {
+describe('HistoryBrowser', function () {
+  it('can be created', function () {
     new HistoryBrowser();
   });
 });

--- a/packages/router/test/unit/link-handler.spec.ts
+++ b/packages/router/test/unit/link-handler.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { LinkHandler } from './../../src/index';
 
-describe('LinkHandler', function() {
+describe('LinkHandler', function () {
   let linkHandler;
   const callback = ((info) => { return; });
   class MockDocument {
@@ -10,16 +10,16 @@ describe('LinkHandler', function() {
     public removeEventListener(handler) { return; }
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     linkHandler = new LinkHandler();
     linkHandler.document = new MockDocument();
   });
 
-  it('can be created', function() {
+  it('can be created', function () {
     expect(linkHandler).not.to.equal(null);
   });
 
-  it('can be activated', function() {
+  it('can be activated', function () {
     const callbackSpy = spy(linkHandler.document, 'addEventListener');
     linkHandler.activate({ callback: callback});
 
@@ -27,7 +27,7 @@ describe('LinkHandler', function() {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('can be deactivated', function() {
+  it('can be deactivated', function () {
     const callbackSpy = spy(linkHandler.document, 'removeEventListener');
     linkHandler.deactivate();
 
@@ -35,7 +35,7 @@ describe('LinkHandler', function() {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('throws when activated while active', function() {
+  it('throws when activated while active', function () {
     const callbackSpy = spy(linkHandler.document, 'addEventListener');
     linkHandler.activate({ callback: callback});
 

--- a/packages/router/test/unit/link-handler.spec.ts
+++ b/packages/router/test/unit/link-handler.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { LinkHandler } from './../../src/index';
 
-describe('LinkHandler', () => {
+describe('LinkHandler', function() {
   let linkHandler;
   const callback = ((info) => { return; });
   class MockDocument {
@@ -10,16 +10,16 @@ describe('LinkHandler', () => {
     public removeEventListener(handler) { return; }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     linkHandler = new LinkHandler();
     linkHandler.document = new MockDocument();
   });
 
-  it('can be created', () => {
+  it('can be created', function() {
     expect(linkHandler).not.to.equal(null);
   });
 
-  it('can be activated', () => {
+  it('can be activated', function() {
     const callbackSpy = spy(linkHandler.document, 'addEventListener');
     linkHandler.activate({ callback: callback});
 
@@ -27,7 +27,7 @@ describe('LinkHandler', () => {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('can be deactivated', () => {
+  it('can be deactivated', function() {
     const callbackSpy = spy(linkHandler.document, 'removeEventListener');
     linkHandler.deactivate();
 
@@ -35,7 +35,7 @@ describe('LinkHandler', () => {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('throws when activated while active', () => {
+  it('throws when activated while active', function() {
     const callbackSpy = spy(linkHandler.document, 'addEventListener');
     linkHandler.activate({ callback: callback});
 

--- a/packages/router/test/unit/nav.spec.ts
+++ b/packages/router/test/unit/nav.spec.ts
@@ -6,7 +6,7 @@ import { NavCustomElement, Router, ViewportCustomElement } from '../../src/index
 import { MockBrowserHistoryLocation } from '../mock/browser-history-location.mock';
 import { registerComponent } from './utils';
 
-describe('Nav', function() {
+describe('Nav', function () {
   it('generates nav with a link', async function () {
     this.timeout(30000);
     const { host, router } = await setup('foo');

--- a/packages/router/test/unit/nav.spec.ts
+++ b/packages/router/test/unit/nav.spec.ts
@@ -6,7 +6,7 @@ import { NavCustomElement, Router, ViewportCustomElement } from '../../src/index
 import { MockBrowserHistoryLocation } from '../mock/browser-history-location.mock';
 import { registerComponent } from './utils';
 
-describe('Nav', () => {
+describe('Nav', function() {
   it('generates nav with a link', async function () {
     this.timeout(30000);
     const { host, router } = await setup('foo');

--- a/packages/router/test/unit/queued-browser-history.spec.ts
+++ b/packages/router/test/unit/queued-browser-history.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { QueuedBrowserHistory } from './../../src/index';
 
-describe('QueuedBrowserHistory', function() {
+describe('QueuedBrowserHistory', function () {
   let qbh;
   const callback = ((info) => { return; });
   class MockWindow {
@@ -10,16 +10,16 @@ describe('QueuedBrowserHistory', function() {
     public removeEventListener(handler) { return; }
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     qbh = new QueuedBrowserHistory();
     qbh.window = new MockWindow();
   });
 
-  it('can be created', function() {
+  it('can be created', function () {
     expect(qbh).not.to.equal(null);
   });
 
-  it('can be activated', function() {
+  it('can be activated', function () {
     const callbackSpy = spy(qbh.window, 'addEventListener');
     qbh.activate({ callback: callback});
 
@@ -27,7 +27,7 @@ describe('QueuedBrowserHistory', function() {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('can be deactivated', function() {
+  it('can be deactivated', function () {
     const callbackSpy = spy(qbh.window, 'removeEventListener');
     qbh.deactivate();
 
@@ -35,7 +35,7 @@ describe('QueuedBrowserHistory', function() {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('throws when activated while active', function() {
+  it('throws when activated while active', function () {
     const callbackSpy = spy(qbh.window, 'addEventListener');
     qbh.activate({ callback: callback});
 
@@ -51,7 +51,7 @@ describe('QueuedBrowserHistory', function() {
     expect(err.message).to.contain('Queued browser history has already been activated');
   });
 
-  it('queues consecutive calls', async function() {
+  it('queues consecutive calls', async function () {
     const callbackSpy = spy(qbh, 'dequeue');
     qbh.activate({ callback: callback});
 

--- a/packages/router/test/unit/queued-browser-history.spec.ts
+++ b/packages/router/test/unit/queued-browser-history.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { QueuedBrowserHistory } from './../../src/index';
 
-describe('QueuedBrowserHistory', () => {
+describe('QueuedBrowserHistory', function() {
   let qbh;
   const callback = ((info) => { return; });
   class MockWindow {
@@ -10,16 +10,16 @@ describe('QueuedBrowserHistory', () => {
     public removeEventListener(handler) { return; }
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     qbh = new QueuedBrowserHistory();
     qbh.window = new MockWindow();
   });
 
-  it('can be created', () => {
+  it('can be created', function() {
     expect(qbh).not.to.equal(null);
   });
 
-  it('can be activated', () => {
+  it('can be activated', function() {
     const callbackSpy = spy(qbh.window, 'addEventListener');
     qbh.activate({ callback: callback});
 
@@ -27,7 +27,7 @@ describe('QueuedBrowserHistory', () => {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('can be deactivated', () => {
+  it('can be deactivated', function() {
     const callbackSpy = spy(qbh.window, 'removeEventListener');
     qbh.deactivate();
 
@@ -35,7 +35,7 @@ describe('QueuedBrowserHistory', () => {
     expect(callbackSpy.calledOnce).to.equal(true);
   });
 
-  it('throws when activated while active', () => {
+  it('throws when activated while active', function() {
     const callbackSpy = spy(qbh.window, 'addEventListener');
     qbh.activate({ callback: callback});
 
@@ -51,7 +51,7 @@ describe('QueuedBrowserHistory', () => {
     expect(err.message).to.contain('Queued browser history has already been activated');
   });
 
-  it('queues consecutive calls', async () => {
+  it('queues consecutive calls', async function() {
     const callbackSpy = spy(qbh, 'dequeue');
     qbh.activate({ callback: callback});
 

--- a/packages/router/test/unit/route-recognizer.spec.ts
+++ b/packages/router/test/unit/route-recognizer.spec.ts
@@ -7,7 +7,7 @@ const dynamicRoute = {'path': 'dynamic/:id', 'handler': {'name': 'dynamic'}};
 const optionalRoute = {'path': 'optional/:id?', 'handler': {'name': 'optional'}};
 const multiNameRoute = {'path': 'static', 'handler': {'name': ['static-multiple', 'static-multiple-alias']}};
 
-describe('route sut', function() {
+describe('route sut', function () {
   interface Spec {
     t: string;
   }
@@ -146,7 +146,7 @@ describe('route sut', function() {
     }
   ];
 
-  it('should reject unknown routes', function() {
+  it('should reject unknown routes', function () {
     const sut = new RouteRecognizer();
 
     expect(sut.hasRoute('static')).to.equal(false);
@@ -155,13 +155,13 @@ describe('route sut', function() {
     expect(sut.recognize('/notfound')).to.equal(undefined);
   });
 
-  it('should reject default parameter values', function() {
+  it('should reject default parameter values', function () {
     const sut = new RouteRecognizer();
 
     expect(() => sut.add([{'path': 'user/:id=1', 'handler': {}}])).to.throw();
   });
 
-  it('should register unnamed routes', function() {
+  it('should register unnamed routes', function () {
     const sut = new RouteRecognizer();
     sut.add([{'path': 'b', 'handler': {}}]);
 
@@ -170,7 +170,7 @@ describe('route sut', function() {
   });
 
   eachCartesianJoin([routeSpecs], function(routeSpec) {
-    it(`should recognize - ${routeSpec.t}`, function() {
+    it(`should recognize - ${routeSpec.t}`, function () {
       const { route, path, isDynamic, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -183,7 +183,7 @@ describe('route sut', function() {
       expect(result[0].params).to.deep.equal(params);
     });
 
-    it(`is case insensitive by default - ${routeSpec.t}`, function() {
+    it(`is case insensitive by default - ${routeSpec.t}`, function () {
       const { route, path, isDynamic, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -201,7 +201,7 @@ describe('route sut', function() {
       });
     });
 
-    it(`should generate - ${routeSpec.t}`, function() {
+    it(`should generate - ${routeSpec.t}`, function () {
       const { route, path, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -210,7 +210,7 @@ describe('route sut', function() {
     });
   });
 
-  it('should require dynamic segment parameters when generating', function() {
+  it('should require dynamic segment parameters when generating', function () {
     const sut = new RouteRecognizer();
     sut.add([dynamicRoute]);
 
@@ -219,7 +219,7 @@ describe('route sut', function() {
     expect(() => sut.generate('dynamic', { id: null })).to.throw();
   });
 
-  it('should generate URIs with extra parameters added to the query string', function() {
+  it('should generate URIs with extra parameters added to the query string', function () {
     const sut = new RouteRecognizer();
     sut.add([staticRoute]);
     sut.add([dynamicRoute]);
@@ -232,7 +232,7 @@ describe('route sut', function() {
     expect(sut.generate('dynamic', { id: 1, test: 2 })).to.equal('/dynamic/1?test=2');
   });
 
-  it('should find handlers by route name', function() {
+  it('should find handlers by route name', function () {
     const sut = new RouteRecognizer();
     sut.add([staticRoute]);
 
@@ -240,7 +240,7 @@ describe('route sut', function() {
     expect(sut.handlersFor('static')[0].handler).to.equal(staticRoute.handler);
   });
 
-  it('should find a handler by multiple names', function() {
+  it('should find a handler by multiple names', function () {
     const sut = new RouteRecognizer();
     sut.add([multiNameRoute]);
 
@@ -248,7 +248,7 @@ describe('route sut', function() {
       .to.equal(sut.handlersFor('static-multiple-alias')[0].handler);
   });
 
-  it('should distinguish between dynamic and static parts', function() {
+  it('should distinguish between dynamic and static parts', function () {
     const sut = new RouteRecognizer();
     const similarRoute = { 'path': 'optionalToo/:id?', 'handler': { 'name': 'similar' }};
     sut.add([optionalRoute, similarRoute]);
@@ -258,7 +258,7 @@ describe('route sut', function() {
     expect(result[0].handler.name).to.equal('similar');
   });
 
-  it('can set case sensitive route and fails', function() {
+  it('can set case sensitive route and fails', function () {
     const sut = new RouteRecognizer();
     const routeTest = {
       t: 'case sensitive route',

--- a/packages/router/test/unit/route-recognizer.spec.ts
+++ b/packages/router/test/unit/route-recognizer.spec.ts
@@ -7,7 +7,7 @@ const dynamicRoute = {'path': 'dynamic/:id', 'handler': {'name': 'dynamic'}};
 const optionalRoute = {'path': 'optional/:id?', 'handler': {'name': 'optional'}};
 const multiNameRoute = {'path': 'static', 'handler': {'name': ['static-multiple', 'static-multiple-alias']}};
 
-describe('route sut', () => {
+describe('route sut', function() {
   interface Spec {
     t: string;
   }
@@ -146,7 +146,7 @@ describe('route sut', () => {
     }
   ];
 
-  it('should reject unknown routes', () => {
+  it('should reject unknown routes', function() {
     const sut = new RouteRecognizer();
 
     expect(sut.hasRoute('static')).to.equal(false);
@@ -155,13 +155,13 @@ describe('route sut', () => {
     expect(sut.recognize('/notfound')).to.equal(undefined);
   });
 
-  it('should reject default parameter values', () => {
+  it('should reject default parameter values', function() {
     const sut = new RouteRecognizer();
 
     expect(() => sut.add([{'path': 'user/:id=1', 'handler': {}}])).to.throw();
   });
 
-  it('should register unnamed routes', () => {
+  it('should register unnamed routes', function() {
     const sut = new RouteRecognizer();
     sut.add([{'path': 'b', 'handler': {}}]);
 
@@ -170,7 +170,7 @@ describe('route sut', () => {
   });
 
   eachCartesianJoin([routeSpecs], function(routeSpec) {
-    it(`should recognize - ${routeSpec.t}`, () => {
+    it(`should recognize - ${routeSpec.t}`, function() {
       const { route, path, isDynamic, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -183,7 +183,7 @@ describe('route sut', () => {
       expect(result[0].params).to.deep.equal(params);
     });
 
-    it(`is case insensitive by default - ${routeSpec.t}`, () => {
+    it(`is case insensitive by default - ${routeSpec.t}`, function() {
       const { route, path, isDynamic, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -201,7 +201,7 @@ describe('route sut', () => {
       });
     });
 
-    it(`should generate - ${routeSpec.t}`, () => {
+    it(`should generate - ${routeSpec.t}`, function() {
       const { route, path, params } = routeSpec;
       const sut = new RouteRecognizer();
       sut.add([route]);
@@ -210,7 +210,7 @@ describe('route sut', () => {
     });
   });
 
-  it('should require dynamic segment parameters when generating', () => {
+  it('should require dynamic segment parameters when generating', function() {
     const sut = new RouteRecognizer();
     sut.add([dynamicRoute]);
 
@@ -219,7 +219,7 @@ describe('route sut', () => {
     expect(() => sut.generate('dynamic', { id: null })).to.throw();
   });
 
-  it('should generate URIs with extra parameters added to the query string', () => {
+  it('should generate URIs with extra parameters added to the query string', function() {
     const sut = new RouteRecognizer();
     sut.add([staticRoute]);
     sut.add([dynamicRoute]);
@@ -232,7 +232,7 @@ describe('route sut', () => {
     expect(sut.generate('dynamic', { id: 1, test: 2 })).to.equal('/dynamic/1?test=2');
   });
 
-  it('should find handlers by route name', () => {
+  it('should find handlers by route name', function() {
     const sut = new RouteRecognizer();
     sut.add([staticRoute]);
 
@@ -240,7 +240,7 @@ describe('route sut', () => {
     expect(sut.handlersFor('static')[0].handler).to.equal(staticRoute.handler);
   });
 
-  it('should find a handler by multiple names', () => {
+  it('should find a handler by multiple names', function() {
     const sut = new RouteRecognizer();
     sut.add([multiNameRoute]);
 
@@ -248,7 +248,7 @@ describe('route sut', () => {
       .to.equal(sut.handlersFor('static-multiple-alias')[0].handler);
   });
 
-  it('should distinguish between dynamic and static parts', () => {
+  it('should distinguish between dynamic and static parts', function() {
     const sut = new RouteRecognizer();
     const similarRoute = { 'path': 'optionalToo/:id?', 'handler': { 'name': 'similar' }};
     sut.add([optionalRoute, similarRoute]);
@@ -258,7 +258,7 @@ describe('route sut', () => {
     expect(result[0].handler.name).to.equal('similar');
   });
 
-  it('can set case sensitive route and fails', () => {
+  it('can set case sensitive route and fails', function() {
     const sut = new RouteRecognizer();
     const routeTest = {
       t: 'case sensitive route',

--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -8,7 +8,7 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('Router', function() {
+describe('Router', function () {
   it('can be created', async function () {
     this.timeout(30000);
     const { host, router } = await setup();

--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -8,7 +8,7 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('Router', () => {
+describe('Router', function() {
   it('can be created', async function () {
     this.timeout(30000);
     const { host, router } = await setup();

--- a/packages/router/test/unit/viewport-content.spec.ts
+++ b/packages/router/test/unit/viewport-content.spec.ts
@@ -8,8 +8,8 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('ViewportContent', function() {
-  it('can be created', function() {
+describe('ViewportContent', function () {
+  it('can be created', function () {
     const sut = new ViewportContent();
   });
 

--- a/packages/router/test/unit/viewport-content.spec.ts
+++ b/packages/router/test/unit/viewport-content.spec.ts
@@ -8,8 +8,8 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('ViewportContent', () => {
-  it('can be created', () => {
+describe('ViewportContent', function() {
+  it('can be created', function() {
     const sut = new ViewportContent();
   });
 

--- a/packages/router/test/unit/viewport.spec.ts
+++ b/packages/router/test/unit/viewport.spec.ts
@@ -7,8 +7,8 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('Viewport', function() {
-  it('can be created', function() {
+describe('Viewport', function () {
+  it('can be created', function () {
     const sut = new Viewport(null, null, null, null, null, null);
   });
 });

--- a/packages/router/test/unit/viewport.spec.ts
+++ b/packages/router/test/unit/viewport.spec.ts
@@ -7,8 +7,8 @@ import { registerComponent } from './utils';
 
 const define = (CustomElementResource as any).define;
 
-describe('Viewport', () => {
-  it('can be created', () => {
+describe('Viewport', function() {
+  it('can be created', function() {
     const sut = new Viewport(null, null, null, null, null, null);
   });
 });

--- a/packages/runtime-html/test/create-element.spec.ts
+++ b/packages/runtime-html/test/create-element.spec.ts
@@ -20,10 +20,10 @@ import {
   TestContext
 } from './util';
 
-describe(`createElement() creates element based on tag`, function() {
+describe(`createElement() creates element based on tag`, function () {
   eachCartesianJoin([['div', 'template']], (tag: string) => {
-    describe(`tag=${tag}`, function() {
-      it(`translates raw object properties to attributes`, function() {
+    describe(`tag=${tag}`, function () {
+      it(`translates raw object properties to attributes`, function () {
         const ctx = TestContext.createHTMLTestContext();
         const actual = sut(ctx.dom, tag, { title: 'asdf', foo: 'bar' });
 
@@ -37,7 +37,7 @@ describe(`createElement() creates element based on tag`, function() {
       });
 
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
-        it(`can handle ${str} props`, function() {
+        it(`can handle ${str} props`, function () {
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
           const actual = sut(ctx.dom, tag, props);
@@ -70,7 +70,7 @@ describe(`createElement() creates element based on tag`, function() {
           ]
         ],
         t => {
-        it(`understands targeted instruction type=${t}`, function() {
+        it(`understands targeted instruction type=${t}`, function () {
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
           const actual = sut(ctx.dom, tag, { prop: { type: t }});
@@ -100,7 +100,7 @@ describe(`createElement() creates element based on tag`, function() {
           (ctx, [children, expected]) => [[sut(ctx.dom, 'div', null, [ctx.createElementFromMarkup('<div>baz</div>')]), ...children], `baz${expected}`]
         ] as ((ctx: HTMLTestContext, $1: [(RenderPlan | string | INode)[], string]) => [(RenderPlan | string | INode)[], string])[]
       ],                       (ctx, $1, [children, expected]) => {
-        it(_`adds children (${children})`, function() {
+        it(_`adds children (${children})`, function () {
           const actual = sut(ctx.dom, tag, null, children);
 
           const node = actual['node'] as Element;
@@ -115,7 +115,7 @@ describe(`createElement() creates element based on tag`, function() {
   });
 });
 
-describe(`createElement() creates element based on type`, function() {
+describe(`createElement() creates element based on type`, function () {
   eachCartesianJoin([
     [
       () => CustomElementResource.define({ name: 'foo' }, class Foo {}),
@@ -123,8 +123,8 @@ describe(`createElement() creates element based on type`, function() {
     ] as (() => ICustomElementType)[]
   ],
                     (createType: () => ICustomElementType) => {
-    describe(_`type=${createType()}`, function() {
-      it(`translates raw object properties to attributes`, function() {
+    describe(_`type=${createType()}`, function () {
+      it(`translates raw object properties to attributes`, function () {
         const ctx = TestContext.createHTMLTestContext();
         const type = createType();
         const actual = sut(ctx.dom, type, { title: 'asdf', foo: 'bar' });
@@ -154,7 +154,7 @@ describe(`createElement() creates element based on type`, function() {
       });
 
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
-        it(`can handle ${str} props`, function() {
+        it(`can handle ${str} props`, function () {
           const type = createType();
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
@@ -191,7 +191,7 @@ describe(`createElement() creates element based on type`, function() {
           ]
         ],
         t => {
-        it(`understands targeted instruction type=${t}`, function() {
+        it(`understands targeted instruction type=${t}`, function () {
           const type = createType();
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
@@ -225,7 +225,7 @@ describe(`createElement() creates element based on type`, function() {
           (ctx, [children, expected]) => [[sut(ctx.dom, 'div', null, [ctx.createElementFromMarkup('<div>baz</div>')]), ...children], `baz${expected}`]
         ] as ((ctx: HTMLTestContext, $1: [(RenderPlan | string | INode)[], string]) => [(RenderPlan | string | INode)[], string])[]
       ],                       (ctx, $1, [children, expected]) => {
-        it(_`adds children (${children})`, function() {
+        it(_`adds children (${children})`, function () {
           const type = createType();
           const actual = sut(ctx.dom, type, null, children);
 

--- a/packages/runtime-html/test/create-element.spec.ts
+++ b/packages/runtime-html/test/create-element.spec.ts
@@ -20,10 +20,10 @@ import {
   TestContext
 } from './util';
 
-describe(`createElement() creates element based on tag`, () => {
+describe(`createElement() creates element based on tag`, function() {
   eachCartesianJoin([['div', 'template']], (tag: string) => {
-    describe(`tag=${tag}`, () => {
-      it(`translates raw object properties to attributes`, () => {
+    describe(`tag=${tag}`, function() {
+      it(`translates raw object properties to attributes`, function() {
         const ctx = TestContext.createHTMLTestContext();
         const actual = sut(ctx.dom, tag, { title: 'asdf', foo: 'bar' });
 
@@ -37,7 +37,7 @@ describe(`createElement() creates element based on tag`, () => {
       });
 
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
-        it(`can handle ${str} props`, () => {
+        it(`can handle ${str} props`, function() {
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
           const actual = sut(ctx.dom, tag, props);
@@ -70,7 +70,7 @@ describe(`createElement() creates element based on tag`, () => {
           ]
         ],
         t => {
-        it(`understands targeted instruction type=${t}`, () => {
+        it(`understands targeted instruction type=${t}`, function() {
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
           const actual = sut(ctx.dom, tag, { prop: { type: t }});
@@ -100,7 +100,7 @@ describe(`createElement() creates element based on tag`, () => {
           (ctx, [children, expected]) => [[sut(ctx.dom, 'div', null, [ctx.createElementFromMarkup('<div>baz</div>')]), ...children], `baz${expected}`]
         ] as ((ctx: HTMLTestContext, $1: [(RenderPlan | string | INode)[], string]) => [(RenderPlan | string | INode)[], string])[]
       ],                       (ctx, $1, [children, expected]) => {
-        it(_`adds children (${children})`, () => {
+        it(_`adds children (${children})`, function() {
           const actual = sut(ctx.dom, tag, null, children);
 
           const node = actual['node'] as Element;
@@ -115,7 +115,7 @@ describe(`createElement() creates element based on tag`, () => {
   });
 });
 
-describe(`createElement() creates element based on type`, () => {
+describe(`createElement() creates element based on type`, function() {
   eachCartesianJoin([
     [
       () => CustomElementResource.define({ name: 'foo' }, class Foo {}),
@@ -123,8 +123,8 @@ describe(`createElement() creates element based on type`, () => {
     ] as (() => ICustomElementType)[]
   ],
                     (createType: () => ICustomElementType) => {
-    describe(_`type=${createType()}`, () => {
-      it(`translates raw object properties to attributes`, () => {
+    describe(_`type=${createType()}`, function() {
+      it(`translates raw object properties to attributes`, function() {
         const ctx = TestContext.createHTMLTestContext();
         const type = createType();
         const actual = sut(ctx.dom, type, { title: 'asdf', foo: 'bar' });
@@ -154,7 +154,7 @@ describe(`createElement() creates element based on type`, () => {
       });
 
       eachCartesianJoin([[[null, 'null'], [undefined, 'undefined']]], ([props, str]) => {
-        it(`can handle ${str} props`, () => {
+        it(`can handle ${str} props`, function() {
           const type = createType();
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
@@ -191,7 +191,7 @@ describe(`createElement() creates element based on type`, () => {
           ]
         ],
         t => {
-        it(`understands targeted instruction type=${t}`, () => {
+        it(`understands targeted instruction type=${t}`, function() {
           const type = createType();
           const ctx = TestContext.createHTMLTestContext();
           //@ts-ignore
@@ -225,7 +225,7 @@ describe(`createElement() creates element based on type`, () => {
           (ctx, [children, expected]) => [[sut(ctx.dom, 'div', null, [ctx.createElementFromMarkup('<div>baz</div>')]), ...children], `baz${expected}`]
         ] as ((ctx: HTMLTestContext, $1: [(RenderPlan | string | INode)[], string]) => [(RenderPlan | string | INode)[], string])[]
       ],                       (ctx, $1, [children, expected]) => {
-        it(_`adds children (${children})`, () => {
+        it(_`adds children (${children})`, function() {
           const type = createType();
           const actual = sut(ctx.dom, type, null, children);
 

--- a/packages/runtime-html/test/dom.spec.ts
+++ b/packages/runtime-html/test/dom.spec.ts
@@ -31,10 +31,10 @@ function verifyDoesNotThrow(call: () => void): void {
   expect(err).to.equal(undefined);
 }
 
-describe('NodeSequenceFactory', () => {
+describe('NodeSequenceFactory', function() {
   const ctx = TestContext.createHTMLTestContext();
 
-  describe('createNodeSequenceFactory', () => {
+  describe('createNodeSequenceFactory', function() {
     const textArr = ['', 'text', '#text'];
     const elementsArr = [[''], ['div'], ['div', 'p']];
     const wrapperArr = ['', 'div', 'template'];
@@ -47,7 +47,7 @@ describe('NodeSequenceFactory', () => {
         for (const wrapper of wrapperArr) {
           const markup = wrap(elementsMarkup, wrapper);
 
-          it(`should create a factory that returns the correct markup for "${markup}"`, () => {
+          it(`should create a factory that returns the correct markup for "${markup}"`, function() {
             const factory = new NodeSequenceFactory(ctx.dom, markup);
             const view = factory.createNodeSequence();
             if (markup.length === 0) {
@@ -70,7 +70,7 @@ describe('NodeSequenceFactory', () => {
             }
           });
 
-          it(`should create a factory that always returns a view with a different fragment instance for "${markup}"`, () => {
+          it(`should create a factory that always returns a view with a different fragment instance for "${markup}"`, function() {
             const factory = new NodeSequenceFactory(ctx.dom, markup);
             const fragment1 = factory.createNodeSequence()['fragment'];
             const fragment2 = factory.createNodeSequence()['fragment'];
@@ -92,21 +92,21 @@ describe('NodeSequenceFactory', () => {
 
     const validInputArr: any[] = ['', 'asdf', 'div', 1, true, false, {}, new Error(), undefined, null, Symbol()];
     for (const validInput of validInputArr) {
-      it(`should not throw for valid input type "${typeof validInput}"`, () => {
+      it(`should not throw for valid input type "${typeof validInput}"`, function() {
         verifyDoesNotThrow(() => new NodeSequenceFactory(ctx.dom, validInput));
       });
     }
 
     const invalidInputArr: any[] = [];
     for (const invalidInput of invalidInputArr) {
-      it(`should throw for invalid input type "${typeof invalidInput}"`, () => {
+      it(`should throw for invalid input type "${typeof invalidInput}"`, function() {
         verifyThrows(() => new NodeSequenceFactory(ctx.dom, invalidInput));
       });
     }
   });
 });
 
-describe('dom', () => {
+describe('dom', function() {
   const ctx = TestContext.createHTMLTestContext();
   // reset dom after each test to make sure self-optimizations do not affect test outcomes
   const DOMBackup = Object.create(null);
@@ -118,7 +118,7 @@ describe('dom', () => {
     Object.assign(ctx.doc, DocumentBackup);
   }
 
-  before(() => {
+  before(function() {
     Object.assign(DOMBackup, ctx.dom);
     for (const propName in ctx.doc) {
       const prop = ctx.doc[propName];
@@ -128,41 +128,41 @@ describe('dom', () => {
     }
   });
 
-  afterEach(() => {
+  afterEach(function() {
     restoreBackups();
   });
 
-  describe('createElement', () => {
-    it('should call document.createElement', () => {
+  describe('createElement', function() {
+    it('should call document.createElement', function() {
       const spyCreateElement = ctx.doc.createElement = spy();
       ctx.dom.createElement('div');
       expect(spyCreateElement).to.have.been.calledWith('div');
     });
 
-    it('should create an element', () => {
+    it('should create an element', function() {
       const el = ctx.dom.createElement('div');
       expect(el['outerHTML']).to.equal('<div></div>');
     });
 
     const validInputArr: any[] = ['asdf', 'div', new Error(), true, false, undefined, null];
     for (const validInput of validInputArr) {
-      it(`should not throw for valid input type "${typeof validInput}"`, () => {
+      it(`should not throw for valid input type "${typeof validInput}"`, function() {
         verifyDoesNotThrow(ctx.dom.createElement.bind(ctx.dom, validInput));
       });
     }
 
     const invalidInputArr: any[] = ['', 1, {}, Object.create(null), Symbol()];
     for (const invalidInput of invalidInputArr) {
-      it(`should throw for invalid input type "${typeof invalidInput}"`, () => {
+      it(`should throw for invalid input type "${typeof invalidInput}"`, function() {
         verifyThrows(ctx.dom.createElement.bind(ctx.dom, invalidInput));
       });
     }
   });
 
-  describe('cloneNode', () => {
+  describe('cloneNode', function() {
     const trueValueArr: any[] = [undefined, null, {}, '', true];
     for (const trueValue of trueValueArr) {
-      it(`should call node.cloneNode(true) when given ${trueValue}`, () => {
+      it(`should call node.cloneNode(true) when given ${trueValue}`, function() {
         const node = ctx.dom.createElement('div');
         node.cloneNode = spy();
         ctx.dom.cloneNode(node, trueValue);
@@ -170,14 +170,14 @@ describe('dom', () => {
       });
     }
 
-    it('should call node.cloneNode(true) by default', () => {
+    it('should call node.cloneNode(true) by default', function() {
       const node = ctx.dom.createElement('div');
       node.cloneNode = spy();
       ctx.dom.cloneNode(node);
       expect(node.cloneNode).to.have.been.calledWith(true);
     });
 
-    it('should call node.cloneNode(false) if given false', () => {
+    it('should call node.cloneNode(false) if given false', function() {
       const node = ctx.dom.createElement('div');
       node.cloneNode = spy();
       ctx.dom.cloneNode(node, false);
@@ -185,7 +185,7 @@ describe('dom', () => {
     });
   });
 
-  describe('isNodeInstance', () => {
+  describe('isNodeInstance', function() {
     const nodes = [
       [ctx.dom.createElement('div'), '<div></div>'],
       [ctx.dom.createElement('asdf'), '<asdf></asdf>'],
@@ -196,7 +196,7 @@ describe('dom', () => {
       [ctx.doc.doctype, '#doctype'],
     ];
     for (const [node, text] of nodes) {
-      it(`should return true if the value is of type ${Object.prototype.toString.call(node)} (${text})`, () => {
+      it(`should return true if the value is of type ${Object.prototype.toString.call(node)} (${text})`, function() {
         const actual = ctx.dom.isNodeInstance(node);
         expect(actual).to.equal(true);
       });
@@ -207,15 +207,15 @@ describe('dom', () => {
       {}
     ];
     for (const nonNode of nonNodes) {
-      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, () => {
+      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, function() {
         const actual = ctx.dom.isNodeInstance(nonNode);
         expect(actual).to.equal(false);
       });
     }
   });
 
-  describe('remove', () => {
-    it('should remove the childNode from its parent (non-polyfilled)', () => {
+  describe('remove', function() {
+    it('should remove the childNode from its parent (non-polyfilled)', function() {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       node.appendChild(childNode);
@@ -223,7 +223,7 @@ describe('dom', () => {
       expect(node.childNodes.length).to.equal(0);
     });
 
-    it('should remove the childNode from its parent (polyfilled)', () => {
+    it('should remove the childNode from its parent (polyfilled)', function() {
       const remove = ctx.Element.prototype.remove;
       ctx.Element.prototype.remove = undefined;
       const node = ctx.dom.createElement('div');
@@ -235,8 +235,8 @@ describe('dom', () => {
     });
   });
 
-  describe('appendChild', () => {
-    it('should append the childNode to the given parent', () => {
+  describe('appendChild', function() {
+    it('should append the childNode to the given parent', function() {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       ctx.dom.appendChild(node, childNode);
@@ -244,8 +244,8 @@ describe('dom', () => {
     });
   });
 
-  describe('insertBefore', () => {
-    it('should insert the childNode before the referenceNode below the parent of the referenceNode', () => {
+  describe('insertBefore', function() {
+    it('should insert the childNode before the referenceNode below the parent of the referenceNode', function() {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       const refNode1 = ctx.dom.createElement('div');
@@ -259,7 +259,7 @@ describe('dom', () => {
     });
   });
 
-  describe('addEventListener', () => {
+  describe('addEventListener', function() {
     it('should add the specified eventListener to the node if the node is specified', done => {
       const node = ctx.dom.createElement('div');
       const eventListener = spy();
@@ -282,7 +282,7 @@ describe('dom', () => {
     });
   });
 
-  describe('removeEventListener', () => {
+  describe('removeEventListener', function() {
     it('should remove the specified eventListener from the node if the node is specified', done => {
       const node = ctx.dom.createElement('div');
       const eventListener = spy();
@@ -307,7 +307,7 @@ describe('dom', () => {
     });
   });
 
-  describe('convertToRenderLocation', () => {
+  describe('convertToRenderLocation', function() {
     function createTestNodes() {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
@@ -315,7 +315,7 @@ describe('dom', () => {
       return {node, childNode};
     }
 
-    it('should replace the provided node with two comment nodes', () => {
+    it('should replace the provided node with two comment nodes', function() {
       const {node, childNode} = createTestNodes();
       const location = ctx.dom.convertToRenderLocation(childNode);
       expect(location['nodeName']).to.equal('#comment');
@@ -328,7 +328,7 @@ describe('dom', () => {
     });
   });
 
-  describe('registerElementResolver', () => {
+  describe('registerElementResolver', function() {
     const keys = [INode, ctx.Node, ctx.Element, ctx.HTMLElement];
     if (typeof Node !== 'undefined') {
       keys.push(Node);
@@ -340,7 +340,7 @@ describe('dom', () => {
       keys.push(HTMLElement);
     }
     for (const key of keys) {
-      it(`should register the resolver for type ${Object.prototype.toString.call(key)}`, () => {
+      it(`should register the resolver for type ${Object.prototype.toString.call(key)}`, function() {
         const mockContainer: any = { registerResolver: spy() };
         const resolver: any = {};
         ctx.dom.registerElementResolver(mockContainer, resolver);
@@ -350,14 +350,14 @@ describe('dom', () => {
   });
 });
 
-describe('FragmentNodeSequence', () => {
+describe('FragmentNodeSequence', function() {
   const ctx = TestContext.createHTMLTestContext();
   let sut: FragmentNodeSequence;
 
   const widthArr = [1, 2, 3];
-  describe('constructor', () => {
+  describe('constructor', function() {
     for (const width of widthArr) {
-      it(`should correctly assign children (depth=1,width=${width})`, () => {
+      it(`should correctly assign children (depth=1,width=${width})`, function() {
         const node = ctx.dom.createElement('div');
         const fragment = createFragment(ctx, node, 0, 1, width);
         sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -368,11 +368,11 @@ describe('FragmentNodeSequence', () => {
     }
   });
   const depthArr = [0, 1, 2, 3];
-  describe('findTargets', () => {
+  describe('findTargets', function() {
     for (const width of widthArr) {
       for (const depth of depthArr) {
         // note: these findTargets tests are quite redundant, but the basic setup might come in handy later
-        it(`should return empty array when there are no targets (depth=${depth},width=${width})`, () => {
+        it(`should return empty array when there are no targets (depth=${depth},width=${width})`, function() {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -380,7 +380,7 @@ describe('FragmentNodeSequence', () => {
           expect(actual.length).to.equal(0);
         });
 
-        it(`should return all elements when all are targets targets (depth=${depth},width=${width})`, () => {
+        it(`should return all elements when all are targets targets (depth=${depth},width=${width})`, function() {
           const node = ctx.dom.createElement('div');
           node.classList.add('au');
           const fragment = createFragment(ctx, node, 0, depth, width);
@@ -392,10 +392,10 @@ describe('FragmentNodeSequence', () => {
     }
   });
 
-  describe('insertBefore', () => {
+  describe('insertBefore', function() {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should insert the view before the refNode under the parent of the refNode (depth=${depth},width=${width})`, () => {
+        it(`should insert the view before the refNode under the parent of the refNode (depth=${depth},width=${width})`, function() {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -421,10 +421,10 @@ describe('FragmentNodeSequence', () => {
     }
   });
 
-  describe('appendTo', () => {
+  describe('appendTo', function() {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should append the view to the parent (depth=${depth},width=${width})`, () => {
+        it(`should append the view to the parent (depth=${depth},width=${width})`, function() {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -442,10 +442,10 @@ describe('FragmentNodeSequence', () => {
     }
   });
 
-  describe('remove', () => {
+  describe('remove', function() {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should put the view back into the fragment (depth=${depth},width=${width})`, () => {
+        it(`should put the view back into the fragment (depth=${depth},width=${width})`, function() {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);

--- a/packages/runtime-html/test/dom.spec.ts
+++ b/packages/runtime-html/test/dom.spec.ts
@@ -31,10 +31,10 @@ function verifyDoesNotThrow(call: () => void): void {
   expect(err).to.equal(undefined);
 }
 
-describe('NodeSequenceFactory', function() {
+describe('NodeSequenceFactory', function () {
   const ctx = TestContext.createHTMLTestContext();
 
-  describe('createNodeSequenceFactory', function() {
+  describe('createNodeSequenceFactory', function () {
     const textArr = ['', 'text', '#text'];
     const elementsArr = [[''], ['div'], ['div', 'p']];
     const wrapperArr = ['', 'div', 'template'];
@@ -47,7 +47,7 @@ describe('NodeSequenceFactory', function() {
         for (const wrapper of wrapperArr) {
           const markup = wrap(elementsMarkup, wrapper);
 
-          it(`should create a factory that returns the correct markup for "${markup}"`, function() {
+          it(`should create a factory that returns the correct markup for "${markup}"`, function () {
             const factory = new NodeSequenceFactory(ctx.dom, markup);
             const view = factory.createNodeSequence();
             if (markup.length === 0) {
@@ -70,7 +70,7 @@ describe('NodeSequenceFactory', function() {
             }
           });
 
-          it(`should create a factory that always returns a view with a different fragment instance for "${markup}"`, function() {
+          it(`should create a factory that always returns a view with a different fragment instance for "${markup}"`, function () {
             const factory = new NodeSequenceFactory(ctx.dom, markup);
             const fragment1 = factory.createNodeSequence()['fragment'];
             const fragment2 = factory.createNodeSequence()['fragment'];
@@ -92,21 +92,21 @@ describe('NodeSequenceFactory', function() {
 
     const validInputArr: any[] = ['', 'asdf', 'div', 1, true, false, {}, new Error(), undefined, null, Symbol()];
     for (const validInput of validInputArr) {
-      it(`should not throw for valid input type "${typeof validInput}"`, function() {
+      it(`should not throw for valid input type "${typeof validInput}"`, function () {
         verifyDoesNotThrow(() => new NodeSequenceFactory(ctx.dom, validInput));
       });
     }
 
     const invalidInputArr: any[] = [];
     for (const invalidInput of invalidInputArr) {
-      it(`should throw for invalid input type "${typeof invalidInput}"`, function() {
+      it(`should throw for invalid input type "${typeof invalidInput}"`, function () {
         verifyThrows(() => new NodeSequenceFactory(ctx.dom, invalidInput));
       });
     }
   });
 });
 
-describe('dom', function() {
+describe('dom', function () {
   const ctx = TestContext.createHTMLTestContext();
   // reset dom after each test to make sure self-optimizations do not affect test outcomes
   const DOMBackup = Object.create(null);
@@ -118,7 +118,7 @@ describe('dom', function() {
     Object.assign(ctx.doc, DocumentBackup);
   }
 
-  before(function() {
+  before(function () {
     Object.assign(DOMBackup, ctx.dom);
     for (const propName in ctx.doc) {
       const prop = ctx.doc[propName];
@@ -128,41 +128,41 @@ describe('dom', function() {
     }
   });
 
-  afterEach(function() {
+  afterEach(function () {
     restoreBackups();
   });
 
-  describe('createElement', function() {
-    it('should call document.createElement', function() {
+  describe('createElement', function () {
+    it('should call document.createElement', function () {
       const spyCreateElement = ctx.doc.createElement = spy();
       ctx.dom.createElement('div');
       expect(spyCreateElement).to.have.been.calledWith('div');
     });
 
-    it('should create an element', function() {
+    it('should create an element', function () {
       const el = ctx.dom.createElement('div');
       expect(el['outerHTML']).to.equal('<div></div>');
     });
 
     const validInputArr: any[] = ['asdf', 'div', new Error(), true, false, undefined, null];
     for (const validInput of validInputArr) {
-      it(`should not throw for valid input type "${typeof validInput}"`, function() {
+      it(`should not throw for valid input type "${typeof validInput}"`, function () {
         verifyDoesNotThrow(ctx.dom.createElement.bind(ctx.dom, validInput));
       });
     }
 
     const invalidInputArr: any[] = ['', 1, {}, Object.create(null), Symbol()];
     for (const invalidInput of invalidInputArr) {
-      it(`should throw for invalid input type "${typeof invalidInput}"`, function() {
+      it(`should throw for invalid input type "${typeof invalidInput}"`, function () {
         verifyThrows(ctx.dom.createElement.bind(ctx.dom, invalidInput));
       });
     }
   });
 
-  describe('cloneNode', function() {
+  describe('cloneNode', function () {
     const trueValueArr: any[] = [undefined, null, {}, '', true];
     for (const trueValue of trueValueArr) {
-      it(`should call node.cloneNode(true) when given ${trueValue}`, function() {
+      it(`should call node.cloneNode(true) when given ${trueValue}`, function () {
         const node = ctx.dom.createElement('div');
         node.cloneNode = spy();
         ctx.dom.cloneNode(node, trueValue);
@@ -170,14 +170,14 @@ describe('dom', function() {
       });
     }
 
-    it('should call node.cloneNode(true) by default', function() {
+    it('should call node.cloneNode(true) by default', function () {
       const node = ctx.dom.createElement('div');
       node.cloneNode = spy();
       ctx.dom.cloneNode(node);
       expect(node.cloneNode).to.have.been.calledWith(true);
     });
 
-    it('should call node.cloneNode(false) if given false', function() {
+    it('should call node.cloneNode(false) if given false', function () {
       const node = ctx.dom.createElement('div');
       node.cloneNode = spy();
       ctx.dom.cloneNode(node, false);
@@ -185,7 +185,7 @@ describe('dom', function() {
     });
   });
 
-  describe('isNodeInstance', function() {
+  describe('isNodeInstance', function () {
     const nodes = [
       [ctx.dom.createElement('div'), '<div></div>'],
       [ctx.dom.createElement('asdf'), '<asdf></asdf>'],
@@ -196,7 +196,7 @@ describe('dom', function() {
       [ctx.doc.doctype, '#doctype'],
     ];
     for (const [node, text] of nodes) {
-      it(`should return true if the value is of type ${Object.prototype.toString.call(node)} (${text})`, function() {
+      it(`should return true if the value is of type ${Object.prototype.toString.call(node)} (${text})`, function () {
         const actual = ctx.dom.isNodeInstance(node);
         expect(actual).to.equal(true);
       });
@@ -207,15 +207,15 @@ describe('dom', function() {
       {}
     ];
     for (const nonNode of nonNodes) {
-      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, function() {
+      it(`should return false if the value is of type ${Object.prototype.toString.call(nonNode)}`, function () {
         const actual = ctx.dom.isNodeInstance(nonNode);
         expect(actual).to.equal(false);
       });
     }
   });
 
-  describe('remove', function() {
-    it('should remove the childNode from its parent (non-polyfilled)', function() {
+  describe('remove', function () {
+    it('should remove the childNode from its parent (non-polyfilled)', function () {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       node.appendChild(childNode);
@@ -223,7 +223,7 @@ describe('dom', function() {
       expect(node.childNodes.length).to.equal(0);
     });
 
-    it('should remove the childNode from its parent (polyfilled)', function() {
+    it('should remove the childNode from its parent (polyfilled)', function () {
       const remove = ctx.Element.prototype.remove;
       ctx.Element.prototype.remove = undefined;
       const node = ctx.dom.createElement('div');
@@ -235,8 +235,8 @@ describe('dom', function() {
     });
   });
 
-  describe('appendChild', function() {
-    it('should append the childNode to the given parent', function() {
+  describe('appendChild', function () {
+    it('should append the childNode to the given parent', function () {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       ctx.dom.appendChild(node, childNode);
@@ -244,8 +244,8 @@ describe('dom', function() {
     });
   });
 
-  describe('insertBefore', function() {
-    it('should insert the childNode before the referenceNode below the parent of the referenceNode', function() {
+  describe('insertBefore', function () {
+    it('should insert the childNode before the referenceNode below the parent of the referenceNode', function () {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
       const refNode1 = ctx.dom.createElement('div');
@@ -259,7 +259,7 @@ describe('dom', function() {
     });
   });
 
-  describe('addEventListener', function() {
+  describe('addEventListener', function () {
     it('should add the specified eventListener to the node if the node is specified', done => {
       const node = ctx.dom.createElement('div');
       const eventListener = spy();
@@ -282,7 +282,7 @@ describe('dom', function() {
     });
   });
 
-  describe('removeEventListener', function() {
+  describe('removeEventListener', function () {
     it('should remove the specified eventListener from the node if the node is specified', done => {
       const node = ctx.dom.createElement('div');
       const eventListener = spy();
@@ -307,7 +307,7 @@ describe('dom', function() {
     });
   });
 
-  describe('convertToRenderLocation', function() {
+  describe('convertToRenderLocation', function () {
     function createTestNodes() {
       const node = ctx.dom.createElement('div');
       const childNode = ctx.dom.createElement('div');
@@ -315,7 +315,7 @@ describe('dom', function() {
       return {node, childNode};
     }
 
-    it('should replace the provided node with two comment nodes', function() {
+    it('should replace the provided node with two comment nodes', function () {
       const {node, childNode} = createTestNodes();
       const location = ctx.dom.convertToRenderLocation(childNode);
       expect(location['nodeName']).to.equal('#comment');
@@ -328,7 +328,7 @@ describe('dom', function() {
     });
   });
 
-  describe('registerElementResolver', function() {
+  describe('registerElementResolver', function () {
     const keys = [INode, ctx.Node, ctx.Element, ctx.HTMLElement];
     if (typeof Node !== 'undefined') {
       keys.push(Node);
@@ -340,7 +340,7 @@ describe('dom', function() {
       keys.push(HTMLElement);
     }
     for (const key of keys) {
-      it(`should register the resolver for type ${Object.prototype.toString.call(key)}`, function() {
+      it(`should register the resolver for type ${Object.prototype.toString.call(key)}`, function () {
         const mockContainer: any = { registerResolver: spy() };
         const resolver: any = {};
         ctx.dom.registerElementResolver(mockContainer, resolver);
@@ -350,14 +350,14 @@ describe('dom', function() {
   });
 });
 
-describe('FragmentNodeSequence', function() {
+describe('FragmentNodeSequence', function () {
   const ctx = TestContext.createHTMLTestContext();
   let sut: FragmentNodeSequence;
 
   const widthArr = [1, 2, 3];
-  describe('constructor', function() {
+  describe('constructor', function () {
     for (const width of widthArr) {
-      it(`should correctly assign children (depth=1,width=${width})`, function() {
+      it(`should correctly assign children (depth=1,width=${width})`, function () {
         const node = ctx.dom.createElement('div');
         const fragment = createFragment(ctx, node, 0, 1, width);
         sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -368,11 +368,11 @@ describe('FragmentNodeSequence', function() {
     }
   });
   const depthArr = [0, 1, 2, 3];
-  describe('findTargets', function() {
+  describe('findTargets', function () {
     for (const width of widthArr) {
       for (const depth of depthArr) {
         // note: these findTargets tests are quite redundant, but the basic setup might come in handy later
-        it(`should return empty array when there are no targets (depth=${depth},width=${width})`, function() {
+        it(`should return empty array when there are no targets (depth=${depth},width=${width})`, function () {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -380,7 +380,7 @@ describe('FragmentNodeSequence', function() {
           expect(actual.length).to.equal(0);
         });
 
-        it(`should return all elements when all are targets targets (depth=${depth},width=${width})`, function() {
+        it(`should return all elements when all are targets targets (depth=${depth},width=${width})`, function () {
           const node = ctx.dom.createElement('div');
           node.classList.add('au');
           const fragment = createFragment(ctx, node, 0, depth, width);
@@ -392,10 +392,10 @@ describe('FragmentNodeSequence', function() {
     }
   });
 
-  describe('insertBefore', function() {
+  describe('insertBefore', function () {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should insert the view before the refNode under the parent of the refNode (depth=${depth},width=${width})`, function() {
+        it(`should insert the view before the refNode under the parent of the refNode (depth=${depth},width=${width})`, function () {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -421,10 +421,10 @@ describe('FragmentNodeSequence', function() {
     }
   });
 
-  describe('appendTo', function() {
+  describe('appendTo', function () {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should append the view to the parent (depth=${depth},width=${width})`, function() {
+        it(`should append the view to the parent (depth=${depth},width=${width})`, function () {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);
@@ -442,10 +442,10 @@ describe('FragmentNodeSequence', function() {
     }
   });
 
-  describe('remove', function() {
+  describe('remove', function () {
     for (const width of widthArr) {
       for (const depth of depthArr.filter(d => d > 0)) {
-        it(`should put the view back into the fragment (depth=${depth},width=${width})`, function() {
+        it(`should put the view back into the fragment (depth=${depth},width=${width})`, function () {
           const node = ctx.dom.createElement('div');
           const fragment = createFragment(ctx, node, 0, depth, width);
           sut = new FragmentNodeSequence(ctx.dom, fragment);

--- a/packages/runtime-html/test/observation/checked-observer.spec.ts
+++ b/packages/runtime-html/test/observation/checked-observer.spec.ts
@@ -18,13 +18,13 @@ type ObservedInputElement = HTMLInputElement & {
 
 const eventDefaults = { bubbles: true };
 
-describe('CheckedObserver', function() {
+describe('CheckedObserver', function () {
 
-  before(function() {
+  before(function () {
     enableArrayObservation();
   });
 
-  describe('setValue() - primitive - type="checkbox"', function() {
+  describe('setValue() - primitive - type="checkbox"', function () {
     function setup(hasSubscriber: boolean) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -57,7 +57,7 @@ describe('CheckedObserver', function() {
               const propValue = checkedBefore ? checkedValue : uncheckedValue;
               const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-              it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
+              it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function () {
 
                 const expectedPropValue = propValue === undefined ? null : propValue;
                 const expectedNewValue = newValue === undefined ? null : newValue;
@@ -91,7 +91,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('handleEvent() - primitive - type="checkbox"', function() {
+  describe('handleEvent() - primitive - type="checkbox"', function () {
     function setup() {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -115,7 +115,7 @@ describe('CheckedObserver', function() {
     for (const checkedBefore of [true, false]) {
       for (const checkedAfter of [true, false]) {
         for (const event of ['change', 'input']) {
-          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function() {
+          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function () {
 
             const { ctx, sut, el, subscriber } = setup();
 
@@ -142,7 +142,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('setValue() - primitive - type="radio"', function() {
+  describe('setValue() - primitive - type="radio"', function () {
     function setup(hasSubscriber: boolean) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -188,7 +188,7 @@ describe('CheckedObserver', function() {
       for (const checkedBefore of ['A', 'B', 'C', null, undefined]) {
         for (const checkedAfter of ['A', 'B', 'C', null, undefined]) {
 
-          it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}`, function() {
+          it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}`, function () {
 
             const expectedPropValue = checkedBefore === undefined ? null : checkedBefore;
             const expectedNewValue = checkedAfter === undefined ? null : checkedAfter;
@@ -237,7 +237,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('handleEvent() - primitive - type="radio"', function() {
+  describe('handleEvent() - primitive - type="radio"', function () {
     function setup() {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -277,7 +277,7 @@ describe('CheckedObserver', function() {
       for (const checkedAfter of ['A', 'B', 'C']) {
         for (const event of ['change', 'input']) {
 
-          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function() {
+          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function () {
 
             const { ctx, sutA, sutB, sutC, elA, elB, elC } = setup();
 
@@ -314,7 +314,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('setValue() - array - type="checkbox"', function() {
+  describe('setValue() - array - type="checkbox"', function () {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -354,7 +354,7 @@ describe('CheckedObserver', function() {
                   const propValue = checkedBefore ? checkedValue : uncheckedValue;
                   const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
+                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function () {
 
                     const changeCountBefore = 1;
                     const changeCountAfter = checkedBefore !== checkedAfter ? 1 : 0;
@@ -387,7 +387,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('mutate collection - array - type="checkbox"', function() {
+  describe('mutate collection - array - type="checkbox"', function () {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -419,7 +419,7 @@ describe('CheckedObserver', function() {
 
           const valueCanBeChecked = prop === 'model' || (typeof value !== 'number' && value !== undefined && value !== null);
 
-          it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}`, function() {
+          it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}`, function () {
 
             const array = [];
 
@@ -451,7 +451,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('handleEvent() - array - type="checkbox"', function() {
+  describe('handleEvent() - array - type="checkbox"', function () {
     function setup(value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, observerLocator } = ctx;
@@ -481,7 +481,7 @@ describe('CheckedObserver', function() {
           for (const checkedAfter of [true, false]) {
             for (const event of ['change', 'input']) {
 
-              it(_`${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, async function() {
+              it(_`${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, async function () {
 
                 const { ctx, sut, el, subscriber } = setup(value, prop);
 
@@ -515,7 +515,7 @@ describe('CheckedObserver', function() {
     }
   });
 
-  describe('SelectValueObserver.setValue() - array - type="checkbox"', function() {
+  describe('SelectValueObserver.setValue() - array - type="checkbox"', function () {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -554,7 +554,7 @@ describe('CheckedObserver', function() {
                   const propValue = checkedBefore ? checkedValue : uncheckedValue;
                   const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
+                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function () {
 
                     const { ctx, sut, el, subscriber, valueOrModelObserver, lifecycle } = setup(hasSubscriber, value, prop);
 

--- a/packages/runtime-html/test/observation/checked-observer.spec.ts
+++ b/packages/runtime-html/test/observation/checked-observer.spec.ts
@@ -18,13 +18,13 @@ type ObservedInputElement = HTMLInputElement & {
 
 const eventDefaults = { bubbles: true };
 
-describe('CheckedObserver', () => {
+describe('CheckedObserver', function() {
 
-  before(() => {
+  before(function() {
     enableArrayObservation();
   });
 
-  describe('setValue() - primitive - type="checkbox"', () => {
+  describe('setValue() - primitive - type="checkbox"', function() {
     function setup(hasSubscriber: boolean) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -57,7 +57,7 @@ describe('CheckedObserver', () => {
               const propValue = checkedBefore ? checkedValue : uncheckedValue;
               const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-              it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, () => {
+              it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
 
                 const expectedPropValue = propValue === undefined ? null : propValue;
                 const expectedNewValue = newValue === undefined ? null : newValue;
@@ -91,7 +91,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('handleEvent() - primitive - type="checkbox"', () => {
+  describe('handleEvent() - primitive - type="checkbox"', function() {
     function setup() {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -115,7 +115,7 @@ describe('CheckedObserver', () => {
     for (const checkedBefore of [true, false]) {
       for (const checkedAfter of [true, false]) {
         for (const event of ['change', 'input']) {
-          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, () => {
+          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function() {
 
             const { ctx, sut, el, subscriber } = setup();
 
@@ -142,7 +142,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('setValue() - primitive - type="radio"', () => {
+  describe('setValue() - primitive - type="radio"', function() {
     function setup(hasSubscriber: boolean) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -188,7 +188,7 @@ describe('CheckedObserver', () => {
       for (const checkedBefore of ['A', 'B', 'C', null, undefined]) {
         for (const checkedAfter of ['A', 'B', 'C', null, undefined]) {
 
-          it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}`, () => {
+          it(_`hasSubscriber=${hasSubscriber}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}`, function() {
 
             const expectedPropValue = checkedBefore === undefined ? null : checkedBefore;
             const expectedNewValue = checkedAfter === undefined ? null : checkedAfter;
@@ -237,7 +237,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('handleEvent() - primitive - type="radio"', () => {
+  describe('handleEvent() - primitive - type="radio"', function() {
     function setup() {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -277,7 +277,7 @@ describe('CheckedObserver', () => {
       for (const checkedAfter of ['A', 'B', 'C']) {
         for (const event of ['change', 'input']) {
 
-          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, () => {
+          it(_`checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, function() {
 
             const { ctx, sutA, sutB, sutC, elA, elB, elC } = setup();
 
@@ -314,7 +314,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('setValue() - array - type="checkbox"', () => {
+  describe('setValue() - array - type="checkbox"', function() {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -354,7 +354,7 @@ describe('CheckedObserver', () => {
                   const propValue = checkedBefore ? checkedValue : uncheckedValue;
                   const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, () => {
+                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
 
                     const changeCountBefore = 1;
                     const changeCountAfter = checkedBefore !== checkedAfter ? 1 : 0;
@@ -387,7 +387,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('mutate collection - array - type="checkbox"', () => {
+  describe('mutate collection - array - type="checkbox"', function() {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -419,7 +419,7 @@ describe('CheckedObserver', () => {
 
           const valueCanBeChecked = prop === 'model' || (typeof value !== 'number' && value !== undefined && value !== null);
 
-          it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}`, () => {
+          it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}`, function() {
 
             const array = [];
 
@@ -451,7 +451,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('handleEvent() - array - type="checkbox"', () => {
+  describe('handleEvent() - array - type="checkbox"', function() {
     function setup(value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, observerLocator } = ctx;
@@ -481,7 +481,7 @@ describe('CheckedObserver', () => {
           for (const checkedAfter of [true, false]) {
             for (const event of ['change', 'input']) {
 
-              it(_`${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, async () => {
+              it(_`${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, event=${event}`, async function() {
 
                 const { ctx, sut, el, subscriber } = setup(value, prop);
 
@@ -515,7 +515,7 @@ describe('CheckedObserver', () => {
     }
   });
 
-  describe('SelectValueObserver.setValue() - array - type="checkbox"', () => {
+  describe('SelectValueObserver.setValue() - array - type="checkbox"', function() {
     function setup(hasSubscriber: boolean, value: any, prop: string) {
       const ctx = TestContext.createHTMLTestContext();
       const { container, lifecycle, observerLocator } = ctx;
@@ -554,7 +554,7 @@ describe('CheckedObserver', () => {
                   const propValue = checkedBefore ? checkedValue : uncheckedValue;
                   const newValue = checkedAfter ? checkedValue : uncheckedValue;
 
-                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, () => {
+                  it(_`hasSubscriber=${hasSubscriber}, ${prop}=${value}, checkedBefore=${checkedBefore}, checkedAfter=${checkedAfter}, propValue=${propValue}, newValue=${newValue}`, function() {
 
                     const { ctx, sut, el, subscriber, valueOrModelObserver, lifecycle } = setup(hasSubscriber, value, prop);
 

--- a/packages/runtime-html/test/observation/event-manager.spec.ts
+++ b/packages/runtime-html/test/observation/event-manager.spec.ts
@@ -62,7 +62,7 @@ function eventPropertiesShallowClone<T extends IManagedEvent>(e: T): T & { insta
   } as any;
 }
 
-describe('ListenerTracker', () => {
+describe('ListenerTracker', function() {
   function setup(eventName: string, listener: EventListenerOrEventListenerObject, capture: boolean, bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handlerPath: ReturnType<typeof eventPropertiesShallowClone>[] = [];
@@ -97,8 +97,8 @@ describe('ListenerTracker', () => {
       for (const capture of [true, false, undefined]) {
         for (const bubbles of [true, false]) {
           for (const listener of [null, { handleEvent: null }]) {
-            describe('increment()', () => {
-              it(_`adds the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, () => {
+            describe('increment()', function() {
+              it(_`adds the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function() {
                 const { ctx, sut, el, event, handlerPath } = setup(eventName, listener, capture, bubbles);
                 for (let i = 0; i < increment; ++i) {
                   sut.increment();
@@ -132,8 +132,8 @@ describe('ListenerTracker', () => {
               });
             });
 
-            describe('decrement()', () => {
-              it(_`removes the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, () => {
+            describe('decrement()', function() {
+              it(_`removes the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function() {
                 const { ctx, sut, el, event, handlerPath } = setup(eventName, listener, capture, bubbles);
                 for (let i = 0; i < increment; ++i) {
                   sut.increment();
@@ -176,7 +176,7 @@ describe('ListenerTracker', () => {
   }
 });
 
-describe('DelegateOrCaptureSubscription', () => {
+describe('DelegateOrCaptureSubscription', function() {
   function setup(eventName: string) {
     const entry = { decrement: spy() } as any as ListenerTracker;
     const lookup = {};
@@ -187,7 +187,7 @@ describe('DelegateOrCaptureSubscription', () => {
   }
 
   for (const eventName of ['foo', 'bar']) {
-    it(_`dispose() decrements and removes the callback (eventName=${eventName})`, () => {
+    it(_`dispose() decrements and removes the callback (eventName=${eventName})`, function() {
       const { sut, lookup, callback, entry } = setup(eventName);
       expect(lookup[eventName]).to.equal(callback, 'lookup[eventName]');
       sut.dispose();
@@ -197,7 +197,7 @@ describe('DelegateOrCaptureSubscription', () => {
   }
 });
 
-describe('TriggerSubscription', () => {
+describe('TriggerSubscription', function() {
   function setup(listener: EventListenerOrEventListenerObject | null, eventName: string, bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handler = spy();
@@ -229,7 +229,7 @@ describe('TriggerSubscription', () => {
   for (const bubbles of [true, false]) {
     for (const eventName of ['foo', 'bar']) {
       for (const listener of [null, { handleEvent: null }]) {
-        it(_`dispose() removes the event listener (eventName=${eventName}, bubbles=${bubbles}, listener=${listener})`, () => {
+        it(_`dispose() removes the event listener (eventName=${eventName}, bubbles=${bubbles}, listener=${listener})`, function() {
           const { ctx, sut, callback, event, el } = setup(listener, eventName, bubbles);
 
           el.dispatchEvent(event);
@@ -255,7 +255,7 @@ describe('TriggerSubscription', () => {
   }
 });
 
-describe('EventSubscriber', () => {
+describe('EventSubscriber', function() {
   function setup(listener: EventListenerOrEventListenerObject, eventNames: string[], bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handler = spy();
@@ -288,7 +288,7 @@ describe('EventSubscriber', () => {
   for (const bubbles of [true, false]) {
     for (const eventNames of [['foo', 'bar', 'baz'], ['click', 'change', 'input']]) {
       for (const listenerObj of [null, { handleEvent: null }]) {
-        it(_`subscribe() adds the event listener (eventNames=${eventNames}, bubbles=${bubbles}, listenerObj=${listenerObj})`, () => {
+        it(_`subscribe() adds the event listener (eventNames=${eventNames}, bubbles=${bubbles}, listenerObj=${listenerObj})`, function() {
           const { ctx, sut, handler, listener, events, el } = setup(listenerObj, eventNames, bubbles);
 
           sut.subscribe(el, listener);
@@ -323,9 +323,9 @@ describe('EventSubscriber', () => {
   }
 });
 
-describe('EventManager', () => {
+describe('EventManager', function() {
 
-  // it(`initializes with correct default element configurations`, () => {
+  // it(`initializes with correct default element configurations`, function() {
   //   const sut = new EventManager();
   //   const lookup = sut.elementHandlerLookup;
 
@@ -361,7 +361,7 @@ describe('EventManager', () => {
   //   expect(lookup['scrollable element']['scrollLeft']).to.include('scroll');
   // });
 
-  // it(`registerElementConfiguration() registers the configuration`, () => {
+  // it(`registerElementConfiguration() registers the configuration`, function() {
   //   const sut = new EventManager();
   //   sut.registerElementConfiguration({
   //     tagName: 'FOO',
@@ -375,7 +375,7 @@ describe('EventManager', () => {
   //   expect(lookup['FOO']['bar']).to.include('baz');
   // });
 
-  // it(`registerElementConfiguration() does not register configuration from higher up the prototype chain`, () => {
+  // it(`registerElementConfiguration() does not register configuration from higher up the prototype chain`, function() {
   //   const sut = new EventManager();
   //   class ElementProperties {
   //     public bar: string[];
@@ -394,7 +394,7 @@ describe('EventManager', () => {
   //   expect(lookup['FOO']['bar']).to.include('baz');
   // });
 
-  // describe(`getElementHandler()`, () => {
+  // describe(`getElementHandler()`, function() {
   //   const sut = new EventManager();
   //   const lookup = sut.elementHandlerLookup;
 
@@ -419,20 +419,20 @@ describe('EventManager', () => {
   //       if (expectedEventNames === undefined) {
   //         expectedEventNames = lookup[tagName][propertyName];
   //       }
-  //       it(_`tagName=${tagName}, propertyName=${propertyName} returns handler with eventNames=${expectedEventNames}`, () => {
+  //       it(_`tagName=${tagName}, propertyName=${propertyName} returns handler with eventNames=${expectedEventNames}`, function() {
   //         const handler = sut.getElementHandler(ctx.dom, ctx.createElement(`<${tagName}></${tagName}>`), propertyName);
   //         expect(handler['events']).to.deep.equal(expectedEventNames);
   //       });
   //     }
   //   }
 
-  //   it(`returns null if the target does not have a tagName`, () => {
+  //   it(`returns null if the target does not have a tagName`, function() {
   //     const text = ctx.doc.createTextNode('asdf');
   //     const handler = sut.getElementHandler(ctx.dom, text, 'textContent');
   //     expect(handler).to.equal(null);
   //   });
 
-  //   it(`returns null if the property does not exist in the configuration`, () => {
+  //   it(`returns null if the property does not exist in the configuration`, function() {
   //     const el = ctx.createElement('<input></input>');
   //     let handler = sut.getElementHandler(ctx.dom, el, 'value');
   //     expect(handler).not.to.equal(null);
@@ -441,7 +441,7 @@ describe('EventManager', () => {
   //   });
   // });
 
-  describe('addEventListener()', () => {
+  describe('addEventListener()', function() {
     function setup(
       eventName: string,
       listener: EventListenerOrEventListenerObject,
@@ -517,7 +517,7 @@ describe('EventManager', () => {
               // TODO: for firefox this won't work because ShadowDOM is not implemented yet. The webcomponents polyfill won't make it work either. Need to investigate what we can or cannot support.
               for (const shadow of hasShadow ? [null, 'open', 'closed'] : [null]) { // TODO: 'open' should probably work in some way, so we need to try and fix this
                 for (const listenerObj of [null, { handleEvent: null }]) {
-                  it(_`strategy=${DelegationStrategy[strategy]}, eventName=${eventName}, bubbles=${bubbles}, stopPropagation=${stopPropagation}, returnValue=${returnValue}, shadow=${shadow}, listener=${listenerObj}`, () => {
+                  it(_`strategy=${DelegationStrategy[strategy]}, eventName=${eventName}, bubbles=${bubbles}, stopPropagation=${stopPropagation}, returnValue=${returnValue}, shadow=${shadow}, listener=${listenerObj}`, function() {
                     const {
                       ctx,
                       wrapper,

--- a/packages/runtime-html/test/observation/event-manager.spec.ts
+++ b/packages/runtime-html/test/observation/event-manager.spec.ts
@@ -62,7 +62,7 @@ function eventPropertiesShallowClone<T extends IManagedEvent>(e: T): T & { insta
   } as any;
 }
 
-describe('ListenerTracker', function() {
+describe('ListenerTracker', function () {
   function setup(eventName: string, listener: EventListenerOrEventListenerObject, capture: boolean, bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handlerPath: ReturnType<typeof eventPropertiesShallowClone>[] = [];
@@ -97,8 +97,8 @@ describe('ListenerTracker', function() {
       for (const capture of [true, false, undefined]) {
         for (const bubbles of [true, false]) {
           for (const listener of [null, { handleEvent: null }]) {
-            describe('increment()', function() {
-              it(_`adds the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function() {
+            describe('increment()', function () {
+              it(_`adds the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function () {
                 const { ctx, sut, el, event, handlerPath } = setup(eventName, listener, capture, bubbles);
                 for (let i = 0; i < increment; ++i) {
                   sut.increment();
@@ -132,8 +132,8 @@ describe('ListenerTracker', function() {
               });
             });
 
-            describe('decrement()', function() {
-              it(_`removes the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function() {
+            describe('decrement()', function () {
+              it(_`removes the event listener (increment=${increment}, eventName=${eventName}, capture=${capture}, bubbles=${bubbles}, listener=${listener})`, function () {
                 const { ctx, sut, el, event, handlerPath } = setup(eventName, listener, capture, bubbles);
                 for (let i = 0; i < increment; ++i) {
                   sut.increment();
@@ -176,7 +176,7 @@ describe('ListenerTracker', function() {
   }
 });
 
-describe('DelegateOrCaptureSubscription', function() {
+describe('DelegateOrCaptureSubscription', function () {
   function setup(eventName: string) {
     const entry = { decrement: spy() } as any as ListenerTracker;
     const lookup = {};
@@ -187,7 +187,7 @@ describe('DelegateOrCaptureSubscription', function() {
   }
 
   for (const eventName of ['foo', 'bar']) {
-    it(_`dispose() decrements and removes the callback (eventName=${eventName})`, function() {
+    it(_`dispose() decrements and removes the callback (eventName=${eventName})`, function () {
       const { sut, lookup, callback, entry } = setup(eventName);
       expect(lookup[eventName]).to.equal(callback, 'lookup[eventName]');
       sut.dispose();
@@ -197,7 +197,7 @@ describe('DelegateOrCaptureSubscription', function() {
   }
 });
 
-describe('TriggerSubscription', function() {
+describe('TriggerSubscription', function () {
   function setup(listener: EventListenerOrEventListenerObject | null, eventName: string, bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handler = spy();
@@ -229,7 +229,7 @@ describe('TriggerSubscription', function() {
   for (const bubbles of [true, false]) {
     for (const eventName of ['foo', 'bar']) {
       for (const listener of [null, { handleEvent: null }]) {
-        it(_`dispose() removes the event listener (eventName=${eventName}, bubbles=${bubbles}, listener=${listener})`, function() {
+        it(_`dispose() removes the event listener (eventName=${eventName}, bubbles=${bubbles}, listener=${listener})`, function () {
           const { ctx, sut, callback, event, el } = setup(listener, eventName, bubbles);
 
           el.dispatchEvent(event);
@@ -255,7 +255,7 @@ describe('TriggerSubscription', function() {
   }
 });
 
-describe('EventSubscriber', function() {
+describe('EventSubscriber', function () {
   function setup(listener: EventListenerOrEventListenerObject, eventNames: string[], bubbles: boolean) {
     const ctx = TestContext.createHTMLTestContext();
     const handler = spy();
@@ -288,7 +288,7 @@ describe('EventSubscriber', function() {
   for (const bubbles of [true, false]) {
     for (const eventNames of [['foo', 'bar', 'baz'], ['click', 'change', 'input']]) {
       for (const listenerObj of [null, { handleEvent: null }]) {
-        it(_`subscribe() adds the event listener (eventNames=${eventNames}, bubbles=${bubbles}, listenerObj=${listenerObj})`, function() {
+        it(_`subscribe() adds the event listener (eventNames=${eventNames}, bubbles=${bubbles}, listenerObj=${listenerObj})`, function () {
           const { ctx, sut, handler, listener, events, el } = setup(listenerObj, eventNames, bubbles);
 
           sut.subscribe(el, listener);
@@ -323,9 +323,9 @@ describe('EventSubscriber', function() {
   }
 });
 
-describe('EventManager', function() {
+describe('EventManager', function () {
 
-  // it(`initializes with correct default element configurations`, function() {
+  // it(`initializes with correct default element configurations`, function () {
   //   const sut = new EventManager();
   //   const lookup = sut.elementHandlerLookup;
 
@@ -361,7 +361,7 @@ describe('EventManager', function() {
   //   expect(lookup['scrollable element']['scrollLeft']).to.include('scroll');
   // });
 
-  // it(`registerElementConfiguration() registers the configuration`, function() {
+  // it(`registerElementConfiguration() registers the configuration`, function () {
   //   const sut = new EventManager();
   //   sut.registerElementConfiguration({
   //     tagName: 'FOO',
@@ -375,7 +375,7 @@ describe('EventManager', function() {
   //   expect(lookup['FOO']['bar']).to.include('baz');
   // });
 
-  // it(`registerElementConfiguration() does not register configuration from higher up the prototype chain`, function() {
+  // it(`registerElementConfiguration() does not register configuration from higher up the prototype chain`, function () {
   //   const sut = new EventManager();
   //   class ElementProperties {
   //     public bar: string[];
@@ -394,7 +394,7 @@ describe('EventManager', function() {
   //   expect(lookup['FOO']['bar']).to.include('baz');
   // });
 
-  // describe(`getElementHandler()`, function() {
+  // describe(`getElementHandler()`, function () {
   //   const sut = new EventManager();
   //   const lookup = sut.elementHandlerLookup;
 
@@ -419,20 +419,20 @@ describe('EventManager', function() {
   //       if (expectedEventNames === undefined) {
   //         expectedEventNames = lookup[tagName][propertyName];
   //       }
-  //       it(_`tagName=${tagName}, propertyName=${propertyName} returns handler with eventNames=${expectedEventNames}`, function() {
+  //       it(_`tagName=${tagName}, propertyName=${propertyName} returns handler with eventNames=${expectedEventNames}`, function () {
   //         const handler = sut.getElementHandler(ctx.dom, ctx.createElement(`<${tagName}></${tagName}>`), propertyName);
   //         expect(handler['events']).to.deep.equal(expectedEventNames);
   //       });
   //     }
   //   }
 
-  //   it(`returns null if the target does not have a tagName`, function() {
+  //   it(`returns null if the target does not have a tagName`, function () {
   //     const text = ctx.doc.createTextNode('asdf');
   //     const handler = sut.getElementHandler(ctx.dom, text, 'textContent');
   //     expect(handler).to.equal(null);
   //   });
 
-  //   it(`returns null if the property does not exist in the configuration`, function() {
+  //   it(`returns null if the property does not exist in the configuration`, function () {
   //     const el = ctx.createElement('<input></input>');
   //     let handler = sut.getElementHandler(ctx.dom, el, 'value');
   //     expect(handler).not.to.equal(null);
@@ -441,7 +441,7 @@ describe('EventManager', function() {
   //   });
   // });
 
-  describe('addEventListener()', function() {
+  describe('addEventListener()', function () {
     function setup(
       eventName: string,
       listener: EventListenerOrEventListenerObject,
@@ -517,7 +517,7 @@ describe('EventManager', function() {
               // TODO: for firefox this won't work because ShadowDOM is not implemented yet. The webcomponents polyfill won't make it work either. Need to investigate what we can or cannot support.
               for (const shadow of hasShadow ? [null, 'open', 'closed'] : [null]) { // TODO: 'open' should probably work in some way, so we need to try and fix this
                 for (const listenerObj of [null, { handleEvent: null }]) {
-                  it(_`strategy=${DelegationStrategy[strategy]}, eventName=${eventName}, bubbles=${bubbles}, stopPropagation=${stopPropagation}, returnValue=${returnValue}, shadow=${shadow}, listener=${listenerObj}`, function() {
+                  it(_`strategy=${DelegationStrategy[strategy]}, eventName=${eventName}, bubbles=${bubbles}, stopPropagation=${stopPropagation}, returnValue=${returnValue}, shadow=${shadow}, listener=${listenerObj}`, function () {
                     const {
                       ctx,
                       wrapper,

--- a/packages/runtime-html/test/observation/observer-locator.spec.ts
+++ b/packages/runtime-html/test/observation/observer-locator.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../src/index';
 import { _, TestContext } from '../util';
 
-describe('ObserverLocator', function() {
+describe('ObserverLocator', function () {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
     const sut = ctx.observerLocator;
@@ -44,7 +44,7 @@ describe('ObserverLocator', function() {
     const el = ctx.createElementFromMarkup(markup);
     const attr = el.attributes[0];
     const expected = sut.getObserver(LF.none, el, attr.name);
-    it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function() {
+    it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function () {
       const actual = sut.getAccessor(LF.none, el, attr.name);
       expect(actual).to.be.instanceof(expected['constructor']);
     });
@@ -65,7 +65,7 @@ describe('ObserverLocator', function() {
   //   `<div aria-=""></div>`,
   //   `<div aria-a=""></div>`,
   // ]) {
-  //   it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
+  //   it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function () {
   //     const el = ctx.createElement(markup) as Element;
   //     const attr = el.attributes[0];
   //     const { sut } = setup();
@@ -82,7 +82,7 @@ describe('ObserverLocator', function() {
     `<div aria-=""></div>`,
     `<div aria-a=""></div>`,
   ]) {
-    it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
+    it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function () {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -99,7 +99,7 @@ describe('ObserverLocator', function() {
     `<div _4:a=""></div>`,
     `<div a:a=""></div>`
   ]) {
-    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
+    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function () {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -123,7 +123,7 @@ describe('ObserverLocator', function() {
     `<div aria=""></div>`,
     `<div ariaa=""></div>`,
   ]) {
-    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
+    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function () {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -133,7 +133,7 @@ describe('ObserverLocator', function() {
     });
   }
 
-  it(_`getAccessor() - {} - returns PropertyAccessor`, function() {
+  it(_`getAccessor() - {} - returns PropertyAccessor`, function () {
     const { sut } = setup();
     const obj = {};
     const actual = sut.getAccessor(LF.none, obj, 'foo');
@@ -145,7 +145,7 @@ describe('ObserverLocator', function() {
     undefined, null, true, false, '', 'foo',
     Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN
   ] as any[]) {
-    it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function() {
+    it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function () {
       const { sut } = setup();
       if (obj === null || obj === undefined) {
         expect(() => sut.getObserver(LF.none, obj, 'foo')).to.throw;
@@ -157,7 +157,7 @@ describe('ObserverLocator', function() {
     });
   }
 
-  it(_`getObserver() - {} - twice in a row - reuses existing observer`, function() {
+  it(_`getObserver() - {} - twice in a row - reuses existing observer`, function () {
     const { sut } = setup();
     const obj = {};
     const expected = sut.getObserver(LF.none, obj, 'foo');
@@ -165,7 +165,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.equal(expected);
   });
 
-  it(_`getObserver() - {} - twice in a row different property - returns different observer`, function() {
+  it(_`getObserver() - {} - twice in a row different property - returns different observer`, function () {
     const { sut } = setup();
     const obj = {};
     const expected = sut.getObserver(LF.none, obj, 'foo');
@@ -189,7 +189,7 @@ describe('ObserverLocator', function() {
     { markup: `<div aria-=""></div>`, ctor: DataAttributeAccessor },
     { markup: `<div aria-a=""></div>`, ctor: DataAttributeAccessor }
   ]) {
-    it(_`getObserver() - ${markup} - returns ${ctor.name}`, function() {
+    it(_`getObserver() - ${markup} - returns ${ctor.name}`, function () {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -208,7 +208,7 @@ describe('ObserverLocator', function() {
               for (const isVolatile of hasOverrides ? [true, false, undefined] : [false]) {
                 for (const hasAdapterObserver of [true, false]) {
                   for (const adapterIsDefined of hasAdapterObserver ? [true, false] : [false]) {
-                    it(_`getObserver() - descriptor=${{ configurable, enumerable }}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
+                    it(_`getObserver() - descriptor=${{ configurable, enumerable }}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function () {
                       const { sut } = setup();
                       const obj = {};
                       const dummyObserver = {} as any;
@@ -292,7 +292,7 @@ describe('ObserverLocator', function() {
           ...Object.getOwnPropertyDescriptors(TestContext.HTMLDivElement.prototype)
         };
         for (const property of Object.keys(descriptors)) {
-          it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
+          it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function () {
             const { ctx, sut } = setup();
             const obj = ctx.createElement('div');
             const dummyObserver = {} as any;
@@ -329,7 +329,7 @@ describe('ObserverLocator', function() {
     }
   }
 
-  it(_`getObserver() - throws if $observers is undefined`, function() {
+  it(_`getObserver() - throws if $observers is undefined`, function () {
     const { sut } = setup();
     const obj = {};
     const write = Reporter.write;
@@ -340,7 +340,7 @@ describe('ObserverLocator', function() {
     Reporter.write = write;
   });
 
-  it(_`getObserver() - Array.foo - returns ArrayObserver`, function() {
+  it(_`getObserver() - Array.foo - returns ArrayObserver`, function () {
     const { sut } = setup();
     const obj = [];
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -348,7 +348,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Array.length - returns ArrayObserver`, function() {
+  it(_`getObserver() - Array.length - returns ArrayObserver`, function () {
     const { sut } = setup();
     const obj = [];
     const actual = sut.getObserver(LF.none, obj, 'length');
@@ -356,7 +356,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.be.instanceof(CollectionLengthObserver);
   });
 
-  it(_`getObserver() - Set.foo - returns SetObserver`, function() {
+  it(_`getObserver() - Set.foo - returns SetObserver`, function () {
     const { sut } = setup();
     const obj = new Set();
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -364,7 +364,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Set.size - returns SetObserver`, function() {
+  it(_`getObserver() - Set.size - returns SetObserver`, function () {
     const { sut } = setup();
     const obj = new Set();
     const actual = sut.getObserver(LF.none, obj, 'size');
@@ -372,7 +372,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.be.instanceof(CollectionLengthObserver);
   });
 
-  it(_`getObserver() - Map.foo - returns MapObserver`, function() {
+  it(_`getObserver() - Map.foo - returns MapObserver`, function () {
     const { sut } = setup();
     const obj = new Map();
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -380,7 +380,7 @@ describe('ObserverLocator', function() {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Map.size - returns MapObserver`, function() {
+  it(_`getObserver() - Map.size - returns MapObserver`, function () {
     const { sut } = setup();
     const obj = new Map();
     const actual = sut.getObserver(LF.none, obj, 'size');

--- a/packages/runtime-html/test/observation/observer-locator.spec.ts
+++ b/packages/runtime-html/test/observation/observer-locator.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../src/index';
 import { _, TestContext } from '../util';
 
-describe('ObserverLocator', () => {
+describe('ObserverLocator', function() {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
     const sut = ctx.observerLocator;
@@ -44,7 +44,7 @@ describe('ObserverLocator', () => {
     const el = ctx.createElementFromMarkup(markup);
     const attr = el.attributes[0];
     const expected = sut.getObserver(LF.none, el, attr.name);
-    it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, () => {
+    it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function() {
       const actual = sut.getAccessor(LF.none, el, attr.name);
       expect(actual).to.be.instanceof(expected['constructor']);
     });
@@ -65,7 +65,7 @@ describe('ObserverLocator', () => {
   //   `<div aria-=""></div>`,
   //   `<div aria-a=""></div>`,
   // ]) {
-  //   it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, () => {
+  //   it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
   //     const el = ctx.createElement(markup) as Element;
   //     const attr = el.attributes[0];
   //     const { sut } = setup();
@@ -82,7 +82,7 @@ describe('ObserverLocator', () => {
     `<div aria-=""></div>`,
     `<div aria-a=""></div>`,
   ]) {
-    it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, () => {
+    it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -99,7 +99,7 @@ describe('ObserverLocator', () => {
     `<div _4:a=""></div>`,
     `<div a:a=""></div>`
   ]) {
-    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, () => {
+    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -123,7 +123,7 @@ describe('ObserverLocator', () => {
     `<div aria=""></div>`,
     `<div ariaa=""></div>`,
   ]) {
-    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, () => {
+    it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -133,7 +133,7 @@ describe('ObserverLocator', () => {
     });
   }
 
-  it(_`getAccessor() - {} - returns PropertyAccessor`, () => {
+  it(_`getAccessor() - {} - returns PropertyAccessor`, function() {
     const { sut } = setup();
     const obj = {};
     const actual = sut.getAccessor(LF.none, obj, 'foo');
@@ -145,7 +145,7 @@ describe('ObserverLocator', () => {
     undefined, null, true, false, '', 'foo',
     Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN
   ] as any[]) {
-    it(_`getObserver() - ${obj} - returns PrimitiveObserver`, () => {
+    it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function() {
       const { sut } = setup();
       if (obj === null || obj === undefined) {
         expect(() => sut.getObserver(LF.none, obj, 'foo')).to.throw;
@@ -157,7 +157,7 @@ describe('ObserverLocator', () => {
     });
   }
 
-  it(_`getObserver() - {} - twice in a row - reuses existing observer`, () => {
+  it(_`getObserver() - {} - twice in a row - reuses existing observer`, function() {
     const { sut } = setup();
     const obj = {};
     const expected = sut.getObserver(LF.none, obj, 'foo');
@@ -165,7 +165,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.equal(expected);
   });
 
-  it(_`getObserver() - {} - twice in a row different property - returns different observer`, () => {
+  it(_`getObserver() - {} - twice in a row different property - returns different observer`, function() {
     const { sut } = setup();
     const obj = {};
     const expected = sut.getObserver(LF.none, obj, 'foo');
@@ -189,7 +189,7 @@ describe('ObserverLocator', () => {
     { markup: `<div aria-=""></div>`, ctor: DataAttributeAccessor },
     { markup: `<div aria-a=""></div>`, ctor: DataAttributeAccessor }
   ]) {
-    it(_`getObserver() - ${markup} - returns ${ctor.name}`, () => {
+    it(_`getObserver() - ${markup} - returns ${ctor.name}`, function() {
       const { ctx, sut } = setup();
       const el = ctx.createElementFromMarkup(markup);
       const attr = el.attributes[0];
@@ -208,7 +208,7 @@ describe('ObserverLocator', () => {
               for (const isVolatile of hasOverrides ? [true, false, undefined] : [false]) {
                 for (const hasAdapterObserver of [true, false]) {
                   for (const adapterIsDefined of hasAdapterObserver ? [true, false] : [false]) {
-                    it(_`getObserver() - descriptor=${{ configurable, enumerable }}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, () => {
+                    it(_`getObserver() - descriptor=${{ configurable, enumerable }}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
                       const { sut } = setup();
                       const obj = {};
                       const dummyObserver = {} as any;
@@ -292,7 +292,7 @@ describe('ObserverLocator', () => {
           ...Object.getOwnPropertyDescriptors(TestContext.HTMLDivElement.prototype)
         };
         for (const property of Object.keys(descriptors)) {
-          it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, () => {
+          it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
             const { ctx, sut } = setup();
             const obj = ctx.createElement('div');
             const dummyObserver = {} as any;
@@ -329,7 +329,7 @@ describe('ObserverLocator', () => {
     }
   }
 
-  it(_`getObserver() - throws if $observers is undefined`, () => {
+  it(_`getObserver() - throws if $observers is undefined`, function() {
     const { sut } = setup();
     const obj = {};
     const write = Reporter.write;
@@ -340,7 +340,7 @@ describe('ObserverLocator', () => {
     Reporter.write = write;
   });
 
-  it(_`getObserver() - Array.foo - returns ArrayObserver`, () => {
+  it(_`getObserver() - Array.foo - returns ArrayObserver`, function() {
     const { sut } = setup();
     const obj = [];
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -348,7 +348,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Array.length - returns ArrayObserver`, () => {
+  it(_`getObserver() - Array.length - returns ArrayObserver`, function() {
     const { sut } = setup();
     const obj = [];
     const actual = sut.getObserver(LF.none, obj, 'length');
@@ -356,7 +356,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.be.instanceof(CollectionLengthObserver);
   });
 
-  it(_`getObserver() - Set.foo - returns SetObserver`, () => {
+  it(_`getObserver() - Set.foo - returns SetObserver`, function() {
     const { sut } = setup();
     const obj = new Set();
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -364,7 +364,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Set.size - returns SetObserver`, () => {
+  it(_`getObserver() - Set.size - returns SetObserver`, function() {
     const { sut } = setup();
     const obj = new Set();
     const actual = sut.getObserver(LF.none, obj, 'size');
@@ -372,7 +372,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.be.instanceof(CollectionLengthObserver);
   });
 
-  it(_`getObserver() - Map.foo - returns MapObserver`, () => {
+  it(_`getObserver() - Map.foo - returns MapObserver`, function() {
     const { sut } = setup();
     const obj = new Map();
     const actual = sut.getObserver(LF.none, obj, 'foo');
@@ -380,7 +380,7 @@ describe('ObserverLocator', () => {
     expect(actual).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it(_`getObserver() - Map.size - returns MapObserver`, () => {
+  it(_`getObserver() - Map.size - returns MapObserver`, function() {
     const { sut } = setup();
     const obj = new Map();
     const actual = sut.getObserver(LF.none, obj, 'size');

--- a/packages/runtime-html/test/observation/select-value-observer.spec.ts
+++ b/packages/runtime-html/test/observation/select-value-observer.spec.ts
@@ -7,7 +7,7 @@ import { _, h, HTMLTestContext, TestContext, verifyEqual } from '../util';
 type Anything = any;
 
 // TODO: need many more tests here, this is just preliminary
-describe('SelectValueObserver', function() {
+describe('SelectValueObserver', function () {
   function createFixture(initialValue: Anything = '', options = [], multiple = false) {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, lifecycle, observerLocator } = ctx;
@@ -22,14 +22,14 @@ describe('SelectValueObserver', function() {
     return { ctx, lifecycle, el, sut, dom };
   }
 
-  describe('setValue()', function() {
+  describe('setValue()', function () {
     const valuesArr = [['', 'foo', 'bar']];
     const initialArr = ['', 'foo', 'bar'];
     const nextArr = ['', 'foo', 'bar'];
     for (const values of valuesArr) {
       for (const initial of initialArr) {
         for (const next of nextArr) {
-          it(`sets 'value' from "${initial}" to "${next}"`, function() {
+          it(`sets 'value' from "${initial}" to "${next}"`, function () {
             const { lifecycle, el } = createFixture(initial, values);
 
             lifecycle.processFlushQueue(LF.none);
@@ -45,10 +45,10 @@ describe('SelectValueObserver', function() {
     }
   });
 
-  describe('bind()', function() {
+  describe('bind()', function () {
 
     if (typeof MutationObserver !== 'undefined') {
-      it('uses private method handleNodeChange as callback', async function() {
+      it('uses private method handleNodeChange as callback', async function () {
         for (const isMultiple of [true, false]) {
           const { ctx, el, sut } = createFixture([], [], isMultiple);
           const callbackSpy = spy(sut, 'handleNodeChange');
@@ -62,8 +62,8 @@ describe('SelectValueObserver', function() {
     }
   });
 
-  describe('unbind()', function() {
-    it('disconnect node observer', function() {
+  describe('unbind()', function () {
+    it('disconnect node observer', function () {
       for (const isMultiple of [true, false]) {
         const { sut } = createFixture([], [], isMultiple);
         let count = 0;
@@ -76,7 +76,7 @@ describe('SelectValueObserver', function() {
         expect(sut['nodeObserver']).to.equal(null);
       }
     });
-    it('unsubscribes array observer', function() {
+    it('unsubscribes array observer', function () {
       for (const isMultiple of [true, false]) {
         const { sut } = createFixture([], [], isMultiple);
         let count = 0;
@@ -98,12 +98,12 @@ describe('SelectValueObserver', function() {
     });
   });
 
-  describe('synchronizeOptions', function() {
+  describe('synchronizeOptions', function () {
 
   });
 
-  describe('synchronizeValue()', function() {
-    describe('<select />', function() {
+  describe('synchronizeValue()', function () {
+    describe('<select />', function () {
 
     });
     // There is subtle difference in behavior of synchronization for SelectObserver
@@ -111,8 +111,8 @@ describe('SelectValueObserver', function() {
     // the behavior is different, as such, if currentValue is an array
     //    1. With synchronizeOptions: source => target => source. Or selected <option/> are based on value array
     //    2. Without synchronizeOptions: target => source. Or selected values are based on selected <option/>
-    describe('<select multiple="true" />', function() {
-      it('synchronizes with array', function() {
+    describe('<select multiple="true" />', function () {
+      it('synchronizes with array', function () {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -126,7 +126,7 @@ describe('SelectValueObserver', function() {
         expect(currentValue['length']).to.equal(2);
       });
 
-      it('synchronizes with null', function() {
+      it('synchronizes with null', function () {
         const { sut } = createMutiSelectSut(null, [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -138,7 +138,7 @@ describe('SelectValueObserver', function() {
         expect(currentValue).to.equal(sut.currentValue);
       });
 
-      it('synchronizes with undefined', function() {
+      it('synchronizes with undefined', function () {
         const { sut } = createMutiSelectSut(undefined, [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -150,7 +150,7 @@ describe('SelectValueObserver', function() {
         expect(currentValue).to.equal(sut.currentValue);
       });
 
-      it('synchronizes with array (2)', function() {
+      it('synchronizes with array (2)', function () {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -169,7 +169,7 @@ describe('SelectValueObserver', function() {
         );
       });
 
-      it('synchronizes with array (3): disregard "value" when there is model', function() {
+      it('synchronizes with array (3): disregard "value" when there is model', function () {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', value: 'BB', _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -188,7 +188,7 @@ describe('SelectValueObserver', function() {
         );
       });
 
-      it('synchronize regardless disabled state of <option/>', function() {
+      it('synchronize regardless disabled state of <option/>', function () {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -207,8 +207,8 @@ describe('SelectValueObserver', function() {
         );
       });
 
-      describe('with <optgroup>', function() {
-        it('synchronizes with array', function() {
+      describe('with <optgroup>', function () {
+        it('synchronizes with array', function () {
           const { sut } = createMutiSelectSut([], [
             optgroup({},
                      option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),

--- a/packages/runtime-html/test/observation/select-value-observer.spec.ts
+++ b/packages/runtime-html/test/observation/select-value-observer.spec.ts
@@ -7,7 +7,7 @@ import { _, h, HTMLTestContext, TestContext, verifyEqual } from '../util';
 type Anything = any;
 
 // TODO: need many more tests here, this is just preliminary
-describe('SelectValueObserver', () => {
+describe('SelectValueObserver', function() {
   function createFixture(initialValue: Anything = '', options = [], multiple = false) {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, lifecycle, observerLocator } = ctx;
@@ -22,14 +22,14 @@ describe('SelectValueObserver', () => {
     return { ctx, lifecycle, el, sut, dom };
   }
 
-  describe('setValue()', () => {
+  describe('setValue()', function() {
     const valuesArr = [['', 'foo', 'bar']];
     const initialArr = ['', 'foo', 'bar'];
     const nextArr = ['', 'foo', 'bar'];
     for (const values of valuesArr) {
       for (const initial of initialArr) {
         for (const next of nextArr) {
-          it(`sets 'value' from "${initial}" to "${next}"`, () => {
+          it(`sets 'value' from "${initial}" to "${next}"`, function() {
             const { lifecycle, el } = createFixture(initial, values);
 
             lifecycle.processFlushQueue(LF.none);
@@ -45,10 +45,10 @@ describe('SelectValueObserver', () => {
     }
   });
 
-  describe('bind()', () => {
+  describe('bind()', function() {
 
     if (typeof MutationObserver !== 'undefined') {
-      it('uses private method handleNodeChange as callback', async () => {
+      it('uses private method handleNodeChange as callback', async function() {
         for (const isMultiple of [true, false]) {
           const { ctx, el, sut } = createFixture([], [], isMultiple);
           const callbackSpy = spy(sut, 'handleNodeChange');
@@ -62,8 +62,8 @@ describe('SelectValueObserver', () => {
     }
   });
 
-  describe('unbind()', () => {
-    it('disconnect node observer', () => {
+  describe('unbind()', function() {
+    it('disconnect node observer', function() {
       for (const isMultiple of [true, false]) {
         const { sut } = createFixture([], [], isMultiple);
         let count = 0;
@@ -76,7 +76,7 @@ describe('SelectValueObserver', () => {
         expect(sut['nodeObserver']).to.equal(null);
       }
     });
-    it('unsubscribes array observer', () => {
+    it('unsubscribes array observer', function() {
       for (const isMultiple of [true, false]) {
         const { sut } = createFixture([], [], isMultiple);
         let count = 0;
@@ -98,12 +98,12 @@ describe('SelectValueObserver', () => {
     });
   });
 
-  describe('synchronizeOptions', () => {
+  describe('synchronizeOptions', function() {
 
   });
 
-  describe('synchronizeValue()', () => {
-    describe('<select />', () => {
+  describe('synchronizeValue()', function() {
+    describe('<select />', function() {
 
     });
     // There is subtle difference in behavior of synchronization for SelectObserver
@@ -111,8 +111,8 @@ describe('SelectValueObserver', () => {
     // the behavior is different, as such, if currentValue is an array
     //    1. With synchronizeOptions: source => target => source. Or selected <option/> are based on value array
     //    2. Without synchronizeOptions: target => source. Or selected values are based on selected <option/>
-    describe('<select multiple="true" />', () => {
-      it('synchronizes with array', () => {
+    describe('<select multiple="true" />', function() {
+      it('synchronizes with array', function() {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -126,7 +126,7 @@ describe('SelectValueObserver', () => {
         expect(currentValue['length']).to.equal(2);
       });
 
-      it('synchronizes with null', () => {
+      it('synchronizes with null', function() {
         const { sut } = createMutiSelectSut(null, [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -138,7 +138,7 @@ describe('SelectValueObserver', () => {
         expect(currentValue).to.equal(sut.currentValue);
       });
 
-      it('synchronizes with undefined', () => {
+      it('synchronizes with undefined', function() {
         const { sut } = createMutiSelectSut(undefined, [
           option({ text: 'A', selected: true }),
           option({ text: 'B', selected: true }),
@@ -150,7 +150,7 @@ describe('SelectValueObserver', () => {
         expect(currentValue).to.equal(sut.currentValue);
       });
 
-      it('synchronizes with array (2)', () => {
+      it('synchronizes with array (2)', function() {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -169,7 +169,7 @@ describe('SelectValueObserver', () => {
         );
       });
 
-      it('synchronizes with array (3): disregard "value" when there is model', () => {
+      it('synchronizes with array (3): disregard "value" when there is model', function() {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', value: 'BB', _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -188,7 +188,7 @@ describe('SelectValueObserver', () => {
         );
       });
 
-      it('synchronize regardless disabled state of <option/>', () => {
+      it('synchronize regardless disabled state of <option/>', function() {
         const { sut } = createMutiSelectSut([], [
           option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
           option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
@@ -207,8 +207,8 @@ describe('SelectValueObserver', () => {
         );
       });
 
-      describe('with <optgroup>', () => {
-        it('synchronizes with array', () => {
+      describe('with <optgroup>', function() {
+        it('synchronizes with array', function() {
           const { sut } = createMutiSelectSut([], [
             optgroup({},
                      option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),

--- a/packages/runtime-html/test/observation/target-observers.spec.ts
+++ b/packages/runtime-html/test/observation/target-observers.spec.ts
@@ -32,7 +32,7 @@ function setup() {
   return { ctx, container, lifecycle, observerLocator };
 }
 
-describe('AttributeNSAccessor', function() {
+describe('AttributeNSAccessor', function () {
   let sut: AttributeNSAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
@@ -46,9 +46,9 @@ describe('AttributeNSAccessor', function() {
     { name: 'show', value: 'false' }
   ];
 
-  describe('getValue()', function() {
+  describe('getValue()', function () {
     for (const { name, value } of tests) {
-      it(`returns ${value} for xlink:${name}`, function() {
+      it(`returns ${value} for xlink:${name}`, function () {
         const { ctx, lifecycle: $lifecycle } = setup();
         lifecycle = $lifecycle;
         el = createSvgUseElement(ctx, name, value) as HTMLElement;
@@ -59,9 +59,9 @@ describe('AttributeNSAccessor', function() {
     }
   });
 
-  describe('setValue()', function() {
+  describe('setValue()', function () {
     for (const { name, value } of tests) {
-      it(`sets xlink:${name} to foo`, function() {
+      it(`sets xlink:${name} to foo`, function () {
         const ctx = TestContext.createHTMLTestContext();
         el = createSvgUseElement(ctx, name, value) as HTMLElement;
         const { lifecycle: $lifecycle } = setup();
@@ -77,16 +77,16 @@ describe('AttributeNSAccessor', function() {
 
 });
 
-describe('DataAttributeAccessor', function() {
+describe('DataAttributeAccessor', function () {
   let sut: DataAttributeAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
 
   const valueArr = [undefined, null, '', 'foo'];
-  describe('getValue()', function() {
+  describe('getValue()', function () {
     for (const name of globalAttributeNames) {
       for (const value of valueArr.filter(v => v !== null && v !== undefined)) {
-        it(`returns "${value}" for attribute "${name}"`, function() {
+        it(`returns "${value}" for attribute "${name}"`, function () {
           const ctx = TestContext.createHTMLTestContext();
           el = ctx.createElementFromMarkup(`<div ${name}="${value}"></div>`);
           const { lifecycle: $lifecycle } = setup();
@@ -99,10 +99,10 @@ describe('DataAttributeAccessor', function() {
     }
   });
 
-  describe('setValue()', function() {
+  describe('setValue()', function () {
     for (const name of globalAttributeNames) {
       for (const value of valueArr) {
-        it(`sets attribute "${name}" to "${value}"`, function() {
+        it(`sets attribute "${name}" to "${value}"`, function () {
           const ctx = TestContext.createHTMLTestContext();
           el = ctx.createElementFromMarkup(`<div></div>`);
           const { lifecycle: $lifecycle } = setup();
@@ -121,7 +121,7 @@ describe('DataAttributeAccessor', function() {
   });
 });
 
-describe('StyleAccessor', function() {
+describe('StyleAccessor', function () {
   const propNames = Object.getOwnPropertyNames(CSS_PROPERTIES);
 
   let sut: StyleAttributeAccessor;
@@ -133,7 +133,7 @@ describe('StyleAccessor', function() {
     const values = CSS_PROPERTIES[propName]['values'];
     const value = values[0];
     const rule = `${propName}:${value}`;
-    it(`setValue - style="${rule}"`, function() {
+    it(`setValue - style="${rule}"`, function () {
       const ctx = TestContext.createHTMLTestContext();
       el = ctx.createElementFromMarkup('<div></div>');
       const { lifecycle: $lifecycle } = setup();
@@ -149,7 +149,7 @@ describe('StyleAccessor', function() {
     });
   }
 
-  it(`getValue - style="display: block;"`, function() {
+  it(`getValue - style="display: block;"`, function () {
     const ctx = TestContext.createHTMLTestContext();
     el = ctx.createElementFromMarkup(`<div style="display: block;"></div>`);
     const { lifecycle: $lifecycle } = setup();
@@ -161,7 +161,7 @@ describe('StyleAccessor', function() {
   });
 });
 
-describe('ClassAccessor', function() {
+describe('ClassAccessor', function () {
   let sut: ClassAttributeAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
@@ -177,7 +177,7 @@ describe('ClassAccessor', function() {
   const secondClassListArr = ['', 'fooo'];
   for (const markup of markupArr) {
     for (const classList of classListArr) {
-      beforeEach(function() {
+      beforeEach(function () {
         const ctx = TestContext.createHTMLTestContext();
         el = ctx.createElementFromMarkup(markup);
         initialClassList = el.classList.toString();
@@ -186,7 +186,7 @@ describe('ClassAccessor', function() {
         sut = new ClassAttributeAccessor(lifecycle, el);
       });
 
-      it(`setValue("${classList}") updates ${markup}`, function() {
+      it(`setValue("${classList}") updates ${markup}`, function () {
         sut.setValue(classList, LifecycleFlags.none);
         expect(el.classList.toString()).to.equal(initialClassList);
         lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -200,7 +200,7 @@ describe('ClassAccessor', function() {
       });
 
       for (const secondClassList of secondClassListArr) {
-        it(`setValue("${secondClassList}") updates already-updated ${markup}`, function() {
+        it(`setValue("${secondClassList}") updates already-updated ${markup}`, function () {
           sut.setValue(classList, LifecycleFlags.none);
           lifecycle.processFlushQueue(LifecycleFlags.none);
           const updatedClassList = el.classList.toString();

--- a/packages/runtime-html/test/observation/target-observers.spec.ts
+++ b/packages/runtime-html/test/observation/target-observers.spec.ts
@@ -32,7 +32,7 @@ function setup() {
   return { ctx, container, lifecycle, observerLocator };
 }
 
-describe('AttributeNSAccessor', () => {
+describe('AttributeNSAccessor', function() {
   let sut: AttributeNSAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
@@ -46,9 +46,9 @@ describe('AttributeNSAccessor', () => {
     { name: 'show', value: 'false' }
   ];
 
-  describe('getValue()', () => {
+  describe('getValue()', function() {
     for (const { name, value } of tests) {
-      it(`returns ${value} for xlink:${name}`, () => {
+      it(`returns ${value} for xlink:${name}`, function() {
         const { ctx, lifecycle: $lifecycle } = setup();
         lifecycle = $lifecycle;
         el = createSvgUseElement(ctx, name, value) as HTMLElement;
@@ -59,9 +59,9 @@ describe('AttributeNSAccessor', () => {
     }
   });
 
-  describe('setValue()', () => {
+  describe('setValue()', function() {
     for (const { name, value } of tests) {
-      it(`sets xlink:${name} to foo`, () => {
+      it(`sets xlink:${name} to foo`, function() {
         const ctx = TestContext.createHTMLTestContext();
         el = createSvgUseElement(ctx, name, value) as HTMLElement;
         const { lifecycle: $lifecycle } = setup();
@@ -77,16 +77,16 @@ describe('AttributeNSAccessor', () => {
 
 });
 
-describe('DataAttributeAccessor', () => {
+describe('DataAttributeAccessor', function() {
   let sut: DataAttributeAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
 
   const valueArr = [undefined, null, '', 'foo'];
-  describe('getValue()', () => {
+  describe('getValue()', function() {
     for (const name of globalAttributeNames) {
       for (const value of valueArr.filter(v => v !== null && v !== undefined)) {
-        it(`returns "${value}" for attribute "${name}"`, () => {
+        it(`returns "${value}" for attribute "${name}"`, function() {
           const ctx = TestContext.createHTMLTestContext();
           el = ctx.createElementFromMarkup(`<div ${name}="${value}"></div>`);
           const { lifecycle: $lifecycle } = setup();
@@ -99,10 +99,10 @@ describe('DataAttributeAccessor', () => {
     }
   });
 
-  describe('setValue()', () => {
+  describe('setValue()', function() {
     for (const name of globalAttributeNames) {
       for (const value of valueArr) {
-        it(`sets attribute "${name}" to "${value}"`, () => {
+        it(`sets attribute "${name}" to "${value}"`, function() {
           const ctx = TestContext.createHTMLTestContext();
           el = ctx.createElementFromMarkup(`<div></div>`);
           const { lifecycle: $lifecycle } = setup();
@@ -121,7 +121,7 @@ describe('DataAttributeAccessor', () => {
   });
 });
 
-describe('StyleAccessor', () => {
+describe('StyleAccessor', function() {
   const propNames = Object.getOwnPropertyNames(CSS_PROPERTIES);
 
   let sut: StyleAttributeAccessor;
@@ -133,7 +133,7 @@ describe('StyleAccessor', () => {
     const values = CSS_PROPERTIES[propName]['values'];
     const value = values[0];
     const rule = `${propName}:${value}`;
-    it(`setValue - style="${rule}"`, () => {
+    it(`setValue - style="${rule}"`, function() {
       const ctx = TestContext.createHTMLTestContext();
       el = ctx.createElementFromMarkup('<div></div>');
       const { lifecycle: $lifecycle } = setup();
@@ -149,7 +149,7 @@ describe('StyleAccessor', () => {
     });
   }
 
-  it(`getValue - style="display: block;"`, () => {
+  it(`getValue - style="display: block;"`, function() {
     const ctx = TestContext.createHTMLTestContext();
     el = ctx.createElementFromMarkup(`<div style="display: block;"></div>`);
     const { lifecycle: $lifecycle } = setup();
@@ -161,7 +161,7 @@ describe('StyleAccessor', () => {
   });
 });
 
-describe('ClassAccessor', () => {
+describe('ClassAccessor', function() {
   let sut: ClassAttributeAccessor;
   let el: HTMLElement;
   let lifecycle: ILifecycle;
@@ -177,7 +177,7 @@ describe('ClassAccessor', () => {
   const secondClassListArr = ['', 'fooo'];
   for (const markup of markupArr) {
     for (const classList of classListArr) {
-      beforeEach(() => {
+      beforeEach(function() {
         const ctx = TestContext.createHTMLTestContext();
         el = ctx.createElementFromMarkup(markup);
         initialClassList = el.classList.toString();
@@ -186,7 +186,7 @@ describe('ClassAccessor', () => {
         sut = new ClassAttributeAccessor(lifecycle, el);
       });
 
-      it(`setValue("${classList}") updates ${markup}`, () => {
+      it(`setValue("${classList}") updates ${markup}`, function() {
         sut.setValue(classList, LifecycleFlags.none);
         expect(el.classList.toString()).to.equal(initialClassList);
         lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -200,7 +200,7 @@ describe('ClassAccessor', () => {
       });
 
       for (const secondClassList of secondClassListArr) {
-        it(`setValue("${secondClassList}") updates already-updated ${markup}`, () => {
+        it(`setValue("${secondClassList}") updates already-updated ${markup}`, function() {
           sut.setValue(classList, LifecycleFlags.none);
           lifecycle.processFlushQueue(LifecycleFlags.none);
           const updatedClassList = el.classList.toString();

--- a/packages/runtime-html/test/observation/value-attribute-observer.spec.ts
+++ b/packages/runtime-html/test/observation/value-attribute-observer.spec.ts
@@ -4,7 +4,7 @@ import { SinonSpy, spy } from 'sinon';
 import { ValueAttributeObserver } from '../../src/index';
 import { _, TestContext } from '../util';
 
-describe('ValueAttributeObserver', function() {
+describe('ValueAttributeObserver', function () {
   const eventDefaults = { bubbles: true };
 
   for (const { inputType, nullValues, validValues } of [
@@ -20,7 +20,7 @@ describe('ValueAttributeObserver', function() {
       { inputType: 'text',     nullValues: [null, undefined], validValues: ['', 'foo'] },
       { inputType: 'url',      nullValues: [null, undefined], validValues: ['', 'foo'] }
     ]) {
-    describe(`setValue() - type="${inputType}"`, function() {
+    describe(`setValue() - type="${inputType}"`, function () {
       function setup(hasSubscriber: boolean) {
         const ctx = TestContext.createHTMLTestContext();
         const { container, lifecycle, observerLocator } = ctx;
@@ -47,7 +47,7 @@ describe('ValueAttributeObserver', function() {
         for (const valueBefore of [...nullValues, ...validValues]) {
           for (const valueAfter of [...nullValues, ...validValues]) {
 
-            it(_`hasSubscriber=${hasSubscriber}, valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function() {
+            it(_`hasSubscriber=${hasSubscriber}, valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function () {
 
               const { ctx, sut, lifecycle, el, subscriber } = setup(hasSubscriber);
 
@@ -88,7 +88,7 @@ describe('ValueAttributeObserver', function() {
       }
     });
 
-    describe(`handleEvent() - type="${inputType}"`, function() {
+    describe(`handleEvent() - type="${inputType}"`, function () {
       function setup() {
         const ctx = TestContext.createHTMLTestContext();
         const { container, observerLocator } = ctx;
@@ -113,7 +113,7 @@ describe('ValueAttributeObserver', function() {
         for (const valueAfter of [...nullValues, ...validValues]) {
           for (const event of ['change', 'input']) {
 
-            it(_`valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function() {
+            it(_`valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function () {
 
               const { ctx, sut, el, subscriber } = setup();
 

--- a/packages/runtime-html/test/observation/value-attribute-observer.spec.ts
+++ b/packages/runtime-html/test/observation/value-attribute-observer.spec.ts
@@ -4,7 +4,7 @@ import { SinonSpy, spy } from 'sinon';
 import { ValueAttributeObserver } from '../../src/index';
 import { _, TestContext } from '../util';
 
-describe('ValueAttributeObserver', () => {
+describe('ValueAttributeObserver', function() {
   const eventDefaults = { bubbles: true };
 
   for (const { inputType, nullValues, validValues } of [
@@ -20,7 +20,7 @@ describe('ValueAttributeObserver', () => {
       { inputType: 'text',     nullValues: [null, undefined], validValues: ['', 'foo'] },
       { inputType: 'url',      nullValues: [null, undefined], validValues: ['', 'foo'] }
     ]) {
-    describe(`setValue() - type="${inputType}"`, () => {
+    describe(`setValue() - type="${inputType}"`, function() {
       function setup(hasSubscriber: boolean) {
         const ctx = TestContext.createHTMLTestContext();
         const { container, lifecycle, observerLocator } = ctx;
@@ -47,7 +47,7 @@ describe('ValueAttributeObserver', () => {
         for (const valueBefore of [...nullValues, ...validValues]) {
           for (const valueAfter of [...nullValues, ...validValues]) {
 
-            it(_`hasSubscriber=${hasSubscriber}, valueBefore=${valueBefore}, valueAfter=${valueAfter}`, () => {
+            it(_`hasSubscriber=${hasSubscriber}, valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function() {
 
               const { ctx, sut, lifecycle, el, subscriber } = setup(hasSubscriber);
 
@@ -88,7 +88,7 @@ describe('ValueAttributeObserver', () => {
       }
     });
 
-    describe(`handleEvent() - type="${inputType}"`, () => {
+    describe(`handleEvent() - type="${inputType}"`, function() {
       function setup() {
         const ctx = TestContext.createHTMLTestContext();
         const { container, observerLocator } = ctx;
@@ -113,7 +113,7 @@ describe('ValueAttributeObserver', () => {
         for (const valueAfter of [...nullValues, ...validValues]) {
           for (const event of ['change', 'input']) {
 
-            it(_`valueBefore=${valueBefore}, valueAfter=${valueAfter}`, () => {
+            it(_`valueBefore=${valueBefore}, valueAfter=${valueAfter}`, function() {
 
               const { ctx, sut, el, subscriber } = setup();
 

--- a/packages/runtime-html/test/projector-locator.spec.ts
+++ b/packages/runtime-html/test/projector-locator.spec.ts
@@ -3,12 +3,12 @@ import { expect } from 'chai';
 import { ContainerlessProjector, HostProjector, HTMLProjectorLocator, ShadowDOMProjector } from '../src/projectors';
 import { TestContext } from './util';
 
-describe(`determineProjector`, () => {
+describe(`determineProjector`, function() {
   const ctx = TestContext.createHTMLTestContext();
   const dom = ctx.dom;
   const locator = new HTMLProjectorLocator();
 
-  it(`@useShadowDOM yields ShadowDOMProjector`, () => {
+  it(`@useShadowDOM yields ShadowDOMProjector`, function() {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -31,7 +31,7 @@ describe(`determineProjector`, () => {
     expect(projector.provideEncapsulationSource()).to.equal(projector['shadowRoot']);
   });
 
-  it(`hasSlots=true yields ShadowDOMProjector`, () => {
+  it(`hasSlots=true yields ShadowDOMProjector`, function() {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -54,7 +54,7 @@ describe(`determineProjector`, () => {
     expect(projector.provideEncapsulationSource()).to.equal(projector['shadowRoot']);
   });
 
-  it(`@containerless yields ContainerlessProjector`, () => {
+  it(`@containerless yields ContainerlessProjector`, function() {
     const host = ctx.createElement('div');
     const parent = ctx.createElement('div');
     parent.appendChild(host);
@@ -84,7 +84,7 @@ describe(`determineProjector`, () => {
     expect(projector.provideEncapsulationSource()).to.equal(parent);
   });
 
-  it(`@containerless yields ContainerlessProjector (with child)`, () => {
+  it(`@containerless yields ContainerlessProjector (with child)`, function() {
     const parent = ctx.createElement('div');
     const host = ctx.createElement('div');
     const child = ctx.createElement('div');
@@ -112,7 +112,7 @@ describe(`determineProjector`, () => {
     expect(projector.provideEncapsulationSource()).to.equal(parent);
   });
 
-  it(`no shadowDOM, slots or containerless yields HostProjector`, () => {
+  it(`no shadowDOM, slots or containerless yields HostProjector`, function() {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -129,7 +129,7 @@ describe(`determineProjector`, () => {
     expect(projector.provideEncapsulationSource()).to.equal(host);
   });
 
-  it(`@containerless + @useShadowDOM throws`, () => {
+  it(`@containerless + @useShadowDOM throws`, function() {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -144,7 +144,7 @@ describe(`determineProjector`, () => {
     expect(() => locator.getElementProjector(dom, component, host, Foo.description)).to.throw(/21/);
   });
 
-  it(`@containerless + hasSlots throws`, () => {
+  it(`@containerless + hasSlots throws`, function() {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {

--- a/packages/runtime-html/test/projector-locator.spec.ts
+++ b/packages/runtime-html/test/projector-locator.spec.ts
@@ -3,12 +3,12 @@ import { expect } from 'chai';
 import { ContainerlessProjector, HostProjector, HTMLProjectorLocator, ShadowDOMProjector } from '../src/projectors';
 import { TestContext } from './util';
 
-describe(`determineProjector`, function() {
+describe(`determineProjector`, function () {
   const ctx = TestContext.createHTMLTestContext();
   const dom = ctx.dom;
   const locator = new HTMLProjectorLocator();
 
-  it(`@useShadowDOM yields ShadowDOMProjector`, function() {
+  it(`@useShadowDOM yields ShadowDOMProjector`, function () {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -31,7 +31,7 @@ describe(`determineProjector`, function() {
     expect(projector.provideEncapsulationSource()).to.equal(projector['shadowRoot']);
   });
 
-  it(`hasSlots=true yields ShadowDOMProjector`, function() {
+  it(`hasSlots=true yields ShadowDOMProjector`, function () {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -54,7 +54,7 @@ describe(`determineProjector`, function() {
     expect(projector.provideEncapsulationSource()).to.equal(projector['shadowRoot']);
   });
 
-  it(`@containerless yields ContainerlessProjector`, function() {
+  it(`@containerless yields ContainerlessProjector`, function () {
     const host = ctx.createElement('div');
     const parent = ctx.createElement('div');
     parent.appendChild(host);
@@ -84,7 +84,7 @@ describe(`determineProjector`, function() {
     expect(projector.provideEncapsulationSource()).to.equal(parent);
   });
 
-  it(`@containerless yields ContainerlessProjector (with child)`, function() {
+  it(`@containerless yields ContainerlessProjector (with child)`, function () {
     const parent = ctx.createElement('div');
     const host = ctx.createElement('div');
     const child = ctx.createElement('div');
@@ -112,7 +112,7 @@ describe(`determineProjector`, function() {
     expect(projector.provideEncapsulationSource()).to.equal(parent);
   });
 
-  it(`no shadowDOM, slots or containerless yields HostProjector`, function() {
+  it(`no shadowDOM, slots or containerless yields HostProjector`, function () {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -129,7 +129,7 @@ describe(`determineProjector`, function() {
     expect(projector.provideEncapsulationSource()).to.equal(host);
   });
 
-  it(`@containerless + @useShadowDOM throws`, function() {
+  it(`@containerless + @useShadowDOM throws`, function () {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {
@@ -144,7 +144,7 @@ describe(`determineProjector`, function() {
     expect(() => locator.getElementProjector(dom, component, host, Foo.description)).to.throw(/21/);
   });
 
-  it(`@containerless + hasSlots throws`, function() {
+  it(`@containerless + hasSlots throws`, function () {
     const host = ctx.createElement('div');
     const Foo = CustomElementResource.define(
       {

--- a/packages/runtime-html/test/renderer.spec.ts
+++ b/packages/runtime-html/test/renderer.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '../src/index';
 import { _, TestContext } from './util';
 
-describe('Renderer', function() {
+describe('Renderer', function () {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, container } = ctx;
@@ -65,10 +65,10 @@ describe('Renderer', function() {
     ctx.doc.body.removeChild(wrapper);
   }
 
-  describe('handles ITextBindingInstruction', function() {
+  describe('handles ITextBindingInstruction', function () {
     for (const from of ['${foo}', new Interpolation(['', ''], [new AccessScope('foo')])] as any[]) {
       const instruction = new TextBindingInstruction(from) as any;
-      it(_`instruction=${instruction}`, function() {
+      it(_`instruction=${instruction}`, function () {
         const { ctx, sut, dom, renderable, target, placeholder, wrapper, renderContext } = setup();
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -90,12 +90,12 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles IListenerBindingInstruction', function() {
+  describe('handles IListenerBindingInstruction', function () {
     for (const Instruction of [TriggerBindingInstruction, DelegateBindingInstruction, CaptureBindingInstruction] as any[]) {
       for (const to of ['foo', 'bar']) {
         for (const from of ['foo', new AccessScope('foo')]) {
           const instruction = new (Instruction)(from, to) as IListenerBindingInstruction;
-          it(_`instruction=${instruction}`, function() {
+          it(_`instruction=${instruction}`, function () {
             const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -118,11 +118,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles IStyleBindingInstruction', function() {
+  describe('handles IStyleBindingInstruction', function () {
     for (const to of ['foo', 'bar']) {
       for (const from of ['foo', new AccessScope('foo')] as any[]) {
         const instruction = new StylePropertyBindingInstruction(from, to) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -143,11 +143,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles ISetAttributeInstruction', function() {
+  describe('handles ISetAttributeInstruction', function () {
     for (const to of ['id', 'accesskey', 'slot', 'tabindex']) {
       for (const value of ['foo', 42, null] as any[]) {
         const instruction = new SetAttributeInstruction(value, to) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);

--- a/packages/runtime-html/test/renderer.spec.ts
+++ b/packages/runtime-html/test/renderer.spec.ts
@@ -26,7 +26,7 @@ import {
 } from '../src/index';
 import { _, TestContext } from './util';
 
-describe('Renderer', () => {
+describe('Renderer', function() {
   function setup() {
     const ctx = TestContext.createHTMLTestContext();
     const { dom, container } = ctx;
@@ -65,10 +65,10 @@ describe('Renderer', () => {
     ctx.doc.body.removeChild(wrapper);
   }
 
-  describe('handles ITextBindingInstruction', () => {
+  describe('handles ITextBindingInstruction', function() {
     for (const from of ['${foo}', new Interpolation(['', ''], [new AccessScope('foo')])] as any[]) {
       const instruction = new TextBindingInstruction(from) as any;
-      it(_`instruction=${instruction}`, () => {
+      it(_`instruction=${instruction}`, function() {
         const { ctx, sut, dom, renderable, target, placeholder, wrapper, renderContext } = setup();
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -90,12 +90,12 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles IListenerBindingInstruction', () => {
+  describe('handles IListenerBindingInstruction', function() {
     for (const Instruction of [TriggerBindingInstruction, DelegateBindingInstruction, CaptureBindingInstruction] as any[]) {
       for (const to of ['foo', 'bar']) {
         for (const from of ['foo', new AccessScope('foo')]) {
           const instruction = new (Instruction)(from, to) as IListenerBindingInstruction;
-          it(_`instruction=${instruction}`, () => {
+          it(_`instruction=${instruction}`, function() {
             const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -118,11 +118,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles IStyleBindingInstruction', () => {
+  describe('handles IStyleBindingInstruction', function() {
     for (const to of ['foo', 'bar']) {
       for (const from of ['foo', new AccessScope('foo')] as any[]) {
         const instruction = new StylePropertyBindingInstruction(from, to) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -143,11 +143,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles ISetAttributeInstruction', () => {
+  describe('handles ISetAttributeInstruction', function() {
     for (const to of ['id', 'accesskey', 'slot', 'tabindex']) {
       for (const value of ['foo', 42, null] as any[]) {
         const instruction = new SetAttributeInstruction(value, to) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { ctx, sut, dom, renderable, target, wrapper, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);

--- a/packages/runtime-html/test/resources/binding-behaviors/attr-binding-behavior.spec.ts
+++ b/packages/runtime-html/test/resources/binding-behaviors/attr-binding-behavior.spec.ts
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 import { AttrBindingBehavior, DataAttributeAccessor } from '../../../src/index';
 import { TestContext } from '../../util';
 
-describe('AttrBindingBehavior', () => {
+describe('AttrBindingBehavior', function() {
   let target: any;
   let targetProperty: string;
   let container: IContainer;
   let sut: AttrBindingBehavior;
   let binding: Binding;
 
-  beforeEach(() => {
+  beforeEach(function() {
     const ctx = TestContext.createHTMLTestContext();
     target = ctx.createElement('div');
     targetProperty = 'foo';
@@ -21,13 +21,13 @@ describe('AttrBindingBehavior', () => {
     sut.bind(undefined, undefined, binding);
   });
 
-  it('bind()   should put a DataAttributeObserver on the binding', () => {
+  it('bind()   should put a DataAttributeObserver on the binding', function() {
     expect(binding.targetObserver instanceof DataAttributeAccessor).to.equal(true);
     expect(binding.targetObserver['obj'] === target).to.equal(true);
     expect(binding.targetObserver['propertyKey'] === targetProperty).to.equal(true);
   });
 
-  // it('unbind() should clear the DataAttributeObserver from the binding', () => {
+  // it('unbind() should clear the DataAttributeObserver from the binding', function() {
   //   // TODO: it doesn't actually do, and it should
   // });
 });

--- a/packages/runtime-html/test/resources/binding-behaviors/attr-binding-behavior.spec.ts
+++ b/packages/runtime-html/test/resources/binding-behaviors/attr-binding-behavior.spec.ts
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 import { AttrBindingBehavior, DataAttributeAccessor } from '../../../src/index';
 import { TestContext } from '../../util';
 
-describe('AttrBindingBehavior', function() {
+describe('AttrBindingBehavior', function () {
   let target: any;
   let targetProperty: string;
   let container: IContainer;
   let sut: AttrBindingBehavior;
   let binding: Binding;
 
-  beforeEach(function() {
+  beforeEach(function () {
     const ctx = TestContext.createHTMLTestContext();
     target = ctx.createElement('div');
     targetProperty = 'foo';
@@ -21,13 +21,13 @@ describe('AttrBindingBehavior', function() {
     sut.bind(undefined, undefined, binding);
   });
 
-  it('bind()   should put a DataAttributeObserver on the binding', function() {
+  it('bind()   should put a DataAttributeObserver on the binding', function () {
     expect(binding.targetObserver instanceof DataAttributeAccessor).to.equal(true);
     expect(binding.targetObserver['obj'] === target).to.equal(true);
     expect(binding.targetObserver['propertyKey'] === targetProperty).to.equal(true);
   });
 
-  // it('unbind() should clear the DataAttributeObserver from the binding', function() {
+  // it('unbind() should clear the DataAttributeObserver from the binding', function () {
   //   // TODO: it doesn't actually do, and it should
   // });
 });

--- a/packages/runtime-html/test/resources/binding-behaviors/self-binding-behavior.spec.ts
+++ b/packages/runtime-html/test/resources/binding-behaviors/self-binding-behavior.spec.ts
@@ -3,28 +3,28 @@ import { Binding } from '@aurelia/runtime';
 import { expect } from 'chai';
 import { SelfBindingBehavior } from '../../../src/index';
 
-describe('SelfBindingBehavior', function() {
+describe('SelfBindingBehavior', function () {
   const container: IContainer = DI.createContainer();
   let sut: SelfBindingBehavior;
   let binding: Binding;
   let originalCallSource: () => void;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sut = new SelfBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container as any);
-    originalCallSource = binding['callSource'] = function() { return; };
+    originalCallSource = binding['callSource'] = function () { return; };
     binding['targetEvent'] = 'foo';
     sut.bind(undefined, undefined, binding as any);
   });
 
   // TODO: test properly (different binding types)
-  it('bind()   should apply the correct behavior', function() {
+  it('bind()   should apply the correct behavior', function () {
     expect(binding['selfEventCallSource'] === originalCallSource).to.equal(true);
     expect(binding['callSource'] === originalCallSource).to.equal(false);
     expect(typeof binding['callSource']).to.equal('function');
   });
 
-  it('unbind() should revert the original behavior', function() {
+  it('unbind() should revert the original behavior', function () {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['selfEventCallSource']).to.equal(null);
     expect(binding['callSource'] === originalCallSource).to.equal(true);

--- a/packages/runtime-html/test/resources/binding-behaviors/self-binding-behavior.spec.ts
+++ b/packages/runtime-html/test/resources/binding-behaviors/self-binding-behavior.spec.ts
@@ -3,13 +3,13 @@ import { Binding } from '@aurelia/runtime';
 import { expect } from 'chai';
 import { SelfBindingBehavior } from '../../../src/index';
 
-describe('SelfBindingBehavior', () => {
+describe('SelfBindingBehavior', function() {
   const container: IContainer = DI.createContainer();
   let sut: SelfBindingBehavior;
   let binding: Binding;
   let originalCallSource: () => void;
 
-  beforeEach(() => {
+  beforeEach(function() {
     sut = new SelfBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container as any);
     originalCallSource = binding['callSource'] = function() { return; };
@@ -18,13 +18,13 @@ describe('SelfBindingBehavior', () => {
   });
 
   // TODO: test properly (different binding types)
-  it('bind()   should apply the correct behavior', () => {
+  it('bind()   should apply the correct behavior', function() {
     expect(binding['selfEventCallSource'] === originalCallSource).to.equal(true);
     expect(binding['callSource'] === originalCallSource).to.equal(false);
     expect(typeof binding['callSource']).to.equal('function');
   });
 
-  it('unbind() should revert the original behavior', () => {
+  it('unbind() should revert the original behavior', function() {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['selfEventCallSource']).to.equal(null);
     expect(binding['callSource'] === originalCallSource).to.equal(true);

--- a/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
+++ b/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
@@ -5,7 +5,7 @@ import { FakeViewFactory } from '../../_doubles/fake-view-factory';
 import { hydrateCustomElement } from '../../behavior-assistance';
 import { HTMLTestContext, TestContext } from '../../util';
 
-describe('The "compose" custom element', function() {
+describe('The "compose" custom element', function () {
   // this is not ideal (same instance will be reused for multiple loops) but probably fine
   // need to revisit this later to give this extra dep a clean atomic entry point for the tests
   const subjectPossibilities = [
@@ -76,7 +76,7 @@ describe('The "compose" custom element', function() {
           () => {
             const child = getCurrentView(element);
             let attachCalled = false;
-            child.$attach = function() { attachCalled = true; };
+            child.$attach = function () { attachCalled = true; };
 
             runAttachLifecycle(ctx, element);
 
@@ -120,7 +120,7 @@ describe('The "compose" custom element', function() {
             const child = getCurrentView(element);
 
             let bindCalled = false;
-            child.$bind = function() { bindCalled = true; };
+            child.$bind = function () { bindCalled = true; };
 
             element.$bind(LifecycleFlags.fromBind);
 
@@ -142,7 +142,7 @@ describe('The "compose" custom element', function() {
           () => {
             const child = getCurrentView(element);
             let detachCalled = false;
-            child.$detach = function() { detachCalled = true; };
+            child.$detach = function () { detachCalled = true; };
 
             runAttachLifecycle(ctx, element);
             runDetachLifecycle(ctx, element);
@@ -165,7 +165,7 @@ describe('The "compose" custom element', function() {
           () => {
             const child = getCurrentView(element);
             let unbindCalled = false;
-            child.$unbind = function() { unbindCalled = true; };
+            child.$unbind = function () { unbindCalled = true; };
 
             element.$bind(LifecycleFlags.fromBind);
             element.$unbind(LifecycleFlags.fromUnbind);
@@ -240,13 +240,13 @@ describe('The "compose" custom element', function() {
 
           let detachCalled = false;
           const detach = view1.$detach;
-          view1.$detach = function() {
+          view1.$detach = function () {
             detachCalled = true;
             detach.apply(view1, [LifecycleFlags.none]);
           };
 
           let unbindCalled = false;
-          view1.$unbind = function() { unbindCalled = true; };
+          view1.$unbind = function () { unbindCalled = true; };
 
           waitForCompositionEnd(
             element,

--- a/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
+++ b/packages/runtime-html/test/resources/custom-elements/compose.spec.ts
@@ -5,7 +5,7 @@ import { FakeViewFactory } from '../../_doubles/fake-view-factory';
 import { hydrateCustomElement } from '../../behavior-assistance';
 import { HTMLTestContext, TestContext } from '../../util';
 
-describe('The "compose" custom element', () => {
+describe('The "compose" custom element', function() {
   // this is not ideal (same instance will be reused for multiple loops) but probably fine
   // need to revisit this later to give this extra dep a clean atomic entry point for the tests
   const subjectPossibilities = [

--- a/packages/runtime-html/test/runtime.spec.ts
+++ b/packages/runtime-html/test/runtime.spec.ts
@@ -1,7 +1,7 @@
 // import { TestBuilder as Test, DefinitionBuilder as D, InstructionBuilder as I } from './test-builder';
 
-// describe('runtime', function() {
-//   it('1', function() {
+// describe('runtime', function () {
+//   it('1', function () {
 //     const appState = { show: true };
 //     const definition =
 //     D.if(
@@ -25,7 +25,7 @@
 //     test.dispose();
 //   });
 
-//   it('2', function() {
+//   it('2', function () {
 //     const appState = { items: [{ childItems: ['a', 'b', 'c'] }] };
 //     const definition =
 //     D.if(

--- a/packages/runtime-html/test/runtime.spec.ts
+++ b/packages/runtime-html/test/runtime.spec.ts
@@ -1,7 +1,7 @@
 // import { TestBuilder as Test, DefinitionBuilder as D, InstructionBuilder as I } from './test-builder';
 
-// describe('runtime', () => {
-//   it('1', () => {
+// describe('runtime', function() {
+//   it('1', function() {
 //     const appState = { show: true };
 //     const definition =
 //     D.if(
@@ -25,7 +25,7 @@
 //     test.dispose();
 //   });
 
-//   it('2', () => {
+//   it('2', function() {
 //     const appState = { items: [{ childItems: ['a', 'b', 'c'] }] };
 //     const definition =
 //     D.if(

--- a/packages/runtime-html/test/test-builder.ts
+++ b/packages/runtime-html/test/test-builder.ts
@@ -325,7 +325,7 @@ export class TestBuilder<T extends Constructable> {
     } else {
       definition = defCbOrBuilder(DefinitionBuilder.app()).build();
     }
-    const Type = obj['prototype'] ? obj : function() {
+    const Type = obj['prototype'] ? obj : function () {
       Object.assign(this, obj);
     };
     const App = CustomElementResource.define(definition, Type as any);
@@ -334,7 +334,7 @@ export class TestBuilder<T extends Constructable> {
 
   public element(obj: Record<string, unknown>, def: DefinitionCb): TestBuilder<T> {
     const definition = def(DefinitionBuilder.element()).build();
-    const Type = obj['prototype'] ? obj : function() {
+    const Type = obj['prototype'] ? obj : function () {
       Object.assign(this, obj);
     };
     const Resource = CustomElementResource.define(definition, Type as any);

--- a/packages/runtime-html/test/util.ts
+++ b/packages/runtime-html/test/util.ts
@@ -360,7 +360,7 @@ export function addChaiAsserts_$state(_chai, utils) {
           `${msg}expected $state to have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`,
           `${msg}expected $state to NOT have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`);
       },
-      function() {
+      function () {
         utils.flag(this, flagName, true);
       }
     );

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -330,7 +330,7 @@ export function createRenderContext(
     return context;
   };
 
-  context.dispose = function(): void {
+  context.dispose = function (): void {
     factoryProvider.dispose();
     renderableProvider.dispose();
     instructionProvider.dispose();
@@ -506,7 +506,7 @@ export class RuntimeBehavior {
 
     Reflect.defineProperty(instance, '$children', {
       enumerable: false,
-      get: function(): unknown {
+      get: function (): unknown {
         return this['$observers'].$children.getValue();
       }
     });
@@ -557,7 +557,7 @@ export class RuntimeBehavior {
 function createGetterSetter(flags: LifecycleFlags, instance: ICustomAttribute | ICustomElement, name: string): void {
   Reflect.defineProperty(instance, name, {
     enumerable: true,
-    get: function(): unknown { return this['$observers'][name].getValue(); },
+    get: function (): unknown { return this['$observers'][name].getValue(); },
     set: function(value: unknown): void { this['$observers'][name].setValue(value, flags & LifecycleFlags.persistentBindingFlags); }
   });
 }

--- a/packages/runtime/test/au-dom.spec.ts
+++ b/packages/runtime/test/au-dom.spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { CustomElementResource, LifecycleFlags } from '../src/index';
 import { AuDOMTest as AU } from './au-dom';
 
-describe('AuDOM', () => {
-  it('works', () => {
+describe('AuDOM', function() {
+  it('works', function() {
     const { au, host, lifecycle } = AU.setup();
 
     const definition = AU.createTemplateControllerDefinition(

--- a/packages/runtime/test/au-dom.spec.ts
+++ b/packages/runtime/test/au-dom.spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { CustomElementResource, LifecycleFlags } from '../src/index';
 import { AuDOMTest as AU } from './au-dom';
 
-describe('AuDOM', function() {
-  it('works', function() {
+describe('AuDOM', function () {
+  it('works', function () {
     const { au, host, lifecycle } = AU.setup();
 
     const definition = AU.createTemplateControllerDefinition(

--- a/packages/runtime/test/aurelia.spec.ts
+++ b/packages/runtime/test/aurelia.spec.ts
@@ -3,18 +3,18 @@ import { spy } from 'sinon';
 import { Aurelia, State } from '../src/index';
 import { AuDOMConfiguration } from './au-dom';
 
-describe('Aurelia', () => {
+describe('Aurelia', function() {
   let sut: Aurelia;
 
-  beforeEach(() => {
+  beforeEach(function() {
     sut = new Aurelia(AuDOMConfiguration.createContainer());
   });
 
-  it('should initialize container directly', () => {
+  it('should initialize container directly', function() {
     expect(sut['container'].get(Aurelia)).to.equal(sut);
   });
 
-  it('should initialize correctly', () => {
+  it('should initialize correctly', function() {
     expect(sut['components'].length).to.equal(0);
     expect(sut['startTasks'].length).to.equal(0);
     expect(sut['stopTasks'].length).to.equal(0);
@@ -22,7 +22,7 @@ describe('Aurelia', () => {
     expect(sut['container']).not.to.equal(undefined);
   });
 
-  it('should register dependencies', () => {
+  it('should register dependencies', function() {
     spy(sut['container'], 'register');
     class Foo {}
     class Bar {}
@@ -31,7 +31,7 @@ describe('Aurelia', () => {
     expect(sut['container'].register).to.have.been.calledWith(Foo, Bar);
   });
 
-  it('should register dependencies as array', () => {
+  it('should register dependencies as array', function() {
     spy(sut['container'], 'register');
     class Foo {}
     class Bar {}
@@ -40,14 +40,14 @@ describe('Aurelia', () => {
     expect(sut['container'].register).to.have.been.calledWith([Foo, Bar]);
   });
 
-  it('should register start and stop task', () => {
+  it('should register start and stop task', function() {
     sut.app({component: {}, host: {}});
 
     expect(sut['startTasks'].length).to.equal(1);
     expect(sut['stopTasks'].length).to.equal(1);
   });
 
-  it('should start', () => {
+  it('should start', function() {
     let hydrated = false;
     let bound = false;
     let attached = false;
@@ -65,7 +65,7 @@ describe('Aurelia', () => {
     expect(attached).to.equal(true);
   });
 
-  it('should stop', () => {
+  it('should stop', function() {
     let unbound = false;
     let detached = false;
 

--- a/packages/runtime/test/aurelia.spec.ts
+++ b/packages/runtime/test/aurelia.spec.ts
@@ -3,18 +3,18 @@ import { spy } from 'sinon';
 import { Aurelia, State } from '../src/index';
 import { AuDOMConfiguration } from './au-dom';
 
-describe('Aurelia', function() {
+describe('Aurelia', function () {
   let sut: Aurelia;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sut = new Aurelia(AuDOMConfiguration.createContainer());
   });
 
-  it('should initialize container directly', function() {
+  it('should initialize container directly', function () {
     expect(sut['container'].get(Aurelia)).to.equal(sut);
   });
 
-  it('should initialize correctly', function() {
+  it('should initialize correctly', function () {
     expect(sut['components'].length).to.equal(0);
     expect(sut['startTasks'].length).to.equal(0);
     expect(sut['stopTasks'].length).to.equal(0);
@@ -22,7 +22,7 @@ describe('Aurelia', function() {
     expect(sut['container']).not.to.equal(undefined);
   });
 
-  it('should register dependencies', function() {
+  it('should register dependencies', function () {
     spy(sut['container'], 'register');
     class Foo {}
     class Bar {}
@@ -31,7 +31,7 @@ describe('Aurelia', function() {
     expect(sut['container'].register).to.have.been.calledWith(Foo, Bar);
   });
 
-  it('should register dependencies as array', function() {
+  it('should register dependencies as array', function () {
     spy(sut['container'], 'register');
     class Foo {}
     class Bar {}
@@ -40,14 +40,14 @@ describe('Aurelia', function() {
     expect(sut['container'].register).to.have.been.calledWith([Foo, Bar]);
   });
 
-  it('should register start and stop task', function() {
+  it('should register start and stop task', function () {
     sut.app({component: {}, host: {}});
 
     expect(sut['startTasks'].length).to.equal(1);
     expect(sut['stopTasks'].length).to.equal(1);
   });
 
-  it('should start', function() {
+  it('should start', function () {
     let hydrated = false;
     let bound = false;
     let attached = false;
@@ -65,7 +65,7 @@ describe('Aurelia', function() {
     expect(attached).to.equal(true);
   });
 
-  it('should stop', function() {
+  it('should stop', function () {
     let unbound = false;
     let detached = false;
 

--- a/packages/runtime/test/binding/ast.spec.ts
+++ b/packages/runtime/test/binding/ast.spec.ts
@@ -94,7 +94,7 @@ function throwsOn<TExpr extends IsBindingBehavior>(expr: TExpr, method: keyof TE
 const $num1 = new PrimitiveLiteral(1);
 const $str1 = new PrimitiveLiteral('1');
 
-describe('AST', function() {
+describe('AST', function () {
 
   const AccessThisList: [string, AccessThis][] = [
     [`$this`,             $this],
@@ -301,35 +301,35 @@ describe('AST', function() {
     [`a&b:c:d`, new BindingBehavior(new AccessScope('a'), 'b', [new AccessScope('c'), new AccessScope('d')])]
   ];
 
-  describe('Literals', function() {
-    describe('evaluate() works without any input', function() {
+  describe('Literals', function () {
+    describe('evaluate() works without any input', function () {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
         ...KeywordLiteralList
       ]) {
-        it(text, function() {
+        it(text, function () {
           expect(expr.evaluate(undefined, undefined, undefined)).to.equal(expr.value);
         });
       }
       for (const [text, expr] of TemplateLiteralList) {
-        it(text, function() {
+        it(text, function () {
           expect(expr.evaluate(undefined, undefined, undefined)).to.equal('');
         });
       }
       for (const [text, expr] of ArrayLiteralList) {
-        it(text, function() {
+        it(text, function () {
           expect(expr.evaluate(undefined, undefined, undefined)).to.be.instanceof(Array);
         });
       }
       for (const [text, expr] of ObjectLiteralList) {
-        it(text, function() {
+        it(text, function () {
           expect(expr.evaluate(undefined, undefined, undefined)).to.be.instanceof(Object);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', function() {
+    describe('connect() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
@@ -338,16 +338,16 @@ describe('AST', function() {
         ...ArrayLiteralList,
         ...ObjectLiteralList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
@@ -356,53 +356,53 @@ describe('AST', function() {
         ...ArrayLiteralList,
         ...ObjectLiteralList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Context Accessors', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Context Accessors', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', function() {
+    describe('connect() does not throw / is a no-op', function () {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Scope Accessors', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Scope Accessors', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
@@ -410,45 +410,45 @@ describe('AST', function() {
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when scope is nil', function() {
+    describe('assign() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
         ...SimpleAccessMemberList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
@@ -456,112 +456,112 @@ describe('AST', function() {
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('CallExpression', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('CallExpression', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...SimpleCallFunctionList,
         ...SimpleCallScopeList,
         ...SimpleCallMemberList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...SimpleCallFunctionList,
         ...SimpleCallScopeList,
         ...SimpleCallMemberList
       ]) {
-          it(`${text}, undefined`, function() {
+          it(`${text}, undefined`, function () {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, function() {
+          it(`${text}, null`, function () {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...SimpleCallMemberList,
         ...SimpleCallFunctionList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', function() {
+    describe('connect() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...SimpleCallScopeList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Unary', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Unary', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of SimpleUnaryList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of SimpleUnaryList) {
-          it(`${text}, undefined`, function() {
+          it(`${text}, undefined`, function () {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, function() {
+          it(`${text}, null`, function () {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of SimpleUnaryList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Binary', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Binary', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -570,16 +570,16 @@ describe('AST', function() {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -588,16 +588,16 @@ describe('AST', function() {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-          it(`${text}, undefined`, function() {
+          it(`${text}, undefined`, function () {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, function() {
+          it(`${text}, null`, function () {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -606,235 +606,235 @@ describe('AST', function() {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Conditional', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Conditional', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of SimpleConditionalList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', function() {
+    describe('assign() does not throw / is a no-op', function () {
       for (const [text, expr] of SimpleConditionalList) {
-          it(`${text}, undefined`, function() {
+          it(`${text}, undefined`, function () {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, function() {
+          it(`${text}, null`, function () {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of SimpleConditionalList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Assign', function() {
-    describe('evaluate() throws when scope is nil', function() {
+  describe('Assign', function () {
+    describe('evaluate() throws when scope is nil', function () {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when scope is nil', function() {
+    describe('assign() throws when scope is nil', function () {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', function() {
+    describe('connect() does not throw / is a no-op', function () {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('ValueConverter', function() {
-    describe('evaluate() throws when locator is nil', function() {
+  describe('ValueConverter', function () {
+    describe('evaluate() throws when locator is nil', function () {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 202', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 202', null, null);
         });
       }
     });
-    describe('evaluate() throws when returned converter is nil', function() {
+    describe('evaluate() throws when returned converter is nil', function () {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 205', null, null, locator);
         });
       }
     });
 
-    describe('assign() throws when locator is nil', function() {
+    describe('assign() throws when locator is nil', function () {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'assign', 'Code 202', null, null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'assign', 'Code 202', null, null, null);
         });
       }
     });
-    describe('assign() throws when returned converter is null', function() {
+    describe('assign() throws when returned converter is null', function () {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'assign', 'Code 205', null, null, locator);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() throws when binding is null', function() {
+    describe('connect() throws when binding is null', function () {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 206', null, {}, null);
         });
       }
     });
 
-    describe('connect() throws when locator is null', function() {
+    describe('connect() throws when locator is null', function () {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 202', null, {}, {});
         });
       }
     });
 
-    describe('connect() throws when returned converter is null', function() {
+    describe('connect() throws when returned converter is null', function () {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 205', null, {}, { locator, observeProperty: () => { return; } });
         });
       }
     });
   });
 
-  describe('BindingBehavior', function() {
-    describe('evaluate() throws when locator is nil', function() {
+  describe('BindingBehavior', function () {
+    describe('evaluate() throws when locator is nil', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when locator is nil', function() {
+    describe('assign() throws when locator is nil', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', function() {
+    describe('connect() throws when scope is nil', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('bind() throws when scope is nil', function() {
+    describe('bind() throws when scope is nil', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'bind', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, function() {
+        it(`${text}, null`, function () {
           throwsOn(expr, 'bind', 'Code 251', null, null);
         });
       }
     });
 
-    describe('bind() throws when binding is null', function() {
+    describe('bind() throws when binding is null', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'bind', 'Code 206', null, {}, null);
         });
       }
     });
 
-    describe('bind() throws when locator is null', function() {
+    describe('bind() throws when locator is null', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'bind', 'Code 202', null, {}, {});
         });
       }
     });
 
-    describe('bind() throws when returned behavior is null', function() {
+    describe('bind() throws when returned behavior is null', function () {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, function() {
+        it(`${text}, undefined`, function () {
           throwsOn(expr, 'bind', 'Code 203', null, {}, { locator, observeProperty: () => { return; } });
         });
       }
@@ -842,13 +842,13 @@ describe('AST', function() {
 
       // TODO: this should throw (or at least verify warning), but leave it be for now due to friction with generated
       // tests (which need to be fixed of course)
-    // describe('bind() throws when returned behavior is already present', function() {
+    // describe('bind() throws when returned behavior is already present', function () {
     //   const behavior = {};
     //   const locator = { get() {
     //     return behavior;
     //   } };
     //   for (const [text, expr] of SimpleBindingBehaviorList) {
-    //     it(`${text}, undefined`, function() {
+    //     it(`${text}, undefined`, function () {
     //       throwsOn(expr, 'bind', 'Code 204', null, {}, { [expr.behaviorKey]: behavior, locator, observeProperty: () => { return; } });
     //     });
     //   }
@@ -856,32 +856,32 @@ describe('AST', function() {
   });
 });
 
-describe('AccessKeyed', function() {
+describe('AccessKeyed', function () {
   let expression: AccessKeyed;
 
-  before(function() {
+  before(function () {
     expression = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral('bar'));
   });
 
-  it('evaluates member on bindingContext', function() {
+  it('evaluates member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('evaluates member on overrideContext', function() {
+  it('evaluates member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('assigns member on bindingContext', function() {
+  it('assigns member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expression.assign(LF.none, scope, null, 'bang');
     // @ts-ignore
     expect(scope.bindingContext.foo.bar).to.equal('bang');
   });
 
-  it('assigns member on overrideContext', function() {
+  it('assigns member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expression.assign(LF.none, scope, null, 'bang');
@@ -889,7 +889,7 @@ describe('AccessKeyed', function() {
     expect(scope.overrideContext.foo.bar).to.equal('bang');
   });
 
-  it('evaluates null/undefined object', function() {
+  it('evaluates null/undefined object', function () {
     let scope = createScopeForTest({ foo: null });
     expect(expression.evaluate(LF.none, scope, null)).to.equal(undefined);
     scope = createScopeForTest({ foo: undefined });
@@ -898,7 +898,7 @@ describe('AccessKeyed', function() {
     expect(expression.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('does not observes property in keyed object access when key is number', function() {
+  it('does not observes property in keyed object access when key is number', function () {
     const scope = createScopeForTest({ foo: { '0': 'hello world' } });
     const expression2 = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral(0));
     expect(expression2.evaluate(LF.none, scope, null)).to.equal('hello world');
@@ -909,7 +909,7 @@ describe('AccessKeyed', function() {
     expect(binding.observeProperty.callCount).to.equal(2);
   });
 
-  it('does not observe property in keyed array access when key is number', function() {
+  it('does not observe property in keyed array access when key is number', function () {
     const scope = createScopeForTest({ foo: ['hello world'] });
     const expression3 = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral(0));
     expect(expression3.evaluate(LF.none, scope, null)).to.equal('hello world');
@@ -920,7 +920,7 @@ describe('AccessKeyed', function() {
     expect(binding.observeProperty.callCount).to.equal(1);
   });
 
-  describe('does not attempt to observe property when object is primitive', function() {
+  describe('does not attempt to observe property when object is primitive', function () {
     const objects: [string, any][] = [
       [`     null`, null],
       [`undefined`, undefined],
@@ -937,7 +937,7 @@ describe('AccessKeyed', function() {
     const inputs: [typeof objects, typeof keys] = [objects, keys];
 
     eachCartesianJoin(inputs, (([t1, obj], [t2, key]) => {
-        it(`${t1}${t2}`, function() {
+        it(`${t1}${t2}`, function () {
           const scope = createScopeForTest({ foo: obj });
           const sut = new AccessKeyed(new AccessScope('foo', 0), key);
           const binding = { observeProperty: spy() };
@@ -949,7 +949,7 @@ describe('AccessKeyed', function() {
   });
 });
 
-describe('AccessMember', function() {
+describe('AccessMember', function () {
 
   const objects: (() => [string, any, boolean, boolean])[] = [
     () => [`     null`, null,      true,     false],
@@ -1043,7 +1043,7 @@ describe('AccessMember', function() {
   const expression: AccessMember = new AccessMember(new AccessScope('foo', 0), 'bar');
 
   eachCartesianJoinFactory(inputs, (([t1, obj, isFalsey, canHaveProperty], [t2, prop, value]) => {
-      it(`${t1}.${t2}.evaluate() -> connect -> assign`, function() {
+      it(`${t1}.${t2}.evaluate() -> connect -> assign`, function () {
         const scope = createScopeForTest({ foo: obj });
         const sut = new AccessMember(new AccessScope('foo', 0), prop);
         const actual = sut.evaluate(LF.none, scope, null);
@@ -1075,25 +1075,25 @@ describe('AccessMember', function() {
     })
   );
 
-  it('evaluates member on bindingContext', function() {
+  it('evaluates member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('evaluates member on overrideContext', function() {
+  it('evaluates member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('assigns member on bindingContext', function() {
+  it('assigns member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expression.assign(LF.none, scope, null, 'bang');
     // @ts-ignore
     expect(scope.bindingContext.foo.bar).to.equal('bang');
   });
 
-  it('assigns member on overrideContext', function() {
+  it('assigns member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expression.assign(LF.none, scope, null, 'bang');
@@ -1101,12 +1101,12 @@ describe('AccessMember', function() {
     expect(scope.overrideContext.foo.bar).to.equal('bang');
   });
 
-  it('returns the assigned value', function() {
+  it('returns the assigned value', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.assign(LF.none, scope, null, 'bang')).to.equal('bang');
   });
 
-  describe('does not attempt to observe property when object is falsey', function() {
+  describe('does not attempt to observe property when object is falsey', function () {
     const objects2: [string, any][] = [
         [`     null`, null],
         [`undefined`, undefined],
@@ -1120,7 +1120,7 @@ describe('AccessMember', function() {
     const inputs2: [typeof objects2, typeof props2] = [objects2, props2];
 
     eachCartesianJoin(inputs2, (([t1, obj], [t2, prop]) => {
-        it(`${t1}${t2}`, function() {
+        it(`${t1}${t2}`, function () {
           const scope = createScopeForTest({ foo: obj });
           const sut = new AccessMember(new AccessScope('foo', 0), prop);
           const binding = { observeProperty: spy() };
@@ -1131,7 +1131,7 @@ describe('AccessMember', function() {
     );
   });
 
-  describe('does not observe if object does not / cannot have the property', function() {
+  describe('does not observe if object does not / cannot have the property', function () {
     const objects3: [string, any][] = [
       [`        1`, 1],
       [`     true`, true],
@@ -1146,7 +1146,7 @@ describe('AccessMember', function() {
     const inputs3: [typeof objects3, typeof props3] = [objects3, props3];
 
     eachCartesianJoin(inputs3, (([t1, obj], [t2, prop]) => {
-        it(`${t1}${t2}`, function() {
+        it(`${t1}${t2}`, function () {
           const scope = createScopeForTest({ foo: obj });
           const expression2 = new AccessMember(new AccessScope('foo', 0), prop);
           const binding = { observeProperty: spy() };
@@ -1158,85 +1158,85 @@ describe('AccessMember', function() {
   });
 });
 
-describe('AccessScope', function() {
+describe('AccessScope', function () {
   const foo: AccessScope = new AccessScope('foo', 0);
   const $parentfoo: AccessScope = new AccessScope('foo', 1);
   const binding = { observeProperty: spy() };
 
-  it('evaluates undefined bindingContext', function() {
+  it('evaluates undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('assigns undefined bindingContext', function() {
+  it('assigns undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects undefined bindingContext', function() {
+  it('connects undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('evaluates null bindingContext', function() {
+  it('evaluates null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('assigns null bindingContext', function() {
+  it('assigns null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects null bindingContext', function() {
+  it('connects null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('evaluates defined property on bindingContext', function() {
+  it('evaluates defined property on bindingContext', function () {
     const scope = createScopeForTest({ foo: 'bar' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('evaluates defined property on overrideContext', function() {
+  it('evaluates defined property on overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('assigns defined property on bindingContext', function() {
+  it('assigns defined property on bindingContext', function () {
     const scope = createScopeForTest({ foo: 'bar' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.bindingContext.foo).to.equal('baz');
   });
 
-  it('assigns undefined property to bindingContext', function() {
+  it('assigns undefined property to bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.bindingContext.foo).to.equal('baz');
   });
 
-  it('assigns defined property on overrideContext', function() {
+  it('assigns defined property on overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects defined property on bindingContext', function() {
+  it('connects defined property on bindingContext', function () {
     const scope = createScopeForTest({ foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'foo');
   });
 
-  it('connects defined property on overrideContext', function() {
+  it('connects defined property on overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     (binding.observeProperty as any).resetHistory();
@@ -1244,27 +1244,27 @@ describe('AccessScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('connects undefined property on bindingContext', function() {
+  it('connects undefined property on bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'foo');
   });
 
-  it('evaluates defined property on first ancestor bindingContext', function() {
+  it('evaluates defined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect($parentfoo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('evaluates defined property on first ancestor overrideContext', function() {
+  it('evaluates defined property on first ancestor overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect($parentfoo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('assigns defined property on first ancestor bindingContext', function() {
+  it('assigns defined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.parentOverrideContext.bindingContext.foo).to.equal('baz');
@@ -1272,7 +1272,7 @@ describe('AccessScope', function() {
     expect(scope.overrideContext.parentOverrideContext.bindingContext.foo).to.equal('beep');
   });
 
-  it('assigns defined property on first ancestor overrideContext', function() {
+  it('assigns defined property on first ancestor overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     foo.assign(LF.none, scope, null, 'baz');
@@ -1281,7 +1281,7 @@ describe('AccessScope', function() {
     expect(scope.overrideContext.parentOverrideContext.foo).to.equal('beep');
   });
 
-  it('connects defined property on first ancestor bindingContext', function() {
+  it('connects defined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1291,7 +1291,7 @@ describe('AccessScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext.bindingContext, 'foo');
   });
 
-  it('connects defined property on first ancestor overrideContext', function() {
+  it('connects defined property on first ancestor overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     (binding.observeProperty as any).resetHistory();
@@ -1302,7 +1302,7 @@ describe('AccessScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext, 'foo');
   });
 
-  it('connects undefined property on first ancestor bindingContext', function() {
+  it('connects undefined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, {});
     // @ts-ignore
     scope.overrideContext.parentOverrideContext.parentOverrideContext = OverrideContext.create({ foo: 'bar' }, null);
@@ -1312,12 +1312,12 @@ describe('AccessScope', function() {
   });
 });
 
-describe('AccessThis', function() {
+describe('AccessThis', function () {
   const $parent2 = new AccessThis(1);
   const $parent$parent = new AccessThis(2);
   const $parent$parent$parent = new AccessThis(3);
 
-  it('evaluates undefined bindingContext', function() {
+  it('evaluates undefined bindingContext', function () {
     const coc = OverrideContext.create;
 
     let scope = { overrideContext: coc(LF.none, undefined, null) };
@@ -1341,7 +1341,7 @@ describe('AccessThis', function() {
     expect($parent$parent$parent.evaluate(LF.none, scope as any, null)).to.equal(undefined);
   });
 
-  it('evaluates null bindingContext', function() {
+  it('evaluates null bindingContext', function () {
     const coc = OverrideContext.create;
 
     let scope = { overrideContext: coc(LF.none, null, null) };
@@ -1365,7 +1365,7 @@ describe('AccessThis', function() {
     expect($parent$parent$parent.evaluate(LF.none, scope as any, null)).to.equal(null);
   });
 
-  it('evaluates defined bindingContext', function() {
+  it('evaluates defined bindingContext', function () {
     const coc = OverrideContext.create;
     const a = { a: 'a' };
     const b = { b: 'b' };
@@ -1393,8 +1393,8 @@ describe('AccessThis', function() {
   });
 });
 
-describe('Assign', function() {
-  it('can chain assignments', function() {
+describe('Assign', function () {
+  it('can chain assignments', function () {
     const foo = new Assign(new AccessScope('foo', 0), new AccessScope('bar', 0));
     const scope = Scope.create(LF.none, undefined, null);
     foo.assign(LF.none, scope, null as any, 1 as any);
@@ -1403,8 +1403,8 @@ describe('Assign', function() {
   });
 });
 
-describe('Conditional', function() {
-  it('evaluates the "yes" branch', function() {
+describe('Conditional', function () {
+  it('evaluates the "yes" branch', function () {
     const condition = $true;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1415,7 +1415,7 @@ describe('Conditional', function() {
     expect(no.calls.length).to.equal(0);
   });
 
-  it('evaluates the "no" branch', function() {
+  it('evaluates the "no" branch', function () {
     const condition = $false;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1426,7 +1426,7 @@ describe('Conditional', function() {
     expect(no.calls.length).to.equal(1);
   });
 
-  it('connects the "yes" branch', function() {
+  it('connects the "yes" branch', function () {
     const condition = $true;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1437,7 +1437,7 @@ describe('Conditional', function() {
     expect(no.calls.length).to.equal(0);
   });
 
-  it('connects the "no" branch', function() {
+  it('connects the "no" branch', function () {
     const condition = $false;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1449,8 +1449,8 @@ describe('Conditional', function() {
   });
 });
 
-describe('Binary', function() {
-  it('concats strings', function() {
+describe('Binary', function () {
+  it('concats strings', function () {
     let expression = new Binary('+', new PrimitiveLiteral('a'), new PrimitiveLiteral('b'));
     let scope = createScopeForTest({});
     expect(expression.evaluate(LF.none, scope, null)).to.equal('ab');
@@ -1472,7 +1472,7 @@ describe('Binary', function() {
     expect(expression.evaluate(LF.none, scope, null)).to.equal('undefinedb');
   });
 
-  it('adds numbers', function() {
+  it('adds numbers', function () {
     let expression = new Binary('+', new PrimitiveLiteral(1), new PrimitiveLiteral(2));
     let scope = createScopeForTest({});
     expect(expression.evaluate(LF.none, scope, null)).to.equal(3);
@@ -1494,7 +1494,7 @@ describe('Binary', function() {
     expect(expression.evaluate(LF.none, scope, null)).to.be.NaN;
   });
 
-  describe('performs \'in\'', function() {
+  describe('performs \'in\'', function () {
     const tests: { expr: Binary; expected: boolean }[] = [
       { expr: new Binary('in', new PrimitiveLiteral('foo'), new ObjectLiteral(['foo'], [$null])), expected: true },
       { expr: new Binary('in', new PrimitiveLiteral('foo'), new ObjectLiteral(['bar'], [$null])), expected: false },
@@ -1514,13 +1514,13 @@ describe('Binary', function() {
     const scope = createScopeForTest({ foo: { bar: null }, bar: null });
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), function() {
+      it(expr.toString(), function () {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 
-  describe('performs \'instanceof\'', function() {
+  describe('performs \'instanceof\'', function () {
     class Foo {}
     class Bar extends Foo {}
     const tests: { expr: Binary; expected: boolean }[] = [
@@ -1573,15 +1573,15 @@ describe('Binary', function() {
     const scope: IScope = createScopeForTest({ foo: new Foo(), bar: new Bar() });
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), function() {
+      it(expr.toString(), function () {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 });
 
-describe('CallMember', function() {
-  it('evaluates', function() {
+describe('CallMember', function () {
+  it('evaluates', function () {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     const bindingContext = { foo: { bar: () => 'baz' } };
     const scope = createScopeForTest(bindingContext);
@@ -1590,14 +1590,14 @@ describe('CallMember', function() {
     expect((bindingContext.foo.bar as any).callCount).to.equal(1);
   });
 
-  it('evaluate handles null/undefined member', function() {
+  it('evaluate handles null/undefined member', function () {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: {} }), null)).to.equal(undefined);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: { bar: undefined } }), null)).to.equal(undefined);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: { bar: null } }), null)).to.equal(undefined);
   });
 
-  it('evaluate throws when mustEvaluate and member is null or undefined', function() {
+  it('evaluate throws when mustEvaluate and member is null or undefined', function () {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     const mustEvaluate = true;
     expect(() => expression.evaluate(LF.mustEvaluate, createScopeForTest({}), null)).to.throw();
@@ -1607,25 +1607,25 @@ describe('CallMember', function() {
   });
 });
 
-describe('CallScope', function() {
+describe('CallScope', function () {
   const foo: CallScope = new CallScope('foo', [], 0);
   const hello: CallScope = new CallScope('hello', [new AccessScope('arg', 0)], 0);
   const binding: { observeProperty: SinonSpy } = { observeProperty: spy() };
 
-  it('evaluates undefined bindingContext', function() {
+  it('evaluates undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
     expect(hello.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('throws when mustEvaluate and evaluating undefined bindingContext', function() {
+  it('throws when mustEvaluate and evaluating undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(LF.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(LF.mustEvaluate, scope, null)).to.throw();
   });
 
-  it('connects undefined bindingContext', function() {
+  it('connects undefined bindingContext', function () {
     const scope = Scope.create(LF.none, undefined, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1634,20 +1634,20 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('evaluates null bindingContext', function() {
+  it('evaluates null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
     expect(hello.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('throws when mustEvaluate and evaluating null bindingContext', function() {
+  it('throws when mustEvaluate and evaluating null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(LF.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(LF.mustEvaluate, scope, null)).to.throw();
   });
 
-  it('connects null bindingContext', function() {
+  it('connects null bindingContext', function () {
     const scope = Scope.create(LF.none, null, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1656,13 +1656,13 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('evaluates defined property on bindingContext', function() {
+  it('evaluates defined property on bindingContext', function () {
     const scope = createScopeForTest({ foo: () => 'bar', hello: arg => arg, arg: 'world' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('evaluates defined property on overrideContext', function() {
+  it('evaluates defined property on overrideContext', function () {
     const scope = createScopeForTest({ abc: () => 'xyz' });
     scope.overrideContext.foo = () => 'bar';
     scope.overrideContext.hello = arg => arg;
@@ -1671,7 +1671,7 @@ describe('CallScope', function() {
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('connects defined property on bindingContext', function() {
+  it('connects defined property on bindingContext', function () {
     const scope = createScopeForTest({ foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1680,7 +1680,7 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'arg');
   });
 
-  it('connects defined property on overrideContext', function() {
+  it('connects defined property on overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = () => 'bar';
     scope.overrideContext.hello = arg => arg;
@@ -1692,7 +1692,7 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('connects undefined property on bindingContext', function() {
+  it('connects undefined property on bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1701,13 +1701,13 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'arg');
   });
 
-  it('evaluates defined property on first ancestor bindingContext', function() {
+  it('evaluates defined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('evaluates defined property on first ancestor overrideContext', function() {
+  it('evaluates defined property on first ancestor overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = () => 'bar';
     scope.overrideContext.parentOverrideContext.hello = arg => arg;
@@ -1716,7 +1716,7 @@ describe('CallScope', function() {
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('connects defined property on first ancestor bindingContext', function() {
+  it('connects defined property on first ancestor bindingContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1725,7 +1725,7 @@ describe('CallScope', function() {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext.bindingContext, 'arg');
   });
 
-  it('connects defined property on first ancestor overrideContext', function() {
+  it('connects defined property on first ancestor overrideContext', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = () => 'bar';
     scope.overrideContext.parentOverrideContext.hello = arg => arg;
@@ -1749,7 +1749,7 @@ class Test {
   }
 }
 
-describe('LiteralTemplate', function() {
+describe('LiteralTemplate', function () {
   const tests: { expr: Template | TaggedTemplate; expected: string; ctx: any }[] = [
     { expr: $tpl, expected: '', ctx: {} },
     { expr: new Template(['foo']), expected: 'foo', ctx: {} },
@@ -1825,15 +1825,15 @@ describe('LiteralTemplate', function() {
   ];
 
   for (const { expr, expected, ctx } of tests) {
-    it(`evaluates ${expected}`, function() {
+    it(`evaluates ${expected}`, function () {
       const scope = createScopeForTest(ctx);
       expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
     });
   }
 });
 
-describe('Unary', function() {
-  describe('performs \'typeof\'', function() {
+describe('Unary', function () {
+  describe('performs \'typeof\'', function () {
     const tests: { expr: Unary; expected: string }[] = [
       { expr: new Unary('typeof', new PrimitiveLiteral('foo')), expected: 'string' },
       { expr: new Unary('typeof', new PrimitiveLiteral(1)), expected: 'number' },
@@ -1850,13 +1850,13 @@ describe('Unary', function() {
     const scope: IScope = createScopeForTest({});
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), function() {
+      it(expr.toString(), function () {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 
-  describe('performs \'void\'', function() {
+  describe('performs \'void\'', function () {
     const tests: { expr: Unary }[] = [
       { expr: new Unary('void', new PrimitiveLiteral('foo')) },
       { expr: new Unary('void', new PrimitiveLiteral(1)) },
@@ -1873,12 +1873,12 @@ describe('Unary', function() {
     let scope: IScope = createScopeForTest({});
 
     for (const { expr } of tests) {
-      it(expr.toString(), function() {
+      it(expr.toString(), function () {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(undefined);
       });
     }
 
-    it('void foo()', function() {
+    it('void foo()', function () {
       let fooCalled = false;
       const foo = () => (fooCalled = true);
       scope = createScopeForTest({ foo });
@@ -1889,7 +1889,7 @@ describe('Unary', function() {
   });
 });
 
-describe('BindingBehavior', function() {
+describe('BindingBehavior', function () {
   type $1 = [/*title*/string, /*flags*/LF];
   type $2 = [/*title*/string, /*$kind*/ExpressionKind];
   type $3 = [/*title*/string, /*scope*/IScope, /*sut*/BindingBehavior, /*mock*/MockBindingBehavior, /*locator*/IServiceLocator, /*binding*/IConnectableBinding, /*value*/any, /*argValues*/any[]];
@@ -2143,7 +2143,7 @@ describe('BindingBehavior', function() {
     = [flagVariations, kindVariations, inputVariations, bindVariations, evaluateVariations, connectVariations, assignVariations, $2ndEvaluateVariations, unbindVariations];
 
   eachCartesianJoinFactory(inputs, ([t1], [t2], [t3], bind, evaluate1, connect, assign, evaluate2, unbind) => {
-      it(`flags=${t1}, kind=${t2}, expr=${t3} -> bind() -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function() {
+      it(`flags=${t1}, kind=${t2}, expr=${t3} -> bind() -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function () {
         bind();
         evaluate1();
         connect();
@@ -2155,7 +2155,7 @@ describe('BindingBehavior', function() {
   );
 });
 
-describe('ValueConverter', function() {
+describe('ValueConverter', function () {
   type $1 = [/*title*/string, /*flags*/LF];
   type $2 = [/*title*/string, /*signals*/string[], /*signaler*/MockSignaler];
   type $3 = [/*title*/string, /*scope*/IScope, /*sut*/ValueConverter, /*mock*/MockValueConverter, /*locator*/IServiceLocator, /*binding*/IConnectableBinding, /*value*/any, /*argValues*/any[], /*methods*/string[]];
@@ -2505,7 +2505,7 @@ describe('ValueConverter', function() {
     = [flagVariations, kindVariations, inputVariations, evaluateVariations, connectVariations, assignVariations, $2ndEvaluateVariations, unbindVariations];
 
   eachCartesianJoinFactory(inputs, ([t1], [t2], [t3], evaluate1, connect, assign, evaluate2, unbind) => {
-      it(`flags=${t1}, signalr=${t2} expr=${t3} -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function() {
+      it(`flags=${t1}, signalr=${t2} expr=${t3} -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function () {
         evaluate1();
         connect();
         const newValue = assign();
@@ -2518,8 +2518,8 @@ describe('ValueConverter', function() {
 
 const e = new PrimitiveLiteral('') as any;
 // tslint:disable:space-within-parens
-describe('helper functions', function() {
-  it('connects', function() {
+describe('helper functions', function () {
+  it('connects', function () {
     expect(connects(new AccessThis()                )).to.equal(false);
     expect(connects(new AccessScope('')             )).to.equal(true);
     expect(connects(new ArrayLiteral([])            )).to.equal(true);
@@ -2546,7 +2546,7 @@ describe('helper functions', function() {
     expect(connects(new Interpolation([])           )).to.equal(false);
   });
 
-  it('observes', function() {
+  it('observes', function () {
     expect(observes(new AccessThis()                )).to.equal(false);
     expect(observes(new AccessScope('')             )).to.equal(true);
     expect(observes(new ArrayLiteral([])            )).to.equal(false);
@@ -2573,7 +2573,7 @@ describe('helper functions', function() {
     expect(observes(new Interpolation([])           )).to.equal(false);
   });
 
-  it('callsFunction', function() {
+  it('callsFunction', function () {
     expect(callsFunction(new AccessThis()                )).to.equal(false);
     expect(callsFunction(new AccessScope('')             )).to.equal(false);
     expect(callsFunction(new ArrayLiteral([])            )).to.equal(false);
@@ -2600,7 +2600,7 @@ describe('helper functions', function() {
     expect(callsFunction(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasAncestor', function() {
+  it('hasAncestor', function () {
     expect(hasAncestor(new AccessThis()                )).to.equal(true);
     expect(hasAncestor(new AccessScope('')             )).to.equal(true);
     expect(hasAncestor(new ArrayLiteral([])            )).to.equal(false);
@@ -2627,7 +2627,7 @@ describe('helper functions', function() {
     expect(hasAncestor(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isAssignable', function() {
+  it('isAssignable', function () {
     expect(isAssignable(new AccessThis()                )).to.equal(false);
     expect(isAssignable(new AccessScope('')             )).to.equal(true);
     expect(isAssignable(new ArrayLiteral([])            )).to.equal(false);
@@ -2654,7 +2654,7 @@ describe('helper functions', function() {
     expect(isAssignable(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isLeftHandSide', function() {
+  it('isLeftHandSide', function () {
     expect(isLeftHandSide(new AccessThis()                )).to.equal(true);
     expect(isLeftHandSide(new AccessScope('')             )).to.equal(true);
     expect(isLeftHandSide(new ArrayLiteral([])            )).to.equal(true);
@@ -2681,7 +2681,7 @@ describe('helper functions', function() {
     expect(isLeftHandSide(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isPrimary', function() {
+  it('isPrimary', function () {
     expect(isPrimary(new AccessThis()                )).to.equal(true);
     expect(isPrimary(new AccessScope('')             )).to.equal(true);
     expect(isPrimary(new ArrayLiteral([])            )).to.equal(true);
@@ -2708,7 +2708,7 @@ describe('helper functions', function() {
     expect(isPrimary(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isResource', function() {
+  it('isResource', function () {
     expect(isResource(new AccessThis()                )).to.equal(false);
     expect(isResource(new AccessScope('')             )).to.equal(false);
     expect(isResource(new ArrayLiteral([])            )).to.equal(false);
@@ -2735,7 +2735,7 @@ describe('helper functions', function() {
     expect(isResource(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasBind', function() {
+  it('hasBind', function () {
     expect(hasBind(new AccessThis()                )).to.equal(false);
     expect(hasBind(new AccessScope('')             )).to.equal(false);
     expect(hasBind(new ArrayLiteral([])            )).to.equal(false);
@@ -2762,7 +2762,7 @@ describe('helper functions', function() {
     expect(hasBind(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasUnbind', function() {
+  it('hasUnbind', function () {
     expect(hasUnbind(new AccessThis()                )).to.equal(false);
     expect(hasUnbind(new AccessScope('')             )).to.equal(false);
     expect(hasUnbind(new ArrayLiteral([])            )).to.equal(false);
@@ -2789,7 +2789,7 @@ describe('helper functions', function() {
     expect(hasUnbind(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isLiteral', function() {
+  it('isLiteral', function () {
     expect(isLiteral(new AccessThis()                )).to.equal(false);
     expect(isLiteral(new AccessScope('')             )).to.equal(false);
     expect(isLiteral(new ArrayLiteral([])            )).to.equal(true);
@@ -2816,7 +2816,7 @@ describe('helper functions', function() {
     expect(isLiteral(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isPureLiteral', function() {
+  it('isPureLiteral', function () {
     expect(isPureLiteral(new AccessThis()                )).to.equal(false);
     expect(isPureLiteral(new AccessScope('')             )).to.equal(false);
     expect(isPureLiteral(new ArrayLiteral([])            )).to.equal(true);

--- a/packages/runtime/test/binding/ast.spec.ts
+++ b/packages/runtime/test/binding/ast.spec.ts
@@ -94,7 +94,7 @@ function throwsOn<TExpr extends IsBindingBehavior>(expr: TExpr, method: keyof TE
 const $num1 = new PrimitiveLiteral(1);
 const $str1 = new PrimitiveLiteral('1');
 
-describe('AST', () => {
+describe('AST', function() {
 
   const AccessThisList: [string, AccessThis][] = [
     [`$this`,             $this],
@@ -301,35 +301,35 @@ describe('AST', () => {
     [`a&b:c:d`, new BindingBehavior(new AccessScope('a'), 'b', [new AccessScope('c'), new AccessScope('d')])]
   ];
 
-  describe('Literals', () => {
-    describe('evaluate() works without any input', () => {
+  describe('Literals', function() {
+    describe('evaluate() works without any input', function() {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
         ...KeywordLiteralList
       ]) {
-        it(text, () => {
+        it(text, function() {
           expect(expr.evaluate(undefined, undefined, undefined)).to.equal(expr.value);
         });
       }
       for (const [text, expr] of TemplateLiteralList) {
-        it(text, () => {
+        it(text, function() {
           expect(expr.evaluate(undefined, undefined, undefined)).to.equal('');
         });
       }
       for (const [text, expr] of ArrayLiteralList) {
-        it(text, () => {
+        it(text, function() {
           expect(expr.evaluate(undefined, undefined, undefined)).to.be.instanceof(Array);
         });
       }
       for (const [text, expr] of ObjectLiteralList) {
-        it(text, () => {
+        it(text, function() {
           expect(expr.evaluate(undefined, undefined, undefined)).to.be.instanceof(Object);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', () => {
+    describe('connect() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
@@ -338,16 +338,16 @@ describe('AST', () => {
         ...ArrayLiteralList,
         ...ObjectLiteralList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...StringLiteralList,
         ...NumberLiteralList,
@@ -356,53 +356,53 @@ describe('AST', () => {
         ...ArrayLiteralList,
         ...ObjectLiteralList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Context Accessors', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Context Accessors', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', () => {
+    describe('connect() does not throw / is a no-op', function() {
       for (const [text, expr] of AccessThisList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Scope Accessors', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Scope Accessors', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
@@ -410,45 +410,45 @@ describe('AST', () => {
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when scope is nil', () => {
+    describe('assign() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
         ...SimpleAccessMemberList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...AccessScopeList,
         ...SimpleAccessKeyedList,
@@ -456,112 +456,112 @@ describe('AST', () => {
         ...TemplateInterpolationList,
         ...SimpleTaggedTemplateList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('CallExpression', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('CallExpression', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...SimpleCallFunctionList,
         ...SimpleCallScopeList,
         ...SimpleCallMemberList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...SimpleCallFunctionList,
         ...SimpleCallScopeList,
         ...SimpleCallMemberList
       ]) {
-          it(`${text}, undefined`, () => {
+          it(`${text}, undefined`, function() {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, () => {
+          it(`${text}, null`, function() {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...SimpleCallMemberList,
         ...SimpleCallFunctionList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', () => {
+    describe('connect() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...SimpleCallScopeList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('Unary', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Unary', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of SimpleUnaryList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of SimpleUnaryList) {
-          it(`${text}, undefined`, () => {
+          it(`${text}, undefined`, function() {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, () => {
+          it(`${text}, null`, function() {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of SimpleUnaryList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Binary', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Binary', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -570,16 +570,16 @@ describe('AST', () => {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -588,16 +588,16 @@ describe('AST', () => {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-          it(`${text}, undefined`, () => {
+          it(`${text}, undefined`, function() {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, () => {
+          it(`${text}, null`, function() {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of [
         ...SimpleMultiplicativeList,
         ...SimpleAdditiveList,
@@ -606,235 +606,235 @@ describe('AST', () => {
         ...SimpleLogicalANDList,
         ...SimpleLogicalORList
       ]) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Conditional', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Conditional', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of SimpleConditionalList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() does not throw / is a no-op', () => {
+    describe('assign() does not throw / is a no-op', function() {
       for (const [text, expr] of SimpleConditionalList) {
-          it(`${text}, undefined`, () => {
+          it(`${text}, undefined`, function() {
             expect(expr.assign(null, undefined, null, undefined)).to.equal(undefined);
           });
-          it(`${text}, null`, () => {
+          it(`${text}, null`, function() {
             expect(expr.assign(null, null, null, undefined)).to.equal(undefined);
           });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of SimpleConditionalList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
   });
 
-  describe('Assign', () => {
-    describe('evaluate() throws when scope is nil', () => {
+  describe('Assign', function() {
+    describe('evaluate() throws when scope is nil', function() {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when scope is nil', () => {
+    describe('assign() throws when scope is nil', function() {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() does not throw / is a no-op', () => {
+    describe('connect() does not throw / is a no-op', function() {
       for (const [text, expr] of SimpleAssignList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           expect(expr.connect(null, undefined, null)).to.equal(undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           expect(expr.connect(null, null, null)).to.equal(undefined);
         });
       }
     });
   });
 
-  describe('ValueConverter', () => {
-    describe('evaluate() throws when locator is nil', () => {
+  describe('ValueConverter', function() {
+    describe('evaluate() throws when locator is nil', function() {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 202', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 202', null, null);
         });
       }
     });
-    describe('evaluate() throws when returned converter is nil', () => {
+    describe('evaluate() throws when returned converter is nil', function() {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 205', null, null, locator);
         });
       }
     });
 
-    describe('assign() throws when locator is nil', () => {
+    describe('assign() throws when locator is nil', function() {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'assign', 'Code 202', null, null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'assign', 'Code 202', null, null, null);
         });
       }
     });
-    describe('assign() throws when returned converter is null', () => {
+    describe('assign() throws when returned converter is null', function() {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'assign', 'Code 205', null, null, locator);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() throws when binding is null', () => {
+    describe('connect() throws when binding is null', function() {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 206', null, {}, null);
         });
       }
     });
 
-    describe('connect() throws when locator is null', () => {
+    describe('connect() throws when locator is null', function() {
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 202', null, {}, {});
         });
       }
     });
 
-    describe('connect() throws when returned converter is null', () => {
+    describe('connect() throws when returned converter is null', function() {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleValueConverterList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 205', null, {}, { locator, observeProperty: () => { return; } });
         });
       }
     });
   });
 
-  describe('BindingBehavior', () => {
-    describe('evaluate() throws when locator is nil', () => {
+  describe('BindingBehavior', function() {
+    describe('evaluate() throws when locator is nil', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'evaluate', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'evaluate', 'Code 251', null, null);
         });
       }
     });
 
-    describe('assign() throws when locator is nil', () => {
+    describe('assign() throws when locator is nil', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'assign', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'assign', 'Code 251', null, null);
         });
       }
     });
 
-    describe('connect() throws when scope is nil', () => {
+    describe('connect() throws when scope is nil', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'connect', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'connect', 'Code 251', null, null);
         });
       }
     });
 
-    describe('bind() throws when scope is nil', () => {
+    describe('bind() throws when scope is nil', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'bind', 'Code 250', null, undefined);
         });
-        it(`${text}, null`, () => {
+        it(`${text}, null`, function() {
           throwsOn(expr, 'bind', 'Code 251', null, null);
         });
       }
     });
 
-    describe('bind() throws when binding is null', () => {
+    describe('bind() throws when binding is null', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'bind', 'Code 206', null, {}, null);
         });
       }
     });
 
-    describe('bind() throws when locator is null', () => {
+    describe('bind() throws when locator is null', function() {
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'bind', 'Code 202', null, {}, {});
         });
       }
     });
 
-    describe('bind() throws when returned behavior is null', () => {
+    describe('bind() throws when returned behavior is null', function() {
       const locator = { get() {
         return null;
       } };
       for (const [text, expr] of SimpleBindingBehaviorList) {
-        it(`${text}, undefined`, () => {
+        it(`${text}, undefined`, function() {
           throwsOn(expr, 'bind', 'Code 203', null, {}, { locator, observeProperty: () => { return; } });
         });
       }
@@ -842,13 +842,13 @@ describe('AST', () => {
 
       // TODO: this should throw (or at least verify warning), but leave it be for now due to friction with generated
       // tests (which need to be fixed of course)
-    // describe('bind() throws when returned behavior is already present', () => {
+    // describe('bind() throws when returned behavior is already present', function() {
     //   const behavior = {};
     //   const locator = { get() {
     //     return behavior;
     //   } };
     //   for (const [text, expr] of SimpleBindingBehaviorList) {
-    //     it(`${text}, undefined`, () => {
+    //     it(`${text}, undefined`, function() {
     //       throwsOn(expr, 'bind', 'Code 204', null, {}, { [expr.behaviorKey]: behavior, locator, observeProperty: () => { return; } });
     //     });
     //   }
@@ -856,32 +856,32 @@ describe('AST', () => {
   });
 });
 
-describe('AccessKeyed', () => {
+describe('AccessKeyed', function() {
   let expression: AccessKeyed;
 
-  before(() => {
+  before(function() {
     expression = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral('bar'));
   });
 
-  it('evaluates member on bindingContext', () => {
+  it('evaluates member on bindingContext', function() {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('evaluates member on overrideContext', () => {
+  it('evaluates member on overrideContext', function() {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('assigns member on bindingContext', () => {
+  it('assigns member on bindingContext', function() {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expression.assign(LF.none, scope, null, 'bang');
     // @ts-ignore
     expect(scope.bindingContext.foo.bar).to.equal('bang');
   });
 
-  it('assigns member on overrideContext', () => {
+  it('assigns member on overrideContext', function() {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expression.assign(LF.none, scope, null, 'bang');
@@ -889,7 +889,7 @@ describe('AccessKeyed', () => {
     expect(scope.overrideContext.foo.bar).to.equal('bang');
   });
 
-  it('evaluates null/undefined object', () => {
+  it('evaluates null/undefined object', function() {
     let scope = createScopeForTest({ foo: null });
     expect(expression.evaluate(LF.none, scope, null)).to.equal(undefined);
     scope = createScopeForTest({ foo: undefined });
@@ -898,7 +898,7 @@ describe('AccessKeyed', () => {
     expect(expression.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('does not observes property in keyed object access when key is number', () => {
+  it('does not observes property in keyed object access when key is number', function() {
     const scope = createScopeForTest({ foo: { '0': 'hello world' } });
     const expression2 = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral(0));
     expect(expression2.evaluate(LF.none, scope, null)).to.equal('hello world');
@@ -909,7 +909,7 @@ describe('AccessKeyed', () => {
     expect(binding.observeProperty.callCount).to.equal(2);
   });
 
-  it('does not observe property in keyed array access when key is number', () => {
+  it('does not observe property in keyed array access when key is number', function() {
     const scope = createScopeForTest({ foo: ['hello world'] });
     const expression3 = new AccessKeyed(new AccessScope('foo', 0), new PrimitiveLiteral(0));
     expect(expression3.evaluate(LF.none, scope, null)).to.equal('hello world');
@@ -920,7 +920,7 @@ describe('AccessKeyed', () => {
     expect(binding.observeProperty.callCount).to.equal(1);
   });
 
-  describe('does not attempt to observe property when object is primitive', () => {
+  describe('does not attempt to observe property when object is primitive', function() {
     const objects: [string, any][] = [
       [`     null`, null],
       [`undefined`, undefined],
@@ -937,7 +937,7 @@ describe('AccessKeyed', () => {
     const inputs: [typeof objects, typeof keys] = [objects, keys];
 
     eachCartesianJoin(inputs, (([t1, obj], [t2, key]) => {
-        it(`${t1}${t2}`, () => {
+        it(`${t1}${t2}`, function() {
           const scope = createScopeForTest({ foo: obj });
           const sut = new AccessKeyed(new AccessScope('foo', 0), key);
           const binding = { observeProperty: spy() };
@@ -949,7 +949,7 @@ describe('AccessKeyed', () => {
   });
 });
 
-describe('AccessMember', () => {
+describe('AccessMember', function() {
 
   const objects: (() => [string, any, boolean, boolean])[] = [
     () => [`     null`, null,      true,     false],
@@ -1043,7 +1043,7 @@ describe('AccessMember', () => {
   const expression: AccessMember = new AccessMember(new AccessScope('foo', 0), 'bar');
 
   eachCartesianJoinFactory(inputs, (([t1, obj, isFalsey, canHaveProperty], [t2, prop, value]) => {
-      it(`${t1}.${t2}.evaluate() -> connect -> assign`, () => {
+      it(`${t1}.${t2}.evaluate() -> connect -> assign`, function() {
         const scope = createScopeForTest({ foo: obj });
         const sut = new AccessMember(new AccessScope('foo', 0), prop);
         const actual = sut.evaluate(LF.none, scope, null);
@@ -1075,25 +1075,25 @@ describe('AccessMember', () => {
     })
   );
 
-  it('evaluates member on bindingContext', () => {
+  it('evaluates member on bindingContext', function() {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('evaluates member on overrideContext', () => {
+  it('evaluates member on overrideContext', function() {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expect(expression.evaluate(LF.none, scope, null)).to.equal('baz');
   });
 
-  it('assigns member on bindingContext', () => {
+  it('assigns member on bindingContext', function() {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expression.assign(LF.none, scope, null, 'bang');
     // @ts-ignore
     expect(scope.bindingContext.foo.bar).to.equal('bang');
   });
 
-  it('assigns member on overrideContext', () => {
+  it('assigns member on overrideContext', function() {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
     expression.assign(LF.none, scope, null, 'bang');
@@ -1101,12 +1101,12 @@ describe('AccessMember', () => {
     expect(scope.overrideContext.foo.bar).to.equal('bang');
   });
 
-  it('returns the assigned value', () => {
+  it('returns the assigned value', function() {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.assign(LF.none, scope, null, 'bang')).to.equal('bang');
   });
 
-  describe('does not attempt to observe property when object is falsey', () => {
+  describe('does not attempt to observe property when object is falsey', function() {
     const objects2: [string, any][] = [
         [`     null`, null],
         [`undefined`, undefined],
@@ -1120,7 +1120,7 @@ describe('AccessMember', () => {
     const inputs2: [typeof objects2, typeof props2] = [objects2, props2];
 
     eachCartesianJoin(inputs2, (([t1, obj], [t2, prop]) => {
-        it(`${t1}${t2}`, () => {
+        it(`${t1}${t2}`, function() {
           const scope = createScopeForTest({ foo: obj });
           const sut = new AccessMember(new AccessScope('foo', 0), prop);
           const binding = { observeProperty: spy() };
@@ -1131,7 +1131,7 @@ describe('AccessMember', () => {
     );
   });
 
-  describe('does not observe if object does not / cannot have the property', () => {
+  describe('does not observe if object does not / cannot have the property', function() {
     const objects3: [string, any][] = [
       [`        1`, 1],
       [`     true`, true],
@@ -1146,7 +1146,7 @@ describe('AccessMember', () => {
     const inputs3: [typeof objects3, typeof props3] = [objects3, props3];
 
     eachCartesianJoin(inputs3, (([t1, obj], [t2, prop]) => {
-        it(`${t1}${t2}`, () => {
+        it(`${t1}${t2}`, function() {
           const scope = createScopeForTest({ foo: obj });
           const expression2 = new AccessMember(new AccessScope('foo', 0), prop);
           const binding = { observeProperty: spy() };
@@ -1158,85 +1158,85 @@ describe('AccessMember', () => {
   });
 });
 
-describe('AccessScope', () => {
+describe('AccessScope', function() {
   const foo: AccessScope = new AccessScope('foo', 0);
   const $parentfoo: AccessScope = new AccessScope('foo', 1);
   const binding = { observeProperty: spy() };
 
-  it('evaluates undefined bindingContext', () => {
+  it('evaluates undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('assigns undefined bindingContext', () => {
+  it('assigns undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects undefined bindingContext', () => {
+  it('connects undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('evaluates null bindingContext', () => {
+  it('evaluates null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('assigns null bindingContext', () => {
+  it('assigns null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects null bindingContext', () => {
+  it('connects null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('evaluates defined property on bindingContext', () => {
+  it('evaluates defined property on bindingContext', function() {
     const scope = createScopeForTest({ foo: 'bar' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('evaluates defined property on overrideContext', () => {
+  it('evaluates defined property on overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('assigns defined property on bindingContext', () => {
+  it('assigns defined property on bindingContext', function() {
     const scope = createScopeForTest({ foo: 'bar' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.bindingContext.foo).to.equal('baz');
   });
 
-  it('assigns undefined property to bindingContext', () => {
+  it('assigns undefined property to bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.bindingContext.foo).to.equal('baz');
   });
 
-  it('assigns defined property on overrideContext', () => {
+  it('assigns defined property on overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.foo).to.equal('baz');
   });
 
-  it('connects defined property on bindingContext', () => {
+  it('connects defined property on bindingContext', function() {
     const scope = createScopeForTest({ foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'foo');
   });
 
-  it('connects defined property on overrideContext', () => {
+  it('connects defined property on overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     (binding.observeProperty as any).resetHistory();
@@ -1244,27 +1244,27 @@ describe('AccessScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'foo');
   });
 
-  it('connects undefined property on bindingContext', () => {
+  it('connects undefined property on bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'foo');
   });
 
-  it('evaluates defined property on first ancestor bindingContext', () => {
+  it('evaluates defined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect($parentfoo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('evaluates defined property on first ancestor overrideContext', () => {
+  it('evaluates defined property on first ancestor overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect($parentfoo.evaluate(LF.none, scope, null)).to.equal('bar');
   });
 
-  it('assigns defined property on first ancestor bindingContext', () => {
+  it('assigns defined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     foo.assign(LF.none, scope, null, 'baz');
     expect(scope.overrideContext.parentOverrideContext.bindingContext.foo).to.equal('baz');
@@ -1272,7 +1272,7 @@ describe('AccessScope', () => {
     expect(scope.overrideContext.parentOverrideContext.bindingContext.foo).to.equal('beep');
   });
 
-  it('assigns defined property on first ancestor overrideContext', () => {
+  it('assigns defined property on first ancestor overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     foo.assign(LF.none, scope, null, 'baz');
@@ -1281,7 +1281,7 @@ describe('AccessScope', () => {
     expect(scope.overrideContext.parentOverrideContext.foo).to.equal('beep');
   });
 
-  it('connects defined property on first ancestor bindingContext', () => {
+  it('connects defined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1291,7 +1291,7 @@ describe('AccessScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext.bindingContext, 'foo');
   });
 
-  it('connects defined property on first ancestor overrideContext', () => {
+  it('connects defined property on first ancestor overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = 'bar';
     (binding.observeProperty as any).resetHistory();
@@ -1302,7 +1302,7 @@ describe('AccessScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext, 'foo');
   });
 
-  it('connects undefined property on first ancestor bindingContext', () => {
+  it('connects undefined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, {});
     // @ts-ignore
     scope.overrideContext.parentOverrideContext.parentOverrideContext = OverrideContext.create({ foo: 'bar' }, null);
@@ -1312,12 +1312,12 @@ describe('AccessScope', () => {
   });
 });
 
-describe('AccessThis', () => {
+describe('AccessThis', function() {
   const $parent2 = new AccessThis(1);
   const $parent$parent = new AccessThis(2);
   const $parent$parent$parent = new AccessThis(3);
 
-  it('evaluates undefined bindingContext', () => {
+  it('evaluates undefined bindingContext', function() {
     const coc = OverrideContext.create;
 
     let scope = { overrideContext: coc(LF.none, undefined, null) };
@@ -1341,7 +1341,7 @@ describe('AccessThis', () => {
     expect($parent$parent$parent.evaluate(LF.none, scope as any, null)).to.equal(undefined);
   });
 
-  it('evaluates null bindingContext', () => {
+  it('evaluates null bindingContext', function() {
     const coc = OverrideContext.create;
 
     let scope = { overrideContext: coc(LF.none, null, null) };
@@ -1365,7 +1365,7 @@ describe('AccessThis', () => {
     expect($parent$parent$parent.evaluate(LF.none, scope as any, null)).to.equal(null);
   });
 
-  it('evaluates defined bindingContext', () => {
+  it('evaluates defined bindingContext', function() {
     const coc = OverrideContext.create;
     const a = { a: 'a' };
     const b = { b: 'b' };
@@ -1393,8 +1393,8 @@ describe('AccessThis', () => {
   });
 });
 
-describe('Assign', () => {
-  it('can chain assignments', () => {
+describe('Assign', function() {
+  it('can chain assignments', function() {
     const foo = new Assign(new AccessScope('foo', 0), new AccessScope('bar', 0));
     const scope = Scope.create(LF.none, undefined, null);
     foo.assign(LF.none, scope, null as any, 1 as any);
@@ -1403,8 +1403,8 @@ describe('Assign', () => {
   });
 });
 
-describe('Conditional', () => {
-  it('evaluates the "yes" branch', () => {
+describe('Conditional', function() {
+  it('evaluates the "yes" branch', function() {
     const condition = $true;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1415,7 +1415,7 @@ describe('Conditional', () => {
     expect(no.calls.length).to.equal(0);
   });
 
-  it('evaluates the "no" branch', () => {
+  it('evaluates the "no" branch', function() {
     const condition = $false;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1426,7 +1426,7 @@ describe('Conditional', () => {
     expect(no.calls.length).to.equal(1);
   });
 
-  it('connects the "yes" branch', () => {
+  it('connects the "yes" branch', function() {
     const condition = $true;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1437,7 +1437,7 @@ describe('Conditional', () => {
     expect(no.calls.length).to.equal(0);
   });
 
-  it('connects the "no" branch', () => {
+  it('connects the "no" branch', function() {
     const condition = $false;
     const yes = new MockTracingExpression($obj);
     const no = new MockTracingExpression($obj);
@@ -1449,8 +1449,8 @@ describe('Conditional', () => {
   });
 });
 
-describe('Binary', () => {
-  it('concats strings', () => {
+describe('Binary', function() {
+  it('concats strings', function() {
     let expression = new Binary('+', new PrimitiveLiteral('a'), new PrimitiveLiteral('b'));
     let scope = createScopeForTest({});
     expect(expression.evaluate(LF.none, scope, null)).to.equal('ab');
@@ -1472,7 +1472,7 @@ describe('Binary', () => {
     expect(expression.evaluate(LF.none, scope, null)).to.equal('undefinedb');
   });
 
-  it('adds numbers', () => {
+  it('adds numbers', function() {
     let expression = new Binary('+', new PrimitiveLiteral(1), new PrimitiveLiteral(2));
     let scope = createScopeForTest({});
     expect(expression.evaluate(LF.none, scope, null)).to.equal(3);
@@ -1494,7 +1494,7 @@ describe('Binary', () => {
     expect(expression.evaluate(LF.none, scope, null)).to.be.NaN;
   });
 
-  describe('performs \'in\'', () => {
+  describe('performs \'in\'', function() {
     const tests: { expr: Binary; expected: boolean }[] = [
       { expr: new Binary('in', new PrimitiveLiteral('foo'), new ObjectLiteral(['foo'], [$null])), expected: true },
       { expr: new Binary('in', new PrimitiveLiteral('foo'), new ObjectLiteral(['bar'], [$null])), expected: false },
@@ -1514,13 +1514,13 @@ describe('Binary', () => {
     const scope = createScopeForTest({ foo: { bar: null }, bar: null });
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), () => {
+      it(expr.toString(), function() {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 
-  describe('performs \'instanceof\'', () => {
+  describe('performs \'instanceof\'', function() {
     class Foo {}
     class Bar extends Foo {}
     const tests: { expr: Binary; expected: boolean }[] = [
@@ -1573,15 +1573,15 @@ describe('Binary', () => {
     const scope: IScope = createScopeForTest({ foo: new Foo(), bar: new Bar() });
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), () => {
+      it(expr.toString(), function() {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 });
 
-describe('CallMember', () => {
-  it('evaluates', () => {
+describe('CallMember', function() {
+  it('evaluates', function() {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     const bindingContext = { foo: { bar: () => 'baz' } };
     const scope = createScopeForTest(bindingContext);
@@ -1590,14 +1590,14 @@ describe('CallMember', () => {
     expect((bindingContext.foo.bar as any).callCount).to.equal(1);
   });
 
-  it('evaluate handles null/undefined member', () => {
+  it('evaluate handles null/undefined member', function() {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: {} }), null)).to.equal(undefined);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: { bar: undefined } }), null)).to.equal(undefined);
     expect(expression.evaluate(LF.none, createScopeForTest({ foo: { bar: null } }), null)).to.equal(undefined);
   });
 
-  it('evaluate throws when mustEvaluate and member is null or undefined', () => {
+  it('evaluate throws when mustEvaluate and member is null or undefined', function() {
     const expression = new CallMember(new AccessScope('foo', 0), 'bar', []);
     const mustEvaluate = true;
     expect(() => expression.evaluate(LF.mustEvaluate, createScopeForTest({}), null)).to.throw();
@@ -1607,25 +1607,25 @@ describe('CallMember', () => {
   });
 });
 
-describe('CallScope', () => {
+describe('CallScope', function() {
   const foo: CallScope = new CallScope('foo', [], 0);
   const hello: CallScope = new CallScope('hello', [new AccessScope('arg', 0)], 0);
   const binding: { observeProperty: SinonSpy } = { observeProperty: spy() };
 
-  it('evaluates undefined bindingContext', () => {
+  it('evaluates undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
     expect(hello.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('throws when mustEvaluate and evaluating undefined bindingContext', () => {
+  it('throws when mustEvaluate and evaluating undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(LF.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(LF.mustEvaluate, scope, null)).to.throw();
   });
 
-  it('connects undefined bindingContext', () => {
+  it('connects undefined bindingContext', function() {
     const scope = Scope.create(LF.none, undefined, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1634,20 +1634,20 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('evaluates null bindingContext', () => {
+  it('evaluates null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     expect(foo.evaluate(LF.none, scope, null)).to.equal(undefined);
     expect(hello.evaluate(LF.none, scope, null)).to.equal(undefined);
   });
 
-  it('throws when mustEvaluate and evaluating null bindingContext', () => {
+  it('throws when mustEvaluate and evaluating null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     const mustEvaluate = true;
     expect(() => foo.evaluate(LF.mustEvaluate, scope, null)).to.throw();
     expect(() => hello.evaluate(LF.mustEvaluate, scope, null)).to.throw();
   });
 
-  it('connects null bindingContext', () => {
+  it('connects null bindingContext', function() {
     const scope = Scope.create(LF.none, null, null);
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1656,13 +1656,13 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('evaluates defined property on bindingContext', () => {
+  it('evaluates defined property on bindingContext', function() {
     const scope = createScopeForTest({ foo: () => 'bar', hello: arg => arg, arg: 'world' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('evaluates defined property on overrideContext', () => {
+  it('evaluates defined property on overrideContext', function() {
     const scope = createScopeForTest({ abc: () => 'xyz' });
     scope.overrideContext.foo = () => 'bar';
     scope.overrideContext.hello = arg => arg;
@@ -1671,7 +1671,7 @@ describe('CallScope', () => {
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('connects defined property on bindingContext', () => {
+  it('connects defined property on bindingContext', function() {
     const scope = createScopeForTest({ foo: 'bar' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1680,7 +1680,7 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'arg');
   });
 
-  it('connects defined property on overrideContext', () => {
+  it('connects defined property on overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = () => 'bar';
     scope.overrideContext.hello = arg => arg;
@@ -1692,7 +1692,7 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext, 'arg');
   });
 
-  it('connects undefined property on bindingContext', () => {
+  it('connects undefined property on bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1701,13 +1701,13 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.bindingContext, 'arg');
   });
 
-  it('evaluates defined property on first ancestor bindingContext', () => {
+  it('evaluates defined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' });
     expect(foo.evaluate(LF.none, scope, null)).to.equal('bar');
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('evaluates defined property on first ancestor overrideContext', () => {
+  it('evaluates defined property on first ancestor overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = () => 'bar';
     scope.overrideContext.parentOverrideContext.hello = arg => arg;
@@ -1716,7 +1716,7 @@ describe('CallScope', () => {
     expect(hello.evaluate(LF.none, scope, null)).to.equal('world');
   });
 
-  it('connects defined property on first ancestor bindingContext', () => {
+  it('connects defined property on first ancestor bindingContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' });
     (binding.observeProperty as any).resetHistory();
     foo.connect(LF.none, scope, binding as any);
@@ -1725,7 +1725,7 @@ describe('CallScope', () => {
     expect(binding.observeProperty).to.have.been.calledWith(LF.none, scope.overrideContext.parentOverrideContext.bindingContext, 'arg');
   });
 
-  it('connects defined property on first ancestor overrideContext', () => {
+  it('connects defined property on first ancestor overrideContext', function() {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.overrideContext.parentOverrideContext.foo = () => 'bar';
     scope.overrideContext.parentOverrideContext.hello = arg => arg;
@@ -1749,7 +1749,7 @@ class Test {
   }
 }
 
-describe('LiteralTemplate', () => {
+describe('LiteralTemplate', function() {
   const tests: { expr: Template | TaggedTemplate; expected: string; ctx: any }[] = [
     { expr: $tpl, expected: '', ctx: {} },
     { expr: new Template(['foo']), expected: 'foo', ctx: {} },
@@ -1825,15 +1825,15 @@ describe('LiteralTemplate', () => {
   ];
 
   for (const { expr, expected, ctx } of tests) {
-    it(`evaluates ${expected}`, () => {
+    it(`evaluates ${expected}`, function() {
       const scope = createScopeForTest(ctx);
       expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
     });
   }
 });
 
-describe('Unary', () => {
-  describe('performs \'typeof\'', () => {
+describe('Unary', function() {
+  describe('performs \'typeof\'', function() {
     const tests: { expr: Unary; expected: string }[] = [
       { expr: new Unary('typeof', new PrimitiveLiteral('foo')), expected: 'string' },
       { expr: new Unary('typeof', new PrimitiveLiteral(1)), expected: 'number' },
@@ -1850,13 +1850,13 @@ describe('Unary', () => {
     const scope: IScope = createScopeForTest({});
 
     for (const { expr, expected } of tests) {
-      it(expr.toString(), () => {
+      it(expr.toString(), function() {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(expected);
       });
     }
   });
 
-  describe('performs \'void\'', () => {
+  describe('performs \'void\'', function() {
     const tests: { expr: Unary }[] = [
       { expr: new Unary('void', new PrimitiveLiteral('foo')) },
       { expr: new Unary('void', new PrimitiveLiteral(1)) },
@@ -1873,12 +1873,12 @@ describe('Unary', () => {
     let scope: IScope = createScopeForTest({});
 
     for (const { expr } of tests) {
-      it(expr.toString(), () => {
+      it(expr.toString(), function() {
         expect(expr.evaluate(LF.none, scope, null)).to.equal(undefined);
       });
     }
 
-    it('void foo()', () => {
+    it('void foo()', function() {
       let fooCalled = false;
       const foo = () => (fooCalled = true);
       scope = createScopeForTest({ foo });
@@ -1889,7 +1889,7 @@ describe('Unary', () => {
   });
 });
 
-describe('BindingBehavior', () => {
+describe('BindingBehavior', function() {
   type $1 = [/*title*/string, /*flags*/LF];
   type $2 = [/*title*/string, /*$kind*/ExpressionKind];
   type $3 = [/*title*/string, /*scope*/IScope, /*sut*/BindingBehavior, /*mock*/MockBindingBehavior, /*locator*/IServiceLocator, /*binding*/IConnectableBinding, /*value*/any, /*argValues*/any[]];
@@ -2143,7 +2143,7 @@ describe('BindingBehavior', () => {
     = [flagVariations, kindVariations, inputVariations, bindVariations, evaluateVariations, connectVariations, assignVariations, $2ndEvaluateVariations, unbindVariations];
 
   eachCartesianJoinFactory(inputs, ([t1], [t2], [t3], bind, evaluate1, connect, assign, evaluate2, unbind) => {
-      it(`flags=${t1}, kind=${t2}, expr=${t3} -> bind() -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, () => {
+      it(`flags=${t1}, kind=${t2}, expr=${t3} -> bind() -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function() {
         bind();
         evaluate1();
         connect();
@@ -2155,7 +2155,7 @@ describe('BindingBehavior', () => {
   );
 });
 
-describe('ValueConverter', () => {
+describe('ValueConverter', function() {
   type $1 = [/*title*/string, /*flags*/LF];
   type $2 = [/*title*/string, /*signals*/string[], /*signaler*/MockSignaler];
   type $3 = [/*title*/string, /*scope*/IScope, /*sut*/ValueConverter, /*mock*/MockValueConverter, /*locator*/IServiceLocator, /*binding*/IConnectableBinding, /*value*/any, /*argValues*/any[], /*methods*/string[]];
@@ -2505,7 +2505,7 @@ describe('ValueConverter', () => {
     = [flagVariations, kindVariations, inputVariations, evaluateVariations, connectVariations, assignVariations, $2ndEvaluateVariations, unbindVariations];
 
   eachCartesianJoinFactory(inputs, ([t1], [t2], [t3], evaluate1, connect, assign, evaluate2, unbind) => {
-      it(`flags=${t1}, signalr=${t2} expr=${t3} -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, () => {
+      it(`flags=${t1}, signalr=${t2} expr=${t3} -> evaluate() -> connect() -> assign() -> evaluate() -> unbind()`, function() {
         evaluate1();
         connect();
         const newValue = assign();
@@ -2518,8 +2518,8 @@ describe('ValueConverter', () => {
 
 const e = new PrimitiveLiteral('') as any;
 // tslint:disable:space-within-parens
-describe('helper functions', () => {
-  it('connects', () => {
+describe('helper functions', function() {
+  it('connects', function() {
     expect(connects(new AccessThis()                )).to.equal(false);
     expect(connects(new AccessScope('')             )).to.equal(true);
     expect(connects(new ArrayLiteral([])            )).to.equal(true);
@@ -2546,7 +2546,7 @@ describe('helper functions', () => {
     expect(connects(new Interpolation([])           )).to.equal(false);
   });
 
-  it('observes', () => {
+  it('observes', function() {
     expect(observes(new AccessThis()                )).to.equal(false);
     expect(observes(new AccessScope('')             )).to.equal(true);
     expect(observes(new ArrayLiteral([])            )).to.equal(false);
@@ -2573,7 +2573,7 @@ describe('helper functions', () => {
     expect(observes(new Interpolation([])           )).to.equal(false);
   });
 
-  it('callsFunction', () => {
+  it('callsFunction', function() {
     expect(callsFunction(new AccessThis()                )).to.equal(false);
     expect(callsFunction(new AccessScope('')             )).to.equal(false);
     expect(callsFunction(new ArrayLiteral([])            )).to.equal(false);
@@ -2600,7 +2600,7 @@ describe('helper functions', () => {
     expect(callsFunction(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasAncestor', () => {
+  it('hasAncestor', function() {
     expect(hasAncestor(new AccessThis()                )).to.equal(true);
     expect(hasAncestor(new AccessScope('')             )).to.equal(true);
     expect(hasAncestor(new ArrayLiteral([])            )).to.equal(false);
@@ -2627,7 +2627,7 @@ describe('helper functions', () => {
     expect(hasAncestor(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isAssignable', () => {
+  it('isAssignable', function() {
     expect(isAssignable(new AccessThis()                )).to.equal(false);
     expect(isAssignable(new AccessScope('')             )).to.equal(true);
     expect(isAssignable(new ArrayLiteral([])            )).to.equal(false);
@@ -2654,7 +2654,7 @@ describe('helper functions', () => {
     expect(isAssignable(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isLeftHandSide', () => {
+  it('isLeftHandSide', function() {
     expect(isLeftHandSide(new AccessThis()                )).to.equal(true);
     expect(isLeftHandSide(new AccessScope('')             )).to.equal(true);
     expect(isLeftHandSide(new ArrayLiteral([])            )).to.equal(true);
@@ -2681,7 +2681,7 @@ describe('helper functions', () => {
     expect(isLeftHandSide(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isPrimary', () => {
+  it('isPrimary', function() {
     expect(isPrimary(new AccessThis()                )).to.equal(true);
     expect(isPrimary(new AccessScope('')             )).to.equal(true);
     expect(isPrimary(new ArrayLiteral([])            )).to.equal(true);
@@ -2708,7 +2708,7 @@ describe('helper functions', () => {
     expect(isPrimary(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isResource', () => {
+  it('isResource', function() {
     expect(isResource(new AccessThis()                )).to.equal(false);
     expect(isResource(new AccessScope('')             )).to.equal(false);
     expect(isResource(new ArrayLiteral([])            )).to.equal(false);
@@ -2735,7 +2735,7 @@ describe('helper functions', () => {
     expect(isResource(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasBind', () => {
+  it('hasBind', function() {
     expect(hasBind(new AccessThis()                )).to.equal(false);
     expect(hasBind(new AccessScope('')             )).to.equal(false);
     expect(hasBind(new ArrayLiteral([])            )).to.equal(false);
@@ -2762,7 +2762,7 @@ describe('helper functions', () => {
     expect(hasBind(new Interpolation([])           )).to.equal(false);
   });
 
-  it('hasUnbind', () => {
+  it('hasUnbind', function() {
     expect(hasUnbind(new AccessThis()                )).to.equal(false);
     expect(hasUnbind(new AccessScope('')             )).to.equal(false);
     expect(hasUnbind(new ArrayLiteral([])            )).to.equal(false);
@@ -2789,7 +2789,7 @@ describe('helper functions', () => {
     expect(hasUnbind(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isLiteral', () => {
+  it('isLiteral', function() {
     expect(isLiteral(new AccessThis()                )).to.equal(false);
     expect(isLiteral(new AccessScope('')             )).to.equal(false);
     expect(isLiteral(new ArrayLiteral([])            )).to.equal(true);
@@ -2816,7 +2816,7 @@ describe('helper functions', () => {
     expect(isLiteral(new Interpolation([])           )).to.equal(false);
   });
 
-  it('isPureLiteral', () => {
+  it('isPureLiteral', function() {
     expect(isPureLiteral(new AccessThis()                )).to.equal(false);
     expect(isPureLiteral(new AccessScope('')             )).to.equal(false);
     expect(isPureLiteral(new ArrayLiteral([])            )).to.equal(true);

--- a/packages/runtime/test/binding/binding.spec.ts
+++ b/packages/runtime/test/binding/binding.spec.ts
@@ -55,7 +55,7 @@ export function padRight(str: any, len: number): string {
 const $nil: any = undefined;
 const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-describe('Binding', function() {
+describe('Binding', function () {
   let dummySourceExpression: IExpression;
   let dummyTarget: Record<string, unknown>;
   let dummyTargetProperty: string;
@@ -70,36 +70,36 @@ describe('Binding', function() {
     return { sut, lifecycle, container, observerLocator };
   }
 
-  beforeEach(function() {
+  beforeEach(function () {
     dummySourceExpression = {} as any;
     dummyTarget = {foo: 'bar'};
     dummyTargetProperty = 'foo';
     dummyMode = BindingMode.twoWay;
   });
 
-  describe('constructor', function() {
+  describe('constructor', function () {
     const invalidInputs: any[] = [null, undefined, {}];
 
     for (const ii of invalidInputs) {
-      it(`throws on invalid input parameters of type ${getName(ii)}`, function() {
+      it(`throws on invalid input parameters of type ${getName(ii)}`, function () {
         expect(() => new Binding(ii, ii, ii, ii, ii, ii), `() => new Binding(ii, ii, ii, ii, ii, ii)`).to.throw;
       });
     }
   });
 
-  describe('updateTarget()', function() {
+  describe('updateTarget()', function () {
 
   });
 
-  describe('updateSource()', function() {
+  describe('updateSource()', function () {
 
   });
 
-  describe('handleChange()', function() {
+  describe('handleChange()', function () {
 
   });
 
-  it(`$bind() [to-view] works with 200 observers`, function() {
+  it(`$bind() [to-view] works with 200 observers`, function () {
     let expr: AccessScope | Binary;
 
     const count = 200;
@@ -143,7 +143,7 @@ describe('Binding', function() {
     expect(target.val, `target.val`).to.equal(count * 3);
   }).timeout(20000);
 
-  describe('$bind() [one-time] assigns the target value', function() {
+  describe('$bind() [one-time] assigns the target value', function () {
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
       () => [({}),             `{}          `]
@@ -180,7 +180,7 @@ describe('Binding', function() {
        = [targetVariations, propVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [flags, $4], [scope, $5]) => {
-        it(`$bind() [one-time]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function() {
+        it(`$bind() [one-time]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function () {
           // - Arrange -
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.oneTime);
           const srcVal = expr.evaluate(LF.none, scope, container);
@@ -214,7 +214,7 @@ describe('Binding', function() {
     );
   });
 
-  describe('$bind() [to-view] assigns the target value and listens for changes', function() {
+  describe('$bind() [to-view] assigns the target value and listens for changes', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
@@ -253,7 +253,7 @@ describe('Binding', function() {
        = [targetVariations, propVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [flags, $4], [scope, $5]) => {
-        it(`$bind() [to-view]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function() {
+        it(`$bind() [to-view]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function () {
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.toView);
           const srcVal = expr.evaluate(LF.none, scope, container);
@@ -441,7 +441,7 @@ describe('Binding', function() {
     );
   });
 
-  describe('$bind() [from-view] does not assign the target, and listens for changes', function() {
+  describe('$bind() [from-view] does not assign the target, and listens for changes', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
@@ -479,7 +479,7 @@ describe('Binding', function() {
        = [targetVariations, propVariations, newValueVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [newValue, $3], [expr, $4], [flags, $5], [scope, $6]) => {
-        it(`$bind() [from-view]  target=${$1} prop=${$2} newValue=${$3} expr=${$4} flags=${$5} scope=${$6}`, function() {
+        it(`$bind() [from-view]  target=${$1} prop=${$2} newValue=${$3} expr=${$4} flags=${$5} scope=${$6}`, function () {
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.fromView);
           const targetObserver = observerLocator.getObserver(LF.none, target, prop) as IBindingTargetObserver;
@@ -555,7 +555,7 @@ describe('Binding', function() {
     );
   });
 
-  describe('$bind() [two-way] assign the targets, and listens for changes', function() {
+  describe('$bind() [two-way] assign the targets, and listens for changes', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [{ foo: 'bar' },       `{foo:'bar'}     `],
@@ -600,7 +600,7 @@ describe('Binding', function() {
        = [targetVariations, propVariations, newValueVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [[newValue1, newValue2], $3], [expr, $4], [flags, $5], [scope, $6]) => {
-        it(`$bind() [two-way]  target=${$1} prop=${$2} newValue1,newValue2=${$3} expr=${$4} flags=${$5} scope=${$6}`, function() {
+        it(`$bind() [two-way]  target=${$1} prop=${$2} newValue1,newValue2=${$3} expr=${$4} flags=${$5} scope=${$6}`, function () {
           const originalScope = JSON.parse(JSON.stringify(scope));
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.twoWay);
@@ -868,8 +868,8 @@ describe('Binding', function() {
     );
   });
 
-  describe('$unbind()', function() {
-    it('should not unbind if it is not already bound', function() {
+  describe('$unbind()', function () {
+    it('should not unbind if it is not already bound', function () {
       const { sut } = setup();
       const scope: any = {};
       sut['$scope'] = scope;
@@ -877,7 +877,7 @@ describe('Binding', function() {
       expect(sut['$scope'] === scope, `sut['$scope'] === scope`).to.equal(true);
     });
 
-    it('should unbind if it is bound', function() {
+    it('should unbind if it is bound', function () {
       const { sut } = setup();
       const scope: any = {};
       sut['$scope'] = scope;
@@ -894,11 +894,11 @@ describe('Binding', function() {
     });
   });
 
-  describe('addObserver()', function() {
+  describe('addObserver()', function () {
     const countArr = [1, 5, 100];
 
     for (const count of countArr) {
-      it(`adds ${count} observers`, function() {
+      it(`adds ${count} observers`, function () {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -910,7 +910,7 @@ describe('Binding', function() {
         }
       });
 
-      it(`calls subscribe() on ${count} observers`, function() {
+      it(`calls subscribe() on ${count} observers`, function () {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -921,7 +921,7 @@ describe('Binding', function() {
         }
       });
 
-      it(`does nothing when ${count} observers already exist`, function() {
+      it(`does nothing when ${count} observers already exist`, function () {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -939,7 +939,7 @@ describe('Binding', function() {
         }
       });
 
-      it(`updates the version for ${count} observers`, function() {
+      it(`updates the version for ${count} observers`, function () {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -957,7 +957,7 @@ describe('Binding', function() {
         }
       });
 
-      it(`only updates the version for for added observers`, function() {
+      it(`only updates the version for for added observers`, function () {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -982,11 +982,11 @@ describe('Binding', function() {
     }
   });
 
-  describe('observeProperty()', function() {
+  describe('observeProperty()', function () {
 
   });
 
-  describe('unobserve()', function() {
+  describe('unobserve()', function () {
 
   });
 

--- a/packages/runtime/test/binding/binding.spec.ts
+++ b/packages/runtime/test/binding/binding.spec.ts
@@ -55,7 +55,7 @@ export function padRight(str: any, len: number): string {
 const $nil: any = undefined;
 const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-describe('Binding', () => {
+describe('Binding', function() {
   let dummySourceExpression: IExpression;
   let dummyTarget: Record<string, unknown>;
   let dummyTargetProperty: string;
@@ -70,36 +70,36 @@ describe('Binding', () => {
     return { sut, lifecycle, container, observerLocator };
   }
 
-  beforeEach(() => {
+  beforeEach(function() {
     dummySourceExpression = {} as any;
     dummyTarget = {foo: 'bar'};
     dummyTargetProperty = 'foo';
     dummyMode = BindingMode.twoWay;
   });
 
-  describe('constructor', () => {
+  describe('constructor', function() {
     const invalidInputs: any[] = [null, undefined, {}];
 
     for (const ii of invalidInputs) {
-      it(`throws on invalid input parameters of type ${getName(ii)}`, () => {
+      it(`throws on invalid input parameters of type ${getName(ii)}`, function() {
         expect(() => new Binding(ii, ii, ii, ii, ii, ii), `() => new Binding(ii, ii, ii, ii, ii, ii)`).to.throw;
       });
     }
   });
 
-  describe('updateTarget()', () => {
+  describe('updateTarget()', function() {
 
   });
 
-  describe('updateSource()', () => {
+  describe('updateSource()', function() {
 
   });
 
-  describe('handleChange()', () => {
+  describe('handleChange()', function() {
 
   });
 
-  it(`$bind() [to-view] works with 200 observers`, () => {
+  it(`$bind() [to-view] works with 200 observers`, function() {
     let expr: AccessScope | Binary;
 
     const count = 200;
@@ -143,7 +143,7 @@ describe('Binding', () => {
     expect(target.val, `target.val`).to.equal(count * 3);
   }).timeout(20000);
 
-  describe('$bind() [one-time] assigns the target value', () => {
+  describe('$bind() [one-time] assigns the target value', function() {
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
       () => [({}),             `{}          `]
@@ -180,7 +180,7 @@ describe('Binding', () => {
        = [targetVariations, propVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [flags, $4], [scope, $5]) => {
-        it(`$bind() [one-time]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, () => {
+        it(`$bind() [one-time]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function() {
           // - Arrange -
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.oneTime);
           const srcVal = expr.evaluate(LF.none, scope, container);
@@ -214,7 +214,7 @@ describe('Binding', () => {
     );
   });
 
-  describe('$bind() [to-view] assigns the target value and listens for changes', () => {
+  describe('$bind() [to-view] assigns the target value and listens for changes', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
@@ -253,7 +253,7 @@ describe('Binding', () => {
        = [targetVariations, propVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [flags, $4], [scope, $5]) => {
-        it(`$bind() [to-view]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, () => {
+        it(`$bind() [to-view]  target=${$1} prop=${$2} expr=${$3} flags=${$4} scope=${$5}`, function() {
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.toView);
           const srcVal = expr.evaluate(LF.none, scope, container);
@@ -441,7 +441,7 @@ describe('Binding', () => {
     );
   });
 
-  describe('$bind() [from-view] does not assign the target, and listens for changes', () => {
+  describe('$bind() [from-view] does not assign the target, and listens for changes', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({ foo: 'bar' }), `{foo:'bar'} `],
@@ -479,7 +479,7 @@ describe('Binding', () => {
        = [targetVariations, propVariations, newValueVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [newValue, $3], [expr, $4], [flags, $5], [scope, $6]) => {
-        it(`$bind() [from-view]  target=${$1} prop=${$2} newValue=${$3} expr=${$4} flags=${$5} scope=${$6}`, () => {
+        it(`$bind() [from-view]  target=${$1} prop=${$2} newValue=${$3} expr=${$4} flags=${$5} scope=${$6}`, function() {
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.fromView);
           const targetObserver = observerLocator.getObserver(LF.none, target, prop) as IBindingTargetObserver;
@@ -555,7 +555,7 @@ describe('Binding', () => {
     );
   });
 
-  describe('$bind() [two-way] assign the targets, and listens for changes', () => {
+  describe('$bind() [two-way] assign the targets, and listens for changes', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [{ foo: 'bar' },       `{foo:'bar'}     `],
@@ -600,7 +600,7 @@ describe('Binding', () => {
        = [targetVariations, propVariations, newValueVariations, exprVariations, flagsVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [[newValue1, newValue2], $3], [expr, $4], [flags, $5], [scope, $6]) => {
-        it(`$bind() [two-way]  target=${$1} prop=${$2} newValue1,newValue2=${$3} expr=${$4} flags=${$5} scope=${$6}`, () => {
+        it(`$bind() [two-way]  target=${$1} prop=${$2} newValue1,newValue2=${$3} expr=${$4} flags=${$5} scope=${$6}`, function() {
           const originalScope = JSON.parse(JSON.stringify(scope));
           // - Arrange - Part 1
           const { sut, lifecycle, container, observerLocator } = setup(expr, target, prop, BindingMode.twoWay);
@@ -868,8 +868,8 @@ describe('Binding', () => {
     );
   });
 
-  describe('$unbind()', () => {
-    it('should not unbind if it is not already bound', () => {
+  describe('$unbind()', function() {
+    it('should not unbind if it is not already bound', function() {
       const { sut } = setup();
       const scope: any = {};
       sut['$scope'] = scope;
@@ -877,7 +877,7 @@ describe('Binding', () => {
       expect(sut['$scope'] === scope, `sut['$scope'] === scope`).to.equal(true);
     });
 
-    it('should unbind if it is bound', () => {
+    it('should unbind if it is bound', function() {
       const { sut } = setup();
       const scope: any = {};
       sut['$scope'] = scope;
@@ -894,11 +894,11 @@ describe('Binding', () => {
     });
   });
 
-  describe('addObserver()', () => {
+  describe('addObserver()', function() {
     const countArr = [1, 5, 100];
 
     for (const count of countArr) {
-      it(`adds ${count} observers`, () => {
+      it(`adds ${count} observers`, function() {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -910,7 +910,7 @@ describe('Binding', () => {
         }
       });
 
-      it(`calls subscribe() on ${count} observers`, () => {
+      it(`calls subscribe() on ${count} observers`, function() {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -921,7 +921,7 @@ describe('Binding', () => {
         }
       });
 
-      it(`does nothing when ${count} observers already exist`, () => {
+      it(`does nothing when ${count} observers already exist`, function() {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -939,7 +939,7 @@ describe('Binding', () => {
         }
       });
 
-      it(`updates the version for ${count} observers`, () => {
+      it(`updates the version for ${count} observers`, function() {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -957,7 +957,7 @@ describe('Binding', () => {
         }
       });
 
-      it(`only updates the version for for added observers`, () => {
+      it(`only updates the version for for added observers`, function() {
         const { sut } = setup();
         let i = 0;
         while (i < count) {
@@ -982,11 +982,11 @@ describe('Binding', () => {
     }
   });
 
-  describe('observeProperty()', () => {
+  describe('observeProperty()', function() {
 
   });
 
-  describe('unobserve()', () => {
+  describe('unobserve()', function() {
 
   });
 

--- a/packages/runtime/test/binding/call.spec.ts
+++ b/packages/runtime/test/binding/call.spec.ts
@@ -27,7 +27,7 @@ import {
   massSpy
 } from '../util';
 
-describe('Call', () => {
+describe('Call', function() {
   function setup(sourceExpression: IExpression, target: any, targetProperty: string) {
     const container = RuntimeBasicConfiguration.createContainer();
     const lifecycle = container.get(ILifecycle) as Lifecycle;
@@ -37,7 +37,7 @@ describe('Call', () => {
     return { sut, lifecycle, container, observerLocator };
   }
 
-  describe('$bind -> $bind', () => {
+  describe('$bind -> $bind', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -67,7 +67,7 @@ describe('Call', () => {
        = [targetVariations, propVariations, exprVariations, scopeVariations, renewScopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4], [renewScope, $5]) => {
-        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, () => {
+        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function() {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;
@@ -126,7 +126,7 @@ describe('Call', () => {
     );
   });
 
-  describe('$bind -> $unbind -> $unbind', () => {
+  describe('$bind -> $unbind -> $unbind', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -151,7 +151,7 @@ describe('Call', () => {
        = [targetVariations, propVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4]) => {
-        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, () => {
+        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function() {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;
@@ -217,7 +217,7 @@ describe('Call', () => {
     );
   });
 
-  describe('$bind -> call -> $unbind', () => {
+  describe('$bind -> call -> $unbind', function() {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -249,7 +249,7 @@ describe('Call', () => {
        = [targetVariations, propVariations, argsVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [args, $3], [expr, $4], [scope, $5]) => {
-        it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, () => {
+        it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function() {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;

--- a/packages/runtime/test/binding/call.spec.ts
+++ b/packages/runtime/test/binding/call.spec.ts
@@ -27,7 +27,7 @@ import {
   massSpy
 } from '../util';
 
-describe('Call', function() {
+describe('Call', function () {
   function setup(sourceExpression: IExpression, target: any, targetProperty: string) {
     const container = RuntimeBasicConfiguration.createContainer();
     const lifecycle = container.get(ILifecycle) as Lifecycle;
@@ -37,7 +37,7 @@ describe('Call', function() {
     return { sut, lifecycle, container, observerLocator };
   }
 
-  describe('$bind -> $bind', function() {
+  describe('$bind -> $bind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -67,7 +67,7 @@ describe('Call', function() {
        = [targetVariations, propVariations, exprVariations, scopeVariations, renewScopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4], [renewScope, $5]) => {
-        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function() {
+        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function () {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;
@@ -126,7 +126,7 @@ describe('Call', function() {
     );
   });
 
-  describe('$bind -> $unbind -> $unbind', function() {
+  describe('$bind -> $unbind -> $unbind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -151,7 +151,7 @@ describe('Call', function() {
        = [targetVariations, propVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4]) => {
-        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function() {
+        it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function () {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;
@@ -217,7 +217,7 @@ describe('Call', function() {
     );
   });
 
-  describe('$bind -> call -> $unbind', function() {
+  describe('$bind -> call -> $unbind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -249,7 +249,7 @@ describe('Call', function() {
        = [targetVariations, propVariations, argsVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [args, $3], [expr, $4], [scope, $5]) => {
-        it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function() {
+        it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function () {
           // - Arrange -
           const { sut, lifecycle, observerLocator } = setup(expr, target, prop);
           const flags = LF.none;

--- a/packages/runtime/test/binding/let-binding.spec.ts
+++ b/packages/runtime/test/binding/let-binding.spec.ts
@@ -6,7 +6,7 @@
 
 // const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-// describe('LetBinding', function() {
+// describe('LetBinding', function () {
 //   let container: IContainer;
 //   let observerLocator: IObserverLocator;
 //   let sut: LetBinding;
@@ -15,7 +15,7 @@
 //   let dummyTargetProperty: string;
 //   let dummyMode: BindingMode;
 
-//   beforeEach(function() {
+//   beforeEach(function () {
 //     container = DI.createContainer();
 //     observerLocator = container.get(IObserverLocator);
 //     dummySourceExpression = <any>{};
@@ -25,18 +25,18 @@
 //     sut = new LetBinding(dummySourceExpression, dummyTargetProperty, observerLocator, container);
 //   });
 
-//   describe('constructor', function() {
+//   describe('constructor', function () {
 //     const invalidInputs: any[] = [null, undefined, {}];
 
 //     for (const ii of invalidInputs) {
-//       it(`does not throw on invalid input parameters of type ${getName(ii)}`, function() {
+//       it(`does not throw on invalid input parameters of type ${getName(ii)}`, function () {
 //         sut = new LetBinding(ii, ii, ii, ii, ii);
 //       });
 //     }
 //   });
 
-//   describe('$bind()', function() {
-//     it('does not change target if scope was not changed', function() {
+//   describe('$bind()', function () {
+//     it('does not change target if scope was not changed', function () {
 //       const vm = {};
 //       const sourceExpression = new MockExpression();
 //       const scope = Scope.create(vm, null);
@@ -47,7 +47,7 @@
 //       expect(sut.target).to.equal(target, 'It should have not recreated target');
 //     });
 
-//     it('creates right target with toViewModel === true', function() {
+//     it('creates right target with toViewModel === true', function () {
 //       const vm = { vm: 5 };
 //       const sourceExpression = new MockExpression();
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -55,7 +55,7 @@
 //       expect(sut.target).to.equal(vm, 'It should have used bindingContext to create target.');
 //     });
 
-//     it('creates right target with toViewModel === false', function() {
+//     it('creates right target with toViewModel === false', function () {
 //       const vm = { vm: 5 };
 //       const view = { view: 6 };
 //       const sourceExpression = new MockExpression();
@@ -65,8 +65,8 @@
 //     });
 //   });
 
-//   describe('handleChange()', function() {
-//     it('handles changes', function() {
+//   describe('handleChange()', function () {
+//     it('handles changes', function () {
 //       const vm = { vm: 5, foo: false };
 //       const sourceExpression = new MockExpression();
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -76,8 +76,8 @@
 //     });
 //   });
 
-//   describe('$unbind()', function() {
-//     it('should not unbind if it is not already bound', function() {
+//   describe('$unbind()', function () {
+//     it('should not unbind if it is not already bound', function () {
 //       const sourceExpression = new MockExpression();
 //       const scope: any = {};
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -86,7 +86,7 @@
 //       expect(sut['$scope'] === scope).to.equal(true);
 //     });
 
-//     it('should unbind if it is bound', function() {
+//     it('should unbind if it is bound', function () {
 //       const sourceExpression = new MockExpression();
 //       const scope: any = {};
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);

--- a/packages/runtime/test/binding/let-binding.spec.ts
+++ b/packages/runtime/test/binding/let-binding.spec.ts
@@ -6,7 +6,7 @@
 
 // const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-// describe('LetBinding', () => {
+// describe('LetBinding', function() {
 //   let container: IContainer;
 //   let observerLocator: IObserverLocator;
 //   let sut: LetBinding;
@@ -15,7 +15,7 @@
 //   let dummyTargetProperty: string;
 //   let dummyMode: BindingMode;
 
-//   beforeEach(() => {
+//   beforeEach(function() {
 //     container = DI.createContainer();
 //     observerLocator = container.get(IObserverLocator);
 //     dummySourceExpression = <any>{};
@@ -25,18 +25,18 @@
 //     sut = new LetBinding(dummySourceExpression, dummyTargetProperty, observerLocator, container);
 //   });
 
-//   describe('constructor', () => {
+//   describe('constructor', function() {
 //     const invalidInputs: any[] = [null, undefined, {}];
 
 //     for (const ii of invalidInputs) {
-//       it(`does not throw on invalid input parameters of type ${getName(ii)}`, () => {
+//       it(`does not throw on invalid input parameters of type ${getName(ii)}`, function() {
 //         sut = new LetBinding(ii, ii, ii, ii, ii);
 //       });
 //     }
 //   });
 
-//   describe('$bind()', () => {
-//     it('does not change target if scope was not changed', () => {
+//   describe('$bind()', function() {
+//     it('does not change target if scope was not changed', function() {
 //       const vm = {};
 //       const sourceExpression = new MockExpression();
 //       const scope = Scope.create(vm, null);
@@ -47,7 +47,7 @@
 //       expect(sut.target).to.equal(target, 'It should have not recreated target');
 //     });
 
-//     it('creates right target with toViewModel === true', () => {
+//     it('creates right target with toViewModel === true', function() {
 //       const vm = { vm: 5 };
 //       const sourceExpression = new MockExpression();
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -55,7 +55,7 @@
 //       expect(sut.target).to.equal(vm, 'It should have used bindingContext to create target.');
 //     });
 
-//     it('creates right target with toViewModel === false', () => {
+//     it('creates right target with toViewModel === false', function() {
 //       const vm = { vm: 5 };
 //       const view = { view: 6 };
 //       const sourceExpression = new MockExpression();
@@ -65,8 +65,8 @@
 //     });
 //   });
 
-//   describe('handleChange()', () => {
-//     it('handles changes', () => {
+//   describe('handleChange()', function() {
+//     it('handles changes', function() {
 //       const vm = { vm: 5, foo: false };
 //       const sourceExpression = new MockExpression();
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -76,8 +76,8 @@
 //     });
 //   });
 
-//   describe('$unbind()', () => {
-//     it('should not unbind if it is not already bound', () => {
+//   describe('$unbind()', function() {
+//     it('should not unbind if it is not already bound', function() {
 //       const sourceExpression = new MockExpression();
 //       const scope: any = {};
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -86,7 +86,7 @@
 //       expect(sut['$scope'] === scope).to.equal(true);
 //     });
 
-//     it('should unbind if it is bound', () => {
+//     it('should unbind if it is bound', function() {
 //       const sourceExpression = new MockExpression();
 //       const scope: any = {};
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);

--- a/packages/runtime/test/lifecycle.spec.ts
+++ b/packages/runtime/test/lifecycle.spec.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { Hooks, ILifecycle, LifecycleFlags, PromiseTask, State } from '../src/index';
 import { IComponent, ILifecycleHooks, Lifecycle } from '../src/lifecycle';
 
-describe('Lifecycle', () => {
+describe('Lifecycle', function() {
 
-  it('initializes properties', () => {
+  it('initializes properties', function() {
     const sut = new Lifecycle();
 
     const linkedListProps = [
@@ -80,8 +80,8 @@ describe('Lifecycle', () => {
   });
 
   // TODO: more tests needed
-  describe('endBind()', () => {
-    it('handles task first', async () => {
+  describe('endBind()', function() {
+    it('handles task first', async function() {
       const sut = new Lifecycle();
       const flags = LifecycleFlags.none;
 

--- a/packages/runtime/test/lifecycle.spec.ts
+++ b/packages/runtime/test/lifecycle.spec.ts
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import { Hooks, ILifecycle, LifecycleFlags, PromiseTask, State } from '../src/index';
 import { IComponent, ILifecycleHooks, Lifecycle } from '../src/lifecycle';
 
-describe('Lifecycle', function() {
+describe('Lifecycle', function () {
 
-  it('initializes properties', function() {
+  it('initializes properties', function () {
     const sut = new Lifecycle();
 
     const linkedListProps = [
@@ -80,8 +80,8 @@ describe('Lifecycle', function() {
   });
 
   // TODO: more tests needed
-  describe('endBind()', function() {
-    it('handles task first', async function() {
+  describe('endBind()', function () {
+    it('handles task first', async function () {
       const sut = new Lifecycle();
       const flags = LifecycleFlags.none;
 

--- a/packages/runtime/test/observation/array-observer.spec.ts
+++ b/packages/runtime/test/observation/array-observer.spec.ts
@@ -31,22 +31,22 @@ export function assertArrayEqual(actual: ReadonlyArray<any>, expected: ReadonlyA
   expect(len).to.equal(expected.length, `expected.length=${expected.length}, actual.length=${actual.length}`);
 }
 
-describe(`ArrayObserver`, () => {
+describe(`ArrayObserver`, function() {
   let sut: ArrayObserver;
 
-  before(() => {
+  before(function() {
     disableArrayObservation();
     enableArrayObservation();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', () => {
-    it('push', () => {
+  describe('should allow subscribing for immediate notification', function() {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -55,7 +55,7 @@ describe(`ArrayObserver`, () => {
       expect(s.handleChange).to.have.been.calledWith('push', match(x => x[0] === 1));
     });
 
-    it('push', () => {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -65,8 +65,8 @@ describe(`ArrayObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', () => {
-    it('push', () => {
+  describe('should allow unsubscribing for immediate notification', function() {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -77,8 +77,8 @@ describe(`ArrayObserver`, () => {
     });
   });
 
-  describe('should allow subscribing for batched notification', () => {
-    it('push', () => {
+  describe('should allow subscribing for batched notification', function() {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -90,7 +90,7 @@ describe(`ArrayObserver`, () => {
       expect(s.handleBatchedChange).to.have.been.calledWith(indexMap);
     });
 
-    it('push', () => {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -103,8 +103,8 @@ describe(`ArrayObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', () => {
-    it('push', () => {
+  describe('should allow unsubscribing for batched notification', function() {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -118,8 +118,8 @@ describe(`ArrayObserver`, () => {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', () => {
-    it('push', () => {
+  describe('should notify batched subscribers even if there are no changes', function() {
+    it('push', function() {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -129,14 +129,14 @@ describe(`ArrayObserver`, () => {
     });
   });
 
-  describe(`observePush`, () => {
+  describe(`observePush`, function() {
     const initArr = [[], [1], [1, 2]];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const arr = init.slice();
             const expectedArr = init.slice();
             const newItems = items && items.slice();
@@ -159,7 +159,7 @@ describe(`ArrayObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const arr = init.slice();
             const copy = init.slice();
             const newItems = items && items.slice();
@@ -183,14 +183,14 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observeUnshift`, () => {
+  describe(`observeUnshift`, function() {
     const initArr = [[], [1], [1, 2]];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const arr = init.slice();
             const expectedArr = init.slice();
             const newItems = items && items.slice();
@@ -213,7 +213,7 @@ describe(`ArrayObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const arr = init.slice();
             const copy = init.slice();
             const newItems = items && items.slice();
@@ -237,12 +237,12 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observePop`, () => {
+  describe(`observePop`, function() {
     const initArr = [[], [1], [1, 2]];
     const repeatArr = [1, 2, 3, 4];
     for (const init of initArr) {
       for (const repeat of repeatArr.filter(r => r <= (init.length + 1))) {
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
           const arr = init.slice();
           const expectedArr = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -258,7 +258,7 @@ describe(`ArrayObserver`, () => {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
           const arr = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -275,14 +275,14 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observeShift`, () => {
+  describe(`observeShift`, function() {
     const initArr = [[], [1], [1, 2]];
     const repeatArr = [1, 2, 3, 4];
     for (const init of initArr) {
       for (const repeat of repeatArr.filter(r => r <= (init.length + 1))) {
         const arr = init.slice();
         const expectedArr = init.slice();
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
           let expectedResult;
           let actualResult;
@@ -296,7 +296,7 @@ describe(`ArrayObserver`, () => {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
           const arr2 = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr2);
@@ -313,7 +313,7 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observeSplice`, () => {
+  describe(`observeSplice`, function() {
     const initArr = [[], [1], [1, 2]];
     const startArr = [undefined, -1, 0, 1, 2];
     const deleteCountArr = [undefined, -1, 0, 1, 2, 3];
@@ -324,7 +324,7 @@ describe(`ArrayObserver`, () => {
         for (const deleteCount of deleteCountArr.filter(d => d === undefined || d <= (init.length + 1))) {
           for (const items of itemsArr) {
             for (const repeat of repeatArr) {
-              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
                 const arr = init.slice();
                 const expectedArr = init.slice();
                 const newItems = items && items.slice();
@@ -357,7 +357,7 @@ describe(`ArrayObserver`, () => {
                 }
               });
 
-              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
                 const arr = init.slice();
                 const copy = init.slice();
                 const newItems = items && items.slice();
@@ -387,12 +387,12 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observeReverse`, () => {
+  describe(`observeReverse`, function() {
     const initArr = [[], [1], [1, 2], [1, 2, 3], [1, 2, 3, 4]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
           const arr = init.slice();
           const expectedArr = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -408,7 +408,7 @@ describe(`ArrayObserver`, () => {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, () => {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
           const arr = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -425,7 +425,7 @@ describe(`ArrayObserver`, () => {
     }
   });
 
-  describe(`observeSort`, () => {
+  describe(`observeSort`, function() {
     const arraySizes = [0, 1, 2, 3, 5, 10, 500, 2500];
     const types = ['undefined', 'null', 'boolean', 'string', 'number', 'object', 'mixed'];
     const compareFns = [
@@ -452,7 +452,7 @@ describe(`ArrayObserver`, () => {
             init.reverse();
           }
           for (const compareFn of compareFns) {
-            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - behaves as native`, () => {
+            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - behaves as native`, function() {
               const arr = init.slice();
               const expectedArr = init.slice();
               sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -481,7 +481,7 @@ describe(`ArrayObserver`, () => {
               }
             });
 
-            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - tracks changes`, () => {
+            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - tracks changes`, function() {
               const arr = init.slice();
               const copy = init.slice();
               sut = new ArrayObserver(LF.none, new Lifecycle(), arr);

--- a/packages/runtime/test/observation/array-observer.spec.ts
+++ b/packages/runtime/test/observation/array-observer.spec.ts
@@ -31,22 +31,22 @@ export function assertArrayEqual(actual: ReadonlyArray<any>, expected: ReadonlyA
   expect(len).to.equal(expected.length, `expected.length=${expected.length}, actual.length=${actual.length}`);
 }
 
-describe(`ArrayObserver`, function() {
+describe(`ArrayObserver`, function () {
   let sut: ArrayObserver;
 
-  before(function() {
+  before(function () {
     disableArrayObservation();
     enableArrayObservation();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', function() {
-    it('push', function() {
+  describe('should allow subscribing for immediate notification', function () {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -55,7 +55,7 @@ describe(`ArrayObserver`, function() {
       expect(s.handleChange).to.have.been.calledWith('push', match(x => x[0] === 1));
     });
 
-    it('push', function() {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -65,8 +65,8 @@ describe(`ArrayObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', function() {
-    it('push', function() {
+  describe('should allow unsubscribing for immediate notification', function () {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -77,8 +77,8 @@ describe(`ArrayObserver`, function() {
     });
   });
 
-  describe('should allow subscribing for batched notification', function() {
-    it('push', function() {
+  describe('should allow subscribing for batched notification', function () {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -90,7 +90,7 @@ describe(`ArrayObserver`, function() {
       expect(s.handleBatchedChange).to.have.been.calledWith(indexMap);
     });
 
-    it('push', function() {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -103,8 +103,8 @@ describe(`ArrayObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', function() {
-    it('push', function() {
+  describe('should allow unsubscribing for batched notification', function () {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -118,8 +118,8 @@ describe(`ArrayObserver`, function() {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', function() {
-    it('push', function() {
+  describe('should notify batched subscribers even if there are no changes', function () {
+    it('push', function () {
       const s = new SpySubscriber();
       const arr = [];
       sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -129,14 +129,14 @@ describe(`ArrayObserver`, function() {
     });
   });
 
-  describe(`observePush`, function() {
+  describe(`observePush`, function () {
     const initArr = [[], [1], [1, 2]];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const arr = init.slice();
             const expectedArr = init.slice();
             const newItems = items && items.slice();
@@ -159,7 +159,7 @@ describe(`ArrayObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const arr = init.slice();
             const copy = init.slice();
             const newItems = items && items.slice();
@@ -183,14 +183,14 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observeUnshift`, function() {
+  describe(`observeUnshift`, function () {
     const initArr = [[], [1], [1, 2]];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const arr = init.slice();
             const expectedArr = init.slice();
             const newItems = items && items.slice();
@@ -213,7 +213,7 @@ describe(`ArrayObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.length, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const arr = init.slice();
             const copy = init.slice();
             const newItems = items && items.slice();
@@ -237,12 +237,12 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observePop`, function() {
+  describe(`observePop`, function () {
     const initArr = [[], [1], [1, 2]];
     const repeatArr = [1, 2, 3, 4];
     for (const init of initArr) {
       for (const repeat of repeatArr.filter(r => r <= (init.length + 1))) {
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function () {
           const arr = init.slice();
           const expectedArr = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -258,7 +258,7 @@ describe(`ArrayObserver`, function() {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function () {
           const arr = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -275,14 +275,14 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observeShift`, function() {
+  describe(`observeShift`, function () {
     const initArr = [[], [1], [1, 2]];
     const repeatArr = [1, 2, 3, 4];
     for (const init of initArr) {
       for (const repeat of repeatArr.filter(r => r <= (init.length + 1))) {
         const arr = init.slice();
         const expectedArr = init.slice();
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function () {
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
           let expectedResult;
           let actualResult;
@@ -296,7 +296,7 @@ describe(`ArrayObserver`, function() {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function () {
           const arr2 = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr2);
@@ -313,7 +313,7 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observeSplice`, function() {
+  describe(`observeSplice`, function () {
     const initArr = [[], [1], [1, 2]];
     const startArr = [undefined, -1, 0, 1, 2];
     const deleteCountArr = [undefined, -1, 0, 1, 2, 3];
@@ -324,7 +324,7 @@ describe(`ArrayObserver`, function() {
         for (const deleteCount of deleteCountArr.filter(d => d === undefined || d <= (init.length + 1))) {
           for (const items of itemsArr) {
             for (const repeat of repeatArr) {
-              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
                 const arr = init.slice();
                 const expectedArr = init.slice();
                 const newItems = items && items.slice();
@@ -357,7 +357,7 @@ describe(`ArrayObserver`, function() {
                 }
               });
 
-              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+              it(`size=${padRight(init.length, 2)} start=${padRight(start, 9)} deleteCount=${padRight(deleteCount, 9)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
                 const arr = init.slice();
                 const copy = init.slice();
                 const newItems = items && items.slice();
@@ -387,12 +387,12 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observeReverse`, function() {
+  describe(`observeReverse`, function () {
     const initArr = [[], [1], [1, 2], [1, 2, 3], [1, 2, 3, 4]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - behaves as native`, function () {
           const arr = init.slice();
           const expectedArr = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -408,7 +408,7 @@ describe(`ArrayObserver`, function() {
           }
         });
 
-        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function() {
+        it(`size=${padRight(init.length, 2)} repeat=${repeat} - tracks changes`, function () {
           const arr = init.slice();
           const copy = init.slice();
           sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -425,7 +425,7 @@ describe(`ArrayObserver`, function() {
     }
   });
 
-  describe(`observeSort`, function() {
+  describe(`observeSort`, function () {
     const arraySizes = [0, 1, 2, 3, 5, 10, 500, 2500];
     const types = ['undefined', 'null', 'boolean', 'string', 'number', 'object', 'mixed'];
     const compareFns = [
@@ -452,7 +452,7 @@ describe(`ArrayObserver`, function() {
             init.reverse();
           }
           for (const compareFn of compareFns) {
-            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - behaves as native`, function() {
+            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - behaves as native`, function () {
               const arr = init.slice();
               const expectedArr = init.slice();
               sut = new ArrayObserver(LF.none, new Lifecycle(), arr);
@@ -481,7 +481,7 @@ describe(`ArrayObserver`, function() {
               }
             });
 
-            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - tracks changes`, function() {
+            it(`size=${padRight(init.length, 4)} type=${padRight(type, 9)} reverse=${padRight(reverse, 5)} sortFunc=${compareFn} - tracks changes`, function () {
               const arr = init.slice();
               const copy = init.slice();
               sut = new ArrayObserver(LF.none, new Lifecycle(), arr);

--- a/packages/runtime/test/observation/binding-context.spec.ts
+++ b/packages/runtime/test/observation/binding-context.spec.ts
@@ -5,9 +5,9 @@ import {
   Scope
 } from '../../src/index';
 
-describe('Scope', function() {
-  describe('create', function() {
-    it('undefined, undefined', function() {
+describe('Scope', function () {
+  describe('create', function () {
+    it('undefined, undefined', function () {
       const actual = Scope.create(LF.none, undefined, undefined);
       expect(actual.bindingContext).to.equal(undefined);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -15,7 +15,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('undefined, null', function() {
+    it('undefined, null', function () {
       const actual = Scope.create(LF.none, undefined, null);
       expect(actual.bindingContext).to.equal(undefined);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -23,7 +23,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('undefined, {}', function() {
+    it('undefined, {}', function () {
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, undefined, overrideContext);
       expect(actual.bindingContext).to.equal(undefined);
@@ -32,7 +32,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('undefined, { bindingContext }', function() {
+    it('undefined, { bindingContext }', function () {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, null, overrideContext);
@@ -42,7 +42,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('null, undefined', function() {
+    it('null, undefined', function () {
       const actual = Scope.create(LF.none, null, undefined);
       expect(actual.bindingContext).to.equal(null);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -50,7 +50,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('null, null', function() {
+    it('null, null', function () {
       const actual = Scope.create(LF.none, null, null);
       expect(actual.bindingContext).to.equal(null);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -58,7 +58,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('null, {}', function() {
+    it('null, {}', function () {
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, null, overrideContext);
       expect(actual.bindingContext).to.equal(null);
@@ -67,7 +67,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('null, { bindingContext }', function() {
+    it('null, { bindingContext }', function () {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, null, overrideContext);
@@ -77,7 +77,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, undefined', function() {
+    it('{}, undefined', function () {
       const bindingContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, undefined);
       expect(actual.bindingContext).to.equal(bindingContext);
@@ -86,7 +86,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, null', function() {
+    it('{}, null', function () {
       const bindingContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, null);
       expect(actual.bindingContext).to.equal(bindingContext);
@@ -95,7 +95,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, {}', function() {
+    it('{}, {}', function () {
       const bindingContext = {} as any;
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, overrideContext);
@@ -105,7 +105,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, { bindingContext }', function() {
+    it('{}, { bindingContext }', function () {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, bindingContext, overrideContext);
@@ -115,7 +115,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, { bindingContext2 }', function() {
+    it('{}, { bindingContext2 }', function () {
       const bindingContext = {} as any;
       const bindingContext2 = {} as any;
       const overrideContext = { bindingContext: bindingContext2 } as any;
@@ -127,16 +127,16 @@ describe('Scope', function() {
     });
   });
 
-  describe('fromOverride', function() {
-    it('undefined', function() {
+  describe('fromOverride', function () {
+    it('undefined', function () {
       expect(() => Scope.fromOverride(LF.none, undefined)).to.throw('Code 252');
     });
 
-    it('null', function() {
+    it('null', function () {
       expect(() => Scope.fromOverride(LF.none, null)).to.throw('Code 252');
     });
 
-    it('{}', function() {
+    it('{}', function () {
       const overrideContext = {} as any;
       const actual = Scope.fromOverride(LF.none, overrideContext);
       expect(actual.bindingContext).to.equal(undefined);
@@ -145,7 +145,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{ bindingContext }', function() {
+    it('{ bindingContext }', function () {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.fromOverride(LF.none, overrideContext);
@@ -156,16 +156,16 @@ describe('Scope', function() {
     });
   });
 
-  describe('fromParent', function() {
-    it('undefined', function() {
+  describe('fromParent', function () {
+    it('undefined', function () {
       expect(() => Scope.fromParent(LF.none, undefined, {})).to.throw('Code 253');
     });
 
-    it('null', function() {
+    it('null', function () {
       expect(() => Scope.fromParent(LF.none, null, {})).to.throw('Code 253');
     });
 
-    it('{}, undefined', function() {
+    it('{}, undefined', function () {
       const parentScope = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, undefined);
       expect(actual.bindingContext).to.equal(undefined);
@@ -174,7 +174,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, null', function() {
+    it('{}, null', function () {
       const parentScope = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, null);
       expect(actual.bindingContext).to.equal(null);
@@ -183,7 +183,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, {}', function() {
+    it('{}, {}', function () {
       const parentScope = {} as any;
       const bindingContext = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, bindingContext);
@@ -193,7 +193,7 @@ describe('Scope', function() {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, { overrideContext }', function() {
+    it('{}, { overrideContext }', function () {
       const overrideContext = {} as any;
       const parentScope = { overrideContext } as any;
       const bindingContext = {} as any;
@@ -206,69 +206,69 @@ describe('Scope', function() {
   });
 });
 
-describe('BindingContext', function() {
-  describe('get', function() {
-    it('undefined', function() {
+describe('BindingContext', function () {
+  describe('get', function () {
+    it('undefined', function () {
       expect(() => BindingContext.get(undefined, undefined, undefined, LF.none)).to.throw('Code 250');
     });
 
-    it('null', function() {
+    it('null', function () {
       expect(() => BindingContext.get(null, undefined, undefined, LF.none)).to.throw('Code 251');
     });
 
-    it('{ bindingContext: undefined, overrideContext: undefined }', function() {
+    it('{ bindingContext: undefined, overrideContext: undefined }', function () {
       const scope = { } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(undefined);
     });
 
-    it('{ bindingContext: undefined, overrideContext: null }', function() {
+    it('{ bindingContext: undefined, overrideContext: null }', function () {
       const scope = { overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(null);
     });
 
-    it('{ bindingContext: undefined, overrideContext: {} }', function() {
+    it('{ bindingContext: undefined, overrideContext: {} }', function () {
       const overrideContext = {} as any;
       const scope = { overrideContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(overrideContext);
     });
 
-    it('{ bindingContext: null, overrideContext: undefined }', function() {
+    it('{ bindingContext: null, overrideContext: undefined }', function () {
       const scope = { } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(undefined);
     });
 
-    it('{ bindingContext: null, overrideContext: null }', function() {
+    it('{ bindingContext: null, overrideContext: null }', function () {
       const scope = { overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(null);
     });
 
-    it('{ bindingContext: null, overrideContext: {} }', function() {
+    it('{ bindingContext: null, overrideContext: {} }', function () {
       const overrideContext = {} as any;
       const scope = { overrideContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(overrideContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: undefined }', function() {
+    it('{ bindingContext: {}, overrideContext: undefined }', function () {
       const bindingContext = {} as any;
       const scope = { bindingContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(bindingContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: null }', function() {
+    it('{ bindingContext: {}, overrideContext: null }', function () {
       const bindingContext = {} as any;
       const scope = { bindingContext, overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(bindingContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: {} }', function() {
+    it('{ bindingContext: {}, overrideContext: {} }', function () {
       const overrideContext = {} as any;
       const bindingContext = {} as any;
       const scope = { bindingContext, overrideContext } as any;
@@ -276,7 +276,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext);
     });
 
-    it('1 ancestor, null, null', function() {
+    it('1 ancestor, null, null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const scope1 = Scope.create(LF.none, bindingContext1, null);
@@ -285,7 +285,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('2 ancestors, null, null', function() {
+    it('2 ancestors, null, null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -296,7 +296,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, null, null', function() {
+    it('3 ancestors, null, null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -309,7 +309,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('1 ancestor, \'foo\', null', function() {
+    it('1 ancestor, \'foo\', null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const scope1 = Scope.create(LF.none, bindingContext1, null);
@@ -318,7 +318,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('2 ancestors, \'foo\', null', function() {
+    it('2 ancestors, \'foo\', null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -329,7 +329,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\', null', function() {
+    it('3 ancestors, \'foo\', null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -342,7 +342,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #1), null', function() {
+    it('3 ancestors, \'foo\' (exist on bc #1), null', function () {
       const bindingContext1 = { foo: 'bar' } as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -355,7 +355,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #2), null', function() {
+    it('3 ancestors, \'foo\' (exist on bc #2), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -368,7 +368,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #3), null', function() {
+    it('3 ancestors, \'foo\' (exist on bc #3), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -381,7 +381,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #4), null', function() {
+    it('3 ancestors, \'foo\' (exist on bc #4), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -394,7 +394,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -408,7 +408,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -422,7 +422,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -436,7 +436,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #4), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #4), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -450,7 +450,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope4.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #1), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #1), null', function () {
       const bindingContext1 = { foo: 'bar' } as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -464,7 +464,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #2), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #2), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -478,7 +478,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #3), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #3), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -492,7 +492,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #4 and bc #4), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #4 and bc #4), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -506,7 +506,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope4.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -520,7 +520,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -534,7 +534,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), null', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), null', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -548,7 +548,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 1', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 1', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -562,7 +562,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope3.bindingContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 1', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 1', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -576,7 +576,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 1', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 1', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -590,7 +590,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 2', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 2', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -604,7 +604,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 2', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 2', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -618,7 +618,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 2', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 2', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -632,7 +632,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 3', function() {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 3', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -646,7 +646,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 3', function() {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 3', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -660,7 +660,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 3', function() {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 3', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -674,7 +674,7 @@ describe('BindingContext', function() {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, null, 4', function() {
+    it('3 ancestors, null, 4', function () {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;

--- a/packages/runtime/test/observation/binding-context.spec.ts
+++ b/packages/runtime/test/observation/binding-context.spec.ts
@@ -5,9 +5,9 @@ import {
   Scope
 } from '../../src/index';
 
-describe('Scope', () => {
-  describe('create', () => {
-    it('undefined, undefined', () => {
+describe('Scope', function() {
+  describe('create', function() {
+    it('undefined, undefined', function() {
       const actual = Scope.create(LF.none, undefined, undefined);
       expect(actual.bindingContext).to.equal(undefined);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -15,7 +15,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('undefined, null', () => {
+    it('undefined, null', function() {
       const actual = Scope.create(LF.none, undefined, null);
       expect(actual.bindingContext).to.equal(undefined);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -23,7 +23,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('undefined, {}', () => {
+    it('undefined, {}', function() {
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, undefined, overrideContext);
       expect(actual.bindingContext).to.equal(undefined);
@@ -32,7 +32,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('undefined, { bindingContext }', () => {
+    it('undefined, { bindingContext }', function() {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, null, overrideContext);
@@ -42,7 +42,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('null, undefined', () => {
+    it('null, undefined', function() {
       const actual = Scope.create(LF.none, null, undefined);
       expect(actual.bindingContext).to.equal(null);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -50,7 +50,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('null, null', () => {
+    it('null, null', function() {
       const actual = Scope.create(LF.none, null, null);
       expect(actual.bindingContext).to.equal(null);
       expect(actual.overrideContext).to.be.instanceof(Object);
@@ -58,7 +58,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('null, {}', () => {
+    it('null, {}', function() {
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, null, overrideContext);
       expect(actual.bindingContext).to.equal(null);
@@ -67,7 +67,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('null, { bindingContext }', () => {
+    it('null, { bindingContext }', function() {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, null, overrideContext);
@@ -77,7 +77,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, undefined', () => {
+    it('{}, undefined', function() {
       const bindingContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, undefined);
       expect(actual.bindingContext).to.equal(bindingContext);
@@ -86,7 +86,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, null', () => {
+    it('{}, null', function() {
       const bindingContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, null);
       expect(actual.bindingContext).to.equal(bindingContext);
@@ -95,7 +95,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, {}', () => {
+    it('{}, {}', function() {
       const bindingContext = {} as any;
       const overrideContext = {} as any;
       const actual = Scope.create(LF.none, bindingContext, overrideContext);
@@ -105,7 +105,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, { bindingContext }', () => {
+    it('{}, { bindingContext }', function() {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.create(LF.none, bindingContext, overrideContext);
@@ -115,7 +115,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{}, { bindingContext2 }', () => {
+    it('{}, { bindingContext2 }', function() {
       const bindingContext = {} as any;
       const bindingContext2 = {} as any;
       const overrideContext = { bindingContext: bindingContext2 } as any;
@@ -127,16 +127,16 @@ describe('Scope', () => {
     });
   });
 
-  describe('fromOverride', () => {
-    it('undefined', () => {
+  describe('fromOverride', function() {
+    it('undefined', function() {
       expect(() => Scope.fromOverride(LF.none, undefined)).to.throw('Code 252');
     });
 
-    it('null', () => {
+    it('null', function() {
       expect(() => Scope.fromOverride(LF.none, null)).to.throw('Code 252');
     });
 
-    it('{}', () => {
+    it('{}', function() {
       const overrideContext = {} as any;
       const actual = Scope.fromOverride(LF.none, overrideContext);
       expect(actual.bindingContext).to.equal(undefined);
@@ -145,7 +145,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(undefined);
     });
 
-    it('{ bindingContext }', () => {
+    it('{ bindingContext }', function() {
       const bindingContext = {} as any;
       const overrideContext = { bindingContext } as any;
       const actual = Scope.fromOverride(LF.none, overrideContext);
@@ -156,16 +156,16 @@ describe('Scope', () => {
     });
   });
 
-  describe('fromParent', () => {
-    it('undefined', () => {
+  describe('fromParent', function() {
+    it('undefined', function() {
       expect(() => Scope.fromParent(LF.none, undefined, {})).to.throw('Code 253');
     });
 
-    it('null', () => {
+    it('null', function() {
       expect(() => Scope.fromParent(LF.none, null, {})).to.throw('Code 253');
     });
 
-    it('{}, undefined', () => {
+    it('{}, undefined', function() {
       const parentScope = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, undefined);
       expect(actual.bindingContext).to.equal(undefined);
@@ -174,7 +174,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, null', () => {
+    it('{}, null', function() {
       const parentScope = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, null);
       expect(actual.bindingContext).to.equal(null);
@@ -183,7 +183,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, {}', () => {
+    it('{}, {}', function() {
       const parentScope = {} as any;
       const bindingContext = {} as any;
       const actual = Scope.fromParent(LF.none, parentScope, bindingContext);
@@ -193,7 +193,7 @@ describe('Scope', () => {
       expect(actual.overrideContext.parentOverrideContext).to.equal(null);
     });
 
-    it('{}, { overrideContext }', () => {
+    it('{}, { overrideContext }', function() {
       const overrideContext = {} as any;
       const parentScope = { overrideContext } as any;
       const bindingContext = {} as any;
@@ -206,69 +206,69 @@ describe('Scope', () => {
   });
 });
 
-describe('BindingContext', () => {
-  describe('get', () => {
-    it('undefined', () => {
+describe('BindingContext', function() {
+  describe('get', function() {
+    it('undefined', function() {
       expect(() => BindingContext.get(undefined, undefined, undefined, LF.none)).to.throw('Code 250');
     });
 
-    it('null', () => {
+    it('null', function() {
       expect(() => BindingContext.get(null, undefined, undefined, LF.none)).to.throw('Code 251');
     });
 
-    it('{ bindingContext: undefined, overrideContext: undefined }', () => {
+    it('{ bindingContext: undefined, overrideContext: undefined }', function() {
       const scope = { } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(undefined);
     });
 
-    it('{ bindingContext: undefined, overrideContext: null }', () => {
+    it('{ bindingContext: undefined, overrideContext: null }', function() {
       const scope = { overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(null);
     });
 
-    it('{ bindingContext: undefined, overrideContext: {} }', () => {
+    it('{ bindingContext: undefined, overrideContext: {} }', function() {
       const overrideContext = {} as any;
       const scope = { overrideContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(overrideContext);
     });
 
-    it('{ bindingContext: null, overrideContext: undefined }', () => {
+    it('{ bindingContext: null, overrideContext: undefined }', function() {
       const scope = { } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(undefined);
     });
 
-    it('{ bindingContext: null, overrideContext: null }', () => {
+    it('{ bindingContext: null, overrideContext: null }', function() {
       const scope = { overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(null);
     });
 
-    it('{ bindingContext: null, overrideContext: {} }', () => {
+    it('{ bindingContext: null, overrideContext: {} }', function() {
       const overrideContext = {} as any;
       const scope = { overrideContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(overrideContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: undefined }', () => {
+    it('{ bindingContext: {}, overrideContext: undefined }', function() {
       const bindingContext = {} as any;
       const scope = { bindingContext } as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(bindingContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: null }', () => {
+    it('{ bindingContext: {}, overrideContext: null }', function() {
       const bindingContext = {} as any;
       const scope = { bindingContext, overrideContext: null} as any;
       const actual = BindingContext.get(scope, null, null, LF.none);
       expect(actual).to.equal(bindingContext);
     });
 
-    it('{ bindingContext: {}, overrideContext: {} }', () => {
+    it('{ bindingContext: {}, overrideContext: {} }', function() {
       const overrideContext = {} as any;
       const bindingContext = {} as any;
       const scope = { bindingContext, overrideContext } as any;
@@ -276,7 +276,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext);
     });
 
-    it('1 ancestor, null, null', () => {
+    it('1 ancestor, null, null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const scope1 = Scope.create(LF.none, bindingContext1, null);
@@ -285,7 +285,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('2 ancestors, null, null', () => {
+    it('2 ancestors, null, null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -296,7 +296,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, null, null', () => {
+    it('3 ancestors, null, null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -309,7 +309,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('1 ancestor, \'foo\', null', () => {
+    it('1 ancestor, \'foo\', null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const scope1 = Scope.create(LF.none, bindingContext1, null);
@@ -318,7 +318,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('2 ancestors, \'foo\', null', () => {
+    it('2 ancestors, \'foo\', null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -329,7 +329,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\', null', () => {
+    it('3 ancestors, \'foo\', null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -342,7 +342,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #1), null', () => {
+    it('3 ancestors, \'foo\' (exist on bc #1), null', function() {
       const bindingContext1 = { foo: 'bar' } as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -355,7 +355,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #2), null', () => {
+    it('3 ancestors, \'foo\' (exist on bc #2), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -368,7 +368,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #3), null', () => {
+    it('3 ancestors, \'foo\' (exist on bc #3), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -381,7 +381,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on bc #4), null', () => {
+    it('3 ancestors, \'foo\' (exist on bc #4), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -394,7 +394,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -408,7 +408,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -422,7 +422,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -436,7 +436,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #4), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #4), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -450,7 +450,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope4.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #1), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #1), null', function() {
       const bindingContext1 = { foo: 'bar' } as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -464,7 +464,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #2), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #2), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -478,7 +478,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #3), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #3), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -492,7 +492,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #4 and bc #4), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #4 and bc #4), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -506,7 +506,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope4.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -520,7 +520,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -534,7 +534,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), null', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), null', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -548,7 +548,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext4);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 1', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 1', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -562,7 +562,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope3.bindingContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 1', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 1', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -576,7 +576,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext3);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 1', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 1', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -590,7 +590,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope3.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 2', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 2', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -604,7 +604,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 2', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 2', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -618,7 +618,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope2.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 2', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 2', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -632,7 +632,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext2);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 3', () => {
+    it('3 ancestors, \'foo\' (exist on oc #1 and bc #2), 3', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = { foo: 'bar' } as any;
       const bindingContext3 = {} as any;
@@ -646,7 +646,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(scope1.overrideContext);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 3', () => {
+    it('3 ancestors, \'foo\' (exist on oc #2 and bc #3), 3', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = { foo: 'bar' } as any;
@@ -660,7 +660,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 3', () => {
+    it('3 ancestors, \'foo\' (exist on oc #3 and bc #4), 3', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;
@@ -674,7 +674,7 @@ describe('BindingContext', () => {
       expect(actual).to.equal(bindingContext1);
     });
 
-    it('3 ancestors, null, 4', () => {
+    it('3 ancestors, null, 4', function() {
       const bindingContext1 = {} as any;
       const bindingContext2 = {} as any;
       const bindingContext3 = {} as any;

--- a/packages/runtime/test/observation/computed-observer.spec.ts
+++ b/packages/runtime/test/observation/computed-observer.spec.ts
@@ -18,7 +18,7 @@ import { disableTracing, enableTracing } from '../util';
 
 declare var document;
 
-describe('ComputedObserver', function() {
+describe('ComputedObserver', function () {
   function setup() {
     const container = RuntimeBasicConfiguration.createContainer();
     const innerLocator = {
@@ -89,7 +89,7 @@ describe('ComputedObserver', function() {
   ];
 
   eachCartesianJoin([computedSpecs, propSpecs, depSpecs], (computedSpec, propSpec, depSpec) => {
-    it(`computedSpec ${computedSpec.t}, propSpec ${propSpec.t}, depSpec ${depSpec.t}`, function() {
+    it(`computedSpec ${computedSpec.t}, propSpec ${propSpec.t}, depSpec ${depSpec.t}`, function () {
       const { locator, dirtyChecker, lifecycle } = setup();
       const { isVolatile, isStatic, exists } = computedSpec;
       const { initialValue: propInitialValue, newValue: propNewValue, descriptor: propDescriptor } = propSpec;
@@ -261,7 +261,7 @@ describe('ComputedObserver', function() {
   // only run this test in browser for now as it hangs in node due to subtleties with prototype stuff
   // TODO: fix this in node
   if (typeof document !== 'undefined') {
-    it(`complex nested dependencies`, function() {
+    it(`complex nested dependencies`, function () {
       this.timeout(30000);
       const { locator, dirtyChecker, lifecycle } = setup();
 
@@ -430,7 +430,7 @@ describe('ComputedObserver', function() {
     });
   }
 
-  it('resorts to dirty checking for non configurable props', function() {
+  it('resorts to dirty checking for non configurable props', function () {
     const { locator, dirtyChecker, lifecycle } = setup();
     class Foo {}
     Reflect.defineProperty(Foo.prototype, 'bar', {
@@ -447,7 +447,7 @@ describe('ComputedObserver', function() {
     expect(sut).to.be.instanceof(DirtyCheckProperty);
   });
 
-  it('throws in case of no getter', function() {
+  it('throws in case of no getter', function () {
     const { locator, dirtyChecker, lifecycle } = setup();
     class Foo {}
     Reflect.defineProperty(Foo.prototype, 'bar', {

--- a/packages/runtime/test/observation/debounce-binding-behavior.spec.ts
+++ b/packages/runtime/test/observation/debounce-binding-behavior.spec.ts
@@ -13,13 +13,13 @@ import {
   LifecycleFlags
 } from '../../src/index';
 
-describe('DebounceBindingBehavior', () => {
+describe('DebounceBindingBehavior', function() {
   const container: IContainer = DI.createContainer();
   let sut: DebounceBindingBehavior;
   let binding: Binding;
   let originalFn: (newValue: unknown, previousValue: unknown, flags: LifecycleFlags) => void;
 
-  beforeEach(() => {
+  beforeEach(function() {
     sut = new DebounceBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container);
     originalFn = binding.handleChange;
@@ -27,7 +27,7 @@ describe('DebounceBindingBehavior', () => {
   });
 
   // TODO: test properly (whether debouncing works etc)
-  it('bind()   should apply the correct behavior', () => {
+  it('bind()   should apply the correct behavior', function() {
     expect(binding['debouncedMethod'] === originalFn).to.equal(true);
     expect(binding['debouncedMethod'].originalName).to.equal('handleChange');
     expect(binding.handleChange === originalFn).to.equal(false);
@@ -36,7 +36,7 @@ describe('DebounceBindingBehavior', () => {
     expect(typeof binding['debounceState']).to.equal('object');
   });
 
-  it('unbind() should revert the original behavior', () => {
+  it('unbind() should revert the original behavior', function() {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['debouncedMethod']).to.equal(null);
     expect(binding.handleChange === originalFn).to.equal(true);

--- a/packages/runtime/test/observation/debounce-binding-behavior.spec.ts
+++ b/packages/runtime/test/observation/debounce-binding-behavior.spec.ts
@@ -13,13 +13,13 @@ import {
   LifecycleFlags
 } from '../../src/index';
 
-describe('DebounceBindingBehavior', function() {
+describe('DebounceBindingBehavior', function () {
   const container: IContainer = DI.createContainer();
   let sut: DebounceBindingBehavior;
   let binding: Binding;
   let originalFn: (newValue: unknown, previousValue: unknown, flags: LifecycleFlags) => void;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sut = new DebounceBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container);
     originalFn = binding.handleChange;
@@ -27,7 +27,7 @@ describe('DebounceBindingBehavior', function() {
   });
 
   // TODO: test properly (whether debouncing works etc)
-  it('bind()   should apply the correct behavior', function() {
+  it('bind()   should apply the correct behavior', function () {
     expect(binding['debouncedMethod'] === originalFn).to.equal(true);
     expect(binding['debouncedMethod'].originalName).to.equal('handleChange');
     expect(binding.handleChange === originalFn).to.equal(false);
@@ -36,7 +36,7 @@ describe('DebounceBindingBehavior', function() {
     expect(typeof binding['debounceState']).to.equal('object');
   });
 
-  it('unbind() should revert the original behavior', function() {
+  it('unbind() should revert the original behavior', function () {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['debouncedMethod']).to.equal(null);
     expect(binding.handleChange === originalFn).to.equal(true);

--- a/packages/runtime/test/observation/dirty-checker.spec.ts
+++ b/packages/runtime/test/observation/dirty-checker.spec.ts
@@ -7,7 +7,7 @@ import {
   RuntimeBasicConfiguration
 } from '../../src/index';
 
-describe('DirtyChecker', function() {
+describe('DirtyChecker', function () {
   afterEach(function () {
     DirtyCheckSettings.resetToDefault();
   });
@@ -292,7 +292,7 @@ describe('DirtyChecker', function() {
     });
   });
 
-  it('throws on property creation if configured', function() {
+  it('throws on property creation if configured', function () {
     DirtyCheckSettings.throw = true;
     const { dirtyChecker } = setup();
 
@@ -306,7 +306,7 @@ describe('DirtyChecker', function() {
     expect(err.message).to.match(/800/);
   });
 
-  it('warns by default', function() {
+  it('warns by default', function () {
     let warnCalled = false;
     const writeBackup = Reporter.write;
     Reporter.write = function(code) {
@@ -322,7 +322,7 @@ describe('DirtyChecker', function() {
     Reporter.write = writeBackup;
   });
 
-  it('does not warn if warn is off', function() {
+  it('does not warn if warn is off', function () {
     let warnCalled = false;
     DirtyCheckSettings.warn = false;
     const writeBackup = Reporter.write;

--- a/packages/runtime/test/observation/map-observer.spec.ts
+++ b/packages/runtime/test/observation/map-observer.spec.ts
@@ -33,22 +33,22 @@ function assetMapEqual(actual: Map<any, any>, expected: Map<any, any>): void {
   }
 }
 
-describe(`MapObserver`, () => {
+describe(`MapObserver`, function() {
   let sut: MapObserver;
 
-  before(() => {
+  before(function() {
     disableMapObservation();
     enableMapObservation();
   });
 
-  afterEach(() => {
+  afterEach(function() {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', () => {
-    it('set', () => {
+  describe('should allow subscribing for immediate notification', function() {
+    it('set', function() {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -58,8 +58,8 @@ describe(`MapObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', () => {
-    it('set', () => {
+  describe('should allow unsubscribing for immediate notification', function() {
+    it('set', function() {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -70,8 +70,8 @@ describe(`MapObserver`, () => {
     });
   });
 
-  describe('should allow subscribing for batched notification', () => {
-    it('set', () => {
+  describe('should allow subscribing for batched notification', function() {
+    it('set', function() {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -84,8 +84,8 @@ describe(`MapObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', () => {
-    it('set', () => {
+  describe('should allow unsubscribing for batched notification', function() {
+    it('set', function() {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -99,8 +99,8 @@ describe(`MapObserver`, () => {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', () => {
-    it('set', () => {
+  describe('should notify batched subscribers even if there are no changes', function() {
+    it('set', function() {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -110,14 +110,14 @@ describe(`MapObserver`, () => {
     });
   });
 
-  describe(`observeSet`, () => {
+  describe(`observeSet`, function() {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const map = new Map(Array.from(init));
             const expectedMap = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -145,7 +145,7 @@ describe(`MapObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const map = new Map(Array.from(init));
             const copy = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -171,14 +171,14 @@ describe(`MapObserver`, () => {
     }
   });
 
-  describe(`observeDelete`, () => {
+  describe(`observeDelete`, function() {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const map = new Map(Array.from(init));
             const expectedMap = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -206,7 +206,7 @@ describe(`MapObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const map = new Map(Array.from(init));
             const copy = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -232,12 +232,12 @@ describe(`MapObserver`, () => {
     }
   });
 
-  describe(`observeClear`, () => {
+  describe(`observeClear`, function() {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, () => {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function() {
           const map = new Map(Array.from(init));
           const expectedMap = new Map(Array.from(init));
           sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -250,7 +250,7 @@ describe(`MapObserver`, () => {
           }
         });
 
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, () => {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function() {
           const map = new Map(Array.from(init));
           const copy = new Map(Array.from(init));
           sut = new MapObserver(LF.none, new Lifecycle(), map);

--- a/packages/runtime/test/observation/map-observer.spec.ts
+++ b/packages/runtime/test/observation/map-observer.spec.ts
@@ -33,22 +33,22 @@ function assetMapEqual(actual: Map<any, any>, expected: Map<any, any>): void {
   }
 }
 
-describe(`MapObserver`, function() {
+describe(`MapObserver`, function () {
   let sut: MapObserver;
 
-  before(function() {
+  before(function () {
     disableMapObservation();
     enableMapObservation();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', function() {
-    it('set', function() {
+  describe('should allow subscribing for immediate notification', function () {
+    it('set', function () {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -58,8 +58,8 @@ describe(`MapObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', function() {
-    it('set', function() {
+  describe('should allow unsubscribing for immediate notification', function () {
+    it('set', function () {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -70,8 +70,8 @@ describe(`MapObserver`, function() {
     });
   });
 
-  describe('should allow subscribing for batched notification', function() {
-    it('set', function() {
+  describe('should allow subscribing for batched notification', function () {
+    it('set', function () {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -84,8 +84,8 @@ describe(`MapObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', function() {
-    it('set', function() {
+  describe('should allow unsubscribing for batched notification', function () {
+    it('set', function () {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -99,8 +99,8 @@ describe(`MapObserver`, function() {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', function() {
-    it('set', function() {
+  describe('should notify batched subscribers even if there are no changes', function () {
+    it('set', function () {
       const s = new SpySubscriber();
       const map = new Map();
       sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -110,14 +110,14 @@ describe(`MapObserver`, function() {
     });
   });
 
-  describe(`observeSet`, function() {
+  describe(`observeSet`, function () {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const map = new Map(Array.from(init));
             const expectedMap = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -145,7 +145,7 @@ describe(`MapObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const map = new Map(Array.from(init));
             const copy = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -171,14 +171,14 @@ describe(`MapObserver`, function() {
     }
   });
 
-  describe(`observeDelete`, function() {
+  describe(`observeDelete`, function () {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const map = new Map(Array.from(init));
             const expectedMap = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -206,7 +206,7 @@ describe(`MapObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const map = new Map(Array.from(init));
             const copy = new Map(Array.from(init));
             const newItems = items && items.slice();
@@ -232,12 +232,12 @@ describe(`MapObserver`, function() {
     }
   });
 
-  describe(`observeClear`, function() {
+  describe(`observeClear`, function () {
     const initArr = [new Map(), new Map([[1, 1]]), new Map([[1, 1], [2, 2]])];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function() {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function () {
           const map = new Map(Array.from(init));
           const expectedMap = new Map(Array.from(init));
           sut = new MapObserver(LF.none, new Lifecycle(), map);
@@ -250,7 +250,7 @@ describe(`MapObserver`, function() {
           }
         });
 
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function() {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function () {
           const map = new Map(Array.from(init));
           const copy = new Map(Array.from(init));
           sut = new MapObserver(LF.none, new Lifecycle(), map);

--- a/packages/runtime/test/observation/observer-locator.spec.ts
+++ b/packages/runtime/test/observation/observer-locator.spec.ts
@@ -29,7 +29,7 @@
 // import { spy } from 'sinon';
 // import { Reporter } from '@aurelia/kernel';
 
-// describe('ObserverLocator', () => {
+// describe('ObserverLocator', function() {
 //   function setup() {
 //     const container = DI.createContainer();
 //     const lifecycle = container.get(ILifecycle);
@@ -55,7 +55,7 @@
 //     const attr = el.attributes[0];
 //     const { sut } = setup();
 //     const expected = sut.getObserver(el, attr.name);
-//     it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, () => {
+//     it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function() {
 //       const actual = sut.getAccessor(el, attr.name);
 //       expect(actual).to.be.instanceof(expected['constructor']);
 //     });
@@ -75,7 +75,7 @@
 //     `<div aria-=""></div>`,
 //     `<div aria-a=""></div>`,
 //   ]) {
-//     it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, () => {
+//     it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -99,7 +99,7 @@
 //     `<div aria=""></div>`,
 //     `<div ariaa=""></div>`,
 //   ]) {
-//     it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, () => {
+//     it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -109,7 +109,7 @@
 //     });
 //   }
 
-//   it(_`getAccessor() - {} - returns PropertyAccessor`, () => {
+//   it(_`getAccessor() - {} - returns PropertyAccessor`, function() {
 //     const { sut } = setup();
 //     const obj = {};
 //     const actual = sut.getAccessor(obj, 'foo');
@@ -121,7 +121,7 @@
 //     undefined, null, true, false, '', 'foo',
 //     Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN
 //   ]) {
-//     it(_`getObserver() - ${obj} - returns PrimitiveObserver`, () => {
+//     it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function() {
 //       const { sut } = setup();
 //       if (obj === null || obj === undefined) {
 //         expect(() => sut.getObserver(obj, 'foo')).to.throw;
@@ -133,7 +133,7 @@
 //     });
 //   }
 
-//   it(_`getObserver() - {} - twice in a row - reuses existing observer`, () => {
+//   it(_`getObserver() - {} - twice in a row - reuses existing observer`, function() {
 //     const { sut } = setup();
 //     const obj = {};
 //     const expected = sut.getObserver(obj, 'foo');
@@ -141,7 +141,7 @@
 //     expect(actual).to.equal(expected);
 //   });
 
-//   it(_`getObserver() - {} - twice in a row different property - returns different observer`, () => {
+//   it(_`getObserver() - {} - twice in a row different property - returns different observer`, function() {
 //     const { sut } = setup();
 //     const obj = {};
 //     const expected = sut.getObserver(obj, 'foo');
@@ -165,7 +165,7 @@
 //     { markup: `<div aria-=""></div>`, ctor: DataAttributeAccessor },
 //     { markup: `<div aria-a=""></div>`, ctor: DataAttributeAccessor }
 //   ]) {
-//     it(_`getObserver() - ${markup} - returns ${ctor.name}`, () => {
+//     it(_`getObserver() - ${markup} - returns ${ctor.name}`, function() {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -209,7 +209,7 @@
 //                     if (hasOverrides) {
 //                       obj.constructor['computed'] = { isVolatile };
 //                     }
-//                     it(_`getObserver() - descriptor=${descriptor}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, () => {
+//                     it(_`getObserver() - descriptor=${descriptor}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
 //                       Reflect.defineProperty(obj, 'foo', descriptor);
 //                       if (hasSetter && configurable && !hasGetter && !(hasAdapterObserver && adapterIsDefined)) {
 //                         expect(() => sut.getObserver(obj, 'foo')).to.throw(/18/);
@@ -268,7 +268,7 @@
 //               sut.addAdapter({getObserver() { return null }});
 //             }
 //           }
-//           it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, () => {
+//           it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
 //             const actual = sut.getObserver(obj, property);
 //             if (property === 'textContent' || property === 'innerHTML' || property === 'scrollTop' || property === 'scrollLeft') {
 //               expect(actual.constructor.name).to.equal(ValueAttributeObserver.name);
@@ -291,7 +291,7 @@
 //     }
 //   }
 
-//   it(_`getObserver() - throws if $observers is undefined`, () => {
+//   it(_`getObserver() - throws if $observers is undefined`, function() {
 //     const { sut } = setup();
 //     const obj = {};
 //     const write = Reporter.write;
@@ -302,7 +302,7 @@
 //     Reporter.write = write;
 //   });
 
-//   it(_`getObserver() - Array.foo - returns ArrayObserver`, () => {
+//   it(_`getObserver() - Array.foo - returns ArrayObserver`, function() {
 //     const { sut } = setup();
 //     const obj = [];
 //     const actual = sut.getObserver(obj, 'foo');
@@ -310,7 +310,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Array.length - returns ArrayObserver`, () => {
+//   it(_`getObserver() - Array.length - returns ArrayObserver`, function() {
 //     const { sut } = setup();
 //     const obj = [];
 //     const actual = sut.getObserver(obj, 'length');
@@ -318,7 +318,7 @@
 //     expect(actual).to.be.instanceof(CollectionLengthObserver);
 //   });
 
-//   it(_`getObserver() - Set.foo - returns SetObserver`, () => {
+//   it(_`getObserver() - Set.foo - returns SetObserver`, function() {
 //     const { sut } = setup();
 //     const obj = new Set();
 //     const actual = sut.getObserver(obj, 'foo');
@@ -326,7 +326,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Set.size - returns SetObserver`, () => {
+//   it(_`getObserver() - Set.size - returns SetObserver`, function() {
 //     const { sut } = setup();
 //     const obj = new Set();
 //     const actual = sut.getObserver(obj, 'size');
@@ -334,7 +334,7 @@
 //     expect(actual).to.be.instanceof(CollectionLengthObserver);
 //   });
 
-//   it(_`getObserver() - Map.foo - returns MapObserver`, () => {
+//   it(_`getObserver() - Map.foo - returns MapObserver`, function() {
 //     const { sut } = setup();
 //     const obj = new Map();
 //     const actual = sut.getObserver(obj, 'foo');
@@ -342,7 +342,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Map.size - returns MapObserver`, () => {
+//   it(_`getObserver() - Map.size - returns MapObserver`, function() {
 //     const { sut } = setup();
 //     const obj = new Map();
 //     const actual = sut.getObserver(obj, 'size');

--- a/packages/runtime/test/observation/observer-locator.spec.ts
+++ b/packages/runtime/test/observation/observer-locator.spec.ts
@@ -29,7 +29,7 @@
 // import { spy } from 'sinon';
 // import { Reporter } from '@aurelia/kernel';
 
-// describe('ObserverLocator', function() {
+// describe('ObserverLocator', function () {
 //   function setup() {
 //     const container = DI.createContainer();
 //     const lifecycle = container.get(ILifecycle);
@@ -55,7 +55,7 @@
 //     const attr = el.attributes[0];
 //     const { sut } = setup();
 //     const expected = sut.getObserver(el, attr.name);
-//     it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function() {
+//     it(_`getAccessor() - ${markup} - returns ${expected.constructor.name}`, function () {
 //       const actual = sut.getAccessor(el, attr.name);
 //       expect(actual).to.be.instanceof(expected['constructor']);
 //     });
@@ -75,7 +75,7 @@
 //     `<div aria-=""></div>`,
 //     `<div aria-a=""></div>`,
 //   ]) {
-//     it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function() {
+//     it(_`getAccessor() - ${markup} - returns DataAttributeAccessor`, function () {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -99,7 +99,7 @@
 //     `<div aria=""></div>`,
 //     `<div ariaa=""></div>`,
 //   ]) {
-//     it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function() {
+//     it(_`getAccessor() - ${markup} - returns ElementPropertyAccessor`, function () {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -109,7 +109,7 @@
 //     });
 //   }
 
-//   it(_`getAccessor() - {} - returns PropertyAccessor`, function() {
+//   it(_`getAccessor() - {} - returns PropertyAccessor`, function () {
 //     const { sut } = setup();
 //     const obj = {};
 //     const actual = sut.getAccessor(obj, 'foo');
@@ -121,7 +121,7 @@
 //     undefined, null, true, false, '', 'foo',
 //     Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN
 //   ]) {
-//     it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function() {
+//     it(_`getObserver() - ${obj} - returns PrimitiveObserver`, function () {
 //       const { sut } = setup();
 //       if (obj === null || obj === undefined) {
 //         expect(() => sut.getObserver(obj, 'foo')).to.throw;
@@ -133,7 +133,7 @@
 //     });
 //   }
 
-//   it(_`getObserver() - {} - twice in a row - reuses existing observer`, function() {
+//   it(_`getObserver() - {} - twice in a row - reuses existing observer`, function () {
 //     const { sut } = setup();
 //     const obj = {};
 //     const expected = sut.getObserver(obj, 'foo');
@@ -141,7 +141,7 @@
 //     expect(actual).to.equal(expected);
 //   });
 
-//   it(_`getObserver() - {} - twice in a row different property - returns different observer`, function() {
+//   it(_`getObserver() - {} - twice in a row different property - returns different observer`, function () {
 //     const { sut } = setup();
 //     const obj = {};
 //     const expected = sut.getObserver(obj, 'foo');
@@ -165,7 +165,7 @@
 //     { markup: `<div aria-=""></div>`, ctor: DataAttributeAccessor },
 //     { markup: `<div aria-a=""></div>`, ctor: DataAttributeAccessor }
 //   ]) {
-//     it(_`getObserver() - ${markup} - returns ${ctor.name}`, function() {
+//     it(_`getObserver() - ${markup} - returns ${ctor.name}`, function () {
 //       const el = <Element>createElement(markup);
 //       const attr = el.attributes[0];
 //       const { sut } = setup();
@@ -209,7 +209,7 @@
 //                     if (hasOverrides) {
 //                       obj.constructor['computed'] = { isVolatile };
 //                     }
-//                     it(_`getObserver() - descriptor=${descriptor}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
+//                     it(_`getObserver() - descriptor=${descriptor}, hasGetter=${hasGetter}, hasSetter=${hasSetter}, hasOverrides=${hasOverrides}, isVolatile=${isVolatile}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function () {
 //                       Reflect.defineProperty(obj, 'foo', descriptor);
 //                       if (hasSetter && configurable && !hasGetter && !(hasAdapterObserver && adapterIsDefined)) {
 //                         expect(() => sut.getObserver(obj, 'foo')).to.throw(/18/);
@@ -268,7 +268,7 @@
 //               sut.addAdapter({getObserver() { return null }});
 //             }
 //           }
-//           it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function() {
+//           it(_`getObserver() - obj=<div></div>, property=${property}, hasAdapterObserver=${hasAdapterObserver}, adapterIsDefined=${adapterIsDefined}`, function () {
 //             const actual = sut.getObserver(obj, property);
 //             if (property === 'textContent' || property === 'innerHTML' || property === 'scrollTop' || property === 'scrollLeft') {
 //               expect(actual.constructor.name).to.equal(ValueAttributeObserver.name);
@@ -291,7 +291,7 @@
 //     }
 //   }
 
-//   it(_`getObserver() - throws if $observers is undefined`, function() {
+//   it(_`getObserver() - throws if $observers is undefined`, function () {
 //     const { sut } = setup();
 //     const obj = {};
 //     const write = Reporter.write;
@@ -302,7 +302,7 @@
 //     Reporter.write = write;
 //   });
 
-//   it(_`getObserver() - Array.foo - returns ArrayObserver`, function() {
+//   it(_`getObserver() - Array.foo - returns ArrayObserver`, function () {
 //     const { sut } = setup();
 //     const obj = [];
 //     const actual = sut.getObserver(obj, 'foo');
@@ -310,7 +310,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Array.length - returns ArrayObserver`, function() {
+//   it(_`getObserver() - Array.length - returns ArrayObserver`, function () {
 //     const { sut } = setup();
 //     const obj = [];
 //     const actual = sut.getObserver(obj, 'length');
@@ -318,7 +318,7 @@
 //     expect(actual).to.be.instanceof(CollectionLengthObserver);
 //   });
 
-//   it(_`getObserver() - Set.foo - returns SetObserver`, function() {
+//   it(_`getObserver() - Set.foo - returns SetObserver`, function () {
 //     const { sut } = setup();
 //     const obj = new Set();
 //     const actual = sut.getObserver(obj, 'foo');
@@ -326,7 +326,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Set.size - returns SetObserver`, function() {
+//   it(_`getObserver() - Set.size - returns SetObserver`, function () {
 //     const { sut } = setup();
 //     const obj = new Set();
 //     const actual = sut.getObserver(obj, 'size');
@@ -334,7 +334,7 @@
 //     expect(actual).to.be.instanceof(CollectionLengthObserver);
 //   });
 
-//   it(_`getObserver() - Map.foo - returns MapObserver`, function() {
+//   it(_`getObserver() - Map.foo - returns MapObserver`, function () {
 //     const { sut } = setup();
 //     const obj = new Map();
 //     const actual = sut.getObserver(obj, 'foo');
@@ -342,7 +342,7 @@
 //     expect(actual).to.be.instanceof(DirtyCheckProperty);
 //   });
 
-//   it(_`getObserver() - Map.size - returns MapObserver`, function() {
+//   it(_`getObserver() - Map.size - returns MapObserver`, function () {
 //     const { sut } = setup();
 //     const obj = new Map();
 //     const actual = sut.getObserver(obj, 'size');

--- a/packages/runtime/test/observation/property-observation.spec.ts
+++ b/packages/runtime/test/observation/property-observation.spec.ts
@@ -10,10 +10,10 @@ import { SpySubscriber } from '../util';
 
 const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-describe('PrimitiveObserver', () => {
+describe('PrimitiveObserver', function() {
   let sut: PrimitiveObserver;
 
-  describe('getValue()', () => {
+  describe('getValue()', function() {
     const primitiveArr = [
       undefined, null, true, false, '', 'foo',
       Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN,
@@ -23,7 +23,7 @@ describe('PrimitiveObserver', () => {
     for (const primitive of primitiveArr) {
       for (const propertyName of propertyNameArr) {
         const propName = typeof propertyName === 'string' ? `'${propertyName}'` : typeof propertyName;
-        it(`should correctly handle ${typeof primitive}[${propName}]`, () => {
+        it(`should correctly handle ${typeof primitive}[${propName}]`, function() {
           sut = new PrimitiveObserver(primitive, propertyName);
           if (propertyName === 'length') {
             if (typeof primitive === 'string') {
@@ -41,26 +41,26 @@ describe('PrimitiveObserver', () => {
     }
   });
 
-  describe('setValue()', () => {
-    it('is a no-op', () => {
+  describe('setValue()', function() {
+    it('is a no-op', function() {
       expect(new PrimitiveObserver(null, 0).setValue === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('subscribe()', () => {
-    it('is a no-op', () => {
+  describe('subscribe()', function() {
+    it('is a no-op', function() {
       expect(new PrimitiveObserver(null, 0).subscribe === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('unsubscribe()', () => {
-    it('is a no-op', () => {
+  describe('unsubscribe()', function() {
+    it('is a no-op', function() {
       expect(new PrimitiveObserver(null, 0).unsubscribe === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('doNotCache', () => {
-    it('is true', () => {
+  describe('doNotCache', function() {
+    it('is true', function() {
       expect(new PrimitiveObserver(null, 0).doNotCache).to.equal(true);
     });
   });
@@ -68,15 +68,15 @@ describe('PrimitiveObserver', () => {
 
 class Foo {}
 
-describe('SetterObserver', () => {
+describe('SetterObserver', function() {
   let sut: SetterObserver;
 
-  describe('getValue()', () => {
+  describe('getValue()', function() {
     const objectArr = createObjectArr();
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
-        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, () => {
+        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function() {
           sut = new SetterObserver(LF.none, object, propertyName as any);
           sut.subscribe(new SpySubscriber());
           const actual = sut.getValue();
@@ -89,7 +89,7 @@ describe('SetterObserver', () => {
     }
   });
 
-  describe('setValue()', () => {
+  describe('setValue()', function() {
     const valueArr = [undefined, null, 0, '', {}];
     const objectArr = createObjectArr();
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
@@ -97,7 +97,7 @@ describe('SetterObserver', () => {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         for (const value of valueArr) {
-          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, () => {
+          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function() {
             sut = new SetterObserver(LF.none, object, propertyName as any);
             sut.subscribe(new SpySubscriber());
             sut.setValue(value, flags);
@@ -108,13 +108,13 @@ describe('SetterObserver', () => {
     }
   });
 
-  describe('subscribe()', () => {
+  describe('subscribe()', function() {
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
     const objectArr = createObjectArr();
     const flags = LF.updateTargetInstance;
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
-        it(`can handle ${getName(object)}[${typeof propertyName}]`, () => {
+        it(`can handle ${getName(object)}[${typeof propertyName}]`, function() {
           sut = new SetterObserver(LF.none, object, propertyName as any);
           sut.subscribe(new SpySubscriber());
         });
@@ -133,7 +133,7 @@ describe('SetterObserver', () => {
           ];
           for (const subscribers of subscribersArr) {
             const object = {};
-            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, () => {
+            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function() {
               sut = new SetterObserver(LF.none, object, propertyName as any);
               for (const subscriber of subscribers) {
                 sut.subscribe(subscriber);
@@ -163,9 +163,9 @@ describe('SetterObserver', () => {
   });
 });
 
-describe('Observer', () => {
+describe('Observer', function() {
 
-  it('initializes the default callback to null', () => {
+  it('initializes the default callback to null', function() {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new SelfObserver(LF.none, {}, 'a', 'aChanged');

--- a/packages/runtime/test/observation/property-observation.spec.ts
+++ b/packages/runtime/test/observation/property-observation.spec.ts
@@ -10,10 +10,10 @@ import { SpySubscriber } from '../util';
 
 const getName = (o: any) => Object.prototype.toString.call(o).slice(8, -1);
 
-describe('PrimitiveObserver', function() {
+describe('PrimitiveObserver', function () {
   let sut: PrimitiveObserver;
 
-  describe('getValue()', function() {
+  describe('getValue()', function () {
     const primitiveArr = [
       undefined, null, true, false, '', 'foo',
       Number.MAX_VALUE, Number.MAX_SAFE_INTEGER, Number.MIN_VALUE, Number.MIN_SAFE_INTEGER, 0, +Infinity, -Infinity, NaN,
@@ -23,7 +23,7 @@ describe('PrimitiveObserver', function() {
     for (const primitive of primitiveArr) {
       for (const propertyName of propertyNameArr) {
         const propName = typeof propertyName === 'string' ? `'${propertyName}'` : typeof propertyName;
-        it(`should correctly handle ${typeof primitive}[${propName}]`, function() {
+        it(`should correctly handle ${typeof primitive}[${propName}]`, function () {
           sut = new PrimitiveObserver(primitive, propertyName);
           if (propertyName === 'length') {
             if (typeof primitive === 'string') {
@@ -41,26 +41,26 @@ describe('PrimitiveObserver', function() {
     }
   });
 
-  describe('setValue()', function() {
-    it('is a no-op', function() {
+  describe('setValue()', function () {
+    it('is a no-op', function () {
       expect(new PrimitiveObserver(null, 0).setValue === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('subscribe()', function() {
-    it('is a no-op', function() {
+  describe('subscribe()', function () {
+    it('is a no-op', function () {
       expect(new PrimitiveObserver(null, 0).subscribe === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('unsubscribe()', function() {
-    it('is a no-op', function() {
+  describe('unsubscribe()', function () {
+    it('is a no-op', function () {
       expect(new PrimitiveObserver(null, 0).unsubscribe === PLATFORM.noop).to.equal(true);
     });
   });
 
-  describe('doNotCache', function() {
-    it('is true', function() {
+  describe('doNotCache', function () {
+    it('is true', function () {
       expect(new PrimitiveObserver(null, 0).doNotCache).to.equal(true);
     });
   });
@@ -68,15 +68,15 @@ describe('PrimitiveObserver', function() {
 
 class Foo {}
 
-describe('SetterObserver', function() {
+describe('SetterObserver', function () {
   let sut: SetterObserver;
 
-  describe('getValue()', function() {
+  describe('getValue()', function () {
     const objectArr = createObjectArr();
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
-        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function() {
+        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
           sut = new SetterObserver(LF.none, object, propertyName as any);
           sut.subscribe(new SpySubscriber());
           const actual = sut.getValue();
@@ -89,7 +89,7 @@ describe('SetterObserver', function() {
     }
   });
 
-  describe('setValue()', function() {
+  describe('setValue()', function () {
     const valueArr = [undefined, null, 0, '', {}];
     const objectArr = createObjectArr();
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
@@ -97,7 +97,7 @@ describe('SetterObserver', function() {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         for (const value of valueArr) {
-          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function() {
+          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
             sut = new SetterObserver(LF.none, object, propertyName as any);
             sut.subscribe(new SpySubscriber());
             sut.setValue(value, flags);
@@ -108,13 +108,13 @@ describe('SetterObserver', function() {
     }
   });
 
-  describe('subscribe()', function() {
+  describe('subscribe()', function () {
     const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
     const objectArr = createObjectArr();
     const flags = LF.updateTargetInstance;
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
-        it(`can handle ${getName(object)}[${typeof propertyName}]`, function() {
+        it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
           sut = new SetterObserver(LF.none, object, propertyName as any);
           sut.subscribe(new SpySubscriber());
         });
@@ -133,7 +133,7 @@ describe('SetterObserver', function() {
           ];
           for (const subscribers of subscribersArr) {
             const object = {};
-            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function() {
+            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
               sut = new SetterObserver(LF.none, object, propertyName as any);
               for (const subscriber of subscribers) {
                 sut.subscribe(subscriber);
@@ -163,9 +163,9 @@ describe('SetterObserver', function() {
   });
 });
 
-describe('Observer', function() {
+describe('Observer', function () {
 
-  it('initializes the default callback to null', function() {
+  it('initializes the default callback to null', function () {
     const values = createObjectArr();
     values.forEach(value => {
       const observer = new SelfObserver(LF.none, {}, 'a', 'aChanged');
@@ -179,6 +179,6 @@ function createObjectArr(): any[] {
     // tslint:disable-next-line:use-primitive-type no-construct
     {}, Object.create(null), new Number(), new Boolean(), new String(),
     new Error(), new Foo(), new Uint8Array(), new WeakMap(), new WeakSet(), JSON.parse('{}'),
-    /asdf/, function() { return; }, Promise.resolve(), new Proxy({}, {})
+    /asdf/, function () { return; }, Promise.resolve(), new Proxy({}, {})
   ];
 }

--- a/packages/runtime/test/observation/proxy-observer.spec.ts
+++ b/packages/runtime/test/observation/proxy-observer.spec.ts
@@ -4,7 +4,7 @@ import { LifecycleFlags, ProxyObserver } from '../../src/index';
 
 class Foo {}
 
-describe('ProxyObserver', function() {
+describe('ProxyObserver', function () {
   interface Spec {
     t: string;
   }
@@ -56,14 +56,14 @@ describe('ProxyObserver', function() {
     { t: '      new WeakSet()', createObj() { return       new WeakSet(); } },
     { t: '   JSON.parse("{}")', createObj() { return    JSON.parse("{}"); } },
     { t: '             /asdf/', createObj() { return              /asdf/; } },
-    { t: '       function(){}', createObj() { return        function(){}; } },
+    { t: '       function (){}', createObj() { return        function (){}; } },
     { t: '  Promise.resolve()', createObj() { return   Promise.resolve(); } },
     { t: '  new Proxy({}, {})', createObj() { return   new Proxy({}, {}); } }
   ];
   // tslint:enable
 
   eachCartesianJoin([valueSpecs, propertySpecs, objSpecs], function(valueSpec, propertySpec, objSpec) {
-    it(`valueSpec ${valueSpec.t}, propertySpec ${propertySpec.t} objSpec ${objSpec.t}`, function() {
+    it(`valueSpec ${valueSpec.t}, propertySpec ${propertySpec.t} objSpec ${objSpec.t}`, function () {
       const { createValue } = valueSpec;
       const { name } = propertySpec;
       const { createObj } = objSpec;
@@ -182,7 +182,7 @@ describe('ProxyObserver', function() {
     });
   });
 
-  it('works with array', function() {
+  it('works with array', function () {
     const obj = [];
 
     const observer = ProxyObserver.getOrCreate(obj);
@@ -223,7 +223,7 @@ describe('ProxyObserver', function() {
     expect(callCount).to.equal(2);
   });
 
-  it('works with set', function() {
+  it('works with set', function () {
     const obj = new Set();
 
     const observer = ProxyObserver.getOrCreate(obj);
@@ -252,7 +252,7 @@ describe('ProxyObserver', function() {
     expect(callCount).to.equal(0);
   });
 
-  it('works with map', function() {
+  it('works with map', function () {
     const obj = new Map();
 
     const observer = ProxyObserver.getOrCreate(obj);

--- a/packages/runtime/test/observation/set-observer.spec.ts
+++ b/packages/runtime/test/observation/set-observer.spec.ts
@@ -33,21 +33,21 @@ function assetSetEqual(actual: Set<any>, expected: Set<any>): void {
   }
 }
 
-describe(`SetObserver`, function() {
+describe(`SetObserver`, function () {
   let sut: SetObserver;
 
-  before(function() {
+  before(function () {
     disableSetObservation();
     enableSetObservation();
   });
-  afterEach(function() {
+  afterEach(function () {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', function() {
-    it('add', function() {
+  describe('should allow subscribing for immediate notification', function () {
+    it('add', function () {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -57,8 +57,8 @@ describe(`SetObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', function() {
-    it('add', function() {
+  describe('should allow unsubscribing for immediate notification', function () {
+    it('add', function () {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -69,8 +69,8 @@ describe(`SetObserver`, function() {
     });
   });
 
-  describe('should allow subscribing for batched notification', function() {
-    it('add', function() {
+  describe('should allow subscribing for batched notification', function () {
+    it('add', function () {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -83,8 +83,8 @@ describe(`SetObserver`, function() {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', function() {
-    it('add', function() {
+  describe('should allow unsubscribing for batched notification', function () {
+    it('add', function () {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -98,8 +98,8 @@ describe(`SetObserver`, function() {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', function() {
-    it('add', function() {
+  describe('should notify batched subscribers even if there are no changes', function () {
+    it('add', function () {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -109,14 +109,14 @@ describe(`SetObserver`, function() {
     });
   });
 
-  describe(`observeAdd`, function() {
+  describe(`observeAdd`, function () {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const set = new Set(Array.from(init));
             const expectedSet = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -144,7 +144,7 @@ describe(`SetObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const set = new Set(Array.from(init));
             const copy = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -170,14 +170,14 @@ describe(`SetObserver`, function() {
     }
   });
 
-  describe(`observeDelete`, function() {
+  describe(`observeDelete`, function () {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function () {
             const set = new Set(Array.from(init));
             const expectedSet = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -205,7 +205,7 @@ describe(`SetObserver`, function() {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function () {
             const set = new Set(Array.from(init));
             const copy = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -231,12 +231,12 @@ describe(`SetObserver`, function() {
     }
   });
 
-  describe(`observeClear`, function() {
+  describe(`observeClear`, function () {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function() {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function () {
           const set = new Set(Array.from(init));
           const expectedSet = new Set(Array.from(init));
           sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -249,7 +249,7 @@ describe(`SetObserver`, function() {
           }
         });
 
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function() {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function () {
           const set = new Set(Array.from(init));
           const copy = new Set(Array.from(init));
           sut = new SetObserver(LF.none, new Lifecycle(), set);

--- a/packages/runtime/test/observation/set-observer.spec.ts
+++ b/packages/runtime/test/observation/set-observer.spec.ts
@@ -33,21 +33,21 @@ function assetSetEqual(actual: Set<any>, expected: Set<any>): void {
   }
 }
 
-describe(`SetObserver`, () => {
+describe(`SetObserver`, function() {
   let sut: SetObserver;
 
-  before(() => {
+  before(function() {
     disableSetObservation();
     enableSetObservation();
   });
-  afterEach(() => {
+  afterEach(function() {
     if (sut) {
       sut.dispose();
     }
   });
 
-  describe('should allow subscribing for immediate notification', () => {
-    it('add', () => {
+  describe('should allow subscribing for immediate notification', function() {
+    it('add', function() {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -57,8 +57,8 @@ describe(`SetObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for immediate notification', () => {
-    it('add', () => {
+  describe('should allow unsubscribing for immediate notification', function() {
+    it('add', function() {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -69,8 +69,8 @@ describe(`SetObserver`, () => {
     });
   });
 
-  describe('should allow subscribing for batched notification', () => {
-    it('add', () => {
+  describe('should allow subscribing for batched notification', function() {
+    it('add', function() {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -83,8 +83,8 @@ describe(`SetObserver`, () => {
     });
   });
 
-  describe('should allow unsubscribing for batched notification', () => {
-    it('add', () => {
+  describe('should allow unsubscribing for batched notification', function() {
+    it('add', function() {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -98,8 +98,8 @@ describe(`SetObserver`, () => {
 
   // the reason for this is because only a change will cause it to queue itself, so it would never normally be called without changes anyway,
   // but for the occasion that it needs to be forced (such as via patch lifecycle), we do want all subscribers to be invoked regardless
-  describe('should notify batched subscribers even if there are no changes', () => {
-    it('add', () => {
+  describe('should notify batched subscribers even if there are no changes', function() {
+    it('add', function() {
       const s = new SpySubscriber();
       const set = new Set();
       sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -109,14 +109,14 @@ describe(`SetObserver`, () => {
     });
   });
 
-  describe(`observeAdd`, () => {
+  describe(`observeAdd`, function() {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const set = new Set(Array.from(init));
             const expectedSet = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -144,7 +144,7 @@ describe(`SetObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const set = new Set(Array.from(init));
             const copy = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -170,14 +170,14 @@ describe(`SetObserver`, () => {
     }
   });
 
-  describe(`observeDelete`, () => {
+  describe(`observeDelete`, function() {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const itemsArr = [undefined, [], [1], [1, 2]];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const items of itemsArr) {
         for (const repeat of repeatArr) {
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - behaves as native`, function() {
             const set = new Set(Array.from(init));
             const expectedSet = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -205,7 +205,7 @@ describe(`SetObserver`, () => {
             }
           });
 
-          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, () => {
+          it(`size=${padRight(init.size, 2)} itemCount=${padRight(items && items.length, 9)} repeat=${repeat} - tracks changes`, function() {
             const set = new Set(Array.from(init));
             const copy = new Set(Array.from(init));
             const newItems = items && items.slice();
@@ -231,12 +231,12 @@ describe(`SetObserver`, () => {
     }
   });
 
-  describe(`observeClear`, () => {
+  describe(`observeClear`, function() {
     const initArr = [new Set(), new Set([1]), new Set([1, 2])];
     const repeatArr = [1, 2];
     for (const init of initArr) {
       for (const repeat of repeatArr) {
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, () => {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - behaves as native`, function() {
           const set = new Set(Array.from(init));
           const expectedSet = new Set(Array.from(init));
           sut = new SetObserver(LF.none, new Lifecycle(), set);
@@ -249,7 +249,7 @@ describe(`SetObserver`, () => {
           }
         });
 
-        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, () => {
+        it(`size=${padRight(init.size, 2)} repeat=${repeat} - tracks changes`, function() {
           const set = new Set(Array.from(init));
           const copy = new Set(Array.from(init));
           sut = new SetObserver(LF.none, new Lifecycle(), set);

--- a/packages/runtime/test/observation/signaler.spec.ts
+++ b/packages/runtime/test/observation/signaler.spec.ts
@@ -7,7 +7,7 @@ import {
 import { Signaler } from '../../src/observation/signaler';
 import { MockPropertySubscriber } from '../_doubles/mock-subscriber';
 
-describe('ISignaler', () => {
+describe('ISignaler', function() {
   type $1 = [string, ISignaler, MockPropertySubscriber[]];
   type $2 = [string, string[]];
   type $3 = [string, LifecycleFlags];
@@ -189,7 +189,7 @@ describe('ISignaler', () => {
     = [sutVariations, signalsVariations, flagsVariations, addSignalVariations, dispatchSignalVariations, removeSignalVariations];
 
   eachCartesianJoinFactory(inputs, ([t1, sut, mocks], [t2, signals], [t3, flags], [t4, addSignalListener], [t5, dispatchSignal], [t6, removeSignalListener]) => {
-      it(`${t1}, signals=${t2}, flags=${t3} -> ${t4} -> ${t5} -> ${t6}`, () => {
+      it(`${t1}, signals=${t2}, flags=${t3} -> ${t4} -> ${t5} -> ${t6}`, function() {
         addSignalListener(sut);
         dispatchSignal(sut);
         removeSignalListener(sut);

--- a/packages/runtime/test/observation/signaler.spec.ts
+++ b/packages/runtime/test/observation/signaler.spec.ts
@@ -7,7 +7,7 @@ import {
 import { Signaler } from '../../src/observation/signaler';
 import { MockPropertySubscriber } from '../_doubles/mock-subscriber';
 
-describe('ISignaler', function() {
+describe('ISignaler', function () {
   type $1 = [string, ISignaler, MockPropertySubscriber[]];
   type $2 = [string, string[]];
   type $3 = [string, LifecycleFlags];
@@ -189,7 +189,7 @@ describe('ISignaler', function() {
     = [sutVariations, signalsVariations, flagsVariations, addSignalVariations, dispatchSignalVariations, removeSignalVariations];
 
   eachCartesianJoinFactory(inputs, ([t1, sut, mocks], [t2, signals], [t3, flags], [t4, addSignalListener], [t5, dispatchSignal], [t6, removeSignalListener]) => {
-      it(`${t1}, signals=${t2}, flags=${t3} -> ${t4} -> ${t5} -> ${t6}`, function() {
+      it(`${t1}, signals=${t2}, flags=${t3} -> ${t4} -> ${t5} -> ${t6}`, function () {
         addSignalListener(sut);
         dispatchSignal(sut);
         removeSignalListener(sut);

--- a/packages/runtime/test/observation/signals.spec.ts
+++ b/packages/runtime/test/observation/signals.spec.ts
@@ -15,14 +15,14 @@ import {
   SignalBindingBehavior
 } from '../../src/index';
 
-describe('SignalBindingBehavior', () => {
+describe('SignalBindingBehavior', function() {
   const container: IContainer = DI.createContainer();
   let sut: SignalBindingBehavior;
   let binding: Binding;
   let signaler: ISignaler;
   let name: string;
 
-  beforeEach(() => {
+  beforeEach(function() {
     name = 'foo';
     signaler = new MockSignaler() as any;
     sut = new SignalBindingBehavior(signaler);
@@ -31,11 +31,11 @@ describe('SignalBindingBehavior', () => {
   });
 
   // TODO: test properly (multiple names etc)
-  it('bind()   should apply the correct behavior', () => {
+  it('bind()   should apply the correct behavior', function() {
     expect(signaler.addSignalListener).to.have.been.calledWith(name, binding);
   });
 
-  it('unbind() should revert the original behavior', () => {
+  it('unbind() should revert the original behavior', function() {
     sut.unbind(undefined, undefined, binding as any);
     expect(signaler.removeSignalListener).to.have.been.calledWith(name, binding);
   });

--- a/packages/runtime/test/observation/signals.spec.ts
+++ b/packages/runtime/test/observation/signals.spec.ts
@@ -15,14 +15,14 @@ import {
   SignalBindingBehavior
 } from '../../src/index';
 
-describe('SignalBindingBehavior', function() {
+describe('SignalBindingBehavior', function () {
   const container: IContainer = DI.createContainer();
   let sut: SignalBindingBehavior;
   let binding: Binding;
   let signaler: ISignaler;
   let name: string;
 
-  beforeEach(function() {
+  beforeEach(function () {
     name = 'foo';
     signaler = new MockSignaler() as any;
     sut = new SignalBindingBehavior(signaler);
@@ -31,11 +31,11 @@ describe('SignalBindingBehavior', function() {
   });
 
   // TODO: test properly (multiple names etc)
-  it('bind()   should apply the correct behavior', function() {
+  it('bind()   should apply the correct behavior', function () {
     expect(signaler.addSignalListener).to.have.been.calledWith(name, binding);
   });
 
-  it('unbind() should revert the original behavior', function() {
+  it('unbind() should revert the original behavior', function () {
     sut.unbind(undefined, undefined, binding as any);
     expect(signaler.removeSignalListener).to.have.been.calledWith(name, binding);
   });

--- a/packages/runtime/test/observation/subscriber-collection.spec.ts
+++ b/packages/runtime/test/observation/subscriber-collection.spec.ts
@@ -9,8 +9,8 @@ import {
 @subscriberCollection(MutationKind.instance)
 class Test {}
 
-describe('subscriberCollection', function() {
-  it('calls subscribers', function() {
+describe('subscriberCollection', function () {
+  it('calls subscribers', function () {
     const flags = LifecycleFlags.updateSourceExpression;
     const observer = new Test();
     const observer2 = new Test();
@@ -53,7 +53,7 @@ describe('subscriberCollection', function() {
     expect(callable10.handleChange).to.have.been.calledWith('new value2', 'old value2', flags);
   });
 
-  it('removes subscribers', function() {
+  it('removes subscribers', function () {
     const observer = new Test();
 
     const subscribers = [];

--- a/packages/runtime/test/observation/subscriber-collection.spec.ts
+++ b/packages/runtime/test/observation/subscriber-collection.spec.ts
@@ -9,8 +9,8 @@ import {
 @subscriberCollection(MutationKind.instance)
 class Test {}
 
-describe('subscriberCollection', () => {
-  it('calls subscribers', () => {
+describe('subscriberCollection', function() {
+  it('calls subscribers', function() {
     const flags = LifecycleFlags.updateSourceExpression;
     const observer = new Test();
     const observer2 = new Test();
@@ -53,7 +53,7 @@ describe('subscriberCollection', () => {
     expect(callable10.handleChange).to.have.been.calledWith('new value2', 'old value2', flags);
   });
 
-  it('removes subscribers', () => {
+  it('removes subscribers', function() {
     const observer = new Test();
 
     const subscribers = [];

--- a/packages/runtime/test/observation/target-observers.spec.ts
+++ b/packages/runtime/test/observation/target-observers.spec.ts
@@ -31,7 +31,7 @@
 // </svg>`).lastElementChild;
 // }
 
-// describe('XLinkAttributeAccessor', () => {
+// describe('XLinkAttributeAccessor', function() {
 //   let sut: XLinkAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
@@ -45,9 +45,9 @@
 //     { name: 'show', value: 'false' }
 //   ];
 
-//   describe('getValue()', () => {
+//   describe('getValue()', function() {
 //     for (const { name, value } of tests) {
-//       it(`returns ${value} for xlink:${name}`, () => {
+//       it(`returns ${value} for xlink:${name}`, function() {
 //         el = createSvgUseElement(name, value);
 //         lifecycle = new Lifecycle();
 //         sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
@@ -57,9 +57,9 @@
 //     }
 //   });
 
-//   describe('setValue()', () => {
+//   describe('setValue()', function() {
 //     for (const { name, value } of tests) {
-//       it(`sets xlink:${name} to foo`, () => {
+//       it(`sets xlink:${name} to foo`, function() {
 //         el = createSvgUseElement(name, value);
 //         lifecycle = new Lifecycle();
 //         sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
@@ -73,16 +73,16 @@
 
 // });
 
-// describe('DataAttributeAccessor', () => {
+// describe('DataAttributeAccessor', function() {
 //   let sut: DataAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
 
 //   const valueArr = [undefined, null, '', 'foo'];
-//   describe('getValue()', () => {
+//   describe('getValue()', function() {
 //     for (const name of globalAttributeNames) {
 //       for (const value of valueArr.filter(v => v !== null && v !== undefined)) {
-//         it(`returns "${value}" for attribute "${name}"`, () => {
+//         it(`returns "${value}" for attribute "${name}"`, function() {
 //           el = createElement(`<div ${name}="${value}"></div>`);
 //           lifecycle = new Lifecycle();
 //           sut = new DataAttributeAccessor(dom, lifecycle, el, name);
@@ -93,10 +93,10 @@
 //     }
 //   });
 
-//   describe('setValue()', () => {
+//   describe('setValue()', function() {
 //     for (const name of globalAttributeNames) {
 //       for (const value of valueArr) {
-//         it(`sets attribute "${name}" to "${value}"`, () => {
+//         it(`sets attribute "${name}" to "${value}"`, function() {
 //           el = createElement(`<div></div>`);
 //           lifecycle = new Lifecycle();
 //           const expected = value !== null && value !== undefined ? `<div ${name}="${value}"></div>` : '<div></div>';
@@ -113,7 +113,7 @@
 //   });
 // });
 
-// describe('StyleAccessor', () => {
+// describe('StyleAccessor', function() {
 //   const propNames = Object.getOwnPropertyNames(CSS_PROPERTIES);
 
 //   let sut: StyleAttributeAccessor;
@@ -125,7 +125,7 @@
 //     const values = CSS_PROPERTIES[propName]['values'];
 //     const value = values[0];
 //     const rule = `${propName}:${value}`;
-//     it(`setValue - style="${rule}"`, () => {
+//     it(`setValue - style="${rule}"`, function() {
 //       el = <HTMLElement>createElement('<div></div>');
 //       lifecycle = new Lifecycle();
 //       sut = new StyleAttributeAccessor(dom, lifecycle, el);
@@ -139,7 +139,7 @@
 //     });
 //   }
 
-//   it(`getValue - style="display: block;"`, () => {
+//   it(`getValue - style="display: block;"`, function() {
 //     el = <HTMLElement>createElement(`<div style="display: block;"></div>`);
 //     lifecycle = new Lifecycle();
 //     sut = new StyleAttributeAccessor(dom, lifecycle, el);
@@ -149,7 +149,7 @@
 //   });
 // });
 
-// describe('ClassAccessor', () => {
+// describe('ClassAccessor', function() {
 //   let sut: ClassAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
@@ -165,14 +165,14 @@
 //   const secondClassListArr = ['', 'fooo'];
 //   for (const markup of markupArr) {
 //     for (const classList of classListArr) {
-//       beforeEach(() => {
+//       beforeEach(function() {
 //         el = createElement(markup);
 //         initialClassList = el.classList.toString();
 //         lifecycle = new Lifecycle();
 //         sut = new ClassAttributeAccessor(dom, lifecycle, el);
 //       });
 
-//       it(`setValue("${classList}") updates ${markup}`, () => {
+//       it(`setValue("${classList}") updates ${markup}`, function() {
 //         sut.setValue(classList);
 //         expect(el.classList.toString()).to.equal(initialClassList);
 //         lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -186,7 +186,7 @@
 //       });
 
 //       for (const secondClassList of secondClassListArr) {
-//         it(`setValue("${secondClassList}") updates already-updated ${markup}`, () => {
+//         it(`setValue("${secondClassList}") updates already-updated ${markup}`, function() {
 //           sut.setValue(classList, LifecycleFlags.none);
 //           lifecycle.processFlushQueue(LifecycleFlags.none);
 //           const updatedClassList = el.classList.toString();

--- a/packages/runtime/test/observation/target-observers.spec.ts
+++ b/packages/runtime/test/observation/target-observers.spec.ts
@@ -31,7 +31,7 @@
 // </svg>`).lastElementChild;
 // }
 
-// describe('XLinkAttributeAccessor', function() {
+// describe('XLinkAttributeAccessor', function () {
 //   let sut: XLinkAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
@@ -45,9 +45,9 @@
 //     { name: 'show', value: 'false' }
 //   ];
 
-//   describe('getValue()', function() {
+//   describe('getValue()', function () {
 //     for (const { name, value } of tests) {
-//       it(`returns ${value} for xlink:${name}`, function() {
+//       it(`returns ${value} for xlink:${name}`, function () {
 //         el = createSvgUseElement(name, value);
 //         lifecycle = new Lifecycle();
 //         sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
@@ -57,9 +57,9 @@
 //     }
 //   });
 
-//   describe('setValue()', function() {
+//   describe('setValue()', function () {
 //     for (const { name, value } of tests) {
-//       it(`sets xlink:${name} to foo`, function() {
+//       it(`sets xlink:${name} to foo`, function () {
 //         el = createSvgUseElement(name, value);
 //         lifecycle = new Lifecycle();
 //         sut = new XLinkAttributeAccessor(dom, lifecycle, el, `xlink:${name}`, name);
@@ -73,16 +73,16 @@
 
 // });
 
-// describe('DataAttributeAccessor', function() {
+// describe('DataAttributeAccessor', function () {
 //   let sut: DataAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
 
 //   const valueArr = [undefined, null, '', 'foo'];
-//   describe('getValue()', function() {
+//   describe('getValue()', function () {
 //     for (const name of globalAttributeNames) {
 //       for (const value of valueArr.filter(v => v !== null && v !== undefined)) {
-//         it(`returns "${value}" for attribute "${name}"`, function() {
+//         it(`returns "${value}" for attribute "${name}"`, function () {
 //           el = createElement(`<div ${name}="${value}"></div>`);
 //           lifecycle = new Lifecycle();
 //           sut = new DataAttributeAccessor(dom, lifecycle, el, name);
@@ -93,10 +93,10 @@
 //     }
 //   });
 
-//   describe('setValue()', function() {
+//   describe('setValue()', function () {
 //     for (const name of globalAttributeNames) {
 //       for (const value of valueArr) {
-//         it(`sets attribute "${name}" to "${value}"`, function() {
+//         it(`sets attribute "${name}" to "${value}"`, function () {
 //           el = createElement(`<div></div>`);
 //           lifecycle = new Lifecycle();
 //           const expected = value !== null && value !== undefined ? `<div ${name}="${value}"></div>` : '<div></div>';
@@ -113,7 +113,7 @@
 //   });
 // });
 
-// describe('StyleAccessor', function() {
+// describe('StyleAccessor', function () {
 //   const propNames = Object.getOwnPropertyNames(CSS_PROPERTIES);
 
 //   let sut: StyleAttributeAccessor;
@@ -125,7 +125,7 @@
 //     const values = CSS_PROPERTIES[propName]['values'];
 //     const value = values[0];
 //     const rule = `${propName}:${value}`;
-//     it(`setValue - style="${rule}"`, function() {
+//     it(`setValue - style="${rule}"`, function () {
 //       el = <HTMLElement>createElement('<div></div>');
 //       lifecycle = new Lifecycle();
 //       sut = new StyleAttributeAccessor(dom, lifecycle, el);
@@ -139,7 +139,7 @@
 //     });
 //   }
 
-//   it(`getValue - style="display: block;"`, function() {
+//   it(`getValue - style="display: block;"`, function () {
 //     el = <HTMLElement>createElement(`<div style="display: block;"></div>`);
 //     lifecycle = new Lifecycle();
 //     sut = new StyleAttributeAccessor(dom, lifecycle, el);
@@ -149,7 +149,7 @@
 //   });
 // });
 
-// describe('ClassAccessor', function() {
+// describe('ClassAccessor', function () {
 //   let sut: ClassAttributeAccessor;
 //   let el: Element;
 //   let lifecycle: Lifecycle;
@@ -165,14 +165,14 @@
 //   const secondClassListArr = ['', 'fooo'];
 //   for (const markup of markupArr) {
 //     for (const classList of classListArr) {
-//       beforeEach(function() {
+//       beforeEach(function () {
 //         el = createElement(markup);
 //         initialClassList = el.classList.toString();
 //         lifecycle = new Lifecycle();
 //         sut = new ClassAttributeAccessor(dom, lifecycle, el);
 //       });
 
-//       it(`setValue("${classList}") updates ${markup}`, function() {
+//       it(`setValue("${classList}") updates ${markup}`, function () {
 //         sut.setValue(classList);
 //         expect(el.classList.toString()).to.equal(initialClassList);
 //         lifecycle.processFlushQueue(LifecycleFlags.none);
@@ -186,7 +186,7 @@
 //       });
 
 //       for (const secondClassList of secondClassListArr) {
-//         it(`setValue("${secondClassList}") updates already-updated ${markup}`, function() {
+//         it(`setValue("${secondClassList}") updates already-updated ${markup}`, function () {
 //           sut.setValue(classList, LifecycleFlags.none);
 //           lifecycle.processFlushQueue(LifecycleFlags.none);
 //           const updatedClassList = el.classList.toString();

--- a/packages/runtime/test/renderer.spec.ts
+++ b/packages/runtime/test/renderer.spec.ts
@@ -29,7 +29,7 @@ import {
 import { AuDOMConfiguration, AuNode } from './au-dom';
 import { _ } from './util';
 
-describe('Renderer', function() {
+describe('Renderer', function () {
   function setup() {
     const container = AuDOMConfiguration.createContainer();
     IExpressionParserRegistration.register(container as any);
@@ -69,12 +69,12 @@ describe('Renderer', function() {
     return { sut, renderable, dom, target, renderContext, renderingEngine };
   }
 
-  describe('handles IPropertyBindingInstruction', function() {
+  describe('handles IPropertyBindingInstruction', function () {
     for (const Instruction of [OneTimeBindingInstruction, ToViewBindingInstruction, FromViewBindingInstruction, TwoWayBindingInstruction] as any[]) {
       for (const to of ['foo', 'bar']) {
         for (const from of ['foo', new AccessScope('foo')]) {
           const instruction = new Instruction(from, to) as IPropertyBindingInstruction;
-          it(_`instruction=${instruction}`, function() {
+          it(_`instruction=${instruction}`, function () {
             const { sut, dom, renderable, target, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -94,11 +94,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles ICallBindingInstruction', function() {
+  describe('handles ICallBindingInstruction', function () {
     for (const to of ['foo', 'bar']) {
       for (const from of ['foo()', new CallScope('foo', [])] as any[]) {
         const instruction = new CallBindingInstruction(from, to) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -116,10 +116,10 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles IRefBindingInstruction', function() {
+  describe('handles IRefBindingInstruction', function () {
     for (const from of ['foo', new AccessScope('foo')] as any[]) {
       const instruction = new RefBindingInstruction(from) as any;
-      it(_`instruction=${instruction}`, function() {
+      it(_`instruction=${instruction}`, function () {
         const { sut, dom, renderable, target, renderContext } = setup();
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -135,11 +135,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles ISetPropertyInstruction', function() {
+  describe('handles ISetPropertyInstruction', function () {
     for (const to of ['foo', 'bar']) {
       for (const value of ['foo', 42, {}] as any[]) {
         const instruction = new SetPropertyInstruction(value, to) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -154,11 +154,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles IHydrateElementInstruction', function() {
+  describe('handles IHydrateElementInstruction', function () {
     for (const res of ['foo', 'bar']) {
       for (const instructions of [[], [{type: TargetedInstructionType.setProperty}, {type: TargetedInstructionType.setProperty}]] as any[]) {
         const instruction = new HydrateElementInstruction(res, instructions) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -172,11 +172,11 @@ describe('Renderer', function() {
     }
   });
 
-  describe('handles IHydrateAttributeInstruction', function() {
+  describe('handles IHydrateAttributeInstruction', function () {
     for (const res of ['if', 'else', 'repeat']) {
       for (const instructions of [[], [new SetPropertyInstruction('bar', 'foo')]] as any[]) {
         const instruction = new HydrateAttributeInstruction(res, instructions) as any;
-        it(_`instruction=${instruction}`, function() {
+        it(_`instruction=${instruction}`, function () {
           const { sut, dom, renderable, target, renderContext, renderingEngine } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -199,9 +199,9 @@ describe('Renderer', function() {
     }
   });
 
-  describe('<let/>', function() {
+  describe('<let/>', function () {
 
-    describe('ILetElementInstruction', function() {
+    describe('ILetElementInstruction', function () {
       for (const to of ['processedFoo', 'processedPoo']) {
         for (const value of ['foo', new AccessScope('foo')] as any[]) {
           const instruction = new LetElementInstruction(
@@ -209,7 +209,7 @@ describe('Renderer', function() {
             // tslint:disable-next-line:insecure-random
             Math.random() > 0.4
           ) as any;
-          it(_`instruction=${instruction}`, function() {
+          it(_`instruction=${instruction}`, function () {
             const { sut, dom, renderable, target, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);

--- a/packages/runtime/test/renderer.spec.ts
+++ b/packages/runtime/test/renderer.spec.ts
@@ -29,7 +29,7 @@ import {
 import { AuDOMConfiguration, AuNode } from './au-dom';
 import { _ } from './util';
 
-describe('Renderer', () => {
+describe('Renderer', function() {
   function setup() {
     const container = AuDOMConfiguration.createContainer();
     IExpressionParserRegistration.register(container as any);
@@ -69,12 +69,12 @@ describe('Renderer', () => {
     return { sut, renderable, dom, target, renderContext, renderingEngine };
   }
 
-  describe('handles IPropertyBindingInstruction', () => {
+  describe('handles IPropertyBindingInstruction', function() {
     for (const Instruction of [OneTimeBindingInstruction, ToViewBindingInstruction, FromViewBindingInstruction, TwoWayBindingInstruction] as any[]) {
       for (const to of ['foo', 'bar']) {
         for (const from of ['foo', new AccessScope('foo')]) {
           const instruction = new Instruction(from, to) as IPropertyBindingInstruction;
-          it(_`instruction=${instruction}`, () => {
+          it(_`instruction=${instruction}`, function() {
             const { sut, dom, renderable, target, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -94,11 +94,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles ICallBindingInstruction', () => {
+  describe('handles ICallBindingInstruction', function() {
     for (const to of ['foo', 'bar']) {
       for (const from of ['foo()', new CallScope('foo', [])] as any[]) {
         const instruction = new CallBindingInstruction(from, to) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -116,10 +116,10 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles IRefBindingInstruction', () => {
+  describe('handles IRefBindingInstruction', function() {
     for (const from of ['foo', new AccessScope('foo')] as any[]) {
       const instruction = new RefBindingInstruction(from) as any;
-      it(_`instruction=${instruction}`, () => {
+      it(_`instruction=${instruction}`, function() {
         const { sut, dom, renderable, target, renderContext } = setup();
 
         sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -135,11 +135,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles ISetPropertyInstruction', () => {
+  describe('handles ISetPropertyInstruction', function() {
     for (const to of ['foo', 'bar']) {
       for (const value of ['foo', 42, {}] as any[]) {
         const instruction = new SetPropertyInstruction(value, to) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -154,11 +154,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles IHydrateElementInstruction', () => {
+  describe('handles IHydrateElementInstruction', function() {
     for (const res of ['foo', 'bar']) {
       for (const instructions of [[], [{type: TargetedInstructionType.setProperty}, {type: TargetedInstructionType.setProperty}]] as any[]) {
         const instruction = new HydrateElementInstruction(res, instructions) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { sut, dom, renderable, target, renderContext } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -172,11 +172,11 @@ describe('Renderer', () => {
     }
   });
 
-  describe('handles IHydrateAttributeInstruction', () => {
+  describe('handles IHydrateAttributeInstruction', function() {
     for (const res of ['if', 'else', 'repeat']) {
       for (const instructions of [[], [new SetPropertyInstruction('bar', 'foo')]] as any[]) {
         const instruction = new HydrateAttributeInstruction(res, instructions) as any;
-        it(_`instruction=${instruction}`, () => {
+        it(_`instruction=${instruction}`, function() {
           const { sut, dom, renderable, target, renderContext, renderingEngine } = setup();
 
           sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);
@@ -199,9 +199,9 @@ describe('Renderer', () => {
     }
   });
 
-  describe('<let/>', () => {
+  describe('<let/>', function() {
 
-    describe('ILetElementInstruction', () => {
+    describe('ILetElementInstruction', function() {
       for (const to of ['processedFoo', 'processedPoo']) {
         for (const value of ['foo', new AccessScope('foo')] as any[]) {
           const instruction = new LetElementInstruction(
@@ -209,7 +209,7 @@ describe('Renderer', () => {
             // tslint:disable-next-line:insecure-random
             Math.random() > 0.4
           ) as any;
-          it(_`instruction=${instruction}`, () => {
+          it(_`instruction=${instruction}`, function() {
             const { sut, dom, renderable, target, renderContext } = setup();
 
             sut.instructionRenderers[instruction.type].render(LF.none, dom, renderContext, renderable, target, instruction);

--- a/packages/runtime/test/resources/binding-behavior.spec.ts
+++ b/packages/runtime/test/resources/binding-behavior.spec.ts
@@ -2,10 +2,10 @@ import { DI, IContainer } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { bindingBehavior, BindingBehaviorResource } from '../../src/index';
 
-describe(`@bindingBehavior('foo')`, () => {
+describe(`@bindingBehavior('foo')`, function() {
   let container: IContainer;
 
-  beforeEach(() => {
+  beforeEach(function() {
     container = DI.createContainer();
   });
 
@@ -13,7 +13,7 @@ describe(`@bindingBehavior('foo')`, () => {
   @bindingBehavior('foo')
   class FooBindingBehavior { }
 
-  it(`should define the binding behavior`, () => {
+  it(`should define the binding behavior`, function() {
     expect(FooBindingBehavior['kind']).to.equal(BindingBehaviorResource);
     expect(FooBindingBehavior['description'].name).to.equal('foo');
     FooBindingBehavior['register'](container);

--- a/packages/runtime/test/resources/binding-behavior.spec.ts
+++ b/packages/runtime/test/resources/binding-behavior.spec.ts
@@ -2,10 +2,10 @@ import { DI, IContainer } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { bindingBehavior, BindingBehaviorResource } from '../../src/index';
 
-describe(`@bindingBehavior('foo')`, function() {
+describe(`@bindingBehavior('foo')`, function () {
   let container: IContainer;
 
-  beforeEach(function() {
+  beforeEach(function () {
     container = DI.createContainer();
   });
 
@@ -13,7 +13,7 @@ describe(`@bindingBehavior('foo')`, function() {
   @bindingBehavior('foo')
   class FooBindingBehavior { }
 
-  it(`should define the binding behavior`, function() {
+  it(`should define the binding behavior`, function () {
     expect(FooBindingBehavior['kind']).to.equal(BindingBehaviorResource);
     expect(FooBindingBehavior['description'].name).to.equal('foo');
     FooBindingBehavior['register'](container);

--- a/packages/runtime/test/resources/binding-behaviors/binding-mode-behaviors.spec.ts
+++ b/packages/runtime/test/resources/binding-behaviors/binding-mode-behaviors.spec.ts
@@ -19,7 +19,7 @@ const tests = [
   { Behavior: TwoWayBindingBehavior, mode: BindingMode.twoWay }
 ];
 
-describe('BindingModeBehavior', function() {
+describe('BindingModeBehavior', function () {
   const container: IContainer = DI.createContainer();
   let sut: OneTimeBindingBehavior;
   let binding: Binding;
@@ -28,18 +28,18 @@ describe('BindingModeBehavior', function() {
     const initModeArr = [BindingMode.oneTime, BindingMode.toView, BindingMode.fromView, BindingMode.twoWay, BindingMode.default];
 
     for (const initMode of initModeArr) {
-      describe(Behavior.name, function() {
-        beforeEach(function() {
+      describe(Behavior.name, function () {
+        beforeEach(function () {
           sut = new Behavior();
           binding = new Binding(undefined, undefined, undefined, initMode, undefined, container as any);
           sut.bind(undefined, undefined, binding);
         });
 
-        it(`bind()   should apply  bindingMode ${mode}`, function() {
+        it(`bind()   should apply  bindingMode ${mode}`, function () {
           expect(binding.mode).to.equal(mode);
         });
 
-        it(`unbind() should revert bindingMode ${initMode}`, function() {
+        it(`unbind() should revert bindingMode ${initMode}`, function () {
           sut.unbind(undefined, undefined, binding);
           expect(binding.mode).to.equal(initMode);
         });

--- a/packages/runtime/test/resources/binding-behaviors/binding-mode-behaviors.spec.ts
+++ b/packages/runtime/test/resources/binding-behaviors/binding-mode-behaviors.spec.ts
@@ -19,7 +19,7 @@ const tests = [
   { Behavior: TwoWayBindingBehavior, mode: BindingMode.twoWay }
 ];
 
-describe('BindingModeBehavior', () => {
+describe('BindingModeBehavior', function() {
   const container: IContainer = DI.createContainer();
   let sut: OneTimeBindingBehavior;
   let binding: Binding;
@@ -28,18 +28,18 @@ describe('BindingModeBehavior', () => {
     const initModeArr = [BindingMode.oneTime, BindingMode.toView, BindingMode.fromView, BindingMode.twoWay, BindingMode.default];
 
     for (const initMode of initModeArr) {
-      describe(Behavior.name, () => {
-        beforeEach(() => {
+      describe(Behavior.name, function() {
+        beforeEach(function() {
           sut = new Behavior();
           binding = new Binding(undefined, undefined, undefined, initMode, undefined, container as any);
           sut.bind(undefined, undefined, binding);
         });
 
-        it(`bind()   should apply  bindingMode ${mode}`, () => {
+        it(`bind()   should apply  bindingMode ${mode}`, function() {
           expect(binding.mode).to.equal(mode);
         });
 
-        it(`unbind() should revert bindingMode ${initMode}`, () => {
+        it(`unbind() should revert bindingMode ${initMode}`, function() {
           sut.unbind(undefined, undefined, binding);
           expect(binding.mode).to.equal(initMode);
         });

--- a/packages/runtime/test/resources/binding-behaviors/throttle-binding-behavior.spec.ts
+++ b/packages/runtime/test/resources/binding-behaviors/throttle-binding-behavior.spec.ts
@@ -9,13 +9,13 @@ import {
   ThrottleBindingBehavior
 } from '../../../src/index';
 
-describe('ThrottleBindingBehavior', () => {
+describe('ThrottleBindingBehavior', function() {
   const container: IContainer = DI.createContainer();
   let sut: ThrottleBindingBehavior;
   let binding: Binding;
   let originalFn: (value: unknown, flags: LifecycleFlags) => void;
 
-  beforeEach(() => {
+  beforeEach(function() {
     sut = new ThrottleBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container);
     originalFn = binding.updateTarget;
@@ -23,7 +23,7 @@ describe('ThrottleBindingBehavior', () => {
   });
 
   // TODO: test properly (whether throttling works etc)
-  it('bind()   should apply the correct behavior', () => {
+  it('bind()   should apply the correct behavior', function() {
     expect(binding['throttledMethod'] === originalFn).to.equal(true);
     expect(binding['throttledMethod'].originalName).to.equal('updateTarget');
     expect(binding.updateTarget === originalFn).to.equal(false);
@@ -32,7 +32,7 @@ describe('ThrottleBindingBehavior', () => {
     expect(typeof binding['throttleState']).to.equal('object');
   });
 
-  it('unbind() should revert the original behavior', () => {
+  it('unbind() should revert the original behavior', function() {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['throttledMethod']).to.equal(null);
     expect(binding.updateTarget === originalFn).to.equal(true);

--- a/packages/runtime/test/resources/binding-behaviors/throttle-binding-behavior.spec.ts
+++ b/packages/runtime/test/resources/binding-behaviors/throttle-binding-behavior.spec.ts
@@ -9,13 +9,13 @@ import {
   ThrottleBindingBehavior
 } from '../../../src/index';
 
-describe('ThrottleBindingBehavior', function() {
+describe('ThrottleBindingBehavior', function () {
   const container: IContainer = DI.createContainer();
   let sut: ThrottleBindingBehavior;
   let binding: Binding;
   let originalFn: (value: unknown, flags: LifecycleFlags) => void;
 
-  beforeEach(function() {
+  beforeEach(function () {
     sut = new ThrottleBindingBehavior();
     binding = new Binding(undefined, undefined, undefined, undefined, undefined, container);
     originalFn = binding.updateTarget;
@@ -23,7 +23,7 @@ describe('ThrottleBindingBehavior', function() {
   });
 
   // TODO: test properly (whether throttling works etc)
-  it('bind()   should apply the correct behavior', function() {
+  it('bind()   should apply the correct behavior', function () {
     expect(binding['throttledMethod'] === originalFn).to.equal(true);
     expect(binding['throttledMethod'].originalName).to.equal('updateTarget');
     expect(binding.updateTarget === originalFn).to.equal(false);
@@ -32,7 +32,7 @@ describe('ThrottleBindingBehavior', function() {
     expect(typeof binding['throttleState']).to.equal('object');
   });
 
-  it('unbind() should revert the original behavior', function() {
+  it('unbind() should revert the original behavior', function () {
     sut.unbind(undefined, undefined, binding as any);
     expect(binding['throttledMethod']).to.equal(null);
     expect(binding.updateTarget === originalFn).to.equal(true);

--- a/packages/runtime/test/resources/custom-attribute.description.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.description.spec.ts
@@ -8,10 +8,10 @@ import { createCustomAttribute } from './custom-attribute._builder';
 // We're intentionally using the less declarative to.equal() syntax for true/false/null equality comparison
 // because this allows us to add a message to the assertion describing which property was checked, making it
 // easier to pin down the source of the error when a test fail.
-describe('@customAttribute', function() {
+describe('@customAttribute', function () {
   const descriptionKeys = ['name', 'aliases', 'defaultBindingMode', 'hasDynamicOptions', 'isTemplateController', 'bindables', 'strategy'];
 
-  it('creates the default attribute description', function() {
+  it('creates the default attribute description', function () {
     const { Type } = createCustomAttribute('foo');
     expect(Type.description).to.be.a('object', 'description');
     expect(Type.description.name).to.equal('foo', 'name');
@@ -68,7 +68,7 @@ describe('@customAttribute', function() {
   ];
 
   eachCartesianJoin([aliasesSpecs], (aliasesSpec) => {
-    it(`${aliasesSpec.expectation} if ${aliasesSpec.description}`, function() {
+    it(`${aliasesSpec.expectation} if ${aliasesSpec.description}`, function () {
       // Arrange
       const def = {
         name: 'foo',
@@ -152,7 +152,7 @@ describe('@customAttribute', function() {
   ];
 
   eachCartesianJoin([bindingModeSpecs], (bindingModeSpec) => {
-    it(`${bindingModeSpec.expectation} if ${bindingModeSpec.description}`, function() {
+    it(`${bindingModeSpec.expectation} if ${bindingModeSpec.description}`, function () {
       // Arrange
       const def = {
         name: 'foo',
@@ -229,7 +229,7 @@ describe('@customAttribute', function() {
   ];
 
   eachCartesianJoin([bindablesSpecs], (bindablesSpec) => {
-    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function() {
+    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function () {
       // Arrange
       const def = {
         name: 'foo',

--- a/packages/runtime/test/resources/custom-attribute.description.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.description.spec.ts
@@ -8,10 +8,10 @@ import { createCustomAttribute } from './custom-attribute._builder';
 // We're intentionally using the less declarative to.equal() syntax for true/false/null equality comparison
 // because this allows us to add a message to the assertion describing which property was checked, making it
 // easier to pin down the source of the error when a test fail.
-describe('@customAttribute', () => {
+describe('@customAttribute', function() {
   const descriptionKeys = ['name', 'aliases', 'defaultBindingMode', 'hasDynamicOptions', 'isTemplateController', 'bindables', 'strategy'];
 
-  it('creates the default attribute description', () => {
+  it('creates the default attribute description', function() {
     const { Type } = createCustomAttribute('foo');
     expect(Type.description).to.be.a('object', 'description');
     expect(Type.description.name).to.equal('foo', 'name');
@@ -68,7 +68,7 @@ describe('@customAttribute', () => {
   ];
 
   eachCartesianJoin([aliasesSpecs], (aliasesSpec) => {
-    it(`${aliasesSpec.expectation} if ${aliasesSpec.description}`, () => {
+    it(`${aliasesSpec.expectation} if ${aliasesSpec.description}`, function() {
       // Arrange
       const def = {
         name: 'foo',
@@ -152,7 +152,7 @@ describe('@customAttribute', () => {
   ];
 
   eachCartesianJoin([bindingModeSpecs], (bindingModeSpec) => {
-    it(`${bindingModeSpec.expectation} if ${bindingModeSpec.description}`, () => {
+    it(`${bindingModeSpec.expectation} if ${bindingModeSpec.description}`, function() {
       // Arrange
       const def = {
         name: 'foo',
@@ -229,7 +229,7 @@ describe('@customAttribute', () => {
   ];
 
   eachCartesianJoin([bindablesSpecs], (bindablesSpec) => {
-    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, () => {
+    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function() {
       // Arrange
       const def = {
         name: 'foo',

--- a/packages/runtime/test/resources/custom-attribute.register.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.register.spec.ts
@@ -2,9 +2,9 @@ import { DI } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { createCustomAttribute } from './custom-attribute._builder';
 
-describe('@customAttribute', () => {
-  describe('register', () => {
-    it('registers the custom attribute as transient', () => {
+describe('@customAttribute', function() {
+  describe('register', function() {
+    it('registers the custom attribute as transient', function() {
       const { Type } = createCustomAttribute();
       const container = DI.createContainer();
 
@@ -15,7 +15,7 @@ describe('@customAttribute', () => {
       expect(resolved1).not.to.equal(resolved2);
     });
 
-    it('registers the custom attribute with aliases that are transient', () => {
+    it('registers the custom attribute with aliases that are transient', function() {
       const { Type } = createCustomAttribute({
         name: 'foo',
         aliases: ['bar', 'baz']

--- a/packages/runtime/test/resources/custom-attribute.register.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.register.spec.ts
@@ -2,9 +2,9 @@ import { DI } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { createCustomAttribute } from './custom-attribute._builder';
 
-describe('@customAttribute', function() {
-  describe('register', function() {
-    it('registers the custom attribute as transient', function() {
+describe('@customAttribute', function () {
+  describe('register', function () {
+    it('registers the custom attribute as transient', function () {
       const { Type } = createCustomAttribute();
       const container = DI.createContainer();
 
@@ -15,7 +15,7 @@ describe('@customAttribute', function() {
       expect(resolved1).not.to.equal(resolved2);
     });
 
-    it('registers the custom attribute with aliases that are transient', function() {
+    it('registers the custom attribute with aliases that are transient', function () {
       const { Type } = createCustomAttribute({
         name: 'foo',
         aliases: ['bar', 'baz']

--- a/packages/runtime/test/resources/custom-attribute.resource.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.resource.spec.ts
@@ -1,21 +1,21 @@
 import { expect } from 'chai';
 import { customAttribute, CustomAttributeResource } from '../../src/index';
 
-describe('CustomAttributeResource', function() {
-  it('name is custom-attribute', function() {
+describe('CustomAttributeResource', function () {
+  it('name is custom-attribute', function () {
     expect(CustomAttributeResource.name).to.equal('custom-attribute');
   });
 
-  it('keyFrom() returns the full key', function() {
+  it('keyFrom() returns the full key', function () {
     expect(CustomAttributeResource.keyFrom('foo')).to.equal('custom-attribute:foo');
   });
 
-  it('isType returns true if it is a custom-attribute', function() {
+  it('isType returns true if it is a custom-attribute', function () {
     const Type = customAttribute('foo')(class {});
     expect(CustomAttributeResource.isType(Type)).to.equal(true, 'isTy[e');
   });
 
-  it('isType returns false if it is NOT a custom-attribute', function() {
+  it('isType returns false if it is NOT a custom-attribute', function () {
     expect(CustomAttributeResource.isType(class {} as any)).to.equal(false, 'isType');
   });
 });

--- a/packages/runtime/test/resources/custom-attribute.resource.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.resource.spec.ts
@@ -1,21 +1,21 @@
 import { expect } from 'chai';
 import { customAttribute, CustomAttributeResource } from '../../src/index';
 
-describe('CustomAttributeResource', () => {
-  it('name is custom-attribute', () => {
+describe('CustomAttributeResource', function() {
+  it('name is custom-attribute', function() {
     expect(CustomAttributeResource.name).to.equal('custom-attribute');
   });
 
-  it('keyFrom() returns the full key', () => {
+  it('keyFrom() returns the full key', function() {
     expect(CustomAttributeResource.keyFrom('foo')).to.equal('custom-attribute:foo');
   });
 
-  it('isType returns true if it is a custom-attribute', () => {
+  it('isType returns true if it is a custom-attribute', function() {
     const Type = customAttribute('foo')(class {});
     expect(CustomAttributeResource.isType(Type)).to.equal(true, 'isTy[e');
   });
 
-  it('isType returns false if it is NOT a custom-attribute', () => {
+  it('isType returns false if it is NOT a custom-attribute', function() {
     expect(CustomAttributeResource.isType(class {} as any)).to.equal(false, 'isType');
   });
 });

--- a/packages/runtime/test/resources/custom-attribute.templatecontroller.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.templatecontroller.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { createTemplateController } from './custom-attribute._builder';
 
-describe('@templateController', function() {
-  it('marks the resource as a template controller if it only has a name', function() {
+describe('@templateController', function () {
+  it('marks the resource as a template controller if it only has a name', function () {
     const { Type } = createTemplateController('foo');
     expect(Type.description.isTemplateController).to.equal(true, 'isTemplateController');
   });
 
-  it('marks the resource as a template controller if it has a def', function() {
+  it('marks the resource as a template controller if it has a def', function () {
     const { Type } = createTemplateController({ name: 'foo' });
     expect(Type.description.isTemplateController).to.equal(true, 'isTemplateController');
   });

--- a/packages/runtime/test/resources/custom-attribute.templatecontroller.spec.ts
+++ b/packages/runtime/test/resources/custom-attribute.templatecontroller.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import { createTemplateController } from './custom-attribute._builder';
 
-describe('@templateController', () => {
-  it('marks the resource as a template controller if it only has a name', () => {
+describe('@templateController', function() {
+  it('marks the resource as a template controller if it only has a name', function() {
     const { Type } = createTemplateController('foo');
     expect(Type.description.isTemplateController).to.equal(true, 'isTemplateController');
   });
 
-  it('marks the resource as a template controller if it has a def', () => {
+  it('marks the resource as a template controller if it has a def', function() {
     const { Type } = createTemplateController({ name: 'foo' });
     expect(Type.description.isTemplateController).to.equal(true, 'isTemplateController');
   });

--- a/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
@@ -33,7 +33,7 @@ import {
   AuNodeSequence
 } from '../../au-dom';
 
-describe(`If/Else`, () => {
+describe(`If/Else`, function() {
   function runBindLifecycle(lifecycle: ILifecycle, sut: If<AuNode>, flags: LifecycleFlags, scope: IScope): void {
     lifecycle.beginBind();
     sut.$bind(flags, scope);
@@ -167,7 +167,7 @@ describe(`If/Else`, () => {
   eachCartesianJoin(
     [strategySpecs, duplicateOperationSpecs, bindSpecs, mutationSpecs, flagsSpecs],
     (strategySpec, duplicateOperationSpec, bindSpec, mutationSpec, flagsSpec) => {
-    it(`verify if/else behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, mutationSpec ${mutationSpec.t}, flagsSpec ${flagsSpec.t}, `, async () => {
+    it(`verify if/else behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, mutationSpec ${mutationSpec.t}, flagsSpec ${flagsSpec.t}, `, async function() {
       const { strategy } = strategySpec;
       const { bindTwice, attachTwice, detachTwice, unbindTwice, newScopeForDuplicateBind, newValueForDuplicateBind } = duplicateOperationSpec;
       const { ifPropName, elsePropName, ifText, elseText, value1, value2 } = bindSpec;

--- a/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.integration.spec.ts
@@ -33,7 +33,7 @@ import {
   AuNodeSequence
 } from '../../au-dom';
 
-describe(`If/Else`, function() {
+describe(`If/Else`, function () {
   function runBindLifecycle(lifecycle: ILifecycle, sut: If<AuNode>, flags: LifecycleFlags, scope: IScope): void {
     lifecycle.beginBind();
     sut.$bind(flags, scope);
@@ -167,7 +167,7 @@ describe(`If/Else`, function() {
   eachCartesianJoin(
     [strategySpecs, duplicateOperationSpecs, bindSpecs, mutationSpecs, flagsSpecs],
     (strategySpec, duplicateOperationSpec, bindSpec, mutationSpec, flagsSpec) => {
-    it(`verify if/else behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, mutationSpec ${mutationSpec.t}, flagsSpec ${flagsSpec.t}, `, async function() {
+    it(`verify if/else behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, mutationSpec ${mutationSpec.t}, flagsSpec ${flagsSpec.t}, `, async function () {
       const { strategy } = strategySpec;
       const { bindTwice, attachTwice, detachTwice, unbindTwice, newScopeForDuplicateBind, newValueForDuplicateBind } = duplicateOperationSpec;
       const { ifPropName, elsePropName, ifText, elseText, value1, value2 } = bindSpec;

--- a/packages/runtime/test/resources/custom-attributes/if.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.spec.ts
@@ -12,8 +12,8 @@ import { AuDOMConfiguration, AuNode } from '../../au-dom';
 import { createScopeForTest } from '../../util';
 import { hydrateCustomAttribute } from './template-controller-tests';
 
-describe('The "if" template controller', function() {
-  it('renders its view when the value is true', function() {
+describe('The "if" template controller', function () {
+  it('renders its view when the value is true', function () {
     const { attribute: ifAttr, location, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -34,7 +34,7 @@ describe('The "if" template controller', function() {
     expect(location.previousSibling).to.equal(ifView.$nodes.lastChild);
   });
 
-  it('queues the view removal via the lifecycle when the value is false', function() {
+  it('queues the view removal via the lifecycle when the value is false', function () {
     const { attribute: ifAttr, location, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -66,7 +66,7 @@ describe('The "if" template controller', function() {
     expect(ifView).to.not.have.$state.isBound();
   });
 
-  it('queues the rendering of an else view when one is linked and its value is false', function() {
+  it('queues the rendering of an else view when one is linked and its value is false', function () {
     const container = AuDOMConfiguration.createContainer();
     const { attribute: ifAttr, location } = hydrateCustomAttribute(If, { container });
     const { attribute: elseAttr, lifecycle } = hydrateCustomAttribute(Else, { container });
@@ -99,7 +99,7 @@ describe('The "if" template controller', function() {
     expect(location.previousSibling).to.equal(elseView.$nodes.lastChild);
   });
 
-  it('detaches its child view when it is detached', function() {
+  it('detaches its child view when it is detached', function () {
     const { attribute: ifAttr, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -114,7 +114,7 @@ describe('The "if" template controller', function() {
     expect(ifAttr).to.not.have.$state.isAttached();
   });
 
-  it('unbinds its child view when it is unbound', function() {
+  it('unbinds its child view when it is unbound', function () {
     const { attribute: ifAttr } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;

--- a/packages/runtime/test/resources/custom-attributes/if.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/if.spec.ts
@@ -12,8 +12,8 @@ import { AuDOMConfiguration, AuNode } from '../../au-dom';
 import { createScopeForTest } from '../../util';
 import { hydrateCustomAttribute } from './template-controller-tests';
 
-describe('The "if" template controller', () => {
-  it('renders its view when the value is true', () => {
+describe('The "if" template controller', function() {
+  it('renders its view when the value is true', function() {
     const { attribute: ifAttr, location, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -34,7 +34,7 @@ describe('The "if" template controller', () => {
     expect(location.previousSibling).to.equal(ifView.$nodes.lastChild);
   });
 
-  it('queues the view removal via the lifecycle when the value is false', () => {
+  it('queues the view removal via the lifecycle when the value is false', function() {
     const { attribute: ifAttr, location, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -66,7 +66,7 @@ describe('The "if" template controller', () => {
     expect(ifView).to.not.have.$state.isBound();
   });
 
-  it('queues the rendering of an else view when one is linked and its value is false', () => {
+  it('queues the rendering of an else view when one is linked and its value is false', function() {
     const container = AuDOMConfiguration.createContainer();
     const { attribute: ifAttr, location } = hydrateCustomAttribute(If, { container });
     const { attribute: elseAttr, lifecycle } = hydrateCustomAttribute(Else, { container });
@@ -99,7 +99,7 @@ describe('The "if" template controller', () => {
     expect(location.previousSibling).to.equal(elseView.$nodes.lastChild);
   });
 
-  it('detaches its child view when it is detached', () => {
+  it('detaches its child view when it is detached', function() {
     const { attribute: ifAttr, lifecycle } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;
@@ -114,7 +114,7 @@ describe('The "if" template controller', () => {
     expect(ifAttr).to.not.have.$state.isAttached();
   });
 
-  it('unbinds its child view when it is unbound', () => {
+  it('unbinds its child view when it is unbound', function() {
     const { attribute: ifAttr } = hydrateCustomAttribute(If);
 
     ifAttr.value = true;

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
@@ -83,7 +83,7 @@
 //   return { sut, host, lifecycle };
 // }
 
-// describe(`Repeat`, () => {
+// describe(`Repeat`, function() {
 
 //   eachCartesianJoinFactory([
 //     // initial input items
@@ -227,7 +227,7 @@
 //     [exec1, exec1Text],
 //     [exec2, exec2Text],
 //     [exec3, exec3Text]) => {
-//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> ${exec3Text}`, () => {
+//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> ${exec3Text}`, function() {
 //       const { sut, host, lifecycle } = setup<IObservedArray>();
 //       sut.items = items1;
 
@@ -238,7 +238,7 @@
 //   });
 // });
 
-// describe('ArrayRepeater - render html', () => {
+// describe('ArrayRepeater - render html', function() {
 //   let container: IContainer;
 //   let lifecycle: ILifecycle;
 //   let au: Aurelia;
@@ -247,7 +247,7 @@
 //   let aureliaConfig: any;
 //   let component: ICustomElement;
 
-//   beforeEach(() => {
+//   beforeEach(function() {
 //     container = DI.createContainer();
 //     container.register(domRegistration);
 //     lifecycle = container.get(ILifecycle);
@@ -256,7 +256,7 @@
 //     dom.appendChild(document.body, host);
 //   });
 
-//   it('triple nested repeater should render correctly', () => {
+//   it('triple nested repeater should render correctly', function() {
 //     const initItems = [
 //       {
 //         id: 1,

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration.spec.ts
@@ -83,7 +83,7 @@
 //   return { sut, host, lifecycle };
 // }
 
-// describe(`Repeat`, function() {
+// describe(`Repeat`, function () {
 
 //   eachCartesianJoinFactory([
 //     // initial input items
@@ -227,7 +227,7 @@
 //     [exec1, exec1Text],
 //     [exec2, exec2Text],
 //     [exec3, exec3Text]) => {
-//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> ${exec3Text}`, function() {
+//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> ${exec3Text}`, function () {
 //       const { sut, host, lifecycle } = setup<IObservedArray>();
 //       sut.items = items1;
 
@@ -238,7 +238,7 @@
 //   });
 // });
 
-// describe('ArrayRepeater - render html', function() {
+// describe('ArrayRepeater - render html', function () {
 //   let container: IContainer;
 //   let lifecycle: ILifecycle;
 //   let au: Aurelia;
@@ -247,7 +247,7 @@
 //   let aureliaConfig: any;
 //   let component: ICustomElement;
 
-//   beforeEach(function() {
+//   beforeEach(function () {
 //     container = DI.createContainer();
 //     container.register(domRegistration);
 //     lifecycle = container.get(ILifecycle);
@@ -256,7 +256,7 @@
 //     dom.appendChild(document.body, host);
 //   });
 
-//   it('triple nested repeater should render correctly', function() {
+//   it('triple nested repeater should render correctly', function () {
 //     const initItems = [
 //       {
 //         id: 1,

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
@@ -64,7 +64,7 @@
 //   return { sut, host, lifecycle };
 // }
 
-// describe(`Repeat`, () => {
+// describe(`Repeat`, function() {
 
 //   eachCartesianJoinFactory([
 //     // initial input items
@@ -492,7 +492,7 @@
 //     [exec3, exec3Text],
 //     [exec4, exec4Text],
 //     [exec5, exec5Text]) => {
-//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> assign=${text2} -> ${exec3Text} -> ${exec4Text} -> ${exec5Text}`, () => {
+//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> assign=${text2} -> ${exec3Text} -> ${exec4Text} -> ${exec5Text}`, function() {
 //       const { sut, host, lifecycle } = setup<IObservedArray>();
 //       sut.items = items1;
 

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration2.spec.ts
@@ -64,7 +64,7 @@
 //   return { sut, host, lifecycle };
 // }
 
-// describe(`Repeat`, function() {
+// describe(`Repeat`, function () {
 
 //   eachCartesianJoinFactory([
 //     // initial input items
@@ -492,7 +492,7 @@
 //     [exec3, exec3Text],
 //     [exec4, exec4Text],
 //     [exec5, exec5Text]) => {
-//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> assign=${text2} -> ${exec3Text} -> ${exec4Text} -> ${exec5Text}`, function() {
+//     it(`assign=${text1} -> ${exec1Text} -> ${exec2Text} -> assign=${text2} -> ${exec3Text} -> ${exec4Text} -> ${exec5Text}`, function () {
 //       const { sut, host, lifecycle } = setup<IObservedArray>();
 //       sut.items = items1;
 

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
@@ -33,7 +33,7 @@ import {
   AuNodeSequence
 } from '../../au-dom';
 
-describe(`Repeat`, function() {
+describe(`Repeat`, function () {
   function runBindLifecycle(lifecycle: ILifecycle, sut: Repeat<IObservedArray, AuNode>, flags: LifecycleFlags, scope: IScope): void {
     lifecycle.beginBind();
     sut.$bind(flags, scope);
@@ -574,7 +574,7 @@ describe(`Repeat`, function() {
   eachCartesianJoin(
     [strategySpecs, duplicateOperationSpecs, bindSpecs, flagsSpecs],
     (strategySpec, duplicateOperationSpec, bindSpec, flagsSpec) => {
-    it(`verify repeat behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, flagsSpec ${flagsSpec.t}, `, async function() {
+    it(`verify repeat behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, flagsSpec ${flagsSpec.t}, `, async function () {
       const { strategy } = strategySpec;
       const { bindTwice, attachTwice, detachTwice, unbindTwice, newScopeForDuplicateBind } = duplicateOperationSpec;
       const { items: $items, flush, mutations } = bindSpec;

--- a/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.integration3.spec.ts
@@ -33,7 +33,7 @@ import {
   AuNodeSequence
 } from '../../au-dom';
 
-describe(`Repeat`, () => {
+describe(`Repeat`, function() {
   function runBindLifecycle(lifecycle: ILifecycle, sut: Repeat<IObservedArray, AuNode>, flags: LifecycleFlags, scope: IScope): void {
     lifecycle.beginBind();
     sut.$bind(flags, scope);
@@ -574,7 +574,7 @@ describe(`Repeat`, () => {
   eachCartesianJoin(
     [strategySpecs, duplicateOperationSpecs, bindSpecs, flagsSpecs],
     (strategySpec, duplicateOperationSpec, bindSpec, flagsSpec) => {
-    it(`verify repeat behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, flagsSpec ${flagsSpec.t}, `, async () => {
+    it(`verify repeat behavior - strategySpec ${strategySpec.t}, duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, flagsSpec ${flagsSpec.t}, `, async function() {
       const { strategy } = strategySpec;
       const { bindTwice, attachTwice, detachTwice, unbindTwice, newScopeForDuplicateBind } = duplicateOperationSpec;
       const { items: $items, flush, mutations } = bindSpec;

--- a/packages/runtime/test/resources/custom-attributes/repeat.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/repeat.spec.ts
@@ -10,7 +10,7 @@
 //   return items;
 // }
 
-// describe.only('longestIncreasingSubsequence', function() {
+// describe.only('longestIncreasingSubsequence', function () {
 
 //   interface Spec {
 //     indexMap: IndexMap;
@@ -500,7 +500,7 @@
 //   ];
 
 //   for (const spec of specs) {
-//     it.only(`${JSON.stringify(spec)}`, function() {
+//     it.only(`${JSON.stringify(spec)}`, function () {
 //       const { indexMap, expected } = spec;
 //       const actual = longestIncreasingSubsequence(indexMap);
 //       assertArrayEqual([...actual], expected);

--- a/packages/runtime/test/resources/custom-attributes/replaceable.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/replaceable.spec.ts
@@ -1,7 +1,7 @@
 import { Replaceable } from '../../../src/index';
 import { ensureSingleChildTemplateControllerBehaviors } from './template-controller-tests';
 
-describe('The "replaceable" template controller', () => {
+describe('The "replaceable" template controller', function() {
   ensureSingleChildTemplateControllerBehaviors(
     Replaceable,
     replaceable => replaceable['currentView']

--- a/packages/runtime/test/resources/custom-attributes/replaceable.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/replaceable.spec.ts
@@ -1,7 +1,7 @@
 import { Replaceable } from '../../../src/index';
 import { ensureSingleChildTemplateControllerBehaviors } from './template-controller-tests';
 
-describe('The "replaceable" template controller', function() {
+describe('The "replaceable" template controller', function () {
   ensureSingleChildTemplateControllerBehaviors(
     Replaceable,
     replaceable => replaceable['currentView']

--- a/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
+++ b/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
@@ -24,14 +24,14 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
   Type: T,
   getChildView: (attribute: ICustomAttribute<AuNode>) => IView<AuNode>
 ) {
-  it('creates a child instance from its template', () => {
+  it('creates a child instance from its template', function() {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 
     expect(child).to.be.instanceof(FakeView);
   });
 
-  it('enforces the attach lifecycle of its child instance', () => {
+  it('enforces the attach lifecycle of its child instance', function() {
     const lifecycle = new Lifecycle();
     const { attribute } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
@@ -44,7 +44,7 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(attachCalled).to.equal(true);
   });
 
-  it('adds a child instance at the render location when attaching', () => {
+  it('adds a child instance at the render location when attaching', function() {
     const lifecycle = new Lifecycle();
     const { attribute, location } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
@@ -54,7 +54,7 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(location.previousSibling).to.equal(child.$nodes['lastChild']);
   });
 
-  it('enforces the bind lifecycle of its child instance', () => {
+  it('enforces the bind lifecycle of its child instance', function() {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 
@@ -66,7 +66,7 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(bindCalled).to.equal(true);
   });
 
-  it('enforces the detach lifecycle of its child instance', () => {
+  it('enforces the detach lifecycle of its child instance', function() {
     const lifecycle = new Lifecycle();
     const { attribute } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
@@ -80,7 +80,7 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(detachCalled).to.equal(true);
   });
 
-  it('enforces the unbind lifecycle of its child instance', () => {
+  it('enforces the unbind lifecycle of its child instance', function() {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 

--- a/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
+++ b/packages/runtime/test/resources/custom-attributes/template-controller-tests.ts
@@ -24,27 +24,27 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
   Type: T,
   getChildView: (attribute: ICustomAttribute<AuNode>) => IView<AuNode>
 ) {
-  it('creates a child instance from its template', function() {
+  it('creates a child instance from its template', function () {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 
     expect(child).to.be.instanceof(FakeView);
   });
 
-  it('enforces the attach lifecycle of its child instance', function() {
+  it('enforces the attach lifecycle of its child instance', function () {
     const lifecycle = new Lifecycle();
     const { attribute } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
 
     let attachCalled = false;
-    child.$attach = function() { attachCalled = true; };
+    child.$attach = function () { attachCalled = true; };
 
     runAttachLifecycle(lifecycle, attribute);
 
     expect(attachCalled).to.equal(true);
   });
 
-  it('adds a child instance at the render location when attaching', function() {
+  it('adds a child instance at the render location when attaching', function () {
     const lifecycle = new Lifecycle();
     const { attribute, location } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
@@ -54,25 +54,25 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(location.previousSibling).to.equal(child.$nodes['lastChild']);
   });
 
-  it('enforces the bind lifecycle of its child instance', function() {
+  it('enforces the bind lifecycle of its child instance', function () {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 
     let bindCalled = false;
-    child.$bind = function() { bindCalled = true; };
+    child.$bind = function () { bindCalled = true; };
 
     attribute.$bind(LF.fromBind, createScopeForTest());
 
     expect(bindCalled).to.equal(true);
   });
 
-  it('enforces the detach lifecycle of its child instance', function() {
+  it('enforces the detach lifecycle of its child instance', function () {
     const lifecycle = new Lifecycle();
     const { attribute } = hydrateCustomAttribute(Type, { lifecycle });
     const child = getChildView(attribute);
 
     let detachCalled = false;
-    child.$detach = function() { detachCalled = true; };
+    child.$detach = function () { detachCalled = true; };
 
     runAttachLifecycle(lifecycle, attribute);
     runDetachLifecycle(lifecycle, attribute);
@@ -80,12 +80,12 @@ export function ensureSingleChildTemplateControllerBehaviors<T extends ICustomAt
     expect(detachCalled).to.equal(true);
   });
 
-  it('enforces the unbind lifecycle of its child instance', function() {
+  it('enforces the unbind lifecycle of its child instance', function () {
     const { attribute } = hydrateCustomAttribute(Type);
     const child = getChildView(attribute);
 
     let unbindCalled = false;
-    child.$unbind = function() { unbindCalled = true; };
+    child.$unbind = function () { unbindCalled = true; };
 
     attribute.$bind(LF.fromBind, createScopeForTest());
     attribute.$unbind(LF.fromUnbind);

--- a/packages/runtime/test/resources/custom-attributes/with.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/with.spec.ts
@@ -3,10 +3,10 @@ import { LifecycleFlags, With } from '../../../src/index';
 import { createScopeForTest } from '../../util';
 import { ensureSingleChildTemplateControllerBehaviors, hydrateCustomAttribute } from './template-controller-tests';
 
-describe('The "with" template controller', () => {
+describe('The "with" template controller', function() {
   ensureSingleChildTemplateControllerBehaviors(With, w => w['currentView']);
 
-  it('updates its child\'s binding context when its value changes', () => {
+  it('updates its child\'s binding context when its value changes', function() {
     const { attribute } = hydrateCustomAttribute(With);
     const child = attribute['currentView'];
 

--- a/packages/runtime/test/resources/custom-attributes/with.spec.ts
+++ b/packages/runtime/test/resources/custom-attributes/with.spec.ts
@@ -3,10 +3,10 @@ import { LifecycleFlags, With } from '../../../src/index';
 import { createScopeForTest } from '../../util';
 import { ensureSingleChildTemplateControllerBehaviors, hydrateCustomAttribute } from './template-controller-tests';
 
-describe('The "with" template controller', function() {
+describe('The "with" template controller', function () {
   ensureSingleChildTemplateControllerBehaviors(With, w => w['currentView']);
 
-  it('updates its child\'s binding context when its value changes', function() {
+  it('updates its child\'s binding context when its value changes', function () {
     const { attribute } = hydrateCustomAttribute(With);
     const child = attribute['currentView'];
 

--- a/packages/runtime/test/resources/custom-element.containerless.spec.ts
+++ b/packages/runtime/test/resources/custom-element.containerless.spec.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 import { containerless } from '../../src/index';
 
-describe('@containerless', function() {
-  it(`non-invocation`, function() {
+describe('@containerless', function () {
+  it(`non-invocation`, function () {
     @containerless
     class Foo {}
 
     expect(Foo['containerless']).to.equal(true);
   });
 
-  it(`invocation`, function() {
+  it(`invocation`, function () {
     @containerless()
     class Foo {}
 

--- a/packages/runtime/test/resources/custom-element.containerless.spec.ts
+++ b/packages/runtime/test/resources/custom-element.containerless.spec.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 import { containerless } from '../../src/index';
 
-describe('@containerless', () => {
-  it(`non-invocation`, () => {
+describe('@containerless', function() {
+  it(`non-invocation`, function() {
     @containerless
     class Foo {}
 
     expect(Foo['containerless']).to.equal(true);
   });
 
-  it(`invocation`, () => {
+  it(`invocation`, function() {
     @containerless()
     class Foo {}
 

--- a/packages/runtime/test/resources/custom-element.dependencies.spec.ts
+++ b/packages/runtime/test/resources/custom-element.dependencies.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { CustomElementResource } from '../../src/index';
 import { AuDOMTest } from '../au-dom';
 
-describe('CustomElementResource', function() {
-  describe(`define`, function() {
-    it(`registers local dependencies`, function() {
+describe('CustomElementResource', function () {
+  describe(`define`, function () {
+    it(`registers local dependencies`, function () {
       const { au, host } = AuDOMTest.setup();
 
       const fooDef = AuDOMTest.createTextDefinition('msg', 'foo');

--- a/packages/runtime/test/resources/custom-element.dependencies.spec.ts
+++ b/packages/runtime/test/resources/custom-element.dependencies.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import { CustomElementResource } from '../../src/index';
 import { AuDOMTest } from '../au-dom';
 
-describe('CustomElementResource', () => {
-  describe(`define`, () => {
-    it(`registers local dependencies`, () => {
+describe('CustomElementResource', function() {
+  describe(`define`, function() {
+    it(`registers local dependencies`, function() {
       const { au, host } = AuDOMTest.setup();
 
       const fooDef = AuDOMTest.createTextDefinition('msg', 'foo');

--- a/packages/runtime/test/resources/custom-element.description.spec.ts
+++ b/packages/runtime/test/resources/custom-element.description.spec.ts
@@ -4,15 +4,15 @@ import { BindingStrategy, customElement } from '../../src/index';
 import { eachCartesianJoin } from '../util';
 import { createCustomElement } from './custom-element._builder';
 
-describe('@customElement', () => {
+describe('@customElement', function() {
 
-  it('throws if input is undefined', () => {
+  it('throws if input is undefined', function() {
     expect(() => createCustomElement(undefined)).to.throw('Code 70');
   });
-  it('throws if input is null', () => {
+  it('throws if input is null', function() {
     expect(() => createCustomElement(null)).to.throw('Code 70');
   });
-  it('throws if input is empty', () => {
+  it('throws if input is empty', function() {
     expect(() => createCustomElement('')).to.throw('Code 70');
   });
 
@@ -31,7 +31,7 @@ describe('@customElement', () => {
     'strategy'
   ];
 
-  it('creates the default template description', () => {
+  it('creates the default template description', function() {
     const { Type } = createCustomElement({} as any);
     expect(Type.description).to.be.a('object', 'description');
     expect(Type.description.name).to.equal('unnamed', 'name');
@@ -77,7 +77,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([nameSpecs], (nameSpec) => {
-    it(`${nameSpec.expectation} if ${nameSpec.description}`, () => {
+    it(`${nameSpec.expectation} if ${nameSpec.description}`, function() {
       const { Type } = createCustomElement({ name: nameSpec.getName() });
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal(nameSpec.getExpectedname(), 'name');
@@ -124,7 +124,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([templateSpecs], (templateSpec) => {
-    it(`${templateSpec.expectation} if ${templateSpec.description}`, () => {
+    it(`${templateSpec.expectation} if ${templateSpec.description}`, function() {
       const { Type } = createCustomElement({ template: templateSpec.getTemplate() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -183,7 +183,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([cacheSpecs], (cacheSpec) => {
-    it(`${cacheSpec.expectation} if ${cacheSpec.description}`, () => {
+    it(`${cacheSpec.expectation} if ${cacheSpec.description}`, function() {
       const { Type } = createCustomElement({ cache: cacheSpec.getCache() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -229,7 +229,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([buildSpecs], (buildSpec) => {
-    it(`${buildSpec.expectation} if ${buildSpec.description}`, () => {
+    it(`${buildSpec.expectation} if ${buildSpec.description}`, function() {
       const { Type } = createCustomElement(buildSpec.getBuild ? { build: buildSpec.getBuild() } : {} as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -301,7 +301,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([bindablesSpecs], (bindablesSpec) => {
-    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, () => {
+    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function() {
       const def = {
         bindables: bindablesSpec.getDefBindables(),
       };
@@ -358,7 +358,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([instructionsSpecs], (instructionsSpec) => {
-    it(`${instructionsSpec.expectation} if ${instructionsSpec.description}`, () => {
+    it(`${instructionsSpec.expectation} if ${instructionsSpec.description}`, function() {
       const { Type } = createCustomElement({ instructions: instructionsSpec.getInstructions() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -414,7 +414,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([dependenciesSpecs], (dependenciesSpec) => {
-    it(`${dependenciesSpec.expectation} if ${dependenciesSpec.description}`, () => {
+    it(`${dependenciesSpec.expectation} if ${dependenciesSpec.description}`, function() {
       const { Type } = createCustomElement({ dependencies: dependenciesSpec.getDependencies() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -470,7 +470,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([surrogatesSpecs], (surrogatesSpec) => {
-    it(`${surrogatesSpec.expectation} if ${surrogatesSpec.description}`, () => {
+    it(`${surrogatesSpec.expectation} if ${surrogatesSpec.description}`, function() {
       const { Type } = createCustomElement({ surrogates: surrogatesSpec.getSurrogates() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -540,7 +540,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([containerlessSpecs], (containerlessSpec) => {
-    it(`${containerlessSpec.expectation} if ${containerlessSpec.description}`, () => {
+    it(`${containerlessSpec.expectation} if ${containerlessSpec.description}`, function() {
       const def = {
         containerless: containerlessSpec.getDefContainerless(),
       };
@@ -604,7 +604,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([shadowOptionsSpecs], (shadowOptionsSpec) => {
-    it(`${shadowOptionsSpec.expectation} if ${shadowOptionsSpec.description}`, () => {
+    it(`${shadowOptionsSpec.expectation} if ${shadowOptionsSpec.description}`, function() {
       const def = {
         shadowOptions: shadowOptionsSpec.getDefShadowOptions(),
       };
@@ -657,7 +657,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([hasSlotsSpecs], (hasSlotsSpec) => {
-    it(`${hasSlotsSpec.expectation} if ${hasSlotsSpec.description}`, () => {
+    it(`${hasSlotsSpec.expectation} if ${hasSlotsSpec.description}`, function() {
       const { Type } = createCustomElement({ hasSlots: hasSlotsSpec.getHasSlots() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -734,7 +734,7 @@ describe('@customElement', () => {
   ];
 
   eachCartesianJoin([strategySpecs], (strategySpec) => {
-    it(`${strategySpec.expectation} if ${strategySpec.description}`, () => {
+    it(`${strategySpec.expectation} if ${strategySpec.description}`, function() {
       const { Type } = createCustomElement({ strategy: strategySpec.getStrategy() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');

--- a/packages/runtime/test/resources/custom-element.description.spec.ts
+++ b/packages/runtime/test/resources/custom-element.description.spec.ts
@@ -4,15 +4,15 @@ import { BindingStrategy, customElement } from '../../src/index';
 import { eachCartesianJoin } from '../util';
 import { createCustomElement } from './custom-element._builder';
 
-describe('@customElement', function() {
+describe('@customElement', function () {
 
-  it('throws if input is undefined', function() {
+  it('throws if input is undefined', function () {
     expect(() => createCustomElement(undefined)).to.throw('Code 70');
   });
-  it('throws if input is null', function() {
+  it('throws if input is null', function () {
     expect(() => createCustomElement(null)).to.throw('Code 70');
   });
-  it('throws if input is empty', function() {
+  it('throws if input is empty', function () {
     expect(() => createCustomElement('')).to.throw('Code 70');
   });
 
@@ -31,7 +31,7 @@ describe('@customElement', function() {
     'strategy'
   ];
 
-  it('creates the default template description', function() {
+  it('creates the default template description', function () {
     const { Type } = createCustomElement({} as any);
     expect(Type.description).to.be.a('object', 'description');
     expect(Type.description.name).to.equal('unnamed', 'name');
@@ -77,7 +77,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([nameSpecs], (nameSpec) => {
-    it(`${nameSpec.expectation} if ${nameSpec.description}`, function() {
+    it(`${nameSpec.expectation} if ${nameSpec.description}`, function () {
       const { Type } = createCustomElement({ name: nameSpec.getName() });
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal(nameSpec.getExpectedname(), 'name');
@@ -124,7 +124,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([templateSpecs], (templateSpec) => {
-    it(`${templateSpec.expectation} if ${templateSpec.description}`, function() {
+    it(`${templateSpec.expectation} if ${templateSpec.description}`, function () {
       const { Type } = createCustomElement({ template: templateSpec.getTemplate() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -183,7 +183,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([cacheSpecs], (cacheSpec) => {
-    it(`${cacheSpec.expectation} if ${cacheSpec.description}`, function() {
+    it(`${cacheSpec.expectation} if ${cacheSpec.description}`, function () {
       const { Type } = createCustomElement({ cache: cacheSpec.getCache() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -229,7 +229,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([buildSpecs], (buildSpec) => {
-    it(`${buildSpec.expectation} if ${buildSpec.description}`, function() {
+    it(`${buildSpec.expectation} if ${buildSpec.description}`, function () {
       const { Type } = createCustomElement(buildSpec.getBuild ? { build: buildSpec.getBuild() } : {} as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -301,7 +301,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([bindablesSpecs], (bindablesSpec) => {
-    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function() {
+    it(`${bindablesSpec.expectation} if ${bindablesSpec.description}`, function () {
       const def = {
         bindables: bindablesSpec.getDefBindables(),
       };
@@ -358,7 +358,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([instructionsSpecs], (instructionsSpec) => {
-    it(`${instructionsSpec.expectation} if ${instructionsSpec.description}`, function() {
+    it(`${instructionsSpec.expectation} if ${instructionsSpec.description}`, function () {
       const { Type } = createCustomElement({ instructions: instructionsSpec.getInstructions() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -414,7 +414,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([dependenciesSpecs], (dependenciesSpec) => {
-    it(`${dependenciesSpec.expectation} if ${dependenciesSpec.description}`, function() {
+    it(`${dependenciesSpec.expectation} if ${dependenciesSpec.description}`, function () {
       const { Type } = createCustomElement({ dependencies: dependenciesSpec.getDependencies() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -470,7 +470,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([surrogatesSpecs], (surrogatesSpec) => {
-    it(`${surrogatesSpec.expectation} if ${surrogatesSpec.description}`, function() {
+    it(`${surrogatesSpec.expectation} if ${surrogatesSpec.description}`, function () {
       const { Type } = createCustomElement({ surrogates: surrogatesSpec.getSurrogates() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -540,7 +540,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([containerlessSpecs], (containerlessSpec) => {
-    it(`${containerlessSpec.expectation} if ${containerlessSpec.description}`, function() {
+    it(`${containerlessSpec.expectation} if ${containerlessSpec.description}`, function () {
       const def = {
         containerless: containerlessSpec.getDefContainerless(),
       };
@@ -604,7 +604,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([shadowOptionsSpecs], (shadowOptionsSpec) => {
-    it(`${shadowOptionsSpec.expectation} if ${shadowOptionsSpec.description}`, function() {
+    it(`${shadowOptionsSpec.expectation} if ${shadowOptionsSpec.description}`, function () {
       const def = {
         shadowOptions: shadowOptionsSpec.getDefShadowOptions(),
       };
@@ -657,7 +657,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([hasSlotsSpecs], (hasSlotsSpec) => {
-    it(`${hasSlotsSpec.expectation} if ${hasSlotsSpec.description}`, function() {
+    it(`${hasSlotsSpec.expectation} if ${hasSlotsSpec.description}`, function () {
       const { Type } = createCustomElement({ hasSlots: hasSlotsSpec.getHasSlots() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');
@@ -734,7 +734,7 @@ describe('@customElement', function() {
   ];
 
   eachCartesianJoin([strategySpecs], (strategySpec) => {
-    it(`${strategySpec.expectation} if ${strategySpec.description}`, function() {
+    it(`${strategySpec.expectation} if ${strategySpec.description}`, function () {
       const { Type } = createCustomElement({ strategy: strategySpec.getStrategy() } as any);
       expect(Type.description).to.be.a('object', 'description');
       expect(Type.description.name).to.equal('unnamed', 'name');

--- a/packages/runtime/test/resources/custom-element.resource.spec.ts
+++ b/packages/runtime/test/resources/custom-element.resource.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { CustomAttributeResource, CustomElementResource } from '../../src/index';
 
-describe('CustomElementResource', () => {
-  describe(`define`, () => {
-    it(`creates a new class when applied to null`, () => {
+describe('CustomElementResource', function() {
+  describe(`define`, function() {
+    it(`creates a new class when applied to null`, function() {
       const type = CustomElementResource.define('foo', null);
       expect(typeof type).to.equal('function');
       expect(typeof type.constructor).to.equal('function');
@@ -11,7 +11,7 @@ describe('CustomElementResource', () => {
       expect(typeof type.prototype).to.equal('object');
     });
 
-    it(`creates a new class when applied to undefined`, () => { // how though?? it explicitly checks for null??
+    it(`creates a new class when applied to undefined`, function() { // how though?? it explicitly checks for null??
       const type = (CustomElementResource as any).define('foo');
       expect(typeof type).to.equal('function');
       expect(typeof type.constructor).to.equal('function');
@@ -19,36 +19,36 @@ describe('CustomElementResource', () => {
       expect(typeof type.prototype).to.equal('object');
     });
 
-    it(`names the resource 'unnamed' if no name is provided`, () => {
+    it(`names the resource 'unnamed' if no name is provided`, function() {
       const type = CustomElementResource.define({} as any, class Foo {});
       expect(type.description.name).to.equal('unnamed');
     });
   });
 
-  describe(`keyFrom`, () => {
-    it(`returns the correct key`, () => {
+  describe(`keyFrom`, function() {
+    it(`returns the correct key`, function() {
       expect(CustomElementResource.keyFrom('foo')).to.equal('custom-element:foo');
     });
   });
 
-  describe(`isType`, () => {
-    it(`returns true when given a resource with the correct kind`, () => {
+  describe(`isType`, function() {
+    it(`returns true when given a resource with the correct kind`, function() {
       const type = CustomElementResource.define('foo', class Foo {});
       expect(CustomElementResource.isType(type)).to.equal(true);
     });
 
-    it(`returns false when given a resource with the wrong kind`, () => {
+    it(`returns false when given a resource with the wrong kind`, function() {
       const type = CustomAttributeResource.define('foo', class Foo {});
       expect(CustomElementResource.isType(type)).to.equal(false);
     });
   });
 
-  describe(`behaviorFor`, () => {
-    it(`returns $customElement variable if it exists`, () => {
+  describe(`behaviorFor`, function() {
+    it(`returns $customElement variable if it exists`, function() {
       expect(CustomElementResource.behaviorFor({$customElement: 'foo'} as any)).to.equal('foo');
     });
 
-    it(`returns null if the $customElement variable does nots`, () => {
+    it(`returns null if the $customElement variable does nots`, function() {
       expect(CustomElementResource.behaviorFor({} as any)).to.equal(null);
     });
   });

--- a/packages/runtime/test/resources/custom-element.resource.spec.ts
+++ b/packages/runtime/test/resources/custom-element.resource.spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { CustomAttributeResource, CustomElementResource } from '../../src/index';
 
-describe('CustomElementResource', function() {
-  describe(`define`, function() {
-    it(`creates a new class when applied to null`, function() {
+describe('CustomElementResource', function () {
+  describe(`define`, function () {
+    it(`creates a new class when applied to null`, function () {
       const type = CustomElementResource.define('foo', null);
       expect(typeof type).to.equal('function');
       expect(typeof type.constructor).to.equal('function');
@@ -11,7 +11,7 @@ describe('CustomElementResource', function() {
       expect(typeof type.prototype).to.equal('object');
     });
 
-    it(`creates a new class when applied to undefined`, function() { // how though?? it explicitly checks for null??
+    it(`creates a new class when applied to undefined`, function () { // how though?? it explicitly checks for null??
       const type = (CustomElementResource as any).define('foo');
       expect(typeof type).to.equal('function');
       expect(typeof type.constructor).to.equal('function');
@@ -19,36 +19,36 @@ describe('CustomElementResource', function() {
       expect(typeof type.prototype).to.equal('object');
     });
 
-    it(`names the resource 'unnamed' if no name is provided`, function() {
+    it(`names the resource 'unnamed' if no name is provided`, function () {
       const type = CustomElementResource.define({} as any, class Foo {});
       expect(type.description.name).to.equal('unnamed');
     });
   });
 
-  describe(`keyFrom`, function() {
-    it(`returns the correct key`, function() {
+  describe(`keyFrom`, function () {
+    it(`returns the correct key`, function () {
       expect(CustomElementResource.keyFrom('foo')).to.equal('custom-element:foo');
     });
   });
 
-  describe(`isType`, function() {
-    it(`returns true when given a resource with the correct kind`, function() {
+  describe(`isType`, function () {
+    it(`returns true when given a resource with the correct kind`, function () {
       const type = CustomElementResource.define('foo', class Foo {});
       expect(CustomElementResource.isType(type)).to.equal(true);
     });
 
-    it(`returns false when given a resource with the wrong kind`, function() {
+    it(`returns false when given a resource with the wrong kind`, function () {
       const type = CustomAttributeResource.define('foo', class Foo {});
       expect(CustomElementResource.isType(type)).to.equal(false);
     });
   });
 
-  describe(`behaviorFor`, function() {
-    it(`returns $customElement variable if it exists`, function() {
+  describe(`behaviorFor`, function () {
+    it(`returns $customElement variable if it exists`, function () {
       expect(CustomElementResource.behaviorFor({$customElement: 'foo'} as any)).to.equal('foo');
     });
 
-    it(`returns null if the $customElement variable does nots`, function() {
+    it(`returns null if the $customElement variable does nots`, function () {
       expect(CustomElementResource.behaviorFor({} as any)).to.equal(null);
     });
   });

--- a/packages/runtime/test/resources/custom-element.useshadowdom.spec.ts
+++ b/packages/runtime/test/resources/custom-element.useshadowdom.spec.ts
@@ -1,29 +1,29 @@
 import { expect } from 'chai';
 import { useShadowDOM } from '../../src/index';
 
-describe('@useShadowDOM', function() {
-  it(`non-invocation`, function() {
+describe('@useShadowDOM', function () {
+  it(`non-invocation`, function () {
     @useShadowDOM
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation without options`, function() {
+  it(`invocation without options`, function () {
     @useShadowDOM()
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation with options mode=open`, function() {
+  it(`invocation with options mode=open`, function () {
     @useShadowDOM({ mode: 'open' })
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation with options mode=closed`, function() {
+  it(`invocation with options mode=closed`, function () {
     @useShadowDOM({ mode: 'closed' })
     class Foo {}
 

--- a/packages/runtime/test/resources/custom-element.useshadowdom.spec.ts
+++ b/packages/runtime/test/resources/custom-element.useshadowdom.spec.ts
@@ -1,29 +1,29 @@
 import { expect } from 'chai';
 import { useShadowDOM } from '../../src/index';
 
-describe('@useShadowDOM', () => {
-  it(`non-invocation`, () => {
+describe('@useShadowDOM', function() {
+  it(`non-invocation`, function() {
     @useShadowDOM
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation without options`, () => {
+  it(`invocation without options`, function() {
     @useShadowDOM()
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation with options mode=open`, () => {
+  it(`invocation with options mode=open`, function() {
     @useShadowDOM({ mode: 'open' })
     class Foo {}
 
     expect(Foo['shadowOptions'].mode).to.equal('open');
   });
 
-  it(`invocation with options mode=closed`, () => {
+  it(`invocation with options mode=closed`, function() {
     @useShadowDOM({ mode: 'closed' })
     class Foo {}
 

--- a/packages/runtime/test/resources/value-converter.spec.ts
+++ b/packages/runtime/test/resources/value-converter.spec.ts
@@ -2,10 +2,10 @@ import { DI, IContainer } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { valueConverter, ValueConverterResource } from '../../src/index';
 
-describe(`@valueConverter('foo')`, () => {
+describe(`@valueConverter('foo')`, function() {
   let container: IContainer;
 
-  beforeEach(() => {
+  beforeEach(function() {
     container = DI.createContainer();
   });
 
@@ -13,7 +13,7 @@ describe(`@valueConverter('foo')`, () => {
   @valueConverter('foo')
   class FooValueConverter { }
 
-  it(`should define the value converter`, () => {
+  it(`should define the value converter`, function() {
     expect(FooValueConverter['kind']).to.equal(ValueConverterResource);
     expect(FooValueConverter['description'].name).to.equal('foo');
     FooValueConverter['register'](container);

--- a/packages/runtime/test/resources/value-converter.spec.ts
+++ b/packages/runtime/test/resources/value-converter.spec.ts
@@ -2,10 +2,10 @@ import { DI, IContainer } from '@aurelia/kernel';
 import { expect } from 'chai';
 import { valueConverter, ValueConverterResource } from '../../src/index';
 
-describe(`@valueConverter('foo')`, function() {
+describe(`@valueConverter('foo')`, function () {
   let container: IContainer;
 
-  beforeEach(function() {
+  beforeEach(function () {
     container = DI.createContainer();
   });
 
@@ -13,7 +13,7 @@ describe(`@valueConverter('foo')`, function() {
   @valueConverter('foo')
   class FooValueConverter { }
 
-  it(`should define the value converter`, function() {
+  it(`should define the value converter`, function () {
     expect(FooValueConverter['kind']).to.equal(ValueConverterResource);
     expect(FooValueConverter['description'].name).to.equal('foo');
     FooValueConverter['register'](container);

--- a/packages/runtime/test/setup-node.ts
+++ b/packages/runtime/test/setup-node.ts
@@ -53,7 +53,7 @@ chai.use(function(_chai, utils) {
           `${msg}expected $state to have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`,
           `${msg}expected $state to NOT have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`);
       },
-      function() {
+      function () {
         utils.flag(this, flagName, true);
       }
     );

--- a/packages/runtime/test/setup.ts
+++ b/packages/runtime/test/setup.ts
@@ -53,7 +53,7 @@ chai.use(function(_chai, utils) {
           `${msg}expected $state to have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`,
           `${msg}expected $state to NOT have flags [${getStateFlagName(currentFlag)}], but got [${getStateFlagName(state)}]`);
       },
-      function() {
+      function () {
         utils.flag(this, flagName, true);
       }
     );

--- a/packages/runtime/test/template.spec.ts
+++ b/packages/runtime/test/template.spec.ts
@@ -22,8 +22,8 @@ import {
   AuNodeSequenceFactory
 } from './au-dom';
 
-describe('createRenderContext', function() {
-  it('properly initializes a renderContext', function() {
+describe('createRenderContext', function () {
+  it('properly initializes a renderContext', function () {
     const parent = AuDOMConfiguration.createContainer();
 
     class Foo {}
@@ -68,9 +68,9 @@ describe('createRenderContext', function() {
   });
 });
 
-describe(`CompiledTemplate`, function() {
-  describe(`constructor`, function() {
-    it(`creates a new createNodeSequence function`, function() {
+describe(`CompiledTemplate`, function () {
+  describe(`constructor`, function () {
+    it(`creates a new createNodeSequence function`, function () {
       class Foo {}
       class Bar {public static register(container2: IContainer) { container2.register(Registration.singleton(Bar, Bar)); }}
       const container = AuDOMConfiguration.createContainer();

--- a/packages/runtime/test/template.spec.ts
+++ b/packages/runtime/test/template.spec.ts
@@ -22,8 +22,8 @@ import {
   AuNodeSequenceFactory
 } from './au-dom';
 
-describe('createRenderContext', () => {
-  it('properly initializes a renderContext', () => {
+describe('createRenderContext', function() {
+  it('properly initializes a renderContext', function() {
     const parent = AuDOMConfiguration.createContainer();
 
     class Foo {}
@@ -68,9 +68,9 @@ describe('createRenderContext', () => {
   });
 });
 
-describe(`CompiledTemplate`, () => {
-  describe(`constructor`, () => {
-    it(`creates a new createNodeSequence function`, () => {
+describe(`CompiledTemplate`, function() {
+  describe(`constructor`, function() {
+    it(`creates a new createNodeSequence function`, function() {
       class Foo {}
       class Bar {public static register(container2: IContainer) { container2.register(Registration.singleton(Bar, Bar)); }}
       const container = AuDOMConfiguration.createContainer();

--- a/packages/runtime/test/templating/custom-attribute.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$attach.spec.ts
@@ -2,9 +2,9 @@ import { Hooks, LifecycleFlags, State } from '../../src/index';
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', function() {
+describe('@customAttribute', function () {
 
-  describe('$attach', function() {
+  describe('$attach', function () {
 
     const propsSpecs = [
       {
@@ -51,7 +51,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomAttribute();
         propsSpec.setProps(sut);
@@ -75,7 +75,7 @@ describe('@customAttribute', function() {
     });
   });
 
-  describe('$detach', function() {
+  describe('$detach', function () {
 
     const propsSpecs = [
       {
@@ -122,7 +122,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomAttribute();
         propsSpec.setProps(sut);
@@ -146,7 +146,7 @@ describe('@customAttribute', function() {
     });
   });
 
-  describe('$cache', function() {
+  describe('$cache', function () {
 
     const hooksSpecs = [
       {
@@ -164,7 +164,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomAttribute();
         const hooks = hooksSpec.getHooks();

--- a/packages/runtime/test/templating/custom-attribute.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$attach.spec.ts
@@ -2,9 +2,9 @@ import { Hooks, LifecycleFlags, State } from '../../src/index';
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', () => {
+describe('@customAttribute', function() {
 
-  describe('$attach', () => {
+  describe('$attach', function() {
 
     const propsSpecs = [
       {
@@ -51,7 +51,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomAttribute();
         propsSpec.setProps(sut);
@@ -75,7 +75,7 @@ describe('@customAttribute', () => {
     });
   });
 
-  describe('$detach', () => {
+  describe('$detach', function() {
 
     const propsSpecs = [
       {
@@ -122,7 +122,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomAttribute();
         propsSpec.setProps(sut);
@@ -146,7 +146,7 @@ describe('@customAttribute', () => {
     });
   });
 
-  describe('$cache', () => {
+  describe('$cache', function() {
 
     const hooksSpecs = [
       {
@@ -164,7 +164,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomAttribute();
         const hooks = hooksSpec.getHooks();

--- a/packages/runtime/test/templating/custom-attribute.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$bind.spec.ts
@@ -3,9 +3,9 @@ import { Hooks, LifecycleFlags as LF, Scope, State } from '../../src/index';
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', () => {
+describe('@customAttribute', function() {
 
-  describe('$bind', () => {
+  describe('$bind', function() {
 
     const propsAndScopeSpecs = [
       // $isBound: true, with 4 variants
@@ -179,7 +179,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, () => {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomAttribute();
         psSpec.setProps(sut);
@@ -212,7 +212,7 @@ describe('@customAttribute', () => {
     });
   });
 
-  describe('$unbind', () => {
+  describe('$unbind', function() {
 
     const propsAndScopeSpecs = [
       {
@@ -308,7 +308,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpec, hooksSpecs],
                       (psSpec, flagsSpec2, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec2.expectation} if ${flagsSpec2.description}`, () => {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec2.expectation} if ${flagsSpec2.description}`, function() {
         // Arrange
         const { sut } = createCustomAttribute();
         psSpec.setProps(sut);

--- a/packages/runtime/test/templating/custom-attribute.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$bind.spec.ts
@@ -3,9 +3,9 @@ import { Hooks, LifecycleFlags as LF, Scope, State } from '../../src/index';
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', function() {
+describe('@customAttribute', function () {
 
-  describe('$bind', function() {
+  describe('$bind', function () {
 
     const propsAndScopeSpecs = [
       // $isBound: true, with 4 variants
@@ -179,7 +179,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomAttribute();
         psSpec.setProps(sut);
@@ -212,7 +212,7 @@ describe('@customAttribute', function() {
     });
   });
 
-  describe('$unbind', function() {
+  describe('$unbind', function () {
 
     const propsAndScopeSpecs = [
       {
@@ -308,7 +308,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpec, hooksSpecs],
                       (psSpec, flagsSpec2, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec2.expectation} if ${flagsSpec2.description}`, function() {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec2.expectation} if ${flagsSpec2.description}`, function () {
         // Arrange
         const { sut } = createCustomAttribute();
         psSpec.setProps(sut);

--- a/packages/runtime/test/templating/custom-attribute.$hydrate.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$hydrate.spec.ts
@@ -4,9 +4,9 @@ import { Hooks, ICustomAttributeType, LifecycleFlags as LF, State } from '../../
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', function() {
+describe('@customAttribute', function () {
 
-  describe('$hydrate', function() {
+  describe('$hydrate', function () {
 
     const hooksSpecs = [
       {
@@ -31,7 +31,7 @@ describe('@customAttribute', function() {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { Type, sut } = createCustomAttribute();
 

--- a/packages/runtime/test/templating/custom-attribute.$hydrate.spec.ts
+++ b/packages/runtime/test/templating/custom-attribute.$hydrate.spec.ts
@@ -4,9 +4,9 @@ import { Hooks, ICustomAttributeType, LifecycleFlags as LF, State } from '../../
 import { createCustomAttribute, CustomAttribute } from '../resources/custom-attribute._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customAttribute', () => {
+describe('@customAttribute', function() {
 
-  describe('$hydrate', () => {
+  describe('$hydrate', function() {
 
     const hooksSpecs = [
       {
@@ -31,7 +31,7 @@ describe('@customAttribute', () => {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { Type, sut } = createCustomAttribute();
 

--- a/packages/runtime/test/templating/custom-element.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$attach.spec.ts
@@ -12,9 +12,9 @@ import {
 import { eachCartesianJoin } from '../util';
 
 //TODO: verify mount callbacks
-describe('@customElement', () => {
+describe('@customElement', function() {
 
-  describe('$attach', () => {
+  describe('$attach', function() {
 
     const propsSpecs = [
       {
@@ -59,7 +59,7 @@ describe('@customElement', () => {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomElement('foo');
         const initState = sut.$state;
@@ -107,7 +107,7 @@ describe('@customElement', () => {
     });
   });
 
-  describe('$detach', () => {
+  describe('$detach', function() {
 
     const propsSpecs = [
       {
@@ -152,7 +152,7 @@ describe('@customElement', () => {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
@@ -190,7 +190,7 @@ describe('@customElement', () => {
     });
   });
 
-  describe('$cache', () => {
+  describe('$cache', function() {
 
     const hooksSpecs = [
       {
@@ -208,7 +208,7 @@ describe('@customElement', () => {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
@@ -231,8 +231,8 @@ describe('@customElement', () => {
     });
   });
 
-  describe('$mount', () => {
-    it('calls $projector.project()', () => {
+  describe('$mount', function() {
+    it('calls $projector.project()', function() {
       const { sut } = createCustomElement('foo');
 
       const nodes = sut.$nodes = {} as any;
@@ -252,8 +252,8 @@ describe('@customElement', () => {
     });
   });
 
-  describe('$unmount', () => {
-    it('calls $projector.take()', () => {
+  describe('$unmount', function() {
+    it('calls $projector.take()', function() {
       const { sut } = createCustomElement('foo');
 
       const nodes = sut.$nodes = {} as any;

--- a/packages/runtime/test/templating/custom-element.$attach.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$attach.spec.ts
@@ -12,9 +12,9 @@ import {
 import { eachCartesianJoin } from '../util';
 
 //TODO: verify mount callbacks
-describe('@customElement', function() {
+describe('@customElement', function () {
 
-  describe('$attach', function() {
+  describe('$attach', function () {
 
     const propsSpecs = [
       {
@@ -59,7 +59,7 @@ describe('@customElement', function() {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomElement('foo');
         const initState = sut.$state;
@@ -107,7 +107,7 @@ describe('@customElement', function() {
     });
   });
 
-  describe('$detach', function() {
+  describe('$detach', function () {
 
     const propsSpecs = [
       {
@@ -152,7 +152,7 @@ describe('@customElement', function() {
     eachCartesianJoin([propsSpecs, hooksSpecs],
                       (propsSpec, hooksSpec) => {
 
-      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${propsSpec.expectation} if ${propsSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
@@ -190,7 +190,7 @@ describe('@customElement', function() {
     });
   });
 
-  describe('$cache', function() {
+  describe('$cache', function () {
 
     const hooksSpecs = [
       {
@@ -208,7 +208,7 @@ describe('@customElement', function() {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomElement('foo');
         sut.$state |= State.isBound;
@@ -231,8 +231,8 @@ describe('@customElement', function() {
     });
   });
 
-  describe('$mount', function() {
-    it('calls $projector.project()', function() {
+  describe('$mount', function () {
+    it('calls $projector.project()', function () {
       const { sut } = createCustomElement('foo');
 
       const nodes = sut.$nodes = {} as any;
@@ -252,8 +252,8 @@ describe('@customElement', function() {
     });
   });
 
-  describe('$unmount', function() {
-    it('calls $projector.take()', function() {
+  describe('$unmount', function () {
+    it('calls $projector.take()', function () {
       const { sut } = createCustomElement('foo');
 
       const nodes = sut.$nodes = {} as any;

--- a/packages/runtime/test/templating/custom-element.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$bind.spec.ts
@@ -2,9 +2,9 @@ import { Hooks, LifecycleFlags as LF, Scope, State } from '../../src/index';
 import { createCustomElement, CustomElement } from '../resources/custom-element._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customElement', () => {
+describe('@customElement', function() {
 
-  describe('$bind', () => {
+  describe('$bind', function() {
 
     const propsAndScopeSpecs = [
       {
@@ -108,7 +108,7 @@ describe('@customElement', () => {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, () => {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
@@ -133,7 +133,7 @@ describe('@customElement', () => {
     });
   });
 
-  describe('$unbind', () => {
+  describe('$unbind', function() {
 
     const propsAndScopeSpecs = [
       {
@@ -217,7 +217,7 @@ describe('@customElement', () => {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, () => {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
         // Arrange
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);

--- a/packages/runtime/test/templating/custom-element.$bind.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$bind.spec.ts
@@ -2,9 +2,9 @@ import { Hooks, LifecycleFlags as LF, Scope, State } from '../../src/index';
 import { createCustomElement, CustomElement } from '../resources/custom-element._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customElement', function() {
+describe('@customElement', function () {
 
-  describe('$bind', function() {
+  describe('$bind', function () {
 
     const propsAndScopeSpecs = [
       {
@@ -108,7 +108,7 @@ describe('@customElement', function() {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);
@@ -133,7 +133,7 @@ describe('@customElement', function() {
     });
   });
 
-  describe('$unbind', function() {
+  describe('$unbind', function () {
 
     const propsAndScopeSpecs = [
       {
@@ -217,7 +217,7 @@ describe('@customElement', function() {
     eachCartesianJoin([propsAndScopeSpecs, flagsSpecs, hooksSpecs],
                       (psSpec, flagsSpec, hooksSpec) => {
 
-      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function() {
+      it(`${psSpec.expectation} if ${psSpec.description} AND ${hooksSpec.expectation} if ${hooksSpec.description} AND ${flagsSpec.expectation} if ${flagsSpec.description}`, function () {
         // Arrange
         const { sut } = createCustomElement('foo');
         psSpec.setProps(sut);

--- a/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
@@ -4,9 +4,9 @@ import { Hooks, ICustomElementType,  IDOM, INode, IProjectorLocator, IRenderingE
 import { createCustomElement, CustomElement } from '../resources/custom-element._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customElement', function() {
+describe('@customElement', function () {
 
-  describe('$hydrate', function() {
+  describe('$hydrate', function () {
 
     const hooksSpecs = [
       {
@@ -31,7 +31,7 @@ describe('@customElement', function() {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
+      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function () {
         // Arrange
         const { Type, sut } = createCustomElement('foo');
 

--- a/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
+++ b/packages/runtime/test/templating/custom-element.$hydrate.spec.ts
@@ -4,9 +4,9 @@ import { Hooks, ICustomElementType,  IDOM, INode, IProjectorLocator, IRenderingE
 import { createCustomElement, CustomElement } from '../resources/custom-element._builder';
 import { eachCartesianJoin } from '../util';
 
-describe('@customElement', () => {
+describe('@customElement', function() {
 
-  describe('$hydrate', () => {
+  describe('$hydrate', function() {
 
     const hooksSpecs = [
       {
@@ -31,7 +31,7 @@ describe('@customElement', () => {
     eachCartesianJoin([hooksSpecs],
                       (hooksSpec) => {
 
-      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, () => {
+      it(`sets properties, applies runtime behavior and ${hooksSpec.expectation} if ${hooksSpec.description}`, function() {
         // Arrange
         const { Type, sut } = createCustomElement('foo');
 

--- a/packages/runtime/test/templating/lifecycle.spec.ts
+++ b/packages/runtime/test/templating/lifecycle.spec.ts
@@ -145,7 +145,7 @@
 //   expect(i).to.equal(count);
 // }
 
-// describe(`LifecycleController `, function() {
+// describe(`LifecycleController `, function () {
 
 //   eachCartesianJoinFactory<
 //     [string, LifecycleFlags],
@@ -298,14 +298,14 @@
 //         ]
 //       ]
 //     ], ([t1, flags], [t2, sut], [count, mock], [t3, exec3]) => {
-//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t2}`, async function() {
+//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t2}`, async function () {
 //         await exec3(count, sut, mock);
 //       });
 //     }
 //   );
 // });
 
-// describe(`LifecycleController `, function() {
+// describe(`LifecycleController `, function () {
 
 //   eachCartesianJoinFactory<
 //     [string, LifecycleFlags],
@@ -511,7 +511,7 @@
 //         ]
 //       ]
 //     ], ([t1, flags], [t2, sut], [count, mock], [t3, exec3], [t4, exec4]) => {
-//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t3} -> ${t4}`, async function() {
+//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t3} -> ${t4}`, async function () {
 //         exec3(count, sut, mock);
 //         await exec4(count, sut, mock);
 //       });

--- a/packages/runtime/test/templating/lifecycle.spec.ts
+++ b/packages/runtime/test/templating/lifecycle.spec.ts
@@ -145,7 +145,7 @@
 //   expect(i).to.equal(count);
 // }
 
-// describe(`LifecycleController `, () => {
+// describe(`LifecycleController `, function() {
 
 //   eachCartesianJoinFactory<
 //     [string, LifecycleFlags],
@@ -298,14 +298,14 @@
 //         ]
 //       ]
 //     ], ([t1, flags], [t2, sut], [count, mock], [t3, exec3]) => {
-//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t2}`, async () => {
+//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t2}`, async function() {
 //         await exec3(count, sut, mock);
 //       });
 //     }
 //   );
 // });
 
-// describe(`LifecycleController `, () => {
+// describe(`LifecycleController `, function() {
 
 //   eachCartesianJoinFactory<
 //     [string, LifecycleFlags],
@@ -511,7 +511,7 @@
 //         ]
 //       ]
 //     ], ([t1, flags], [t2, sut], [count, mock], [t3, exec3], [t4, exec4]) => {
-//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t3} -> ${t4}`, async () => {
+//       it(`${t1} ctrl=${t2} mockCount=${count<10?' ':''}${count} -> ${t3} -> ${t4}`, async function() {
 //         exec3(count, sut, mock);
 //         await exec4(count, sut, mock);
 //       });

--- a/packages/runtime/test/templating/view.spec.ts
+++ b/packages/runtime/test/templating/view.spec.ts
@@ -46,8 +46,8 @@ class StubTemplate {
   }
 }
 
-describe(`ViewFactory`, () => {
-  describe(`tryReturnToCache`, () => {
+describe(`ViewFactory`, function() {
+  describe(`tryReturnToCache`, function() {
     const doNotOverrideVariations: [string, boolean][] = [
       [' true', true],
       ['false', false]
@@ -86,7 +86,7 @@ describe(`ViewFactory`, () => {
       = [doNotOverrideVariations, sizeVariations, doNotOverrideVariations2, sizeVariations2];
 
     eachCartesianJoin(inputs, ([text1, doNotOverride1], [text2, size2, isPositive2], [text3, doNotOverride3], [text4, size4, isPositive4]) => {
-        it(`setCacheSize(${text2},${text1}) -> tryReturnToCache -> create x2 -> setCacheSize(${text4},${text3}) -> tryReturnToCache -> create x2`, () => {
+        it(`setCacheSize(${text2},${text1}) -> tryReturnToCache -> create x2 -> setCacheSize(${text4},${text3}) -> tryReturnToCache -> create x2`, function() {
           const template = new StubTemplate();
           const sut = new ViewFactory(null, template as any, new Lifecycle());
           const view1 = new StubView();
@@ -147,7 +147,7 @@ describe(`ViewFactory`, () => {
 //   const nodes = (<Writable<IRenderable>>renderable).$nodes = new MockTextNodeSequence();
 //   addBinding(renderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
 // }
-describe('View', () => {
+describe('View', function() {
   function runBindLifecycle(lifecycle: ILifecycle, view: IView<AuNode>, flags: LF, scope: IScope): void {
     lifecycle.beginBind();
     view.$bind(flags, scope);
@@ -283,7 +283,7 @@ describe('View', () => {
     = [cacheSpecs, duplicateOperationSpecs, bindSpecs, relSpecs, flagsSpecs];
 
   eachCartesianJoin(inputs, (cacheSpec, duplicateOpSpec, bindSpec, relSpec, flagsSpec) => {
-    it(`verify view behavior - cacheSpec ${cacheSpec.t}, duplicateOpSpec ${duplicateOpSpec.t}, bindSpec ${bindSpec.t}, relSpec ${relSpec.t}, flagsSpec ${flagsSpec.t}`, () => {
+    it(`verify view behavior - cacheSpec ${cacheSpec.t}, duplicateOpSpec ${duplicateOpSpec.t}, bindSpec ${bindSpec.t}, relSpec ${relSpec.t}, flagsSpec ${flagsSpec.t}`, function() {
       const { childCount, cacheSize } = cacheSpec;
       const { bindTwice, duplicateBindValue, attachTwice, detachTwice, unbindTwice } = duplicateOpSpec;
       const { propName, propValue1, lockScope1, newScopeForSecondBind, propValue2, lockScope2 } = bindSpec;

--- a/packages/runtime/test/templating/view.spec.ts
+++ b/packages/runtime/test/templating/view.spec.ts
@@ -46,8 +46,8 @@ class StubTemplate {
   }
 }
 
-describe(`ViewFactory`, function() {
-  describe(`tryReturnToCache`, function() {
+describe(`ViewFactory`, function () {
+  describe(`tryReturnToCache`, function () {
     const doNotOverrideVariations: [string, boolean][] = [
       [' true', true],
       ['false', false]
@@ -86,7 +86,7 @@ describe(`ViewFactory`, function() {
       = [doNotOverrideVariations, sizeVariations, doNotOverrideVariations2, sizeVariations2];
 
     eachCartesianJoin(inputs, ([text1, doNotOverride1], [text2, size2, isPositive2], [text3, doNotOverride3], [text4, size4, isPositive4]) => {
-        it(`setCacheSize(${text2},${text1}) -> tryReturnToCache -> create x2 -> setCacheSize(${text4},${text3}) -> tryReturnToCache -> create x2`, function() {
+        it(`setCacheSize(${text2},${text1}) -> tryReturnToCache -> create x2 -> setCacheSize(${text4},${text3}) -> tryReturnToCache -> create x2`, function () {
           const template = new StubTemplate();
           const sut = new ViewFactory(null, template as any, new Lifecycle());
           const view1 = new StubView();
@@ -147,7 +147,7 @@ describe(`ViewFactory`, function() {
 //   const nodes = (<Writable<IRenderable>>renderable).$nodes = new MockTextNodeSequence();
 //   addBinding(renderable, new Binding(this.sourceExpression, nodes.firstChild, 'textContent', BindingMode.toView, this.observerLocator, this.container));
 // }
-describe('View', function() {
+describe('View', function () {
   function runBindLifecycle(lifecycle: ILifecycle, view: IView<AuNode>, flags: LF, scope: IScope): void {
     lifecycle.beginBind();
     view.$bind(flags, scope);
@@ -283,7 +283,7 @@ describe('View', function() {
     = [cacheSpecs, duplicateOperationSpecs, bindSpecs, relSpecs, flagsSpecs];
 
   eachCartesianJoin(inputs, (cacheSpec, duplicateOpSpec, bindSpec, relSpec, flagsSpec) => {
-    it(`verify view behavior - cacheSpec ${cacheSpec.t}, duplicateOpSpec ${duplicateOpSpec.t}, bindSpec ${bindSpec.t}, relSpec ${relSpec.t}, flagsSpec ${flagsSpec.t}`, function() {
+    it(`verify view behavior - cacheSpec ${cacheSpec.t}, duplicateOpSpec ${duplicateOpSpec.t}, bindSpec ${bindSpec.t}, relSpec ${relSpec.t}, flagsSpec ${flagsSpec.t}`, function () {
       const { childCount, cacheSize } = cacheSpec;
       const { bindTwice, duplicateBindValue, attachTwice, detachTwice, unbindTwice } = duplicateOpSpec;
       const { propName, propValue1, lockScope1, newScopeForSecondBind, propValue2, lockScope2 } = bindSpec;

--- a/test/browserstack/browserstack.conf.ts
+++ b/test/browserstack/browserstack.conf.ts
@@ -221,7 +221,7 @@ exports.config = {
      */
     onComplete: function (exitCode, config, capabilities) {
       console.log(`onComplete, exitCode: ${exitCode}`);
-      exports.bs_local.stop(function() {});
+      exports.bs_local.stop(function () {});
     },
     /**
     * Gets executed when an error happens, good place to take a screenshot


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Replaces all `() =>` with `function ()` in tests as per mocha's recommendation (provides access to test context and better context isolation, improving garbage collection and lowering memory usage esp. in heavily looped tests)
- Adds a space between `function` and the opening paren as per recommendation of airbnb and many other style guides
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

N/A
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Lots of files affected, but the only changes executed are:
- replace `(it|describe|before|after|beforeEach|afterEach)\((.*)\(\) => ` with `$1($2function() ` in `packages/*/test/**/*.ts` (with regex)
- replace `function()` with `function ()` in `**/*.ts` (without regex)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

N/A
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

N/A
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
