### PR TITLE
Dynamic routing: improve queued browser history

### DIFF
--- a/packages/router/src/queued-browser-history.ts
+++ b/packages/router/src/queued-browser-history.ts
@@ -22,6 +22,9 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
   private currentHistoryActivity: QueueItem;
   private callback: (ev?: PopStateEvent) => void;
 
+  private goResolve: ((value?: void | PromiseLike<void>) => void);
+  private suppressPopstateResolve: ((value?: void | PromiseLike<void>) => void);
+
   constructor() {
     this.window = window;
     this.history = window.history;
@@ -29,6 +32,7 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
     this.isActive = false;
     this.currentHistoryActivity = null;
     this.callback = null;
+    this.suppressPopstateResolve = null;
   }
 
   public activate(callback: (ev?: PopStateEvent) => void): void {
@@ -58,8 +62,13 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
     return this.history.scrollRestoration;
   }
 
-  public async go(delta?: number): Promise<void> {
-    await this.enqueue(this.history, 'go', [delta]);
+  public async go(delta?: number, suppressPopstate: boolean = false): Promise<void> {
+    if (!suppressPopstate) {
+      return this.enqueue(this, '_go', [delta], true);
+    }
+    const promise = this.enqueue(this, 'suppressPopstate', [], true);
+    this.enqueue(this.history, 'go', [delta]);
+    return promise;
   }
   public back(): Promise<void> {
     return this.go(-1);
@@ -70,28 +79,53 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
 
   // tslint:disable-next-line:no-any - typed according to DOM
   public async pushState(data: any, title: string, url?: string | null): Promise<void> {
-    await this.enqueue(this.history, 'pushState', [data, title, url]);
+    return this.enqueue(this.history, 'pushState', [data, title, url]);
   }
 
   // tslint:disable-next-line:no-any - typed according to DOM
   public async replaceState(data: any, title: string, url?: string | null): Promise<void> {
-    await this.enqueue(this.history, 'replaceState', [data, title, url]);
+    return this.enqueue(this.history, 'replaceState', [data, title, url]);
   }
 
   private readonly handlePopstate = async (ev: PopStateEvent): Promise<void> => {
-    await this.enqueue(this, 'popstate', [ev]);
+    return this.enqueue(this, 'popstate', [ev]);
   }
 
-  private popstate(ev: PopStateEvent): void {
-    this.callback(ev);
+  private async popstate(ev: PopStateEvent): Promise<void> {
+    if (!this.suppressPopstateResolve) {
+      if (this.goResolve) {
+        const resolve = this.goResolve;
+        this.goResolve = null;
+        resolve();
+        await Promise.resolve();
+      }
+      this.callback(ev);
+    } else {
+      const resolve = this.suppressPopstateResolve;
+      this.suppressPopstate = null;
+      resolve();
+    }
   }
 
-  private enqueue(target: object, methodName: string, parameters: unknown[]): Promise<void> {
+  private _go(delta: number, resolve: ((value?: void | PromiseLike<void>) => void)): void{
+    this.goResolve = resolve;
+    this.history.go(delta);
+  }
+
+  private suppressPopstate(resolve: ((value?: void | PromiseLike<void>) => void)): void {
+    this.suppressPopstateResolve = resolve;
+  }
+
+  private enqueue(target: object, methodName: string, parameters: unknown[], resolveInParameters: boolean = false): Promise<void> {
     let _resolve;
     // tslint:disable-next-line:promise-must-complete
     const promise: Promise<void> = new Promise((resolve) => {
       _resolve = resolve;
     });
+    if (resolveInParameters) {
+      parameters.push(_resolve);
+      _resolve = null;
+    }
     this.queue.push({
       target: target,
       methodName: methodName,
@@ -111,6 +145,8 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
     method.apply(this.currentHistoryActivity.target, this.currentHistoryActivity.parameters);
     const resolve = this.currentHistoryActivity.resolve;
     this.currentHistoryActivity = null;
-    resolve();
+    if (resolve) {
+      resolve();
+    }
   }
 }

--- a/packages/router/src/queued-browser-history.ts
+++ b/packages/router/src/queued-browser-history.ts
@@ -103,7 +103,7 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
       this.callback(ev);
     } else {
       const resolve = this.suppressPopstateResolve;
-      this.suppressPopstate = null;
+      this.suppressPopstateResolve = null;
       resolve();
     }
   }

--- a/packages/router/src/queued-browser-history.ts
+++ b/packages/router/src/queued-browser-history.ts
@@ -68,7 +68,7 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
       return this.enqueue(this, '_go', [delta], true);
     }
     const promise = this.enqueue(this, 'suppressPopstate', [], true);
-    this.enqueue(this.history, 'go', [delta]);
+    this.enqueue(this.history, 'go', [delta]).catch(error => { throw error; });
     return promise;
   }
   public back(): Promise<void> {
@@ -108,7 +108,7 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
     }
   }
 
-  private _go(delta: number, resolve: ((value?: void | PromiseLike<void>) => void)): void{
+  private _go(delta: number, resolve: ((value?: void | PromiseLike<void>) => void)): void {
     this.goResolve = resolve;
     this.history.go(delta);
   }

--- a/packages/router/src/queued-browser-history.ts
+++ b/packages/router/src/queued-browser-history.ts
@@ -32,6 +32,7 @@ export class QueuedBrowserHistory implements QueuedBrowserHistory {
     this.isActive = false;
     this.currentHistoryActivity = null;
     this.callback = null;
+    this.goResolve = null;
     this.suppressPopstateResolve = null;
   }
 

--- a/packages/router/test/e2e/doc-example/src/components/about.ts
+++ b/packages/router/test/e2e/doc-example/src/components/about.ts
@@ -1,5 +1,6 @@
 import { inject } from '@aurelia/kernel';
 import { customElement, ICustomElement } from '@aurelia/runtime';
+import { Router } from '../../../../../src';
 import { State } from '../state';
 import { wait } from '../utils';
 
@@ -33,13 +34,26 @@ In other words, I scroll you
 </pre></div>
 <br>
 <input>
+<span style="display: inline-block; width: 150px; border: 1px solid green" click.trigger="goClick(false)">Go</span>
+<span style="display: inline-block; width: 150px; border: 1px solid green" click.trigger="goClick(true)">Go with suppress</span>
 </template>` })
-@inject(State)
+@inject(State, Router)
 export class About {
-  constructor(private readonly state: State) { }
+  constructor(private readonly state: State, private readonly router: Router) { }
 
   public enter() {
     return wait(this.state.noDelay ? 0 : 4000);
+  }
+  async goClick(suppress) {
+    await this.router.historyBrowser.history.pushState('books', null, '#books');
+    // tslint:disable-next-line:no-console
+    console.log('books', this.router.historyBrowser.history.history.state);
+    await this.router.historyBrowser.history.pushState('two', null, '#two');
+    // tslint:disable-next-line:no-console
+    console.log('two', this.router.historyBrowser.history.history.state);
+    await this.router.historyBrowser.history.go(-1, suppress);
+    // tslint:disable-next-line:no-console
+    console.log('books', this.router.historyBrowser.history.history.state);
   }
 }
 export interface About extends ICustomElement<HTMLElement> { }

--- a/packages/router/test/unit/instruction-resolver.spec.ts
+++ b/packages/router/test/unit/instruction-resolver.spec.ts
@@ -7,8 +7,8 @@ import { MockBrowserHistoryLocation } from '../mock/browser-history-location.moc
 import { ViewportInstruction } from './../../src/viewport-instruction';
 
 describe('InstructionResolver', () => {
+  this.timeout(30000);
   it('can be created', async function () {
-    this.timeout(30000);
     const { host, router } = await setup();
     await waitForNavigation(router);
 
@@ -16,7 +16,6 @@ describe('InstructionResolver', () => {
   });
 
   it('handles state strings', async function () {
-    this.timeout(30000);
     const { host, router } = await setup();
     await waitForNavigation(router);
 

--- a/packages/router/test/unit/instruction-resolver.spec.ts
+++ b/packages/router/test/unit/instruction-resolver.spec.ts
@@ -6,7 +6,7 @@ import { Router, ViewportCustomElement } from '../../src/index';
 import { MockBrowserHistoryLocation } from '../mock/browser-history-location.mock';
 import { ViewportInstruction } from './../../src/viewport-instruction';
 
-describe('InstructionResolver', () => {
+describe('InstructionResolver', function () {
   this.timeout(30000);
   it('can be created', async function () {
     const { host, router } = await setup();

--- a/packages/router/test/unit/queued-browser-history.spec.ts
+++ b/packages/router/test/unit/queued-browser-history.spec.ts
@@ -3,8 +3,12 @@ import { spy } from 'sinon';
 import { QueuedBrowserHistory } from './../../src/index';
 
 describe('QueuedBrowserHistory', function () {
+  this.timeout(30000);
   let qbh;
-  const callback = ((info) => { return; });
+  let callbackCount = 0;
+  const callback = ((info) => {
+    callbackCount++;
+  });
   class MockWindow {
     public addEventListener(event, handler, preventDefault) { return; }
     public removeEventListener(handler) { return; }
@@ -12,7 +16,8 @@ describe('QueuedBrowserHistory', function () {
 
   beforeEach(function () {
     qbh = new QueuedBrowserHistory();
-    qbh.window = new MockWindow();
+    // qbh.window = new MockWindow();
+    callbackCount = 0;
   });
 
   it('can be created', function () {
@@ -21,14 +26,20 @@ describe('QueuedBrowserHistory', function () {
 
   it('can be activated', function () {
     const callbackSpy = spy(qbh.window, 'addEventListener');
-    qbh.activate({ callback: callback});
+    qbh.activate(callback);
 
     expect(qbh.isActive).to.equal(true);
     expect(callbackSpy.calledOnce).to.equal(true);
+
+    qbh.deactivate();
   });
 
   it('can be deactivated', function () {
     const callbackSpy = spy(qbh.window, 'removeEventListener');
+
+    qbh.activate(callback);
+    expect(qbh.isActive).to.equal(true);
+
     qbh.deactivate();
 
     expect(qbh.isActive).to.equal(false);
@@ -36,24 +47,24 @@ describe('QueuedBrowserHistory', function () {
   });
 
   it('throws when activated while active', function () {
-    const callbackSpy = spy(qbh.window, 'addEventListener');
-    qbh.activate({ callback: callback});
+    qbh.activate(callback);
 
     expect(qbh.isActive).to.equal(true);
-    expect(callbackSpy.calledOnce).to.equal(true);
 
     let err;
     try {
-      qbh.activate({ callback: callback});
+      qbh.activate(callback);
     } catch (e) {
       err = e;
     }
     expect(err.message).to.contain('Queued browser history has already been activated');
+
+    qbh.deactivate();
   });
 
   it('queues consecutive calls', async function () {
     const callbackSpy = spy(qbh, 'dequeue');
-    qbh.activate({ callback: callback});
+    qbh.activate(callback);
 
     const length = qbh.length;
     qbh.pushState({}, null, '#one');
@@ -63,5 +74,50 @@ describe('QueuedBrowserHistory', function () {
     expect(callbackSpy.callCount).to.equal(0);
     expect(qbh.length).to.equal(length);
     expect(qbh.queue.length).to.equal(4);
+    await wait();
+
+    qbh.deactivate();
+  });
+
+  it('awaits go', async function () {
+    let counter = 0;
+    qbh.activate(function () {
+      counter++;
+    });
+
+    await qbh.pushState('one', null, '#one');
+    expect(qbh.history.state).to.equal('one');
+    await qbh.pushState('two', null, '#two');
+    expect(qbh.history.state).to.equal('two');
+    await qbh.go(-1);
+    expect(qbh.history.state).to.equal('one');
+
+    expect(counter).to.equal(1);
+
+    qbh.deactivate();
+  });
+
+  it('suppresses popstate event callback', async function () {
+    let counter = 0;
+    qbh.activate(function () {
+      counter++;
+    });
+
+    await qbh.pushState('one', null, '#one');
+    expect(qbh.history.state).to.equal('one');
+    await qbh.pushState('two', null, '#two');
+    expect(qbh.history.state).to.equal('two');
+    await qbh.go(-1, true);
+    expect(qbh.history.state).to.equal('one');
+
+    expect(counter).to.equal(0);
+
+    qbh.deactivate();
   });
 });
+
+const wait = async (time = 100) => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+};

--- a/packages/router/test/unit/queued-browser-history.spec.ts
+++ b/packages/router/test/unit/queued-browser-history.spec.ts
@@ -90,6 +90,7 @@ describe('QueuedBrowserHistory', function () {
     await qbh.pushState('two', null, '#two');
     expect(qbh.history.state).to.equal('two');
     await qbh.go(-1);
+    await Promise.resolve();
     expect(qbh.history.state).to.equal('one');
 
     expect(counter).to.equal(1);
@@ -108,6 +109,7 @@ describe('QueuedBrowserHistory', function () {
     await qbh.pushState('two', null, '#two');
     expect(qbh.history.state).to.equal('two');
     await qbh.go(-1, true);
+    await Promise.resolve();
     expect(qbh.history.state).to.equal('one');
 
     expect(counter).to.equal(0);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the `go` method in the queued browser history await the following `popstate` event before resolving. It also adds the option to make `go` not trigger the `popstate` event callback and thereby behaving like `pushState` and `replaceState`.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

A small thing that'll be important for the refactor that's currently going on.

## 📑 Test Plan

- Tests still pass.
- Added some new tests to verify change.

## ⏭ Next Steps

- Continue refactor with part 2 (out of probably no more than 3)
