### PR TITLE
chore(replaceable): add failing tests for common scenarios

### DIFF
--- a/packages/jit-html-browser/test/setup.ts
+++ b/packages/jit-html-browser/test/setup.ts
@@ -24,5 +24,5 @@ TestContext.createHTMLTestContext = createHTMLTestContext;
 
 chai.use(sinonChai);
 
-const testContext = require.context('../../jit-html/test', true, /\.spec\.ts$/);
+const testContext = require.context('../../jit-html/test', true, /\.spec\.tsx?$/);
 testContext.keys().forEach(testContext);

--- a/packages/jit-html/test/integration/replaceable.spec.ts
+++ b/packages/jit-html/test/integration/replaceable.spec.ts
@@ -249,7 +249,7 @@ describe('replaceable', function () {
 
   });
 
-  describe('Difficult cases', function() {
+  describe.skip('Difficult cases', function() {
     describe('with multiple nested replaceable from 1 -> 10 levels', function() {
       const createReplaceableDiv = (level: number) => {
         let currentLevel = 0;

--- a/packages/jit-html/test/integration/replaceable.spec.ts
+++ b/packages/jit-html/test/integration/replaceable.spec.ts
@@ -248,4 +248,221 @@ describe('replaceable', function () {
     expect(host.textContent).to.equal('abc');
 
   });
+
+  describe('Difficult cases', function() {
+    describe('with multiple nested replaceable from 1 -> 10 levels', function() {
+      const createReplaceableDiv = (level: number) => {
+        let currentLevel = 0;
+        let template = '';
+        while (level > currentLevel) {
+          template += `<div replaceable part="p-${currentLevel + 1}">replaceable-p-${currentLevel + 1}`;
+          ++currentLevel;
+        }
+        while (currentLevel > 0) {
+          template += '</div>';
+          --currentLevel;
+        }
+        return template;
+      };
+      const buildExpectedTextContent = (level: number) => {
+        if (level === 1) {
+          return 'replace-part-p';
+        }
+        let content = '';
+        let i = 0;
+        while (level > i) {
+          content += i === level - 1 ? `replaceable-p-${i}` : 'replace-part-p';
+          ++i;
+        }
+        return content;
+      };
+
+      for (let i = 1; 11 > i; ++i) {
+        it(`works with replaceable on normal <div/> with. Nesting level: ${i}`, function() {
+          const App = CustomElementResource.define(
+            { name: 'app', template: `<template><foo><template replace-part="p-${i}"><span>replace-part-p</span><template></foo></template>` },
+            class App {}
+          );
+          const Foo = CustomElementResource.define(
+            { name: 'foo', template: `<template>${createReplaceableDiv(i)}</template>` },
+            class Foo {}
+          );
+
+          const ctx = TestContext.createHTMLTestContext();
+          ctx.container.register(Foo);
+          const au = new Aurelia(ctx.container);
+
+          const host = ctx.createElement('div');
+          const component = new App();
+
+          au.app({ host, component });
+
+          au.start();
+
+          expect(host.textContent, 'host.textContent').to.equal(buildExpectedTextContent(i));
+          tearDown(au);
+        });
+      }
+    });
+
+    describe('with multiple replaceables + all no nested replaceable + From 1 -> 10 siblings', function() {
+      const buildReplacementTemplate = (count: number) => {
+        let template = '';
+        let i = 0;
+        while (count > i) {
+          template += `<template replace-part="p-${i}">replace-part-p</template>`;
+          ++i;
+        }
+        return template;
+      };
+      const buildReplaceableDiv = (count: number) => {
+        let template = '';
+        let i = 0;
+        while (count > i) {
+          template += `<div replaceable part="p-${i}"></div>`;
+          ++i;
+        }
+        return template;
+      };
+      for (let i = 1; 11 > i; ++i) {
+        it(`works with replaceable on normal <div/>. Siblings count: ${i}`, function() {
+          const App = CustomElementResource.define(
+            { name: 'app', template:
+              `<template><foo>${buildReplacementTemplate(i)}</foo></template>`
+            },
+            class App {}
+          );
+          const Foo = CustomElementResource.define(
+            { name: 'foo', template: `<template>${buildReplaceableDiv(i)}</template>` },
+            class Foo {}
+          );
+          
+          const ctx = TestContext.createHTMLTestContext();
+          ctx.container.register(Foo);
+          const au = new Aurelia(ctx.container);
+
+          const host = ctx.createElement('div');
+          const component = new App();
+
+          au.app({ host, component });
+          au.start();
+
+          expect(host.textContent, `[i=${i}]host.textContent`).to.equal(`replace-part-p`.repeat(i));
+          tearDown(au);
+        });
+      }
+    });
+
+    describe('with multiple replaceables + with nested replaceables + from 1 -> 10 siblings + from 1 -> nesting levels', function() {
+      // in this part, we will test replacing a replaceable somewhere between 1 -> 10 levels of nesting replaceable
+      // with only 1 replacement
+      const maxReplaceableSiblingCount = 10;
+      const maxDepth = 10;
+      const buildNestedReplaceableDiv = (baseSiblingIndex: number, nestedDepth: number) => {
+        let template = '';
+        let currentBaseLevel = 0;
+        while (baseSiblingIndex > currentBaseLevel) {
+          let currentDepth = 0;
+          let $template = `<div replaceable part="p-${currentBaseLevel}-0">replaceable-p-${currentBaseLevel}-0`;
+          while (nestedDepth > currentDepth) {
+            $template += `<div replaceable part="p-${currentBaseLevel}-${currentDepth}">replaceable-p-${currentBaseLevel}-${currentDepth}`;
+            ++currentDepth;
+          }
+          while (currentDepth > 0) {
+            $template += '</div>';
+            --currentDepth;
+          }
+          $template += '<div>';
+          template += $template;
+          ++currentBaseLevel;
+        }
+        return template;
+      };
+      const buildNestedReplacementTemplate = (baseSiblingIndex: number, nestedDepth: number) => {
+        return `<template replace-part="p-${baseSiblingIndex}-${nestedDepth}">replace-part-p${baseSiblingIndex}-${nestedDepth}</template>`;
+      };
+      const buildExpectedTextContent = (baseSiblingIndex: number, nestedDepth: number) => {
+        let currentBaseIndex = 0;
+        let finalTextContent = '';
+        while (maxReplaceableSiblingCount > currentBaseIndex) {
+          if (baseSiblingIndex > currentBaseIndex) {
+            let i = 0;
+            while (maxDepth > i) {
+              finalTextContent += `replaceable-p-${currentBaseIndex}-${i}`;
+              ++i;
+            }
+          } else if (baseSiblingIndex === currentBaseIndex) {
+            let currentDepth = 0;
+            /**
+             * <template replaceable>
+             *   <template replaceable>
+             *      <template replaceable>  <----- replacement here won't affect any level above it
+             *        <template>            <--x-- but will terminate all replacement after it
+             */
+            while (nestedDepth > currentDepth) {
+              finalTextContent += `replaceable-p-${currentBaseIndex}-${currentDepth}`;
+            }
+            finalTextContent += `replace-part-p-${currentBaseIndex}-${nestedDepth}`;
+          } else {
+            let i = 0;
+            while (maxDepth > i) {
+              finalTextContent += `replaceable-p-${currentBaseIndex}-${i}`;
+              ++i;
+            }
+          }
+          ++currentBaseIndex;
+        }
+        return finalTextContent;
+      };
+
+      for (let baseReplaceableCount = 0; 10 > baseReplaceableCount; ++baseReplaceableCount) {
+        for (let nestedDepth = 0; 10 > nestedDepth; ++nestedDepth) {
+          it(`works with replaceable on normal <div/>. Siblings count: ${baseReplaceableCount}`, function() {
+            const App = CustomElementResource.define(
+              { name: 'app', template:
+                `<template><foo>${buildNestedReplacementTemplate(baseReplaceableCount, nestedDepth)}</foo></template>`
+              },
+              class App {}
+            );
+            const Foo = CustomElementResource.define(
+              { name: 'foo', template: `<template>${buildNestedReplaceableDiv(baseReplaceableCount, nestedDepth)}</template>` },
+              class Foo {}
+            );
+
+            const ctx = TestContext.createHTMLTestContext();
+            ctx.container.register(Foo);
+            const au = new Aurelia(ctx.container);
+
+            const host = ctx.createElement('div');
+            const component = new App();
+
+            au.app({ host, component });
+            au.start();
+
+            expect(
+              host.textContent,
+              `[base=${baseReplaceableCount}, depth=${nestedDepth}]host.textContent`
+            ).to.equal(buildExpectedTextContent(baseReplaceableCount, nestedDepth));
+            tearDown(au);
+          });
+        }
+      }
+    });
+  });
+
+  interface ITestItem {
+    idx: number;
+    name: string;
+  }
+
+  function tearDown(au: Aurelia) {
+    au.stop();
+    (au.root().$host as Element).remove();
+  }
+
+  function createItems(count: number, baseName: string = 'item') {
+    return Array.from({ length: count }, (_, idx) => {
+      return { idx, name: `${baseName}-${idx}` }
+    });
+  }
 });

--- a/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
@@ -15,25 +15,23 @@ describe('replaceable', function () {
         const testCases: [string, HTMLElement, HTMLElement, ITestItem[], string][] = [
           [
             [
-              '\n----',
               '[repeat]',
-              '  [replaceable] <-- replace this'
+              '  [replaceable #0] << replace this'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">{'${item.name}'}</div>
             </div>,
             <foo>
-              <template replace-part="p0">replacement of {'${item.idx}-${item.name}'}</template>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            `replacement of 0-item-0replacement of 1-item-1`
+            `replacement of 0-item-0.replacement of 1-item-1`
           ],
           [
             [
-              '\n----',
               '[repeat]',
-              '  [replaceable] <-- replace this',
-              '    [replaceable]'
+              '  [replaceable #0] << replace this',
+              '    [replaceable #1]'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
@@ -42,17 +40,16 @@ describe('replaceable', function () {
               </div>
             </div>,
             <foo>
-              <template replace-part="p0">replacement of {'${item.idx}-${item.name}'}</template>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
             createExpectedReplacementText(2)
           ],
           [
             [
-              '\n----',
               '[repeat]',
-              '  [replaceable]',
-              '    [replaceable] <-- replace this'
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace this'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
@@ -61,17 +58,16 @@ describe('replaceable', function () {
               </div>
             </div>,
             <foo>
-              <template replace-part="p1">replacement of {'${item.idx}-${item.name}</>'}</template>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            'item-0replacement of 0-item-0</>item-1replacement of 1-item-1</>'
+            'item-0replacement of 0-item-0.item-1replacement of 1-item-1.'
           ],
           [
             [
-              '\n----',
-              '[replaceable]',
+              '[replaceable #0]',
               '  [repeat]',
-              '    [replaceable] <-- replace this'
+              '    [replaceable #1] << replace this'
             ].join('\n'),
             <div replaceable part="p0">
               item-0
@@ -80,10 +76,55 @@ describe('replaceable', function () {
               </div>
             </div>,
             <foo>
-              <template replace-part="p1">{'${item.idx}-${item.name}'}</template>
+              <template replace-part="p1">{'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            'item-0replacement of 0-item-0replacement of 1-item-1'
+            'item-0replacement of 0-item-0.replacement of 1-item-1.'
+          ],
+          [
+            [
+              '[repeat]',
+              '  [replaceable #0] << replace this',
+              '[repeat]',
+              '  [replaceable #0] << replace this'
+            ].join('\n'),
+            <div>
+              <div repeat$for="item of items">
+                <div replaceable part="p0">{'${item.name}'}</div>
+              </div>
+              <div repeat$for="item of items">
+                <div replaceable part="p0">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'replacement of 0-item0.replacement of 1-item-1.replacement of 0-item-0.replacement of 1-item-1'
+          ],
+          [
+            [
+              '[repeat]',
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace this',
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace this'
+            ].join('\n'),
+            <div repeat$for="item of items">
+              <div replaceable part="p0">
+                {'${item.name}.'}
+                <div replaceable part="p1">{'${item.name}.'}</div>
+              </div>
+              <div replaceable part="p0">
+                {'${item.name}.'}
+                <div replaceable part="p1">{'${item.name}.'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.item-0.replacement of 0-item-0.item-1.replacement of 1-item-1.item-1.replacement of 1-item-1.'
           ]
         ];
         for (
@@ -95,7 +136,7 @@ describe('replaceable', function () {
             expectedTextContent
           ] of testCases
         ) {
-          it(testTitle, function() {
+          it(`\n----\n${testTitle}`, function() {
             const Foo = CustomElementResource.define(
               { name: 'foo', template: <template>{fooContentTemplate}</template> },
               class Foo { items = fooItems }
@@ -104,6 +145,7 @@ describe('replaceable', function () {
               { name: 'app', template: <template>{appContentTemplate}</template> },
               class App { }
             );
+            debugger;
 
             const ctx = TestContext.createHTMLTestContext();
             ctx.container.register(Foo);
@@ -123,7 +165,7 @@ describe('replaceable', function () {
         function createExpectedReplacementText(count: number, itemBaseName: string = 'item') {
           let text = '';
           for (let i = 0; count > i; ++i) {
-            text += `replacement of ${i}-${itemBaseName}-${i}`
+            text += `replacement of ${i}-${itemBaseName}-${i}.`
           }
           return text;
         }

--- a/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
@@ -14,7 +14,11 @@ describe('replaceable', function () {
       describe('+ [repeat]', function() {
         const testCases: [string, HTMLElement, HTMLElement, ITestItem[], string][] = [
           [
-            `It works with: 1 level of [replaceable] + access member {item} of [repeat] BC`,
+            [
+              '\n----',
+              '[repeat]',
+              '  [replaceable] <-- replace this'
+            ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">{'${item.name}'}</div>
             </div>,
@@ -25,7 +29,12 @@ describe('replaceable', function () {
             `replacement of 0-item-0replacement of 1-item-1`
           ],
           [
-            `It works with 2 levels of [replaceable] + access memeber {item} of [repeat] BC in 1st [replaceable]`,
+            [
+              '\n----',
+              '[repeat]',
+              '  [replaceable] <-- replace this',
+              '    [replaceable]'
+            ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
                 {'${item.name}'}
@@ -39,7 +48,12 @@ describe('replaceable', function () {
             createExpectedReplacementText(2)
           ],
           [
-            `It works with 2 levels of [replaceable] + access member {item} of [repeat] BC in 2nd [replaceable]`,
+            [
+              '\n----',
+              '[repeat]',
+              '  [replaceable]',
+              '    [replaceable] <-- replace this'
+            ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
                 {'${item.name}'}
@@ -54,7 +68,8 @@ describe('replaceable', function () {
           ],
           [
             [
-              '\n----\n[replaceable]',
+              '\n----',
+              '[replaceable]',
               '  [repeat]',
               '    [replaceable] <-- replace this'
             ].join('\n'),

--- a/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
@@ -16,7 +16,7 @@ describe('replaceable', function () {
           [
             [
               '[repeat]',
-              '  [replaceable #0] << replace this'
+              '  [replaceable #0] << replace #0'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">{'${item.name}'}</div>
@@ -27,10 +27,22 @@ describe('replaceable', function () {
             createItems(2),
             `replacement of 0-item-0.replacement of 1-item-1`
           ],
+          // Same with previous, though [repeat] + [replaceable] are on same element
+          [
+            [
+              '[repeat] [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div repeat$for="item of items" replaceable part="p0">{'${item.name}'}</div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.replacement of 1-item-1`
+          ],
           [
             [
               '[repeat]',
-              '  [replaceable #0] << replace this',
+              '  [replaceable #0] << replace #0',
               '    [replaceable #1]'
             ].join('\n'),
             <div repeat$for="item of items">
@@ -43,13 +55,29 @@ describe('replaceable', function () {
               <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            createExpectedReplacementText(2)
+            `replacement of 0-item-0. replacement of 1-item-1.`
+          ],
+          // Same with previous, though [repeat] + [replaceable] are on same element
+          [
+            [
+              '[repeat] [replaceable #0] << replace #0',
+              '  [replaceable #1]'
+            ].join('\n'),
+            <div repeat$for="item of items" replaceable part="p0">
+              {'${item.name}'}
+              <div replaceable part="p1">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.replacement of 1-item-1.`
           ],
           [
             [
               '[repeat]',
               '  [replaceable #0]',
-              '    [replaceable #1] << replace this'
+              '    [replaceable #1] << replace #1'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
@@ -67,26 +95,42 @@ describe('replaceable', function () {
             [
               '[replaceable #0]',
               '  [repeat]',
-              '    [replaceable #1] << replace this'
+              '    [replaceable #1] << replace #1'
             ].join('\n'),
             <div replaceable part="p0">
-              item-0
+              item-0.
               <div repeat$for="item of items">
                 <div replaceable part="p1">{'${item.name}'}</div>
               </div>
             </div>,
             <foo>
-              <template replace-part="p1">{'${item.idx}-${item.name}.'}</template>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            'item-0replacement of 0-item-0.replacement of 1-item-1.'
+            'item-0.replacement of 0-item-0.replacement of 1-item-1.'
+          ],
+          [
+            [
+              '[replaceable #0]',
+              '  [repeat]',
+              '    [replaceable #1] << replace #1'
+            ].join('\n'),
+            <div replaceable part="p0">
+              item-0.
+              <div repeat$for="item of items" replaceable part="p1">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.replacement of 1-item-1.'
           ],
           [
             [
               '[repeat]',
-              '  [replaceable #0] << replace this',
+              '  [replaceable #0] << replace #0',
               '[repeat]',
-              '  [replaceable #0] << replace this'
+              '  [replaceable #0] << replace #0'
             ].join('\n'),
             <div>
               <div repeat$for="item of items">
@@ -100,15 +144,31 @@ describe('replaceable', function () {
               <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            'replacement of 0-item0.replacement of 1-item-1.replacement of 0-item-0.replacement of 1-item-1'
+            'replacement of 0-item-0.replacement of 1-item-1.replacement of 0-item-0.replacement of 1-item-1.'
+          ],
+          // Same with previous. Though [repeat] + [replaceable] are on same element
+          [
+            [
+              '[repeat] [replaceable #0] << replace #0',
+              '[repeat] [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div>
+              <div repeat$for="item of items" replaceable part="p0">{'${item.name}'}</div>
+              <div repeat$for="item of items" replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'replacement of 0-item-0.replacement of 1-item-1.replacement of 0-item-0.replacement of 1-item-1.'
           ],
           [
             [
               '[repeat]',
               '  [replaceable #0]',
-              '    [replaceable #1] << replace this',
+              '    [replaceable #1] << replace #1',
               '  [replaceable #0]',
-              '    [replaceable #1] << replace this'
+              '    [replaceable #1] << replace #1'
             ].join('\n'),
             <div repeat$for="item of items">
               <div replaceable part="p0">
@@ -129,7 +189,7 @@ describe('replaceable', function () {
           [
             [
               '[repeat]',
-              '  [replaceable #0] << replace this',
+              '  [replaceable #0] << replace #0',
               '🔻',
               '[foo]',
               '  [${}] <-- by interpolation binding from consumer'
@@ -150,12 +210,36 @@ describe('replaceable', function () {
                 .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia');
             }
           ],
+          // Same with previous. Though [repeat] + [replaceable] are on same element
+          [
+            [
+              '[repeat] [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              '  [${}] <-- by interpolation binding from consumer'
+            ].join('\n'),
+            <div repeat$for="item of items" replaceable part="p0">{'${item.name}'}</div>,
+            <foo>
+              <template replace-part="p0">{'${item.idx}-${item.name}. Message: ${message}.'}</template>
+            </foo>,
+            createItems(2),
+            `0-item-0. Message: Aurelia.1-item-1 Message: Aurelia`,
+            async (host, app, foo) => {
+              app.message = 'Hello world from Aurelia';
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia');
+            }
+          ],
           [
             [
               '[repeat]',
-              '  [replaceable #0] << replace this',
+              '  [replaceable #0] << replace #0',
               '🔻',
               '[foo]',
+              // note that we are not repeating this template, as it seems to be incorrect usage
+              // if there are two replace-part aiming for 1 replaceable, which should be the right one?
               '  [template r#0]',
               '    [repeat] <-- by a repeat'
             ].join('\n'),
@@ -168,7 +252,75 @@ describe('replaceable', function () {
               </template>
             </foo>,
             createItems(2),
-            `0-item-0.1-item-1.0-item-0.1-item-1.`
+            `0-item-0.1-item-1.0-item-0.1-item-1.`,
+            async (host, app, foo) => {
+              foo.items = createItems(3, 'ITEM');
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal(`0-ITEM-0.1-ITEM-1.2-ITEM-2.`.repeat(3));
+              
+              foo.items = [];
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[]').to.equal('');
+
+              foo.items.push(...createItems(1));
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[1]').to.equal('0-item-0.');
+
+              foo.items.push(...createItems(2).slice(1));
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[1]').to.equal('0-item-0.1-item-1.');
+
+              foo.items.sort((i1, i2) => i1.idx > i2.idx ? -1 : 1);
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[0🔁1]').to.equal('1-item-1.0-item-0.');
+            }
+          ],
+          // Same with previous. Though [repeat] + [replaceable] are on same element
+          [
+            [
+              '[repeat] [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              // note that we are not repeating this template, as it seems to be incorrect usage
+              // if there are two replace-part aiming for 1 replaceable, which should be the right one?
+              '  [template r#0]',
+              '    [repeat] <-- by a repeat'
+            ].join('\n'),
+            <div repeat$for="item of items">
+              <div replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">
+                <template repeat$for="item of items">{'${item.idx}-${item.name}.'}</template>
+              </template>
+            </foo>,
+            createItems(2),
+            `0-item-0.1-item-1.0-item-0.1-item-1.`,
+            async (host, app, foo) => {
+              foo.items = createItems(3, 'ITEM');
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal(`0-ITEM-0.1-ITEM-1.2-ITEM-2.`.repeat(3));
+              
+              foo.items = [];
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[]').to.equal('');
+
+              foo.items.push(...createItems(1));
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[1]').to.equal('0-item-0.');
+
+              foo.items.push(...createItems(2).slice(1));
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[1]').to.equal('0-item-0.1-item-1.');
+
+              foo.items.sort((i1, i2) => i1.idx > i2.idx ? -1 : 1);
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[0🔁1]').to.equal('1-item-1.0-item-0.');
+            }
           ]
         ];
         for (

--- a/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_n_tc.spec.tsx
@@ -1,0 +1,138 @@
+import { Aurelia, CustomElementResource } from '@aurelia/runtime';
+import { expect } from 'chai';
+import { TestContext } from '../util';
+import { h } from './util';
+
+// IMPORTANT:
+//      JSX is used to eliminate space between tags so test result can be easier to manually constructed
+//      if template string can be used to achieve the same effect, it could be converted back
+
+describe('replaceable', function () {
+
+  describe.only('Difficult cases', function() {
+    describe.only('+ scope altering template controllers', function() {
+      describe('+ [repeat]', function() {
+        const testCases: [string, HTMLElement, HTMLElement, ITestItem[], string][] = [
+          [
+            `It works with: 1 level of [replaceable] + access member {item} of [repeat] BC`,
+            <div repeat$for="item of items">
+              <div replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0replacement of 1-item-1`
+          ],
+          [
+            `It works with 2 levels of [replaceable] + access memeber {item} of [repeat] BC in 1st [replaceable]`,
+            <div repeat$for="item of items">
+              <div replaceable part="p0">
+                {'${item.name}'}
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}'}</template>
+            </foo>,
+            createItems(2),
+            createExpectedReplacementText(2)
+          ],
+          [
+            `It works with 2 levels of [replaceable] + access member {item} of [repeat] BC in 2nd [replaceable]`,
+            <div repeat$for="item of items">
+              <div replaceable part="p0">
+                {'${item.name}'}
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}</>'}</template>
+            </foo>,
+            createItems(2),
+            'item-0replacement of 0-item-0</>item-1replacement of 1-item-1</>'
+          ],
+          [
+            [
+              '\n----\n[replaceable]',
+              '  [repeat]',
+              '    [replaceable] <-- replace this'
+            ].join('\n'),
+            <div replaceable part="p0">
+              item-0
+              <div repeat$for="item of items">
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">{'${item.idx}-${item.name}'}</template>
+            </foo>,
+            createItems(2),
+            'item-0replacement of 0-item-0replacement of 1-item-1'
+          ]
+        ];
+        for (
+          const [
+            testTitle,
+            fooContentTemplate,
+            appContentTemplate,
+            fooItems,
+            expectedTextContent
+          ] of testCases
+        ) {
+          it(testTitle, function() {
+            const Foo = CustomElementResource.define(
+              { name: 'foo', template: <template>{fooContentTemplate}</template> },
+              class Foo { items = fooItems }
+            );
+            const App = CustomElementResource.define(
+              { name: 'app', template: <template>{appContentTemplate}</template> },
+              class App { }
+            );
+
+            const ctx = TestContext.createHTMLTestContext();
+            ctx.container.register(Foo);
+            const au = new Aurelia(ctx.container);
+
+            const host = ctx.createElement('div');
+            const component = new App();
+
+            au.app({ host, component });
+            au.start();
+
+            expect(host.textContent, `host.textContent`).to.equal(expectedTextContent);
+            tearDown(au);
+          });
+        }
+
+        function createExpectedReplacementText(count: number, itemBaseName: string = 'item') {
+          let text = '';
+          for (let i = 0; count > i; ++i) {
+            text += `replacement of ${i}-${itemBaseName}-${i}`
+          }
+          return text;
+        }
+      });
+
+      describe('+ [with]', function() {
+
+      });
+    });
+  });
+
+  interface ITestItem {
+    idx: number;
+    name: string;
+  }
+
+  function tearDown(au: Aurelia) {
+    au.stop();
+    (au.root().$host as Element).remove();
+  }
+
+  function createItems(count: number, baseName: string = 'item') {
+    return Array.from({ length: count }, (_, idx) => {
+      return { idx, name: `${baseName}-${idx}` }
+    });
+  }
+});

--- a/packages/jit-html/test/integration/replaceable_repeat.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_repeat.spec.tsx
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElementResource, ICustomElement } from '@aurelia/runtime';
 import { expect } from 'chai';
-import { TestContext } from '../util';
-import { h } from './util';
+import { TestContext, HTMLTestContext } from '../util';
+import { hJsx } from './util';
 
 // IMPORTANT:
 //      JSX is used to eliminate space between tags so test result can be easier to manually constructed

--- a/packages/jit-html/test/integration/replaceable_repeat.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_repeat.spec.tsx
@@ -7,10 +7,10 @@ import { h } from './util';
 //      JSX is used to eliminate space between tags so test result can be easier to manually constructed
 //      if template string can be used to achieve the same effect, it could be converted back
 
-describe('replaceable', function () {
+describe.skip('replaceable', function () {
 
-  describe.only('Difficult cases', function() {
-    describe.only('+ scope altering template controllers', function() {
+  describe('Difficult cases', function() {
+    describe('+ scope altering template controllers', function() {
       describe('+ [repeat]', function() {
         const testCases: [string, HTMLElement, HTMLElement, ITestItem[], string, ICustomAssertion?][] = [
           [
@@ -25,7 +25,7 @@ describe('replaceable', function () {
               <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            `replacement of 0-item-0.replacement of 1-item-1`
+            `replacement of 0-item-0.replacement of 1-item-1.`
           ],
           // Same with previous, though [repeat] + [replaceable] are on same element
           [
@@ -37,7 +37,7 @@ describe('replaceable', function () {
               <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            `replacement of 0-item-0.replacement of 1-item-1`
+            `replacement of 0-item-0.replacement of 1-item-1.`
           ],
           [
             [
@@ -55,7 +55,7 @@ describe('replaceable', function () {
               <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
             </foo>,
             createItems(2),
-            `replacement of 0-item-0. replacement of 1-item-1.`
+            `replacement of 0-item-0.replacement of 1-item-1.`
           ],
           // Same with previous, though [repeat] + [replaceable] are on same element
           [
@@ -201,13 +201,13 @@ describe('replaceable', function () {
               <template replace-part="p0">{'${item.idx}-${item.name}. Message: ${message}.'}</template>
             </foo>,
             createItems(2),
-            `0-item-0. Message: Aurelia.1-item-1 Message: Aurelia`,
+            `0-item-0. Message: Aurelia.1-item-1 Message: Aurelia.`,
             async (host, app, foo) => {
               app.message = 'Hello world from Aurelia';
               await Promise.resolve();
               expect(host.textContent, 'host.textContent@changed')
                 .to
-                .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia');
+                .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia.');
             }
           ],
           // Same with previous. Though [repeat] + [replaceable] are on same element
@@ -223,13 +223,13 @@ describe('replaceable', function () {
               <template replace-part="p0">{'${item.idx}-${item.name}. Message: ${message}.'}</template>
             </foo>,
             createItems(2),
-            `0-item-0. Message: Aurelia.1-item-1 Message: Aurelia`,
+            `0-item-0. Message: Aurelia.1-item-1 Message: Aurelia.`,
             async (host, app, foo) => {
               app.message = 'Hello world from Aurelia';
               await Promise.resolve();
               expect(host.textContent, 'host.textContent@changed')
                 .to
-                .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia');
+                .equal('0-item-0. Message: Hello world from Aurelia.1-item-1. Message: Hello world from Aurelia.');
             }
           ],
           [
@@ -288,9 +288,7 @@ describe('replaceable', function () {
               '  [template r#0]',
               '    [repeat] <-- by a repeat'
             ].join('\n'),
-            <div repeat$for="item of items">
-              <div replaceable part="p0">{'${item.name}'}</div>
-            </div>,
+            <div repeat$for="item of items" replaceable part="p0">{'${item.name}'}</div>,
             <foo>
               <template replace-part="p0">
                 <template repeat$for="item of items">{'${item.idx}-${item.name}.'}</template>
@@ -376,10 +374,6 @@ describe('replaceable', function () {
           }
           return text;
         }
-      });
-
-      describe('+ [with]', function() {
-
       });
     });
   });

--- a/packages/jit-html/test/integration/replaceable_with.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_with.spec.tsx
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElementResource, ICustomElement } from '@aurelia/runtime';
 import { expect } from 'chai';
-import { TestContext } from '../util';
-import { h } from './util';
+import { TestContext, HTMLTestContext } from '../util';
+import { hJsx } from './util';
 
 // IMPORTANT:
 //      JSX is used to eliminate space between tags so test result can be easier to manually constructed

--- a/packages/jit-html/test/integration/replaceable_with.spec.tsx
+++ b/packages/jit-html/test/integration/replaceable_with.spec.tsx
@@ -1,0 +1,360 @@
+import { Aurelia, CustomElementResource, ICustomElement } from '@aurelia/runtime';
+import { expect } from 'chai';
+import { TestContext } from '../util';
+import { h } from './util';
+
+// IMPORTANT:
+//      JSX is used to eliminate space between tags so test result can be easier to manually constructed
+//      if template string can be used to achieve the same effect, it could be converted back
+
+describe.skip('replaceable', function () {
+
+  describe('Difficult cases', function() {
+    describe('+ scope altering template controllers', function() {
+      describe('+ [with]', function() {
+        const testCases: [string, HTMLElement, HTMLElement, ITestItem[], string, ICustomAssertion?][] = [
+          [
+            [
+              '[with]',
+              '  [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.`
+          ],
+          // Same with previous, though [with] + [replaceable] are on same element
+          [
+            [
+              '[with] [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div with$="{ item: items[0] }" replaceable part="p0">{'${item.name}'}</div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.`
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0] << replace #0',
+              '    [replaceable #1]'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">
+                {'${item.name}'}
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.`
+          ],
+          // Same with previous, though [with] + [replaceable] are on same element
+          [
+            [
+              '[with] [replaceable #0] << replace #0',
+              '  [replaceable #1]'
+            ].join('\n'),
+            <div with$="{ item: items[0] }" replaceable part="p0">
+              {'${item.name}'}
+              <div replaceable part="p1">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            `replacement of 0-item-0.`
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace #1'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">
+                {'${item.name}.'}
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.'
+          ],
+          [
+            [
+              '[replaceable #0]',
+              '  [with]',
+              '    [replaceable #1] << replace #1'
+            ].join('\n'),
+            <div replaceable part="p0">
+              item-0.
+              <div with$="{ item: items[0] }">
+                <div replaceable part="p1">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.'
+          ],
+          [
+            [
+              '[replaceable #0]',
+              '  [with]',
+              '    [replaceable #1] << replace #1'
+            ].join('\n'),
+            <div replaceable part="p0">
+              item-0.
+              <div with$="{ item: items[0] }" replaceable part="p1">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.'
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0] << replace #0',
+              '[with]',
+              '  [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div>
+              <div with$="{ item: items[0] }">
+                <div replaceable part="p0">{'${item.name}'}</div>
+              </div>
+              <div with$="{ item: items[0] }">
+                <div replaceable part="p0">{'${item.name}'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'replacement of 0-item-0.replacement of 0-item-0.'
+          ],
+          // Same with previous. Though [with] + [replaceable] are on same element
+          [
+            [
+              '[with] [replaceable #0] << replace #0',
+              '[with] [replaceable #0] << replace #0'
+            ].join('\n'),
+            <div>
+              <div with$="{ item: items[0] }" replaceable part="p0">{'${item.name}'}</div>
+              <div with$="{ item: items[0] }" replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'replacement of 0-item-0.replacement of 0-item-0.'
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace #1',
+              '  [replaceable #0]',
+              '    [replaceable #1] << replace #1'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">
+                {'${item.name}.'}
+                <div replaceable part="p1">{'${item.name}.'}</div>
+              </div>
+              <div replaceable part="p0">
+                {'${item.name}.'}
+                <div replaceable part="p1">{'${item.name}.'}</div>
+              </div>
+            </div>,
+            <foo>
+              <template replace-part="p1">replacement of {'${item.idx}-${item.name}.'}</template>
+            </foo>,
+            createItems(2),
+            'item-0.replacement of 0-item-0.item-0.replacement of 0-item-0.'
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              '  [${}] <-- by interpolation binding from consumer'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">{'${item.idx}-${item.name}. Message: ${message}.'}</template>
+            </foo>,
+            createItems(2),
+            `0-item-0. Message: Aurelia.`,
+            async (host, app, foo) => {
+              app.message = 'Hello world from Aurelia';
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal('0-item-0. Message: Hello world from Aurelia.');
+            }
+          ],
+          // Same with previous. Though [with] + [replaceable] are on same element
+          [
+            [
+              '[with] [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              '  [${}] <-- by interpolation binding from consumer'
+            ].join('\n'),
+            <div with$="{ item: items[0] }" replaceable part="p0">{'${item.name}'}</div>,
+            <foo>
+              <template replace-part="p0">{'${item.idx}-${item.name}. Message: ${message}.'}</template>
+            </foo>,
+            createItems(2),
+            `0-item-0. Message: Aurelia.`,
+            async (host, app, foo) => {
+              app.message = 'Hello world from Aurelia';
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal('0-item-0. Message: Hello world from Aurelia.');
+            }
+          ],
+          [
+            [
+              '[with]',
+              '  [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              '  [template r#0]',
+              '    [with] <-- by a with'
+            ].join('\n'),
+            <div with$="{ item: items[0] }">
+              <div replaceable part="p0">{'${item.name}'}</div>
+            </div>,
+            <foo>
+              <template replace-part="p0">
+                <template with$="{ item: items[0] }">{'${item.idx}-${item.name}.'}</template>
+              </template>
+            </foo>,
+            createItems(2),
+            `0-item-0.`,
+            async (host, app, foo) => {
+              foo.items = createItems(3, 'ITEM');
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal(`0-ITEM-0`);
+
+              foo.items = [];
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[]').to.equal('');
+            }
+          ],
+          // Same with previous. Though [with] + [replaceable] are on same element
+          [
+            [
+              '[with] [replaceable #0] << replace #0',
+              '🔻',
+              '[foo]',
+              '  [template r#0]',
+              '    [with] <-- by a with'
+            ].join('\n'),
+            <div with$="{ item: items[0] }" replaceable part="p0">{'${item.name}'}</div>,
+            <foo>
+              <template replace-part="p0">
+                <template with$="{ item: items[0] }">{'${item.idx}-${item.name}.'}</template>
+              </template>
+            </foo>,
+            createItems(2),
+            `0-item-0.`,
+            async (host, app, foo) => {
+              foo.items = createItems(3, 'ITEM');
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@changed')
+                .to
+                .equal(`0-ITEM-0.`);
+
+              foo.items = [];
+              await Promise.resolve();
+              expect(host.textContent, 'host.textContent@[]').to.equal('');
+            }
+          ]
+        ];
+        for (
+          const [
+            testTitle,
+            fooContentTemplate,
+            appContentTemplate,
+            fooItems,
+            expectedTextContent,
+            customAssertion
+          ] of testCases
+        ) {
+          it(`\n----\n${testTitle}`, async function() {
+            const Foo = CustomElementResource.define(
+              { name: 'foo', template: <template>{fooContentTemplate}</template> },
+              class Foo { items = fooItems }
+            );
+            const App = CustomElementResource.define(
+              { name: 'app', template: <template>{appContentTemplate}</template> },
+              class App { message = 'Aurelia' }
+            );
+
+            const ctx = TestContext.createHTMLTestContext();
+            ctx.container.register(Foo);
+            const au = new Aurelia(ctx.container);
+
+            const host = ctx.createElement('div');
+            const component = new App();
+
+            au.app({ host, component });
+            au.start();
+            
+            expect(host.textContent, `host.textContent`).to.equal(expectedTextContent);
+            if (customAssertion) {
+              await customAssertion(host, component, component.$componentHead as any as IFoo);
+            }
+            tearDown(au);
+          });
+        }
+
+        interface IFoo {
+          items: ITestItem[];
+        }
+        interface IApp {
+          message: string;
+        }
+        type ICustomAssertion = (host: HTMLElement, app: IApp, foo: IFoo) => void;
+      });
+    });
+  });
+
+  interface ITestItem {
+    idx: number;
+    name: string;
+  }
+
+  function tearDown(au: Aurelia) {
+    au.stop();
+    (au.root().$host as Element).remove();
+  }
+
+  function createItems(count: number, baseName: string = 'item') {
+    return Array.from({ length: count }, (_, idx) => {
+      return { idx, name: `${baseName}-${idx}` }
+    });
+  }
+});

--- a/packages/jit-html/test/integration/util.ts
+++ b/packages/jit-html/test/integration/util.ts
@@ -24,6 +24,9 @@ import {
   stringify,
   verifyEqual
 } from '../../../../scripts/test-lib';
+import {
+  h
+} from '../../../../scripts/test-lib-dom';
 import { HTMLTestContext, TestContext } from '../util';
 
 export function cleanup(ctx: HTMLTestContext): void {
@@ -84,14 +87,14 @@ export function trimFull(text: string) {
   return text.replace(reg, '');
 }
 
-export { _, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinFactory };
+export { _, h, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinFactory };
 
 const eventCmds = { delegate: 1, capture: 1, call: 1 };
 
 /**
  * jsx with aurelia binding command friendly version of h
  */
-export const h = (name: string, attrs: Record<string, string> | null, ...children: (Node | string)[]) => {
+export const hJsx = function(name: string, attrs: Record<string, string> | null, ...children: (Node | string)[]) {
   const el = document.createElement(name === 'let$' ? 'let' : name);
   if (attrs !== null) {
     let value: string | string[];

--- a/packages/jit-html/test/integration/util.ts
+++ b/packages/jit-html/test/integration/util.ts
@@ -24,7 +24,6 @@ import {
   stringify,
   verifyEqual
 } from '../../../../scripts/test-lib';
-import { h } from '../../../../scripts/test-lib-dom';
 import { HTMLTestContext, TestContext } from '../util';
 
 export function cleanup(ctx: HTMLTestContext): void {
@@ -85,4 +84,73 @@ export function trimFull(text: string) {
   return text.replace(reg, '');
 }
 
-export { _, h, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinFactory };
+export { _, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinFactory };
+
+const eventCmds = { delegate: 1, capture: 1, call: 1 };
+
+/**
+ * jsx with aurelia binding command friendly version of h
+ */
+export const h = (name: string, attrs: Record<string, string> | null, ...children: (Node | string)[]) => {
+  const el = document.createElement(name === 'let$' ? 'let' : name);
+  if (attrs !== null) {
+    let value: string | string[];
+    let len: number;
+    for (const attr in attrs) {
+      value = attrs[attr];
+      // if attr is class or its alias
+      // split up by splace and add to element via classList API
+      if (attr === 'class' || attr === 'className' || attr === 'cls') {
+        value = value === undefined || value === null
+          ? []
+          : Array.isArray(value)
+            ? value
+            : ('' + value).split(' ');
+        el.classList.add(...value as string[]);
+      }
+      // for attributes with matching properties, simply assign
+      // other if special attribute like data, or ones start with _
+      // assign as well
+      else if (attr in el || attr === 'data' || attr[0] === '_') {
+        el[attr] = value;
+      }
+      // if it's an asElement attribute, camel case it
+      else if (attr === 'asElement') {
+        el.setAttribute('as-element', value);
+      }
+      // ortherwise do fallback check
+      else {
+        // is it an event handler?
+        if (attr[0] === 'o' && attr[1] === 'n' && attr[attr.length] !== '$') {
+          const decoded = PLATFORM.kebabCase(attr.slice(2));
+          const parts = decoded.split('-');
+          if (parts.length > 1) {
+            const lastPart = parts[parts.length - 1];
+            const cmd = eventCmds[lastPart] ? lastPart : 'trigger';
+            el.setAttribute(`${parts.slice(0, -1).join('-')}.${cmd}`, value);
+          } else {
+            el.setAttribute(`${parts[0]}.trigger`, value);
+          }
+        } else {
+          const len = attr.length;
+          const lastIdx = attr.lastIndexOf('$');
+          if (lastIdx === -1) {
+            el.setAttribute(PLATFORM.kebabCase(attr), value);
+          } else {
+            let cmd = attr.slice(lastIdx + 1);
+            cmd = cmd ? PLATFORM.kebabCase(cmd) : 'bind';
+            el.setAttribute(`${PLATFORM.kebabCase(attr.slice(0, lastIdx))}.${cmd}`, value);
+          }
+        }
+      }
+    }
+  }
+  const appender = (el instanceof HTMLTemplateElement) ? el.content : el;
+  for (const child of children) {
+    if (child === null || child === undefined) {
+      continue;
+    }
+    appender.appendChild(child instanceof Node ? child : document.createTextNode('' + child));
+  }
+  return el;
+}

--- a/packages/jit-html/test/tsconfig.json
+++ b/packages/jit-html/test/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "../tsconfig-test.json"
+  "extends": "../tsconfig-test.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "jsxFactory": "h"
+  }
 }

--- a/packages/jit-html/test/tsconfig.json
+++ b/packages/jit-html/test/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../tsconfig-test.json",
   "compilerOptions": {
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "hJsx"
   }
 }

--- a/scripts/karma.conf.ts
+++ b/scripts/karma.conf.ts
@@ -84,7 +84,7 @@ export default function(config: IKarmaConfig): void {
       devtool: browsers.indexOf('ChromeDebugging') > -1 ? 'eval-source-map' : 'inline-source-map',
       module: {
         rules: [{
-          test: /\.ts$/,
+          test: /\.tsx?$/,
           loader: 'ts-loader',
           exclude: /node_modules/,
           options: {

--- a/scripts/tsconfig.test.json
+++ b/scripts/tsconfig.test.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "target": "es2018",
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "hJsx"
   },
   "include": [
     "../packages/*/src",

--- a/scripts/tsconfig.test.json
+++ b/scripts/tsconfig.test.json
@@ -11,7 +11,9 @@
     "preserveConstEnums": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "es2018"
+    "target": "es2018",
+    "jsx": "react",
+    "jsxFactory": "h"
   },
   "include": [
     "../packages/*/src",


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds test cases (most are failing) for many common scenarios where `[replaceable]` is being used in conjunction with important template controllers `[repeat]`, `[with]`

### 🎫 Issues

Backward compatibility and feature completeness

## 👩‍💻 Reviewer Notes

I started to use some JSX as empty space in is hard to eliminate within the middle of template string

## 📑 Test Plan

N/A

## ⏭ Next Steps

Moar tests

@EisenbergEffect @fkleuver 