### PR TITLE
Dynamic routing: clean up history pop

### DIFF
--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -92,8 +92,8 @@ export class ViewportContent {
     // Don't terminate cached content
     if (!stateful) {
       this.component.$unbind(LifecycleFlags.fromStopTask | LifecycleFlags.fromUnbind);
+      this.contentStatus = ContentStatus.loaded;
     }
-    this.contentStatus = ContentStatus.loaded;
   }
 
   public addComponent(element: Element): void {

--- a/packages/router/test/e2e/doc-example/src/app.ts
+++ b/packages/router/test/e2e/doc-example/src/app.ts
@@ -23,8 +23,19 @@ import { State } from './state';
       and the navigation is rolled back after 2 seconds.)
     </div>
     <div class="info">
-    <label><input type="checkbox" checked.two-way="state.noDelay">Disable loading delays for components</label><br>
-    <label><input type="checkbox" checked.two-way="state.allowEnterAuthorDetails">Allow entering <i>Author details</i></label><br>
+      <label><input type="checkbox" checked.two-way="state.noDelay">Disable loading delays for components</label><br>
+      <label><input type="checkbox" checked.two-way="state.allowEnterAuthorDetails">Allow entering <i>Author details</i></label><br>
+    </div>
+    <div class="info">
+      <select value.two-way="color">
+        <option value="yellow">Yellow</option>
+        <option value="green">Green</option>
+      <select>
+      <div style="--primary-color: \${color}">
+        <div style="background-color: var(--primary-color)">
+          The background is in the --primary-color: \${color}.
+        </div>
+      </div>
     </div>
     <au-viewport name="lists" used-by="authors,books" default="authors"></au-viewport>
     <au-viewport name="content" stateful default="about"></au-viewport>
@@ -33,6 +44,7 @@ import { State } from './state';
 </template>
 ` })
 export class App {
+  public color: string = 'green';
   constructor(private readonly router: Router, authorsRepository: AuthorsRepository, private readonly state: State) {
     authorsRepository.authors(); // Only here to initialize repositories
     this.router.activate({


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the `pop` method take advantage of the new suppress popstate event parameter of the `go` method in the queued browser history.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Some low hanging fruit before the bigger refactoring continues.

## 📑 Test Plan

- Tests still pass.

## ⏭ Next Steps

- Continue refactor
