### PR TITLE
Dynamic routing: clean up history cancel

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -113,11 +113,6 @@ export class Router {
       this.options.reportCallback(instruction);
     }
 
-    if (instruction.isCancel) {
-      this.processingNavigation = null;
-      return this.processNavigations();
-    }
-
     let fullStateInstruction: boolean = false;
     if ((instruction.isBack || instruction.isForward) && instruction.fullStatePath) {
       instruction.path = instruction.fullStatePath;
@@ -382,6 +377,7 @@ export class Router {
   }
 
   private async cancelNavigation(updatedViewports: Viewport[], instruction: INavigationInstruction): Promise<void> {
+    // TODO: Take care of disabling viewports when cancelling and stateful!
     updatedViewports.forEach((viewport) => {
       viewport.abortContentChange().catch(error => { throw error; });
     });

--- a/packages/router/test/e2e/doc-example/index.ejs
+++ b/packages/router/test/e2e/doc-example/index.ejs
@@ -158,7 +158,7 @@
 
     div.scrollbox {
       height: 75px;
-      background-color: lightgreen;
+      background-color: var(--primary-color);
     }
 
     .close {

--- a/packages/router/test/e2e/doc-example/src/app.ts
+++ b/packages/router/test/e2e/doc-example/src/app.ts
@@ -11,7 +11,7 @@ import { State } from './state';
 @customElement({
   name: 'app', template:
     `<template>
-  <div class="\${router.isNavigating ? 'routing' : ''}">
+  <div class="\${router.isNavigating ? 'routing' : ''}" style="--primary-color: \${color}">
     <div>
       <au-nav name="app-menu"></au-nav>
       <span class="loader \${router.isNavigating ? 'routing' : ''}">&nbsp;</span>
@@ -28,13 +28,11 @@ import { State } from './state';
     </div>
     <div class="info">
       <select value.two-way="color">
-        <option value="yellow">Yellow</option>
-        <option value="green">Green</option>
+        <option value="lightblue">Light blue</option>
+        <option value="lightgreen">Light green</option>
       <select>
-      <div style="--primary-color: \${color}">
-        <div style="background-color: var(--primary-color)">
-          The background is in the --primary-color: \${color}.
-        </div>
+      <div style="background-color: var(--primary-color)">
+        The background is in the --primary-color: \${color}.
       </div>
     </div>
     <au-viewport name="lists" used-by="authors,books" default="authors"></au-viewport>
@@ -44,7 +42,7 @@ import { State } from './state';
 </template>
 ` })
 export class App {
-  public color: string = 'green';
+  public color: string = 'lightgreen';
   constructor(private readonly router: Router, authorsRepository: AuthorsRepository, private readonly state: State) {
     authorsRepository.authors(); // Only here to initialize repositories
     this.router.activate({


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the `cancel` method take advantage of the new suppress popstate event parameter of the `go` method in the queued browser history.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Some low hanging fruit before the bigger refactoring continues.

## 📑 Test Plan

- Tests still pass.

## ⏭ Next Steps

- Continue refactor
