### PR TITLE
Dynamic routing: remove redirect from history browser

### DIFF
--- a/packages/router/src/history-browser.ts
+++ b/packages/router/src/history-browser.ts
@@ -45,7 +45,6 @@ export class HistoryBrowser {
   private isActive: boolean;
 
   private lastHistoryMovement: number;
-  private cancelRedirectHistoryMovement: number;
   private isReplacing: boolean;
   private isRefreshing: boolean;
 
@@ -64,7 +63,6 @@ export class HistoryBrowser {
     this.isActive = false;
 
     this.lastHistoryMovement = null;
-    this.cancelRedirectHistoryMovement = null;
     this.isReplacing = false;
     this.isRefreshing = false;
   }
@@ -109,11 +107,6 @@ export class HistoryBrowser {
     };
     return this.setPath(path, true);
   }
-  public redirect(path: string, title?: string, data?: Record<string, unknown>): Promise<void> {
-    // This makes sure we can cancel redirects from both pushes and replaces
-    this.cancelRedirectHistoryMovement = this.lastHistoryMovement + 1;
-    return this.replace(path, title, data);
-  }
 
   public async refresh(): Promise<void> {
     if (!this.currentEntry) {
@@ -132,7 +125,7 @@ export class HistoryBrowser {
   }
 
   public cancel(): Promise<void> {
-    const movement = this.lastHistoryMovement || this.cancelRedirectHistoryMovement;
+    const movement = this.lastHistoryMovement;
     if (movement) {
       this.lastHistoryMovement = 0;
       return this.history.go(-movement, true);
@@ -291,10 +284,6 @@ export class HistoryBrowser {
       this.currentEntry = historyEntry;
     }
     this.activeEntry = null;
-
-    if (this.cancelRedirectHistoryMovement) {
-      this.cancelRedirectHistoryMovement--;
-    }
 
     Reporter.write(10000, 'navigated', this.getState('HistoryEntry'), this.historyEntries, this.getState('HistoryOffset'));
     this.callback(this.currentEntry, navigationFlags, previousEntry);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -39,7 +39,6 @@ export class Router {
 
   private options: IRouterOptions;
   private isActive: boolean = false;
-  private isRedirecting: boolean = false;
 
   private readonly pendingNavigations: INavigationInstruction[] = [];
   private processingNavigation: INavigationInstruction = null;
@@ -194,16 +193,6 @@ export class Router {
         if (vp.setNextContent(vp.options.default, instruction)) {
           changedViewports.push(vp);
         }
-      }
-
-      // We've gone via a redirected route back to same viewport status so
-      // we need to remove the added history entry for the redirect
-      // TODO: Take care of empty subsets/iterations where previous has length
-      if (!changedViewports.length && this.isRedirecting) {
-        const result = this.cancelNavigation([...changedViewports, ...updatedViewports], instruction);
-        this.isRedirecting = false;
-        await this.processNavigations();
-        return result;
       }
 
       let results = await Promise.all(changedViewports.map((value) => value.canLeave()));


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the `redirect` method from history browser.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Some low hanging fruit before the bigger refactoring continues. This should be reviewed and merged after https://github.com/aurelia/aurelia/pull/438.

## 📑 Test Plan

- Tests still pass.

## ⏭ Next Steps

- Continue refactor
