### PR TITLE
Dynamic routing: RouteTable skeleton and extension points

### DIFF
--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -2,7 +2,7 @@ import { Router } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 /**
- * Class that handles routes configured into a route table
+ * Class that handles routes configured in a route table
  */
 export class RouteTable {
 
@@ -32,11 +32,11 @@ export class RouteTable {
     if (this.matchViewportInstructions(instructions, components)) {
       return 'welcome';
     }
-
     return instructions;
   }
 
-  // Check if instruction sets matches
+  // Check if instruction sets match. NOT COMPLETE CODE: it should also check viewport
+  // and, possibly, parameters (or their configuration)
   private matchViewportInstructions(instructionsA: ViewportInstruction[], instructionsB: ViewportInstruction[]): boolean {
     for (const instruction of instructionsA) {
       if (!instructionsB.find((i) => i.sameComponent(instruction))) {

--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -14,9 +14,7 @@ export class RouteTable {
    * @returns The viewport instructions for a found route or the route if not found.
    */
   public transformFromUrl = (route: string, router: Router): string | ViewportInstruction[] => {
-    if (route === 'welcome' || route === '/welcome') {
-      return [new ViewportInstruction('books'), new ViewportInstruction('about')];
-    }
+    // TODO: Implement route recognizing to transform a configured route to a set of viewport instructions
     return route;
   }
 
@@ -28,26 +26,7 @@ export class RouteTable {
    * @returns The route for a found set of viewport instructions or the viewport instructions if not found.
    */
   public transformToUrl = (instructions: ViewportInstruction[], router: Router): string | ViewportInstruction[] => {
-    const components = router.instructionResolver.viewportInstructionsFromString('books+about');
-    if (this.matchViewportInstructions(instructions, components)) {
-      return 'welcome';
-    }
+    // TODO: Implement mapping from set of viewport instructions to a configured route
     return instructions;
-  }
-
-  // Check if instruction sets match. NOT COMPLETE CODE: it should also check viewport
-  // and, possibly, parameters (or their configuration)
-  private matchViewportInstructions(instructionsA: ViewportInstruction[], instructionsB: ViewportInstruction[]): boolean {
-    for (const instruction of instructionsA) {
-      if (!instructionsB.find((i) => i.sameComponent(instruction))) {
-        return false;
-      }
-    }
-    for (const instruction of instructionsB) {
-      if (!instructionsA.find((i) => i.sameComponent(instruction))) {
-        return false;
-      }
-    }
-    return true;
   }
 }

--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -1,0 +1,53 @@
+import { Router } from './router';
+import { ViewportInstruction } from './viewport-instruction';
+
+/**
+ * Class that handles routes configured into a route table
+ */
+export class RouteTable {
+
+  /**
+   * Check a route against the route table and return the appropriate viewport instructions.
+   *
+   * @param route The route to match.
+   * @param router The application router.
+   * @returns The viewport instructions for a found route or the route if not found.
+   */
+  public transformFromUrl = (route: string, router: Router): string | ViewportInstruction[] => {
+    if (route === 'welcome' || route === '/welcome') {
+      return [new ViewportInstruction('books'), new ViewportInstruction('about')];
+    }
+    return route;
+  }
+
+  /**
+   * Find the route in the route table for a set of viewport instructions.
+   *
+   * @param instructions The set of viewport instructions to match.
+   * @param router The application router.
+   * @returns The route for a found set of viewport instructions or the viewport instructions if not found.
+   */
+  public transformToUrl = (instructions: ViewportInstruction[], router: Router): string | ViewportInstruction[] => {
+    const components = router.instructionResolver.viewportInstructionsFromString('books+about');
+    if (this.matchViewportInstructions(instructions, components)) {
+      return 'welcome';
+    }
+
+    return instructions;
+  }
+
+  // Check if instruction sets matches
+  private matchViewportInstructions(instructionsA: ViewportInstruction[], instructionsB: ViewportInstruction[]): boolean {
+    for (const instruction of instructionsA) {
+      if (!instructionsB.find((i) => i.sameComponent(instruction))) {
+        return false;
+      }
+    }
+    for (const instruction of instructionsB) {
+      if (!instructionsA.find((i) => i.sameComponent(instruction))) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -1,10 +1,10 @@
-import { Router } from './router';
+import { IRouteTransformer, Router } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 /**
  * Class that handles routes configured in a route table
  */
-export class RouteTable {
+export class RouteTable implements IRouteTransformer {
 
   /**
    * Check a route against the route table and return the appropriate viewport instructions.

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -45,7 +45,7 @@ export class Router {
   private processingNavigation: INavigationInstruction = null;
   private lastNavigation: INavigationInstruction = null;
 
-  private routeTable: RouteTable;
+  private readonly routeTable: RouteTable;
 
   constructor(public container: IContainer, routeTable: RouteTable) {
     this.historyBrowser = new HistoryBrowser();


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR illustrates how the router's extension points are used to integrate traditional route table routes with the router. It contains a `RouteTable` skeleton that uses the extension points with a simple, hard coded example.

In summary, any route component, be it a route table or a dynamic routing syntax, can do whatever it wants and offer whatever API it wants towards developers as long as it translates to and from sets of viewport instructions when dealing with the router.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

The `RouteTable` contains a simple, hard coded example that works (with limitations) for the application in `packages/router/test/e2e/doc-example` to illustrate the principles. Needless to say, it should eventually be removed.

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Re-visit scoped viewports
- Add a before navigation hook with accompanying redirect
- Finish refactoring to make router work solely with `ViewportInstruction` instead of strings