### PR TITLE
build: fix browserstack

### DIFF
--- a/test/browserstack/tsconfig.json
+++ b/test/browserstack/tsconfig.json
@@ -13,7 +13,7 @@
       "mocha",
       "chai",
       "node",
-      "webdriverio"
+      "@wdio/sync"
     ]
   },
   "include": ["src", "specs"]


### PR DESCRIPTION
# Pull Request

## 📖 Description

Our `browserstack` broke with the release of [webdriverio 5.6.0](https://twitter.com/webdriverio/status/1098534277459918848)
> 💥 Another update for all our @typescriptlang users: with the latest v5.6.0 (just released) we changed the way you have to define your WebdriverIO types depending whether you use the sync mode or async mode. Please have a look here: https://t.co/h0PkcfRBK7

They made async the default and sync opt-in, while it used to be the other way round.

See #444, #425, and #430 for examples of `browserstack` currently failing.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Switched to the `@wdio/sync` types, as described in the article linked from the tweet.

## 📑 Test Plan

See if CircleCI starts working again.

## ⏭ Next Steps

n/a
