### PR TITLE
chore: nuke renovate.json to retrigger onboarding

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
# Pull Request

## 📖 Description

We want to "automate" dependency updating a bit through `renovate`. By removing the `renovate.json` we can retrigger the onboarding experience and set it up the way we want.

From: https://renovatebot.com/docs/reconfigure-renovate/
 

### 🎫 Issues

Follow up to #450
Reverts #284 

## 👩‍💻 Reviewer Notes

Restarts the `renovate` onboarding experience so we can (re)configure it the way we want.

## 📑 Test Plan

n/a

## ⏭ Next Steps

Re-configure `renovate`
