### PR TITLE
Dynamic routing: refactor viewport instruction, part 3

### DIFF
--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -98,43 +98,6 @@ export class InstructionResolver {
     return { clearViewports, newPath };
   }
 
-  public findViews(path: string): Record<string, string> {
-    const views: Record<string, string> = {};
-    // TODO: Let this govern start of scope
-    if (path.startsWith('/')) {
-      path = path.substring(1);
-    }
-    const sections: string[] = path.split(this.separators.sibling);
-
-    // TODO: Remove this once multi level recursiveness is fixed
-    // Expand with instances for all containing views
-    // const expandedSections: string[] = [];
-    // while (sections.length) {
-    //   const part = sections.shift();
-    //   const parts = part.split(this.separators.scope);
-    //   for (let i = 1; i <= parts.length; i++) {
-    //     expandedSections.push(parts.slice(0, i).join(this.separators.scope));
-    //   }
-    // }
-    // sections = expandedSections;
-
-    let index = 0;
-    while (sections.length) {
-      const view = sections.shift();
-      const scopes = view.split(this.separators.scope);
-      const leaf = scopes.pop();
-      const parts = leaf.split(this.separators.viewport);
-      // Noooooo?
-      const component = parts[0];
-      scopes.push(parts.length ? parts.join(this.separators.viewport) : `?${index++}`);
-      const name = scopes.join(this.separators.scope);
-      if (component) {
-        views[name] = component;
-      }
-    }
-    return views;
-  }
-
   public removeStateDuplicates(states: string[]): string[] {
     let sorted: string[] = states.slice().sort((a, b) => b.split(this.separators.scope).length - a.split(this.separators.scope).length);
     sorted = sorted.map((value) => `${this.separators.scope}${value}${this.separators.scope}`);

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -39,39 +39,22 @@ export class InstructionResolver {
   }
 
   public parseViewportInstruction(instruction: string): ViewportInstruction {
-    let component, viewport, parameters, scope;
-    const [componentPart, rest] = instruction.split(this.separators.viewport);
-    if (rest === undefined) {
-      [component, ...parameters] = componentPart.split(this.separators.parameters);
-      if (component.endsWith(this.separators.ownsScope)) {
-        scope = true;
-        component = component.slice(0, component.length - 1);
-      }
-    } else {
-      component = componentPart;
-      [viewport, ...parameters] = rest.split(this.separators.parameters);
-      if (viewport.endsWith(this.separators.ownsScope)) {
-        scope = true;
-        viewport = viewport.slice(0, viewport.length - 1);
-      }
+    const instructions = instruction.split(this.separators.scope).map((scopeInstruction) => this._parseViewportInstruction(scopeInstruction));
+    for (let i = 0; i < instructions.length - 1; i++) {
+      instructions[i].nextScopeInstruction = instructions[i + 1];
     }
-    parameters = parameters.length ? parameters.join(this.separators.parameters) : undefined;
-    return new ViewportInstruction(component, viewport, parameters, scope);
+    return instructions[0];
   }
 
   public stringifyViewportInstruction(instruction: ViewportInstruction | string, excludeViewport: boolean = false): string {
     if (typeof instruction === 'string') {
-      return this.stringifyViewportInstruction(this.parseViewportInstruction(instruction), excludeViewport);
+      return this._stringifyViewportInstruction(instruction, excludeViewport);
     } else {
-      let instructionString = instruction.componentName;
-      if (instruction.viewportName && !excludeViewport) {
-        instructionString += this.separators.viewport + instruction.viewportName;
+      const instructions = [instruction];
+      while (instruction = instruction.nextScopeInstruction) {
+        instructions.push(instruction);
       }
-      if (instruction.parametersString) {
-        // TODO: Review parameters in ViewportInstruction
-        instructionString += this.separators.parameters + instruction.parametersString;
-      }
-      return instructionString;
+      return instructions.map((scopeInstruction) => this._stringifyViewportInstruction(scopeInstruction, excludeViewport)).join(this.separators.scope);
     }
   }
 
@@ -181,5 +164,42 @@ export class InstructionResolver {
       strings.unshift(this.clearViewportInstruction);
     }
     return strings.join(this.separators.sibling);
+  }
+
+  private _parseViewportInstruction(instruction: string): ViewportInstruction {
+    let component, viewport, parameters, scope;
+    const [componentPart, rest] = instruction.split(this.separators.viewport);
+    if (rest === undefined) {
+      [component, ...parameters] = componentPart.split(this.separators.parameters);
+      if (component.endsWith(this.separators.ownsScope)) {
+        scope = true;
+        component = component.slice(0, component.length - 1);
+      }
+    } else {
+      component = componentPart;
+      [viewport, ...parameters] = rest.split(this.separators.parameters);
+      if (viewport.endsWith(this.separators.ownsScope)) {
+        scope = true;
+        viewport = viewport.slice(0, viewport.length - 1);
+      }
+    }
+    parameters = parameters.length ? parameters.join(this.separators.parameters) : undefined;
+    return new ViewportInstruction(component, viewport, parameters, scope);
+  }
+
+  private _stringifyViewportInstruction(instruction: ViewportInstruction | string, excludeViewport: boolean = false): string {
+    if (typeof instruction === 'string') {
+      return this.stringifyViewportInstruction(this.parseViewportInstruction(instruction), excludeViewport);
+    } else {
+      let instructionString = instruction.componentName;
+      if (instruction.viewportName && !excludeViewport) {
+        instructionString += this.separators.viewport + instruction.viewportName;
+      }
+      if (instruction.parametersString) {
+        // TODO: Review parameters in ViewportInstruction
+        instructionString += this.separators.parameters + instruction.parametersString;
+      }
+      return instructionString;
+    }
   }
 }

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -10,6 +10,7 @@ export interface IRouteSeparators {
   scope: string;
   ownsScope: string;
   parameters: string;
+  parameter: string;
   add: string;
   clear: string;
   action: string;
@@ -27,6 +28,7 @@ export class InstructionResolver {
         scope: '/', // '+',
         ownsScope: '!',
         parameters: '=',
+        parameter: '&',
         add: '+',
         clear: '-',
         action: '.',
@@ -170,14 +172,14 @@ export class InstructionResolver {
       [component, ...parameters] = componentPart.split(this.separators.parameters);
       if (component.endsWith(this.separators.ownsScope)) {
         scope = true;
-        component = component.slice(0, component.length - 1);
+        component = component.slice(0, -1);
       }
     } else {
       component = componentPart;
       [viewport, ...parameters] = rest.split(this.separators.parameters);
       if (viewport.endsWith(this.separators.ownsScope)) {
         scope = true;
-        viewport = viewport.slice(0, viewport.length - 1);
+        viewport = viewport.slice(0, -1);
       }
     }
     parameters = parameters.length ? parameters.join(this.separators.parameters) : undefined;

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -39,6 +39,12 @@ export class InstructionResolver {
   }
 
   public parseViewportInstructions(instructions: string): ViewportInstruction[] {
+    if (instructions === null || instructions === '') {
+      return [];
+    }
+    if (instructions.startsWith('/')) {
+      instructions = instructions.slice(1);
+    }
     return instructions.split(this.separators.sibling).map((instruction) => this.parseViewportInstruction(instruction));
   }
 
@@ -86,7 +92,7 @@ export class InstructionResolver {
 
   public shouldClearViewports(path: string): { clearViewports: boolean; newPath: string } {
     const clearViewports = (path === this.separators.clear || path.startsWith(this.separators.clear + this.separators.add));
-    const newPath = path.startsWith(this.separators.clear) ? path.substring(1) : path;
+    const newPath = path.startsWith(this.separators.clear) ? path.slice(2) : path;
     return { clearViewports, newPath };
   }
 

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -38,12 +38,20 @@ export class InstructionResolver {
     return this.separators.clear;
   }
 
+  public parseViewportInstructions(instructions: string): ViewportInstruction[] {
+    return instructions.split(this.separators.sibling).map((instruction) => this.parseViewportInstruction(instruction));
+  }
+
   public parseViewportInstruction(instruction: string): ViewportInstruction {
     const instructions = instruction.split(this.separators.scope).map((scopeInstruction) => this._parseViewportInstruction(scopeInstruction));
     for (let i = 0; i < instructions.length - 1; i++) {
       instructions[i].nextScopeInstruction = instructions[i + 1];
     }
     return instructions[0];
+  }
+
+  public stringifyViewportInstructions(instructions: ViewportInstruction[]): string {
+    return instructions.map((instruction) => this.stringifyViewportInstruction(instruction)).join(this.separators.sibling);
   }
 
   public stringifyViewportInstruction(instruction: ViewportInstruction | string, excludeViewport: boolean = false): string {
@@ -117,23 +125,6 @@ export class InstructionResolver {
       }
     }
     return views;
-  }
-
-  public viewportInstructionsToString(instructions: ViewportInstruction[]): string {
-    const stringInstructions: string[] = [];
-    for (const instruction of instructions) {
-      stringInstructions.push(this.stringifyViewportInstruction(instruction));
-    }
-    return stringInstructions.join(this.separators.sibling);
-  }
-
-  public viewportInstructionsFromString(instructionsString: string): ViewportInstruction[] {
-    const instructions = [];
-    const instructionStrings = instructionsString.split(this.separators.sibling);
-    for (const instructionString of instructionStrings) {
-      instructions.push(this.parseViewportInstruction(instructionString));
-    }
-    return instructions;
   }
 
   public removeStateDuplicates(states: string[]): string[] {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -46,7 +46,7 @@ export class NavRoute {
   }
 
   public _active(): string {
-    const components = this.nav.router.instructionResolver.viewportInstructionsFromString(this.linkActive);
+    const components = this.nav.router.instructionResolver.parseViewportInstructions(this.linkActive);
     const activeComponents = this.nav.router.activeComponents.map((state) => this.nav.router.instructionResolver.parseViewportInstruction(state));
     for (const component of components) {
       if (!activeComponents.find((active) => active.sameComponent(component))) {
@@ -61,7 +61,7 @@ export class NavRoute {
   }
 
   public _link(instructions: ViewportInstruction[]): string {
-    return this.nav.router.instructionResolver.viewportInstructionsToString(instructions);
+    return this.nav.router.instructionResolver.stringifyViewportInstructions(instructions);
   }
 
   private parseRoute(routes: NavInstruction | NavInstruction[]): ViewportInstruction[] {

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -26,11 +26,10 @@ export class Nav {
 
   public router: Router;
 
-  constructor(router: Router, name: string) {
+  constructor(router: Router, name: string, routes: NavRoute[] = []) {
     this.router = router;
     this.name = name;
-
-    this.routes = [];
+    this.routes = routes;
   }
 
   public addRoutes(routes: INavRoute[]): void {

--- a/packages/router/src/resources/nav.ts
+++ b/packages/router/src/resources/nav.ts
@@ -36,7 +36,7 @@ export class NavCustomElement {
   }
 
   get navRoutes(): NavRoute[] {
-    const nav = this.router.findNav(this.name);
+    const nav = this.router.navs[this.name];
     return (nav ? nav.routes : []);
   }
 

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -127,4 +127,4 @@ export class ViewportCustomElement {
   }
 }
 // tslint:disable-next-line:no-invalid-template-strings
-CustomElementResource.define({ name: 'au-viewport', template: '<template><div class="viewport-header"> Viewport: <b>${name}</b> </div></template>' }, ViewportCustomElement);
+CustomElementResource.define({ name: 'au-viewport', template: '<template><div class="viewport-header"> Viewport: <b>${name}</b> ${scope ? "[new scope]" : ""} : <b>${viewport.content && viewport.content.componentName()}</b></div></template>' }, ViewportCustomElement);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -365,8 +365,7 @@ export class Router {
       nav = this.navs[name] = new Nav(this, name);
     }
     nav.addRoutes(routes);
-    // tslint:disable-next-line:prefer-object-spread
-    this.navs[name] = Object.assign({}, nav);
+    this.navs[name] = new Nav(nav.router, nav.name, nav.routes);
   }
   public findNav(name: string): Nav {
     return this.navs[name];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -6,8 +6,7 @@ import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
 import { IParsedQuery, parseQuery } from './parser';
 import { RouteTable } from './route-table';
-import { ChildContainer, Scope } from './scope';
-import { closestCustomElement } from './utils';
+import { Scope } from './scope';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -111,7 +110,6 @@ export class Router {
     this.processNavigations().catch(error => { throw error; });
   }
 
-  // TODO: Reduce complexity (currently at 46)
   public async processNavigations(): Promise<void> {
     if (this.processingNavigation !== null || !this.pendingNavigations.length) {
       return Promise.resolve();
@@ -154,10 +152,8 @@ export class Router {
 
     // TODO: Fetch title (probably when done)
     const title = null;
-    // const views: Record<string, string> = this.instructionResolver.findViews(path);
     const views = this.instructionResolver.parseViewportInstructions(path);
 
-    // if (!views && !Object.keys(views).length && !clearViewports) {
     if (!views && !views.length && !clearViewports) {
       this.processingNavigation = null;
       return this.processNavigations();
@@ -233,15 +229,6 @@ export class Router {
         return this.cancelNavigation([...changedViewports, ...updatedViewports], instruction);
       }
 
-      // TODO: Should it be kept here?
-      // await Promise.all(changedViewports.map((value) => value.loadContent()));
-
-      // TODO: Remove this once multi level recursiveness has been fixed
-      // results = await Promise.all(changedViewports.map((value) => value.loadContent()));
-      // if (results.findIndex((value) => value === false) >= 0) {
-      //   return this.historyBrowser.cancel();
-      // }
-
       for (const viewport of changedViewports) {
         if (!updatedViewports.find((value) => value === viewport)) {
           updatedViewports.push(viewport);
@@ -303,10 +290,6 @@ export class Router {
       this.processNavigations().catch(error => { throw error; });
     }
   }
-
-  // public findViewport(name: string): Viewport {
-  //   return this.rootScope.findViewport(name);
-  // }
 
   public findScope(element: Element): Scope {
     this.ensureRootScope();

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -140,7 +140,7 @@ export class Router {
     if (this.options.transformFromUrl && !fullStateInstruction) {
       const routeOrInstructions = this.options.transformFromUrl(path, this);
       // TODO: Don't go via string here, use instructions as they are
-      path = Array.isArray(routeOrInstructions) ? this.instructionResolver.viewportInstructionsToString(routeOrInstructions) : routeOrInstructions;
+      path = Array.isArray(routeOrInstructions) ? this.instructionResolver.stringifyViewportInstructions(routeOrInstructions) : routeOrInstructions;
     }
 
     const { clearViewports, newPath } = this.instructionResolver.shouldClearViewports(path);
@@ -419,8 +419,8 @@ export class Router {
     viewportStates = this.instructionResolver.removeStateDuplicates(viewportStates);
     let state = this.instructionResolver.stateStringsToString(viewportStates);
     if (this.options.transformToUrl) {
-      const routeOrInstructions = this.options.transformToUrl(this.instructionResolver.viewportInstructionsFromString(state), this);
-      state = Array.isArray(routeOrInstructions) ? this.instructionResolver.viewportInstructionsToString(routeOrInstructions) : routeOrInstructions;
+      const routeOrInstructions = this.options.transformToUrl(this.instructionResolver.parseViewportInstructions(state), this);
+      state = Array.isArray(routeOrInstructions) ? this.instructionResolver.stringifyViewportInstructions(routeOrInstructions) : routeOrInstructions;
     }
 
     let fullViewportStates = this.rootScope.viewportStates(true);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -366,7 +366,7 @@ export class Router {
     }
     nav.addRoutes(routes);
     // tslint:disable-next-line:prefer-object-spread
-    nav = Object.assign({}, nav);
+    this.navs[name] = Object.assign({}, nav);
   }
   public findNav(name: string): Nav {
     return this.navs[name];

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -124,7 +124,7 @@ export class Scope {
         instructions.push(...found.viewportInstructions);
         viewportsRemaining = viewportsRemaining || found.viewportsRemaining;
         this.availableViewports[viewport.name] = null;
-        this.viewportInstructions.splice(i--, 1);
+        this.viewportInstructions.splice(i, 1);
         break;
       }
     }

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -103,7 +103,7 @@ export class Scope {
       if (!name || !name.length || name.startsWith('?')) {
         continue;
       }
-      const newScope = instruction.scope;
+      const newScope = instruction.ownsScope;
       if (!this.getEnabledViewports()[name]) {
         this.addViewport(name, null, null, { scope: newScope, forceDescription: true });
         this.availableViewports[name] = this.getEnabledViewports()[name];

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -28,7 +28,6 @@ export class Scope {
 
   private readonly router: Router;
 
-  private scopeViewportParts: Record<string, ViewportInstruction[][]>;
   private viewportInstructions: ViewportInstruction[];
   private availableViewports: Record<string, Viewport>;
 
@@ -41,7 +40,6 @@ export class Scope {
     this.viewport = null;
     this.children = [];
     this.viewports = [];
-    this.scopeViewportParts = {};
     this.availableViewports = null;
 
     if (this.parent) {
@@ -131,7 +129,7 @@ export class Scope {
       }
     }
 
-    viewportsRemaining = viewportsRemaining || Object.keys(this.scopeViewportParts).length > 0;
+    viewportsRemaining = viewportsRemaining || this.viewportInstructions.length > 0;
 
     // If it's a repeat there might be remaining viewports in scope children
     if (!viewportInstructions) {

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -103,7 +103,7 @@ export class ViewportContent {
     }
     return result as Promise<ViewportInstruction[]>;
   }
-  public canLeave(nextInstruction: INavigationInstruction): boolean | Promise<boolean> {
+  public canLeave(nextInstruction: INavigationInstruction): Promise<boolean> {
     if (!this.component || !this.component.canLeave) {
       return Promise.resolve(true);
     }

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,6 +1,8 @@
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, Reporter } from '@aurelia/kernel';
 import { CustomElementResource, ICustomElement, ICustomElementType, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
 import { INavigationInstruction } from './history-browser';
+import { mergeParameters } from './parser';
+import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IRouteableCustomElementType extends Partial<ICustomElementType> {
@@ -8,7 +10,7 @@ export interface IRouteableCustomElementType extends Partial<ICustomElementType>
 }
 
 export interface IRouteableCustomElement extends ICustomElement {
-  canEnter?(nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
+  canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
   enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): void | Promise<void>;
   canLeave?(nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): boolean | Promise<boolean>;
   leave?(nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): void | Promise<void>;
@@ -16,9 +18,9 @@ export interface IRouteableCustomElement extends ICustomElement {
 
 export const enum ContentStatus {
   none = 0,
-  loaded = 1,
-  initialized = 2,
-  entered = 3,
+  created = 1,
+  loaded = 2,
+  initialized = 3,
   added = 4,
 }
 
@@ -28,6 +30,7 @@ export class ViewportContent {
   public instruction: INavigationInstruction;
   public component: IRouteableCustomElement;
   public contentStatus: ContentStatus;
+  public entered: boolean;
   public fromCache: boolean;
 
   constructor(content: Partial<ICustomElementType> | string = null, parameters: string = null, instruction: INavigationInstruction = null, context: IRenderContext = null) {
@@ -37,6 +40,7 @@ export class ViewportContent {
     this.instruction = instruction;
     this.component = null;
     this.contentStatus = ContentStatus.none;
+    this.entered = false;
     this.fromCache = false;
 
     // If we've got a container, we're good to resolve type
@@ -58,10 +62,89 @@ export class ViewportContent {
       this.parameters === other.parameters;
   }
 
-  public loadComponent(context: IRenderContext, element: Element): Promise<void> {
+  public createComponent(context: IRenderContext): void {
+    if (this.contentStatus !== ContentStatus.none) {
+      return;
+    }
     // Don't load cached content
     if (!this.fromCache) {
       this.component = this.componentInstance(context);
+    }
+    this.contentStatus = ContentStatus.created;
+  }
+  public destroyComponent(): void {
+    // TODO: We might want to do something here eventually, who knows?
+    if (this.contentStatus !== ContentStatus.created) {
+      return;
+    }
+    // Don't destroy components when stateful
+    this.contentStatus = ContentStatus.none;
+  }
+
+  public canEnter(viewport: Viewport, previousInstruction: INavigationInstruction): Promise<boolean | ViewportInstruction[]> {
+    if (!this.component) {
+      return Promise.resolve(false);
+    }
+
+    if (!this.component.canEnter) {
+      return Promise.resolve(true);
+    }
+
+    const merged = mergeParameters(this.parameters, this.instruction.query, (this.content as IRouteableCustomElementType).parameters);
+    this.instruction.parameters = merged.namedParameters;
+    this.instruction.parameterList = merged.parameterList;
+    const result = this.component.canEnter(merged.merged, this.instruction, previousInstruction);
+    Reporter.write(10000, 'viewport canEnter', result);
+    if (typeof result === 'boolean') {
+      return Promise.resolve(result);
+    }
+    if (typeof result === 'string') {
+      return Promise.resolve([new ViewportInstruction(result, viewport)]);
+    }
+    return result as Promise<ViewportInstruction[]>;
+  }
+  public canLeave(nextInstruction: INavigationInstruction): boolean | Promise<boolean> {
+    if (!this.component || !this.component.canLeave) {
+      return Promise.resolve(true);
+    }
+
+    const result = this.component.canLeave(this.instruction, nextInstruction);
+    Reporter.write(10000, 'viewport canLeave', result);
+
+    if (typeof result === 'boolean') {
+      return Promise.resolve(result);
+    }
+    return result;
+  }
+
+  public async enter(previousInstruction: INavigationInstruction): Promise<void> {
+    if (this.contentStatus !== ContentStatus.created || this.entered) {
+      return;
+    }
+    if (this.component.enter) {
+      const merged = mergeParameters(this.parameters, this.instruction.query, (this.content as IRouteableCustomElementType).parameters);
+      this.instruction.parameters = merged.namedParameters;
+      this.instruction.parameterList = merged.parameterList;
+      await this.component.enter(merged.merged, this.instruction, previousInstruction);
+    }
+    this.entered = true;
+  }
+  public async leave(nextInstruction: INavigationInstruction): Promise<void> {
+    if (this.contentStatus !== ContentStatus.added || !this.entered) {
+      return;
+    }
+    if (this.component.leave) {
+      await this.component.leave(this.instruction, nextInstruction);
+    }
+    this.entered = false;
+  }
+
+  public loadComponent(context: IRenderContext, element: Element): Promise<void> {
+    if (this.contentStatus !== ContentStatus.created || !this.entered) {
+      return;
+    }
+    // Don't load cached content
+    if (!this.fromCache) {
       const host: INode = element as INode;
       const container = context;
       this.component.$hydrate(LifecycleFlags.none, container, host);
@@ -75,10 +158,13 @@ export class ViewportContent {
       return;
     }
     // Don't unload components when stateful
-    this.contentStatus = ContentStatus.none;
+    this.contentStatus = ContentStatus.created;
   }
 
   public initializeComponent(): void {
+    if (this.contentStatus !== ContentStatus.loaded) {
+      return;
+    }
     // Don't initialize cached content
     if (!this.fromCache) {
       this.component.$bind(LifecycleFlags.fromStartTask | LifecycleFlags.fromBind, null);
@@ -97,6 +183,9 @@ export class ViewportContent {
   }
 
   public addComponent(element: Element): void {
+    if (this.contentStatus !== ContentStatus.initialized) {
+      return;
+    }
     this.component.$attach(LifecycleFlags.fromStartTask);
     if (this.fromCache) {
       const elements = Array.from(element.getElementsByTagName('*'));
@@ -111,7 +200,7 @@ export class ViewportContent {
     this.contentStatus = ContentStatus.added;
   }
   public removeComponent(element: Element, stateful: boolean = false): void {
-    if (this.contentStatus !== ContentStatus.added) {
+    if (this.contentStatus !== ContentStatus.added || this.entered) {
       return;
     }
     if (stateful) {
@@ -123,24 +212,21 @@ export class ViewportContent {
       }
     }
     this.component.$detach(LifecycleFlags.fromStopTask);
-    this.contentStatus = ContentStatus.added;
+    this.contentStatus = ContentStatus.initialized;
   }
 
-  public async freeContent(element: Element, stateful: boolean = false): Promise<void> {
+  public async freeContent(element: Element, nextInstruction: INavigationInstruction, stateful: boolean = false): Promise<void> {
     switch (this.contentStatus) {
       case ContentStatus.added:
+        await this.leave(nextInstruction);
         this.removeComponent(element, stateful);
-      case ContentStatus.entered:
-        if (this.component.leave) {
-          await this.component.leave();
-        }
-        this.contentStatus = ContentStatus.initialized;
       case ContentStatus.initialized:
         this.terminateComponent(stateful);
       case ContentStatus.loaded:
         this.unloadComponent();
+      case ContentStatus.created:
+        this.destroyComponent();
     }
-    this.contentStatus = ContentStatus.none;
   }
 
   public componentName(): string {

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -16,13 +16,17 @@ export class ViewportInstruction {
   public nextScopeInstruction?: ViewportInstruction;
 
   constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = false, nextScopeInstruction: ViewportInstruction = null) {
+    this.component = null;
+    this.componentName = null;
+    this.viewport = null;
+    this.viewportName = null;
+    this.parametersString = null;
+    this.parameters = null;
+    this.parametersList = null;
+
     this.setComponent(component);
-    if (viewport) {
-      this.setViewport(viewport);
-    }
-    if (parameters) {
-      this.setParameters(parameters);
-    }
+    this.setViewport(viewport);
+    this.setParameters(parameters);
 
     this.ownsScope = ownsScope;
     this.nextScopeInstruction = nextScopeInstruction;
@@ -39,18 +43,24 @@ export class ViewportInstruction {
   }
 
   public setViewport(viewport: Viewport | string): void {
+    if (viewport === undefined || viewport === '') {
+      viewport = null;
+    }
     if (typeof viewport === 'string') {
       this.viewportName = viewport;
       this.viewport = null;
     } else {
       this.viewport = viewport;
-      if (viewport) {
+      if (viewport !== null) {
         this.viewportName = viewport.name;
       }
     }
   }
 
   public setParameters(parameters: Record<string, unknown> | string): void {
+    if (parameters === undefined || parameters === '') {
+      parameters = null;
+    }
     if (typeof parameters === 'string') {
       this.parametersString = parameters;
       // TODO: Initialize parameters better and more of them and just fix this

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -12,9 +12,9 @@ export class ViewportInstruction {
   public parametersString?: string;
   public parameters?: Record<string, unknown>;
   public parametersList?: string[];
-  public scope?: boolean;
+  public ownsScope?: boolean;
 
-  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, scope?: boolean) {
+  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope?: boolean) {
     this.setComponent(component);
     if (viewport) {
       this.setViewport(viewport);
@@ -23,7 +23,7 @@ export class ViewportInstruction {
       this.setParameters(parameters);
     }
 
-    this.scope = !!scope;
+    this.ownsScope = !!ownsScope;
   }
 
   public setComponent(component: Partial<ICustomElementType> | string): void {

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -13,8 +13,9 @@ export class ViewportInstruction {
   public parameters?: Record<string, unknown>;
   public parametersList?: string[];
   public ownsScope?: boolean;
+  public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope?: boolean) {
+  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = false, nextScopeInstruction: ViewportInstruction = null) {
     this.setComponent(component);
     if (viewport) {
       this.setViewport(viewport);
@@ -23,7 +24,8 @@ export class ViewportInstruction {
       this.setParameters(parameters);
     }
 
-    this.ownsScope = !!ownsScope;
+    this.ownsScope = ownsScope;
+    this.nextScopeInstruction = nextScopeInstruction;
   }
 
   public setComponent(component: Partial<ICustomElementType> | string): void {

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -157,7 +157,6 @@ export class Viewport {
 
     await this.waitForElement();
 
-    // await this.nextContent.loadComponent(this.context, this.element);
     this.nextContent.createComponent(this.context);
 
     return this.nextContent.canEnter(this, this.content.instruction);

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -175,7 +175,7 @@ export class Viewport {
 
     await this.nextContent.enter(this.content.instruction);
     await this.nextContent.loadComponent(this.context, this.element);
-    await this.nextContent.initializeComponent();
+    this.nextContent.initializeComponent();
     return true;
   }
 

--- a/packages/router/test/e2e/doc-example/src/components/authors/author.ts
+++ b/packages/router/test/e2e/doc-example/src/components/authors/author.ts
@@ -35,7 +35,15 @@ export class Author {
 
   constructor(private readonly router: Router, private readonly authorsRepository: AuthorsRepository, private readonly state: State) { }
 
+  public created() {
+    console.log('### created', this);
+  }
+  public canEnter(parameters) {
+    console.log('### canEnter', this, parameters);
+    return true;
+  }
   public enter(parameters) {
+    console.log('### enter', this, parameters);
     if (parameters.id) {
       this.author = this.authorsRepository.author(+parameters.id);
     }
@@ -54,5 +62,38 @@ export class Author {
       },
     ]);
     return wait(this.state.noDelay ? 0 : 2000);
+  }
+  public binding() {
+    console.log('### binding', this);
+  }
+  public bound() {
+    console.log('### bound', this);
+  }
+  public attaching() {
+    console.log('### attaching', this);
+  }
+  public attached() {
+    console.log('### attached', this);
+  }
+
+  public canLeave(parameters) {
+    console.log('### canLeave', this, parameters);
+    return true;
+  }
+  public leave(parameters) {
+    console.log('### leave', this, parameters);
+    return true;
+  }
+  public detaching() {
+    console.log('### detaching', this);
+  }
+  public detached() {
+    console.log('### detached', this);
+  }
+  public unbinding() {
+    console.log('### unbinding', this);
+  }
+  public unbound() {
+    console.log('### unbound', this);
   }
 }

--- a/packages/router/test/e2e/doc-example/src/components/books/redirect-about.ts
+++ b/packages/router/test/e2e/doc-example/src/components/books/redirect-about.ts
@@ -1,4 +1,5 @@
 import { customElement } from '@aurelia/runtime';
+import { ViewportInstruction } from './../../../../../../src/viewport-instruction';
 
 @customElement({
   name: 'redirect-about', template: `<template>
@@ -6,6 +7,6 @@ import { customElement } from '@aurelia/runtime';
 </template>` })
 export class RedirectAbout {
   public canEnter() {
-    return [{ component: 'about', viewport: 'content' }, { component: 'authors', viewport: 'lists' }];
+    return [new ViewportInstruction('about', 'content'), new ViewportInstruction('authors', 'lists')];
   }
 }

--- a/packages/router/test/e2e/scope/index.ejs
+++ b/packages/router/test/e2e/scope/index.ejs
@@ -80,6 +80,22 @@
 
     au-viewport {
       padding: 10px;
+      margin: 10px;
+      display: block;
+      border: 1px solid gray;
+      background-color: #55f;
+    }
+    au-viewport au-viewport {
+      background-color: #88f;
+    }
+    au-viewport au-viewport au-viewport {
+      background-color: #aaf;
+    }
+    au-viewport au-viewport au-viewport au-viewport {
+      background-color: #ccf;
+    }
+    au-viewport au-viewport au-viewport au-viewport au-viewport {
+      background-color: #eef;
     }
 
     .viewport-header {

--- a/packages/router/test/unit/instruction-resolver.spec.ts
+++ b/packages/router/test/unit/instruction-resolver.spec.ts
@@ -51,6 +51,8 @@ describe('InstructionResolver', function () {
     { instruction: 'foo@left', viewportInstruction: new ViewportInstruction('foo', 'left') },
     { instruction: 'foo@left=123', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
     { instruction: 'foo=123', viewportInstruction: new ViewportInstruction('foo', undefined, '123') },
+    { instruction: 'foo/bar', viewportInstruction: new ViewportInstruction('foo', undefined, undefined, false, new ViewportInstruction('bar')) },
+    { instruction: 'foo=123/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', false, new ViewportInstruction('bar', 'left', undefined, false, new ViewportInstruction('baz'))) },
   ];
 
   for (const instructionTest of instructions) {
@@ -62,6 +64,8 @@ describe('InstructionResolver', function () {
 
       const parsed = router.instructionResolver.parseViewportInstruction(instruction);
       expect(parsed).to.deep.equal(viewportInstruction);
+      const newInstruction = router.instructionResolver.stringifyViewportInstruction(parsed);
+      expect(newInstruction).to.equal(instruction);
 
       await teardown(host, router);
     });

--- a/packages/router/test/unit/instruction-resolver.spec.ts
+++ b/packages/router/test/unit/instruction-resolver.spec.ts
@@ -23,9 +23,9 @@ describe('InstructionResolver', function () {
       new ViewportInstruction('foo', 'left', '123'),
       new ViewportInstruction('bar', 'right', '456'),
     ];
-    let instructionsString = router.instructionResolver.viewportInstructionsToString(instructions);
+    let instructionsString = router.instructionResolver.stringifyViewportInstructions(instructions);
     expect(instructionsString).to.equal('foo@left=123+bar@right=456');
-    let newInstructions = router.instructionResolver.viewportInstructionsFromString(instructionsString);
+    let newInstructions = router.instructionResolver.parseViewportInstructions(instructionsString);
     expect(newInstructions).to.deep.equal(instructions);
 
     instructions = [
@@ -33,9 +33,9 @@ describe('InstructionResolver', function () {
       new ViewportInstruction('bar', 'right'),
       new ViewportInstruction('baz'),
     ];
-    instructionsString = router.instructionResolver.viewportInstructionsToString(instructions);
+    instructionsString = router.instructionResolver.stringifyViewportInstructions(instructions);
     expect(instructionsString).to.equal('foo=123+bar@right+baz');
-    newInstructions = router.instructionResolver.viewportInstructionsFromString(instructionsString);
+    newInstructions = router.instructionResolver.parseViewportInstructions(instructionsString);
     expect(newInstructions).to.deep.equal(instructions);
 
     await teardown(host, router);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR contains the third part of the refactor towards viewport instruction and instruction resolver. It primarily removes the string parsing and handling from scope and replaces it with instruction resolver calls. It's one step closer having the router only deal with viewport instructions internally.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in packages/router/test/e2e/** since they are just my own test applications while working.

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Review the extension points
- Re-visit scoped viewports
- Add a before navigation hook with accompanying redirect
