### PR TITLE
Always hoist

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,9 @@
 {
+  "command": {
+    "bootstrap": {
+      "hoist": "**"
+    }
+  },
   "lerna": "3.13.0",
   "packages": [
     "packages/aot",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "commit": "git-cz",
     "init": "npm ci && npm run bootstrap && npm run build",
-    "bootstrap": "lerna bootstrap --ci --hoist",
-    "postinstall": "lerna bootstrap --ci --hoist",
+    "bootstrap": "lerna bootstrap --ci",
+    "postinstall": "lerna bootstrap --ci",
     "build": "lerna run build",
     "build:test": "lerna run build:test",
     "dev": "lerna run dev --parallel",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Always `hoist` all packages through `lerna`.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

I can't think of a situation where we don't want to have `lerna` host packages.

The `package.json` scripts have the `--hoist` argument, but that doesn't ensure hoisting when somebody manually does a `lerna bootstrap`. By adding it to `lerna.json` we can guarantee hosting.

## 📑 Test Plan

CircleCI.

## ⏭ Next Steps

n/a