### PR TITLE
Dynamic routing: use parantheses around parameters in url syntax

### DIFF
--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -10,6 +10,7 @@ export interface IRouteSeparators {
   scope: string;
   ownsScope: string;
   parameters: string;
+  parametersEnd: string;
   parameter: string;
   add: string;
   clear: string;
@@ -27,7 +28,8 @@ export class InstructionResolver {
         sibling: '+', // '/',
         scope: '/', // '+',
         ownsScope: '!',
-        parameters: '=',
+        parameters: '(', // '='
+        parametersEnd: ')', // ''
         parameter: '&',
         add: '+',
         clear: '-',
@@ -148,7 +150,10 @@ export class InstructionResolver {
         viewport = viewport.slice(0, -this.separators.ownsScope.length);
       }
     }
-    const parametersString = parameters.length ? parameters.join(this.separators.parameters) : undefined;
+    let parametersString = parameters.length ? parameters.join(this.separators.parameters) : undefined;
+    if (this.separators.parametersEnd.length && parametersString && parametersString.endsWith(this.separators.parametersEnd)) {
+      parametersString = parametersString.slice(0, -this.separators.parametersEnd.length);
+    }
     return new ViewportInstruction(component, viewport, parametersString, scope);
   }
 
@@ -162,7 +167,7 @@ export class InstructionResolver {
       }
       if (instruction.parametersString) {
         // TODO: Review parameters in ViewportInstruction
-        instructionString += this.separators.parameters + instruction.parametersString;
+        instructionString += this.separators.parameters + instruction.parametersString + this.separators.parametersEnd;
       }
       return instructionString;
     }

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -151,6 +151,8 @@ export class InstructionResolver {
       }
     }
     let parametersString = parameters.length ? parameters.join(this.separators.parameters) : undefined;
+    // The parameter separator can be either a standalone character (such as / or =) or a pair of enclosing characters
+    // (such as ()). The separating character is consumed but the end character is not, so we still need to remove that.
     if (this.separators.parametersEnd.length && parametersString && parametersString.endsWith(this.separators.parametersEnd)) {
       parametersString = parametersString.slice(0, -this.separators.parametersEnd.length);
     }

--- a/packages/router/test/e2e/doc-example/src/components/authors/author.ts
+++ b/packages/router/test/e2e/doc-example/src/components/authors/author.ts
@@ -12,7 +12,7 @@ import { Information } from './information';
 <div>Born: \${author.born}</div>
 <div>Books:
   <ul>
-    <li repeat.for="book of author.books"><a href="book=\${book.id}">\${book.title}</a></li>
+    <li repeat.for="book of author.books"><a href="book(\${book.id})">\${book.title}</a></li>
   </ul>
 </div>
 <div class="info">
@@ -20,7 +20,7 @@ import { Information } from './information';
 </div>
 <div if.bind="!hideTabs">
   <au-nav name="author-menu"></au-nav>
-  <au-viewport name="author-tabs" stateful default="author-details=\${author.id}" used-by="about-authors,author-details,information" no-history></au-viewport>
+  <au-viewport name="author-tabs" stateful default="author-details(\${author.id})" used-by="about-authors,author-details,information" no-history></au-viewport>
 </div>
 </template>`,
   dependencies: [Information as any]
@@ -50,7 +50,7 @@ export class Author {
     this.router.setNav('author-menu', [
       {
         title: 'Details',
-        route: `author-details=${this.author.id}`
+        route: `author-details(${this.author.id})`
       },
       {
         title: 'About authors',

--- a/packages/router/test/e2e/doc-example/src/components/authors/authors.ts
+++ b/packages/router/test/e2e/doc-example/src/components/authors/authors.ts
@@ -9,7 +9,7 @@ import { wait } from '../../utils';
 <h3>Authors</h3>
 <ul>
   <li repeat.for="author of authors">
-    <a href="author=\${author.id}">\${author.name}</a>
+    <a href="author(\${author.id})">\${author.name}</a>
     <ul><li repeat.for="book of author.books">\${book.title}</li></ul>
   </li>
 </ul>

--- a/packages/router/test/e2e/doc-example/src/components/books/book.ts
+++ b/packages/router/test/e2e/doc-example/src/components/books/book.ts
@@ -12,11 +12,11 @@ import { RedirectInformation } from './redirect-information';
 <div>Published: \${book.year}</div>
 <div>Author(s):
   <ul>
-    <li repeat.for="author of book.authors"><a href="author=\${author.id}">\${author.name}</a></li>
+    <li repeat.for="author of book.authors"><a href="author(\${author.id})">\${author.name}</a></li>
   </ul>
 </div>
 <au-nav name="book-menu"></au-nav>
-<au-viewport name="book-tabs" default="book-details=\${book.id}" used-by="about-books,book-details,information,redirect-information,redirect-about" no-link></au-viewport>
+<au-viewport name="book-tabs" default="book-details(\${book.id})" used-by="about-books,book-details,information,redirect-information,redirect-about" no-link></au-viewport>
 </template>`,
   dependencies: [Information as any, RedirectInformation as any, RedirectAbout as any]
 })
@@ -35,7 +35,7 @@ export class Book {
     this.router.setNav('book-menu', [
       {
         title: 'Details',
-        route: `book-details=${this.book.id}`
+        route: `book-details(${this.book.id})`
       },
       {
         title: 'About books',

--- a/packages/router/test/e2e/doc-example/src/components/books/books.ts
+++ b/packages/router/test/e2e/doc-example/src/components/books/books.ts
@@ -7,7 +7,7 @@ import { BooksRepository } from '../../repositories/books';
 <h3>Books</h3>
 <ul>
   <li repeat.for="book of books">
-    <a href="book=\${book.id}">\${book.title}</a>
+    <a href="book(\${book.id})">\${book.title}</a>
     <ul><li repeat.for="author of book.authors">\${author.name}</li></ul>
   </li>
 </ul>

--- a/packages/router/test/e2e/doc-example/src/components/chat/chat-users.ts
+++ b/packages/router/test/e2e/doc-example/src/components/chat/chat-users.ts
@@ -6,7 +6,7 @@ import { UsersRepository } from '../../repositories/users';
   name: 'chat-users', template: `<template>
 <ul>
   <li repeat.for="user of users">
-    <a href="chat-user=\${user.id}">\${user.id} (\${user.name})</a>
+    <a href="chat-user(\${user.id})">\${user.id} (\${user.name})</a>
   </li>
 </ul>
 </template>` })

--- a/packages/router/test/e2e/layouts/src/components/contacts.ts
+++ b/packages/router/test/e2e/layouts/src/components/contacts.ts
@@ -5,7 +5,7 @@ import { ContactList } from './../contact-list';
 @customElement({
   name: 'contacts', template: `<template>CONTACTS <input>
 <ul>
-  <li repeat.for="contact of contacts"><a href="contact=\${contact.id}">\${contact.name}</a></li>
+  <li repeat.for="contact of contacts"><a href="contact(\${contact.id})">\${contact.name}</a></li>
 </ul>
 <au-viewport name="contact" used-by="contact"></au-viewport>
 </template>` })

--- a/packages/router/test/e2e/nav/src/app.ts
+++ b/packages/router/test/e2e/nav/src/app.ts
@@ -10,8 +10,8 @@ import { Router } from '../../../../../router/src/index';
     <p>A layout test, with game and lobby "layouts".</p>
     <a href="lobby">Lobby</a>
     <a href="game">Game</a>
-    <a href="lobby@app+contacts@lobby+contact@contact=123">Lobby + contacts + 123</a>
-    <a href="lobby@app+contact@contact=123+contacts@lobby">Lobby + 123 + contacts</a>
+    <a href="lobby@app+contacts@lobby+contact@contact(123)">Lobby + contacts + 123</a>
+    <a href="lobby@app+contact@contact(123)+contacts@lobby">Lobby + 123 + contacts</a>
     <a href="game+board@game">Game + board (5 + 5, parent-child)</a>
     <a href="game+delayed">Game + delayed (5 + 5, siblings)</a>
     <a href="cancel">Cancel</a>

--- a/packages/router/test/e2e/nav/src/components/contacts.ts
+++ b/packages/router/test/e2e/nav/src/components/contacts.ts
@@ -5,7 +5,7 @@ import { ContactList } from './../contact-list';
 @customElement({
   name: 'contacts', template: `<template>CONTACTS <input>
 <ul>
-  <li repeat.for="contact of contacts"><a href="contact=\${contact.id}">\${contact.name}</a></li>
+  <li repeat.for="contact of contacts"><a href="contact(\${contact.id})">\${contact.name}</a></li>
 </ul>
 <au-viewport name="contact" used-by="contact"></au-viewport>
 </template>` })

--- a/packages/router/test/unit/instruction-resolver.spec.ts
+++ b/packages/router/test/unit/instruction-resolver.spec.ts
@@ -24,7 +24,7 @@ describe('InstructionResolver', function () {
       new ViewportInstruction('bar', 'right', '456'),
     ];
     let instructionsString = router.instructionResolver.stringifyViewportInstructions(instructions);
-    expect(instructionsString).to.equal('foo@left=123+bar@right=456');
+    expect(instructionsString).to.equal('foo@left(123)+bar@right(456)');
     let newInstructions = router.instructionResolver.parseViewportInstructions(instructionsString);
     expect(newInstructions).to.deep.equal(instructions);
 
@@ -34,7 +34,7 @@ describe('InstructionResolver', function () {
       new ViewportInstruction('baz'),
     ];
     instructionsString = router.instructionResolver.stringifyViewportInstructions(instructions);
-    expect(instructionsString).to.equal('foo=123+bar@right+baz');
+    expect(instructionsString).to.equal('foo(123)+bar@right+baz');
     newInstructions = router.instructionResolver.parseViewportInstructions(instructionsString);
     expect(newInstructions).to.deep.equal(instructions);
 
@@ -49,10 +49,10 @@ describe('InstructionResolver', function () {
   const instructions: InstructionTest[] = [
     { instruction: 'foo', viewportInstruction: new ViewportInstruction('foo') },
     { instruction: 'foo@left', viewportInstruction: new ViewportInstruction('foo', 'left') },
-    { instruction: 'foo@left=123', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
-    { instruction: 'foo=123', viewportInstruction: new ViewportInstruction('foo', undefined, '123') },
+    { instruction: 'foo@left(123)', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
+    { instruction: 'foo(123)', viewportInstruction: new ViewportInstruction('foo', undefined, '123') },
     { instruction: 'foo/bar', viewportInstruction: new ViewportInstruction('foo', undefined, undefined, false, new ViewportInstruction('bar')) },
-    { instruction: 'foo=123/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', false, new ViewportInstruction('bar', 'left', undefined, false, new ViewportInstruction('baz'))) },
+    { instruction: 'foo(123)/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', false, new ViewportInstruction('bar', 'left', undefined, false, new ViewportInstruction('baz'))) },
   ];
 
   for (const instructionTest of instructions) {

--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -253,11 +253,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=123', router);
+    await goto('/bar@left(123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@left=456', router);
+    await goto('/bar@left(456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
@@ -268,11 +268,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=id=123', router);
+    await goto('/bar@left(id=123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@left=id=456', router);
+    await goto('/bar@left(id=456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
@@ -283,11 +283,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=123', router);
+    await goto('/bar@left(123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@right=456', router);
+    await goto('/bar@right(456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter id: [456]');
@@ -302,7 +302,7 @@ describe('Router', function () {
     await goto('/corge@left', router);
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/baz=123', router);
+    await goto('/baz(123)', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
@@ -316,7 +316,7 @@ describe('Router', function () {
     await goto('/corge@left', router);
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/baz=id=123', router);
+    await goto('/baz(id=123)', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
@@ -327,12 +327,12 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=123&OneTwoThree', router);
+    await goto('/bar@left(123&OneTwoThree)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter name: [OneTwoThree]');
 
-    await goto('/bar@left=456&FourFiveSix', router);
+    await goto('/bar@left(456&FourFiveSix)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
@@ -344,12 +344,12 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=id=123&name=OneTwoThree', router);
+    await goto('/bar@left(id=123&name=OneTwoThree)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter name: [OneTwoThree]');
 
-    await goto('/bar@left=name=FourFiveSix&id=456', router);
+    await goto('/bar@left(name=FourFiveSix&id=456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
@@ -377,16 +377,16 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left=456?id=123', router);
+    await goto('/bar@left(456)?id=123', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
-    await goto('/bar@left=456&FourFiveSix?id=123&name=OneTwoThree', router);
+    await goto('/bar@left(456&FourFiveSix)?id=123&name=OneTwoThree', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
 
-    await goto('/bar@left=name=SevenEightNine&id=789?id=123&name=OneTwoThree', router);
+    await goto('/bar@left(name=SevenEightNine&id=789)?id=123&name=OneTwoThree', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [789]');
     expect(host.textContent).to.contain('Parameter name: [SevenEightNine]');


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR replaces the equals separator before parameters with a parantheses around the parameters for the default url syntax. The link
```html
<a href="book(3)">Night Watch</a>
```
results in the url (using hash)

`www.something.com/#/book(3)`

which navigates to the component `book` and pass the parameter `3` to `canEnter`/`enter`. Other examples:
```html
<a href="todos">All todos</a>
<a href="todos(active)">Todos left to, well, to do</a>
```

This PR doesn't do anything about parameter format with named parameters and/or more than one parameter (`parameter=value&parameter=value`). That will come in a later PR.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in packages/router/test/e2e/** since they are just my own test applications while working.

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Review the extension points
- Re-visit scoped viewports
- Add a before navigation hook with accompanying redirect
