### PR TITLE
feat(attr-binding): add class/style binding

### DIFF
--- a/packages/jit-html/src/attribute-pattern.ts
+++ b/packages/jit-html/src/attribute-pattern.ts
@@ -1,0 +1,51 @@
+import { attributePattern, AttrSyntax, IAttributePattern } from '@aurelia/jit';
+import { IRegistry } from '@aurelia/kernel';
+
+export interface AttrPattern extends IAttributePattern {}
+export class AttrPattern implements AttrPattern {
+  public static register: IRegistry['register'];
+
+  public ['attr.PART'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[1], 'attr');
+  }
+
+  public ['PART.attr'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[0], 'attr');
+  }
+}
+
+export interface StyleAttributePattern extends IAttributePattern {}
+export class StyleAttributePattern implements StyleAttributePattern {
+  public static register: IRegistry['register'];
+
+  public ['style.PART'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[1], 'style');
+  }
+
+  public ['PART.style'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[0], 'style');
+  }
+}
+
+attributePattern(
+  { pattern: 'style.PART', symbols: '.' },
+  { pattern: 'PART.style', symbols: '.' }
+)(StyleAttributePattern);
+
+export interface ClassAttributePattern extends IAttributePattern {}
+export class ClassAttributePattern implements ClassAttributePattern {
+  public static register: IRegistry['register'];
+
+  public ['class.PART'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[1], 'class');
+  }
+
+  public ['PART.class'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, parts[0], 'class');
+  }
+}
+
+attributePattern(
+  { pattern: 'class.PART', symbols: '.' },
+  { pattern: 'PART.class', symbols: '.' }
+)(ClassAttributePattern);

--- a/packages/jit-html/src/attribute-pattern.ts
+++ b/packages/jit-html/src/attribute-pattern.ts
@@ -2,6 +2,13 @@ import { attributePattern, AttrSyntax, IAttributePattern } from '@aurelia/jit';
 import { IRegistry } from '@aurelia/kernel';
 
 export interface AttrAttributePattern extends IAttributePattern {}
+/**
+ * Attribute syntax pattern recognizer, helping Aurelia understand template:
+ * ```html
+ * <div attr.some-attr="someAttrValue"></div>
+ * <div some-attr.attr="someAttrValue"></div>
+ * ````
+ */
 export class AttrAttributePattern implements AttrAttributePattern {
   public static register: IRegistry['register'];
 
@@ -20,6 +27,19 @@ attributePattern(
 )(AttrAttributePattern);
 
 export interface StyleAttributePattern extends IAttributePattern {}
+/**
+ * Style syntax pattern recognizer, helps Aurelia understand template:
+ * ```html
+ * <div background.style="bg"></div>
+ * <div style.background="bg"></div>
+ * <div background-color.style="bg"></div>
+ * <div style.background-color="bg"></div>
+ * <div -webkit-user-select.style="select"></div>
+ * <div style.-webkit-user-select="select"></div>
+ * <div --custom-prop-css.style="cssProp"></div>
+ * <div style.--custom-prop-css="cssProp"></div>
+ * ```
+ */
 export class StyleAttributePattern implements StyleAttributePattern {
   public static register: IRegistry['register'];
 
@@ -38,6 +58,15 @@ attributePattern(
 )(StyleAttributePattern);
 
 export interface ClassAttributePattern extends IAttributePattern {}
+/**
+ * Class syntax pattern recognizer, helps Aurelia understand template:
+ * ```html
+ * <div my-class.class="class"></div>
+ * <div class.my-class="class"></div>
+ * <div ✔.class="checked"></div>
+ * <div class.✔="checked"></div>
+ * ```
+ */
 export class ClassAttributePattern implements ClassAttributePattern {
   public static register: IRegistry['register'];
 

--- a/packages/jit-html/src/attribute-pattern.ts
+++ b/packages/jit-html/src/attribute-pattern.ts
@@ -14,6 +14,11 @@ export class AttrAttributePattern implements AttrAttributePattern {
   }
 }
 
+attributePattern(
+  { pattern: 'attr.PART', symbols: '.' },
+  { pattern: 'PART.attr', symbols: '.' }
+)(AttrAttributePattern);
+
 export interface StyleAttributePattern extends IAttributePattern {}
 export class StyleAttributePattern implements StyleAttributePattern {
   public static register: IRegistry['register'];

--- a/packages/jit-html/src/attribute-pattern.ts
+++ b/packages/jit-html/src/attribute-pattern.ts
@@ -1,8 +1,8 @@
 import { attributePattern, AttrSyntax, IAttributePattern } from '@aurelia/jit';
 import { IRegistry } from '@aurelia/kernel';
 
-export interface AttrPattern extends IAttributePattern {}
-export class AttrPattern implements AttrPattern {
+export interface AttrAttributePattern extends IAttributePattern {}
+export class AttrAttributePattern implements AttrAttributePattern {
   public static register: IRegistry['register'];
 
   public ['attr.PART'](rawName: string, rawValue: string, parts: string[]): AttrSyntax {

--- a/packages/jit-html/src/binding-command.ts
+++ b/packages/jit-html/src/binding-command.ts
@@ -8,6 +8,7 @@ import {
 import { IRegistry } from '@aurelia/kernel';
 import { BindingType, IsBindingBehavior } from '@aurelia/runtime';
 import {
+  AttributeBindingInstruction,
   CaptureBindingInstruction,
   DelegateBindingInstruction,
   HTMLAttributeInstruction,
@@ -58,3 +59,49 @@ export class CaptureBindingCommand implements IBindingCommand {
   }
 }
 BindingCommandResource.define('capture', CaptureBindingCommand);
+
+export interface AttrBindingCommand extends IBindingCommand {}
+export class AttrBindingCommand implements IBindingCommand {
+  public static readonly register: IRegistry['register'];
+  public readonly bindingType: BindingType.IsProperty;
+
+  constructor() {
+    this.bindingType = BindingType.IsProperty;
+  }
+
+  public compile(binding: PlainAttributeSymbol | BindingSymbol): HTMLAttributeInstruction {
+    const target = getTarget(binding, false);
+    return new AttributeBindingInstruction(target, binding.expression as IsBindingBehavior, target);
+  }
+}
+BindingCommandResource.define('attr', AttrBindingCommand);
+
+export interface StyleBindingCommand extends IBindingCommand {}
+export class StyleBindingCommand implements IBindingCommand {
+  public static readonly register: IRegistry['register'];
+  public readonly bindingType: BindingType.IsProperty;
+
+  constructor() {
+    this.bindingType = BindingType.IsProperty;
+  }
+
+  public compile(binding: PlainAttributeSymbol | BindingSymbol): HTMLAttributeInstruction {
+    return new AttributeBindingInstruction('style', binding.expression as IsBindingBehavior, getTarget(binding, true));
+  }
+}
+BindingCommandResource.define('style', StyleBindingCommand);
+
+export interface ClassBindingCommand extends IBindingCommand {}
+export class ClassBindingCommand implements IBindingCommand {
+  public static readonly register: IRegistry['register'];
+  public readonly bindingType: BindingType.IsProperty;
+
+  constructor() {
+    this.bindingType = BindingType.IsProperty;
+  }
+
+  public compile(binding: PlainAttributeSymbol | BindingSymbol): HTMLAttributeInstruction {
+    return new AttributeBindingInstruction('class', binding.expression as IsBindingBehavior, getTarget(binding, false));
+  }
+}
+BindingCommandResource.define('class', ClassBindingCommand);

--- a/packages/jit-html/src/binding-command.ts
+++ b/packages/jit-html/src/binding-command.ts
@@ -86,7 +86,7 @@ export class StyleBindingCommand implements IBindingCommand {
   }
 
   public compile(binding: PlainAttributeSymbol | BindingSymbol): HTMLAttributeInstruction {
-    return new AttributeBindingInstruction('style', binding.expression as IsBindingBehavior, getTarget(binding, true));
+    return new AttributeBindingInstruction('style', binding.expression as IsBindingBehavior, getTarget(binding, false));
   }
 }
 BindingCommandResource.define('style', StyleBindingCommand);

--- a/packages/jit-html/src/binding-command.ts
+++ b/packages/jit-html/src/binding-command.ts
@@ -16,6 +16,9 @@ import {
 } from '@aurelia/runtime-html';
 
 export interface TriggerBindingCommand extends IBindingCommand {}
+/**
+ * Trigger binding command. Compile attr with binding symbol with command `trigger` to `TriggerBindingInstruction`
+ */
 export class TriggerBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.TriggerCommand;
@@ -31,6 +34,9 @@ export class TriggerBindingCommand implements IBindingCommand {
 BindingCommandResource.define('trigger', TriggerBindingCommand);
 
 export interface DelegateBindingCommand extends IBindingCommand {}
+/**
+ * Delegate binding command. Compile attr with binding symbol with command `delegate` to `DelegateBindingInstruction`
+ */
 export class DelegateBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.DelegateCommand;
@@ -46,6 +52,9 @@ export class DelegateBindingCommand implements IBindingCommand {
 BindingCommandResource.define('delegate', DelegateBindingCommand);
 
 export interface CaptureBindingCommand extends IBindingCommand {}
+/**
+ * Capture binding command. Compile attr with binding symbol with command `capture` to `CaptureBindingInstruction`
+ */
 export class CaptureBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.CaptureCommand;
@@ -61,6 +70,9 @@ export class CaptureBindingCommand implements IBindingCommand {
 BindingCommandResource.define('capture', CaptureBindingCommand);
 
 export interface AttrBindingCommand extends IBindingCommand {}
+/**
+ * Attr binding command. Compile attr with binding symbol with command `attr` to `AttributeBindingInstruction`
+ */
 export class AttrBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.IsProperty;
@@ -77,6 +89,9 @@ export class AttrBindingCommand implements IBindingCommand {
 BindingCommandResource.define('attr', AttrBindingCommand);
 
 export interface StyleBindingCommand extends IBindingCommand {}
+/**
+ * Style binding command. Compile attr with binding symbol with command `style` to `AttributeBindingInstruction`
+ */
 export class StyleBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.IsProperty;
@@ -92,6 +107,9 @@ export class StyleBindingCommand implements IBindingCommand {
 BindingCommandResource.define('style', StyleBindingCommand);
 
 export interface ClassBindingCommand extends IBindingCommand {}
+/**
+ * Class binding command. Compile attr with binding symbol with command `class` to `AttributeBindingInstruction`
+ */
 export class ClassBindingCommand implements IBindingCommand {
   public static readonly register: IRegistry['register'];
   public readonly bindingType: BindingType.IsProperty;

--- a/packages/jit-html/src/configuration.ts
+++ b/packages/jit-html/src/configuration.ts
@@ -39,7 +39,8 @@ export const DefaultComponents = [
  */
 export const JitAttrBindingSyntax = [
   StyleAttributePattern,
-  ClassAttributePattern
+  ClassAttributePattern,
+  AttrAttributePattern
 ];
 
 export const TriggerBindingCommandRegistration = TriggerBindingCommand as IRegistry;

--- a/packages/jit-html/src/configuration.ts
+++ b/packages/jit-html/src/configuration.ts
@@ -6,8 +6,16 @@ import {
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
 import { BasicConfiguration as RuntimeHtmlBasicConfiguration } from '@aurelia/runtime-html';
 import {
+  AttrAttributePattern,
+  ClassAttributePattern,
+  StyleAttributePattern
+} from './attribute-pattern';
+import {
+  AttrBindingCommand,
   CaptureBindingCommand,
+  ClassBindingCommand,
   DelegateBindingCommand,
+  StyleBindingCommand,
   TriggerBindingCommand
 } from './binding-command';
 import { TemplateCompiler } from './template-compiler';
@@ -26,9 +34,20 @@ export const DefaultComponents = [
   ITemplateElementFactoryRegistration
 ];
 
+/**
+ * Default HTML-specific (but environment-agnostic) implementations for style binding
+ */
+export const JitAttrBindingSyntax = [
+  StyleAttributePattern,
+  ClassAttributePattern
+];
+
 export const TriggerBindingCommandRegistration = TriggerBindingCommand as IRegistry;
 export const DelegateBindingCommandRegistration = DelegateBindingCommand as IRegistry;
 export const CaptureBindingCommandRegistration = CaptureBindingCommand as IRegistry;
+export const AttrBindingCommandRegistration = AttrBindingCommand as IRegistry;
+export const ClassBindingCommandRegistration = ClassBindingCommand as IRegistry;
+export const StyleBindingCommandRegistration = StyleBindingCommand as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) binding commands:
@@ -37,7 +56,10 @@ export const CaptureBindingCommandRegistration = CaptureBindingCommand as IRegis
 export const DefaultBindingLanguage = [
   TriggerBindingCommandRegistration,
   DelegateBindingCommandRegistration,
-  CaptureBindingCommandRegistration
+  CaptureBindingCommandRegistration,
+  ClassBindingCommandRegistration,
+  StyleBindingCommandRegistration,
+  AttrBindingCommandRegistration
 ];
 
 /**
@@ -59,6 +81,7 @@ export const BasicConfiguration = {
       .register(
         ...JitDefaultComponents,
         ...JitDefaultBindingSyntax,
+        ...JitAttrBindingSyntax,
         ...JitDefaultBindingLanguage,
         ...DefaultComponents,
         ...DefaultBindingLanguage

--- a/packages/jit-html/src/index.ts
+++ b/packages/jit-html/src/index.ts
@@ -1,7 +1,10 @@
 export {
   TriggerBindingCommand,
   DelegateBindingCommand,
-  CaptureBindingCommand
+  CaptureBindingCommand,
+  AttrBindingCommand,
+  ClassBindingCommand,
+  StyleBindingCommand
 } from './binding-command';
 export {
   ITemplateCompilerRegistration,
@@ -12,6 +15,9 @@ export {
   TriggerBindingCommandRegistration,
   DelegateBindingCommandRegistration,
   CaptureBindingCommandRegistration,
+  AttrBindingCommandRegistration,
+  ClassBindingCommandRegistration,
+  StyleBindingCommandRegistration,
 
   DefaultBindingLanguage,
 

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -44,6 +44,9 @@ const attributesToIgnore = {
   'replace-part': true
 };
 
+/**
+ * TemplateBinder. Todo: describe goal of this class
+ */
 export class TemplateBinder {
   public dom: IDOM;
   public resources: ResourceModel;
@@ -530,6 +533,9 @@ interface IAttrLike {
   value: string;
 }
 
+/**
+ * ParserState. Todo: describe goal of this class
+ */
 class ParserState {
   public input: string;
   public index: number;

--- a/packages/jit-html/test/integration/binding-command.class.spec.ts
+++ b/packages/jit-html/test/integration/binding-command.class.spec.ts
@@ -7,7 +7,7 @@ import { TestContext } from '../util';
 import { eachCartesianJoin, eachCartesianJoinAsync, tearDown } from './util';
 
 // TemplateCompiler - Binding Commands integration
-describe('template-compiler.binding-commands.class', function() {
+describe.only('template-compiler.binding-commands.class', function() {
 
   const falsyValues = [0, false, null, undefined, ''];
   const truthyValues = [1, '1', true, {}, [], Symbol(), function() {/**/}, Number, new Proxy({}, {})];
@@ -144,7 +144,8 @@ describe('template-compiler.binding-commands.class', function() {
             : testCase.selector(ctx.doc);
           for (let i = 0, ii = els.length; ii > i; ++i) {
             const el = els[i];
-            expect(el.classList.contains(className.toLowerCase()), `[true]classList.contains(${className})`).to.equal(true);
+            debugger;
+            expect(el.classList.contains(className.toLowerCase()), `[true]classList.contains(${className})`).to.equal(true, `Actual: "${el.className}"`);
           }
 
           await eachCartesianJoinAsync(

--- a/packages/jit-html/test/integration/binding-command.class.spec.ts
+++ b/packages/jit-html/test/integration/binding-command.class.spec.ts
@@ -22,6 +22,10 @@ describe('template-compiler.binding-commands.class', function() {
     'SOME_RIDI-COU@#$%-class',
     '1',
     '__1',
+    '✔',
+    '⛓',
+    '🤷‍♂️', // double characters
+    '🤯',
     ...[
     '@',
     '#',

--- a/packages/jit-html/test/integration/binding-command.class.spec.ts
+++ b/packages/jit-html/test/integration/binding-command.class.spec.ts
@@ -1,0 +1,202 @@
+import { Constructable } from '@aurelia/kernel';
+import { Aurelia, BindingMode, CustomElementResource, ILifecycle } from '@aurelia/runtime';
+import { IEventManager } from '@aurelia/runtime-html';
+import { expect } from 'chai';
+import { BasicConfiguration } from '../../src/index';
+import { TestContext } from '../util';
+import { eachCartesianJoin, eachCartesianJoinAsync, tearDown } from './util';
+
+// TemplateCompiler - Binding Commands integration
+describe('template-compiler.binding-commands.class', function() {
+
+  const falsyValues = [0, false, null, undefined, ''];
+  const truthyValues = [1, '1', true, {}, [], Symbol(), function() {/**/}, Number, new Proxy({}, {})];
+
+  const classNameTests: string[] = [
+    'background',
+    'color',
+    'background-color',
+    'font-size',
+    'font-family',
+    '-webkit-user-select',
+    'SOME_RIDI-COU@#$%-class',
+    '1',
+    '__1',
+    ...[
+    '@',
+    '#',
+    '$',
+    '!',
+    '^',
+    '~',
+    '&',
+    '*',
+    '(',
+    ')',
+    '+',
+    // '=', // todo: better test for this scenario
+    '*',
+    // '/', // todo: better test for this scenario
+    '\\',
+    ':',
+    '[',
+    ']',
+    '{',
+    '}',
+    '|',
+    '<',
+    // '>', // todo: better test for this scenario
+    ',',
+    '%'].map(s => `${s}1`)
+  ];
+
+  const testCases: ITestCase[] = [
+    {
+      selector: 'button',
+      title: (className: string, callIndex: number) => `${callIndex}. <button class.${className}=value>`,
+      template: (className) => {
+        return `
+        <button ${className}.class="value"></button>
+        <button class.${className}="value"></button>
+        <child value.bind="value"></child>
+        <child repeat.for="i of 5" value.bind="value"></child>
+      `;
+      },
+      assert: async (au, lifecycle, host, component, testCase, className) => {
+        const childEls = host.querySelectorAll('child');
+        expect(childEls.length).to.equal(6);
+        await eachCartesianJoinAsync(
+          [falsyValues, truthyValues],
+          async (falsyValue, truthyValue) => {
+            for (let i = 0, ii = childEls.length; ii > i; ++i) {
+              const el = childEls[i];
+              expect(
+                el.classList.contains(className.toLowerCase()),
+                `classList.contains(${className})`
+              ).to.equal(true);
+            }
+
+            component.value = falsyValue;
+            await Promise.resolve();
+            for (let i = 0, ii = childEls.length; ii > i; ++i) {
+              const el = childEls[i];
+              expect(
+                el.classList.contains(className.toLowerCase()),
+                `[${String(falsyValue)}]classList.contains(${className})`
+              ).to.equal(false);
+            }
+
+            component.value = truthyValue;
+            await Promise.resolve();
+            for (let i = 0, ii = childEls.length; ii > i; ++i) {
+              const el = childEls[i];
+              expect(
+                el.classList.contains(className.toLowerCase()),
+                `[${String(truthyValue)}]classList.contains(${className})`
+              ).to.equal(true);
+            }
+          }
+        );
+      }
+    }
+  ];
+
+  /**
+   * For each combination of class name and test case
+   * Check the following:
+   * 1. The element contains the class
+   * 2. Each `value` of falsy values, set bound view model value to `value` and:
+   *  - wait for 1 promise tick
+   *  - the element does not contain the class
+   * 3. Each `value` of truthy values, set bound view model value to `value` and:
+   *  - wait for 1 promise tick
+   *  - the element does contain the class
+   * 4. TODO: assert class binding command on root surrogate once root surrogate rendering is supported
+   */
+  eachCartesianJoin(
+    [classNameTests, testCases],
+    (className, testCase, callIndex) => {
+      it(testCase.title(className, callIndex), async function() {
+        const { ctx, au, lifecycle, host, component } = setup(
+          testCase.template(className),
+          class App {
+            public value: unknown = true;
+          },
+          BasicConfiguration,
+          CustomElementResource.define(
+            {
+              name: 'child',
+              template: `<template ${className}.class="value"></template>`
+            },
+            class Child {
+              public static bindables = {
+                value: { property: 'value', attribute: 'value', mode: BindingMode.twoWay }
+              };
+              public value = true;
+            }
+          )
+        );
+        au.app({ host, component });
+        au.start();
+        try {
+          const els = typeof testCase.selector === 'string'
+            ? host.querySelectorAll(testCase.selector) as NodeListOf<HTMLElement>
+            : testCase.selector(ctx.doc);
+          for (let i = 0, ii = els.length; ii > i; ++i) {
+            const el = els[i];
+            expect(el.classList.contains(className.toLowerCase()), `[true]classList.contains(${className})`).to.equal(true);
+          }
+
+          await eachCartesianJoinAsync(
+            [falsyValues, truthyValues],
+            async (falsyValue, truthyValue) => {
+              component.value = falsyValue;
+              await Promise.resolve();
+              for (let i = 0, ii = els.length; ii > i; ++i) {
+                const el = els[i];
+                expect(el.classList.contains(className.toLowerCase()), `[${String(falsyValue)}]classList.contains(${className})`).to.equal(false);
+              }
+
+              component.value = truthyValue;
+              await Promise.resolve();
+              for (let i = 0, ii = els.length; ii > i; ++i) {
+                const el = els[i];
+                expect(el.classList.contains(className.toLowerCase()), `[${String(truthyValue)}]classList.contains(${className})`).to.equal(true);
+              }
+            }
+          );
+          await testCase.assert(au, lifecycle, host, component, testCase, className);
+        } finally {
+          const em = ctx.container.get(IEventManager);
+          em.dispose();
+          tearDown(au, lifecycle, host);
+        }
+      });
+    }
+  );
+
+  function noop() {/**/}
+
+  interface IApp {
+    value: any;
+  }
+
+  interface ITestCase {
+    selector: string | ((document: Document) => ArrayLike<Element>);
+    title(...args: unknown[]): string;
+    template(...args: string[]): string;
+    assert(au: Aurelia, lifecycle: ILifecycle, host: HTMLElement, component: IApp, testCase: ITestCase, className: string): void | Promise<void>;
+  }
+
+  function setup<T>(template: string | Node, $class: Constructable<T> | null, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    container.register(...registrations);
+    const host = ctx.doc.body.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElementResource.define({ name: 'app', template }, $class);
+    const component = new App() as T;
+
+    return { container, lifecycle, ctx, host, au, component, observerLocator };
+  }
+});

--- a/packages/jit-html/test/integration/binding-command.class.spec.ts
+++ b/packages/jit-html/test/integration/binding-command.class.spec.ts
@@ -7,7 +7,7 @@ import { TestContext } from '../util';
 import { eachCartesianJoin, eachCartesianJoinAsync, tearDown } from './util';
 
 // TemplateCompiler - Binding Commands integration
-describe.only('template-compiler.binding-commands.class', function() {
+describe('template-compiler.binding-commands.class', function() {
 
   const falsyValues = [0, false, null, undefined, ''];
   const truthyValues = [1, '1', true, {}, [], Symbol(), function() {/**/}, Number, new Proxy({}, {})];
@@ -72,7 +72,7 @@ describe.only('template-compiler.binding-commands.class', function() {
               const el = childEls[i];
               expect(
                 el.classList.contains(className.toLowerCase()),
-                `classList.contains(${className})`
+                `[[truthy]]${el.className}.contains(${className}) 1`
               ).to.equal(true);
             }
 
@@ -82,7 +82,7 @@ describe.only('template-compiler.binding-commands.class', function() {
               const el = childEls[i];
               expect(
                 el.classList.contains(className.toLowerCase()),
-                `[${String(falsyValue)}]classList.contains(${className})`
+                `[${String(falsyValue)}]${el.className}.contains(${className}) 2`
               ).to.equal(false);
             }
 
@@ -92,7 +92,7 @@ describe.only('template-compiler.binding-commands.class', function() {
               const el = childEls[i];
               expect(
                 el.classList.contains(className.toLowerCase()),
-                `[${String(truthyValue)}]classList.contains(${className})`
+                `[${String(truthyValue)}]${el.className}.contains(${className}) 3`
               ).to.equal(true);
             }
           }
@@ -140,12 +140,14 @@ describe.only('template-compiler.binding-commands.class', function() {
         au.start();
         try {
           const els = typeof testCase.selector === 'string'
-            ? host.querySelectorAll(testCase.selector) as NodeListOf<HTMLElement>
-            : testCase.selector(ctx.doc);
+            ? host.querySelectorAll(testCase.selector)
+            : testCase.selector(ctx.doc) as ArrayLike<HTMLElement>;
           for (let i = 0, ii = els.length; ii > i; ++i) {
             const el = els[i];
-            debugger;
-            expect(el.classList.contains(className.toLowerCase()), `[true]classList.contains(${className})`).to.equal(true, `Actual: "${el.className}"`);
+            expect(
+              el.classList.contains(className.toLowerCase()),
+              `[true]${el.className}.contains(${className}) 1`
+            ).to.equal(true);
           }
 
           await eachCartesianJoinAsync(
@@ -155,14 +157,20 @@ describe.only('template-compiler.binding-commands.class', function() {
               await Promise.resolve();
               for (let i = 0, ii = els.length; ii > i; ++i) {
                 const el = els[i];
-                expect(el.classList.contains(className.toLowerCase()), `[${String(falsyValue)}]classList.contains(${className})`).to.equal(false);
+                expect(
+                  el.classList.contains(className.toLowerCase()),
+                  `[${String(falsyValue)}]${el.className}.contains(${className}) 2`
+                ).to.equal(false);
               }
 
               component.value = truthyValue;
               await Promise.resolve();
               for (let i = 0, ii = els.length; ii > i; ++i) {
                 const el = els[i];
-                expect(el.classList.contains(className.toLowerCase()), `[${String(truthyValue)}]classList.contains(${className})`).to.equal(true);
+                expect(
+                  el.classList.contains(className.toLowerCase()),
+                  `[${String(truthyValue)}]${el.className}.contains(${className}) 3`
+                ).to.equal(true);
               }
             }
           );
@@ -196,7 +204,7 @@ describe.only('template-compiler.binding-commands.class', function() {
     const host = ctx.doc.body.appendChild(ctx.createElement('app'));
     const au = new Aurelia(container);
     const App = CustomElementResource.define({ name: 'app', template }, $class);
-    const component = new App() as T;
+    const component = new App();
 
     return { container, lifecycle, ctx, host, au, component, observerLocator };
   }

--- a/packages/jit-html/test/integration/binding-command.style.spec.ts
+++ b/packages/jit-html/test/integration/binding-command.style.spec.ts
@@ -1,0 +1,188 @@
+import { Constructable } from '@aurelia/kernel';
+import { Aurelia, CustomElementResource, ILifecycle } from '@aurelia/runtime';
+import { IEventManager } from '@aurelia/runtime-html';
+import { expect } from 'chai';
+import { BasicConfiguration } from '../../src/index';
+import { TestContext } from '../util';
+import { eachCartesianJoin, eachCartesianJoinAsync, tearDown } from './util';
+
+// TemplateCompiler - Binding Commands integration
+describe('template-compiler.binding-commands.style', () => {
+  const falsyValues = [0, false, null, undefined, ''];
+  const truthyValues = [1, '1', true, {}, [], Symbol(), function() {/**/}, Number, new Proxy({}, {})];
+
+  /** [ruleName, ruleValue, defaultValue] */
+  const rulesTests: [string, string, string][] = [
+    ['background', 'red', ''],
+    ['color', 'red', ''],
+    ['background-color', 'red', ''],
+    ['font-size', '10px', ''],
+    ['font-family', 'Arial', ''],
+    ['-webkit-user-select', 'none', 'none']
+  ];
+
+  const testCases: ITestCase[] = [
+    {
+      selector: 'button',
+      title: (ruleName: string, ruleValue: string, callIndex: number) => `${callIndex}. ${ruleName}=${ruleValue}`,
+      template: (ruleTest) => {
+        return `
+        <button ${ruleTest}.style="value"></button>
+        <button style.${ruleTest}="value"></button>
+        <child value.bind="value"></child>
+        <child repeat.for="i of 5" value.bind="value"></child>`;
+      },
+      assert: async (au, lifecycle, host, component, [ruleName, ruleValue, ruleDefaultValue], testCase) => {
+        const childEls = host.querySelectorAll('child') as ArrayLike<HTMLElement>;
+        expect(childEls.length).to.equal(6);
+
+        component.value = ruleValue;
+        await Promise.resolve();
+        for (let i = 0, ii = childEls.length; ii > i; ++i) {
+          const child = childEls[i];
+          expect(child.style[ruleName], `[${ruleName}]component.value="${ruleValue}"`).to.equal(ruleValue);
+        }
+
+        component.value = '';
+        await Promise.resolve();
+        for (let i = 0, ii = childEls.length; ii > i; ++i) {
+          const child = childEls[i];
+          expect(child.style[ruleName], `[${ruleName}]component.value=""`).to.equal(ruleDefaultValue);
+        }
+
+        component.value = ruleValue;
+        await Promise.resolve();
+        for (let i = 0, ii = childEls.length; ii > i; ++i) {
+          const child = childEls[i];
+          expect(child.style[ruleName], `[${ruleName}]component.value="${ruleValue}"`).to.equal(ruleValue);
+        }
+
+        // TODO: for inlined css, there are rules that employs fallback value when incoming value is inappropriate
+        //        better test those scenarios
+      }
+    }
+  ];
+
+  /**
+   * For each combination of style rule and test case:
+   * Test the following:
+   * ----
+   * 1. on init, select all elements specified by `testCase.selector`
+   *  - verify it has inline style matching `ruleValue` (2nd var in destructed 1st tuple param)
+   *  - if `ruleValue` has `"!important"`, verify priority of inline style is `"important"`
+   * 
+   * 2. set `value` of bound view model to empty string. For each of all elements queried by `testCase.selector` 
+   *  - verify each element has inline style value equal empty string,
+   *    or default value (3rd var in destructed 1st tuple param)
+   * 
+   * 3. set `value` of bound view model to `ruleValue` (2nd var in destructed 1st tuple param)
+   *  - verify each element has inline style value equal `ruleValue`
+   *  - if `ruleValue` has `"!important"`, verify priority of inline style is `"important"`
+   * 
+   * 4. repeat step 2
+   * 5. Call custom `assert` of each test case with necessary parameters
+   */
+  eachCartesianJoin(
+    [rulesTests, testCases],
+    ([ruleName, ruleValue, ruleDefaultValue], testCase, callIndex) => {
+      it(testCase.title(ruleName, ruleValue, callIndex), async () => {
+        const { ctx, au, lifecycle, host, component } = setup(
+          testCase.template(ruleName),
+          class App {
+            public value: string = ruleValue;
+          },
+          BasicConfiguration,
+          CustomElementResource.define(
+            {
+              name: 'child',
+              template: `<template ${ruleName}.style="value"></template>`
+            },
+            class Child {
+              public static bindables = {
+                value: { property: 'value', attribute: 'value' }
+              };
+            }
+          )
+        );
+        au.app({ host, component });
+        au.start();
+        try {
+          const els = typeof testCase.selector === 'string'
+            ? host.querySelectorAll(testCase.selector) as NodeListOf<HTMLElement>
+            : testCase.selector(ctx.doc);
+          for (let i = 0, ii = els.length; ii > i; ++i) {
+            const el = els[i];
+            expect(el.style.getPropertyValue(ruleName)).to.equal(ruleValue);
+            if (ruleValue.indexOf('!important') > -1) {
+              expect(el.style.getPropertyPriority(ruleName)).to.equal('important');
+            }
+          }
+
+          component.value = '';
+          await Promise.resolve();
+          for (let i = 0, ii = els.length; ii > i; ++i) {
+            const el = els[i];
+            expect(el.style.getPropertyValue(ruleName), `[${ruleName}]component.value="${ruleValue}"`).to.equal(ruleDefaultValue);
+            if (ruleValue.indexOf('!important') > -1) {
+              expect(el.style.getPropertyPriority(ruleName)).to.equal('important');
+            }
+          }
+
+          component.value = ruleValue;
+          await Promise.resolve();
+          for (let i = 0, ii = els.length; ii > i; ++i) {
+            const el = els[i];
+            expect(el.style.getPropertyValue(ruleName), `[${ruleName}]component.value="${ruleValue}"`).to.equal(ruleValue);
+            if (ruleValue.indexOf('!important') > -1) {
+              expect(el.style.getPropertyPriority(ruleName)).to.equal('important');
+            }
+          }
+
+          component.value = '';
+          await Promise.resolve();
+          for (let i = 0, ii = els.length; ii > i; ++i) {
+            const el = els[i];
+            expect(el.style.getPropertyValue(ruleName), `[${ruleName}]component.value="${ruleValue}"`).to.equal(ruleDefaultValue);
+            if (ruleValue.indexOf('!important') > -1) {
+              expect(el.style.getPropertyPriority(ruleName)).to.equal('important');
+            }
+          }
+
+          // TODO: for inlined css, there are rules that employs fallback value when incoming value is inappropriate
+          //        better test those scenarios
+
+          await testCase.assert(au, lifecycle, host, component, [ruleName, ruleValue, ruleDefaultValue], testCase);
+        } finally {
+          const em = ctx.container.get(IEventManager);
+          em.dispose();
+          tearDown(au, lifecycle, host);
+        }
+      });
+    }
+  );
+
+  function noop() {/**/}
+
+  interface IApp {
+    value: any;
+  }
+
+  interface ITestCase {
+    selector: string | ((document: Document) => ArrayLike<HTMLElement>);
+    title(...args: unknown[]): string;
+    template(...args: string[]): string;
+    assert(au: Aurelia, lifecycle: ILifecycle, host: HTMLElement, component: IApp, ruleCase: [string, string, string], testCase): void | Promise<void>;
+  }
+
+  function setup<T>(template: string | Node, $class: Constructable<T> | null, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    container.register(...registrations);
+    const host = ctx.doc.body.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElementResource.define({ name: 'app', template }, $class);
+    const component: T = new App();
+
+    return { container, lifecycle, ctx, host, au, component, observerLocator };
+  }
+});

--- a/packages/jit-html/test/integration/util.ts
+++ b/packages/jit-html/test/integration/util.ts
@@ -12,6 +12,7 @@ import { expect } from 'chai';
 import {
   _,
   eachCartesianJoin,
+  eachCartesianJoinAsync,
   eachCartesianJoinFactory,
   ensureNotCalled,
   htmlStringify,
@@ -87,7 +88,7 @@ export function trimFull(text: string) {
   return text.replace(reg, '');
 }
 
-export { _, h, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinFactory };
+export { _, h, stringify, jsonStringify, htmlStringify, verifyEqual, padRight, massSpy, massStub, massReset, massRestore, ensureNotCalled, eachCartesianJoin, eachCartesianJoinAsync, eachCartesianJoinFactory };
 
 const eventCmds = { delegate: 1, capture: 1, call: 1 };
 
@@ -124,7 +125,7 @@ export const hJsx = function(name: string, attrs: Record<string, string> | null,
       // ortherwise do fallback check
       else {
         // is it an event handler?
-        if (attr[0] === 'o' && attr[1] === 'n' && attr[attr.length] !== '$') {
+        if (attr[0] === 'o' && attr[1] === 'n' && !attr.endsWith('$')) {
           const decoded = PLATFORM.kebabCase(attr.slice(2));
           const parts = decoded.split('-');
           if (parts.length > 1) {

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -12,6 +12,9 @@ const toViewOrOneTime = toView | oneTime;
 
 export interface AttributeBinding extends IConnectableBinding {}
 
+/**
+ * Attribute binding. Handle attribute binding betwen view/view model. Understand Html special attributes
+ */
 @connectable()
 export class AttributeBinding implements IPartialConnectableBinding {
   public $nextBinding: IBinding;

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -16,6 +16,9 @@ import { IEventManager } from '../observation/event-manager';
 const slice = Array.prototype.slice;
 
 export interface Listener extends IConnectableBinding {}
+/**
+ * Listener binding. Handle event binding between view and view model
+ */
 export class Listener implements IBinding {
   public dom: IDOM;
 

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -2,6 +2,7 @@ import { DI, IContainer, IRegistry } from '@aurelia/kernel';
 import { RuntimeBasicConfiguration } from '@aurelia/runtime';
 import { HTMLTemplateFactory } from './dom';
 import {
+  AttributeBindingRenderer,
   ListenerBindingRenderer,
   SetAttributeRenderer,
   StylePropertyBindingRenderer,
@@ -51,6 +52,7 @@ export const DefaultResources = [
 ];
 
 export const ListenerBindingRendererRegistration = ListenerBindingRenderer as IRegistry;
+export const AttributeBindingRendererRegistration = AttributeBindingRenderer as IRegistry;
 export const SetAttributeRendererRegistration = SetAttributeRenderer as IRegistry;
 export const StylePropertyBindingRendererRegistration = StylePropertyBindingRenderer as IRegistry;
 export const TextBindingRendererRegistration = TextBindingRenderer as IRegistry;
@@ -64,6 +66,7 @@ export const TextBindingRendererRegistration = TextBindingRenderer as IRegistry;
  */
 export const DefaultRenderers = [
   ListenerBindingRendererRegistration,
+  AttributeBindingRendererRegistration,
   SetAttributeRendererRegistration,
   StylePropertyBindingRendererRegistration,
   TextBindingRendererRegistration

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -32,6 +32,9 @@ export function createElement<T extends INode = Node>(
   }
 }
 
+/**
+ * RenderPlan. Todo: describe goal of this class
+ */
 export class RenderPlan<T extends INode = Node> {
   private readonly dom: IDOM<T>;
   private readonly dependencies: ReadonlyArray<IRegistry>;

--- a/packages/runtime-html/src/definitions.ts
+++ b/packages/runtime-html/src/definitions.ts
@@ -63,7 +63,7 @@ export interface ISetAttributeInstruction extends ITargetedInstruction {
 export interface IAttributeBindingInstruction extends ITargetedInstruction {
   type: HTMLTargetedInstructionType.attributeBinding;
   from: string | IsBindingBehavior;
-  
+
   /**
    * `attr` and `to` have the same value on a normal attribute
    * Will be different on `class` and `style`

--- a/packages/runtime-html/src/definitions.ts
+++ b/packages/runtime-html/src/definitions.ts
@@ -62,7 +62,7 @@ export interface ISetAttributeInstruction extends ITargetedInstruction {
 
 export interface IAttributeBindingInstruction extends ITargetedInstruction {
   type: HTMLTargetedInstructionType.attributeBinding;
-  from: string;
+  from: string | IsBindingBehavior;
   
   /**
    * `attr` and `to` have the same value on a normal attribute

--- a/packages/runtime-html/src/definitions.ts
+++ b/packages/runtime-html/src/definitions.ts
@@ -10,8 +10,9 @@ import {
 export const enum HTMLTargetedInstructionType {
   textBinding = 'ha',
   listenerBinding = 'hb',
-  stylePropertyBinding = 'hc',
-  setAttribute = 'hd'
+  attributeBinding = 'hc',
+  stylePropertyBinding = 'hd',
+  setAttribute = 'he',
 }
 
 export type HTMLNodeInstruction =
@@ -21,6 +22,7 @@ export type HTMLNodeInstruction =
 export type HTMLAttributeInstruction =
   AttributeInstruction |
   IListenerBindingInstruction |
+  IAttributeBindingInstruction |
   IStylePropertyBindingInstruction |
   ISetAttributeInstruction;
 
@@ -55,5 +57,19 @@ export interface IStylePropertyBindingInstruction extends ITargetedInstruction {
 export interface ISetAttributeInstruction extends ITargetedInstruction {
   type: HTMLTargetedInstructionType.setAttribute;
   value: string;
+  to: string;
+}
+
+export interface IAttributeBindingInstruction extends ITargetedInstruction {
+  type: HTMLTargetedInstructionType.attributeBinding;
+  from: string;
+  
+  /**
+   * `attr` and `to` have the same value on a normal attribute
+   * Will be different on `class` and `style`
+   * on `class`: attr = `class` (from binding command), to = attribute name
+   * on `style`: attr = `style` (from binding command), to = attribute name
+   */
+  attr: string;
   to: string;
 }

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -42,6 +42,9 @@ function isRenderLocation(node: Node): node is Node & IRenderLocation {
   return node.textContent === 'au-end';
 }
 
+/**
+ * IDOM implementation for Html.
+ */
 export class HTMLDOM implements IDOM {
   public readonly Node: typeof Node;
   public readonly Element: typeof Element;
@@ -266,7 +269,10 @@ export class TextNodeSequence implements INodeSequence {
 // has an instance of this under the hood. Anyone who wants to create a node sequence from
 // a string of markup would also receive an instance of this.
 // CompiledTemplates create instances of FragmentNodeSequence.
-/** @internal */
+/**
+ * This is the most common form of INodeSequence.
+ * @internal
+ */
 export class FragmentNodeSequence implements INodeSequence {
   public dom: IDOM;
   public firstChild: Node;

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -16,17 +16,17 @@ import {
   LifecycleFlags,
   MultiInterpolationBinding
 } from '@aurelia/runtime';
+import { AttributeBinding } from './binding/attribute';
 import { Listener } from './binding/listener';
 import {
   HTMLTargetedInstructionType,
+  IAttributeBindingInstruction,
   IListenerBindingInstruction,
   ISetAttributeInstruction,
   IStylePropertyBindingInstruction,
-  ITextBindingInstruction,
-  IAttributeBindingInstruction
+  ITextBindingInstruction
 } from './definitions';
 import { IEventManager } from './observation/event-manager';
-import { AttributeBinding } from './binding/attribute';
 
 const slice = Array.prototype.slice;
 
@@ -140,8 +140,8 @@ export class AttributeBindingRenderer implements IInstructionRenderer {
     const binding = new AttributeBinding(
       expr,
       target,
-      /*targetAttribute*/instruction.attr,
-      /*targetKey*/instruction.to,
+      instruction.attr/*targetAttribute*/,
+      instruction.to/*targetKey*/,
       BindingMode.toView,
       this.observerLocator,
       context

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -22,9 +22,11 @@ import {
   IListenerBindingInstruction,
   ISetAttributeInstruction,
   IStylePropertyBindingInstruction,
-  ITextBindingInstruction
+  ITextBindingInstruction,
+  IAttributeBindingInstruction
 } from './definitions';
 import { IEventManager } from './observation/event-manager';
+import { AttributeBinding } from './binding/attribute';
 
 const slice = Array.prototype.slice;
 
@@ -113,6 +115,37 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
     if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const binding = new Binding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
+    addBinding(renderable, binding);
+    if (Tracer.enabled) { Tracer.leave(); }
+  }
+}
+
+@instructionRenderer(HTMLTargetedInstructionType.attributeBinding)
+/** @internal */
+export class AttributeBindingRenderer implements IInstructionRenderer {
+  public static readonly inject: ReadonlyArray<InterfaceSymbol> = [IExpressionParser, IObserverLocator];
+  public static readonly register: IRegistry['register'];
+
+  private readonly parser: IExpressionParser;
+  private readonly observerLocator: IObserverLocator;
+
+  constructor(parser: IExpressionParser, observerLocator: IObserverLocator) {
+    this.parser = parser;
+    this.observerLocator = observerLocator;
+  }
+
+  public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IRenderable, target: HTMLElement, instruction: IAttributeBindingInstruction): void {
+    if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer', 'render', slice.call(arguments)); }
+    const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
+    const binding = new AttributeBinding(
+      expr,
+      target,
+      /*targetAttribute*/instruction.attr,
+      /*targetKey*/instruction.to,
+      BindingMode.toView,
+      this.observerLocator,
+      context
+    );
     addBinding(renderable, binding);
     if (Tracer.enabled) { Tracer.leave(); }
   }

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -1,6 +1,9 @@
 export {
   Listener
 } from './binding/listener';
+export {
+  AttributeBinding
+} from './binding/attribute';
 
 export {
   AttributeNSAccessor
@@ -82,6 +85,7 @@ export {
 
   DefaultResources,
 
+  AttributeBindingRendererRegistration,
   ListenerBindingRendererRegistration,
   SetAttributeRendererRegistration,
   StylePropertyBindingRendererRegistration,
@@ -101,6 +105,7 @@ export {
   HTMLNodeInstruction,
   HTMLTargetedInstruction,
   HTMLTargetedInstructionType,
+  IAttributeBindingInstruction,
   IListenerBindingInstruction,
   ISetAttributeInstruction,
   isHTMLTargetedInstruction,
@@ -113,6 +118,7 @@ export {
   DOM
 } from './dom';
 export {
+  AttributeBindingInstruction,
   CaptureBindingInstruction,
   DelegateBindingInstruction,
   SetAttributeInstruction,

--- a/packages/runtime-html/src/instructions.ts
+++ b/packages/runtime-html/src/instructions.ts
@@ -8,7 +8,8 @@ import {
   HTMLTargetedInstructionType,
   IListenerBindingInstruction,
   IStylePropertyBindingInstruction,
-  ITextBindingInstruction
+  ITextBindingInstruction,
+  IAttributeBindingInstruction
 } from './definitions';
 
 export class TextBindingInstruction implements ITextBindingInstruction {
@@ -102,5 +103,27 @@ export class SetAttributeInstruction implements ITargetedInstruction {
 
     this.to = to;
     this.value = value;
+  }
+}
+
+export class AttributeBindingInstruction implements IAttributeBindingInstruction {
+  public type: HTMLTargetedInstructionType.attributeBinding;
+
+  public from: string;
+  /**
+   * `attr` and `to` have the same value on a normal attribute
+   * Will be different on `class` and `style`
+   * on `class`: attr = `class` (from binding command), to = attribute name
+   * on `style`: attr = `style` (from binding command), to = attribute name
+   */
+  public attr: string;
+  public to: string;
+
+  constructor(attr: string, from: string, to: string) {
+    this.type = HTMLTargetedInstructionType.attributeBinding;
+
+    this.from = from;
+    this.attr = attr;
+    this.to = to;
   }
 }

--- a/packages/runtime-html/src/instructions.ts
+++ b/packages/runtime-html/src/instructions.ts
@@ -6,10 +6,10 @@ import {
 } from '@aurelia/runtime';
 import {
   HTMLTargetedInstructionType,
+  IAttributeBindingInstruction,
   IListenerBindingInstruction,
   IStylePropertyBindingInstruction,
-  ITextBindingInstruction,
-  IAttributeBindingInstruction
+  ITextBindingInstruction
 } from './definitions';
 
 export class TextBindingInstruction implements ITextBindingInstruction {

--- a/packages/runtime-html/src/instructions.ts
+++ b/packages/runtime-html/src/instructions.ts
@@ -109,7 +109,7 @@ export class SetAttributeInstruction implements ITargetedInstruction {
 export class AttributeBindingInstruction implements IAttributeBindingInstruction {
   public type: HTMLTargetedInstructionType.attributeBinding;
 
-  public from: string;
+  public from: string | IsBindingBehavior;
   /**
    * `attr` and `to` have the same value on a normal attribute
    * Will be different on `class` and `style`
@@ -119,7 +119,7 @@ export class AttributeBindingInstruction implements IAttributeBindingInstruction
   public attr: string;
   public to: string;
 
-  constructor(attr: string, from: string, to: string) {
+  constructor(attr: string, from: string | IsBindingBehavior, to: string) {
     this.type = HTMLTargetedInstructionType.attributeBinding;
 
     this.from = from;

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -23,6 +23,11 @@ export interface AttributeObserver extends
   IBatchedCollectionSubscriber,
   IPropertySubscriber { }
 
+/**
+ * Observer for handling two-way binding with attributes
+ * Has different strategy for class/style and normal attributes
+ * TODO: handle SVG/attributes with namespace
+ */
 @targetObserver('')
 export class AttributeObserver implements AttributeObserver, ElementMutationSubscription {
 
@@ -39,7 +44,6 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   // DOM related properties
   public obj: IHtmlElement;
   private readonly targetAttribute: string;
-  private readonly targetKey: string;
 
   constructor(
     flags: LifecycleFlags,
@@ -64,7 +68,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
       this.setValueCore = this.setValueCoreInlineStyle;
       this.getValue = this.getValueInlineStyle;
     }
-    this.targetKey = targetKey;
+    this.propertyKey = targetKey;
   }
 
   public getValue(): unknown {
@@ -72,7 +76,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   }
 
   public getValueInlineStyle(): string {
-    return this.obj.style.getPropertyValue(this.targetKey);
+    return this.obj.style.getPropertyValue(this.propertyKey);
   }
   public getValueClassName(): boolean {
     return this.obj.classList.contains(this.propertyKey);
@@ -94,10 +98,10 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
       priority = 'important';
       value = value.replace('!important', '');
     }
-    this.obj.style.setProperty(this.targetKey, value as string, priority);
+    this.obj.style.setProperty(this.propertyKey, value as string, priority);
   }
   public setValueCoreClassName(newValue: unknown): void {
-    const className = this.targetKey;
+    const className = this.propertyKey;
     const classList = this.obj.classList;
     // Why is class attribute observer setValue look different with class attribute accessor?
     // ==============
@@ -139,7 +143,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   }
   public handleMutationInlineStyle(): void {
     const css = this.obj.style;
-    const rule = this.targetKey;
+    const rule = this.propertyKey;
     const newValue = css.getPropertyValue(rule);
     if (newValue !== this.currentValue) {
       this.currentValue = newValue;
@@ -147,7 +151,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
     }
   }
   public handleMutationClassName(): void {
-    const className = this.targetKey;
+    const className = this.propertyKey;
     const newValue = this.obj.classList.contains(className);
     if (newValue !== this.currentValue) {
       this.currentValue = newValue;

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,0 +1,204 @@
+import { PLATFORM } from '@aurelia/kernel';
+import {
+  DOM,
+  IBatchedCollectionSubscriber,
+  IBindingTargetObserver,
+  ILifecycle,
+  IObserverLocator,
+  IPropertySubscriber,
+  LifecycleFlags,
+  targetObserver
+} from '@aurelia/runtime';
+
+export interface IHtmlElement extends HTMLElement {
+  $mObserver: MutationObserver;
+  $eMObservers: Set<ElementMutationSubscription>;
+}
+
+export interface ElementMutationSubscription {
+  handleMutation(mutationRecords: MutationRecord[]): void;
+}
+
+export interface AttributeObserver extends
+  IBindingTargetObserver<IHtmlElement, string>,
+  IBatchedCollectionSubscriber,
+  IPropertySubscriber { }
+
+@targetObserver('')
+export class AttributeObserver implements AttributeObserver, ElementMutationSubscription {
+
+  // observation related properties
+  public readonly isDOMObserver: true;
+  public readonly persistentFlags: LifecycleFlags;
+  public observerLocator: IObserverLocator;
+  public lifecycle: ILifecycle;
+  public currentValue: unknown;
+  public currentFlags: LifecycleFlags;
+  public oldValue: unknown;
+  public defaultValue: unknown;
+
+  // DOM related properties
+  public obj: IHtmlElement;
+  private targetAttribute: string;
+  private targetKey: string;
+  private hyphenatedCssRule: string;
+
+  constructor(
+    flags: LifecycleFlags,
+    lifecycle: ILifecycle,
+    observerLocator: IObserverLocator,
+    element: Element,
+    targetAttribute: string,
+    targetKey: string
+  ) {
+    this.isDOMObserver = true;
+    this.persistentFlags = flags & LifecycleFlags.persistentBindingFlags;
+    this.observerLocator = observerLocator;
+    this.lifecycle = lifecycle;
+    this.obj = element as IHtmlElement;
+    this.targetAttribute = targetAttribute;
+    this.handleMutationCore = targetAttribute === 'class'
+      ? this.handleMutationClassName
+      : targetAttribute === 'style'
+        ? this.handleMutationInlineStyle
+        : this.handleMutationCore;
+    this.targetKey = targetKey;
+    this.hyphenatedCssRule = PLATFORM.kebabCase(targetKey);
+  }
+
+  public getValue(): string {
+    return this.obj.getAttribute(this.propertyKey);
+  }
+
+  public getValueInlineStyle() {
+    return this.obj.style.getPropertyValue(this.hyphenatedCssRule);
+  }
+  public getValueClassName() {
+    return this.obj.classList
+  }
+
+  public setValueCore(newValue: unknown, flags: LifecycleFlags): void {
+    const obj = this.obj;
+    const targetAttribute = this.targetAttribute;
+    if (newValue === null || newValue === undefined) {
+      obj.removeAttribute(targetAttribute);
+    } else {
+      obj.setAttribute(targetAttribute, newValue as string);
+    }
+  }
+  public setValueCoreInlineStyle(value: unknown) {
+    let priority = '';
+
+    if (typeof value === 'string' && value.indexOf('!important') !== -1) {
+      priority = 'important';
+      value = value.replace('!important', '');
+    }
+    this.obj.style.setProperty(this.hyphenatedCssRule, value as string, priority);
+  }
+  public setValueCoreClassName(newValue: unknown) {
+    const className = this.targetKey;
+    const classList = this.obj.classList;
+    // Why is class attribute observer setValue look different with class attribute accessor?
+    // ==============
+    // For class list
+    // newValue is simply checked if truthy or falsy
+    // and toggle the class accordingly
+    // -- the rule of this is quite different to normal attribute
+    //
+    // for class attribute, observer is different in a way that it only observe a particular class at a time
+    // this also comes from syntax, where it would typically be my-class.class="someProperty"
+    //
+    // so there is no need for separating class by space and add all of them like class accessor
+    if (newValue) {
+      classList.add(className);
+    }
+    else {
+      classList.remove(className);
+    }
+  }
+
+  public handleMutation(mutationRecords: MutationRecord[]): void {
+    let shouldProcess = false;
+    for (let i = 0, ii = mutationRecords.length; ii > i; ++i) {
+      const record = mutationRecords[i];
+      if (record.type === 'attributes' && record.attributeName === this.targetAttribute) {
+        shouldProcess = true;
+        break;
+      }
+    }
+    if (shouldProcess) {
+      this.handleMutationCore();
+    }
+  }
+  public handleMutationCore(): void {
+    const newValue = this.obj.getAttribute(this.targetAttribute);
+    if (newValue !== this.currentValue) {
+      this.currentValue = newValue;
+      this.setValue(newValue, LifecycleFlags.none);
+    }
+  }
+  public handleMutationInlineStyle(): void {
+    const css = this.obj.style;
+    const rule = this.targetKey;
+    const newValue = css.getPropertyValue(rule);
+    if (newValue !== this.currentValue) {
+      this.currentValue = newValue;
+      this.setValue(newValue, LifecycleFlags.none);
+    }
+  }
+  public handleMutationClassName(): void {
+    const className = this.targetKey;
+    const newValue = this.obj.classList.contains(className);
+    if (newValue !== this.currentValue) {
+      this.currentValue = newValue;
+      this.setValue(newValue, LifecycleFlags.none);
+    }
+  }
+
+  public subscribe(subscriber: IPropertySubscriber): void {
+    if (!this.hasSubscribers()) {
+      startObservation(this.obj, this);
+    }
+    this.addSubscriber(subscriber);
+  }
+
+  public unsubscribe(subscriber: IPropertySubscriber): void {
+    if (this.removeSubscriber(subscriber) && !this.hasSubscribers()) {
+      stopObservation(this.obj, this);
+    }
+  }
+}
+
+const startObservation = (element: IHtmlElement, subscription: ElementMutationSubscription): void => {
+  if (element.$eMObservers === undefined) {
+    element.$eMObservers = new Set();
+  }
+  if (element.$mObserver === undefined) {
+    element.$mObserver = DOM.createNodeObserver(
+      element,
+      handleMutation,
+      { attributes: true }
+    ) as MutationObserver;
+  }
+  element.$eMObservers.add(subscription);
+};
+
+const stopObservation = (element: IHtmlElement, subscription: ElementMutationSubscription): boolean => {
+  const $eMObservers = element.$eMObservers;
+  if ($eMObservers.delete(subscription)) {
+    if ($eMObservers.size === 0) {
+      element.$mObserver.disconnect();
+      element.$mObserver = undefined;
+    }
+    return true;
+  }
+  return false;
+};
+
+const handleMutation = (mutationRecords: MutationRecord[]): void => {
+  (mutationRecords[0].target as IHtmlElement).$eMObservers.forEach(invokeHandleMutation, mutationRecords);
+};
+
+function invokeHandleMutation(this: MutationRecord[], s: ElementMutationSubscription): void {
+  s.handleMutation(this);
+}

--- a/scripts/test-lib.ts
+++ b/scripts/test-lib.ts
@@ -446,39 +446,39 @@ function updateElementByIndicesFactory<T extends any>(arrays: ((...args: T[]) =>
 
 export function eachCartesianJoin<T1,U>(
   arrays: [T1[]],
-  callback: (arg1: T1) => U): void;
+  callback: (arg1: T1, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,U>(
   arrays: [T1[],T2[]],
-  callback: (arg1: T1, arg2: T2) => U): void;
+  callback: (arg1: T1, arg2: T2, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,U>(
   arrays: [T1[],T2[],T3[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,U>(
   arrays: [T1[],T2[],T3[],T4[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,T5,U>(
   arrays: [T1[],T2[],T3[],T4[],T5[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,T5,T6,U>(
   arrays: [T1[],T2[],T3[],T4[],T5[],T6[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,T5,T6,T7,U>(
   arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,T5,T6,T7,T8,U>(
   arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[],T8[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T1,T2,T3,T4,T5,T6,T7,T8,T9,U>(
   arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[],T8[],T9[]],
-  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9) => U): void;
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callIndex: number) => U): void;
 
 export function eachCartesianJoin<T extends any,U>(
   arrays: T[][],
@@ -494,7 +494,7 @@ export function eachCartesianJoin<T extends any,U>(
   const totalCallCount: number = arrays.reduce((count: number, arr: T[]) => count *= arr.length, 1);
   const argsIndices = Array(arrays.length).fill(0);
   const args: T[] = updateElementByIndices(arrays, Array(arrays.length), argsIndices);
-  callback(...args);
+  callback(...args, 0);
   let callCount = 1;
   if (totalCallCount === callCount) {
     return;
@@ -503,7 +503,77 @@ export function eachCartesianJoin<T extends any,U>(
   while (!stop) {
     const hasUpdate = updateIndices(arrays, argsIndices);
     if (hasUpdate) {
-      callback(...updateElementByIndices(arrays, args, argsIndices));
+      callback(...updateElementByIndices(arrays, args, argsIndices), callCount);
+      callCount++;
+      if (totalCallCount < callCount) {
+        throw new Error('Invalid loop implementation.');
+      }
+    } else {
+      stop = true;
+    }
+  }
+}
+
+export function eachCartesianJoinAsync<T1,U>(
+  arrays: [T1[]],
+  callback: (arg1: T1, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,U>(
+  arrays: [T1[],T2[]],
+  callback: (arg1: T1, arg2: T2, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,U>(
+  arrays: [T1[],T2[],T3[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,U>(
+  arrays: [T1[],T2[],T3[],T4[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,T5,U>(
+  arrays: [T1[],T2[],T3[],T4[],T5[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,T5,T6,U>(
+  arrays: [T1[],T2[],T3[],T4[],T5[],T6[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,T5,T6,T7,U>(
+  arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,T5,T6,T7,T8,U>(
+  arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[],T8[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, callIndex: number) => U): Promise<void>;
+
+export function eachCartesianJoinAsync<T1,T2,T3,T4,T5,T6,T7,T8,T9,U>(
+  arrays: [T1[],T2[],T3[],T4[],T5[],T6[],T7[],T8[],T9[]],
+  callback: (arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, callIndex: number) => U): Promise<void>;
+
+export async function eachCartesianJoinAsync<T extends any,U>(
+  arrays: T[][],
+  callback: (...args: any[]) => U): Promise<void> {
+
+  arrays = arrays.slice(0).filter(arr => arr.length > 0);
+  if (typeof callback !== 'function') {
+    throw new Error('Callback is not a function');
+  }
+  if (arrays.length === 0) {
+    return;
+  }
+  const totalCallCount: number = arrays.reduce((count: number, arr: T[]) => count *= arr.length, 1);
+  const argsIndices = Array(arrays.length).fill(0);
+  const args: T[] = updateElementByIndices(arrays, Array(arrays.length), argsIndices);
+  await callback(...args, 0);
+  let callCount = 1;
+  if (totalCallCount === callCount) {
+    return;
+  }
+  let stop = false;
+  while (!stop) {
+    const hasUpdate = updateIndices(arrays, argsIndices);
+    if (hasUpdate) {
+      await callback(...updateElementByIndices(arrays, args, argsIndices), callCount);
       callCount++;
       if (totalCallCount < callCount) {
         throw new Error('Invalid loop implementation.');


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR is extracted from #364 to make the process easier. It adds support for class/style binding with the following syntax:
```html
<div class.my-class="shouldHaveMyClass">
<div my-class.class="shouldHaveMyClass">
<div style.background="bgValue">
<div background.style="bgValue">
<!-- vendor specific rules -->
<div -webkit-user-select.style="bgValue">
<div style.-webkit-user-select="bgValue">
<!-- custom properties -->
<div --my-custom.style="value">
<div style.--my-custom="value">
```
Class will be toggle based on truthy/falsy evaluation, while style will be set as is.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

Ignore the `AttrAttributePattern` and `AttrBindingCommand`. They are there for future work related to following template:
```html
<div my-attr.attr="myAttr">
<div attr.my-attr="myAttr">

<!-- interoperability with web components that operate on attribute -->
<a-web-component disabled.attr="disabled">
<a-web-component attr.disabled="disabled">
```

## 📑 Test Plan

All tests are in two new files, with tests described before the loop.

## ⏭ Next Steps

Add `AttrAttributePattern` and `AttrBindingCommand`
