### PR TITLE
ci: run cypress tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,34 @@ jobs:
             cd test/browserstack
             npm run e2e
 
+  e2e_cypress_doc_example:
+    executor: docker-circleci
+    steps:
+      - checkout_install_bootstrap
+      - run: npm run build
+      - run:
+          name: "Install cypress"
+          command: |
+            cd packages/router/test/e2e/doc-example
+            npm install
+      - run:
+          name: "Install and build test app"
+          command: |
+            cd packages/router/test/e2e/doc-example/app
+            npm install
+            npm run build
+      - run:
+          name: "Serve test app in the background"
+          background: true
+          command: |
+            cd packages/router/test/e2e/doc-example/app
+            npm run serve
+      - run:
+          name: "Run e2e tests"
+          command: |
+            cd packages/router/test/e2e/doc-example
+            npm run test
+
   publish_npm:
     executor: docker-aurelia
     parameters:
@@ -275,6 +303,8 @@ workflows:
           <<: *filter_ignore_develop_release
       - e2e_browserstack:
           <<: *filter_ignore_develop_release
+      - e2e_cypress_doc_example:
+          <<: *filter_ignore_develop_release
       - e2e_wdio:
           <<: *filter_ignore_develop_release
           name: jit-aurelia-cli-ts
@@ -320,6 +350,7 @@ workflows:
             - unit_test_node
             - lint_packages
             - e2e_browserstack
+            - e2e_cypress_doc_example
             - jit-aurelia-cli-ts
             - jit-fuse-box-ts
             - jit-webpack-ts
@@ -353,6 +384,8 @@ workflows:
           <<: *filter_only_tag
       - e2e_browserstack:
           <<: *filter_only_tag
+      - e2e_cypress_doc_example:
+          <<: *filter_only_tag
       - merge_and_dist:
           <<: *filter_only_tag
           requires:
@@ -361,6 +394,7 @@ workflows:
             - unit_test_node
             - lint_packages
             - e2e_browserstack
+            - e2e_cypress_doc_example
           from: $CIRCLE_TAG
           to: release
           channel: latest


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR integrates the cypress tests added by @rowellx68  in his pr https://github.com/aurelia/aurelia/pull/461 so that they run on CIrcleCI automatically on each push/commit, as well as during the nightly and before releases. Thanks again @rowellx68  !
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Follow up to https://github.com/aurelia/aurelia/pull/461
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Nothing spectacular, just roughly copy-pasted the browserstack configuration and adjusted some paths.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Verified job outcome @ https://circleci.com/gh/aurelia/aurelia/16814
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Perhaps a little bit of cleanup in the circleci config as well as moving some stuff around
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
