### PR TITLE
Tweak Renovate Configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,6 @@
     ":automergeDisabled",
     ":disableRateLimiting",
     ":maintainLockFilesMonthly",
-    ":prNotPending",
     "helpers:disableTypesNodeMajor",
     "schedule:weekly",
     "group:all"


### PR DESCRIPTION
# Pull Request

## 📖 Description

With #454 we've introduced `renovate` to keep our dependencies up to date, but it's not working as intended. `renovate` is creating branches (and keeping those up to date) put not creating corresponding PR's. This PR should fix that.

### 🎫 Issues

Follow up tweak to #454.

## 👩‍💻 Reviewer Notes

Every Monday morning `renovate` is supposed to look at packages needing updates as per our scheduled configuration and if any need an upgrade, create a PR for that.

We also configured `:prNotPending`, which according to the [docs](https://renovatebot.com/docs/presets-default/#prnotpending) should: `Wait until branch tests have passed or failed before creating the PR`. But for some reason the branch tests are always in a `pending` state.

So the fix is to remove that setting and have it create the PR's immediately (based on the set schedule) as waiting was added as noise reduction (which it's now doing a too good job at 😊) and is not actually needed.


## 📑 Test Plan

Wait till next monday after merging to see if PR's start to appear.

Also note that you can browse back in the `renovate` log for a max of 3 days, so you can only debug this issue on Monday, Tuesday and Wednesday. 😞 

## ⏭ Next Steps

n/a
