### PR TITLE
chore: pin typescript and harmonize renovate deps

### DIFF
--- a/examples/jit-pixi-webpack-ts/package.json
+++ b/examples/jit-pixi-webpack-ts/package.json
@@ -14,7 +14,7 @@
     "@aurelia/runtime-html": "file:../../packages/runtime-html",
     "@aurelia/runtime-pixi": "file:../../packages/runtime-pixi",
     "@aurelia/runtime": "file:../../packages/runtime",
-    "pixi.js": "^4.8.6"
+    "pixi.js": "^4.8.7"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,8 +1545,7 @@
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
-      "dev": true
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -1567,8 +1566,7 @@
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-      "dev": true
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -1580,7 +1578,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
       "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
-      "dev": true,
       "requires": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -1589,8 +1586,7 @@
     "acorn-walk": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
-      "dev": true
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "after": {
       "version": "0.8.2",
@@ -1783,8 +1779,7 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
       "version": "0.0.1",
@@ -1871,7 +1866,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -1916,8 +1910,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -1946,14 +1939,12 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -1964,14 +1955,12 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -2250,7 +2239,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2285,8 +2273,7 @@
     "bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4=",
-      "dev": true
+      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
     },
     "blob": {
       "version": "0.0.5",
@@ -2421,8 +2408,7 @@
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
-      "dev": true
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -2719,8 +2705,7 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -2967,7 +2952,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3961,8 +3945,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.0.7",
@@ -4066,14 +4049,12 @@
     "cssom": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
-      "dev": true
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
     },
     "cssstyle": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
       "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
-      "dev": true,
       "requires": {
         "cssom": "0.3.x"
       }
@@ -4134,7 +4115,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -4143,7 +4123,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
@@ -4241,8 +4220,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "3.2.0",
@@ -4388,8 +4366,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -4544,7 +4521,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-      "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
@@ -4579,14 +4555,12 @@
     "earcut": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.5.tgz",
-      "integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==",
-      "dev": true
+      "integrity": "sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4963,8 +4937,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -5168,8 +5141,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5277,8 +5249,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fancy-log": {
       "version": "1.3.3",
@@ -5315,14 +5286,12 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -5872,14 +5841,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -6645,7 +6612,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -7197,14 +7163,12 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -7214,7 +7178,6 @@
           "version": "6.9.1",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
           "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-          "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -7225,14 +7188,12 @@
         "fast-deep-equal": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
         },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         }
       }
     },
@@ -7431,7 +7392,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
@@ -7526,7 +7486,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -7580,7 +7539,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8075,8 +8033,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -8120,8 +8077,7 @@
     "ismobilejs": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-0.5.1.tgz",
-      "integrity": "sha512-QX4STsOcBYqlTjVGuAdP1MiRVxtiUbRHOKH0v7Gn1EvfUVIQnrSdgCM4zB4VCZuIejnb2NUMUx0Bwd3EIG6yyA==",
-      "dev": true
+      "integrity": "sha512-QX4STsOcBYqlTjVGuAdP1MiRVxtiUbRHOKH0v7Gn1EvfUVIQnrSdgCM4zB4VCZuIejnb2NUMUx0Bwd3EIG6yyA=="
     },
     "isobject": {
       "version": "3.0.1",
@@ -8132,8 +8088,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -8407,14 +8362,12 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.0.0.tgz",
       "integrity": "sha512-/VkyPmdtbwqpJSkwDx3YyJ3U1oawYNB/h5z8vTUZGAzjtu2OHTeFRfnJqyMHsJ5Cyes23trOmvUpM1GfHH1leA==",
-      "dev": true,
       "requires": {
         "abab": "^2.0.0",
         "acorn": "^6.0.4",
@@ -8448,7 +8401,6 @@
           "version": "1.11.1",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
           "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
-          "dev": true,
           "requires": {
             "esprima": "^3.1.3",
             "estraverse": "^4.2.0",
@@ -8460,26 +8412,22 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "estraverse": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-          "dev": true
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
         },
         "parse5": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-          "dev": true
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -8499,8 +8447,7 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -8511,8 +8458,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json3": {
       "version": "3.3.2",
@@ -8562,7 +8508,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -8862,7 +8807,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -8973,8 +8917,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -9009,8 +8952,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -9360,14 +9302,12 @@
     "mime-db": {
       "version": "1.38.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
-      "dev": true
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
     },
     "mime-types": {
       "version": "2.1.22",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
-      "dev": true,
       "requires": {
         "mime-db": "~1.38.0"
       }
@@ -9381,8 +9321,7 @@
     "mini-signals": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.2.0.tgz",
-      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=",
-      "dev": true
+      "integrity": "sha1-RbCAE8X65RokqhqTXNMXye1yHXQ="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -10037,20 +9976,17 @@
     "nwsapi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
-      "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==",
-      "dev": true
+      "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg=="
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "dev": true
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",
@@ -10218,7 +10154,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -10503,8 +10438,7 @@
     "parse-uri": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.0.tgz",
-      "integrity": "sha1-KHLcwi8aeXrN4Vg9igrClVLdrCA=",
-      "dev": true
+      "integrity": "sha1-KHLcwi8aeXrN4Vg9igrClVLdrCA="
     },
     "parse-url": {
       "version": "5.0.1",
@@ -10664,8 +10598,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pidtree": {
       "version": "0.3.0",
@@ -10697,14 +10630,12 @@
     "pixi-gl-core": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz",
-      "integrity": "sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I=",
-      "dev": true
+      "integrity": "sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I="
     },
     "pixi.js": {
       "version": "4.8.7",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.7.tgz",
       "integrity": "sha512-mx7YbHPkkWoj8FT3qBMkieAjBuuJ4yZWU7rq9NnCSUGpNrVlocrW179xrJQPVR2Q7JZ73ZGTwH7NOUZ9wgh7wA==",
-      "dev": true,
       "requires": {
         "bit-twiddle": "^1.0.2",
         "earcut": "^2.1.4",
@@ -10719,8 +10650,7 @@
         "eventemitter3": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=",
-          "dev": true
+          "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
         }
       }
     },
@@ -10745,8 +10675,7 @@
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "portfinder": {
       "version": "1.0.20",
@@ -10785,8 +10714,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process": {
       "version": "0.11.10",
@@ -10871,8 +10799,7 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
-      "dev": true
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -10924,8 +10851,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -10942,8 +10868,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -11204,8 +11129,7 @@
     "remove-array-items": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-      "integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA==",
-      "dev": true
+      "integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -11238,7 +11162,6 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -11265,14 +11188,12 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -11284,7 +11205,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -11293,7 +11213,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
       "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
-      "dev": true,
       "requires": {
         "request-promise-core": "1.1.2",
         "stealthy-require": "^1.1.1",
@@ -11362,7 +11281,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/resource-loader/-/resource-loader-2.2.3.tgz",
       "integrity": "sha512-SsxilncV7gxwr12clSq0E2HZh8QjcosVVSEAnZ3VF9VtBNNtO3UFxxXT9pJgkVEJUHAlXg26MkkTOMjyz1kDdw==",
-      "dev": true,
       "requires": {
         "mini-signals": "^1.1.1",
         "parse-uri": "^1.0.0"
@@ -11543,8 +11461,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -11558,14 +11475,12 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saxes": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.6.tgz",
       "integrity": "sha512-LAYs+lChg1v5uKNzPtsgTxSS5hLo8aIhSMCJt1WMpefAxm3D1RTpMwSpb6ebdL31cubiLTnhokVktBW+cv9Y9w==",
-      "dev": true,
       "requires": {
         "xmlchars": "^1.3.1"
       }
@@ -12333,7 +12248,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -12385,8 +12299,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -12547,8 +12460,7 @@
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "tapable": {
       "version": "1.1.1",
@@ -12801,7 +12713,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -12811,7 +12722,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -13267,7 +13177,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -13275,14 +13184,12 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -13483,7 +13390,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -13574,8 +13480,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.0.2",
@@ -13624,7 +13529,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -13650,7 +13554,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
-      "dev": true,
       "requires": {
         "browser-process-hrtime": "^0.1.2"
       }
@@ -13659,7 +13562,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.0.1.tgz",
       "integrity": "sha512-XZGI1OH/OLQr/NaJhhPmzhngwcAnZDLytsvXnRmlYeRkmbb0I7sqFFA22erq4WQR0sUu17ZSQOAV9mFwCqKRNg==",
-      "dev": true,
       "requires": {
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
@@ -13698,8 +13600,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webpack": {
       "version": "4.29.6",
@@ -14071,7 +13972,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.24"
       }
@@ -14079,14 +13979,12 @@
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-      "dev": true
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
       "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
-      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -14158,8 +14056,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "worker-farm": {
       "version": "1.6.0",
@@ -14262,7 +14159,6 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
       "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
-      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
       }
@@ -14270,8 +14166,7 @@
     "xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "dev": true
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
     },
     "xmlbuilder": {
       "version": "8.2.2",
@@ -14282,8 +14177,7 @@
     "xmlchars": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-1.3.1.tgz",
-      "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw==",
-      "dev": true
+      "integrity": "sha512-tGkGJkN8XqCod7OT+EvGYK5Z4SfDQGD30zAa58OcnAa0RRWgzUEK72tkXhsX1FZd+rgnhRxFtmO+ihkp8LHSkw=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "generate-tests:template-compiler.static": "ts-node -P scripts/tsconfig.json scripts/generate-tests/template-compiler.static.ts",
     "generate-tests:template-compiler.mutations": "ts-node -P scripts/tsconfig.json scripts/generate-tests/template-compiler.mutations.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "jsdom": "^13.2.0 || ^14.0.0",
+    "pixi.js": "^4.8.7"
+  },
   "devDependencies": {
     "@types/acorn": "^4.0.5",
     "@types/chai": "^4.1.7",
@@ -68,7 +71,6 @@
     "husky": "^1.3.1",
     "istanbul": "^0.4.5",
     "istanbul-instrumenter-loader": "^3.0.1",
-    "jsdom": "^14.0.0",
     "karma": "^4.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -87,7 +89,6 @@
     "mocha": "^6.0.2",
     "npm-run-all": "^4.1.5",
     "path": "^0.12.7",
-    "pixi.js": "^4.8.7",
     "reflect-metadata": "^0.1.13",
     "request": "^2.88.0",
     "rollup": "^1.7.3",
@@ -107,7 +108,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "validate-commit-msg": "^2.14.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",

--- a/packages/aot/package.json
+++ b/packages/aot/package.json
@@ -84,7 +84,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/examples/dbmonster-a/package.json
+++ b/packages/examples/dbmonster-a/package.json
@@ -24,7 +24,7 @@
     "path": "^0.12.7",
     "rimraf": "^2.6.3",
     "tsify": "^4.0.1",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.11.1"
   }

--- a/packages/examples/e2e-benchmark/vcurrent/package.json
+++ b/packages/examples/e2e-benchmark/vcurrent/package.json
@@ -55,7 +55,7 @@
     "ts-node": "^8.0.3",
     "tsconfig-paths": "^3.8.0",
     "tsify": "^4.0.1",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "vinyl-source-stream": "^2.0.0"
   }
 }

--- a/packages/examples/e2e-benchmark/vnext/package.json
+++ b/packages/examples/e2e-benchmark/vnext/package.json
@@ -31,7 +31,7 @@
     "ts-loader": "^5.3.3",
     "ts-node": "^8.0.3",
     "tsconfig-paths": "^3.8.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0"
   }

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -84,7 +84,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/jit-html-browser/package.json
+++ b/packages/jit-html-browser/package.json
@@ -87,7 +87,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/jit-html-jsdom/package.json
+++ b/packages/jit-html-jsdom/package.json
@@ -70,6 +70,6 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000"
+    "typescript": "~3.3.4000"
   }
 }

--- a/packages/jit-html/package.json
+++ b/packages/jit-html/package.json
@@ -78,7 +78,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/jit-pixi/package.json
+++ b/packages/jit-pixi/package.json
@@ -88,7 +88,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/jit/package.json
+++ b/packages/jit/package.json
@@ -86,7 +86,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -82,7 +82,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/plugin-parcel/package.json
+++ b/packages/plugin-parcel/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/plugin-requirejs/package.json
+++ b/packages/plugin-requirejs/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/plugin-svg/package.json
+++ b/packages/plugin-svg/package.json
@@ -84,7 +84,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/runtime-html-browser/package.json
+++ b/packages/runtime-html-browser/package.json
@@ -84,7 +84,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/runtime-html-jsdom/package.json
+++ b/packages/runtime-html-jsdom/package.json
@@ -67,6 +67,6 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000"
+    "typescript": "~3.3.4000"
   }
 }

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -52,6 +52,6 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000"
+    "typescript": "~3.3.4000"
   }
 }

--- a/packages/runtime-pixi/package.json
+++ b/packages/runtime-pixi/package.json
@@ -52,7 +52,7 @@
     "@aurelia/runtime": "0.3.0",
     "@aurelia/runtime-html": "0.3.0",
     "@aurelia/runtime-html-browser": "0.3.0",
-    "pixi.js": "^4.8.6"
+    "pixi.js": "^4.8.7"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -87,7 +87,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -84,7 +84,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -83,7 +83,7 @@
     "tslint": "^5.14.0",
     "tslint-microsoft-contrib": "^6.1.0",
     "tslint-sonarts": "^1.9.0",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
     {
       "packageNames": ["chromedriver"],
       "allowedVersions": "~2.45.0"
+    },
+    {
+      "packageNames": ["typescript"],
+      "allowedVersions": "~3.3.4000"
     }
   ]
 }

--- a/test/browserstack/package.json
+++ b/test/browserstack/package.json
@@ -42,7 +42,7 @@
     "ts-node": "^8.0.3",
     "tsconfig-paths": "^3.8.0",
     "tslib": "^1.9.3",
-    "typescript": "^3.3.4000",
+    "typescript": "~3.3.4000",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0"
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Pin typescript and fix some `renovate` warnings.

### 🎫 Issues

* https://github.com/Microsoft/TypeScript/issues/30662
* #471 

## 👩‍💻 Reviewer Notes

Due to Typescript introducing breaking changes in version `3.4.0`, for which there is no clean workaround, we need to stick to `~3.3.4000` for the foreseeable future.

Another (minor) change is that I moved some `devDependencies` to `dependencies` in the root `package.json`, as they're specified as `dependencies` in the individual packages, which was causing those versions to go out of sync as we have different upgrade policies for `devDependencies` and `dependencies`.

Once this is merged #471 should auto-update after the next run of the `renovate` job.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

Hope the `typescript` folks fix this one way or another.