### PR TITLE
chore: more typescript pinning

### DIFF
--- a/examples/jit-aurelia-cli-ts/package.json
+++ b/examples/jit-aurelia-cli-ts/package.json
@@ -40,6 +40,6 @@
     "http-server": "latest",
     "minimatch": "latest",
     "rimraf": "latest",
-    "typescript": "latest"
+    "typescript": "~3.3.4000"
   }
 }

--- a/examples/jit-browserify-ts/package.json
+++ b/examples/jit-browserify-ts/package.json
@@ -30,7 +30,7 @@
     "rimraf": "latest",
     "stringify": "latest",
     "tsify": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "vinyl-source-stream": "latest",
     "watchify": "latest"
   }

--- a/examples/jit-fuse-box-ts/package.json
+++ b/examples/jit-fuse-box-ts/package.json
@@ -25,7 +25,7 @@
     "@types/node": "latest",
     "http-server": "latest",
     "rimraf": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "fuse-box": "latest",
     "uglify-es": "latest",
     "uglify-js": "latest"

--- a/examples/jit-parcel-ts/package.json
+++ b/examples/jit-parcel-ts/package.json
@@ -30,6 +30,6 @@
     "parcel-bundler": "latest",
     "parcel-plugin-typescript": "latest",
     "rimraf": "latest",
-    "typescript": "latest"
+    "typescript": "~3.3.4000"
   }
 }

--- a/examples/jit-pixi-webpack-ts/package.json
+++ b/examples/jit-pixi-webpack-ts/package.json
@@ -26,7 +26,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack": "latest",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest"

--- a/examples/jit-webpack-ts/package.json
+++ b/examples/jit-webpack-ts/package.json
@@ -28,7 +28,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"

--- a/packages/router/test/e2e/doc-example/app/package.json
+++ b/packages/router/test/e2e/doc-example/app/package.json
@@ -22,7 +22,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack": "latest",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest"

--- a/packages/router/test/e2e/doc-example/package.json
+++ b/packages/router/test/e2e/doc-example/package.json
@@ -11,7 +11,7 @@
     "@types/node": "latest",
     "cypress": "^3.2.0",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack": "latest"
   }
 }

--- a/packages/router/test/e2e/layouts/package.json
+++ b/packages/router/test/e2e/layouts/package.json
@@ -20,7 +20,7 @@
     "rimraf": "latest",
     "stringify": "latest",
     "tsify": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "vinyl-source-stream": "latest",
     "watchify": "latest"
   }

--- a/packages/router/test/e2e/modules/package.json
+++ b/packages/router/test/e2e/modules/package.json
@@ -20,7 +20,7 @@
     "rimraf": "latest",
     "stringify": "latest",
     "tsify": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "vinyl-source-stream": "latest",
     "watchify": "latest"
   }

--- a/packages/router/test/e2e/nav/package.json
+++ b/packages/router/test/e2e/nav/package.json
@@ -21,7 +21,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"

--- a/packages/router/test/e2e/scope/package.json
+++ b/packages/router/test/e2e/scope/package.json
@@ -22,7 +22,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"

--- a/packages/router/test/e2e/siblings/package.json
+++ b/packages/router/test/e2e/siblings/package.json
@@ -22,7 +22,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"

--- a/packages/router/test/e2e/wizard/package.json
+++ b/packages/router/test/e2e/wizard/package.json
@@ -22,7 +22,7 @@
     "http-server": "latest",
     "rimraf": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"

--- a/test/cypress/app/package.json
+++ b/test/cypress/app/package.json
@@ -33,7 +33,7 @@
     "rimraf": "latest",
     "style-loader": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack": "latest",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest"

--- a/test/kitchen-sink/package.json
+++ b/test/kitchen-sink/package.json
@@ -37,7 +37,7 @@
     "sass-loader": "latest",
     "style-loader": "latest",
     "ts-loader": "latest",
-    "typescript": "latest",
+    "typescript": "~3.3.4000",
     "webpack-cli": "latest",
     "webpack-dev-server": "latest",
     "webpack": "latest"


### PR DESCRIPTION
# Pull Request

## 📖 Description

More `typescript` pinning in the hope it fixes e2e on CircleCI. And it appears it does...

### 🎫 Issues

Follow up to #472.

## 👩‍💻 Reviewer Notes

Also pins `typescript` to `~3.3.4000` where it ws previously set to `latest`.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a
