### PR TITLE
Dynamic routing: component reentry behavior

### DIFF
--- a/packages/router/src/history-browser.ts
+++ b/packages/router/src/history-browser.ts
@@ -178,7 +178,7 @@ export class HistoryBrowser {
       return;
     }
 
-    const newHash = `#/${path}`;
+    const newHash = `#${path}`;
     const { pathname, search, hash } = this.location;
     // tslint:disable-next-line:possible-timing-attack
     if (newHash === hash && this.currentEntry.path === path && this.currentEntry.fullStatePath === fullStatePath) {
@@ -295,9 +295,10 @@ export class HistoryBrowser {
   }
   private async setPath(path: string, replace: boolean = false): Promise<void> {
     // More checks, such as parameters, needed
-    if (this.currentEntry && this.currentEntry.path === path && !this.isRefreshing) {
-      return;
-    }
+    // Not used at all since we can now reenter exactly same component+parameters
+    // if (this.currentEntry && this.currentEntry.path === path && !this.isRefreshing) {
+    //   return;
+    // }
 
     const { pathname, search } = this.location;
     const hash = `#${path}`;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -296,6 +296,11 @@ export class Router {
     return this.closestScope(element);
   }
 
+  // External API to get viewport by name
+  public getViewport(name: string): Viewport {
+    return this.allViewports().find(viewport => viewport.name === name);
+  }
+
   // Called from the viewport custom element in attached()
   public addViewport(name: string, element: Element, context: IRenderContext, options?: IViewportOptions): Viewport {
     Reporter.write(10000, 'Viewport added', name, element);

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -71,7 +71,7 @@ export class ViewportContent {
   }
 
   public reentryBehavior(): ReentryBehavior {
-    return this.component.reentryBehavior || ReentryBehavior.default;
+    return 'reentryBehavior' in this.component ? this.component.reentryBehavior : ReentryBehavior.default;
   }
 
   public isCacheEqual(other: ViewportContent): boolean {

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -10,7 +10,7 @@ export interface IRouteableCustomElementType extends Partial<ICustomElementType>
 }
 
 export interface IRouteableCustomElement extends ICustomElement {
-  reentryBehavior?: 'disallow' | 'enter' | 'refresh';
+  reentryBehavior?: ReentryBehavior;
   canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
   enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): void | Promise<void>;
   canLeave?(nextInstruction?: INavigationInstruction, instruction?: INavigationInstruction): boolean | Promise<boolean>;
@@ -23,6 +23,13 @@ export const enum ContentStatus {
   loaded = 2,
   initialized = 3,
   added = 4,
+}
+
+export const enum ReentryBehavior {
+  default = 'default',
+  disallow = 'disallow',
+  enter = 'enter',
+  refresh = 'refresh',
 }
 
 export class ViewportContent {
@@ -52,15 +59,19 @@ export class ViewportContent {
     }
   }
 
-  public isChange(other: ViewportContent): boolean {
-    return ((typeof other.content === 'string' && this.componentName() !== other.content) ||
-      (typeof other.content !== 'string' && this.content !== other.content) ||
-      this.parameters !== other.parameters ||
-      !this.instruction || this.instruction.query !== other.instruction.query);
+  public equalComponent(other: ViewportContent): boolean {
+    return (typeof other.content === 'string' && this.componentName() === other.content) ||
+      (typeof other.content !== 'string' && this.content === other.content);
   }
 
-  public reentryBehavior(): string {
-    return this.component.reentryBehavior || 'disallow';
+  public equalParameters(other: ViewportContent): boolean {
+    // TODO: Review this
+    return this.parameters === other.parameters &&
+      this.instruction.query === other.instruction.query;
+  }
+
+  public reentryBehavior(): ReentryBehavior {
+    return this.component.reentryBehavior || ReentryBehavior.default;
   }
 
   public isCacheEqual(other: ViewportContent): boolean {

--- a/packages/router/test/e2e/doc-example/app/src/components/authors/about-authors.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/authors/about-authors.ts
@@ -5,16 +5,38 @@ import { State } from '../../state';
 @customElement({
   name: 'about-authors', template: `<template>
 <div>
-<h3>About authors</h3>
+<h3>About authors [Entry: \${entries}]
+[
+  Reentry behavior:
+  <label repeat.for="behavior of reentryBehaviors">
+    <input type="radio" name="reentry" model.bind="behavior" checked.two-way="reentryBehavior">\${behavior}
+  </label>
+]</h3>
 <p>Authors write books. Books are good for you. End of story.</p>
 <div class="scrollbox">Space out!</div>
 </div>
 </template>` })
 @inject(State)
 export class AboutAuthors {
+  public reentryBehaviors = ['disallow', 'refresh', 'enter'];
+  public reentryBehavior: string = 'disallow';
+  public entries = 0;
+
   constructor(private readonly state: State) { }
 
   public canEnter() {
+    console.log('### about-authors: canEnter');
     return this.state.allowEnterAuthorDetails;
+  }
+  public enter() {
+    this.entries++;
+    console.log('### about-authors: enter');
+  }
+  public canLeave() {
+    console.log('### about-authors: canLeave');
+    return true;
+  }
+  public leave() {
+    console.log('### about-authors: leave');
   }
 }

--- a/packages/router/test/e2e/doc-example/app/src/components/authors/about-authors.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/authors/about-authors.ts
@@ -18,8 +18,8 @@ import { State } from '../../state';
 </template>` })
 @inject(State)
 export class AboutAuthors {
-  public reentryBehaviors = ['disallow', 'refresh', 'enter'];
-  public reentryBehavior: string = 'disallow';
+  public reentryBehaviors = ['default', 'disallow', 'refresh', 'enter'];
+  public reentryBehavior: string = 'default';
   public entries = 0;
 
   constructor(private readonly state: State) { }

--- a/packages/router/test/e2e/doc-example/app/src/components/authors/author.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/authors/author.ts
@@ -44,23 +44,17 @@ export class Author {
   }
   public enter(parameters) {
     console.log('### enter', this, parameters);
-    if (parameters.id) {
-      this.author = this.authorsRepository.author(+parameters.id);
-    }
+    this.author = this.authorsRepository.author(+parameters.id);
     this.router.setNav('author-menu', [
-      {
-        title: 'Details',
-        route: `author-details(${this.author.id})`
-      },
-      {
-        title: 'About authors',
-        route: 'about-authors'
-      },
-      {
-        title: 'Author information',
-        route: 'information'
-      },
+      { title: 'Details', route: `author-details(${this.author.id})` },
+      { title: 'About authors', route: 'about-authors' },
+      { title: 'Author information', route: 'information' },
     ]);
+    const vp = this.router.getViewport('author-tabs');
+    const component = vp && vp.content && vp.content.componentName();
+    if (component) {
+      this.router.goto(component + (component === 'author-details' ? `(${this.author.id})` : ''));
+    }
     return wait(this.state.noDelay ? 0 : 2000);
   }
   public binding() {

--- a/packages/router/test/e2e/doc-example/app/src/components/authors/author.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/authors/author.ts
@@ -20,7 +20,7 @@ import { Information } from './information';
 </div>
 <div if.bind="!hideTabs">
   <au-nav data-test="author-menu" name="author-menu"></au-nav>
-  <au-viewport name="author-tabs" stateful default="author-details(\${author.id})" used-by="about-authors,author-details,information" no-history></au-viewport>
+  <au-viewport name="author-tabs" default="author-details(\${author.id})" used-by="about-authors,author-details,information" no-history></au-viewport>
 </div>
 </template>`,
   dependencies: [Information as any]

--- a/packages/router/test/e2e/doc-example/cypress/integration/books-route.spec.ts
+++ b/packages/router/test/e2e/doc-example/cypress/integration/books-route.spec.ts
@@ -112,7 +112,7 @@ describe('doc-example / books route', () => {
 
   describe('book details component', () => {
     before(() => {
-      cy.get(BooksComponent.items)
+      cy.get(BooksComponent.bookLinks)
         .eq(0)
         .click();
     });

--- a/packages/router/test/e2e/doc-example/cypress/integration/default-route.spec.ts
+++ b/packages/router/test/e2e/doc-example/cypress/integration/default-route.spec.ts
@@ -4,12 +4,12 @@ describe('doc-example / default route', () => {
   it('navigates to default route', () => {
     cy.visit('/')
       .url()
-      .should('contain', '/authors+about');
+      .should('contain', 'authors+about');
   });
 
   it('redirects to the default route', () => {
     cy.url()
-      .should('contain', '/authors+about');
+      .should('contain', 'authors+about');
   });
 
   it('sets the correct nav items as active', () => {

--- a/packages/router/test/mock/browser-history-location.mock.ts
+++ b/packages/router/test/mock/browser-history-location.mock.ts
@@ -105,11 +105,13 @@ export class MockBrowserHistoryLocation {
     this.paths[this.index] = path;
   }
 
-  public go(movement: number) {
+  public go(movement: number, suppressPopstate: boolean = false) {
     const newIndex = this.index + movement;
     if (newIndex >= 0 && newIndex < this.states.length) {
       this.index = newIndex;
-      this.notifyChange();
+      if (!suppressPopstate) {
+        this.notifyChange();
+      }
     }
   }
 

--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -67,9 +67,9 @@ describe('Router', function () {
     this.timeout(40000);
     const { host, router } = await setup();
 
-    await router.goto('/uier@left');
+    await router.goto('uier@left');
     await wait(100);
-    await router.goto('/bar@left');
+    await router.goto('bar@left');
     expect(router.pendingNavigations.length).to.equal(1);
     await waitForNavigation(router);
     expect(host.textContent).to.contain('Viewport: bar');
@@ -98,7 +98,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@right', router);
+    await goto('bar@right', router);
     expect(host.textContent).to.contain('bar');
 
     await teardown(host, router, 1);
@@ -108,11 +108,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/foo@left', router);
+    await goto('foo@left', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.not.contain('Viewport: bar');
 
-    await goto('/bar@right', router);
+    await goto('bar@right', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.contain('Viewport: bar');
 
@@ -123,11 +123,11 @@ describe('Router', function () {
     this.timeout(40000);
     const { host, router } = await setup();
 
-    await goto('/foo@left', router);
+    await goto('foo@left', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.not.contain('Viewport: bar');
 
-    await goto('/bar@left', router);
+    await goto('bar@left', router);
     expect(host.textContent).to.not.contain('Viewport: foo');
     expect(host.textContent).to.contain('Viewport: bar');
 
@@ -148,11 +148,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/foo@left', router);
+    await goto('foo@left', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.not.contain('Viewport: bar');
 
-    await goto('/bar@right', router);
+    await goto('bar@right', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.contain('Viewport: bar');
 
@@ -173,7 +173,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/foo@left+bar@right', router);
+    await goto('foo@left+bar@right', router);
     expect(host.textContent).to.contain('foo');
     expect(host.textContent).to.contain('bar');
 
@@ -184,11 +184,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/baz@left+qux@right', router);
+    await goto('baz@left+qux@right', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Viewport: qux');
 
-    await goto('/foo@left+bar@right', router);
+    await goto('foo@left+bar@right', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Viewport: qux');
     expect(host.textContent).to.not.contain('Viewport: foo');
@@ -201,7 +201,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/foo@left+bar@right+baz@foo+qux@bar', router);
+    await goto('foo@left+bar@right+baz@foo+qux@bar', router);
     expect(host.textContent).to.contain('Viewport: foo');
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Viewport: baz');
@@ -214,7 +214,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/foo@left', router);
+    await goto('foo@left', router);
     expect(host.textContent).to.contain('foo');
 
     host.getElementsByTagName('SPAN')[0].click();
@@ -229,10 +229,10 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/corge@left', router);
+    await goto('corge@left', router);
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/baz', router);
+    await goto('baz', router);
     expect(host.textContent).to.contain('Viewport: baz');
 
     await teardown(host, router, 1);
@@ -242,9 +242,9 @@ describe('Router', function () {
     this.timeout(40000);
     const { host, router } = await setup();
 
-    await goto('/foo@left', router);
-    await goto('/bar@left', router);
-    await goto('/baz@left', router);
+    await goto('foo@left', router);
+    await goto('bar@left', router);
+    await goto('baz@left', router);
 
     await teardown(host, router, 4);
   });
@@ -253,11 +253,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(123)', router);
+    await goto('bar@left(123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@left(456)', router);
+    await goto('bar@left(456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
@@ -268,11 +268,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(id=123)', router);
+    await goto('bar@left(id=123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@left(id=456)', router);
+    await goto('bar@left(id=456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
@@ -283,11 +283,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(123)', router);
+    await goto('bar@left(123)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@right(456)', router);
+    await goto('bar@right(456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter id: [456]');
@@ -299,10 +299,10 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/corge@left', router);
+    await goto('corge@left', router);
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/baz(123)', router);
+    await goto('baz(123)', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
@@ -313,10 +313,10 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/corge@left', router);
+    await goto('corge@left', router);
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/baz(id=123)', router);
+    await goto('baz(id=123)', router);
     expect(host.textContent).to.contain('Viewport: baz');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
@@ -327,12 +327,12 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(123&OneTwoThree)', router);
+    await goto('bar@left(123&OneTwoThree)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter name: [OneTwoThree]');
 
-    await goto('/bar@left(456&FourFiveSix)', router);
+    await goto('bar@left(456&FourFiveSix)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
@@ -344,12 +344,12 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(id=123&name=OneTwoThree)', router);
+    await goto('bar@left(id=123&name=OneTwoThree)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
     expect(host.textContent).to.contain('Parameter name: [OneTwoThree]');
 
-    await goto('/bar@left(name=FourFiveSix&id=456)', router);
+    await goto('bar@left(name=FourFiveSix&id=456)', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
@@ -361,11 +361,11 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left?id=123', router);
+    await goto('bar@left?id=123', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [123]');
 
-    await goto('/bar@left?id=456&name=FourFiveSix', router);
+    await goto('bar@left?id=456&name=FourFiveSix', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
@@ -377,19 +377,79 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/bar@left(456)?id=123', router);
+    await goto('bar@left(456)?id=123', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
 
-    await goto('/bar@left(456&FourFiveSix)?id=123&name=OneTwoThree', router);
+    await goto('bar@left(456&FourFiveSix)?id=123&name=OneTwoThree', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [456]');
     expect(host.textContent).to.contain('Parameter name: [FourFiveSix]');
 
-    await goto('/bar@left(name=SevenEightNine&id=789)?id=123&name=OneTwoThree', router);
+    await goto('bar@left(name=SevenEightNine&id=789)?id=123&name=OneTwoThree', router);
     expect(host.textContent).to.contain('Viewport: bar');
     expect(host.textContent).to.contain('Parameter id: [789]');
     expect(host.textContent).to.contain('Parameter name: [SevenEightNine]');
+
+    await teardown(host, router, 1);
+  });
+
+  it('uses default reentry behavior', async function () {
+    this.timeout(30000);
+    const { host, router } = await setup();
+
+    await goto('plugh@left(123)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 1');
+
+    await goto('plugh@left(123)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 1');
+
+    await goto('plugh@left(456)', router);
+    expect(host.textContent).to.contain('Parameter: 456');
+    expect(host.textContent).to.contain('Entry: 2');
+
+    await goto('plugh@left(456)', router);
+    expect(host.textContent).to.contain('Parameter: 456');
+    expect(host.textContent).to.contain('Entry: 2');
+
+    await teardown(host, router, 1);
+  });
+
+  it('uses overriding reentry behavior', async function () {
+    this.timeout(30000);
+    const { host, router } = await setup();
+
+    plughReentryBehavior = 'enter'; // Affects navigation AFTER this one
+    await goto('plugh@left(123)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 1');
+
+    plughReentryBehavior = 'refresh'; // Affects navigation AFTER this one
+    await goto('plugh@left(123)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 2');
+
+    plughReentryBehavior = 'default'; // Affects navigation AFTER this one
+    await goto('plugh@left(456)', router);
+    expect(host.textContent).to.contain('Parameter: 456');
+    expect(host.textContent).to.contain('Entry: 1');
+
+    plughReentryBehavior = 'enter'; // Affects navigation AFTER this one
+    await goto('plugh@left(456)', router);
+    expect(host.textContent).to.contain('Parameter: 456');
+    expect(host.textContent).to.contain('Entry: 1');
+
+    plughReentryBehavior = 'disallow'; // Affects navigation AFTER this one
+    await goto('plugh@left(123)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 2');
+
+    plughReentryBehavior = 'default'; // Affects navigation AFTER this one
+    await goto('plugh@left(456)', router);
+    expect(host.textContent).to.contain('Parameter: 123');
+    expect(host.textContent).to.contain('Entry: 2');
 
     await teardown(host, router, 1);
   });
@@ -398,7 +458,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/grault@left', router);
+    await goto('grault@left', router);
     expect(host.textContent).to.contain('toggle');
     expect(host.textContent).to.not.contain('Viewport: grault');
     expect(host.textContent).to.not.contain('garply');
@@ -428,7 +488,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/grault@left', router);
+    await goto('grault@left', router);
     expect(host.textContent).to.contain('toggle');
     expect(host.textContent).to.not.contain('Viewport: grault');
     expect(host.textContent).to.not.contain('garply');
@@ -441,12 +501,12 @@ describe('Router', function () {
 
     (host as any).getElementsByTagName('INPUT')[1].value = 'asdf';
 
-    await goto('/corge@grault', router);
+    await goto('corge@grault', router);
 
     expect(host.textContent).to.not.contain('garply');
     expect(host.textContent).to.contain('Viewport: corge');
 
-    await goto('/garply@grault', router);
+    await goto('garply@grault', router);
 
     expect(host.textContent).to.not.contain('Viewport: corge');
     expect(host.textContent).to.contain('garply');
@@ -460,7 +520,7 @@ describe('Router', function () {
     this.timeout(30000);
     const { host, router } = await setup();
 
-    await goto('/waldo@left', router);
+    await goto('waldo@left', router);
     expect(host.textContent).to.contain('Viewport: waldo');
     expect(host.textContent).to.contain('toggle');
     expect(host.textContent).to.not.contain('Viewport: grault');
@@ -474,12 +534,12 @@ describe('Router', function () {
 
     (host as any).getElementsByTagName('INPUT')[1].value = 'asdf';
 
-    await goto('/foo@waldo', router);
+    await goto('foo@waldo', router);
 
     expect(host.textContent).to.not.contain('Viewport: grault');
     expect(host.textContent).to.contain('Viewport: foo');
 
-    await goto('/grault@waldo', router);
+    await goto('grault@waldo', router);
 
     expect(host.textContent).to.not.contain('Viewport: corge');
     expect(host.textContent).to.contain('Viewport: grault');
@@ -775,7 +835,7 @@ describe('Router', function () {
 });
 
 let quxCantLeave = 2;
-
+let plughReentryBehavior = 'default';
 const setup = async (): Promise<{ au; container; host; router }> => {
   const container = BasicConfiguration.createContainer();
 
@@ -832,15 +892,22 @@ const setup = async (): Promise<{ au; container; host; router }> => {
     class {
       public text;
     });
-  const Waldo = (CustomElementResource as any).define(
-    {
-      name: 'waldo', template: '<template>Viewport: waldo<au-viewport name="waldo" stateful used-by="grault,foo" default="grault"></au-viewport></div></template>'
-    },
-    class { });
+  const Waldo = (CustomElementResource as any).define({ name: 'waldo', template: '<template>Viewport: waldo<au-viewport name="waldo" stateful used-by="grault,foo" default="grault"></au-viewport></div></template>' }, class { });
+
+  const Plugh = (CustomElementResource as any).define({ name: 'plugh', template: 'Parameter: ${param} Entry: ${entry}' }, class {
+    public param: number;
+    public entry: number = 0;
+    public reentryBehavior: string = 'default';
+    public enter(params) {
+      this.param = +params[0];
+      this.entry++;
+      this.reentryBehavior = plughReentryBehavior;
+    }
+  });
 
   container.register(Router as any);
   container.register(ViewportCustomElement as any);
-  registerComponent(container, Foo, Bar, Baz, Qux, Quux, Corge, Uier, Grault, Garply, Waldo);
+  registerComponent(container, Foo, Bar, Baz, Qux, Quux, Corge, Uier, Grault, Garply, Waldo, Plugh);
 
   const router = container.get(Router);
   const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds the possibility for a component to specify a `reentryBehavior` property that controls whether it's possible to reenter the same component (even with identical parameters). Allowed values are:
- `disallow` - don't allow reentries into component at all (no navigation)
- `refresh` - create a new instance of the component (like a browser _refresh_) which replace the existing
- `enter` - reuse the existing component and call the navigation methods 
- `default` - use default behavior (`enter` if parameters are different, otherwise `disallow`)

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in packages/router/test/e2e/** since they are just my own test applications while working.

## 📑 Test Plan

- Make sure tests still pass.
- Added new tests for the different behaviors

## ⏭ Next Steps

- Review the extension points
- Re-visit scoped viewports
- Add a before navigation hook with accompanying redirect
