### PR TITLE
fix(di): make the decorators compatible with ts strict mode for end users

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -6,7 +6,7 @@ import { IResourceType } from './resource';
 
 const slice = Array.prototype.slice;
 
-export type ResolveCallback<T = unknown> = (handler?: IContainer, requestor?: IContainer, resolver?: IResolver) => T;
+export type ResolveCallback<T = any> = (handler?: IContainer, requestor?: IContainer, resolver?: IResolver) => T;
 
 export type Key<T> = InterfaceSymbol<T> | Primitive | IIndexable | Constructable;
 
@@ -151,8 +151,8 @@ export const DI = {
     return dependencies;
   },
 
-  createInterface<T = unknown>(friendlyName?: string): IDefaultableInterfaceSymbol<T> {
-    const Interface: IDefaultableInterfaceSymbol<T> & Partial<IRegistration<T> & {friendlyName: string}> = function(target: Injectable, property: string, index: number): unknown {
+  createInterface<T = any>(friendlyName?: string): IDefaultableInterfaceSymbol<T> {
+    const Interface: IDefaultableInterfaceSymbol<T> & Partial<IRegistration<T> & {friendlyName: string}> = function(target: Injectable, property: string, index: number): any {
       if (target === undefined) {
         throw Reporter.error(16, Interface.friendlyName, Interface); // TODO: add error (trying to resolve an InterfaceSymbol that has no registrations)
       }
@@ -197,7 +197,7 @@ export const DI = {
     return Interface;
   },
 
-  inject(...dependencies: Key<unknown>[]): (target: Injectable, key?: string, descriptor?: PropertyDescriptor | number) => void {
+  inject(...dependencies: Key<any>[]): (target: Injectable, key?: string, descriptor?: PropertyDescriptor | number) => void {
     return function(target: Injectable, key?: string, descriptor?: PropertyDescriptor | number): void {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         if (!target.hasOwnProperty('inject')) {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -4,6 +4,8 @@ import { PLATFORM } from './platform';
 import { Reporter, Tracer } from './reporter';
 import { IResourceType } from './resource';
 
+// tslint:disable: no-any
+
 const slice = Array.prototype.slice;
 
 export type ResolveCallback<T = any> = (handler?: IContainer, requestor?: IContainer, resolver?: IResolver) => T;

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -1,3 +1,5 @@
+// tslint:disable: no-any
+
 export interface IPerformance {
   now(): number;
   mark(name: string): void;

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -67,12 +67,12 @@ export interface IDisposable {
 
 export type Constructable<T = {}> = {
   // tslint:disable-next-line:callable-types
-  new(...args: unknown[]): T;
+  new(...args: any[]): T;
 };
 
 export type Class<T, C = IIndexable> = C & {
   readonly prototype: T;
-  new(...args: unknown[]): T;
+  new(...args: any[]): T;
 };
 
 // For resources, we want the 'constructor' property to remain on the instance type but we need to do that
@@ -81,10 +81,10 @@ export type Class<T, C = IIndexable> = C & {
 // So, in lack of a better name.. we probably need to clean this up, but this is how it works for now.
 export type ConstructableClass<T, C = IIndexable> = C & {
   readonly prototype: T & { constructor: C };
-  new(...args: unknown[]): T & { constructor: C };
+  new(...args: any[]): T & { constructor: C };
 };
 
-export type InterfaceSymbol<T = unknown> = (target: Injectable<T>, property: string, index: number) => unknown;
+export type InterfaceSymbol<T = any> = (target: Injectable<T>, property: string, index: number) => any;
 
 export type InjectArray = ReadonlyArray<InterfaceSymbol<any> | Constructable | string>;
 

--- a/packages/kernel/src/interfaces.ts
+++ b/packages/kernel/src/interfaces.ts
@@ -88,7 +88,7 @@ export type ConstructableClass<T, C = IIndexable> = C & {
 
 export type InterfaceSymbol<T = any> = (target: Injectable<T>, property: string, index: number) => any;
 
-export type InjectArray = ReadonlyArray<InterfaceSymbol<any> | Constructable | string>;
+export type InjectArray = ReadonlyArray<InterfaceSymbol | Constructable | string>;
 
 export type Injectable<T = {}> = Constructable<T> & { inject?: (InterfaceSymbol | Constructable)[] };
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -68,7 +68,13 @@ export function instructionRenderer<TType extends string>(instructionType: TType
   return function decorator<TProto, TClass>(target: DecoratableInstructionRenderer<TType, TProto, TClass>): DecoratedInstructionRenderer<TType, TProto, TClass> {
     // wrap the constructor to set the instructionType to the instance (for better performance than when set on the prototype)
     const decoratedTarget = function(...args: unknown[]): TProto {
+      // tslint:disable: no-commented-code
+      // tslint:disable: no-unnecessary-type-assertion
+      // tslint:disable: no-any
       const instance = new (target as any)(...args);
+      // tslint:enable: no-unnecessary-type-assertion
+      // tslint:enable: no-any
+      // tslint:enable: no-commented-code
       instance.instructionType = instructionType;
       return instance;
     } as unknown as DecoratedInstructionRenderer<TType, TProto, TClass>;

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -68,7 +68,7 @@ export function instructionRenderer<TType extends string>(instructionType: TType
   return function decorator<TProto, TClass>(target: DecoratableInstructionRenderer<TType, TProto, TClass>): DecoratedInstructionRenderer<TType, TProto, TClass> {
     // wrap the constructor to set the instructionType to the instance (for better performance than when set on the prototype)
     const decoratedTarget = function(...args: unknown[]): TProto {
-      const instance = new target(...args);
+      const instance = new (target as any)(...args);
       instance.instructionType = instructionType;
       return instance;
     } as unknown as DecoratedInstructionRenderer<TType, TProto, TClass>;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

The `unknown` default of `InterfaceSymbol`, `Constructable` etc are making DI completely unusable in end user projects with the TypeScript `strict` mode enabled, so I'm reverting them back to `any`. The way TypeScript handles decorators simply doesn't allow anything else, unfortunately.

I'm pushing this in between the other things because it's an easy (yet fairly critical) fix.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Exclusively contains a few `unknown` -> `any` type changes and a couple of tslint suppressions accompanied with that. Changes should speak for themselves
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

No new tests should fail
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Merge to #464 and continue from there with the rest
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
 

<a id="e3dedcd0-5ccf-11e9-bc99-bbe5d5810388" href="none" codereview-uuid-reserved-tag />