### PR TITLE
Fixed typos in router.spec.ts

### DIFF
--- a/packages/router/test/unit/router.spec.ts
+++ b/packages/router/test/unit/router.spec.ts
@@ -57,8 +57,8 @@ describe('Router', function () {
     await goto('bar@right', router);
     expect(host.textContent).to.contain('Viewport: bar');
     await goto('-', router);
-    expect(host.textContent).to.not.contain('Viewport foo');
-    expect(host.textContent).to.not.contain('Viewport bar');
+    expect(host.textContent).to.not.contain('Viewport: foo');
+    expect(host.textContent).to.not.contain('Viewport: bar');
 
     await teardown(host, router, 1);
   });


### PR DESCRIPTION
# Pull Request

## 📖 Description
It seems two colons are missing in one of the test, making these tests always pass no matter what.
Should here be used the positive (equals to) checks instead of negative (not equals to) ones?

### 🎫 Issues
Two typos and two useless test assertions as the very result.

## 👩‍💻 Reviewer Notes
Probably, this should be fixed by changing assertions to checking what values are, not that they no longer have some value.

## 📑 Test Plan
Not Applicable 

## ⏭ Next Steps
Explained above
