### PR TITLE
Fixed typos in router.spec.ts

### DIFF
--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -181,8 +181,8 @@ describe('Router', function () {
     await $goto('bar@right', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     await $goto('-', router, lifecycle);
-    assert.notIncludes(host.textContent, 'Viewport foo', `host.textContent`);
-    assert.notIncludes(host.textContent, 'Viewport bar', `host.textContent`);
+    assert.notIncludes(host.textContent, 'Viewport: foo', `host.textContent`);
+    assert.notIncludes(host.textContent, 'Viewport: bar', `host.textContent`);
 
     await tearDown();
   });


### PR DESCRIPTION
# Pull Request

## 📖 Description
It seems two colons are missing in one of the test, making these tests always pass no matter what.
Probably, this should be fixed by changing assertions to checking what values are, not that they no longer have some value.

### 🎫 Issues
see also [https://github.com/aurelia/aurelia/pull/489](url)