### PR TITLE
Dynamic routing: fix clear all viewports

### DIFF
--- a/packages/__tests__/router/e2e/doc-example/app/package.json
+++ b/packages/__tests__/router/e2e/doc-example/app/package.json
@@ -14,6 +14,7 @@
     "@aurelia/jit-html-browser": "file:../../../../../jit-html-browser",
     "@aurelia/jit": "file:../../../../../jit",
     "@aurelia/kernel": "file:../../../../../kernel",
+    "@aurelia/router": "file:../../../../../router",
     "@aurelia/runtime-html": "file:../../../../../runtime-html",
     "@aurelia/runtime": "file:../../../../../runtime"
   },

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -181,8 +181,8 @@ describe('Router', function () {
     await $goto('bar@right', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     await $goto('-', router, lifecycle);
-    assert.notIncludes(host.textContent, 'Viewport foo', `host.textContent`);
-    assert.notIncludes(host.textContent, 'Viewport bar', `host.textContent`);
+    assert.notIncludes(host.textContent, 'Viewport: foo', `host.textContent`);
+    assert.notIncludes(host.textContent, 'Viewport: bar', `host.textContent`);
 
     await tearDown();
   });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -214,7 +214,11 @@ export class Router implements IRouter {
 
     const usedViewports = (clearViewports ? this.allViewports().filter((value) => value.content.component !== null) : []);
     const doneDefaultViewports: Viewport[] = [];
-    let defaultViewports = this.allViewports().filter((viewport) => viewport.options.default && viewport.content.component === null && !doneDefaultViewports.find(done => done === viewport));
+    let defaultViewports = this.allViewports().filter(viewport =>
+      viewport.options.default
+      && viewport.content.component === null
+      && doneDefaultViewports.every(done => done !== viewport)
+    );
     const updatedViewports: Viewport[] = [];
 
     // TODO: Take care of cancellations down in subsets/iterations
@@ -228,7 +232,7 @@ export class Router implements IRouter {
 
       for (const defaultViewport of defaultViewports) {
         doneDefaultViewports.push(defaultViewport);
-        if (!viewportInstructions.find(value => value.viewport === defaultViewport)) {
+        if (viewportInstructions.every(value => value.viewport !== defaultViewport)) {
           const defaultInstruction = this.instructionResolver.parseViewportInstruction(defaultViewport.options.default);
           defaultInstruction.viewport = defaultViewport;
           viewportInstructions.push(defaultInstruction);
@@ -276,7 +280,7 @@ export class Router implements IRouter {
       }
 
       for (const viewport of changedViewports) {
-        if (!updatedViewports.find((value) => value === viewport)) {
+        if (updatedViewports.every(value => value !== viewport)) {
           updatedViewports.push(viewport);
         }
       }
@@ -287,13 +291,17 @@ export class Router implements IRouter {
       let addedViewport: ViewportInstruction;
       while (addedViewport = this.addedViewports.shift()) {
         // TODO: Should this overwrite instead? I think so.
-        if (!remaining.viewportInstructions.find((value) => value.viewport === addedViewport.viewport)) {
+        if (remaining.viewportInstructions.every(value => value.viewport !== addedViewport.viewport)) {
           viewportInstructions.push(addedViewport);
         }
       }
       viewportInstructions = [...viewportInstructions, ...remaining.viewportInstructions];
       viewportsRemaining = remaining.viewportsRemaining;
-      defaultViewports = this.allViewports().filter((viewport) => viewport.options.default && viewport.content.component === null && !doneDefaultViewports.find(done => done === viewport));
+      defaultViewports = this.allViewports().filter(viewport =>
+        viewport.options.default
+        && viewport.content.component === null
+        && doneDefaultViewports.every(done => done !== viewport)
+      );
       if (!this.allViewports().length) {
         viewportsRemaining = false;
       }
@@ -324,13 +332,13 @@ export class Router implements IRouter {
       if (componentOrInstruction instanceof ViewportInstruction) {
         if (!componentOrInstruction.viewport) {
           // TODO: Deal with not yet existing viewports
-          componentOrInstruction.viewport = this.allViewports().find((vp) => vp.name === componentOrInstruction.viewportName);
+          componentOrInstruction.viewport = this.allViewports().find(vp => vp.name === componentOrInstruction.viewportName);
         }
         this.addedViewports.push(componentOrInstruction);
       } else {
         if (typeof viewport === 'string') {
           // TODO: Deal with not yet existing viewports
-          viewport = this.allViewports().find((vp) => vp.name === viewport);
+          viewport = this.allViewports().find(vp => vp.name === viewport);
         }
         this.addedViewports.push(new ViewportInstruction(componentOrInstruction, viewport));
       }
@@ -452,7 +460,7 @@ export class Router implements IRouter {
   private closestScope(element: Element): Scope {
     let el = element;
     while (el.parentElement) {
-      const viewport = this.allViewports().find((item) => item.element === el);
+      const viewport = this.allViewports().find(item => item.element === el);
       if (viewport && viewport.owningScope) {
         return viewport.owningScope;
       }

--- a/packages/router/src/utils.ts
+++ b/packages/router/src/utils.ts
@@ -10,10 +10,8 @@ export function closestCustomElement(element: CustomElementHost<Element>): Custo
   return element;
 }
 
-// tslint:disable-next-line:no-any
-export function arrayRemove(arr: any[], func: (value: any, index?: number, obj?: any[]) => boolean): any[] {
-  // tslint:disable-next-line:no-any
-  const removed: any[] = [];
+export function arrayRemove<T>(arr: T[], func: (value: T, index?: number, obj?: T[]) => boolean): T[] {
+  const removed: T[] = [];
   let arrIndex = arr.findIndex(func);
   while (arrIndex >= 0) {
     removed.push(arr.splice(arrIndex, 1)[0]);

--- a/packages/router/src/utils.ts
+++ b/packages/router/src/utils.ts
@@ -9,3 +9,15 @@ export function closestCustomElement(element: CustomElementHost<Element>): Custo
   }
   return element;
 }
+
+// tslint:disable-next-line:no-any
+export function arrayRemove(arr: any[], func: (value: any, index?: number, obj?: any[]) => boolean): any[] {
+  // tslint:disable-next-line:no-any
+  const removed: any[] = [];
+  let arrIndex = arr.findIndex(func);
+  while (arrIndex >= 0) {
+    removed.push(arr.splice(arrIndex, 1)[0]);
+    arrIndex = arr.findIndex(func);
+  }
+  return removed;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue with clearing all viewports as well as slightly restructures handling of viewport defaults.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Add a before navigation hook with accompanying redirect
- Review the extension points
- Re-visit scoped viewports

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
