### PR TITLE
fix(replaceable): retain parts through template controllers in the replace-part

### DIFF
--- a/packages/__tests__/jit-html/replaceable.spec.ts
+++ b/packages/__tests__/jit-html/replaceable.spec.ts
@@ -67,6 +67,27 @@ describe('replaceable', function () {
 
   });
 
+  // TODO: run this case with more combinations
+  it(`replaceable - bind to parent scope when binding inside replace-part has multiple template controllers in between`, function () {
+
+    const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar"><div if.bind="true" repeat.for="i of 1">\${baz}</div></div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { });
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
   it(`replaceable - bind to parent scope`, function () {
 
     const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -275,14 +275,25 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     const component = context.get<object>(customAttributeKey(instruction.res));
     const instructionRenderers = context.get(IRenderer).instructionRenderers;
     const childInstructions = instruction.instructions;
+    if (instruction.parts !== void 0) {
+      if (parts === void 0) {
+        // Just assign it, no need to create new variables
+        parts = instruction.parts;
+      } else {
+        // Create a new object because we shouldn't accidentally put child information in the parent part object.
+        // If the parts conflict, the instruction's parts overwrite the passed-in parts because they were declared last.
+        parts = {
+          ...parts,
+          ...instruction.parts,
+        };
+      }
+    }
 
     const controller = Controller.forCustomAttribute(
       component,
       context,
       flags,
-      instruction.parts == void 0
-        ? PLATFORM.emptyArray
-        : Object.keys(instruction.parts),
+      parts == void 0 ? PLATFORM.emptyArray : Object.keys(parts),
     );
 
     if (instruction.link) {


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes a scope bug in replaceable where if there are template controllers between the `replace-part` and the binding that needs to access the parent scope, the scope would actually not be reachable.
This is because `parts` were not passed through from outside the immediate parent when rendering a template controller, but rather only the parts from the immediate parent.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

A small enough change that the code can speak for itself.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

One test added to verify the particular scenario I ran into. 
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Added a note that this needs to be verified in more combinations of similar nature that I don't have time to write right now.

This might actually also fix one or more of the cases @bigopon wrote and had commented out. Could you double check?
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
