### PR TITLE
fix(replaceable): make part scopes also work when not immediately bound from the wrapping replaceable

### DIFF
--- a/packages/__tests__/jit-html/replaceable.spec.ts
+++ b/packages/__tests__/jit-html/replaceable.spec.ts
@@ -1,4 +1,4 @@
-import { Aurelia, CustomElementResource } from '@aurelia/runtime';
+import { Aurelia, CustomElementResource, LifecycleFlags as LF } from '@aurelia/runtime';
 import { TestContext, assert } from '@aurelia/testing';
 
 describe('replaceable', function () {
@@ -86,6 +86,32 @@ describe('replaceable', function () {
 
     assert.strictEqual(host.textContent, 'def', `host.textContent`);
 
+  });
+
+  // TODO: run this case with more combinations
+  it(`replaceable - bind to parent scope when binding inside replace-part has an if that starts as false`, async function () {
+
+    const App = CustomElementResource.define({ name: 'app', template: `<template><foo><div replace-part="bar"><div if.bind="show">\${baz}</div></div></foo></template>` }, class { public baz = 'def'; public show = false; });
+    const Foo = CustomElementResource.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { });
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    await au.start().wait();
+
+    assert.strictEqual(host.textContent, '', `host.textContent`);
+
+    component.show = true;
+
+    ctx.lifecycle.processRAFQueue(LF.none)
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
   });
 
   it(`replaceable - bind to parent scope`, function () {

--- a/packages/__tests__/runtime/ast.spec.ts
+++ b/packages/__tests__/runtime/ast.spec.ts
@@ -2002,7 +2002,7 @@ describe('BindingBehavior', function () {
         assert.strictEqual(mock.calls[0][4 + i], argValues[i], `mock.calls[0][4 + i]`);
         // verify the arguments that the bb's argument expressions were called with to obtain the values
         assert.strictEqual(arg.calls.length, 1, `arg.calls.length`);
-        assert.strictEqual(arg.calls[0].length, 4, `arg.calls[0].length`);
+        assert.strictEqual(arg.calls[0].length, 5, `arg.calls[0].length`);
         assert.strictEqual(arg.calls[0][0], 'evaluate', `arg.calls[0][0]`);
         assert.strictEqual(arg.calls[0][1], flags, `arg.calls[0][1]`);
         assert.strictEqual(arg.calls[0][2], scope, `arg.calls[0][2]`);
@@ -2036,7 +2036,7 @@ describe('BindingBehavior', function () {
 
       const callCount = ($kind & ExpressionKind.HasBind) > 0 ? 2 : 1;
       assert.strictEqual(expr.calls.length, callCount, `expr.calls.length`);
-      assert.strictEqual(expr.calls[callCount - 1].length, 4, `expr.calls[callCount - 1].length`);
+      assert.strictEqual(expr.calls[callCount - 1].length, 5, `expr.calls[callCount - 1].length`);
       assert.strictEqual(expr.calls[callCount - 1][0], 'evaluate', `expr.calls[callCount - 1][0]`);
       assert.strictEqual(expr.calls[callCount - 1][1], flags, `expr.calls[callCount - 1][1]`);
       assert.strictEqual(expr.calls[callCount - 1][2], scope, `expr.calls[callCount - 1][2]`);
@@ -2060,7 +2060,7 @@ describe('BindingBehavior', function () {
 
       const callCount = ($kind & ExpressionKind.HasBind) > 0 ? 3 : 2;
       assert.strictEqual(expr.calls.length, callCount, `expr.calls.length`);
-      assert.strictEqual(expr.calls[callCount - 1].length, 4, `expr.calls[callCount - 1].length`);
+      assert.strictEqual(expr.calls[callCount - 1].length, 5, `expr.calls[callCount - 1].length`);
       assert.strictEqual(expr.calls[callCount - 1][0], 'connect', `expr.calls[callCount - 1][0]`);
       assert.strictEqual(expr.calls[callCount - 1][1], flags, `expr.calls[callCount - 1][1]`);
       assert.strictEqual(expr.calls[callCount - 1][2], scope, `expr.calls[callCount - 1][2]`);
@@ -2083,7 +2083,7 @@ describe('BindingBehavior', function () {
 
       const callCount = ($kind & ExpressionKind.HasBind) > 0 ? 4 : 3;
       assert.strictEqual(expr.calls.length, callCount, `expr.calls.length`);
-      assert.strictEqual(expr.calls[callCount - 1].length, 5, `expr.calls[callCount - 1].length`);
+      assert.strictEqual(expr.calls[callCount - 1].length, 6, `expr.calls[callCount - 1].length`);
       assert.strictEqual(expr.calls[callCount - 1][0], 'assign', `expr.calls[callCount - 1][0]`);
       assert.strictEqual(expr.calls[callCount - 1][1], flags, `expr.calls[callCount - 1][1]`);
       assert.strictEqual(expr.calls[callCount - 1][2], scope, `expr.calls[callCount - 1][2]`);
@@ -2108,7 +2108,7 @@ describe('BindingBehavior', function () {
 
       const callCount = ($kind & ExpressionKind.HasBind) > 0 ? 5 : 4;
       assert.strictEqual(expr.calls.length, callCount, `expr.calls.length`);
-      assert.strictEqual(expr.calls[callCount - 1].length, 4, `expr.calls[callCount - 1].length`);
+      assert.strictEqual(expr.calls[callCount - 1].length, 5, `expr.calls[callCount - 1].length`);
       assert.strictEqual(expr.calls[callCount - 1][0], 'evaluate', `expr.calls[callCount - 1][0]`);
       assert.strictEqual(expr.calls[callCount - 1][1], flags, `expr.calls[callCount - 1][1]`);
       assert.strictEqual(expr.calls[callCount - 1][2], scope, `expr.calls[callCount - 1][2]`);
@@ -2321,7 +2321,7 @@ describe('ValueConverter', function () {
       }
 
       assert.strictEqual(expr.calls.length, 1, `expr.calls.length`);
-      assert.strictEqual(expr.calls[0].length, 4, `expr.calls[0].length`);
+      assert.strictEqual(expr.calls[0].length, 5, `expr.calls[0].length`);
       assert.strictEqual(expr.calls[0][0], 'evaluate', `expr.calls[0][0]`);
       assert.strictEqual(expr.calls[0][1], flags, `expr.calls[0][1]`);
       assert.strictEqual(expr.calls[0][2], scope, `expr.calls[0][2]`);
@@ -2331,7 +2331,7 @@ describe('ValueConverter', function () {
         const arg = args[i];
         if (methods.includes('toView')) {
           assert.strictEqual(arg.calls.length, 1, `arg.calls.length`);
-          assert.strictEqual(arg.calls[0].length, 4, `arg.calls[0].length`);
+          assert.strictEqual(arg.calls[0].length, 5, `arg.calls[0].length`);
           assert.strictEqual(arg.calls[0][0], 'evaluate', `arg.calls[0][0]`);
           assert.strictEqual(arg.calls[0][1], flags, `arg.calls[0][1]`);
           assert.strictEqual(arg.calls[0][2], scope, `arg.calls[0][2]`);
@@ -2359,7 +2359,7 @@ describe('ValueConverter', function () {
       const expr = sut.expression as any as MockTracingExpression;
 
       assert.strictEqual(expr.calls.length, 2, `expr.calls.length`);
-      assert.strictEqual(expr.calls[1].length, 4, `expr.calls[1].length`);
+      assert.strictEqual(expr.calls[1].length, 5, `expr.calls[1].length`);
       assert.strictEqual(expr.calls[1][0], 'connect', `expr.calls[1][0]`);
       assert.strictEqual(expr.calls[1][1], flags, `expr.calls[1][1]`);
       assert.strictEqual(expr.calls[1][2], scope, `expr.calls[1][2]`);
@@ -2370,7 +2370,7 @@ describe('ValueConverter', function () {
         const arg = args[i];
         const offset = hasToView ? 1 : 0;
         assert.strictEqual(arg.calls.length, offset + 1, `arg.calls.length`);
-        assert.strictEqual(arg.calls[offset].length, 4, `arg.calls[offset].length`);
+        assert.strictEqual(arg.calls[offset].length, 5, `arg.calls[offset].length`);
         assert.strictEqual(arg.calls[offset][0], 'connect', `arg.calls[offset][0]`);
         assert.strictEqual(arg.calls[offset][1], flags, `arg.calls[offset][1]`);
         assert.strictEqual(arg.calls[offset][2], scope, `arg.calls[offset][2]`);
@@ -2418,7 +2418,7 @@ describe('ValueConverter', function () {
       }
 
       assert.strictEqual(expr.calls.length, 3, `expr.calls.length`);
-      assert.strictEqual(expr.calls[2].length, 5, `expr.calls[2].length`);
+      assert.strictEqual(expr.calls[2].length, 6, `expr.calls[2].length`);
       assert.strictEqual(expr.calls[2][0], 'assign', `expr.calls[2][0]`);
       assert.strictEqual(expr.calls[2][1], flags, `expr.calls[2][1]`);
       assert.strictEqual(expr.calls[2][2], scope, `expr.calls[2][2]`);
@@ -2429,7 +2429,7 @@ describe('ValueConverter', function () {
         const arg = args[i];
         const callCount = hasToView ? hasFromView ? 3 : 2 : 1;
         assert.strictEqual(arg.calls.length, callCount, `arg.calls.length`);
-        assert.strictEqual(arg.calls[callCount - 1].length, 4, `arg.calls[callCount - 1].length`);
+        assert.strictEqual(arg.calls[callCount - 1].length, 5, `arg.calls[callCount - 1].length`);
         assert.strictEqual(arg.calls[callCount - 1][0], 'evaluate', `arg.calls[callCount - 1][0]`);
         assert.strictEqual(arg.calls[callCount - 1][1], flags, `arg.calls[callCount - 1][1]`);
         assert.strictEqual(arg.calls[callCount - 1][2], scope, `arg.calls[callCount - 1][2]`);
@@ -2468,7 +2468,7 @@ describe('ValueConverter', function () {
         const arg = args[i];
         assert.strictEqual(arg.calls.length, callCount + 1, `arg.calls.length`);
         if (hasToView) {
-          assert.strictEqual(arg.calls[callCount - 1].length, 4, `arg.calls[callCount - 1].length`);
+          assert.strictEqual(arg.calls[callCount - 1].length, 5, `arg.calls[callCount - 1].length`);
           assert.strictEqual(arg.calls[callCount - 1][0], 'evaluate', `arg.calls[callCount - 1][0]`);
           assert.strictEqual(arg.calls[callCount - 1][1], flags, `arg.calls[callCount - 1][1]`);
           assert.strictEqual(arg.calls[callCount - 1][2], scope, `arg.calls[callCount - 1][2]`);
@@ -2477,7 +2477,7 @@ describe('ValueConverter', function () {
       }
 
       assert.strictEqual(expr.calls.length, 4, `expr.calls.length`);
-      assert.strictEqual(expr.calls[3].length, 4, `expr.calls[3].length`);
+      assert.strictEqual(expr.calls[3].length, 5, `expr.calls[3].length`);
       assert.strictEqual(expr.calls[3][0], 'evaluate', `expr.calls[3][0]`);
       assert.strictEqual(expr.calls[3][1], flags, `expr.calls[3][1]`);
       assert.strictEqual(expr.calls[3][2], scope, `expr.calls[3][2]`);

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -24,6 +24,7 @@ export class Listener implements IBinding {
 
   public $state: State;
   public $scope!: IScope;
+  public part?: string;
 
   public delegationStrategy: DelegationStrategy;
   public locator: IServiceLocator;
@@ -64,7 +65,7 @@ export class Listener implements IBinding {
     const overrideContext = this.$scope.overrideContext;
     overrideContext.$event = event;
 
-    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator);
+    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope, this.locator, this.part);
 
     Reflect.deleteProperty(overrideContext, '$event');
 
@@ -80,7 +81,7 @@ export class Listener implements IBinding {
     this.callSource(event);
   }
 
-  public $bind(flags: LifecycleFlags, scope: IScope): void {
+  public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
     if (Tracer.enabled) { Tracer.enter('Listener', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
@@ -94,6 +95,7 @@ export class Listener implements IBinding {
     this.$state |= State.isBinding;
 
     this.$scope = scope;
+    this.part = part;
 
     const sourceExpression = this.sourceExpression;
     if (hasBind(sourceExpression)) {

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -244,7 +244,7 @@ export class Compose<T extends INode = Node> {
 
   private bindView(flags: LifecycleFlags): ILifecycleTask {
     if (this.view != void 0 && (this.$controller.state & (State.isBoundOrBinding)) > 0) {
-      return this.view.bind(flags, this.renderable.scope);
+      return this.view.bind(flags, this.renderable.scope, this.$controller.part);
     }
     return LifecycleTask.done;
   }

--- a/packages/runtime/src/ast.ts
+++ b/packages/runtime/src/ast.ts
@@ -65,9 +65,9 @@ export interface IVisitor<T = unknown> {
 export interface IExpression {
   readonly $kind: ExpressionKind;
   accept<T>(visitor: IVisitor<T>): T;
-  connect(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
-  evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null): unknown;
-  assign?(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, value: unknown): unknown;
+  connect(flags: LifecycleFlags, scope: IScope, binding: IConnectable, part?: string): void;
+  evaluate(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, part?: string): unknown;
+  assign?(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator | null, value: unknown, part?: string): unknown;
   bind?(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
   unbind?(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
 }
@@ -83,7 +83,7 @@ export interface IBindingBehaviorExpression extends IExpression {
   readonly name: string;
   readonly args: ReadonlyArray<IsAssign>;
   readonly behaviorKey: string;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
   bind(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
   unbind(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
 }
@@ -94,7 +94,7 @@ export interface IValueConverterExpression extends IExpression {
   readonly name: string;
   readonly args: ReadonlyArray<IsAssign>;
   readonly converterKey: string;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
   unbind(flags: LifecycleFlags, scope: IScope, binding: IConnectable): void;
 }
 
@@ -102,7 +102,7 @@ export interface IAssignExpression extends IExpression {
   readonly $kind: ExpressionKind.Assign;
   readonly target: IsAssignable;
   readonly value: IsAssign;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
 }
 
 export interface IConditionalExpression extends IExpression {
@@ -121,21 +121,21 @@ export interface IAccessScopeExpression extends IExpression {
   readonly $kind: ExpressionKind.AccessScope;
   readonly name: string;
   readonly ancestor: number;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
 }
 
 export interface IAccessMemberExpression extends IExpression {
   readonly $kind: ExpressionKind.AccessMember;
   readonly object: IsLeftHandSide;
   readonly name: string;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
 }
 
 export interface IAccessKeyedExpression extends IExpression {
   readonly $kind: ExpressionKind.AccessKeyed;
   readonly object: IsLeftHandSide;
   readonly key: IsAssign;
-  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown): unknown;
+  assign(flags: LifecycleFlags, scope: IScope, locator: IServiceLocator, value: unknown, part?: string): unknown;
 }
 
 export interface ICallScopeExpression extends IExpression {

--- a/packages/runtime/src/binding/call.ts
+++ b/packages/runtime/src/binding/call.ts
@@ -28,6 +28,7 @@ export interface Call extends IConnectableBinding {}
 export class Call {
   public $state: State;
   public $scope?: IScope;
+  public part?: string;
 
   public locator: IServiceLocator;
   public sourceExpression: IsBindingBehavior;
@@ -51,7 +52,7 @@ export class Call {
     if (Tracer.enabled) { Tracer.enter('Call', 'callSource', slice.call(arguments)); }
     const overrideContext = this.$scope!.overrideContext;
     Object.assign(overrideContext, args);
-    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope!, this.locator);
+    const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope!, this.locator, this.part);
 
     for (const prop in args) {
       Reflect.deleteProperty(overrideContext, prop);
@@ -61,7 +62,7 @@ export class Call {
     return result;
   }
 
-  public $bind(flags: LifecycleFlags, scope: IScope): void {
+  public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
     if (Tracer.enabled) { Tracer.enter('Call', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
@@ -75,6 +76,7 @@ export class Call {
     this.$state |= State.isBinding;
 
     this.$scope = scope;
+    this.part = part;
 
     if (hasBind(this.sourceExpression)) {
       this.sourceExpression.bind(flags, scope, this);

--- a/packages/runtime/src/binding/ref.ts
+++ b/packages/runtime/src/binding/ref.ts
@@ -26,6 +26,7 @@ export interface Ref extends IConnectableBinding {}
 export class Ref implements IBinding {
   public $state: State;
   public $scope?: IScope;
+  public part?: string;
 
   public locator: IServiceLocator;
   public sourceExpression: IsBindingBehavior;
@@ -44,7 +45,7 @@ export class Ref implements IBinding {
     this.target = target as IObservable;
   }
 
-  public $bind(flags: LifecycleFlags, scope: IScope): void {
+  public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
     if (Tracer.enabled) { Tracer.enter('Ref', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
@@ -58,12 +59,13 @@ export class Ref implements IBinding {
     this.$state |= State.isBinding;
 
     this.$scope = scope;
+    this.part = part;
 
     if (hasBind(this.sourceExpression)) {
       this.sourceExpression.bind(flags, scope, this);
     }
 
-    this.sourceExpression.assign!(flags, this.$scope, this.locator, this.target);
+    this.sourceExpression.assign!(flags, this.$scope, this.locator, this.target, part);
 
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
@@ -80,8 +82,8 @@ export class Ref implements IBinding {
     // add isUnbinding flag
     this.$state |= State.isUnbinding;
 
-    if (this.sourceExpression.evaluate(flags, this.$scope!, this.locator) === this.target) {
-      this.sourceExpression.assign!(flags, this.$scope!, this.locator, null);
+    if (this.sourceExpression.evaluate(flags, this.$scope!, this.locator, this.part) === this.target) {
+      this.sourceExpression.assign!(flags, this.$scope!, this.locator, null, this.part);
     }
 
     const sourceExpression = this.sourceExpression;

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -43,8 +43,9 @@ const slice = Array.prototype.slice;
 export interface IBinding {
   readonly locator: IServiceLocator;
   readonly $scope?: IScope;
+  readonly part?: string;
   readonly $state: State;
-  $bind(flags: LifecycleFlags, scope: IScope): void;
+  $bind(flags: LifecycleFlags, scope: IScope, part?: string): void;
   $unbind(flags: LifecycleFlags): void;
 }
 
@@ -96,6 +97,7 @@ export interface IController<
   readonly vmKind: ViewModelKind;
 
   scope?: IScope;
+  part?: string;
   projector?: IElementProjector;
 
   nodes?: INodeSequence<T>;
@@ -107,7 +109,7 @@ export interface IController<
   lockScope(scope: IScope): void;
   hold(location: IRenderLocation<T>): void;
   release(flags: LifecycleFlags): boolean;
-  bind(flags: LifecycleFlags, scope?: IScope): ILifecycleTask;
+  bind(flags: LifecycleFlags, scope?: IScope, partName?: string): ILifecycleTask;
   unbind(flags: LifecycleFlags): ILifecycleTask;
   bound(flags: LifecycleFlags): void;
   unbound(flags: LifecycleFlags): void;

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -41,8 +41,6 @@ export class InternalObserversLookup {
 export type BindingContextValue = ObservedCollection | StrictPrimitive | IIndexable;
 
 export class BindingContext implements IBindingContext {
-  public static partName: string | null = null;
-
   [key: string]: unknown;
 
   public readonly $synthetic: true;
@@ -93,7 +91,7 @@ export class BindingContext implements IBindingContext {
     return bc;
   }
 
-  public static get(scope: IScope, name: string, ancestor: number, flags: LifecycleFlags): IBindingContext | IOverrideContext | IBinding | undefined | null {
+  public static get(scope: IScope, name: string, ancestor: number, flags: LifecycleFlags, part?: string): IBindingContext | IOverrideContext | IBinding | undefined | null {
     if (Tracer.enabled) { Tracer.enter('BindingContext', 'get', slice.call(arguments)); }
     if (scope == null) {
       throw Reporter.error(RuntimeError.NilScope);
@@ -128,7 +126,7 @@ export class BindingContext implements IBindingContext {
 
     // the name wasn't found. see if parent scope traversal is allowed and if so, try that
     if ((flags & LifecycleFlags.allowParentScopeTraversal) > 0) {
-      const partScope = scope.partScopes![BindingContext.partName!]!;
+      const partScope = scope.partScopes![part!]!;
       const result = this.get(partScope, name, ancestor, flags
         // unset the flag; only allow one level of scope boundary traversal
         & ~LifecycleFlags.allowParentScopeTraversal

--- a/packages/runtime/src/observation/property-accessor.ts
+++ b/packages/runtime/src/observation/property-accessor.ts
@@ -13,7 +13,11 @@ export class PropertyAccessor implements PropertyAccessor {
     if (Tracer.enabled) { Tracer.enter('PropertyAccessor', 'constructor', slice.call(arguments)); }
     this.obj = obj;
     this.propertyKey = propertyKey;
-    if (obj.$observers !== void 0 && (obj.$observers as Record<string, unknown>)[propertyKey] !== void 0) {
+    if (
+      obj.$observers !== void 0
+      && (obj.$observers as Record<string, unknown>)[propertyKey] !== void 0
+      && ((obj.$observers as Record<string, unknown>)[propertyKey] as IBindingTargetAccessor).setValue !== void 0
+    ) {
       this.setValue = this.setValueDirect;
     }
     if (Tracer.enabled) { Tracer.leave(); }

--- a/packages/runtime/src/resources/custom-attributes/if.ts
+++ b/packages/runtime/src/resources/custom-attributes/if.ts
@@ -256,7 +256,7 @@ export class If<T extends INode = INode> {
 
   private bindView(flags: LifecycleFlags): ILifecycleTask {
     if (this.view !== void 0 && (this.$controller.state & State.isBoundOrBinding) > 0) {
-      return this.view.bind(flags, this.$controller.scope);
+      return this.view.bind(flags, this.$controller.scope, this.$controller.part);
     }
     return LifecycleTask.done;
   }

--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -376,6 +376,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
     let task: ILifecycleTask;
     let view: IController<T>;
     this.$controller.lifecycle.bound.begin();
+    const part = this.$controller.part;
     const factory = this.factory;
     const local = this.local;
     const items = this.items;
@@ -383,7 +384,7 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
     const views = this.views = Array(newLen);
     this.forOf.iterate(flags, items, (arr, i, item) => {
       view = views[i] = factory.create(flags);
-      task = view.bind(flags, this.createScope(flags, local, item, view));
+      task = view.bind(flags, this.createScope(flags, local, item, view), part);
 
       if (!task.done) {
         if (tasks === undefined) {
@@ -415,12 +416,13 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
     const local = this.local;
     const items = this.items;
     this.$controller.lifecycle.bound.begin();
+    const part = this.$controller.part;
     const mapLen = indexMap.length;
     for (let i = 0; i < mapLen; ++i) {
       if (indexMap[i] === -2) {
         view = factory.create(flags);
         // TODO: test with map/set/undefined/null, make sure we can use strong typing here as well, etc
-        task = view.bind(flags, this.createScope(flags, local, (items as any)[i], view));
+        task = view.bind(flags, this.createScope(flags, local, (items as any)[i], view), part);
         views.splice(i, 0, view);
 
         if (!task.done) {

--- a/packages/runtime/src/resources/custom-attributes/replaceable.ts
+++ b/packages/runtime/src/resources/custom-attributes/replaceable.ts
@@ -26,9 +26,6 @@ import {
   ILifecycleTask,
 } from '../../lifecycle-task';
 import {
-  BindingContext,
-} from '../../observation/binding-context';
-import {
   CustomAttributeResource,
   ICustomAttributeResource,
 } from '../custom-attribute';
@@ -74,17 +71,7 @@ export class Replaceable<T extends INode = INode> {
   }
 
   public binding(flags: LifecycleFlags): ILifecycleTask {
-    const prevName = BindingContext.partName;
-    BindingContext.partName = this.factory.name;
-    const task = this.view.bind(flags | LifecycleFlags.allowParentScopeTraversal, this.$controller.scope);
-    if (task.done) {
-      BindingContext.partName = prevName;
-    } else {
-      task.wait().then(() => {
-        BindingContext.partName = prevName;
-      });
-    }
-    return task;
+    return this.view.bind(flags | LifecycleFlags.allowParentScopeTraversal, this.$controller.scope, this.factory.name);
   }
 
   public attaching(flags: LifecycleFlags): void {

--- a/packages/runtime/src/resources/custom-attributes/with.ts
+++ b/packages/runtime/src/resources/custom-attributes/with.ts
@@ -113,6 +113,7 @@ export class With<T extends INode = INode> {
 
   private bindChild(flags: LifecycleFlags): void {
     const scope = Scope.fromParent(flags, this.$controller.scope!, this.value === void 0 ? {} : this.value);
-    this.view.bind(flags, scope);
+    scope.partScopes = this.$controller.scope!.partScopes;
+    this.view.bind(flags, scope, this.$controller.part);
   }
 }

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -144,6 +144,7 @@ export class Controller<
   public readonly vmKind: ViewModelKind;
 
   public scope?: IScope;
+  public part?: string;
   public projector?: IElementProjector;
 
   public nodes?: INodeSequence<T>;
@@ -412,7 +413,8 @@ export class Controller<
     return this.unmountSynthetic(flags);
   }
 
-  public bind(flags: LifecycleFlags, scope?: IScope): ILifecycleTask {
+  public bind(flags: LifecycleFlags, scope?: IScope, part?: string): ILifecycleTask {
+    this.part = part;
     // TODO: benchmark which of these techniques is fastest:
     // - the current one (enum with switch)
     // - set the name of the method in the constructor, e.g. this.bindMethod = 'bindCustomElement'
@@ -668,7 +670,7 @@ export class Controller<
     if (bindings !== void 0) {
       const { length } = bindings;
       for (let i = 0; i < length; ++i) {
-        bindings[i].$bind(flags, scope);
+        bindings[i].$bind(flags, scope, this.part);
       }
     }
   }
@@ -681,7 +683,7 @@ export class Controller<
     if (controllers !== void 0) {
       const { length } = controllers;
       for (let i = 0; i < length; ++i) {
-        task = controllers[i].bind(flags, scope);
+        task = controllers[i].bind(flags, scope, this.part);
         if (!task.done) {
           if (tasks === void 0) {
             tasks = [];


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

A more involved fix that addresses a deeper underlying issue with the "quick-n-dirty" part propagation logic I wrote earlier: the scope from the target `replace-part` was only bindable when every binding inside the `replace-part` was bound at the same time as the wrapping `replaceable`.

Now, by propagating the selected part name through the binding and AST (in a similar manner to how the flags flow through it), it will also work in a large number of edge cases that weren't accounted for earlier.

Most notably, when the content of a `replace-part` is wrapped inside an `if` which starts as `false`, when that `if` turns to `true` the scope of the inner binding would not have proper access to the part scope. This case (and probably many others, still need more tests) is now working.


<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

A number of files were touched but the changes themselves are fairly repetitive in nature, so the code should be able to speak for itself.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Added one test specifically for the `if` scenario mentioned above. This will need more combinations (possibly a few thousand actually).
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Implement said tests.

@bigopon you may want to look at this and see if any of your commented-out tests work now
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
