### PR TITLE
fix(replaceable): fix some more edge cases with multi nested elements and template controllers

### DIFF
--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -674,7 +674,6 @@ describe(`TemplateCompiler - combinations`, function () {
           instructions: [],
           surrogates: [],
         };
-
         const expected = {
           template: ctx.createElementFromMarkup(`<template><${el} ${n1}="${v1}" class="au"></${el}></template>`),
           instructions: [[i1]],

--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -463,7 +463,8 @@ function createTemplateController(ctx: HTMLTestContext, attr: string, target: st
         name: target,
         template: ctx.createElementFromMarkup(`<template><au-m class="au"></au-m></template>`),
         instructions: [[childInstr]],
-        build: buildNotRequired
+        build: buildNotRequired,
+        scopeParts: [],
       },
       instructions: createTplCtrlAttributeInstruction(attr, value),
       link: attr === 'else'
@@ -476,6 +477,7 @@ function createTemplateController(ctx: HTMLTestContext, attr: string, target: st
       template: ctx.createElementFromMarkup(`<template><div><au-m class="au"></au-m></div></template>`),
       instructions: [[instruction]],
       build: buildNotRequired,
+      scopeParts: [],
     };
     // @ts-ignore
     return [input, output];
@@ -496,7 +498,8 @@ function createTemplateController(ctx: HTMLTestContext, attr: string, target: st
         name: target,
         template: ctx.createElementFromMarkup(tagName === 'template' ? compiledMarkup : `<template>${compiledMarkup}</template>`),
         instructions,
-        build: buildNotRequired
+        build: buildNotRequired,
+        scopeParts: [],
       },
       instructions: createTplCtrlAttributeInstruction(attr, value),
       link: attr === 'else'
@@ -510,6 +513,7 @@ function createTemplateController(ctx: HTMLTestContext, attr: string, target: st
       template: ctx.createElementFromMarkup(finalize ? `<template><div><au-m class="au"></au-m></div></template>` : `<au-m class="au"></au-m>`),
       instructions: [[instruction]],
       build: buildNotRequired,
+      scopeParts: [],
     };
     // @ts-ignore
     return [input, output];
@@ -535,6 +539,7 @@ function createCustomElement(ctx: HTMLTestContext, tagName: string, finalize: bo
     template: finalize ? ctx.createElementFromMarkup(`<template><div>${outputMarkup.outerHTML}</div></template>`) : outputMarkup,
     instructions: [[instruction, ...siblingInstructions], ...nestedElInstructions],
     build: buildNotRequired,
+    scopeParts: [],
   };
   return [input, output];
 }
@@ -664,8 +669,19 @@ describe(`TemplateCompiler - combinations`, function () {
       const markup = `<${el} ${n1}="${v1}"></${el}>`;
 
       it(markup, function () {
-        const input = { template: markup, instructions: [], surrogates: [] };
-        const expected = { template: ctx.createElementFromMarkup(`<template><${el} ${n1}="${v1}" class="au"></${el}></template>`), instructions: [[i1]], surrogates: [], build: buildNotRequired };
+        const input = {
+          template: markup,
+          instructions: [],
+          surrogates: [],
+        };
+
+        const expected = {
+          template: ctx.createElementFromMarkup(`<template><${el} ${n1}="${v1}" class="au"></${el}></template>`),
+          instructions: [[i1]],
+          surrogates: [],
+          build: buildNotRequired,
+          scopeParts: [],
+        };
 
         const { sut, resources, dom } = setup(ctx);
 
@@ -721,9 +737,23 @@ describe(`TemplateCompiler - combinations`, function () {
       const markup = `<div ${name}="${value}"></div>`;
 
       it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, function () {
-        const input = { template: markup, instructions: [], surrogates: [] };
-        const instruction = { type: TT.hydrateAttribute, res: def.name, instructions: [childInstruction] };
-        const expected = { template: ctx.createElementFromMarkup(`<template><div ${name}="${value}" class="au"></div></template>`), instructions: [[instruction]], surrogates: [], build: buildNotRequired };
+        const input = {
+          template: markup,
+          instructions: [],
+          surrogates: [],
+        };
+        const instruction = {
+          type: TT.hydrateAttribute,
+          res: def.name,
+          instructions: [childInstruction],
+        };
+        const expected = {
+          template: ctx.createElementFromMarkup(`<template><div ${name}="${value}" class="au"></div></template>`),
+          instructions: [[instruction]],
+          surrogates: [],
+          build: buildNotRequired,
+          scopeParts: [],
+        };
 
         const $def = CustomAttributeResource.define(def, ctor);
         const { sut, resources, dom  } = setup(ctx, $def);
@@ -990,6 +1020,7 @@ describe(`TemplateCompiler - combinations`, function () {
           template: ctx.createElementFromMarkup(`<template><div>${output1.template['outerHTML']}${output2.template['outerHTML']}${output3.template['outerHTML']}</div></template>`),
           instructions: [output1.instructions[0], output2.instructions[0], output3.instructions[0]],
           build: buildNotRequired,
+          scopeParts: [],
         };
         //enableTracing();
         //Tracer.enableLiveLogging(SymbolTraceWriter);

--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -562,6 +562,7 @@ function createCustomAttribute(ctx: HTMLTestContext, resName: string, finalize: 
     template: finalize ? ctx.createElementFromMarkup(`<template><div>${outputMarkup.outerHTML}</div></template>`) : outputMarkup,
     instructions: [[instruction, ...siblingInstructions], ...nestedElInstructions],
     build: buildNotRequired,
+    scopeParts: [],
   };
   return [input, output];
 }

--- a/packages/__tests__/runtime/controller.spec.ts
+++ b/packages/__tests__/runtime/controller.spec.ts
@@ -148,6 +148,7 @@ describe.skip('controller', function () {
       hasSlots: false,
       strategy: BindingStrategy.getterSetter,
       hooks,
+      scopeParts: PLATFORM.emptyArray,
     });
   }
 

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -1,3 +1,5 @@
+import { PLATFORM } from './platform';
+
 const camelCaseLookup: Record<string, string> = {};
 const kebabCaseLookup: Record<string, string> = {};
 const isNumericLookup: Record<string, boolean> = {};
@@ -139,4 +141,54 @@ export function resetId(context: string): void {
  */
 export function compareNumber(a: number, b: number): number {
   return a - b;
+}
+
+const emptyArray = PLATFORM.emptyArray;
+
+/**
+ * Efficiently merge and deduplicate the (primitive) values in two arrays.
+ *
+ * Does not deduplicate existing values in the first array.
+ *
+ * Guards against null or undefined arrays.
+ *
+ * Returns `PLATFORM.emptyArray` if both arrays are either `null`, `undefined` or `PLATFORM.emptyArray`
+ *
+ * @param slice If `true`, always returns a new array copy (unless neither array is/has a value)
+ */
+export function mergeDistinct<T>(
+  arr1: readonly T[] | T[] | null | undefined,
+  arr2: readonly T[] | T[] | null | undefined,
+  slice: boolean,
+): T[] {
+  if (arr1 === void 0 || arr1 === null || arr1 === emptyArray) {
+    if (arr2 === void 0 || arr2 === null || arr2 === emptyArray) {
+      return emptyArray;
+    } else {
+      return slice ? arr2.slice(0) : arr2 as T[];
+    }
+  } else if (arr2 === void 0 || arr2 === null || arr2 === emptyArray) {
+    return slice ? arr1.slice(0) : arr1 as T[];
+  }
+
+  const lookup: Record<string, true | undefined> = {};
+  const arr3 = slice ? arr1.slice(0) : arr1 as (readonly T[]) & T[];
+
+  let len1 = arr1.length;
+  let len2 = arr2.length;
+
+  while (len1-- > 0) {
+    lookup[arr1[len1] as unknown as string] = true;
+  }
+
+  let item;
+  while (len2-- > 0) {
+    item = arr2[len2];
+    if (lookup[item as unknown as string] === void 0) {
+      arr3.push(item);
+      lookup[item as unknown as string] = true;
+    }
+  }
+
+  return arr3;
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -99,4 +99,5 @@ export {
   nextId,
   resetId,
   compareNumber,
+  mergeDistinct,
 } from './functions';

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -1,8 +1,8 @@
 import {
   Constructable,
   IContainer,
-  Key,
   IRegistry,
+  Key,
   nextId,
   PLATFORM,
   Registration,
@@ -67,6 +67,7 @@ export class Compose<T extends INode = Node> {
     hasSlots: false,
     strategy: BindingStrategy.getterSetter,
     hooks: Object.freeze(new HooksDefinition(Compose.prototype)),
+    scopeParts: PLATFORM.emptyArray,
   });
 
   public readonly id: number;

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -409,7 +409,16 @@ export class AccessThis implements IAccessThisExpression {
     }
 
     if ((flags & LifecycleFlags.allowParentScopeTraversal) > 0) {
-      scope = scope.partScopes![part!]!;
+      let parent = scope.parentScope;
+      while (parent !== null) {
+        if (!parent.scopeParts.includes(part!)) {
+          parent = parent.parentScope;
+        }
+      }
+
+      if (parent === null) {
+        throw new Error(`No target scope cold be found for part "${part}"`);
+      }
     }
     let oc: IOverrideContext | null = scope.overrideContext;
     let i = this.ancestor;

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -98,6 +98,7 @@ export interface ITemplateDefinition extends IResourceDefinition {
   hasSlots?: boolean;
   strategy?: BindingStrategy;
   hooks?: Readonly<HooksDefinition>;
+  scopeParts?: readonly string[]
 }
 
 export type TemplateDefinition = ResourceDescription<ITemplateDefinition>;
@@ -282,6 +283,7 @@ class DefaultTemplateDefinition implements Required<ITemplateDefinition> {
   public hasSlots: boolean;
   public strategy: BindingStrategy;
   public hooks: Readonly<HooksDefinition>;
+  public scopeParts: readonly string[];
 
   constructor() {
     this.name = 'unnamed';
@@ -297,6 +299,7 @@ class DefaultTemplateDefinition implements Required<ITemplateDefinition> {
     this.hasSlots = false;
     this.strategy = BindingStrategy.getterSetter;
     this.hooks = HooksDefinition.none;
+    this.scopeParts = PLATFORM.emptyArray;
   }
 }
 

--- a/packages/runtime/src/lifecycle.ts
+++ b/packages/runtime/src/lifecycle.ts
@@ -96,6 +96,8 @@ export interface IController<
 
   readonly vmKind: ViewModelKind;
 
+  readonly scopeParts?: readonly string[];
+
   scope?: IScope;
   part?: string;
   projector?: IElementProjector;
@@ -103,8 +105,6 @@ export interface IController<
   nodes?: INodeSequence<T>;
   context?: IContainer | IRenderContext<T>;
   location?: IRenderLocation<T>;
-
-  readonly scopeParts: readonly string[];
 
   lockScope(scope: IScope): void;
   hold(location: IRenderLocation<T>): void;

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -337,12 +337,10 @@ export interface IOverrideContext {
 }
 
 export interface IScope {
+  readonly parentScope: IScope | null;
+  readonly scopeParts: readonly string[];
   readonly bindingContext: IBindingContext;
   readonly overrideContext: IOverrideContext;
-  /**
-   * Associates replace-part names with the scopes they have access to.
-   */
-  readonly partScopes?: Record<string, IScope | undefined>;
 }
 
 export type ObserversLookup = IIndexable<

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -1,4 +1,4 @@
-import { IIndexable, Reporter, StrictPrimitive, Tracer } from '@aurelia/kernel';
+import { IIndexable, Reporter, StrictPrimitive, Tracer, PLATFORM } from '@aurelia/kernel';
 import { LifecycleFlags } from '../flags';
 import { IBinding, ILifecycle } from '../lifecycle';
 import {
@@ -19,6 +19,8 @@ const enum RuntimeError {
   NilOverrideContext = 252,
   NilParentScope = 253
 }
+
+const marker = Object.freeze({});
 
 /** @internal */
 export class InternalObserversLookup {
@@ -126,15 +128,27 @@ export class BindingContext implements IBindingContext {
 
     // the name wasn't found. see if parent scope traversal is allowed and if so, try that
     if ((flags & LifecycleFlags.allowParentScopeTraversal) > 0) {
-      const partScope = scope.partScopes![part!]!;
-      const result = this.get(partScope, name, ancestor, flags
-        // unset the flag; only allow one level of scope boundary traversal
-        & ~LifecycleFlags.allowParentScopeTraversal
-        // tell the scope to return null if the name could not be found
-        | LifecycleFlags.isTraversingParentScope);
-      if (result !== null) {
-        if (Tracer.enabled) { Tracer.leave(); }
-        return result;
+      let parent = scope.parentScope;
+      while (parent !== null) {
+        if (parent.scopeParts.includes(part!)) {
+          const result = this.get(parent, name, ancestor, flags
+            // unset the flag; only allow one level of scope boundary traversal
+            & ~LifecycleFlags.allowParentScopeTraversal
+            // tell the scope to return null if the name could not be found
+            | LifecycleFlags.isTraversingParentScope);
+          if (Tracer.enabled) { Tracer.leave(); }
+          if (result === marker) {
+            return scope.bindingContext || scope.overrideContext;
+          } else {
+            return result;
+          }
+        } else {
+          parent = parent.parentScope;
+        }
+      }
+
+      if (parent === null) {
+        throw new Error(`No target scope could be found for part "${part}"`);
       }
     }
 
@@ -143,7 +157,7 @@ export class BindingContext implements IBindingContext {
     // correct level)
     if (flags & LifecycleFlags.isTraversingParentScope) {
       if (Tracer.enabled) { Tracer.leave(); }
-      return null;
+      return marker;
     }
     if (Tracer.enabled) { Tracer.leave(); }
     return scope.bindingContext || scope.overrideContext;
@@ -160,19 +174,20 @@ export class BindingContext implements IBindingContext {
 }
 
 export class Scope implements IScope {
+  public parentScope: IScope | null;
+  public scopeParts: readonly string[];
   public bindingContext: IBindingContext;
   public overrideContext: IOverrideContext;
 
-  public partScopes?: Record<string, IScope | undefined>;
-
   private constructor(
+    parentScope: IScope | null,
     bindingContext: IBindingContext,
     overrideContext: IOverrideContext,
-    partScopes?: Record<string, IScope | undefined>
   ) {
+    this.parentScope = parentScope;
+    this.scopeParts = PLATFORM.emptyArray;
     this.bindingContext = bindingContext;
     this.overrideContext = overrideContext;
-    this.partScopes = partScopes;
   }
 
   /**
@@ -206,7 +221,7 @@ export class Scope implements IScope {
   public static create(flags: LifecycleFlags, bc: object, oc?: IOverrideContext | null): Scope {
     if (Tracer.enabled) { Tracer.enter('Scope', 'create', slice.call(arguments)); }
     if (Tracer.enabled) { Tracer.leave(); }
-    return new Scope(bc as IBindingContext, oc == null ? OverrideContext.create(flags, bc, oc!) : oc);
+    return new Scope(null, bc as IBindingContext, oc == null ? OverrideContext.create(flags, bc, oc!) : oc);
   }
 
   public static fromOverride(flags: LifecycleFlags, oc: IOverrideContext): Scope {
@@ -215,7 +230,7 @@ export class Scope implements IScope {
       throw Reporter.error(RuntimeError.NilOverrideContext);
     }
     if (Tracer.enabled) { Tracer.leave(); }
-    return new Scope(oc.bindingContext, oc);
+    return new Scope(null, oc.bindingContext, oc);
   }
 
   public static fromParent(flags: LifecycleFlags, ps: IScope | null, bc: object): Scope {
@@ -224,7 +239,7 @@ export class Scope implements IScope {
       throw Reporter.error(RuntimeError.NilParentScope);
     }
     if (Tracer.enabled) { Tracer.leave(); }
-    return new Scope(bc as IBindingContext, OverrideContext.create(flags, bc, ps.overrideContext), ps.partScopes);
+    return new Scope(ps, bc as IBindingContext, OverrideContext.create(flags, bc, ps.overrideContext));
   }
 }
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -289,12 +289,7 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
       }
     }
 
-    const controller = Controller.forCustomAttribute(
-      component,
-      context,
-      flags,
-      parts == void 0 ? PLATFORM.emptyArray : Object.keys(parts),
-    );
+    const controller = Controller.forCustomAttribute(component, context, flags);
 
     if (instruction.link) {
       const controllers = renderable.controllers!;

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -117,6 +117,7 @@ export class CompiledTemplate<T extends INode = INode> implements ITemplate {
     }
     const nodes = (controller as Writable<IController>).nodes = this.factory.createNodeSequence();
     (controller as Writable<IController>).context = this.renderContext;
+    (controller as Writable<IController>).scopeParts = this.definition.scopeParts;
     flags |= this.definition.strategy;
     this.renderContext.render(flags, controller, nodes.findTargets(), this.definition, host, parts);
   }

--- a/packages/runtime/src/resources/custom-attributes/with.ts
+++ b/packages/runtime/src/resources/custom-attributes/with.ts
@@ -113,7 +113,6 @@ export class With<T extends INode = INode> {
 
   private bindChild(flags: LifecycleFlags): void {
     const scope = Scope.fromParent(flags, this.$controller.scope!, this.value === void 0 ? {} : this.value);
-    scope.partScopes = this.$controller.scope!.partScopes;
     this.view.bind(flags, scope, this.$controller.part);
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

A refactor to clean things up a bit, use less resources, and offload some work to the template compiler so the controllers and resources have less tracking and tracing to do.

Important design change is that it adds an extra property to `ITemplateDefinition`: `scopeParts`. If anyone can think of a better (but not too long) name I'm all ears. The property is an array of the part names that need access to the scope of the resource on which that property sits.

Likely some improvements are still needed, but I need to sleep some nights on a more general internal refactor for smoother information exchange between different moving parts.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Mostly more code deleted than added. Added one `mergeDistinct` helper function to the kernel to efficiently merge and deduplicate two primitive arrays. I put it next to similar-flavored helpers and I believe it can be utilized in quite a few other places in the framework.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

No additional tests added, just making sure the existing still pass.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Nothing for now :)
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
