### PR TITLE
chore(di): use key type for dependencies array

### DIFF
--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -3,6 +3,7 @@ import {
   DI,
   IRegistry,
   IResourceDefinition,
+  Key,
   Omit,
   PLATFORM,
   ResourceDescription,
@@ -89,7 +90,7 @@ export interface ITemplateDefinition extends IResourceDefinition {
   cache?: '*' | number;
   template?: unknown;
   instructions?: ITargetedInstruction[][];
-  dependencies?: IRegistry[];
+  dependencies?: Key[];
   build?: IBuildInstruction;
   surrogates?: ITargetedInstruction[];
   bindables?: Record<string, IBindableDescription> | string[];


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

A small change to make the `customElement` decorator a bit more typescript friendly. Change the constraint from `IRegistry` to `Key`, which more or less allows you to specify anything in there.

While not as "safe" from a typing perspective, this pretty much can't be accomplished anyway because we also allow string dependencies.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
