### PR TITLE
Misc fixes

### DIFF
--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -733,7 +733,7 @@ describe(`TemplateCompiler - combinations`, function () {
       if (childInstruction.mode !== undefined) {
         childInstruction.oneTime = childInstruction.mode === BindingMode.oneTime;
       }
-      const def = { name: camelCase(attr), defaultBindingMode, bindables };
+      const def = { name: attr, defaultBindingMode, bindables };
       const markup = `<div ${name}="${value}"></div>`;
 
       it(`${markup}  CustomAttribute=${JSON.stringify(def)}`, function () {

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -28,7 +28,8 @@ import {
   BindingMode,
   BindingType,
   IDOM,
-  IExpressionParser
+  IExpressionParser,
+  AnyBindingExpression
 } from '@aurelia/runtime';
 import {
   NodeType,
@@ -429,7 +430,16 @@ export class TemplateBinder {
     const command = this.resources.getBindingCommand(attrSyntax);
     const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
     const manifest = this.manifest;
-    const expr = this.exprParser.parse(attrSyntax.rawValue, bindingType);
+    let expr: AnyBindingExpression;
+    if (
+      attrSyntax.rawValue.length === 0
+      && (bindingType & BindingType.BindCommand | BindingType.OneTimeCommand | BindingType.ToViewCommand | BindingType.TwoWayCommand) > 0
+    ) {
+      // Default to the name of the attr for empty binding commands
+      expr = this.exprParser.parse(camelCase(attrSyntax.rawName), bindingType);
+    } else {
+      expr = this.exprParser.parse(attrSyntax.rawValue, bindingType);
+    }
 
     if (manifest!.flags & SymbolFlags.isCustomElement) {
       const bindable = (manifest as CustomElementSymbol).bindables[attrSyntax.target];

--- a/packages/jit/src/resource-model.ts
+++ b/packages/jit/src/resource-model.ts
@@ -61,16 +61,15 @@ export class ResourceModel {
    * @returns The resource information if the attribute exists, or `null` if it does not exist.
    */
   public getAttributeInfo(syntax: AttrSyntax): AttrInfo | null {
-    const name = camelCase(syntax.target);
-    let result = this.attributeLookup[name];
+    let result = this.attributeLookup[syntax.target];
     if (result === void 0) {
-      const def = this.resources.find(CustomAttributeResource, name);
+      const def = this.resources.find(CustomAttributeResource, syntax.target);
       if (def == null) {
         result = null!;
       } else {
         result = createAttributeInfo(def);
       }
-      this.attributeLookup[name] = result;
+      this.attributeLookup[syntax.target] = result;
     }
     return result;
   }

--- a/packages/jit/src/resource-model.ts
+++ b/packages/jit/src/resource-model.ts
@@ -1,5 +1,4 @@
 import {
-  camelCase,
   IResourceDescriptions,
   kebabCase,
   Reporter,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Fixes attribute name registrations (they were erroneously being camelCased before, so that `attribute-name` would be mapped to `attributeName` - now it's back to normal again)

- Adds a new binding shorthand. If you leave the attribute value empty in a binding command (`.bind`, `.one-time`, `.to-view`, `.from-view`, `.two-way` and the `.bind` shorthand `:`) then it will default to the camelCased attribute name.

So, these:

```html
<my-element value.bind></my-element>
<my-element :value></my-element>
<my-element some-value.bind></my-element>
<my-element :some-value></my-element>
<input value.two-way>
```

Are equivalent to these:

```html
<my-element value.bind="value"></my-element>
<my-element :value="value"></my-element>
<my-element some-value.bind="someValue"></my-element>
<my-element :some-value="someValue"></my-element>
<input value.two-way="value">
```

It can clean up the template quite nicely :)

@bigopon @EisenbergEffect 

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
 

<a id="b0023ec0-987a-11e9-b4ae-ffbb0e5c703c" href="none" codereview-uuid-reserved-tag />