### PR TITLE
chore: fixate pixi.js for now

### DIFF
--- a/examples/jit-pixi-webpack-ts/package.json
+++ b/examples/jit-pixi-webpack-ts/package.json
@@ -15,11 +15,11 @@
     "@aurelia/runtime-html-browser": "file:../../packages/runtime-html-browser",
     "@aurelia/runtime-html": "file:../../packages/runtime-html",
     "@aurelia/runtime": "file:../../packages/runtime",
-    "pixi.js": "^4.8.7"
+    "pixi.js": "^4.8.8"
   },
   "devDependencies": {
     "@types/node": "latest",
-    "@types/pixi.js": "^4.8.6",
+    "@types/pixi.js": "^4.8.8",
     "copy-webpack-plugin": "^5.0.2",
     "file-loader": "^3.0.1",
     "html-loader": "latest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,9 +1178,9 @@
       "dev": true
     },
     "@types/pixi.js": {
-      "version": "4.8.6",
-      "resolved": "https://registry.npmjs.org/@types/pixi.js/-/pixi.js-4.8.6.tgz",
-      "integrity": "sha512-70PcmzoHG723nMLx7OzMM7xoH8EnJfVVQmh1WQgXGaXdU9ygq3VlsXLRt/g6Z124abKDvmzg3hfRpA8CvBp2eA==",
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/@types/pixi.js/-/pixi.js-4.8.8.tgz",
+      "integrity": "sha512-5wmLnmL3foK/rqYMrrEM/3DxEwvwxJaP73RyqY8aMqq8zUm6CBlmc+12RIBH6iR/RHqU76XL238vWWJV1IN/zw==",
       "dev": true
     },
     "@types/request": {
@@ -9577,9 +9577,9 @@
       "integrity": "sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I="
     },
     "pixi.js": {
-      "version": "4.8.7",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.7.tgz",
-      "integrity": "sha512-mx7YbHPkkWoj8FT3qBMkieAjBuuJ4yZWU7rq9NnCSUGpNrVlocrW179xrJQPVR2Q7JZ73ZGTwH7NOUZ9wgh7wA==",
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.8.8.tgz",
+      "integrity": "sha512-wQzuLAWSMfV+x2guL5jZBp37pwCmYXHiTXG7ZWXu4E/5IsC9xozwmOfLeCNEyPzlyucOgxAx/HS+tLqxWPYX7Q==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "earcut": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "jsdom": "^15.1.1",
-    "pixi.js": "^4.8.7"
+    "pixi.js": "^4.8.8"
   },
   "devDependencies": {
     "@types/acorn": "^4.0.5",
@@ -47,7 +47,7 @@
     "@types/karma": "^3.0.2",
     "@types/mocha": "^5.2.6",
     "@types/node": "^10.12.27",
-    "@types/pixi.js": "^4.8.6",
+    "@types/pixi.js": "^4.8.8",
     "@types/request": "^2.48.1",
     "@types/webpack": "^4.4.26",
     "@types/webpack-env": "^1.13.9",

--- a/packages/plugin-pixi/package.json
+++ b/packages/plugin-pixi/package.json
@@ -41,7 +41,7 @@
     "@aurelia/runtime": "0.3.0",
     "@aurelia/runtime-html": "0.3.0",
     "@aurelia/runtime-html-browser": "0.3.0",
-    "pixi.js": "^4.8.7"
+    "pixi.js": "^4.8.8"
   },
   "devDependencies": {
     "@types/node": "^10.12.27",

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
     {
       "packageNames": ["chromedriver"],
       "allowedVersions": "~2.45.0"
+    },
+    {
+      "packageNames": ["pixi.js", "@types/pixi.js"],
+      "allowedVersions": "~4.8.8"
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixate `pixi.js` on `~4.8.8` for now, as `^5` contains breaking changes which will need some more effort to resolve.

### 🎫 Issues

This should unblock #505.

## 👩‍💻 Reviewer Notes

Updated to and fixated on the latest `pixi.js@^4`

## 📑 Test Plan

Trust CircleCI.

## ⏭ Next Steps

See if this bring #505 in a mergeable state.
