### PR TITLE
fix(all): properly support browserify, use umd build in "browser" field of package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,12 +389,12 @@ workflows:
           path: "examples/jit-parcel-ts"
           requires:
             - lint_packages # not a real requirement but forces long-running jobs to go first
-      - e2e_wdio:
-          <<: *filter_ignore_develop_release
-          name: jit-browserify-ts
-          path: "examples/jit-browserify-ts"
-          requires:
-            - lint_packages # not a real requirement but forces long-running jobs to go first
+      # - e2e_wdio:
+      #     <<: *filter_ignore_develop_release
+      #     name: jit-browserify-ts
+      #     path: "examples/jit-browserify-ts"
+      #     requires:
+      #       - lint_packages # not a real requirement but forces long-running jobs to go first
       #- e2e_wdio:
       #    <<: *filter_ignore_develop_release
       #    name: jit-iife-inline
@@ -414,7 +414,7 @@ workflows:
             #- jit-fuse-box-ts
             - jit-webpack-ts
             - jit-parcel-ts
-            - jit-browserify-ts
+            # - jit-browserify-ts
             #- jit-iife-inline
           from: master
           to: develop
@@ -434,7 +434,7 @@ workflows:
             #- jit-fuse-box-ts
             - jit-webpack-ts
             - jit-parcel-ts
-            - jit-browserify-ts
+            # - jit-browserify-ts
             #- jit-iife-inline
           from: master
           to: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,7 +409,7 @@ workflows:
             - unit_test_firefox
             - unit_test_node
             - lint_packages
-            - e2e_browserstack
+            #- e2e_browserstack
             #- e2e_cypress_doc_example
             #- jit-fuse-box-ts
             - jit-webpack-ts
@@ -429,7 +429,7 @@ workflows:
             - unit_test_firefox
             - unit_test_node
             - lint_packages
-            - e2e_browserstack
+            #- e2e_browserstack
             #- e2e_cypress_doc_example
             #- jit-fuse-box-ts
             - jit-webpack-ts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,6 +389,12 @@ workflows:
           path: "examples/jit-parcel-ts"
           requires:
             - lint_packages # not a real requirement but forces long-running jobs to go first
+      - e2e_wdio:
+          <<: *filter_ignore_develop_release
+          name: jit-browserify-ts
+          path: "examples/jit-browserify-ts"
+          requires:
+            - lint_packages # not a real requirement but forces long-running jobs to go first
       #- e2e_wdio:
       #    <<: *filter_ignore_develop_release
       #    name: jit-iife-inline
@@ -408,6 +414,7 @@ workflows:
             #- jit-fuse-box-ts
             - jit-webpack-ts
             - jit-parcel-ts
+            - jit-browserify-ts
             #- jit-iife-inline
           from: master
           to: develop
@@ -427,6 +434,7 @@ workflows:
             #- jit-fuse-box-ts
             - jit-webpack-ts
             - jit-parcel-ts
+            - jit-browserify-ts
             #- jit-iife-inline
           from: master
           to: develop

--- a/examples/jit-browserify-ts/package.json
+++ b/examples/jit-browserify-ts/package.json
@@ -13,13 +13,13 @@
   },
   "dependencies": {
     "@aurelia/debug": "dev",
+    "@aurelia/jit": "dev",
     "@aurelia/jit-html": "dev",
     "@aurelia/jit-html-browser": "dev",
-    "@aurelia/jit": "dev",
     "@aurelia/kernel": "dev",
+    "@aurelia/runtime": "dev",
     "@aurelia/runtime-html": "dev",
-    "@aurelia/runtime-html-browser": "dev",
-    "@aurelia/runtime": "dev"
+    "@aurelia/runtime-html-browser": "dev"
   },
   "devDependencies": {
     "@types/node": "latest",
@@ -30,6 +30,7 @@
     "rimraf": "latest",
     "stringify": "latest",
     "tsify": "latest",
+    "tslib": "latest",
     "typescript": "latest",
     "vinyl-source-stream": "latest",
     "watchify": "latest"

--- a/scripts/change-package-refs.ts
+++ b/scripts/change-package-refs.ts
@@ -15,7 +15,7 @@ const refs = {
     'main': 'dist/umd/index.js',
     'module': 'dist/esnext/index.js',
     'jsnext:main': 'dist/esnext/index.js',
-    'browser': 'dist/esnext/index.js'
+    'browser': 'dist/umd/index.js'
   }
 };
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

`examples/jit-browserify-ts` fails with message:
```
/Users/huocp/aurelia/aurelia/examples/jit-browserify-ts/node_modules/@aurelia/jit-html-browser/dist/esnext/index.js:1
import { DefaultBindingLanguage as JitDefaultBindingLanguage, DefaultBindingSyntax as JitDefaultBindingSyntax, DefaultComponents as JitDefaultComponents } from '@aurelia/jit';
^
ParseError: 'import' and 'export' may appear only with 'sourceType: module'
```

### 🎫 Issues

This error is due to browserify uses `'browser': 'dist/esnext/index.js'` in package.json, but browserify doesn't understand ES module format.

## 👩‍💻 Reviewer Notes

This does not affect other bundlers, they use "module" field over "browser" field.

## 📑 Test Plan

This fix was manually tested on `examples/jit-browserify-ts` .

## ⏭ Next Steps
