### PR TITLE
chore: remove duplicate lerna bootstrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "commit": "git-cz",
-    "init": "npm ci && npm run bootstrap && npm run build",
+    "init": "npm ci && npm run build",
     "bootstrap": "lerna bootstrap --ci",
     "postinstall": "lerna bootstrap --ci",
     "rebuild": "npm run clean && npm run build",
@@ -31,7 +31,7 @@
     "publish:latest": "ts-node -P scripts/tsconfig.json scripts/publish.ts latest",
     "bump-version:dev": "ts-node -P scripts/tsconfig.json scripts/bump-version.ts dev",
     "bump-version:latest": "ts-node -P scripts/tsconfig.json scripts/bump-version.ts latest",
-    "refresh": "lerna clean -y && nodetouch ensurestash && git add . && git stash && git clean -xfd && git stash pop && git rm -f ensurestash && npm ci && npm run bootstrap && npm run build",
+    "refresh": "lerna clean -y && nodetouch ensurestash && git add . && git stash && git clean -xfd && git stash pop && git rm -f ensurestash && npm ci && npm run build",
     "generate-tests:template-compiler.static": "ts-node -P scripts/tsconfig.json scripts/generate-tests/template-compiler.static.ts",
     "generate-tests:template-compiler.mutations": "ts-node -P scripts/tsconfig.json scripts/generate-tests/template-compiler.mutations.ts"
   },


### PR DESCRIPTION
# Pull Request

## 📖 Description

I noticed that during `npm init` and/or `npm refresh` it's calling `lerna bootstrap` twice.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

After running `npm ci` it automatically triggers the `postinstall` script, which does a `lerna bootstrap --ci`, so there is no need to call it again ourselves.

## 📑 Test Plan

Running `npm init` and/or `npm refresh` no longer shows the `lerna bootstrap` output twice.

## ⏭ Next Steps

n/a