### PR TITLE
chore(all): remove browser field in package.json

### DIFF
--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -81,6 +81,5 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "version": "0.4.0-dev.201907110209"
 }

--- a/packages/aot/package.json
+++ b/packages/aot/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/jit-html-browser/package.json
+++ b/packages/jit-html-browser/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/jit-html-jsdom/package.json
+++ b/packages/jit-html-jsdom/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/jit-html/package.json
+++ b/packages/jit-html/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/jit-pixi/package.json
+++ b/packages/jit-pixi/package.json
@@ -4,7 +4,6 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.es6.js",
   "jsnext:main": "dist/index.es6.js",
-  "browser": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/jit/package.json
+++ b/packages/jit/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/plugin-parcel/package.json
+++ b/packages/plugin-parcel/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/plugin-pixi/package.json
+++ b/packages/plugin-pixi/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/plugin-requirejs/package.json
+++ b/packages/plugin-requirejs/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/plugin-svg/package.json
+++ b/packages/plugin-svg/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/plugin-webpack/package.json
+++ b/packages/plugin-webpack/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-html-browser/package.json
+++ b/packages/runtime-html-browser/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-html-jsdom/package.json
+++ b/packages/runtime-html-jsdom/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-pixi/package.json
+++ b/packages/runtime-pixi/package.json
@@ -4,7 +4,6 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.es6.js",
   "jsnext:main": "dist/index.es6.js",
-  "browser": "dist/index.umd.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -4,7 +4,6 @@
   "main": "dist/umd/index.js",
   "module": "dist/esnext/index.js",
   "jsnext:main": "dist/esnext/index.js",
-  "browser": "dist/umd/index.js",
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "license": "MIT",

--- a/scripts/change-package-refs.ts
+++ b/scripts/change-package-refs.ts
@@ -8,18 +8,16 @@ const refs = {
   dev: {
     'main': 'dist/esnext/index.js',
     'module': 'dist/esnext/index.js',
-    'jsnext:main': 'dist/esnext/index.js',
-    'browser': 'dist/esnext/index.js'
+    'jsnext:main': 'dist/esnext/index.js'
   },
   release: {
     'main': 'dist/umd/index.js',
     'module': 'dist/esnext/index.js',
-    'jsnext:main': 'dist/esnext/index.js',
-    'browser': 'dist/umd/index.js'
+    'jsnext:main': 'dist/esnext/index.js'
   }
 };
 
-const fields = ['main', 'module', 'jsnext:main', 'browser'];
+const fields = ['main', 'module', 'jsnext:main'];
 
 async function run(): Promise<void> {
   const ref = process.argv.slice(2)[0];


### PR DESCRIPTION
Previous change on browser field to umd had small side-effect. I forgot webpack actually uses "browser" over "module" field, and it complains about static analysis bla bla, although it still can compile successfully. Removing browser field just makes all bundlers happier.
