### PR TITLE
chore: tweak package.json files

### DIFF
--- a/packages/__tests__/router/e2e/navigation-skeleton/app/package.json
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/package.json
@@ -17,7 +17,7 @@
     "@aurelia/router": "file:../../../../../router",
     "@aurelia/runtime": "file:../../../../../runtime",
     "@aurelia/runtime-html": "file:../../../../../runtime-html",
-    "bootstrap": "^3.3.6 || ^4.0.0",
+    "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.3"
   },
   "devDependencies": {

--- a/packages/examples/e2e-benchmark/package-lock.json
+++ b/packages/examples/e2e-benchmark/package-lock.json
@@ -29,9 +29,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -222,9 +222,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.45.0.tgz",
-      "integrity": "sha512-Qwmcr+2mU3INeR6mVsQ8gO00vZpL8ZeTJLclX44C0dcs88jrSDgckPqbG+qkVX+m2L/aOPnF0lYgPdOiOiLt5w==",
+      "version": "74.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-74.0.0.tgz",
+      "integrity": "sha512-xXgsq0l4gVTY9X5vuccOSVj/iEBm3Bf5MIwzSAASIRJagt4BlWw77SxQq1f4JAJ35/9Ys4NLMA/kWFbd7A/gfQ==",
       "dev": true,
       "requires": {
         "del": "^3.0.0",
@@ -267,9 +267,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -961,18 +961,18 @@
       }
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -1296,9 +1296,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
       "dev": true
     },
     "pump": {
@@ -1564,9 +1564,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }

--- a/packages/examples/e2e-benchmark/package.json
+++ b/packages/examples/e2e-benchmark/package.json
@@ -9,7 +9,7 @@
     "@types/node": "^10.12.27",
     "@types/selenium-webdriver": "^4.0.1",
     "chai": "^4.2.0",
-    "chromedriver": "~2.45.0",
+    "chromedriver": "^74.0.0",
     "esm": "^3.2.25",
     "mocha": "^6.1.4",
     "path": "^0.12.7",

--- a/packages/examples/e2e-benchmark/vcurrent/package.json
+++ b/packages/examples/e2e-benchmark/vcurrent/package.json
@@ -35,7 +35,7 @@
     "aurelia-cli": "^1.0.2",
     "browserify": "^16.3.0",
     "chai": "^4.2.0",
-    "chromedriver": "~2.45.0",
+    "chromedriver": "^74.0.0",
     "cross-env": "^5.2.0",
     "esm": "^3.2.25",
     "event-stream": "4.0.1",

--- a/packages/examples/e2e-benchmark/vnext/package.json
+++ b/packages/examples/e2e-benchmark/vnext/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.12.27",
     "@types/selenium-webdriver": "^4.0.1",
     "chai": "^4.2.0",
-    "chromedriver": "~2.45.0",
+    "chromedriver": "^74.0.0",
     "cross-env": "^5.2.0",
     "http-server": "^0.11.1",
     "mocha": "^6.1.4",

--- a/renovate.json
+++ b/renovate.json
@@ -29,8 +29,8 @@
       "rangeStrategy": "widen"
     },
     {
-      "packageNames": ["chromedriver"],
-      "allowedVersions": "~2.45.0"
+      "packageNames": ["bootstrap"],
+      "allowedVersions": "^3.3.6"
     },
     {
       "packageNames": ["pixi.js", "@types/pixi.js"],


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some `package.json` tweaks:
- Fixate `bootstrap`, as migrating to `^4` requires usage changes.
- Unpin `chromedriver`. The new CircleCI setup should support newer versions again.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

With the *recent* CircleCI build changes we should now be on a version of the images that support newer versions of Chrome, making the pinning no longer needed.

And migrating from Bootstrap V3 to V4 requires manual changes to the used HTML, so I've pinned it for now until (and if) we decide to put in the effort to switch to V4.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a