### PR TITLE
Dynamic routing: Hide viewport header

### DIFF
--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -150,4 +150,4 @@ export class ViewportCustomElement {
   }
 }
 // tslint:disable-next-line:no-invalid-template-strings
-CustomElement.define({ name: 'au-viewport', template: '<template><div class="viewport-header"> Viewport: <b>${name}</b> ${scope ? "[new scope]" : ""} : <b>${viewport.content && viewport.content.componentName()}</b></div></template>' }, ViewportCustomElement);
+CustomElement.define({ name: 'au-viewport', template: '<template><div class="viewport-header" style="display: none;"> Viewport: <b>${name}</b> ${scope ? "[new scope]" : ""} : <b>${viewport.content && viewport.content.componentName()}</b></div></template>' }, ViewportCustomElement);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR just hides the viewport header element (but keeps it around for now to make my life easier).

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working. In fact, the interim nature of this PR means there's probably not that much to actually review.

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points
- Add a before navigation hook with accompanying redirect

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
