### PR TITLE
Dynamic routing: router guards

### DIFF
--- a/packages/__tests__/router/e2e/doc-example/app/index.ejs
+++ b/packages/__tests__/router/e2e/doc-example/app/index.ejs
@@ -165,6 +165,16 @@
       float: right;
       text-align: right;
     }
+
+    .login {
+      border: 1px solid #777;
+      background-color: #ff000055;
+      padding: 25px;
+      margin: 0;
+      position: absolute;
+      left: 50%;
+      transform: translate(-50%, 0%);
+    }
   </style>
 </head>
 

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -132,7 +132,7 @@ export class App {
       this.state.loginReturnTo = this.router.instructionResolver.stringifyViewportInstructions(instructions);
       this.state.loggedIn = false;
       return false;
-    }, { exclude: ['login'] });
+    }, { exclude: ['', 'login'] });
 
     this.router.guardian.addGuard((instructions) => {
       if (this.verifyLogin(true)) { // true makes it separate and "special"
@@ -141,7 +141,7 @@ export class App {
       const params = this.router.instructionResolver.encodeViewportInstructions(instructions);
       this.router.goto(`login(${params}&1)`);
       return [];
-    }, { include: [{ viewportName: 'author-tabs' }], exclude: ['login'] });
+    }, { include: [{ viewportName: 'author-tabs' }], exclude: ['', 'login'] });
 
     // this.router.guardian.addGuard((instructions) => {
     //   return this.notify('Guarded (all)', instructions);
@@ -166,9 +166,14 @@ export class App {
   }
 
   private verifyLogin(special: boolean = false): boolean {
-    return special
-      ? this.state.loggedInSpecial && (new Date().getTime() - this.state.loggedInSpecialAt.getTime() < 5 * 1000)
-      : this.state.loggedIn && (new Date().getTime() - this.state.loggedInAt.getTime() < 15 * 1000);
+    if (!(special ? this.state.loggedInSpecial : this.state.loggedIn)) {
+      return false;
+    }
+    const timeout = special
+      ? this.state.loggedInSpecialAt.getTime() + 5 * 1000
+      : this.state.loggedInAt.getTime() + 15 * 1000;
+    const now = new Date().getTime();
+    return timeout > now;
   }
 
   notify(message, instructions) {

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -1,13 +1,13 @@
 import { inject } from '@aurelia/kernel';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
+import { Guardian, Router, GuardTypes } from '@aurelia/router';
 import { About } from './components/about';
 import { Authors } from './components/authors/authors';
 import { Books } from './components/books/books';
 import { AuthorsRepository } from './repositories/authors';
 import { State } from './state';
 
-@inject(Router, AuthorsRepository, State)
+@inject(Router, Guardian, AuthorsRepository, State)
 @customElement({
   name: 'app', template:
     `<template>
@@ -43,7 +43,7 @@ import { State } from './state';
 ` })
 export class App {
   public color: string = 'lightgreen';
-  constructor(private readonly router: Router, authorsRepository: AuthorsRepository, private readonly state: State) {
+  constructor(private readonly router: Router, private readonly guardian: Guardian, authorsRepository: AuthorsRepository, private readonly state: State) {
     authorsRepository.authors(); // Only here to initialize repositories
   }
 
@@ -107,5 +107,30 @@ export class App {
         title: 'Chat',
       },
     ]);
+
+    this.router.guardian.addGuard((instructions) => {
+      return this.notify('Guarded (all)', instructions);
+    });
+
+    this.router.guardian.addGuard((instructions) => {
+      return this.notify('Guarded (all but "author")', instructions);
+    }, { exclude: ['author'] });
+
+    this.router.guardian.addGuard((instructions) => {
+      return this.notify('Guarded ("author" and "book")', instructions);
+    }, { include: ['author', 'book'] });
+
+    this.router.guardian.addGuard((instructions) => {
+      return this.notify('Guarded (everything in VIEWPORT "author-tabs")', instructions);
+    }, { include: [{ viewportName: 'author-tabs' }] });
+
+    console.log('#### guardian', this.router.guardian.guards);
+    // console.log('#### passes', this.guardian.passes(GuardTypes.Before, { path: 'some-component', fullStatePath: null }));
+  }
+
+  notify(message, instructions) {
+    alert(message + ': ' + instructions.map(i => i.componentName).join(', '));
+    console.log('#####', message, instructions);
+    return true;
   }
 }

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -129,7 +129,8 @@ export class App {
       if (this.verifyLogin()) {
         return true;
       }
-      this.state.loginReturnTo = this.router.instructionResolver.stringifyViewportInstructions(instructions);
+      this.state.loginReturnTo.push(this.router.instructionResolver.stringifyViewportInstructions(instructions));
+      alert("You've timed out!");
       this.state.loggedIn = false;
       return false;
     }, { exclude: ['', 'login'] });
@@ -140,6 +141,7 @@ export class App {
       }
       const params = this.router.instructionResolver.encodeViewportInstructions(instructions);
       this.router.goto(`login(${params}&1)`);
+      this.state.loggedInSpecial = false;
       return [];
     }, { include: [{ viewportName: 'author-tabs' }], exclude: ['', 'login'] });
 

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -13,53 +13,15 @@ import { arrayRemove } from '../../../../../../router/src/utils';
 @customElement({
   name: 'app', template:
     `
-<div if.bind="!state.loggedIn">
-  <login></login>
+<div class="info">
+  <label><input data-test="timed-out-checkbox" type="checkbox" checked.two-way="state.timedOut">Timed out</label><br>
+  <label><input data-test="special-timed-out-checkbox" type="checkbox" checked.two-way="state.specialTimedOut"><i>Special</i> timed out</label><br>
 </div>
-<div if.bind="state.loggedIn">
-  <div class="\${router.isNavigating ? 'routing' : ''}" style="--primary-color: \${color}">
-    <div>
-      <au-nav data-test="app-menu" name="app-menu"></au-nav>
-      <span class="loader \${router.isNavigating ? 'routing' : ''}">&nbsp;</span>
-    </div>
-    <div class="info">
-      In this test, the <i>Authors</i> list and <i>Author</i> component have a 2 second wait/delay on <pre>enter</pre>,
-      the <i>About</i> component has a 4 second delay on <pre>enter</pre> and <i>Author details</i> stops navigation
-      in <pre>canEnter</pre>. (Meaning that <i>Author</i> can't be opened since it has <i>Author details</i> as default
-      and the navigation is rolled back after 2 seconds.)
-    </div>
-    <div class="info">
-      <label><input data-test="no-delay-checkbox" type="checkbox" checked.two-way="state.noDelay">Disable loading delays for components</label><br>
-      <label><input data-test="allow-enter-author-details-checkbox" type="checkbox" checked.two-way="state.allowEnterAuthorDetails">Allow entering <i>Author details</i></label><br>
-    </div>
-    <div class="info" style="background-color: var(--primary-color)">
-      <select data-test="info-background-color-select" value.two-way="color">
-        <option value="lightblue">Light blue</option>
-        <option value="lightgreen">Light green</option>
-      <select>
-      <div style="display: inline-block;">
-        The background is in the --primary-color: <span data-test="info-background-color">\${color}</span>.
-      </div>
-    </div>
-    <au-viewport name="lists" used-by="authors,books" default="authors"></au-viewport>
-    <au-viewport name="content" default="about"></au-viewport>
-    <au-viewport name="chat" used-by="chat" no-link no-history></au-viewport>
-  </div>
-</div>
+<div><a href="login">login</a></div>
+<au-viewport name="gate" used-by="main,login" default="\${!state.loggedIn ? 'login' : 'main'}"></au-viewport>
 ` })
 export class App {
-  public color: string = 'lightgreen';
   constructor(private readonly router: Router, authorsRepository: AuthorsRepository, private readonly state: State) {
-    let arr: any = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 2 }];
-    console.log('§§§§§', arr);
-    console.log('§§§§§', arrayRemove(arr, value => value.id === 2));
-    console.log('§§§§§', arr);
-
-    arr = [1, 2, 3, 2];
-    console.log('§§§§§', arr);
-    console.log('§§§§§', arrayRemove(arr, value => value === 2));
-    console.log('§§§§§', arr);
-
     authorsRepository.authors(); // Only here to initialize repositories
   }
 
@@ -104,34 +66,20 @@ export class App {
       // }
     }).catch(error => { throw error; });
 
-    this.router.addNav('app-menu', [
-      {
-        title: 'Authors',
-        route: [Authors, About],
-        consideredActive: [Authors],
-      },
-      {
-        title: 'Books',
-        route: [Books, About],
-        consideredActive: Books,
-      },
-      {
-        route: About,
-        title: 'About',
-      },
-      {
-        route: 'chat',
-        title: 'Chat',
-      },
-    ]);
-
     this.router.guardian.addGuard((instructions) => {
       if (this.verifyLogin()) {
         return true;
       }
-      this.state.loginReturnTo.push(this.router.instructionResolver.stringifyViewportInstructions(instructions));
+      this.state.loginReturnTo = this.router.instructionResolver.mergeViewportInstructions([
+        ...this.state.loginReturnTo,
+        ...this.router.activeComponents,
+        ...instructions
+      ]);
+      // this.state.loginReturnTo.push(...this.router.activeComponents)
+      // this.state.loginReturnTo.push(this.router.instructionResolver.stringifyViewportInstructions(instructions));
       alert("You've timed out!");
       this.state.loggedIn = false;
+      this.router.goto('login');
       return false;
     }, { exclude: ['', 'login'] });
 
@@ -139,11 +87,16 @@ export class App {
       if (this.verifyLogin(true)) { // true makes it separate and "special"
         return true;
       }
-      const params = this.router.instructionResolver.encodeViewportInstructions(instructions);
-      this.router.goto(`login(${params}&1)`);
+      // this.state.loginReturnTo.push(this.router.instructionResolver.stringifyViewportInstructions(instructions));
+      this.state.loginReturnTo = this.router.instructionResolver.mergeViewportInstructions([
+        ...this.state.loginReturnTo,
+        ...this.router.activeComponents,
+        ...instructions
+      ]);
       this.state.loggedInSpecial = false;
+      this.router.goto(`login-special`);
       return [];
-    }, { include: [{ viewportName: 'author-tabs' }], exclude: ['', 'login'] });
+    }, { include: [{ viewportName: 'author-tabs' }], exclude: ['', 'login-special'] });
 
     // this.router.guardian.addGuard((instructions) => {
     //   return this.notify('Guarded (all)', instructions);
@@ -171,14 +124,15 @@ export class App {
     if (!(special ? this.state.loggedInSpecial : this.state.loggedIn)) {
       return false;
     }
-    const timeout = special
-      ? this.state.loggedInSpecialAt.getTime() + 5 * 1000
-      : this.state.loggedInAt.getTime() + 15 * 1000;
-    const now = new Date().getTime();
-    return timeout > now;
+    return !(special ? this.state.specialTimedOut : this.state.timedOut);
+    // const timeout = special
+    //   ? this.state.loggedInSpecialAt.getTime() + 5 * 1000
+    //   : this.state.loggedInAt.getTime() + 15 * 1000;
+    // const now = new Date().getTime();
+    // return timeout > now;
   }
 
-  notify(message, instructions) {
+  private notify(message, instructions) {
     alert(message + ': ' + instructions.map(i => i.componentName).join(', '));
     console.log('#####', message, instructions);
     return true;

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
@@ -20,7 +20,7 @@ import { Information } from './information';
 </div>
 <div if.bind="!hideTabs">
   <au-nav data-test="author-menu" name="author-menu"></au-nav>
-  <au-viewport name="author-tabs" default="author-details(\${author.id})" used-by="about-authors,author-details,information" no-history></au-viewport>
+  <au-viewport name="author-tabs" default="author-details(\${author.id})" used-by="about-authors,author-details,information,login" no-history></au-viewport>
 </div>
 </template>`,
   dependencies: [Information as any]

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
@@ -20,7 +20,7 @@ import { Information } from './information';
 </div>
 <div if.bind="!hideTabs">
   <au-nav data-test="author-menu" name="author-menu"></au-nav>
-  <au-viewport name="author-tabs" default="author-details(\${author.id})" used-by="about-authors,author-details,information,login" no-history></au-viewport>
+  <au-viewport name="author-tabs" default="author-details(\${author.id})" used-by="about-authors,author-details,information,login-special" no-history></au-viewport>
 </div>
 </template>`,
   dependencies: [Information as any]

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/books/book.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/books/book.ts
@@ -29,8 +29,9 @@ export class Book {
   constructor(private readonly router: Router, private readonly booksRepository: BooksRepository) { }
 
   public enter(parameters) {
-    if (parameters.id) {
-      this.book = this.booksRepository.book(+parameters.id);
+    let id = +(parameters.id ? parameters.id : parameters[0]);
+    if (id) {
+      this.book = this.booksRepository.book(id);
     }
     this.router.setNav('book-menu', [
       {

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/login-special.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/login-special.ts
@@ -1,0 +1,28 @@
+import { inject } from '@aurelia/kernel';
+import { customElement, ICustomElementType } from '@aurelia/runtime';
+import { Router } from '@aurelia/router';
+import { State } from '../state';
+
+@customElement({
+  name: 'login-special', template: `
+<div class="login">
+  <p>You need to be logged in SPECIAL to continue.</p>
+  <button data-test="login-button" click.trigger="login()">Okay, log me in SPECIAL</button>
+</div>` })
+@inject(State, Router)
+export class LoginSpecial {
+  constructor(private readonly state: State, private readonly router: Router) { }
+
+  public login() {
+    this.state.loggedIn = true;
+    this.state.loggedInAt = new Date();
+    this.state.loggedInSpecial = true;
+    this.state.loggedInSpecialAt = new Date();
+    const instructions = this.state.loginReturnTo.length ? this.state.loginReturnTo : [];
+    const goto = this.router.instructionResolver.stringifyViewportInstructions(instructions);
+    console.log('login-special', goto);
+    this.state.loginReturnTo = [];
+    this.router.replace(goto);
+  }
+}
+export interface LoginSpecial extends ICustomElementType { }

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/login.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/login.ts
@@ -1,0 +1,27 @@
+import { inject } from '@aurelia/kernel';
+import { customElement, ICustomElementType } from '@aurelia/runtime';
+import { Router, ViewportInstruction } from '@aurelia/router';
+import { State } from '../state';
+
+@customElement({
+  name: 'login', template: `
+<div class="login">
+  <p>You need to be logged in to continue.</p>
+  <button data-test="login-button" click.trigger="login()">Okay, log me in</button>
+</div>` })
+@inject(State, Router)
+export class Login {
+  constructor(private readonly state: State, private readonly router: Router) { }
+
+  public login() {
+    this.state.loggedIn = true;
+    this.state.timedOut = false;
+    this.state.loggedInAt = new Date();
+    const instructions = this.state.loginReturnTo.length ? this.state.loginReturnTo : [new ViewportInstruction('main', 'gate')];
+    const goto = this.router.instructionResolver.stringifyViewportInstructions(instructions);
+    console.log(goto);
+    this.state.loginReturnTo = [];
+    this.router.replace(goto);
+  }
+}
+export interface Login extends ICustomElementType { }

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
@@ -1,0 +1,65 @@
+import { inject } from '@aurelia/kernel';
+import { customElement } from '@aurelia/runtime';
+import { Router } from '@aurelia/router';
+import { State } from '../state';
+import { About } from './about';
+import { Authors } from './authors/authors';
+import { Books } from './books/books';
+
+@inject(Router, State)
+@customElement({
+  name: 'main', template:
+    `
+  <div class="\${router.isNavigating ? 'routing' : ''}" style="--primary-color: \${color}">
+    <div>
+      <au-nav data-test="main-menu" name="main-menu"></au-nav>
+      <span class="loader \${router.isNavigating ? 'routing' : ''}">&nbsp;</span>
+    </div>
+    <div class="info">
+      In this test, the <i>Authors</i> list and <i>Author</i> component have a 2 second wait/delay on <pre>enter</pre>,
+      the <i>About</i> component has a 4 second delay on <pre>enter</pre> and <i>Author details</i> stops navigation
+      in <pre>canEnter</pre>. (Meaning that <i>Author</i> can't be opened since it has <i>Author details</i> as default
+      and the navigation is rolled back after 2 seconds.)
+    </div>
+    <div class="info">
+      <label><input data-test="no-delay-checkbox" type="checkbox" checked.two-way="state.noDelay">Disable loading delays for components</label><br>
+      <label><input data-test="allow-enter-author-details-checkbox" type="checkbox" checked.two-way="state.allowEnterAuthorDetails">Allow entering <i>Author details</i></label><br>
+    </div>
+    <div class="info" style="background-color: var(--primary-color)">
+      <select data-test="info-background-color-select" value.two-way="color">
+        <option value="lightblue">Light blue</option>
+        <option value="lightgreen">Light green</option>
+      <select>
+      <div style="display: inline-block;">
+        The background is in the --primary-color: <span data-test="info-background-color">\${color}</span>.
+      </div>
+    </div>
+    <au-viewport name="lists" used-by="authors,books" default="authors"></au-viewport>
+    <au-viewport name="content" default="about"></au-viewport>
+    <au-viewport name="chat" used-by="chat" no-link no-history></au-viewport>
+  </div>
+` })
+export class Main {
+  constructor(private readonly router: Router, private readonly state: State) {
+    this.router.setNav('main-menu', [
+      {
+        title: 'Authors',
+        route: [Authors, About],
+        consideredActive: [Authors],
+      },
+      {
+        title: 'Books',
+        route: [Books, About],
+        consideredActive: Books,
+      },
+      {
+        route: About,
+        title: 'About',
+      },
+      {
+        route: 'chat',
+        title: 'Chat',
+      },
+    ]);
+  }
+}

--- a/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
@@ -19,6 +19,7 @@ import { Books } from './components/books/books';
 import { Chat } from './components/chat/chat';
 import { ChatUser } from './components/chat/chat-user';
 import { ChatUsers } from './components/chat/chat-users';
+import { Login } from './components/login';
 import { State } from './state';
 
 const container = BasicConfiguration.createContainer();
@@ -42,6 +43,8 @@ registerComponent(
   Chat as any,
   ChatUser as any,
   ChatUsers as any,
+
+  Login as any,
 );
 
 window['au'] = new Aurelia(container)

--- a/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
@@ -20,6 +20,8 @@ import { Chat } from './components/chat/chat';
 import { ChatUser } from './components/chat/chat-user';
 import { ChatUsers } from './components/chat/chat-users';
 import { Login } from './components/login';
+import { LoginSpecial } from './components/login-special';
+import { Main } from './components/main';
 import { State } from './state';
 
 const container = BasicConfiguration.createContainer();
@@ -45,6 +47,8 @@ registerComponent(
   ChatUsers as any,
 
   Login as any,
+  LoginSpecial as any,
+  Main as any,
 );
 
 window['au'] = new Aurelia(container)

--- a/packages/__tests__/router/e2e/doc-example/app/src/state.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/state.ts
@@ -1,3 +1,5 @@
+import { ViewportInstruction } from "../../../../../src/viewport-instruction";
+
 export class State {
   public noDelay: boolean = true;
   public allowEnterAuthorDetails: boolean = true;
@@ -5,5 +7,7 @@ export class State {
   public loggedInSpecial: boolean = false;
   public loggedInAt: Date;
   public loggedInSpecialAt: Date;
-  public loginReturnTo: string[] = [];
+  public timedOut: boolean = false;
+  public specialTimedOut: boolean = false;
+  public loginReturnTo: ViewportInstruction[] = [];
 }

--- a/packages/__tests__/router/e2e/doc-example/app/src/state.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/state.ts
@@ -1,4 +1,9 @@
 export class State {
   public noDelay: boolean = true;
   public allowEnterAuthorDetails: boolean = true;
+  public loggedIn: boolean = false;
+  public loggedInSpecial: boolean = false;
+  public loggedInAt: Date;
+  public loggedInSpecialAt: Date;
+  public loginReturnTo: string;
 }

--- a/packages/__tests__/router/e2e/doc-example/app/src/state.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/state.ts
@@ -1,4 +1,4 @@
-import { ViewportInstruction } from "../../../../../src/viewport-instruction";
+import { ViewportInstruction } from '@aurelia/router';
 
 export class State {
   public noDelay: boolean = true;

--- a/packages/__tests__/router/e2e/doc-example/app/src/state.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/state.ts
@@ -5,5 +5,5 @@ export class State {
   public loggedInSpecial: boolean = false;
   public loggedInAt: Date;
   public loggedInSpecialAt: Date;
-  public loginReturnTo: string;
+  public loginReturnTo: string[] = [];
 }

--- a/packages/__tests__/router/e2e/doc-example/cypress.json
+++ b/packages/__tests__/router/e2e/doc-example/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:9000",
   "ignoreTestFiles": "*.po.ts",
   "testFiles": "**/*.spec.ts",
-  "video": false
+  "video": false,
+  "chromeWebSecurity": false
 }

--- a/packages/__tests__/router/e2e/doc-example/cypress/integration/books-route.spec.ts
+++ b/packages/__tests__/router/e2e/doc-example/cypress/integration/books-route.spec.ts
@@ -1,6 +1,12 @@
-import { BooksComponent, Shared, BookComponent } from './selectors.po';
+import { BooksComponent, Shared, BookComponent, LoginComponent } from './selectors.po';
 
 describe('doc-example / books route', () => {
+  it('shows login button', () => {
+    cy.visit('/#/books+about');
+    cy.get(LoginComponent.loginButton)
+      .should('exist');
+  });
+
   it('navigates to books route', () => {
     cy.visit('/#/books+about')
       .url()

--- a/packages/__tests__/router/e2e/doc-example/cypress/integration/books-route.spec.ts
+++ b/packages/__tests__/router/e2e/doc-example/cypress/integration/books-route.spec.ts
@@ -1,19 +1,33 @@
-import { BooksComponent, Shared, BookComponent, LoginComponent } from './selectors.po';
+import * as cypressConfig from '../../cypress.json';
+import { BookComponent, BooksComponent, LoginComponent, Shared } from './selectors.po';
 
 describe('doc-example / books route', () => {
-  it('shows login button', () => {
-    cy.visit('/#/books+about');
-    cy.get(LoginComponent.loginButton)
-      .should('exist');
-  });
-
   it('navigates to books route', () => {
-    cy.visit('/#/books+about')
+    cy.visit(cypressConfig.baseUrl + '/#/books+about')
       .url()
       .should('contain', '/#/books+about');
   });
 
+  it('shows login button', () => {
+    cy.get(LoginComponent.loginButton)
+      .should('exist');
+  });
+
+  it('performs login', () => {
+    cy.get(LoginComponent.loginButton)
+      .click();
+
+    cy.get(LoginComponent.loginButton)
+      .should('not.exist');
+  });
+
   it('displays the correct viewports', () => {
+    before(async () => {
+      cy.get(LoginComponent.loginButton)
+        .click();
+      await Promise.resolve();
+    });
+
     cy.get(Shared.listsViewport)
       .should('exist');
     cy.get(Shared.listsViewportHeader)

--- a/packages/__tests__/router/e2e/doc-example/cypress/integration/selectors.po.ts
+++ b/packages/__tests__/router/e2e/doc-example/cypress/integration/selectors.po.ts
@@ -66,3 +66,7 @@ export const ChatDetailsComponent = {
   chatTitle: '[data-test=chat-user-element-title]',
   chatInput: '[data-test=chat-user-element-input]'
 };
+
+export const LoginComponent = {
+  loginButton: '[data-test=login-button]'
+};

--- a/packages/__tests__/router/e2e/doc-example/tsconfig.json
+++ b/packages/__tests__/router/e2e/doc-example/tsconfig.json
@@ -5,11 +5,13 @@
       "target": "es5",
       "lib": [
           "es5",
+          "es2015",
           "dom"
       ],
       "types": [
           "cypress"
       ],
+      "resolveJsonModule": true
   },
   "include": [
       "**/*.ts",

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -53,7 +53,7 @@ describe('InstructionResolver', function () {
       new ViewportInstruction('bar', 'right', '456'),
     ];
     let instructionsString = router.instructionResolver.stringifyViewportInstructions(instructions);
-    assert.strictEqual(instructionsString, 'foo@left(123)+bar@right(456)', `instructionsString`);
+    assert.strictEqual(instructionsString, 'foo(123)@left+bar(456)@right', `instructionsString`);
     let newInstructions = router.instructionResolver.parseViewportInstructions(instructionsString);
     assert.deepStrictEqual(newInstructions, instructions, `newInstructions`);
 
@@ -78,7 +78,7 @@ describe('InstructionResolver', function () {
   const instructions: InstructionTest[] = [
     { instruction: 'foo', viewportInstruction: new ViewportInstruction('foo') },
     { instruction: 'foo@left', viewportInstruction: new ViewportInstruction('foo', 'left') },
-    { instruction: 'foo@left(123)', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
+    { instruction: 'foo(123)@left', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
     { instruction: 'foo(123)', viewportInstruction: new ViewportInstruction('foo', undefined, '123') },
     { instruction: 'foo/bar', viewportInstruction: new ViewportInstruction('foo', undefined, undefined, false, new ViewportInstruction('bar')) },
     { instruction: 'foo(123)/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', false, new ViewportInstruction('bar', 'left', undefined, false, new ViewportInstruction('baz'))) },

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -393,48 +393,48 @@ describe('Router', function () {
     await tearDown();
   });
 
-  it('parses parameters after viewport', async function () {
+  it('parses parameters after component', async function () {
     this.timeout(5000);
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(123)', router, lifecycle);
+    await $goto('bar(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
 
-    await $goto('bar@left(456)', router, lifecycle);
+    await $goto('bar(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
 
     await tearDown();
   });
 
-  it('parses named parameters after viewport', async function () {
+  it('parses named parameters after component', async function () {
     this.timeout(5000);
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(id=123)', router, lifecycle);
+    await $goto('bar(id=123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
 
-    await $goto('bar@left(id=456)', router, lifecycle);
+    await $goto('bar(id=456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
 
     await tearDown();
   });
 
-  it('parses parameters after viewport individually', async function () {
+  it('parses parameters after component individually', async function () {
     this.timeout(5000);
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(123)', router, lifecycle);
+    await $goto('bar(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
 
-    await $goto('bar@right(456)', router, lifecycle);
+    await $goto('bar(456)@right', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
@@ -472,17 +472,17 @@ describe('Router', function () {
     await tearDown();
   });
 
-  it('parses multiple parameters after viewport', async function () {
+  it('parses multiple parameters after component', async function () {
     this.timeout(5000);
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(123&OneTwoThree)', router, lifecycle);
+    await $goto('bar(123&OneTwoThree)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [OneTwoThree]', `host.textContent`);
 
-    await $goto('bar@left(456&FourFiveSix)', router, lifecycle);
+    await $goto('bar(456&FourFiveSix)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [FourFiveSix]', `host.textContent`);
@@ -490,17 +490,17 @@ describe('Router', function () {
     await tearDown();
   });
 
-  it('parses multiple name parameters after viewport', async function () {
+  it('parses multiple name parameters after component', async function () {
     this.timeout(5000);
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(id=123&name=OneTwoThree)', router, lifecycle);
+    await $goto('bar(id=123&name=OneTwoThree)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [OneTwoThree]', `host.textContent`);
 
-    await $goto('bar@left(name=FourFiveSix&id=456)', router, lifecycle);
+    await $goto('bar(name=FourFiveSix&id=456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [FourFiveSix]', `host.textContent`);
@@ -530,16 +530,16 @@ describe('Router', function () {
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('bar@left(456)?id=123', router, lifecycle);
+    await $goto('bar(456)@left?id=123', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
 
-    await $goto('bar@left(456&FourFiveSix)?id=123&name=OneTwoThree', router, lifecycle);
+    await $goto('bar(456&FourFiveSix)@left?id=123&name=OneTwoThree', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [456]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [FourFiveSix]', `host.textContent`);
 
-    await $goto('bar@left(name=SevenEightNine&id=789)?id=123&name=OneTwoThree', router, lifecycle);
+    await $goto('bar(name=SevenEightNine&id=789)@left?id=123&name=OneTwoThree', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [789]', `host.textContent`);
     assert.includes(host.textContent, 'Parameter name: [SevenEightNine]', `host.textContent`);
@@ -552,19 +552,19 @@ describe('Router', function () {
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('plugh@left(123)', router, lifecycle);
+    await $goto('plugh(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 1', `host.textContent`);
 
-    await $goto('plugh@left(123)', router, lifecycle);
+    await $goto('plugh(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 1', `host.textContent`);
 
-    await $goto('plugh@left(456)', router, lifecycle);
+    await $goto('plugh(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 456', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 2', `host.textContent`);
 
-    await $goto('plugh@left(456)', router, lifecycle);
+    await $goto('plugh(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 456', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 2', `host.textContent`);
 
@@ -577,32 +577,32 @@ describe('Router', function () {
     const { lifecycle, host, router, tearDown } = await setup();
 
     plughReentryBehavior = 'enter'; // Affects navigation AFTER this one
-    await $goto('plugh@left(123)', router, lifecycle);
+    await $goto('plugh(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 1', `host.textContent`);
 
     plughReentryBehavior = 'refresh'; // Affects navigation AFTER this one
-    await $goto('plugh@left(123)', router, lifecycle);
+    await $goto('plugh(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 2', `host.textContent`);
 
     plughReentryBehavior = 'default'; // Affects navigation AFTER this one
-    await $goto('plugh@left(456)', router, lifecycle);
+    await $goto('plugh(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 456', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 1', `host.textContent`);
 
     plughReentryBehavior = 'enter'; // Affects navigation AFTER this one
-    await $goto('plugh@left(456)', router, lifecycle);
+    await $goto('plugh(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 456', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 1', `host.textContent`);
 
     plughReentryBehavior = 'disallow'; // Affects navigation AFTER this one
-    await $goto('plugh@left(123)', router, lifecycle);
+    await $goto('plugh(123)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 2', `host.textContent`);
 
     plughReentryBehavior = 'default'; // Affects navigation AFTER this one
-    await $goto('plugh@left(456)', router, lifecycle);
+    await $goto('plugh(456)@left', router, lifecycle);
     assert.includes(host.textContent, 'Parameter: 123', `host.textContent`);
     assert.includes(host.textContent, 'Entry: 2', `host.textContent`);
 
@@ -688,6 +688,7 @@ describe('Router', function () {
 
     (host as any).getElementsByTagName('INPUT')[0].click();
     await Promise.resolve();
+    await wait();
     await waitForNavigation(router);
     assert.includes(host.textContent, 'Viewport: grault', `host.textContent`);
     assert.includes(host.textContent, 'garply', `host.textContent`);

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,7 +1,7 @@
 import { ICustomElementType } from '@aurelia/runtime';
 
 import { GuardFunction, GuardIdentity, GuardTarget, GuardTypes, IGuardOptions, IGuardTarget } from './guardian';
-import { INavigationInstruction } from './history-browser';
+import { INavigationInstruction } from './navigator';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,0 +1,76 @@
+import { ICustomElementType } from '@aurelia/runtime';
+
+import { GuardFunction, GuardIdentity, GuardTarget, GuardTypes, IGuardOptions, IGuardTarget } from './guardian';
+import { INavigationInstruction } from './history-browser';
+import { Viewport } from './viewport';
+import { ViewportInstruction } from './viewport-instruction';
+
+export class Guard {
+  public type: GuardTypes;
+  public includeTargets: Target[];
+  public excludeTargets: Target[];
+  public guard: GuardFunction;
+  public id: GuardIdentity;
+
+  constructor(guard: GuardFunction, options: IGuardOptions, id: GuardIdentity) {
+    this.type = options.type || GuardTypes.Before;
+    this.guard = guard;
+    this.id = id;
+
+    this.includeTargets = [];
+    for (const target of options.include || []) {
+      this.includeTargets.push(new Target(target));
+    }
+    this.excludeTargets = [];
+    for (const target of options.exclude || []) {
+      this.excludeTargets.push(new Target(target));
+    }
+  }
+
+  public matches(viewportInstructions: ViewportInstruction[]): boolean {
+    if (this.includeTargets.length && !this.includeTargets.some(target => target.matches(viewportInstructions))) {
+      return false;
+    }
+    if (this.excludeTargets.length && this.excludeTargets.some(target => target.matches(viewportInstructions))) {
+      return false;
+    }
+    return true;
+  }
+
+  public check(viewportInstructions: ViewportInstruction[], navigationInstruction: INavigationInstruction): boolean | ViewportInstruction[] {
+    return this.guard(viewportInstructions, navigationInstruction);
+  }
+}
+
+class Target {
+  public component?: Partial<ICustomElementType>;
+  public componentName?: string;
+  public viewport?: Viewport;
+  public viewportName?: string;
+
+  constructor(target: GuardTarget) {
+    const { component, componentName, viewport, viewportName } = target as IGuardTarget;
+    if (typeof target === 'string') {
+      this.componentName = target;
+    } else if (component || componentName || viewport || viewportName) {
+      this.component = component;
+      this.componentName = componentName;
+      this.viewport = viewport;
+      this.viewportName = viewportName;
+    } else {
+      this.component = target as Partial<ICustomElementType>;
+    }
+  }
+
+  public matches(viewportInstructions: ViewportInstruction[]): boolean {
+    for (const instruction of viewportInstructions) {
+      if (this.componentName === instruction.componentName ||
+        this.component === instruction.component ||
+        this.viewportName === instruction.viewportName ||
+        this.viewport === instruction.viewport) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -63,7 +63,11 @@ class Target {
   }
 
   public matches(viewportInstructions: ViewportInstruction[]): boolean {
-    for (const instruction of viewportInstructions) {
+    const instructions = viewportInstructions.slice();
+    if (!instructions.length) {
+      instructions.push(new ViewportInstruction(''));
+    }
+    for (const instruction of instructions) {
       if (this.componentName === instruction.componentName ||
         this.component === instruction.component ||
         this.viewportName === instruction.viewportName ||

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,0 +1,144 @@
+import { ICustomElementType } from '@aurelia/runtime';
+
+import { INavigationInstruction } from './history-browser';
+import { Viewport } from './viewport';
+import { ViewportInstruction } from './viewport-instruction';
+
+export interface IGuardTarget {
+  component?: Partial<ICustomElementType>;
+  componentName?: string;
+  viewport?: Viewport;
+  viewportName?: string;
+}
+
+export class Target {
+  public component?: Partial<ICustomElementType>;
+  public componentName?: string;
+  public viewport?: Viewport;
+  public viewportName?: string;
+
+  constructor(target: GuardTarget) {
+    const { component, componentName, viewport, viewportName } = target as IGuardTarget;
+    if (typeof target === 'string') {
+      this.componentName = target;
+    } else if (component || componentName || viewport || viewportName) {
+      this.component = component;
+      this.componentName = componentName;
+      this.viewport = viewport;
+      this.viewportName = viewportName;
+    } else {
+      this.component = target as Partial<ICustomElementType>;
+    }
+  }
+
+  public matches(viewportInstructions: ViewportInstruction[]): boolean {
+    for (const instruction of viewportInstructions) {
+      if (this.componentName === instruction.componentName ||
+        this.component === instruction.component ||
+        this.viewportName === instruction.viewportName ||
+        this.viewport === instruction.viewport) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+// Only one so far, but it's easier to support more from the start
+export const enum GuardTypes {
+  Before = 'before',
+}
+
+export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigationInstruction) => boolean;
+export type GuardTarget = IGuardTarget | Partial<ICustomElementType> | string;
+export type GuardIdentity = number;
+
+export interface IGuardOptions {
+  type?: GuardTypes;
+  include?: GuardTarget[];
+  exclude?: GuardTarget[];
+}
+
+export class Guard {
+  public type: GuardTypes;
+  public includeTargets: Target[];
+  public excludeTargets: Target[];
+  public guard: GuardFunction;
+  public id: GuardIdentity;
+
+  constructor(guard: GuardFunction, options: IGuardOptions, id: GuardIdentity) {
+    this.type = options.type || GuardTypes.Before;
+    this.guard = guard;
+    this.id = id;
+
+    this.includeTargets = [];
+    for (const target of options.include || []) {
+      this.includeTargets.push(new Target(target));
+    }
+    this.excludeTargets = [];
+    for (const target of options.exclude || []) {
+      this.excludeTargets.push(new Target(target));
+    }
+  }
+
+  public matches(viewportInstructions: ViewportInstruction[]): boolean {
+    if (!this.includeTargets.length && !this.excludeTargets.length) {
+      return true;
+    }
+    if (this.includeTargets.length) {
+      return this.includeTargets.some(target => target.matches(viewportInstructions));
+    } else {
+      return !this.excludeTargets.some(target => target.matches(viewportInstructions));
+    }
+  }
+
+  public check(viewportInstructions: ViewportInstruction[], navigationInstruction: INavigationInstruction): boolean | ViewportInstruction[] {
+    return this.guard(viewportInstructions, navigationInstruction);
+  }
+}
+
+export class Guardian {
+  public guards: Record<GuardTypes, Guard[]> = { before: [] };
+
+  private lastIdentity: number;
+
+  constructor() {
+    this.guards = { before: [] };
+    this.lastIdentity = 0;
+  }
+
+  public addGuard(guardFunction: GuardFunction, options?: IGuardOptions): GuardIdentity {
+    const guard = new Guard(guardFunction, options || {}, ++this.lastIdentity);
+
+    this.guards[guard.type].push(guard);
+
+    return this.lastIdentity;
+  }
+
+  public removeGuard(id: GuardIdentity): void {
+    const index = this.guards.before.findIndex(guard => guard.id === id);
+    if (index > -1) {
+      this.guards.before.splice(index, 1);
+    }
+  }
+
+  public passes(type: GuardTypes, viewportInstructions: ViewportInstruction[], navigationInstruction: INavigationInstruction): boolean | ViewportInstruction[] {
+    let modified: boolean = false;
+    for (const guard of this.guards[type]) {
+      if (guard.matches(viewportInstructions)) {
+        console.log('#### Guard matches:', guard);
+        const outcome = guard.check(viewportInstructions, navigationInstruction);
+        if (typeof outcome === 'boolean') {
+          if (!outcome) {
+            return false;
+          }
+        } else {
+          viewportInstructions = outcome;
+          modified = true;
+          console.log('#### Instructions modified:', viewportInstructions);
+        }
+      }
+    }
+    return modified ? viewportInstructions : true;
+  }
+}

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -58,7 +58,6 @@ export class Guardian {
     let modified: boolean = false;
     for (const guard of this.guards[type]) {
       if (guard.matches(viewportInstructions)) {
-        console.log('#### Guard matches:', guard);
         const outcome = guard.check(viewportInstructions, navigationInstruction);
         if (typeof outcome === 'boolean') {
           if (!outcome) {
@@ -67,7 +66,6 @@ export class Guardian {
         } else {
           viewportInstructions = outcome;
           modified = true;
-          console.log('#### Instructions modified:', viewportInstructions);
         }
       }
     }

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,7 +1,7 @@
 import { ICustomElementType } from '@aurelia/runtime';
 
 import { Guard } from './guard';
-import { INavigationInstruction } from './history-browser';
+import { INavigationInstruction } from './navigator';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -14,14 +14,16 @@ export {
 } from './link-handler';
 
 export {
+  Guard,
+} from './guard';
+
+export {
   IGuardTarget,
-  Target,
   GuardTypes,
   GuardFunction,
   GuardTarget,
   GuardIdentity,
   IGuardOptions,
-  Guard,
   Guardian,
 } from './guardian';
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -14,6 +14,18 @@ export {
 } from './link-handler';
 
 export {
+  IGuardTarget,
+  Target,
+  GuardTypes,
+  GuardFunction,
+  GuardTarget,
+  GuardIdentity,
+  IGuardOptions,
+  Guard,
+  Guardian,
+} from './guardian';
+
+export {
   IViewportComponent,
   NavInstruction,
   INavRoute,

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -107,6 +107,23 @@ export class InstructionResolver {
     return { clear: clearViewports, newPath };
   }
 
+  public mergeViewportInstructions(instructions: (string | ViewportInstruction)[]): ViewportInstruction[] {
+    const merged: ViewportInstruction[] = [];
+
+    for (let instruction of instructions) {
+      if (typeof instruction === 'string') {
+        instruction = this.parseViewportInstruction(instruction);
+      }
+      const index = merged.findIndex(merge => merge.sameViewport(instruction as ViewportInstruction));
+      if (index >= 0) {
+        merged.splice(index, 1, instruction);
+      } else {
+        merged.push(instruction);
+      }
+    }
+    return merged;
+  }
+
   public removeStateDuplicates(states: string[]): string[] {
     let sorted: string[] = states.slice().sort((a, b) => b.split(this.separators.scope).length - a.split(this.separators.scope).length);
     sorted = sorted.map((value) => `${this.separators.scope}${value}${this.separators.scope}`);

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -87,6 +87,13 @@ export class InstructionResolver {
     return instructions.map((instruction) => this.stringifyViewportInstruction(instruction)).join(this.separators.scope);
   }
 
+  public encodeViewportInstructions(instructions: ViewportInstruction[]): string {
+    return encodeURIComponent(this.stringifyViewportInstructions(instructions)).replace(/\(/g, '%28').replace(/\)/g, '%29');
+  }
+  public decodeViewportInstructions(instructions: string): ViewportInstruction[] {
+    return this.parseViewportInstructions(decodeURIComponent(instructions));
+  }
+
   public buildScopedLink(scopeContext: string, href: string): string {
     if (scopeContext) {
       href = `/${scopeContext}${this.separators.scope}${href}`;
@@ -131,25 +138,17 @@ export class InstructionResolver {
   }
 
   private parseAViewportInstruction(instruction: string): ViewportInstruction {
-    let component: string;
-    let viewport: string;
-    let parameters: string[];
     let scope: boolean;
-    const [componentPart, rest] = instruction.split(this.separators.viewport);
-    if (rest === undefined) {
-      [component, ...parameters] = componentPart.split(this.separators.parameters);
-      if (component.endsWith(this.separators.ownsScope)) {
-        scope = true;
-        component = component.slice(0, -this.separators.ownsScope.length);
-      }
-    } else {
-      component = componentPart;
-      [viewport, ...parameters] = rest.split(this.separators.parameters);
-      if (viewport.endsWith(this.separators.ownsScope)) {
-        scope = true;
-        viewport = viewport.slice(0, -this.separators.ownsScope.length);
-      }
+
+    // Scope is always at the end, regardless of anything else
+    if (instruction.endsWith(this.separators.ownsScope)) {
+      scope = true;
+      instruction = instruction.slice(0, -this.separators.ownsScope.length);
     }
+
+    const [componentPart, viewport] = instruction.split(this.separators.viewport);
+    const [component, ...parameters] = componentPart.split(this.separators.parameters);
+
     let parametersString = parameters.length ? parameters.join(this.separators.parameters) : undefined;
     // The parameter separator can be either a standalone character (such as / or =) or a pair of enclosing characters
     // (such as ()). The separating character is consumed but the end character is not, so we still need to remove that.
@@ -164,12 +163,12 @@ export class InstructionResolver {
       return this.stringifyViewportInstruction(this.parseViewportInstruction(instruction), excludeViewport);
     } else {
       let instructionString = instruction.componentName;
-      if (instruction.viewportName != null && !excludeViewport) {
-        instructionString += this.separators.viewport + instruction.viewportName;
-      }
       if (instruction.parametersString) {
         // TODO: Review parameters in ViewportInstruction
         instructionString += this.separators.parameters + instruction.parametersString + this.separators.parametersEnd;
+      }
+      if (instruction.viewportName !== null && !excludeViewport) {
+        instructionString += this.separators.viewport + instruction.viewportName;
       }
       if (instruction.ownsScope) {
         instructionString += this.separators.ownsScope;

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -108,7 +108,8 @@ export class ViewportContent {
       return Promise.resolve(true);
     }
 
-    const merged = mergeParameters(this.parameters, this.instruction.query, (this.content as IRouteableCustomElementType).parameters);
+    const contentType: IRouteableCustomElementType = this.component !== null ? this.component.constructor : this.content as IRouteableCustomElementType;
+    const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
     this.instruction.parameters = merged.namedParameters;
     this.instruction.parameterList = merged.parameterList;
     const result = this.component.canEnter(merged.merged, this.instruction, previousInstruction);
@@ -140,7 +141,8 @@ export class ViewportContent {
       return;
     }
     if (this.component.enter) {
-      const merged = mergeParameters(this.parameters, this.instruction.query, (this.content as IRouteableCustomElementType).parameters);
+      const contentType: IRouteableCustomElementType = this.component !== null ? this.component.constructor : this.content as IRouteableCustomElementType;
+      const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
       this.instruction.parameters = merged.namedParameters;
       this.instruction.parameterList = merged.parameterList;
       await this.component.enter(merged.merged, this.instruction, previousInstruction);

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -97,4 +97,8 @@ export class ViewportInstruction {
     }
     return compareType ? this.component === other.component : this.componentName === other.componentName;
   }
+
+  public sameViewport(other: ViewportInstruction): boolean {
+    return (this.viewport ? this.viewport.name : this.viewportName) === (other.viewport ? other.viewport.name : other.viewportName);
+  }
 }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -153,7 +153,7 @@ export class Viewport {
     }
 
     if (!this.content.component && (!this.nextContent || !this.nextContent.component) && this.options.default) {
-      this.router.addProcessingViewport(this.options.default, this);
+      this.router.addProcessingViewport(this.options.default, this, false);
     }
   }
 

--- a/packages/router/test/e2e/doc-example/app/src/components/login-special.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login-special.ts
@@ -2,27 +2,27 @@ import { inject } from '@aurelia/kernel';
 import { customElement, ICustomElement } from '@aurelia/runtime';
 import { Router } from '../../../../../../src';
 import { State } from '../state';
-import { ViewportInstruction } from '../../../../../../src/viewport-instruction';
 
 @customElement({
-  name: 'login', template: `
+  name: 'login-special', template: `
 <div class="login">
-  <p>You need to be logged in to continue.</p>
-  <button data-test="login-button" click.trigger="login()">Okay, log me in</button>
+  <p>You need to be logged in SPECIAL to continue.</p>
+  <button data-test="login-button" click.trigger="login()">Okay, log me in SPECIAL</button>
 </div>` })
 @inject(State, Router)
-export class Login {
+export class LoginSpecial {
   constructor(private readonly state: State, private readonly router: Router) { }
 
   public login() {
     this.state.loggedIn = true;
-    this.state.timedOut = false;
     this.state.loggedInAt = new Date();
-    const instructions = this.state.loginReturnTo.length ? this.state.loginReturnTo : [new ViewportInstruction('main', 'gate')];
+    this.state.loggedInSpecial = true;
+    this.state.loggedInSpecialAt = new Date();
+    const instructions = this.state.loginReturnTo.length ? this.state.loginReturnTo : [];
     const goto = this.router.instructionResolver.stringifyViewportInstructions(instructions);
-    console.log(goto);
+    console.log('login-special', goto);
     this.state.loginReturnTo = [];
     this.router.replace(goto);
   }
 }
-export interface Login extends ICustomElement<HTMLElement> { }
+export interface LoginSpecial extends ICustomElement<HTMLElement> { }

--- a/packages/router/test/e2e/doc-example/app/src/components/login.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login.ts
@@ -1,0 +1,47 @@
+import { inject } from '@aurelia/kernel';
+import { customElement, ICustomElement } from '@aurelia/runtime';
+import { Router } from '../../../../../../src';
+import { State } from '../state';
+import { wait } from '../utils';
+
+@customElement({
+  name: 'login', template: `
+<div class="login">
+  <p>You need to be logged in \${specialText} to continue.</p>
+  <button click.trigger="login()">Okay, log me in \${specialText}</button>
+</div>` })
+@inject(State, Router)
+export class Login {
+  private returnTo: string = '';
+  private specialLogin: boolean = false;
+  private specialText: string = '';
+
+  constructor(private readonly state: State, private readonly router: Router) { }
+
+  public enter(params) {
+    params = params || [];
+    const returnTo = this.router.instructionResolver.decodeViewportInstructions(params[0]);
+    this.returnTo = this.router.instructionResolver.stringifyViewportInstructions(returnTo);
+    console.log('>>>>>>>>>', this.returnTo);
+    this.specialLogin = !!params[1];
+    this.specialText = this.specialLogin ? 'SPECIAL ' : '';
+    if (!this.specialLogin) {
+      alert("You've timed out!");
+      this.state.loggedIn = false;
+    }
+    this.state.loggedInSpecial = false;
+  }
+
+  public login() {
+    this.state.loggedIn = true;
+    this.state.loggedInAt = new Date();
+    if (this.specialLogin) {
+      this.state.loggedInSpecial = true;
+      this.state.loggedInSpecialAt = new Date();
+    }
+    console.log(this.router.instructionResolver.parseViewportInstructions(this.returnTo));
+    this.router.goto(this.returnTo || this.state.loginReturnTo || 'authors+about');
+    this.state.loginReturnTo = null;
+  }
+}
+export interface Login extends ICustomElement<HTMLElement> { }

--- a/packages/router/test/e2e/doc-example/app/src/components/login.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login.ts
@@ -8,7 +8,7 @@ import { wait } from '../utils';
   name: 'login', template: `
 <div class="login">
   <p>You need to be logged in \${specialText} to continue.</p>
-  <button click.trigger="login()">Okay, log me in \${specialText}</button>
+  <button data-test="login-button" click.trigger="login()">Okay, log me in \${specialText}</button>
 </div>` })
 @inject(State, Router)
 export class Login {

--- a/packages/router/test/e2e/doc-example/app/src/components/login.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login.ts
@@ -25,11 +25,6 @@ export class Login {
     console.log('>>>>>>>>>', this.returnTo);
     this.specialLogin = !!params[1];
     this.specialText = this.specialLogin ? 'SPECIAL ' : '';
-    if (!this.specialLogin) {
-      alert("You've timed out!");
-      this.state.loggedIn = false;
-    }
-    this.state.loggedInSpecial = false;
   }
 
   public login() {
@@ -39,16 +34,14 @@ export class Login {
       this.state.loggedInSpecial = true;
       this.state.loggedInSpecialAt = new Date();
     }
-    const returnTos = [];
     if (this.returnTo) {
-      returnTos.push(this.returnTo);
+      this.state.loginReturnTo.push(this.returnTo);
     }
-    if (this.state.loginReturnTo) {
-      returnTos.push(this.state.loginReturnTo);
+    if (this.state.loginReturnTo.length) {
+      console.log(this.state.loginReturnTo.join('+'));
+      this.router.goto(this.state.loginReturnTo.join('+'));
     }
-    console.log(this.router.instructionResolver.parseViewportInstructions(this.returnTo));
-    this.router.goto(returnTos.length ? returnTos.join('+') : 'authors+about');
-    this.state.loginReturnTo = null;
+    this.state.loginReturnTo = [];
   }
 }
 export interface Login extends ICustomElement<HTMLElement> { }

--- a/packages/router/test/e2e/doc-example/app/src/components/login.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login.ts
@@ -39,8 +39,15 @@ export class Login {
       this.state.loggedInSpecial = true;
       this.state.loggedInSpecialAt = new Date();
     }
+    const returnTos = [];
+    if (this.returnTo) {
+      returnTos.push(this.returnTo);
+    }
+    if (this.state.loginReturnTo) {
+      returnTos.push(this.state.loginReturnTo);
+    }
     console.log(this.router.instructionResolver.parseViewportInstructions(this.returnTo));
-    this.router.goto(this.returnTo || this.state.loginReturnTo || 'authors+about');
+    this.router.goto(returnTos.length ? returnTos.join('+') : 'authors+about');
     this.state.loginReturnTo = null;
   }
 }

--- a/packages/router/test/e2e/doc-example/app/src/components/main.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/main.ts
@@ -1,0 +1,65 @@
+import { inject } from '@aurelia/kernel';
+import { customElement } from '@aurelia/runtime';
+import { Router } from '../../../../../../../router/src/index';
+import { State } from '../state';
+import { About } from './about';
+import { Authors } from './authors/authors';
+import { Books } from './books/books';
+
+@inject(Router, State)
+@customElement({
+  name: 'main', template:
+    `
+  <div class="\${router.isNavigating ? 'routing' : ''}" style="--primary-color: \${color}">
+    <div>
+      <au-nav data-test="main-menu" name="main-menu"></au-nav>
+      <span class="loader \${router.isNavigating ? 'routing' : ''}">&nbsp;</span>
+    </div>
+    <div class="info">
+      In this test, the <i>Authors</i> list and <i>Author</i> component have a 2 second wait/delay on <pre>enter</pre>,
+      the <i>About</i> component has a 4 second delay on <pre>enter</pre> and <i>Author details</i> stops navigation
+      in <pre>canEnter</pre>. (Meaning that <i>Author</i> can't be opened since it has <i>Author details</i> as default
+      and the navigation is rolled back after 2 seconds.)
+    </div>
+    <div class="info">
+      <label><input data-test="no-delay-checkbox" type="checkbox" checked.two-way="state.noDelay">Disable loading delays for components</label><br>
+      <label><input data-test="allow-enter-author-details-checkbox" type="checkbox" checked.two-way="state.allowEnterAuthorDetails">Allow entering <i>Author details</i></label><br>
+    </div>
+    <div class="info" style="background-color: var(--primary-color)">
+      <select data-test="info-background-color-select" value.two-way="color">
+        <option value="lightblue">Light blue</option>
+        <option value="lightgreen">Light green</option>
+      <select>
+      <div style="display: inline-block;">
+        The background is in the --primary-color: <span data-test="info-background-color">\${color}</span>.
+      </div>
+    </div>
+    <au-viewport name="lists" used-by="authors,books" default="authors"></au-viewport>
+    <au-viewport name="content" default="about"></au-viewport>
+    <au-viewport name="chat" used-by="chat" no-link no-history></au-viewport>
+  </div>
+` })
+export class Main {
+  constructor(private readonly router: Router, private readonly state: State) {
+    this.router.setNav('main-menu', [
+      {
+        title: 'Authors',
+        route: [Authors, About],
+        consideredActive: [Authors],
+      },
+      {
+        title: 'Books',
+        route: [Books, About],
+        consideredActive: Books,
+      },
+      {
+        route: About,
+        title: 'About',
+      },
+      {
+        route: 'chat',
+        title: 'Chat',
+      },
+    ]);
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR contains the first version of router guards before navigation (such as an auth guard). It works, but could use a nicer API regarding "state to continue back to". Basic usage example:

```typescript
    this.router.guardian.addGuard((instructions) => {
      if (this.verifyLogin()) {
        return true;
      }
      this.state.loginReturnTo = this.router.instructionResolver.mergeViewportInstructions([
        ...this.state.loginReturnTo,
        ...this.router.activeComponents,
        ...instructions
      ]);
      alert("You've timed out!");
      this.state.loggedIn = false;
      this.router.goto('login');
      return false;
    }, { exclude: ['', 'login'] });
```

**Note** that this PR contains a **breaking change** in that component arguments move from after the viewport to after the component in hrefs/urls.
```
book@detail-viewport(id=123) -> book(id=123)@detail-viewport
```

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working. _I need to add tests_, but am submitting this now anyway since there are developers urgently waiting for it. 

## 📑 Test Plan

- Make sure tests still pass. And _add new tests_.

## ⏭ Next Steps

- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
