### PR TITLE
Allow default value for attributes that are bound with no explicit value being set

### DIFF
--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -185,7 +185,7 @@ export class SetPropertyRenderer implements IInstructionRenderer {
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: ISetPropertyInstruction): void {
     if (Tracer.enabled) { Tracer.enter('SetPropertyRenderer', 'render', slice.call(arguments)); }
-    getTarget(target)[instruction.to as keyof object] = instruction.value as never; // Yeah, yeah..
+    getTarget(target)[instruction.to as keyof object] = (instruction.value === '' ? true : instruction.value) as never; // Yeah, yeah..
     if (Tracer.enabled) { Tracer.leave(); }
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

-This allows a a bindable to be set to true when nothing is passed in to the attribute.  This greatly reduces the boilerplate for times when you want to set a static true value. *see below
```html
<element disabled outlined ></element>
```
```typescript
class Element{
@bindable public disabled: boolean = false; //THIS WILL BE TRUE
@bindable public outlined: boolean = false; //THIS WILL BE TRUE
}
```
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
