### PR TITLE
perf(all): remove tracer/profiler from ts source

### DIFF
--- a/packages/jit-html-browser/src/index.ts
+++ b/packages/jit-html-browser/src/index.ts
@@ -26,7 +26,6 @@ export const BasicConfiguration = {
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    if (Profiler.enabled) { enter(); }
     RuntimeHtmlBrowserBasicConfiguration
       .register(container)
       .register(
@@ -36,16 +35,13 @@ export const BasicConfiguration = {
         ...JitHtmlDefaultBindingLanguage,
         ...JitHtmlDefaultComponents
       );
-    if (Profiler.enabled) { leave(); }
     return container;
   },
   /**
    * Create a new container with this configuration applied to it.
    */
   createContainer(): IContainer {
-    if (Profiler.enabled) { enter(); }
     const container = this.register(DI.createContainer());
-    if (Profiler.enabled) { leave(); }
     return container;
   }
 };

--- a/packages/jit-html-jsdom/src/index.ts
+++ b/packages/jit-html-jsdom/src/index.ts
@@ -26,7 +26,6 @@ export const BasicConfiguration = {
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    if (Profiler.enabled) { enter(); }
     RuntimeJSDOMBrowserBasicConfiguration
       .register(container)
       .register(
@@ -36,16 +35,13 @@ export const BasicConfiguration = {
         ...JitHtmlDefaultBindingLanguage,
         ...JitHtmlDefaultComponents
       );
-    if (Profiler.enabled) { leave(); }
     return container;
   },
   /**
    * Create a new container with this configuration applied to it.
    */
   createContainer(): IContainer {
-    if (Profiler.enabled) { enter(); }
     const container = this.register(DI.createContainer());
-    if (Profiler.enabled) { leave(); }
     return container;
   }
 };

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -89,8 +89,6 @@ export class TemplateBinder {
   }
 
   public bind(node: HTMLTemplateElement): PlainElementSymbol {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bind', slice.call(arguments)); }
-    if (Profiler.enabled) { enter(); }
 
     const surrogateSave = this.surrogate;
     const parentManifestRootSave = this.parentManifestRoot;
@@ -106,7 +104,6 @@ export class TemplateBinder {
       const attrSyntax = this.attrParser.parse(attr.name, attr.value);
 
       if (invalidSurrogateAttribute[attrSyntax.target as keyof typeof invalidSurrogateAttribute] === true) {
-        if (Profiler.enabled) { leave(); }
         throw new Error(`Invalid surrogate attribute: ${attrSyntax.target}`);
         // TODO: use reporter
       }
@@ -114,7 +111,6 @@ export class TemplateBinder {
       if (attrInfo == null) {
         this.bindPlainAttribute(attrSyntax, attr);
       } else if (attrInfo.isTemplateController) {
-        if (Profiler.enabled) { leave(); }
         throw new Error('Cannot have template controller on surrogate element.');
         // TODO: use reporter
       } else {
@@ -130,19 +126,15 @@ export class TemplateBinder {
     this.manifestRoot = manifestRootSave;
     this.manifest = manifestSave;
 
-    if (Profiler.enabled) { leave(); }
-    if (Tracer.enabled) { Tracer.leave(); }
     return manifest;
   }
 
   private bindManifest(parentManifest: IElementSymbol, node: HTMLTemplateElement | HTMLElement): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindManifest', slice.call(arguments)); }
 
     switch (node.nodeName) {
       case 'LET':
         // let cannot have children and has some different processing rules, so return early
         this.bindLetElement(parentManifest, node);
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       case 'SLOT':
         this.surrogate!.hasSlots = true;
@@ -194,7 +186,6 @@ export class TemplateBinder {
     this.manifest = manifestSave;
     this.partName = partNameSave;
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private bindLetElement(parentManifest: IElementSymbol, node: HTMLElement): void {
@@ -224,7 +215,6 @@ export class TemplateBinder {
   }
 
   private bindAttributes(node: HTMLTemplateElement | HTMLElement, parentManifest: IElementSymbol): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindAttributes', slice.call(arguments)); }
 
     const { parentManifestRoot, manifestRoot, manifest } = this;
     // This is the top-level symbol for the current depth.
@@ -386,11 +376,9 @@ export class TemplateBinder {
       processReplacePart(this.dom, replacePart, manifestProxy);
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private bindChildNodes(node: HTMLTemplateElement | HTMLElement): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindChildNodes', slice.call(arguments)); }
 
     let childNode: ChildNode;
     if (node.nodeName === 'TEMPLATE') {
@@ -422,11 +410,9 @@ export class TemplateBinder {
       }
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private bindText(node: Text): ChildNode {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindText', slice.call(arguments)); }
     const interpolation = this.exprParser.parse(node.wholeText, BindingType.Interpolation);
     if (interpolation != null) {
       const symbol = new TextSymbol(this.dom, node, interpolation);
@@ -436,12 +422,10 @@ export class TemplateBinder {
     while (node.nextSibling != null && node.nextSibling.nodeType === NodeType.Text) {
       node = node.nextSibling as Text;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return node;
   }
 
   private declareTemplateController(attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'declareTemplateController', slice.call(arguments)); }
 
     let symbol: TemplateControllerSymbol;
     // dynamicOptions logic here is similar to (and explained in) bindCustomAttribute
@@ -456,12 +440,10 @@ export class TemplateBinder {
       symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable, expr, attrSyntax.rawValue, attrSyntax.target));
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return symbol;
   }
 
   private bindCustomAttribute(attrSyntax: AttrSyntax, attrInfo: AttrInfo): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindCustomAttribute', slice.call(arguments)); }
 
     const command = this.resources.getBindingCommand(attrSyntax);
     let symbol: CustomAttributeSymbol;
@@ -481,11 +463,9 @@ export class TemplateBinder {
     this.manifest!.attributes.push(symbol);
     this.manifest!.isTarget = true;
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private bindMultiAttribute(symbol: IResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindMultiAttribute', slice.call(arguments)); }
 
     const attributes = parseMultiAttributeBinding(value);
     let attr: IAttrLike;
@@ -504,11 +484,9 @@ export class TemplateBinder {
       symbol.bindings.push(new BindingSymbol(command, bindable, expr, attrSyntax.rawValue, attrSyntax.target));
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private bindPlainAttribute(attrSyntax: AttrSyntax, attr: Attr): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'bindPlainAttribute', slice.call(arguments)); }
 
     const command = this.resources.getBindingCommand(attrSyntax);
     const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
@@ -522,7 +500,6 @@ export class TemplateBinder {
         // Default to the name of the attr for empty binding commands
         expr = this.exprParser.parse(camelCase(attrSyntax.target), bindingType);
       } else {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
     } else {
@@ -556,22 +533,18 @@ export class TemplateBinder {
       attr.value = '';
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private declareReplacePart(node: HTMLTemplateElement | HTMLElement): ReplacePartSymbol {
-    if (Tracer.enabled) { Tracer.enter('TemplateBinder', 'declareReplacePart', slice.call(arguments)); }
 
     const name = node.getAttribute('replace-part');
     if (name == null) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return null!;
     }
     node.removeAttribute('replace-part');
 
     const symbol = new ReplacePartSymbol(name);
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return symbol;
   }
 }

--- a/packages/jit-html/src/template-compiler.ts
+++ b/packages/jit-html/src/template-compiler.ts
@@ -101,7 +101,6 @@ export class TemplateCompiler implements ITemplateCompiler {
   }
 
   public compile(dom: IDOM, definition: ITemplateDefinition, descriptions: IResourceDescriptions): TemplateDefinition {
-    if (Profiler.enabled) { enter(); }
     const binder = new TemplateBinder(dom, new ResourceModel(descriptions), this.attrParser, this.exprParser);
     const template = definition.template = this.factory.createTemplate(definition.template) as HTMLTemplateElement;
     const surrogate = binder.bind(template);
@@ -140,7 +139,6 @@ export class TemplateCompiler implements ITemplateCompiler {
 
     definition.build = buildNotRequired;
 
-    if (Profiler.enabled) { leave(); }
     return definition as TemplateDefinition;
   }
 

--- a/packages/jit-html/src/template-element-factory.ts
+++ b/packages/jit-html/src/template-element-factory.ts
@@ -63,7 +63,6 @@ export class HTMLTemplateElementFactory implements ITemplateElementFactory {
   public createTemplate(node: Node): HTMLTemplateElement;
   public createTemplate(input: unknown): HTMLTemplateElement;
   public createTemplate(input: string | Node): HTMLTemplateElement {
-    if (Profiler.enabled) { enter(); }
     if (typeof input === 'string') {
       let result = markupCache[input];
       if (result === void 0) {
@@ -85,14 +84,12 @@ export class HTMLTemplateElementFactory implements ITemplateElementFactory {
         markupCache[input] = result;
       }
 
-      if (Profiler.enabled) { leave(); }
       return result.cloneNode(true) as HTMLTemplateElement;
     }
     if (input.nodeName !== 'TEMPLATE') {
       // if we get one node that is not a template, wrap it in one
       const template = this.dom.createTemplate() as HTMLTemplateElement;
       template.content.appendChild(input);
-      if (Profiler.enabled) { leave(); }
       return template;
     }
     // we got a template element, remove it from the DOM if it's present there and don't
@@ -100,7 +97,6 @@ export class HTMLTemplateElementFactory implements ITemplateElementFactory {
     if (input.parentNode != null) {
       input.parentNode.removeChild(input);
     }
-    if (Profiler.enabled) { leave(); }
     return input as HTMLTemplateElement;
   }
 }

--- a/packages/jit/src/attribute-parser.ts
+++ b/packages/jit/src/attribute-parser.ts
@@ -33,17 +33,14 @@ export class AttributeParser implements IAttributeParser {
   }
 
   public parse(name: string, value: string): AttrSyntax {
-    if (Profiler.enabled) { enter(); }
     let interpretation = this.cache[name];
     if (interpretation == null) {
       interpretation = this.cache[name] = this.interpreter.interpret(name);
     }
     const pattern = interpretation.pattern;
     if (pattern == null) {
-      if (Profiler.enabled) { leave(); }
       return new AttrSyntax(name, value, name, null);
     } else {
-      if (Profiler.enabled) { leave(); }
       return this.patterns[pattern][pattern](name, value, interpretation.parts);
     }
   }

--- a/packages/jit/src/expression-parser.ts
+++ b/packages/jit/src/expression-parser.ts
@@ -143,17 +143,14 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
     TType extends BindingType.Interpolation ? IInterpolationExpression :
     TType extends BindingType.ForCommand ? IForOfStatement :
     never : never {
-  if (Profiler.enabled) { enter(); }
 
   if (state.index === 0) {
     if (bindingType & BindingType.Interpolation) {
-      if (Profiler.enabled) { leave(); }
       // tslint:disable-next-line:no-any
       return parseInterpolation(state) as any;
     }
     nextToken(state);
     if (state.currentToken & Token.ExpressionTerminal) {
-      if (Profiler.enabled) { leave(); }
       throw Reporter.error(SyntaxError.InvalidExpressionStart, { state });
     }
   }
@@ -217,10 +214,8 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
         access++; // ancestor
         if (consumeOpt(state, Token.Dot)) {
           if ((state.currentToken as Token) === Token.Dot) {
-            if (Profiler.enabled) { leave(); }
             throw Reporter.error(SyntaxError.DoubleDot, { state });
           } else if ((state.currentToken as Token) === Token.EOF) {
-            if (Profiler.enabled) { leave(); }
             throw Reporter.error(SyntaxError.ExpectedIdentifier, { state });
           }
         } else if (state.currentToken & Token.AccessScopeTerminal) {
@@ -229,7 +224,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
           access = Access.This;
           break primary;
         } else {
-          if (Profiler.enabled) { leave(); }
           throw Reporter.error(SyntaxError.InvalidMemberExpression, { state });
         }
       } while (state.currentToken === Token.ParentScope);
@@ -292,21 +286,17 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
       break;
     default:
       if (state.index >= state.length) {
-        if (Profiler.enabled) { leave(); }
         throw Reporter.error(SyntaxError.UnexpectedEndOfExpression, { state });
       } else {
-        if (Profiler.enabled) { leave(); }
         throw Reporter.error(SyntaxError.UnconsumedToken, { state });
       }
     }
 
     if (bindingType & BindingType.IsIterator) {
-      if (Profiler.enabled) { leave(); }
       // tslint:disable-next-line:no-any
       return parseForOfStatement(state, result as BindingIdentifierOrPattern) as any;
     }
     if (Precedence.LeftHandSide < minPrecedence) {
-      if (Profiler.enabled) { leave(); }
       // tslint:disable-next-line:no-any
       return result as any;
     }
@@ -342,7 +332,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
           state.assignable = true;
           nextToken(state);
           if ((state.currentToken & Token.IdentifierName) === 0) {
-            if (Profiler.enabled) { leave(); }
             throw Reporter.error(SyntaxError.ExpectedIdentifier, { state });
           }
           name = state.tokenValue as string;
@@ -402,7 +391,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
   }
 
   if (Precedence.Binary < minPrecedence) {
-    if (Profiler.enabled) { leave(); }
     // tslint:disable-next-line:no-any
     return result as any;
   }
@@ -444,7 +432,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
     state.assignable = false;
   }
   if (Precedence.Conditional < minPrecedence) {
-    if (Profiler.enabled) { leave(); }
     // tslint:disable-next-line:no-any
     return result as any;
   }
@@ -468,7 +455,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
     state.assignable = false;
   }
   if (Precedence.Assign < minPrecedence) {
-    if (Profiler.enabled) { leave(); }
     // tslint:disable-next-line:no-any
     return result as any;
   }
@@ -486,13 +472,11 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
    */
   if (consumeOpt(state, Token.Equals)) {
     if (!state.assignable) {
-      if (Profiler.enabled) { leave(); }
       throw Reporter.error(SemanticError.NotAssignable, { state });
     }
     result = new AssignExpression(result as IsAssignable, parse(state, access, Precedence.Assign, bindingType));
   }
   if (Precedence.Variadic < minPrecedence) {
-    if (Profiler.enabled) { leave(); }
     // tslint:disable-next-line:no-any
     return result as any;
   }
@@ -501,7 +485,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
    */
   while (consumeOpt(state, Token.Bar)) {
     if (state.currentToken === Token.EOF) {
-      if (Profiler.enabled) { leave(); }
       throw Reporter.error(112);
     }
     const name = state.tokenValue as string;
@@ -517,7 +500,6 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
    */
   while (consumeOpt(state, Token.Ampersand)) {
     if (state.currentToken === Token.EOF) {
-      if (Profiler.enabled) { leave(); }
       throw Reporter.error(113);
     }
     const name = state.tokenValue as string;
@@ -530,18 +512,14 @@ export function parse<TPrec extends Precedence, TType extends BindingType>(state
   }
   if (state.currentToken !== Token.EOF) {
     if (bindingType & BindingType.Interpolation) {
-      if (Profiler.enabled) { leave(); }
       // tslint:disable-next-line:no-any
       return result as any;
     }
     if (state.tokenRaw === 'of') {
-      if (Profiler.enabled) { leave(); }
       throw Reporter.error(SemanticError.UnexpectedForOf, { state });
     }
-    if (Profiler.enabled) { leave(); }
     throw Reporter.error(SyntaxError.UnconsumedToken, { state });
   }
-  if (Profiler.enabled) { leave(); }
   // tslint:disable-next-line:no-any
   return result as any;
 }

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -492,14 +492,12 @@ export class Factory<T extends Constructable = any> implements IFactory<T> {
   }
 
   public construct(container: IContainer, dynamicDependencies?: Key[]): Resolved<T> {
-    if (Tracer.enabled) { Tracer.enter('Factory', 'construct', [this.Type, ...slice.call(arguments)]); }
     const transformers = this.transformers;
     let instance = dynamicDependencies !== void 0
       ? this.invoker.invokeWithDynamicDependencies(container, this.Type, this.dependencies, dynamicDependencies)
       : this.invoker.invoke(container, this.Type, this.dependencies);
 
     if (transformers == null) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return instance;
     }
 
@@ -507,7 +505,6 @@ export class Factory<T extends Constructable = any> implements IFactory<T> {
       instance = transformers[i](instance);
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return instance;
   }
 
@@ -564,7 +561,6 @@ export class Container implements IContainer {
   }
 
   public register(...params: any[]): IContainer {
-    if (Tracer.enabled) { Tracer.enter('Container', 'register', slice.call(arguments)); }
     if (++this.registerDepth === 100) {
       throw new Error('Unable to autoregister dependency');
       // TODO: change to reporter.error and add various possible causes in description.
@@ -599,7 +595,6 @@ export class Container implements IContainer {
       }
     }
     --this.registerDepth;
-    if (Tracer.enabled) { Tracer.leave(); }
     return this;
   }
 
@@ -683,11 +678,9 @@ export class Container implements IContainer {
   }
 
   public get<K extends Key>(key: K): Resolved<K> {
-    if (Tracer.enabled) { Tracer.enter('Container', 'get', slice.call(arguments)); }
     validateKey(key);
 
     if ((key as IResolver).resolve !== void 0) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return (key as IResolver).resolve(this, this);
     }
 
@@ -700,13 +693,11 @@ export class Container implements IContainer {
       if (resolver == null) {
         if (current.parent == null) {
           resolver = this.jitRegister(key, current);
-          if (Tracer.enabled) { Tracer.leave(); }
           return resolver.resolve(current, this);
         }
 
         current = current.parent;
       } else {
-        if (Tracer.enabled) { Tracer.leave(); }
         return resolver.resolve(current, this);
       }
     }
@@ -715,7 +706,6 @@ export class Container implements IContainer {
   }
 
   public getAll<K extends Key>(key: K): readonly Resolved<K>[] {
-    if (Tracer.enabled) { Tracer.enter('Container', 'getAll', slice.call(arguments)); }
     validateKey(key);
 
     let current: Container | null = this;
@@ -726,18 +716,15 @@ export class Container implements IContainer {
 
       if (resolver == null) {
         if (this.parent == null) {
-          if (Tracer.enabled) { Tracer.leave(); }
           return PLATFORM.emptyArray;
         }
 
         current = current.parent;
       } else {
-        if (Tracer.enabled) { Tracer.leave(); }
         return buildAllResponse(resolver, current, this);
       }
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return PLATFORM.emptyArray;
   }
 
@@ -753,12 +740,10 @@ export class Container implements IContainer {
   }
 
   public createChild(): IContainer {
-    if (Tracer.enabled) { Tracer.enter('Container', 'createChild', slice.call(arguments)); }
     const config = this.configuration;
     const childConfig = { factories: config.factories, resourceLookup: Object.assign(Object.create(null), config.resourceLookup) };
     const child = new Container(childConfig);
     child.parent = this;
-    if (Tracer.enabled) { Tracer.leave(); }
     return child;
   }
 

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -78,9 +78,7 @@ export class AttributeBinding implements IPartialConnectableBinding {
   }
 
   public handleChange(newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', 'handleChange', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -105,7 +103,6 @@ export class AttributeBinding implements IPartialConnectableBinding {
         this.sourceExpression.connect(flags, this.$scope, this, this.part);
         this.unobserve(false);
       }
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -113,7 +110,6 @@ export class AttributeBinding implements IPartialConnectableBinding {
       if (newValue !== this.sourceExpression.evaluate(flags, this.$scope, this.locator, this.part)) {
         this.updateSource(newValue, flags);
       }
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -121,10 +117,8 @@ export class AttributeBinding implements IPartialConnectableBinding {
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
       this.$unbind(flags | LifecycleFlags.fromBind);
@@ -174,13 +168,10 @@ export class AttributeBinding implements IPartialConnectableBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -205,15 +196,12 @@ export class AttributeBinding implements IPartialConnectableBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public connect(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', 'connect', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       flags |= this.persistentFlags;
       this.sourceExpression.connect(flags | LifecycleFlags.mustEvaluate, this.$scope, this, this.part); // why do we have a connect method here in the first place? will this be called after bind?
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -61,7 +61,6 @@ export class Listener implements IBinding {
   }
 
   public callSource(event: Event): ReturnType<IsBindingBehavior['evaluate']> {
-    if (Tracer.enabled) { Tracer.enter('Listener', 'callSource', slice.call(arguments)); }
     const overrideContext = this.$scope.overrideContext;
     overrideContext.$event = event;
 
@@ -73,7 +72,6 @@ export class Listener implements IBinding {
       event.preventDefault();
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return result;
   }
 
@@ -82,10 +80,8 @@ export class Listener implements IBinding {
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('Listener', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
 
@@ -113,13 +109,10 @@ export class Listener implements IBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Listener', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -136,7 +129,6 @@ export class Listener implements IBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public observeProperty(flags: LifecycleFlags, obj: IIndexable, propertyName: string): void {

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -98,7 +98,6 @@ export class RenderPlan<T extends INode = Node> {
 }
 
 function createElementForTag<T extends INode>(dom: IDOM<T>, tagName: string, props?: Record<string, string | HTMLTargetedInstruction>, children?: ArrayLike<unknown>): RenderPlan<T> {
-  if (Tracer.enabled) { Tracer.enter('createElement', 'createElementForTag', slice.call(arguments)); }
   const instructions: HTMLTargetedInstruction[] = [];
   const allInstructions: HTMLTargetedInstruction[][] = [];
   const dependencies: IRegistry[] = [];
@@ -128,7 +127,6 @@ function createElementForTag<T extends INode>(dom: IDOM<T>, tagName: string, pro
     addChildren(dom, element, children, allInstructions, dependencies);
   }
 
-  if (Tracer.enabled) { Tracer.leave(); }
   return new RenderPlan(dom, element, allInstructions, dependencies);
 }
 
@@ -138,7 +136,6 @@ function createElementForType<T extends INode>(
   props?: Record<string, unknown>,
   children?: ArrayLike<unknown>,
 ): RenderPlan<T> {
-  if (Tracer.enabled) { Tracer.enter('createElement', 'createElementForType', slice.call(arguments)); }
   const tagName = Type.description.name;
   const instructions: HTMLTargetedInstruction[] = [];
   const allInstructions = [instructions];
@@ -182,7 +179,6 @@ function createElementForType<T extends INode>(
     addChildren(dom, element, children, allInstructions, dependencies);
   }
 
-  if (Tracer.enabled) { Tracer.leave(); }
   return new RenderPlan<T>(dom, element, allInstructions, dependencies);
 }
 

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -45,7 +45,6 @@ export class TextBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: ChildNode, instruction: ITextBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('TextBindingRenderer', 'render', slice.call(arguments)); }
     const next = target.nextSibling;
     if (dom.isMarker(target)) {
       dom.remove(target);
@@ -58,7 +57,6 @@ export class TextBindingRenderer implements IInstructionRenderer {
       binding = new InterpolationBinding(expr.firstExpression, expr, next!, 'textContent', BindingMode.toView, this.observerLocator, context, true);
     }
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -77,11 +75,9 @@ export class ListenerBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: HTMLElement, instruction: IListenerBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('ListenerBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
     const binding = new Listener(dom, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventManager, context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -91,9 +87,7 @@ export class SetAttributeRenderer implements IInstructionRenderer {
   public static readonly register: IRegistry['register'];
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: HTMLElement, instruction: ISetAttributeInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('SetAttributeRenderer', 'render', slice.call(arguments)); }
     target.setAttribute(instruction.to, instruction.value);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -112,11 +106,9 @@ export class StylePropertyBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: HTMLElement, instruction: IStylePropertyBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const binding = new PropertyBinding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -136,7 +128,6 @@ export class AttributeBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: HTMLElement, instruction: IAttributeBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('StylePropertyBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const binding = new AttributeBinding(
       expr,
@@ -148,6 +139,5 @@ export class AttributeBindingRenderer implements IInstructionRenderer {
       context
     );
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -86,16 +86,12 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
   }
 
   public project(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('ShadowDOMProjector', 'project', slice.call(arguments)); }
     nodes.appendTo(this.shadowRoot);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public take(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('ShadowDOMProjector', 'take', slice.call(arguments)); }
     nodes.remove();
     nodes.unlink();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -131,16 +127,12 @@ export class ContainerlessProjector implements IElementProjector<Node> {
   }
 
   public project(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('ContainerlessProjector', 'project', slice.call(arguments)); }
     nodes.insertBefore(this.host);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public take(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('ContainerlessProjector', 'take', slice.call(arguments)); }
     nodes.remove();
     nodes.unlink();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -166,15 +158,11 @@ export class HostProjector implements IElementProjector<Node> {
   }
 
   public project(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('HostProjector', 'project', slice.call(arguments)); }
     nodes.appendTo(this.host);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public take(nodes: INodeSequence<Node>): void {
-    if (Tracer.enabled) { Tracer.enter('HostProjector', 'take', slice.call(arguments)); }
     nodes.remove();
     nodes.unlink();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -263,7 +263,6 @@ export class Aurelia<TNode extends INode = INode> {
     Reflect.set(root.host, '$au', this);
     this._root = root;
     this._isStarting = true;
-    if (Profiler.enabled) { enterStart(); }
   }
 
   private onAfterStart(root: CompositionRoot): ILifecycleTask {
@@ -271,14 +270,12 @@ export class Aurelia<TNode extends INode = INode> {
     this._isStarting = false;
     this.dispatchEvent(root, 'aurelia-composed', root.dom);
     this.dispatchEvent(root, 'au-started', root.host as Publisher);
-    if (Profiler.enabled) { leaveStart(); }
     return LifecycleTask.done;
   }
 
   private onBeforeStop(root: CompositionRoot): void {
     this._isRunning = false;
     this._isStopping = true;
-    if (Profiler.enabled) { enterStop(); }
   }
 
   private onAfterStop(root: CompositionRoot): ILifecycleTask {
@@ -286,7 +283,6 @@ export class Aurelia<TNode extends INode = INode> {
     this._root = void 0;
     this._isStopping = false;
     this.dispatchEvent(root, 'au-stopped', root.host as Publisher);
-    if (Profiler.enabled) { leaveStop(); }
     return LifecycleTask.done;
   }
 

--- a/packages/runtime/src/binding/call-binding.ts
+++ b/packages/runtime/src/binding/call-binding.ts
@@ -46,7 +46,6 @@ export class CallBinding {
   }
 
   public callSource(args: object): unknown {
-    if (Tracer.enabled) { Tracer.enter('CallBinding', 'callSource', slice.call(arguments)); }
     const overrideContext = this.$scope!.overrideContext;
     Object.assign(overrideContext, args);
     const result = this.sourceExpression.evaluate(LifecycleFlags.mustEvaluate, this.$scope!, this.locator, this.part);
@@ -55,15 +54,12 @@ export class CallBinding {
       Reflect.deleteProperty(overrideContext, prop);
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     return result;
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('CallBinding', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
 
@@ -84,13 +80,10 @@ export class CallBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('CallBinding', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -105,7 +98,6 @@ export class CallBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public observeProperty(flags: LifecycleFlags, obj: object, propertyName: string): void {

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -80,7 +80,6 @@ export function addObserver(
 
 /** @internal */
 export function observeProperty(this: IConnectableBinding, flags: LifecycleFlags, obj: object, propertyName: string): void {
-  if (Tracer.enabled) { Tracer.enter(this['constructor'].name, 'observeProperty', slice.call(arguments)); }
   const observer = this.observerLocator.getObserver(flags, obj, propertyName) as IBindingTargetObserver;
   /* Note: we need to cast here because we can indeed get an accessor instead of an observer,
    *  in which case the call to observer.subscribe will throw. It's not very clean and we can solve this in 2 ways:
@@ -90,7 +89,6 @@ export function observeProperty(this: IConnectableBinding, flags: LifecycleFlags
    * We'll probably want to implement some global configuration (like a "strict" toggle) so users can pick between enforced correctness vs. ease-of-use
    */
   this.addObserver(observer);
-  if (Tracer.enabled) { Tracer.leave(); }
 }
 
 /** @internal */

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -66,9 +66,7 @@ export class LetBinding implements IPartialConnectableBinding {
   }
 
   public handleChange(_newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('LetBinding', 'handleChange', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -79,7 +77,6 @@ export class LetBinding implements IPartialConnectableBinding {
       if (newValue !== previousValue) {
         target[targetProperty] = newValue;
       }
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -87,10 +84,8 @@ export class LetBinding implements IPartialConnectableBinding {
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('LetBinding', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
       this.$unbind(flags | LifecycleFlags.fromBind);
@@ -113,13 +108,10 @@ export class LetBinding implements IPartialConnectableBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('LetBinding', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -134,6 +126,5 @@ export class LetBinding implements IPartialConnectableBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/src/binding/property-binding.ts
+++ b/packages/runtime/src/binding/property-binding.ts
@@ -95,9 +95,7 @@ export class PropertyBinding implements IPartialConnectableBinding {
   }
 
   public handleChange(newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', 'handleChange', slice.call(arguments)); }
     if ((this.$state & State.isBound) === 0) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -117,7 +115,6 @@ export class PropertyBinding implements IPartialConnectableBinding {
         this.sourceExpression.connect(flags, this.$scope!, this, this.part);
         this.unobserve(false);
       }
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
@@ -125,19 +122,15 @@ export class PropertyBinding implements IPartialConnectableBinding {
       if (newValue !== this.sourceExpression.evaluate(flags, this.$scope!, this.locator, this.part)) {
         this.updateSource(newValue, flags);
       }
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
 
-    if (Tracer.enabled) { Tracer.leave(); }
     throw Reporter.error(15, flags);
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
       this.$unbind(flags | LifecycleFlags.fromBind);
@@ -185,13 +178,10 @@ export class PropertyBinding implements IPartialConnectableBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Binding', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -216,6 +206,5 @@ export class PropertyBinding implements IPartialConnectableBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/runtime/src/binding/ref-binding.ts
+++ b/packages/runtime/src/binding/ref-binding.ts
@@ -46,10 +46,8 @@ export class RefBinding implements IBinding {
   }
 
   public $bind(flags: LifecycleFlags, scope: IScope, part?: string): void {
-    if (Tracer.enabled) { Tracer.enter('Ref', '$bind', slice.call(arguments)); }
     if (this.$state & State.isBound) {
       if (this.$scope === scope) {
-        if (Tracer.enabled) { Tracer.leave(); }
         return;
       }
 
@@ -70,13 +68,10 @@ export class RefBinding implements IBinding {
     // add isBound flag and remove isBinding flag
     this.$state |= State.isBound;
     this.$state &= ~State.isBinding;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public $unbind(flags: LifecycleFlags): void {
-    if (Tracer.enabled) { Tracer.enter('Ref', '$unbind', slice.call(arguments)); }
     if (!(this.$state & State.isBound)) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return;
     }
     // add isUnbinding flag
@@ -95,7 +90,6 @@ export class RefBinding implements IBinding {
 
     // remove isBound and isUnbinding flags
     this.$state &= ~(State.isBound | State.isUnbinding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public observeProperty(flags: LifecycleFlags, obj: IIndexable, propertyName: string): void {

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -382,7 +382,6 @@ export class ArrayObserver {
   public inBatch: boolean;
 
   constructor(flags: LifecycleFlags, lifecycle: ILifecycle, array: IObservedArray) {
-    if (Tracer.enabled) { Tracer.enter('ArrayObserver', 'constructor', slice.call(arguments)); }
 
     if (!enableArrayObservationCalled) {
       enableArrayObservationCalled = true;
@@ -408,7 +407,6 @@ export class ArrayObserver {
       },
     );
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public notify(): void {

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -31,11 +31,9 @@ export class InternalObserversLookup {
     obj: IBindingContext | IOverrideContext,
     key: string,
   ): PropertyObserver {
-    if (Tracer.enabled) { Tracer.enter('InternalObserversLookup', 'getOrCreate', slice.call(arguments)); }
     if (this[key] === void 0) {
       this[key] = new SetterObserver(lifecycle, flags, obj, key);
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return this[key];
   }
 }
@@ -94,7 +92,6 @@ export class BindingContext implements IBindingContext {
   }
 
   public static get(scope: IScope, name: string, ancestor: number, flags: LifecycleFlags, part?: string): IBindingContext | IOverrideContext | IBinding | undefined | null {
-    if (Tracer.enabled) { Tracer.enter('BindingContext', 'get', slice.call(arguments)); }
     if (scope == null) {
       throw Reporter.error(RuntimeError.NilScope);
     }
@@ -104,14 +101,12 @@ export class BindingContext implements IBindingContext {
       // jump up the required number of ancestor contexts (eg $parent.$parent requires two jumps)
       while (ancestor > 0) {
         if (overrideContext.parentOverrideContext == null) {
-          if (Tracer.enabled) { Tracer.leave(); }
           return void 0;
         }
         ancestor--;
         overrideContext = overrideContext.parentOverrideContext;
       }
 
-      if (Tracer.enabled) { Tracer.leave(); }
       return name in overrideContext ? overrideContext : overrideContext.bindingContext;
     }
 
@@ -121,7 +116,6 @@ export class BindingContext implements IBindingContext {
     }
 
     if (overrideContext) {
-      if (Tracer.enabled) { Tracer.leave(); }
       // we located a context with the property.  return it.
       return name in overrideContext ? overrideContext : overrideContext.bindingContext;
     }
@@ -136,7 +130,6 @@ export class BindingContext implements IBindingContext {
             & ~LifecycleFlags.allowParentScopeTraversal
             // tell the scope to return null if the name could not be found
             | LifecycleFlags.isTraversingParentScope);
-          if (Tracer.enabled) { Tracer.leave(); }
           if (result === marker) {
             return scope.bindingContext || scope.overrideContext;
           } else {
@@ -156,19 +149,15 @@ export class BindingContext implements IBindingContext {
     // if this is a parent scope traversal, to ensure we fall back to the
     // correct level)
     if (flags & LifecycleFlags.isTraversingParentScope) {
-      if (Tracer.enabled) { Tracer.leave(); }
       return marker;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return scope.bindingContext || scope.overrideContext;
   }
 
   public getObservers(flags: LifecycleFlags): ObserversLookup {
-    if (Tracer.enabled) { Tracer.enter('BindingContext', 'getObservers', slice.call(arguments)); }
     if (this.$observers == null) {
       this.$observers = new InternalObserversLookup() as ObserversLookup;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return this.$observers;
   }
 }
@@ -219,26 +208,20 @@ export class Scope implements IScope {
    */
   public static create(flags: LifecycleFlags, bc: object, oc: null): Scope;
   public static create(flags: LifecycleFlags, bc: object, oc?: IOverrideContext | null): Scope {
-    if (Tracer.enabled) { Tracer.enter('Scope', 'create', slice.call(arguments)); }
-    if (Tracer.enabled) { Tracer.leave(); }
     return new Scope(null, bc as IBindingContext, oc == null ? OverrideContext.create(flags, bc, oc!) : oc);
   }
 
   public static fromOverride(flags: LifecycleFlags, oc: IOverrideContext): Scope {
-    if (Tracer.enabled) { Tracer.enter('Scope', 'fromOverride', slice.call(arguments)); }
     if (oc == null) {
       throw Reporter.error(RuntimeError.NilOverrideContext);
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return new Scope(null, oc.bindingContext, oc);
   }
 
   public static fromParent(flags: LifecycleFlags, ps: IScope | null, bc: object): Scope {
-    if (Tracer.enabled) { Tracer.enter('Scope', 'fromParent', slice.call(arguments)); }
     if (ps == null) {
       throw Reporter.error(RuntimeError.NilParentScope);
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return new Scope(ps, bc as IBindingContext, OverrideContext.create(flags, bc, ps.overrideContext));
   }
 }
@@ -258,17 +241,13 @@ export class OverrideContext implements IOverrideContext {
   }
 
   public static create(flags: LifecycleFlags, bc: object, poc: IOverrideContext | null): OverrideContext {
-    if (Tracer.enabled) { Tracer.enter('OverrideContext', 'create', slice.call(arguments)); }
-    if (Tracer.enabled) { Tracer.leave(); }
     return new OverrideContext(bc as IBindingContext, poc === void 0 ? null : poc);
   }
 
   public getObservers(): ObserversLookup {
-    if (Tracer.enabled) { Tracer.enter('OverrideContext', 'getObservers', slice.call(arguments)); }
     if (this.$observers === void 0) {
       this.$observers = new InternalObserversLookup() as ObserversLookup;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
     return this.$observers;
   }
 }

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -126,12 +126,10 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
   private readonly dirtyChecker: IDirtyChecker;
 
   constructor(dirtyChecker: IDirtyChecker, obj: object, propertyKey: string) {
-    if (Tracer.enabled) { Tracer.enter('DirtyCheckProperty', 'constructor', slice.call(arguments)); }
     this.obj = obj as IObservable & IIndexable;
     this.propertyKey = propertyKey;
 
     this.dirtyChecker = dirtyChecker;
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public isDirty(): boolean {

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -150,7 +150,6 @@ export class MapObserver {
   public inBatch: boolean;
 
   constructor(flags: LifecycleFlags, lifecycle: ILifecycle, map: IObservedMap) {
-    if (Tracer.enabled) { Tracer.enter('MapObserver', 'constructor', slice.call(arguments)); }
 
     if (!enableMapObservationCalled) {
       enableMapObservationCalled = true;
@@ -167,7 +166,6 @@ export class MapObserver {
 
     map.$observer = this;
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public notify(): void {

--- a/packages/runtime/src/observation/primitive-observer.ts
+++ b/packages/runtime/src/observation/primitive-observer.ts
@@ -22,7 +22,6 @@ export class PrimitiveObserver implements IAccessor, ISubscribable {
   public obj: Primitive;
 
   constructor(obj: Primitive, propertyKey: PropertyKey) {
-    if (Tracer.enabled) { Tracer.enter('PrimitiveObserver', 'constructor', slice.call(arguments)); }
     // we don't need to store propertyName because only 'length' can return a useful value
     if (propertyKey === 'length') {
       // deliberately not checking for typeof string as users probably still want to know via an error that their string is undefined
@@ -31,7 +30,6 @@ export class PrimitiveObserver implements IAccessor, ISubscribable {
     } else {
       this.getValue = this.returnUndefined;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   private getStringLength(): number {

--- a/packages/runtime/src/observation/property-accessor.ts
+++ b/packages/runtime/src/observation/property-accessor.ts
@@ -10,7 +10,6 @@ export class PropertyAccessor implements PropertyAccessor {
   public propertyKey: string;
 
   constructor(obj: Record<string, unknown>, propertyKey: string) {
-    if (Tracer.enabled) { Tracer.enter('PropertyAccessor', 'constructor', slice.call(arguments)); }
     this.obj = obj;
     this.propertyKey = propertyKey;
     if (
@@ -20,7 +19,6 @@ export class PropertyAccessor implements PropertyAccessor {
     ) {
       this.setValue = this.setValueDirect;
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public getValue(): unknown {

--- a/packages/runtime/src/observation/proxy-observer.ts
+++ b/packages/runtime/src/observation/proxy-observer.ts
@@ -24,7 +24,6 @@ export class ProxySubscriberCollection<TObj extends object = object> implements 
   public readonly raw: TObj;
   public readonly key: string | number;
   constructor(proxy: IProxy<TObj>, raw: TObj, key: string | number) {
-    if (Tracer.enabled) { Tracer.enter('ProxySubscriberCollection', 'constructor', slice.call(arguments)); }
 
     this.inBatch = false;
 
@@ -36,7 +35,6 @@ export class ProxySubscriberCollection<TObj extends object = object> implements 
     if (raw[key as keyof TObj] instanceof Object) { // Ensure we observe array indices and newly created object properties
       raw[key as keyof TObj] = ProxyObserver.getOrCreate(raw[key as keyof TObj] as unknown as object).proxy as unknown as TObj[keyof TObj];
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public setValue(value: unknown, flags?: LifecycleFlags): void {
@@ -64,12 +62,10 @@ export class ProxyObserver<TObj extends object = object> implements ProxyObserve
   private readonly subscribers: Record<string | number, ProxySubscriberCollection<TObj>>;
 
   constructor(obj: TObj) {
-    if (Tracer.enabled) { Tracer.enter('ProxyObserver', 'constructor', slice.call(arguments)); }
     this.raw = obj;
     this.proxy = new Proxy<TObj>(obj, this) as IProxy<TObj>;
     lookup.set(obj, this.proxy);
     this.subscribers = {};
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public static getProxyOrSelf<T extends object = object>(obj: T): T {

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -135,7 +135,6 @@ export class SetObserver {
   public inBatch: boolean;
 
   constructor(flags: LifecycleFlags, lifecycle: ILifecycle, observedSet: IObservedSet) {
-    if (Tracer.enabled) { Tracer.enter('SetObserver', 'constructor', slice.call(arguments)); }
 
     if (!enableSetObservationCalled) {
       enableSetObservationCalled = true;
@@ -152,7 +151,6 @@ export class SetObserver {
 
     observedSet.$observer = this;
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public notify(): void {

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -37,7 +37,6 @@ export class SetterObserver {
     this.observing = false;
     this.persistentFlags = flags & LifecycleFlags.persistentBindingFlags;
 
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public getValue(): unknown {

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -108,7 +108,6 @@ export class Renderer implements IRenderer {
 
   // tslint:disable-next-line:parameters-max-number
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, targets: ArrayLike<INode>, definition: TemplateDefinition, host?: INode, parts?: TemplatePartDefinitions): void {
-    if (Tracer.enabled) { Tracer.enter('Renderer', 'render', slice.call(arguments)); }
     const targetInstructions = definition.instructions;
     const instructionRenderers = this.instructionRenderers;
 
@@ -140,7 +139,6 @@ export class Renderer implements IRenderer {
         instructionRenderers[current.type].render(flags, dom, context, renderable, host, current, parts);
       }
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -152,23 +150,19 @@ export function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TF
 }
 
 export function addBinding(renderable: IController, binding: IBinding): void {
-  if (Tracer.enabled) { Tracer.enter('Renderer', 'addBinding', slice.call(arguments)); }
   if (renderable.bindings == void 0) {
     renderable.bindings = [binding];
   } else {
     renderable.bindings.push(binding);
   }
-  if (Tracer.enabled) { Tracer.leave(); }
 }
 
 export function addComponent(renderable: IController, component: IController): void {
-  if (Tracer.enabled) { Tracer.enter('Renderer', 'addComponent', slice.call(arguments)); }
   if (renderable.controllers == void 0) {
     renderable.controllers = [component];
   } else {
     renderable.controllers.push(component);
   }
-  if (Tracer.enabled) { Tracer.leave(); }
 }
 
 export function getTarget(potentialTarget: object): object {
@@ -184,9 +178,7 @@ export class SetPropertyRenderer implements IInstructionRenderer {
   public static readonly register: IRegistry['register'];
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: ISetPropertyInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('SetPropertyRenderer', 'render', slice.call(arguments)); }
     getTarget(target)[instruction.to as keyof object] = (instruction.value === '' ? true : instruction.value) as never; // Yeah, yeah..
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -196,7 +188,6 @@ export class CustomElementRenderer implements IInstructionRenderer {
   public static readonly register: IRegistry['register'];
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: INode, instruction: IHydrateElementInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('CustomElementRenderer', 'render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction, null!, null!, target, true);
     const component = context.get<object>(customElementKey(instruction.res));
     const instructionRenderers = context.get(IRenderer).instructionRenderers;
@@ -219,7 +210,6 @@ export class CustomElementRenderer implements IInstructionRenderer {
     addComponent(renderable, controller);
 
     operation.dispose();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -229,7 +219,6 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
   public static readonly register: IRegistry['register'];
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: INode, instruction: IHydrateAttributeInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('CustomAttributeRenderer', 'render', slice.call(arguments)); }
     const operation = context.beginComponentOperation(renderable, target, instruction);
     const component = context.get<object>(customAttributeKey(instruction.res));
     const instructionRenderers = context.get(IRenderer).instructionRenderers;
@@ -250,7 +239,6 @@ export class CustomAttributeRenderer implements IInstructionRenderer {
     addComponent(renderable, controller);
 
     operation.dispose();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -267,7 +255,6 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: INode, instruction: IHydrateTemplateController, parts?: TemplatePartDefinitions): void {
-    if (Tracer.enabled) { Tracer.enter('TemplateControllerRenderer', 'render', slice.call(arguments)); }
     const factory = this.renderingEngine.getViewFactory(dom, instruction.def, context);
     const operation = context.beginComponentOperation(renderable, target, instruction, factory, parts, dom.convertToRenderLocation(target), false);
     const component = context.get<object>(customAttributeKey(instruction.res));
@@ -303,7 +290,6 @@ export class TemplateControllerRenderer implements IInstructionRenderer {
     addComponent(renderable, controller);
 
     operation.dispose();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -322,7 +308,6 @@ export class LetElementRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: INode, instruction: IHydrateLetElementInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('LetElementRenderer', 'render', slice.call(arguments)); }
     dom.remove(target);
     const childInstructions = instruction.instructions;
     const toViewModel = instruction.toViewModel;
@@ -336,7 +321,6 @@ export class LetElementRenderer implements IInstructionRenderer {
       binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
       addBinding(renderable, binding);
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -355,11 +339,9 @@ export class CallBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: ICallBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('CallBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
     const binding = new CallBinding(expr, getTarget(target), instruction.to, this.observerLocator, context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -376,11 +358,9 @@ export class RefBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: IRefBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('RefBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
     const binding = new RefBinding(expr, getTarget(target), context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -399,7 +379,6 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: IInterpolationInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('InterpolationBindingRenderer', 'render', slice.call(arguments)); }
     let binding: MultiInterpolationBinding | InterpolationBinding;
     const expr = ensureExpression(this.parser, instruction.from, BindingType.Interpolation);
     if (expr.isMulti) {
@@ -408,7 +387,6 @@ export class InterpolationBindingRenderer implements IInstructionRenderer {
       binding = new InterpolationBinding(expr.firstExpression, expr, getTarget(target), instruction.to, BindingMode.toView, this.observerLocator, context, true);
     }
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -427,11 +405,9 @@ export class PropertyBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: IPropertyBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('PropertyBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const binding = new PropertyBinding(expr, getTarget(target), instruction.to, instruction.mode, this.observerLocator, context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -450,10 +426,8 @@ export class IteratorBindingRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: IController, instruction: IIteratorBindingInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('IteratorBindingRenderer', 'render', slice.call(arguments)); }
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
     const binding = new PropertyBinding(expr, getTarget(target), instruction.to, BindingMode.toView, this.observerLocator, context);
     addBinding(renderable, binding);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }

--- a/packages/testing/src/au-dom.ts
+++ b/packages/testing/src/au-dom.ts
@@ -408,19 +408,15 @@ export class AuProjector implements IElementProjector {
   }
 
   public project(nodes: INodeSequence): void {
-    if (Tracer.enabled) { Tracer.enter('AuProjector', 'project', slice.call(arguments)); }
     if (this.host.isRenderLocation) {
       nodes.insertBefore(this.host);
     } else {
       nodes.appendTo(this.host);
     }
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 
   public take(nodes: INodeSequence): void {
-    if (Tracer.enabled) { Tracer.enter('AuProjector', 'take', slice.call(arguments)); }
     nodes.remove();
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 
@@ -664,7 +660,6 @@ export class AuTextRenderer implements IInstructionRenderer {
   }
 
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext<AuNode>, renderable: IController<AuNode>, target: AuNode, instruction: AuTextInstruction): void {
-    if (Tracer.enabled) { Tracer.enter('AuTextRenderer', 'render', slice.call(arguments)); }
     let realTarget: AuNode;
     if (target.isRenderLocation) {
       realTarget = AuNode.createText();
@@ -674,7 +669,6 @@ export class AuTextRenderer implements IInstructionRenderer {
     }
     const bindable = new PropertyBinding(instruction.from, realTarget, 'textContent', BindingMode.toView, this.observerLocator, context);
     addBinding(renderable, bindable);
-    if (Tracer.enabled) { Tracer.leave(); }
   }
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR removes all `Tracer` and `Profiler` calls from the source code, as a first step in cleaning things up a bit and improving the performance for JIT. Later, AOT will add these calls based on configuration flags.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

N/A
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Just a project-wide find/replace, not much to see.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

No new behavior introduced. Existing tests should still pass.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps


<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
