### PR TITLE
feat(runtime): initial implementation for startup tasks

### DIFF
--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -19,7 +19,8 @@ export {
   transient,
   Injectable,
   InterfaceSymbol,
-  InstanceProvider
+  InstanceProvider,
+  Resolved,
 } from './di';
 export {
   Class,

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -1,8 +1,9 @@
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
+import { StartTask } from '@aurelia/runtime';
 
 import { NavCustomElement } from './resources/nav';
 import { ViewportCustomElement } from './resources/viewport';
-import { IRouterOptions, Router } from './router';
+import { IRouterOptions, Router, IRouter } from './router';
 
 export const RouterRegistration = Router as unknown as IRegistry;
 
@@ -11,7 +12,7 @@ export const RouterRegistration = Router as unknown as IRegistry;
  * - `IRouter`
  */
 export const DefaultComponents = [
-  RouterRegistration
+  RouterRegistration,
 ];
 
 export {
@@ -41,7 +42,8 @@ const routerConfiguration = {
   register(container: IContainer): IContainer {
     return container.register(
       ...DefaultComponents,
-      ...DefaultResources
+      ...DefaultResources,
+      StartTask.with(IRouter).beforeAttach().call(router => router.activate())
     );
   },
   /**

--- a/packages/runtime/src/activator.ts
+++ b/packages/runtime/src/activator.ts
@@ -4,11 +4,12 @@ import {
   IResolver,
   IServiceLocator,
   Registration,
+  Key,
 } from '@aurelia/kernel';
 
 import { INode } from './dom';
 import { LifecycleFlags } from './flags';
-import { IViewModel, IController } from './lifecycle';
+import { IController, IViewModel } from './lifecycle';
 import {
   ContinuationTask,
   ILifecycleTask,
@@ -27,6 +28,8 @@ export const IActivator = DI.createInterface<IActivator>('IActivator').withDefau
 
 /** @internal */
 export class Activator implements IActivator {
+  public static readonly inject: readonly Key[] = [IStartTaskManager];
+
   constructor(
     private readonly taskManager: IStartTaskManager,
   ) {}

--- a/packages/runtime/src/activator.ts
+++ b/packages/runtime/src/activator.ts
@@ -8,10 +8,11 @@ import {
 
 import { INode } from './dom';
 import { LifecycleFlags } from './flags';
-import { IViewModel } from './lifecycle';
+import { IViewModel, IController } from './lifecycle';
 import {
   ContinuationTask,
   ILifecycleTask,
+  IStartTaskManager,
 } from './lifecycle-task';
 import { IScope } from './observation';
 import { ExposedContext } from './rendering-engine';
@@ -26,6 +27,10 @@ export const IActivator = DI.createInterface<IActivator>('IActivator').withDefau
 
 /** @internal */
 export class Activator implements IActivator {
+  constructor(
+    private readonly taskManager: IStartTaskManager,
+  ) {}
+
   public static register(container: IContainer): IResolver<IActivator> {
     return Registration.singleton(IActivator, this).register(container);
   }
@@ -38,24 +43,79 @@ export class Activator implements IActivator {
     parentScope?: IScope
   ): ILifecycleTask {
     flags = flags === void 0 ? LifecycleFlags.none : flags;
-    const controller = Controller.forCustomElement(
+    const mgr = this.taskManager;
+
+    let task = mgr.runBeforeRender();
+
+    if (task.done) {
+      this.render(host, component, locator, flags);
+    } else {
+      task = new ContinuationTask(task, this.render, this, host, component, locator, flags);
+    }
+
+    if (task.done) {
+      task = mgr.runBeforeBind();
+    } else {
+      task = new ContinuationTask(task, mgr.runBeforeBind, mgr);
+    }
+
+    if (task.done) {
+      task = this.bind(component, flags, parentScope);
+    } else {
+      task = new ContinuationTask(task, this.bind, this, component, flags, parentScope);
+    }
+
+    if (task.done) {
+      task = mgr.runBeforeAttach();
+    } else {
+      task = new ContinuationTask(task, mgr.runBeforeAttach, mgr);
+    }
+
+    if (task.done) {
+      this.attach(component, flags);
+    } else {
+      task = new ContinuationTask(task, this.attach, this, component, flags);
+    }
+
+    return task;
+  }
+
+  public deactivate(component: IViewModel, flags: LifecycleFlags = LifecycleFlags.fromStopTask): ILifecycleTask {
+    const controller = this.getController(component);
+    controller.detach(flags | LifecycleFlags.fromDetach);
+    return controller.unbind(flags | LifecycleFlags.fromUnbind);
+  }
+
+  private render(
+    host: INode,
+    component: IViewModel,
+    locator: IServiceLocator,
+    flags: LifecycleFlags,
+  ): void {
+    Controller.forCustomElement(
       component,
       locator as ExposedContext,
       host,
       flags,
     );
-    let task = controller.bind(flags | LifecycleFlags.fromBind, parentScope);
-    if (task.done) {
-      controller.attach(flags | LifecycleFlags.fromAttach);
-    } else {
-      task = new ContinuationTask(task, controller.attach, controller, flags | LifecycleFlags.fromAttach);
-    }
-    return task;
   }
 
-  public deactivate(component: IViewModel, flags: LifecycleFlags = LifecycleFlags.fromStopTask): ILifecycleTask {
-    const controller = Controller.forCustomElement(component, (void 0)!, (void 0)!);
-    controller.detach(flags | LifecycleFlags.fromDetach);
-    return controller.unbind(flags | LifecycleFlags.fromUnbind);
+  private bind(
+    component: IViewModel,
+    flags: LifecycleFlags,
+    parentScope?: IScope,
+  ): ILifecycleTask {
+    return this.getController(component).bind(flags | LifecycleFlags.fromBind, parentScope);
+  }
+
+  private attach(
+    component: IViewModel,
+    flags: LifecycleFlags,
+  ): void {
+    this.getController(component).attach(flags | LifecycleFlags.fromAttach);
+  }
+
+  private getController(component: IViewModel): IController {
+    return Controller.forCustomElement(component, (void 0)!, (void 0)!);
   }
 }

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -25,6 +25,7 @@ import {
 import {
   ContinuationTask,
   ILifecycleTask,
+  IStartTaskManager,
   LifecycleTask,
 } from './lifecycle-task';
 import { ExposedContext } from './rendering-engine';
@@ -33,9 +34,6 @@ import {
   ICustomElementType
 } from './resources/custom-element';
 import { Controller } from './templating/controller';
-
-const { enter: enterStart, leave: leaveStart } = Profiler.createTimer('Aurelia.start');
-const { enter: enterStop, leave: leaveStop } = Profiler.createTimer('Aurelia.stop');
 
 export interface ISinglePageApp<THost extends INode = INode> {
   enableTimeSlicing?: boolean;
@@ -51,16 +49,17 @@ type Publisher = { dispatchEvent(evt: unknown, options?: unknown): void };
 export class CompositionRoot<T extends INode = INode> {
   public readonly config: ISinglePageApp<T>;
   public readonly container: IContainer;
-  public readonly controller: IController;
   public readonly host: T & { $au?: Aurelia<T> };
   public readonly dom: IDOM<T>;
-  public readonly viewModel: IHydratedViewModel<T>;
   public readonly strategy: BindingStrategy;
   public readonly lifecycle: ILifecycle;
   public readonly activator: IActivator;
   public task: ILifecycleTask;
-  public hasPendingStartFrame: boolean;
-  public hasPendingStopFrame: boolean;
+
+  public controller?: IController;
+  public viewModel?: IHydratedViewModel<T>;
+
+  private createTask?: ILifecycleTask;
 
   constructor(
     config: ISinglePageApp<T>,
@@ -86,31 +85,30 @@ export class CompositionRoot<T extends INode = INode> {
     const initializer = this.container.get(IDOMInitializer);
     this.dom = initializer.initialize(config) as IDOM<T>;
 
-    this.viewModel = CustomElement.isType(config.component as ICustomElementType)
-      ? this.container.get(config.component as Constructable | {}) as IHydratedViewModel<T>
-      : config.component as IHydratedViewModel<T>;
-
-    this.controller = Controller.forCustomElement(
-      this.viewModel,
-      this.container as ExposedContext,
-      this.host,
-      this.strategy as number,
-    );
     this.lifecycle = this.container.get(ILifecycle);
     this.activator = this.container.get(IActivator);
-    if (config.enableTimeSlicing === true) {
-      this.lifecycle.enableTimeslicing(config.adaptiveTimeSlicing);
+
+    const taskManager = this.container.get(IStartTaskManager);
+    const beforeCreateTask = taskManager.runBeforeCreate();
+
+    if (beforeCreateTask.done) {
+      this.task = LifecycleTask.done;
+      this.create();
     } else {
-      this.lifecycle.disableTimeslicing();
+      this.task = new ContinuationTask(beforeCreateTask, this.create, this);
     }
-    this.task = LifecycleTask.done;
-    this.hasPendingStartFrame = true;
-    this.hasPendingStopFrame = true;
   }
 
   public activate(antecedent?: ILifecycleTask): ILifecycleTask {
     const { task, host, viewModel, container, activator, strategy } = this;
     const flags = strategy | LifecycleFlags.fromStartTask;
+
+    if (viewModel === void 0) {
+      if (this.createTask === void 0) {
+        this.createTask = new ContinuationTask(task, this.activate, this, antecedent);
+      }
+      return this.createTask;
+    }
 
     if (task.done) {
       if (antecedent == void 0 || antecedent.done) {
@@ -134,6 +132,13 @@ export class CompositionRoot<T extends INode = INode> {
     const { task, viewModel, activator, strategy } = this;
     const flags = strategy | LifecycleFlags.fromStopTask;
 
+    if (viewModel === void 0) {
+      if (this.createTask === void 0) {
+        this.createTask = new ContinuationTask(task, this.deactivate, this, antecedent);
+      }
+      return this.createTask;
+    }
+
     if (task.done) {
       if (antecedent == void 0 || antecedent.done) {
         this.task = activator.deactivate(viewModel, flags);
@@ -150,6 +155,25 @@ export class CompositionRoot<T extends INode = INode> {
     }
 
     return this.task;
+  }
+
+  private create(): void {
+    const config = this.config;
+    this.viewModel = CustomElement.isType(config.component as ICustomElementType)
+      ? this.container.get(config.component as Constructable | {}) as IHydratedViewModel<T>
+      : config.component as IHydratedViewModel<T>;
+
+    this.controller = Controller.forCustomElement(
+      this.viewModel,
+      this.container as ExposedContext,
+      this.host,
+      this.strategy as number,
+    );
+    if (config.enableTimeSlicing === true) {
+      this.lifecycle.enableTimeslicing(config.adaptiveTimeSlicing);
+    } else {
+      this.lifecycle.disableTimeslicing();
+    }
   }
 }
 

--- a/packages/runtime/src/configuration.ts
+++ b/packages/runtime/src/configuration.ts
@@ -5,6 +5,7 @@ import {
 } from '@aurelia/kernel';
 
 import { Lifecycle } from './lifecycle';
+import { StartTaskManager } from './lifecycle-task';
 import { ObserverLocator } from './observation/observer-locator';
 import {
   CallBindingRenderer,
@@ -41,6 +42,7 @@ import { SanitizeValueConverter } from './resources/value-converters/sanitize';
 export const IObserverLocatorRegistration = ObserverLocator as IRegistry;
 export const ILifecycleRegistration = Lifecycle as IRegistry;
 export const IRendererRegistration = Renderer as IRegistry;
+export const IStartTaskManagerRegistration = StartTaskManager as IRegistry;
 
 /**
  * Default implementations for the following interfaces:
@@ -51,7 +53,8 @@ export const IRendererRegistration = Renderer as IRegistry;
 export const DefaultComponents = [
   IObserverLocatorRegistration,
   ILifecycleRegistration,
-  IRendererRegistration
+  IRendererRegistration,
+  IStartTaskManagerRegistration,
 ];
 
 export const IfRegistration = If as IRegistry;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -408,7 +408,12 @@ export {
   ContinuationTask,
   ILifecycleTask,
   LifecycleTask,
-  PromiseTask
+  PromiseTask,
+  TaskSlot,
+  StartTask,
+  IStartTask,
+  IStartTaskManager,
+  ProviderTask,
 } from './lifecycle-task';
 export {
   AccessorOrObserver,

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -1,3 +1,12 @@
+import {
+  DI,
+  IContainer,
+  IResolver,
+  IServiceLocator,
+  Key,
+  Registration,
+  Resolved,
+} from '@aurelia/kernel';
 
 export type PromiseOrTask = Promise<unknown> | ILifecycleTask;
 export type MaybePromiseOrTask = void | PromiseOrTask;
@@ -10,6 +19,211 @@ export const LifecycleTask = {
     wait(): Promise<unknown> { return Promise.resolve(); }
   }
 };
+
+export const enum TaskSlot {
+  beforeCreate = 0,
+  beforeRender = 1,
+  beforeBind   = 2,
+  beforeAttach = 3,
+}
+
+export const IStartTask = DI.createInterface<IStartTask>('IStartTask').noDefault();
+
+export interface IStartTask {
+  readonly slot: TaskSlot;
+  resolveTask(): ILifecycleTask;
+  register(container: IContainer): IContainer;
+}
+
+export interface ISlotChooser {
+  beforeCreate(): IStartTask;
+  beforeRender(): IStartTask;
+  beforeBind(): IStartTask;
+  beforeAttach(): IStartTask;
+  at(slot: TaskSlot): IStartTask;
+}
+
+export interface ICallbackSlotChooser<K extends Key> {
+  beforeCreate(): ICallbackChooser<K>;
+  beforeRender(): ICallbackChooser<K>;
+  beforeBind(): ICallbackChooser<K>;
+  beforeAttach(): ICallbackChooser<K>;
+  at(slot: TaskSlot): ICallbackChooser<K>;
+}
+
+export interface ICallbackChooser<K extends Key> {
+  call<K1 extends Key = K>(fn: (instance: Resolved<K1>) => PromiseOrTask): IStartTask;
+}
+
+const enum TaskType {
+  with,
+  from,
+}
+
+export const StartTask = class $StartTask implements IStartTask {
+  public get slot(): TaskSlot {
+    if (this._slot === void 0) {
+      throw new Error('StartTask.slot is not set');
+    }
+    return this._slot;
+  }
+  public get promiseOrTask(): PromiseOrTask {
+    if (this._promiseOrTask === void 0) {
+      throw new Error('StartTask.promiseOrTask is not set');
+    }
+    return this._promiseOrTask;
+  }
+  public get container(): IContainer {
+    if (this._container === void 0) {
+      throw new Error('StartTask.container is not set');
+    }
+    return this._container;
+  }
+  public get key(): Key {
+    if (this._key === void 0) {
+      throw new Error('StartTask.key is not set');
+    }
+    return this._key;
+  }
+  public get callback(): (instance: unknown) => PromiseOrTask {
+    if (this._callback === void 0) {
+      throw new Error('StartTask.callback is not set');
+    }
+    return this._callback;
+  }
+  public get task(): ILifecycleTask {
+    if (this._task === void 0) {
+      throw new Error('StartTask.task is not set');
+    }
+    return this._task;
+  }
+
+  private _slot?: TaskSlot = void 0;
+  private _promiseOrTask?: PromiseOrTask = void 0;
+  private _container?: IContainer = void 0;
+  private _key?: Key = void 0;
+  private _callback?: (instance: unknown) => PromiseOrTask = void 0;
+  private _task?: ILifecycleTask = void 0;
+
+  private constructor(
+    private readonly type: TaskType,
+  ) {}
+
+  public static with<K extends Key>(key: K): ICallbackSlotChooser<K> {
+    const task = new $StartTask(TaskType.with);
+    task._key = key;
+    return task as ICallbackSlotChooser<K>;
+  }
+
+  public static from(task: ILifecycleTask): ISlotChooser;
+  public static from(promise: Promise<unknown>): ISlotChooser;
+  public static from(promiseOrTask: PromiseOrTask): ISlotChooser;
+  public static from(promiseOrTask: PromiseOrTask): ISlotChooser {
+    const task = new $StartTask(TaskType.from);
+    task._promiseOrTask = promiseOrTask;
+    return task;
+  }
+
+  public beforeCreate(): $StartTask {
+    return this.at(TaskSlot.beforeCreate);
+  }
+
+  public beforeRender(): $StartTask {
+    return this.at(TaskSlot.beforeRender);
+  }
+
+  public beforeBind(): $StartTask {
+    return this.at(TaskSlot.beforeBind);
+  }
+
+  public beforeAttach(): $StartTask {
+    return this.at(TaskSlot.beforeAttach);
+  }
+
+  public at(slot: TaskSlot): $StartTask {
+    this._slot = slot;
+    return this;
+  }
+
+  public call(fn: (instance: unknown) => PromiseOrTask): $StartTask {
+    this._callback = fn;
+    return this;
+  }
+
+  public register(container: IContainer): IContainer {
+    return this._container = container.register(Registration.instance(IStartTask, this));
+  }
+
+  public resolveTask(): ILifecycleTask {
+    if (this._task === void 0) {
+      switch (this.type) {
+        case TaskType.with:
+          this._task = new TerminalTask(this.promiseOrTask);
+          break;
+        case TaskType.from:
+          this._task = new ProviderTask(this.container, this.key, this.callback);
+          break;
+      }
+    }
+    return this.task;
+  }
+} as {
+  with<K extends Key>(key: K): ICallbackSlotChooser<K>;
+  from(task: ILifecycleTask): ISlotChooser;
+  from(promise: Promise<unknown>): ISlotChooser;
+  from(promiseOrTask: PromiseOrTask): ISlotChooser;
+};
+
+export const IStartTaskManager = DI.createInterface<IStartTaskManager>('IStartTaskManager').noDefault();
+
+export interface IStartTaskManager {
+  runBeforeCreate(container?: IContainer): ILifecycleTask;
+  runBeforeRender(container?: IContainer): ILifecycleTask;
+  runBeforeBind(container?: IContainer): ILifecycleTask;
+  runBeforeAttach(container?: IContainer): ILifecycleTask;
+  run(slot: TaskSlot, container?: IContainer): ILifecycleTask;
+}
+
+export class StartTaskManager implements IStartTaskManager {
+  public static readonly inject: readonly Key[] = [IServiceLocator];
+
+  constructor(
+    private readonly locator: IServiceLocator,
+  ) {}
+
+  public static register(container: IContainer): IResolver<IStartTaskManager> {
+    return Registration.singleton(IStartTaskManager, this).register(container);
+  }
+
+  public runBeforeCreate(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeCreate, locator);
+  }
+
+  public runBeforeRender(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeRender, locator);
+  }
+
+  public runBeforeBind(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeBind, locator);
+  }
+
+  public runBeforeAttach(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeAttach, locator);
+  }
+
+  public run(slot: TaskSlot, locator: IServiceLocator = this.locator): ILifecycleTask {
+    const tasks = locator.getAll(IStartTask)
+      .filter(startTask => startTask.slot === slot)
+      .map(startTask => startTask.resolveTask())
+      .filter(task => !task.done);
+
+    if (tasks.length === 0) {
+      return LifecycleTask.done;
+    }
+
+    return new AggregateTerminalTask(tasks);
+  }
+}
 
 export interface ILifecycleTask<T = unknown> {
   readonly done: boolean;
@@ -67,6 +281,47 @@ export class PromiseTask<TArgs extends unknown[], T = void> implements ILifecycl
   }
 
   public wait(): Promise<unknown> {
+    return this.promise;
+  }
+}
+
+export class ProviderTask implements ILifecycleTask {
+  public done: boolean;
+
+  private promise?: Promise<unknown>;
+
+  constructor(
+    private container: IContainer,
+    private key: Key,
+    private callback: (instance: unknown) => PromiseOrTask,
+  ) {
+    this.done = false;
+  }
+
+  public canCancel(): boolean {
+    return false;
+  }
+
+  public cancel(): void {
+    return;
+  }
+
+  public wait(): Promise<unknown> {
+    if (this.promise === void 0) {
+      const instance = this.container.get(this.key);
+      const promiseOrTask = this.callback.call(void 0, instance);
+
+      this.promise = (promiseOrTask as Promise<unknown>).then instanceof Function
+        ? promiseOrTask as Promise<unknown>
+        : (promiseOrTask as ILifecycleTask).wait();
+
+      this.promise = this.promise.then(() => {
+        this.done = true;
+        this.container = (void 0)!;
+        this.key = (void 0)!;
+        this.callback = (void 0)!;
+      }).catch(e => { throw e; });
+    }
     return this.promise;
   }
 }

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -386,7 +386,7 @@ export function fail(message: string | Error = 'Failed'): never {
 }
 
 export function visibleTextEqual(root: CompositionRoot, expectedText: string, message?: string): void {
-  const actualText = getVisibleText(root.controller, root.host as Node);
+  const actualText = getVisibleText(root.controller!, root.host as Node);
   if (actualText !== expectedText) {
     innerFail({
       actual: actualText,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This is a somewhat quick-n-dirty startup task implementation, mostly to get some API feedback and get the ball rolling. I hope others can help me refine/improve/test this.

The idea is that you create a task from a fluent API and register the created object with DI. The activator then resolves all tasks and executes them at the right times during initial startup.

There are 4 "slots": `beforeCreate`, `beforeRender`, `beforeBind` and `beforeAttach`.
- `beforeCreate` will run "before app()" in a sense, that is, it will run before the root App is instantiated from DI. This is where you can, for example, manipulate container registrations while all static registrations are already available.
-`beforeRender` runs before the app root is rendered / controller created. So you could for example manipulate the app root before its compilation. Technically equivalent to the `constructor` of the app root.
- `beforeBind` runs after render and before the bind lifecycle starts on the root. Technically equivalent to the `created` hook in the app root.
- `beforeAttach` runs after the `binding` + `bound` lifecycles fully completed and before `attach` starts. Technically equivalent to the `bound` hook in the app root.

So while `beforeRender`, `beforeBind` and `beforeAttach` can, timing-wise, be accomplished from within the app root, these hooks actually allow plugin authors (who have no control over the app root) to plug in logic at these points in time.

Furthermore, there are 2 "methods": `from` and `with`
- `from` creates the task "from" a promise or existing task.
- `with` allows you to specify a registration key, and a callback that returns that resolved component where you can then perform logic (e.g. call a method on the component) that then returns a promise or task.

To just dive in with some examples:

```ts
StartTask.with(IRouter).beforeAttach().call(router => router.activate()) // initial idea for the router
StartTask.with(IComponent).beforeCreate().call(component => component.doStuff())
StartTask.with(IComponent).at(TaskSlot.beforeCreate).call(component => component.doStuff())
StartTask.from(async () => {
  await doStuff();
  doOtherStuff();
}).beforeBind();
```

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

- There's a new task type `ProviderTask` for the DI callback, [implementation here](https://github.com/aurelia/aurelia/compare/start-task?expand=1#diff-5aa3f5afe915c59e4045e33de04f8339R288)
- `StartTaskManager` is the facade that wraps all tasks for a slot into an aggregate task, [implementation here](https://github.com/aurelia/aurelia/compare/start-task?expand=1#diff-5aa3f5afe915c59e4045e33de04f8339R187)
- The placement of `beforeCreate` sits in [the CompositionRoot](https://github.com/aurelia/aurelia/compare/start-task?expand=1#diff-0bcdaa7de1d39a267573c522d86a0850R92)
- The placements of `beforeRender`, `beforeBind` and `beforeAttach` sit [in the activator](https://github.com/aurelia/aurelia/compare/start-task?expand=1#diff-d98c0115270b529c1d794c910c81f1d5R48)
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

There are no tests at the moment. Any volunteers to help out would be greatly appreciated.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Test it :)
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
