### PR TITLE
Child Observation

### DIFF
--- a/packages/__tests__/runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/runtime-html/children-observer.spec.ts
@@ -1,0 +1,93 @@
+import { children, Aurelia, CustomElement } from '@aurelia/runtime';
+import { TestContext, assert } from '@aurelia/testing';
+import { IContainer } from '@aurelia/kernel';
+
+describe('ChildrenObserver', () => {
+  it('populates children array with child view models', () => {
+    const { au, viewModel, ChildOne, ChildTwo } = createAppAndStart();
+    const children = viewModel.children;
+
+    assert.equal(viewModel.children.length, 2);
+    assert.instanceOf(children[0], ChildOne);
+    assert.instanceOf(children[1], ChildTwo);
+
+    au.stop();
+  });
+
+  function createAppAndStart() {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container } = ctx;
+
+    const ElementWithChildren = defineAndRegisterElementWithChildren(container);
+    const ChildOne = defineAndRegisterElement('child-one', container);
+    const ChildTwo = defineAndRegisterElement('child-two', container);
+    const HostElement = defineAndRegisterElementWithTemplate(
+      'host-element',
+      `
+        <element-with-children>
+          <child-one></child-one>
+          <child-two></child-two>
+        </element-with-children>
+      `,
+      container
+    );
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement(HostElement.description.name);
+
+    au.app({ host, component: HostElement });
+    au.start();
+
+    const viewModel = (host.childNodes[1] as any).$controller.viewModel;
+
+    return {
+      au,
+      viewModel,
+      ChildOne,
+      ChildTwo
+    };
+  }
+
+  function defineAndRegisterElementWithChildren(container: IContainer) {
+    class ElementWithChildren {
+      @children children;
+    }
+
+    const element = CustomElement.define({
+      name: 'element-with-children',
+      template: `<slot></slot>`
+    }, ElementWithChildren);
+
+    container.register(element);
+
+    return element;
+  }
+
+  function defineAndRegisterElementWithTemplate(name: string, template: string, container: IContainer) {
+    class ElementWithTemplate {
+    }
+
+    const element = CustomElement.define({
+      name: name,
+      template
+    }, ElementWithTemplate);
+
+    container.register(element);
+
+    return element;
+  }
+
+  function defineAndRegisterElement(name: string, container: IContainer) {
+    class Element {
+    }
+
+    const element = CustomElement.define({
+      name: name,
+      template: `<div>My name is ${name}.`
+    }, Element);
+
+    container.register(element);
+
+    return element;
+  }
+});

--- a/packages/__tests__/runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/runtime-html/children-observer.spec.ts
@@ -1,56 +1,165 @@
 import { children, Aurelia, CustomElement } from '@aurelia/runtime';
 import { TestContext, assert } from '@aurelia/testing';
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, PLATFORM } from '@aurelia/kernel';
+import { ChildrenObserverSource } from '@aurelia/runtime/dist/definitions';
 
 describe('ChildrenObserver', () => {
-  it('populates children array with child view models', () => {
-    const { au, viewModel, ChildOne, ChildTwo } = createAppAndStart();
-    const children = viewModel.children;
+  describe('populates', () => {
+    it('children array with child view models', () => {
+      const { au, viewModel, ChildOne, ChildTwo } = createAppAndStart();
+      assert.equal(viewModel.children.length, 2);
+      assert.instanceOf(viewModel.children[0], ChildOne);
+      assert.instanceOf(viewModel.children[1], ChildTwo);
 
-    assert.equal(viewModel.children.length, 2);
-    assert.instanceOf(children[0], ChildOne);
-    assert.instanceOf(children[1], ChildTwo);
+      au.stop();
+    });
 
-    au.stop();
+    it('children array with by custom query', () => {
+      const { au, viewModel, ChildOne } = createAppAndStart({
+        query: p => (p.host as HTMLElement).querySelectorAll('.child-one')
+      });
+
+      assert.equal(viewModel.children.length, 1);
+      assert.instanceOf(viewModel.children[0], ChildOne);
+
+      au.stop();
+    });
+
+    it('children array with by custom query, filter, and map', () => {
+      const { au, viewModel, ChildOne } = createAppAndStart({
+        query: p => (p.host as HTMLElement).querySelectorAll('.child-one'),
+        filter: (node) => !!node,
+        map: (node) => node
+      });
+
+      assert.equal(viewModel.children.length, 1);
+      assert.equal(viewModel.children[0].tagName, ChildOne.description.name.toUpperCase());
+
+      au.stop();
+    });
   });
 
-  function createAppAndStart() {
+  describe('updates', () => {
+    if (!PLATFORM.isBrowserLike) {
+      return;
+    }
+
+    it('children array with child view models', (done) => {
+      const { au, viewModel, ChildOne, ChildTwo, hostViewModel } = createAppAndStart();
+
+      assert.equal(viewModel.children.length, 2);
+      assert.equal(viewModel.childrenChangedCallCount, 0);
+
+      hostViewModel.oneCount = 2;
+      hostViewModel.twoCount = 2;
+
+      waitForUpdate(() => {
+        assert.equal(viewModel.children.length, 4);
+        assert.equal(viewModel.childrenChangedCallCount, 1);
+        assert.instanceOf(viewModel.children[0], ChildOne);
+        assert.instanceOf(viewModel.children[1], ChildOne);
+        assert.instanceOf(viewModel.children[2], ChildTwo);
+        assert.instanceOf(viewModel.children[3], ChildTwo);
+        au.stop();
+        done();
+      });
+    });
+
+    it('children array with by custom query', (done) => {
+      const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
+        query: p => (p.host as HTMLElement).querySelectorAll('.child-two')
+      });
+
+      assert.equal(viewModel.children.length, 1);
+      assert.instanceOf(viewModel.children[0], ChildTwo);
+      assert.equal(viewModel.childrenChangedCallCount, 0);
+
+      hostViewModel.oneCount = 2;
+      hostViewModel.twoCount = 2;
+
+      waitForUpdate(() => {
+        assert.equal(viewModel.children.length, 2);
+        assert.equal(viewModel.childrenChangedCallCount, 1);
+        assert.instanceOf(viewModel.children[0], ChildTwo);
+        assert.instanceOf(viewModel.children[1], ChildTwo);
+        au.stop();
+        done();
+      });
+    });
+
+    it('children array with by custom query, filter, and map', (done) => {
+      const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
+        query: p => (p.host as HTMLElement).querySelectorAll('.child-two'),
+        filter: (node) => !!node,
+        map: (node) => node
+      });
+
+      const tagName = ChildTwo.description.name.toUpperCase();
+
+      assert.equal(viewModel.children.length, 1);
+      assert.equal(viewModel.children[0].tagName, tagName);
+      assert.equal(viewModel.childrenChangedCallCount, 0);
+
+      hostViewModel.oneCount = 2;
+      hostViewModel.twoCount = 2;
+
+      waitForUpdate(() => {
+        assert.equal(viewModel.children.length, 2);
+        assert.equal(viewModel.childrenChangedCallCount, 1);
+        assert.equal(viewModel.children[0].tagName, tagName);
+        assert.equal(viewModel.children[1].tagName, tagName);
+        au.stop();
+        done();
+      });
+    });
+  });
+
+  function waitForUpdate(callback: Function) {
+    Promise.resolve().then(() => callback());
+  }
+
+  function createAppAndStart(childrenOptions?: ChildrenObserverSource) {
     const ctx = TestContext.createHTMLTestContext();
     const { container } = ctx;
 
-    const ElementWithChildren = defineAndRegisterElementWithChildren(container);
+    const HostElement = defineAndRegisterElementWithChildren(container, childrenOptions);
     const ChildOne = defineAndRegisterElement('child-one', container);
     const ChildTwo = defineAndRegisterElement('child-two', container);
-    const HostElement = defineAndRegisterElementWithTemplate(
-      'host-element',
+    const component = defineAndRegisterHost(
       `
         <element-with-children>
-          <child-one></child-one>
-          <child-two></child-two>
+          <child-one repeat.for="n of oneCount" class="child-one"></child-one>
+          <child-two repeat.for="n of twoCount" class="child-two"></child-two>
         </element-with-children>
       `,
       container
     );
 
     const au = new Aurelia(container);
-    const host = ctx.createElement(HostElement.description.name);
+    const host = ctx.createElement(component.description.name);
 
-    au.app({ host, component: HostElement });
+    au.app({ host, component });
     au.start();
 
-    const viewModel = (host.childNodes[1] as any).$controller.viewModel;
+    const hostViewModel = (host as any).$controller.viewModel;
+    const viewModel = (host.children[0] as any).$controller.viewModel;
 
     return {
       au,
+      hostViewModel,
       viewModel,
       ChildOne,
       ChildTwo
     };
   }
 
-  function defineAndRegisterElementWithChildren(container: IContainer) {
+  function defineAndRegisterElementWithChildren(container: IContainer, options?: ChildrenObserverSource) {
     class ElementWithChildren {
-      @children children;
+      @children(options) public children;
+      public childrenChangedCallCount = 0;
+      public childrenChanged() {
+        this.childrenChangedCallCount++;
+      }
     }
 
     const element = CustomElement.define({
@@ -63,14 +172,16 @@ describe('ChildrenObserver', () => {
     return element;
   }
 
-  function defineAndRegisterElementWithTemplate(name: string, template: string, container: IContainer) {
-    class ElementWithTemplate {
+  function defineAndRegisterHost(template: string, container: IContainer) {
+    class HostElement {
+      oneCount = 1;
+      twoCount = 1;
     }
 
     const element = CustomElement.define({
-      name: name,
+      name: 'host-element',
       template
-    }, ElementWithTemplate);
+    }, HostElement);
 
     container.register(element);
 

--- a/packages/__tests__/runtime/controller.spec.ts
+++ b/packages/__tests__/runtime/controller.spec.ts
@@ -147,6 +147,7 @@ describe.skip('controller', function () {
       strategy: BindingStrategy.getterSetter,
       hooks,
       scopeParts: PLATFORM.emptyArray,
+      childrenObservers: PLATFORM.emptyObject
     });
   }
 

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -76,9 +76,9 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
     return this.host.childNodes;
   }
 
-  public subscribeToChildrenChange(callback: () => void): void {
+  public subscribeToChildrenChange(callback: () => void, options = childObserverOptions): void {
     // TODO: add a way to dispose/disconnect
-    this.dom.createNodeObserver!(this.host, callback, childObserverOptions);
+    this.dom.createNodeObserver!(this.host, callback, options);
   }
 
   public provideEncapsulationSource(): CustomElementHost<ShadowRoot> {
@@ -117,9 +117,7 @@ export class ContainerlessProjector implements IElementProjector<Node> {
   }
 
   public subscribeToChildrenChange(callback: () => void): void {
-    // TODO: add a way to dispose/disconnect
-    const observer = new MutationObserver(callback);
-    observer.observe(this.host, childObserverOptions);
+    // Containerless does not have a container node to observe children on.
   }
 
   public provideEncapsulationSource(): Node {

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -73,12 +73,12 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
   }
 
   public get children(): ArrayLike<CustomElementHost<Node>> {
-    return this.shadowRoot.childNodes;
+    return this.host.childNodes;
   }
 
   public subscribeToChildrenChange(callback: () => void): void {
     // TODO: add a way to dispose/disconnect
-    this.dom.createNodeObserver!(this.shadowRoot, callback, childObserverOptions);
+    this.dom.createNodeObserver!(this.host, callback, childObserverOptions);
   }
 
   public provideEncapsulationSource(): CustomElementHost<ShadowRoot> {

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -117,6 +117,7 @@ export class ContainerlessProjector implements IElementProjector<Node> {
   }
 
   public subscribeToChildrenChange(callback: () => void): void {
+    // TODO: turn this into an error
     // Containerless does not have a container node to observe children on.
   }
 

--- a/packages/runtime-html/src/resources/custom-elements/compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/compose.ts
@@ -68,6 +68,7 @@ export class Compose<T extends INode = Node> {
     strategy: BindingStrategy.getterSetter,
     hooks: Object.freeze(new HooksDefinition(Compose.prototype)),
     scopeParts: PLATFORM.emptyArray,
+    childrenObservers: PLATFORM.emptyObject
   });
 
   public readonly id: number;

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -22,6 +22,8 @@ import {
   ensureValidStrategy
 } from './flags';
 import { Bindable } from './templating/bindable';
+import { INode } from './dom';
+import { IController } from './lifecycle';
 
 export type IElementHydrationOptions = { parts?: Record<string, TemplateDefinition> };
 
@@ -32,6 +34,13 @@ export interface IBindableDescription {
   callback?: string;
   attribute?: string;
   property?: string;
+}
+
+export interface IChildrenObserverDescription {
+  callback?: string;
+  property?: string;
+  filter?: (node: INode, controller?: IController, viewModel?: any) => boolean;
+  select?: (node: INode, controller?: IController, viewModel?: any) => any;
 }
 
 /**
@@ -70,6 +79,7 @@ export interface ITemplateDefinition extends IResourceDefinition {
   build?: IBuildInstruction;
   surrogates?: ITargetedInstruction[];
   bindables?: Record<string, IBindableDescription> | string[];
+  childrenObservers?: Record<string, IChildrenObserverDescription>
   containerless?: boolean;
   shadowOptions?: { mode: 'open' | 'closed' };
   hasSlots?: boolean;

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -43,7 +43,7 @@ export interface IChildrenObserverDescription<TNode extends INode = INode> {
   options?: MutationObserverInit;
   query?: (projector: IElementProjector<TNode>) => ArrayLike<TNode>;
   filter?: (node: INode, controller?: IController<TNode>, viewModel?: IViewModel<TNode>) => boolean;
-  map?: <T>(node: INode, controller?: IController<TNode>, viewModel?: IViewModel<TNode>) => T;
+  map?: (node: INode, controller?: IController<TNode>, viewModel?: IViewModel<TNode>) => any;
 }
 
 export type ChildrenObserverSource = Omit<IChildrenObserverDescription, 'property'>;

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -23,7 +23,7 @@ import {
 } from './flags';
 import { Bindable } from './templating/bindable';
 import { INode } from './dom';
-import { IController } from './lifecycle';
+import { IController, IViewModel } from './lifecycle';
 import { IElementProjector } from './resources/custom-element';
 
 export type IElementHydrationOptions = { parts?: Record<string, TemplateDefinition> };
@@ -37,14 +37,16 @@ export interface IBindableDescription {
   property?: string;
 }
 
-export interface IChildrenObserverDescription {
+export interface IChildrenObserverDescription<TNode extends INode = INode> {
   callback?: string;
   property?: string;
   options?: MutationObserverInit;
-  query?: (projector: IElementProjector) => ArrayLike<INode>;
-  filter?: (node: INode, controller?: IController, viewModel?: any) => boolean;
-  map?: (node: INode, controller?: IController, viewModel?: any) => any;
+  query?: (projector: IElementProjector<TNode>) => ArrayLike<TNode>;
+  filter?: (node: INode, controller?: IController<TNode>, viewModel?: IViewModel<TNode>) => boolean;
+  map?: <T>(node: INode, controller?: IController<TNode>, viewModel?: IViewModel<TNode>) => T;
 }
+
+export type ChildrenObserverSource = Omit<IChildrenObserverDescription, 'property'>;
 
 /**
  * TargetedInstructionType enum values become the property names for the associated renderers when they are injected
@@ -268,6 +270,7 @@ class DefaultTemplateDefinition implements Required<ITemplateDefinition> {
   public build: IBuildInstruction;
   public surrogates: ITargetedInstruction[];
   public bindables: Record<string, IBindableDescription> | string[];
+  public childrenObservers: Record<string, IChildrenObserverDescription>;
   public containerless: boolean;
   public shadowOptions: { mode: 'open' | 'closed' };
   public hasSlots: boolean;
@@ -281,6 +284,7 @@ class DefaultTemplateDefinition implements Required<ITemplateDefinition> {
     this.cache = 0;
     this.build = buildNotRequired;
     this.bindables = PLATFORM.emptyObject;
+    this.childrenObservers = PLATFORM.emptyObject;
     this.instructions = PLATFORM.emptyArray as typeof PLATFORM.emptyArray & this['instructions'];
     this.dependencies = PLATFORM.emptyArray as typeof PLATFORM.emptyArray & this['dependencies'];
     this.surrogates = PLATFORM.emptyArray as typeof PLATFORM.emptyArray & this['surrogates'];
@@ -313,6 +317,7 @@ export type CustomElementConstructor = Constructable & {
   containerless?: TemplateDefinition['containerless'];
   shadowOptions?: TemplateDefinition['shadowOptions'];
   bindables?: TemplateDefinition['bindables'];
+  childrenObservers?: TemplateDefinition['childrenObservers'];
 };
 
 export function buildTemplateDefinition(
@@ -339,7 +344,8 @@ export function buildTemplateDefinition(
   containerless?: boolean | null,
   shadowOptions?: { mode: 'open' | 'closed' } | null,
   hasSlots?: boolean | null,
-  strategy?: BindingStrategy | null): TemplateDefinition;
+  strategy?: BindingStrategy | null,
+  childrenObservers?: Record<string, IChildrenObserverDescription> | null): TemplateDefinition;
 // tslint:disable-next-line:parameters-max-number // TODO: Reduce complexity (currently at 64)
 export function buildTemplateDefinition(
   ctor: CustomElementConstructor | null,
@@ -354,13 +360,15 @@ export function buildTemplateDefinition(
   containerless?: boolean | null,
   shadowOptions?: { mode: 'open' | 'closed' } | null,
   hasSlots?: boolean | null,
-  strategy?: BindingStrategy | null): TemplateDefinition {
+  strategy?: BindingStrategy | null,
+  childrenObservers?: Record<string, IChildrenObserverDescription> | null): TemplateDefinition {
 
   const def = new DefaultTemplateDefinition();
 
   // all cases fall through intentionally
   const argLen = arguments.length;
   switch (argLen) {
+    case 14: if (childrenObservers !== null) def.childrenObservers = { ...childrenObservers };
     case 13: if (strategy != null) def.strategy = ensureValidStrategy(strategy);
     case 12: if (hasSlots != null) def.hasSlots = hasSlots!;
     case 11: if (shadowOptions != null) def.shadowOptions = shadowOptions!;
@@ -382,6 +390,9 @@ export function buildTemplateDefinition(
         }
         if (ctor.shadowOptions) {
           def.shadowOptions = ctor.shadowOptions as unknown as { mode: 'open' | 'closed' };
+        }
+        if (ctor.childrenObservers) {
+          def.childrenObservers = ctor.childrenObservers;
         }
         if (ctor.prototype) {
           def.hooks = new HooksDefinition(ctor.prototype);
@@ -410,6 +421,13 @@ export function buildTemplateDefinition(
             def.bindables = Bindable.for(nameOrDef as unknown as {}).get();
           } else {
             Object.assign(def.bindables, nameOrDef.bindables);
+          }
+        }
+        if (nameOrDef['childrenObservers']) {
+          if (def.childrenObservers === PLATFORM.emptyObject) {
+            def.childrenObservers = { ...nameOrDef.childrenObservers };
+          } else {
+            Object.assign(def.childrenObservers, nameOrDef.childrenObservers);
           }
         }
       }

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -24,6 +24,7 @@ import {
 import { Bindable } from './templating/bindable';
 import { INode } from './dom';
 import { IController } from './lifecycle';
+import { IElementProjector } from './resources/custom-element';
 
 export type IElementHydrationOptions = { parts?: Record<string, TemplateDefinition> };
 
@@ -39,8 +40,10 @@ export interface IBindableDescription {
 export interface IChildrenObserverDescription {
   callback?: string;
   property?: string;
+  options?: MutationObserverInit;
+  query?: (projector: IElementProjector) => ArrayLike<INode>;
   filter?: (node: INode, controller?: IController, viewModel?: any) => boolean;
-  select?: (node: INode, controller?: IController, viewModel?: any) => any;
+  map?: (node: INode, controller?: IController, viewModel?: any) => any;
 }
 
 /**

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -464,7 +464,7 @@ export {
 export {
   CompiledTemplate,
   createRenderContext,
-  IChildrenObserver,
+  ChildrenObserver,
   IInstructionRenderer,
   IInstructionTypeClassifier,
   IRenderer,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -272,6 +272,13 @@ export {
   WithBindables,
   Bindable,
 } from './templating/bindable';
+
+export {
+  children,
+  ChildrenDecorator,
+  HasChildrenObservers
+} from './templating/children';
+
 // These exports are temporary until we have a proper way to unit test them
 export {
   Controller,

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -425,7 +425,6 @@ export class ChildrenObserver implements Partial<IChildrenObserver> {
   private select: typeof defaultChildSelect;
 
   constructor(
-    lifecycle: ILifecycle,
     controller: IController,
     filter = defaultChildFilter,
     select = defaultChildSelect
@@ -435,7 +434,7 @@ export class ChildrenObserver implements Partial<IChildrenObserver> {
     this.select = select;
     this.children = (void 0)!;
     this.controller = controller;
-    this.lifecycle = lifecycle;
+    this.lifecycle = controller.lifecycle;
     this.projector = this.controller.projector!;
     this.observing = false;
     this.ticking = false;

--- a/packages/runtime/src/rendering-engine.ts
+++ b/packages/runtime/src/rendering-engine.ts
@@ -437,6 +437,8 @@ export class ChildrenObserver {
     this.observing = false;
     this.persistentFlags = flags & LifecycleFlags.persistentBindingFlags;
 
+    this.createGetterSetter();
+
     if (this.callback === void 0) {
       this.observing = false;
     } else {
@@ -461,7 +463,6 @@ export class ChildrenObserver {
       this.observing = true;
       this.children = filterChildren(this.projector.children, this.filter, this.select);
       this.projector.subscribeToChildrenChange(() => { this.onChildrenChanged(); });
-      this.createGetterSetter();
     }
   }
 

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -44,7 +44,7 @@ export interface IElementProjector<T extends INode = INode> {
   project(nodes: INodeSequence<T>): void;
   take(nodes: INodeSequence<T>): void;
 
-  subscribeToChildrenChange(callback: () => void): void;
+  subscribeToChildrenChange(callback: () => void, options?: any): void;
 }
 
 export const IProjectorLocator = DI.createInterface<IProjectorLocator>('IProjectorLocator').noDefault();

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -106,31 +106,6 @@ export const CustomElement: Readonly<ICustomElementResource> = Object.freeze({
   },
 });
 
-// tslint:enable:align
-
-// TODO
-// ## DefaultSlotProjector
-// An implementation of IElementProjector that can handle a subset of default
-// slot projection scenarios without needing real Shadow DOM.
-// ### Conditions
-// We can do a one-time, static composition of the content and view,
-// to emulate shadow DOM, if the following constraints are met:
-// * There must be exactly one slot and it must be a default slot.
-// * The default slot must not have any fallback content.
-// * The default slot must not have a custom element as its immediate parent or
-//   a slot attribute (re-projection).
-// ### Projection
-// The projector copies all content nodes to the slot's location.
-// The copy process should inject a comment node before and after the slotted
-// content, so that the bounds of the content can be clearly determined,
-// even if the slotted content has template controllers or string interpolation.
-// ### Encapsulation Source
-// Uses the same strategy as HostProjector.
-// ### Children
-// The projector adds a mutation observer to the parent node of the
-// slot comment. When direct children of that node change, the projector
-// will gather up all nodes between the start and end slot comments.
-
 export interface ICustomElementDecorator {
   // Using a type breaks syntax highlighting: https://github.com/Microsoft/TypeScript-TmLanguage/issues/481
   // tslint:disable-next-line:callable-types

--- a/packages/runtime/src/templating/children.ts
+++ b/packages/runtime/src/templating/children.ts
@@ -1,0 +1,67 @@
+import { ChildrenObserverSource, ITemplateDefinition, IChildrenObserverDescription } from '../definitions';
+import { Constructable } from '@aurelia/kernel';
+
+export type HasChildrenObservers = Pick<ITemplateDefinition, 'childrenObservers'>;
+export type ChildrenDecorator = <T extends InstanceType<Constructable & Partial<HasChildrenObservers>>>
+  (target: T, prop: string) => void;
+
+/**
+ * Decorator: Specifies custom behavior for an array children property that synchronizes its items with child content nodes of the element.
+ * @param config The overrides
+ */
+export function children(config?: ChildrenObserverSource): ChildrenDecorator;
+/**
+ * Decorator: Specifies an array property on a class that synchronizes its items with child content nodes of the element.
+ * @param prop The property name
+ */
+export function children(prop: string): ClassDecorator;
+/**
+ * Decorator: Decorator: Specifies an array property that synchronizes its items with child content nodes of the element.
+ * @param target The class
+ * @param prop The property name
+ */
+export function children<T extends InstanceType<Constructable & Partial<HasChildrenObservers>>>(target: T, prop: string): void;
+export function children<T extends InstanceType<Constructable & Partial<HasChildrenObservers>>>(configOrTarget?: ChildrenObserverSource | T, prop?: string): void | ChildrenDecorator | ClassDecorator {
+  let config: IChildrenObserverDescription;
+
+  const decorator = function decorate($target: T, $prop: string): void {
+    if (arguments.length > 1) {
+      // Non invocation:
+      // - @children
+      // Invocation with or w/o opts:
+      // - @children()
+      // - @children({...opts})
+      config.property = $prop;
+    }
+
+    const childrenObservers =
+      $target.constructor.childrenObservers || ($target.constructor.childrenObservers = {});
+
+    if (!config.callback) {
+      config.callback = `${config.property}Changed`;
+    }
+
+    childrenObservers[config.property!] = config;
+  };
+
+  if (arguments.length > 1) {
+    // Non invocation:
+    // - @children
+    config = {};
+    decorator(configOrTarget as T, prop!);
+    return;
+  } else if (typeof configOrTarget === 'string') {
+    // ClassDecorator
+    // - @children('bar')
+    // Direct call:
+    // - @children('bar')(Foo)
+    config = {};
+    return decorator as ChildrenDecorator;
+  }
+
+  // Invocation with or w/o opts:
+  // - @children()
+  // - @children({...opts})
+  config = (configOrTarget || {}) as IChildrenObserverDescription;
+  return decorator as ChildrenDecorator;
+}

--- a/packages/runtime/src/templating/children.ts
+++ b/packages/runtime/src/templating/children.ts
@@ -1,5 +1,5 @@
-import { ChildrenObserverSource, ITemplateDefinition, IChildrenObserverDescription } from '../definitions';
 import { Constructable } from '@aurelia/kernel';
+import { ChildrenObserverSource, IChildrenObserverDescription, ITemplateDefinition } from '../definitions';
 
 export type HasChildrenObservers = Pick<ITemplateDefinition, 'childrenObservers'>;
 export type ChildrenDecorator = <T extends InstanceType<Constructable & Partial<HasChildrenObservers>>>
@@ -35,7 +35,7 @@ export function children<T extends InstanceType<Constructable & Partial<HasChild
     }
 
     const childrenObservers =
-      $target.constructor.childrenObservers || ($target.constructor.childrenObservers = {});
+      ($target.constructor as HasChildrenObservers).childrenObservers || (($target.constructor as HasChildrenObservers).childrenObservers = {});
 
     if (!config.callback) {
       config.callback = `${config.property}Changed`;

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -1055,6 +1055,7 @@ function createObservers(
           const childrenDescription = childrenObservers[name];
           observers[name] = new ChildrenObserver(
             controller,
+            instance,
             flags,
             name,
             childrenDescription.callback,

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -1022,6 +1022,7 @@ function createObservers(
   const observableNames = Object.getOwnPropertyNames(bindables);
   const useProxy = (flags & LifecycleFlags.proxyStrategy) > 0 ;
   const lifecycle = controller.lifecycle;
+  let hasChildrenObservers = 'childrenObservers' in description;
 
   const { length } = observableNames;
   let name: string;
@@ -1039,8 +1040,8 @@ function createObservers(
     }
   }
 
-  if ('childrenObservers' in description) {
-    const childrenObservers = description.childrenObservers as Record<string, Required<IChildrenObserverDescription>>;
+  if (hasChildrenObservers) {
+    const childrenObservers = (description as any).childrenObservers as Record<string, Required<IChildrenObserverDescription>>;
 
     if (childrenObservers) {
       const childObserverNames = Object.getOwnPropertyNames(childrenObservers);
@@ -1065,7 +1066,7 @@ function createObservers(
     }
   }
 
-  if (!useProxy) {
+  if (!useProxy || hasChildrenObservers) {
     Reflect.defineProperty(instance, '$observers', {
       enumerable: false,
       value: observers

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -1058,8 +1058,10 @@ function createObservers(
             flags,
             name,
             childrenDescription.callback,
+            childrenDescription.query,
             childrenDescription.filter,
-            childrenDescription.select
+            childrenDescription.map,
+            childrenDescription.options
           );
         }
       }


### PR DESCRIPTION
# Pull Request

## 📖 Description

The ShadowDOMProjector was observing and providing it’s shadow children instead of content children. This PR fixes that. It also introduces filter and select functions to the ChildrenObserver, so that consumers can decide just which children they want and whether they want the element, controller, or viewModel (or whatever else).

There’s still no `@children` decorator or runtime capability to set this up. That still needs to be done. I’d like to be able to have some simple defaults like `@children(TabItem)` or `@children(HTMLElement)` or even `@children(TabItem, ‘.some-selector’)` to get all child view models of a type, or all elements, or all child view models of a type where the element matches a selector, for example. Here’s something that’s typical:

```TypeScript
export class TabControl {
  @children(TabItem) items: TabItem[];
}
```

Advanced scenarios could allow passing the custom filter and select functions, which all of this would be built on.

## 👩‍💻 Reviewer Notes

The code changes are relatively small at this point. Mainly this was about fixing the bugs in the projector and the child observer, and laying a small foundation for the scenarios listed above.

## ⏭ Next Steps

I need some guidance from @fkleuver when he gets a chance on what the best way to handle the decorator and runtime is with the latest iteration. This PR could be merged as is and then we could come back and add the decorator bit, if that’s involved.