### PR TITLE
Dynamic routing: use RouterConfiguration

### DIFF
--- a/packages/__tests__/router/browser-navigation.spec.ts
+++ b/packages/__tests__/router/browser-navigation.spec.ts
@@ -1,7 +1,5 @@
-import { assert, TestContext, createSpy, MockBrowserHistoryLocation } from '@aurelia/testing';
-import { DOM } from '@aurelia/runtime-html';
-import { Writable } from '@aurelia/kernel';
 import { BrowserNavigation, INavigationState } from '@aurelia/router';
+import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 
 describe('BrowserNavigation', function () {
   this.timeout(5000);

--- a/packages/__tests__/router/browser-navigation.spec.ts
+++ b/packages/__tests__/router/browser-navigation.spec.ts
@@ -120,7 +120,7 @@ describe('BrowserNavigation', function () {
 
     let counter = 0;
     await sut.activate(
-      // Called once as part of activation and then for each url/location change
+      // Called once for each url/location change (no longer in as part of activation)
       function () {
         counter++;
       });
@@ -133,7 +133,7 @@ describe('BrowserNavigation', function () {
     await Promise.resolve();
     assert.strictEqual(sut.history.state.NavigationEntry.instruction, 'one', `sut.history.state.NavigationEntry.instruction`);
 
-    assert.strictEqual(counter, 1, `counter`); // Initial (and not + the above 'go')
+    assert.strictEqual(counter, 0, `counter`); // Not the above 'go' (and no longer initial)
 
     sut.deactivate();
 
@@ -166,7 +166,7 @@ describe('BrowserNavigation', function () {
 
     let counter = 0;
     await sut.activate(
-      // Called once as part of activation and then for each url/location change
+      // Called once for each url/location change (no longer in as part of activation)
       function () {
         counter++;
       });
@@ -179,7 +179,7 @@ describe('BrowserNavigation', function () {
     await Promise.resolve();
     assert.strictEqual(sut.history.state.NavigationEntry.instruction, 'one', `sut.history.state.NavigationEntry.instruction`);
 
-    assert.strictEqual(counter, 2, `counter`);
+    assert.strictEqual(counter, 1, `counter`);
 
     sut.deactivate();
 

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
+import { IRouter, Router } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
 import { About } from './components/about';
 import { Authors } from './components/authors/authors';
 import { Books } from './components/books/books';
@@ -9,7 +9,7 @@ import { State } from './state';
 
 import { arrayRemove } from '../../../../../../router/src/utils';
 
-@inject(Router, AuthorsRepository, State)
+@inject(IRouter, AuthorsRepository, State)
 @customElement({
   name: 'app', template:
     `
@@ -26,7 +26,7 @@ export class App {
   }
 
   public bound() {
-    this.router.activate({
+    // this.router.activate({
       // transformFromUrl: (path, router) => {
       //   if (!path.length) {
       //     return path;
@@ -64,7 +64,7 @@ export class App {
       //   }
       //   return parts.join('/');
       // }
-    }).catch(error => { throw error; });
+    // }).catch(error => { throw error; });
 
     this.router.guardian.addGuard((instructions) => {
       if (this.verifyLogin()) {

--- a/packages/__tests__/router/e2e/doc-example/app/src/app.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/app.ts
@@ -1,5 +1,5 @@
 import { inject } from '@aurelia/kernel';
-import { IRouter, Router } from '@aurelia/router';
+import { IRouter } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
 import { About } from './components/about';
 import { Authors } from './components/authors/authors';
@@ -21,7 +21,7 @@ import { arrayRemove } from '../../../../../../router/src/utils';
 <au-viewport name="gate" used-by="main,login" default="\${!state.loggedIn ? 'login' : 'main'}"></au-viewport>
 ` })
 export class App {
-  constructor(private readonly router: Router, authorsRepository: AuthorsRepository, private readonly state: State) {
+  constructor(private readonly router: IRouter, authorsRepository: AuthorsRepository, private readonly state: State) {
     authorsRepository.authors(); // Only here to initialize repositories
   }
 

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/about.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/about.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
 import { customElement, IViewModel } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
+import { IRouter } from '@aurelia/router';
 import { State } from '../state';
 import { wait } from '../utils';
 
@@ -35,9 +35,9 @@ In other words, I scroll you
 <br>
 <input data-test="about-inputbox">
 </template>` })
-@inject(State, Router)
+@inject(State, IRouter)
 export class About {
-  constructor(private readonly state: State, private readonly router: Router) { }
+  constructor(private readonly state: State, private readonly router: IRouter) { }
 
   public enter() {
     return wait(this.state.noDelay ? 0 : 4000);

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/authors/author.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia//kernel';
+import { IRouter } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
 import { AuthorsRepository } from '../../repositories/authors';
 import { State } from '../../state';
 import { wait } from '../../utils';
@@ -25,7 +25,7 @@ import { Information } from './information';
 </template>`,
   dependencies: [Information as any]
 })
-@inject(Router, AuthorsRepository, State)
+@inject(IRouter, AuthorsRepository, State)
 export class Author {
   public static parameters = ['id'];
 
@@ -33,7 +33,7 @@ export class Author {
 
   public hideTabs: boolean = false;
 
-  constructor(private readonly router: Router, private readonly authorsRepository: AuthorsRepository, private readonly state: State) { }
+  constructor(private readonly router: IRouter, private readonly authorsRepository: AuthorsRepository, private readonly state: State) { }
 
   public created() {
     console.log('### created', this);

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/books/book.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/books/book.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia//kernel';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
+import { IRouter } from '@aurelia/router';
 import { BooksRepository } from '../../repositories/books';
 import { Information } from './information';
 import { RedirectAbout } from './redirect-about';
@@ -20,13 +20,13 @@ import { RedirectInformation } from './redirect-information';
 </template>`,
   dependencies: [Information as any, RedirectInformation as any, RedirectAbout as any]
 })
-@inject(Router, BooksRepository)
+@inject(IRouter, BooksRepository)
 export class Book {
   public static parameters = ['id'];
 
   public book: { id: number };
 
-  constructor(private readonly router: Router, private readonly booksRepository: BooksRepository) { }
+  constructor(private readonly router: IRouter, private readonly booksRepository: BooksRepository) { }
 
   public enter(parameters) {
     let id = +(parameters.id ? parameters.id : parameters[0]);

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/login-special.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/login-special.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
+import { IRouter } from '@aurelia/router';
 import { customElement, ICustomElementType } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
 import { State } from '../state';
 
 @customElement({
@@ -9,9 +9,9 @@ import { State } from '../state';
   <p>You need to be logged in SPECIAL to continue.</p>
   <button data-test="login-button" click.trigger="login()">Okay, log me in SPECIAL</button>
 </div>` })
-@inject(State, Router)
+@inject(State, IRouter)
 export class LoginSpecial {
-  constructor(private readonly state: State, private readonly router: Router) { }
+  constructor(private readonly state: State, private readonly router: IRouter) { }
 
   public login() {
     this.state.loggedIn = true;

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/login.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/login.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
 import { customElement, ICustomElementType } from '@aurelia/runtime';
-import { Router, ViewportInstruction } from '@aurelia/router';
+import { IRouter, ViewportInstruction } from '@aurelia/router';
 import { State } from '../state';
 
 @customElement({
@@ -9,9 +9,9 @@ import { State } from '../state';
   <p>You need to be logged in to continue.</p>
   <button data-test="login-button" click.trigger="login()">Okay, log me in</button>
 </div>` })
-@inject(State, Router)
+@inject(State, IRouter)
 export class Login {
-  constructor(private readonly state: State, private readonly router: Router) { }
+  constructor(private readonly state: State, private readonly router: IRouter) { }
 
   public login() {
     this.state.loggedIn = true;

--- a/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
@@ -1,12 +1,12 @@
 import { inject } from '@aurelia/kernel';
+import { IRouter } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '@aurelia/router';
 import { State } from '../state';
 import { About } from './about';
 import { Authors } from './authors/authors';
 import { Books } from './books/books';
 
-@inject(Router, State)
+@inject(IRouter, State)
 @customElement({
   name: 'main', template:
     `
@@ -40,7 +40,7 @@ import { Books } from './books/books';
   </div>
 ` })
 export class Main {
-  constructor(private readonly router: Router, private readonly state: State) {
+  constructor(private readonly router: IRouter, private readonly state: State) {
     this.router.setNav('main-menu', [
       {
         title: 'Authors',

--- a/packages/__tests__/router/e2e/navigation-skeleton/app/src/app.ts
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/src/app.ts
@@ -1,6 +1,6 @@
-import { customElement } from '@aurelia/runtime';
 import { inject } from '@aurelia/kernel';
-import { Router } from '@aurelia/router';
+import { IRouter } from '@aurelia/router';
+import { customElement } from '@aurelia/runtime';
 import * as html from './app.html';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -9,14 +9,13 @@ import './styles.css';
 
 import './nav-bar.html';
 
-@inject(Router)
+@inject(IRouter)
 @customElement({ name: 'app', template: html })
 export class App {
   public count: number = 3;
   public maxWindows: number = 5;
-  constructor(public router: Router) { }
+  constructor(public router: IRouter) { }
   public bound() {
-    this.router.activate();
     // Yeah, this is cheating somewhat, should've reacted to actual count
     for (let i = 1; i <= this.maxWindows; i++) {
       this.router.setNav(`app-menu-${i}`, [

--- a/packages/__tests__/router/e2e/navigation-skeleton/app/src/child-router.ts
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/src/child-router.ts
@@ -1,17 +1,17 @@
+import { inject } from '@aurelia/kernel';
+import { IRouter } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
 import * as html from './child-router.html';
-import { Router, ReentryBehavior } from '@aurelia/router';
-import { inject } from '@aurelia/kernel';
 
-@inject(Router)
+@inject(IRouter)
 @customElement({ name: 'child-router', template: html })
 export class ChildRouter {
   // public reentryBehavior: ReentryBehavior = ReentryBehavior.refresh;
 
   public heading = 'Child Router';
-  public router: Router;
+  public router: IRouter;
 
-  constructor(router: Router) {
+  constructor(router: IRouter) {
     this.router = router;
   }
 

--- a/packages/__tests__/router/e2e/navigation-skeleton/app/src/startup.ts
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/src/startup.ts
@@ -1,15 +1,15 @@
-import { ChildRouter } from './child-router';
 import { DebugConfiguration } from '@aurelia/debug';
 import { BasicConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
 import { RouterConfiguration } from '@aurelia/router';
+import { Aurelia } from '@aurelia/runtime';
+import { ChildRouter } from './child-router';
 import { registerComponent } from './utils';
 
 import { App } from './app';
 
 import { State } from './state';
-import { Welcome, UpperValueConverter } from './welcome';
 import { Users } from './users';
+import { UpperValueConverter, Welcome } from './welcome';
 
 const container = BasicConfiguration.createContainer();
 

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -9,8 +9,13 @@ describe('InstructionResolver', function () {
     const container = ctx.container;
 
     const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-    container.register(IRouter);
-    container.register(ViewportCustomElement);
+
+    const host = ctx.doc.createElement('div');
+    ctx.doc.body.appendChild(host);
+
+    const au = ctx.wnd['au'] = new Aurelia(container)
+      .register(DebugConfiguration, RouterConfiguration)
+      .app({ host: host, component: App });
 
     const router = container.get(IRouter);
     const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
@@ -18,25 +23,16 @@ describe('InstructionResolver', function () {
     router.navigation.history = mockBrowserHistoryLocation as any;
     router.navigation.location = mockBrowserHistoryLocation as any;
 
-    const host = ctx.doc.createElement('div');
-    ctx.doc.body.appendChild(host);
-
-    const au = ctx.wnd['au'] = new Aurelia(container)
-      .register(DebugConfiguration)
-      .app({ host: host, component: App });
-
     await au.start().wait();
 
     async function tearDown() {
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
       router.deactivate();
-    };
-
-    await router.activate();
+    }
 
     return { au, container, host, router, tearDown, ctx };
-  };
+  }
 
   this.timeout(5000);
   it('can be created', async function () {
@@ -105,8 +101,6 @@ async function setup() {
   const { container } = ctx;
 
   const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-  container.register(IRouter);
-  container.register(ViewportCustomElement);
 
   const host = ctx.createElement('div');
   ctx.doc.body.appendChild(host);
@@ -115,14 +109,13 @@ async function setup() {
     .register(DebugConfiguration, RouterConfiguration)
     .app({ host: host, component: App });
 
-  await au.start().wait();
-
   const router = container.get(IRouter);
   const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
   mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate as any;
   router.navigation.history = mockBrowserHistoryLocation as any;
   router.navigation.location = mockBrowserHistoryLocation as any;
 
-  await router.activate();
+  await au.start().wait();
+
   return { au, container, host, router };
-};
+}

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -1,6 +1,6 @@
 import { DebugConfiguration } from '@aurelia/debug';
 import { Aurelia, CustomElement } from '@aurelia/runtime';
-import { Router, RouterConfiguration, ViewportCustomElement, ViewportInstruction } from '@aurelia/router';
+import { IRouter, RouterConfiguration, ViewportCustomElement, ViewportInstruction } from '@aurelia/router';
 import { MockBrowserHistoryLocation, TestContext, assert } from '@aurelia/testing';
 
 describe('InstructionResolver', function () {
@@ -9,10 +9,10 @@ describe('InstructionResolver', function () {
     const container = ctx.container;
 
     const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-    container.register(Router);
+    container.register(IRouter);
     container.register(ViewportCustomElement);
 
-    const router = container.get(Router);
+    const router = container.get(IRouter);
     const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
     mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
     router.navigation.history = mockBrowserHistoryLocation as any;
@@ -105,7 +105,7 @@ async function setup() {
   const { container } = ctx;
 
   const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-  container.register(Router);
+  container.register(IRouter);
   container.register(ViewportCustomElement);
 
   const host = ctx.createElement('div');
@@ -117,7 +117,7 @@ async function setup() {
 
   await au.start().wait();
 
-  const router = container.get(Router);
+  const router = container.get(IRouter);
   const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
   mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate as any;
   router.navigation.history = mockBrowserHistoryLocation as any;

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -1,7 +1,7 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { Aurelia, CustomElement } from '@aurelia/runtime';
 import { IRouter, RouterConfiguration, ViewportCustomElement, ViewportInstruction } from '@aurelia/router';
-import { MockBrowserHistoryLocation, TestContext, assert } from '@aurelia/testing';
+import { Aurelia, CustomElement } from '@aurelia/runtime';
+import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 
 describe('InstructionResolver', function () {
   async function setup() {

--- a/packages/__tests__/router/link-handler.spec.ts
+++ b/packages/__tests__/router/link-handler.spec.ts
@@ -1,7 +1,7 @@
-import { LinkHandler } from '@aurelia/router';
-import { assert, createSpy } from '@aurelia/testing';
-import { DOM } from '@aurelia/runtime-html';
 import { Writable } from '@aurelia/kernel';
+import { LinkHandler } from '@aurelia/router';
+import { DOM } from '@aurelia/runtime-html';
+import { assert, createSpy } from '@aurelia/testing';
 
 describe('LinkHandler', function () {
   const callback = ((info) => { return; });

--- a/packages/__tests__/router/nav.spec.ts
+++ b/packages/__tests__/router/nav.spec.ts
@@ -1,7 +1,7 @@
 import { DebugConfiguration } from '@aurelia/debug';
+import { IRouter, NavCustomElement, RouterConfiguration, ViewportCustomElement } from '@aurelia/router';
 import { Aurelia, CustomElement } from '@aurelia/runtime';
-import { NavCustomElement, Router, ViewportCustomElement } from '@aurelia/router';
-import { MockBrowserHistoryLocation, TestContext, assert } from '@aurelia/testing';
+import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 
 describe('Nav', function () {
   async function setup(component) {
@@ -10,44 +10,47 @@ describe('Nav', function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><au-viewport name="app" used-by="${component}" default="${component}"></au-viewport></template>` });
     const Foo = CustomElement.define({ name: 'foo', template: '<template>Nav: foo <au-nav name="main-nav"></au-nav></template>' }, class {
-      public static inject = [Router];
-      constructor(private readonly r: Router) { }
+      public static inject = [IRouter];
+      constructor(private readonly r: IRouter) { }
       public enter() { this.r.setNav('main-nav', [{ title: 'Bar', route: 'bar' }]); }
     });
     const Bar = CustomElement.define({ name: 'bar', template: '<template>Nav: bar <au-nav name="main-nav"></au-nav><au-viewport name="main-viewport" default="baz"></au-viewport></template>' }, class {
-      public static inject = [Router];
-      constructor(private readonly r: Router) { }
+      public static inject = [IRouter];
+      constructor(private readonly r: IRouter) { }
       public enter() { this.r.setNav('main-nav', [{ title: 'Baz', route: 'baz' }]); }
     });
     const Baz = CustomElement.define({ name: 'baz', template: '<template>Baz</template>' }, class { });
     const Qux = CustomElement.define({ name: 'qux', template: '<template>Nav: qux <au-nav name="main-nav"></au-nav><au-viewport name="main-viewport" default="baz"></au-viewport></template>' }, class {
-      public static inject = [Router];
-      constructor(private readonly r: Router) { }
+      public static inject = [IRouter];
+      constructor(private readonly r: IRouter) { }
       public enter() {
         this.r.addNav('main-nav', [{ title: 'Baz', route: Baz, children: [{ title: 'Bar', route: ['bar', Baz] }] }, { title: 'Foo', route: { component: Foo, viewport: 'main-viewport' } }]);
       }
     });
 
-    container.register(Router);
-    container.register(ViewportCustomElement, NavCustomElement);
-    container.register(Foo, Bar, Baz, Qux);
-
-    const router = container.get(Router);
-    const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
-    mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
-    router.navigation.history = mockBrowserHistoryLocation as any;
-    router.navigation.location = mockBrowserHistoryLocation as any;
+    // container.register(IRouter);
+    // container.register(ViewportCustomElement, NavCustomElement);
+    // container.register(Foo, Bar, Baz, Qux);
 
     const host = ctx.doc.createElement('div');
     ctx.doc.body.appendChild(host);
 
     const au = ctx.wnd['au'] = new Aurelia(container)
-      .register(DebugConfiguration)
+      .register(DebugConfiguration, RouterConfiguration)
       .app({ host: host, component: App });
+
+    const router = container.get(IRouter);
+    const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
+    mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
+    router.navigation.history = mockBrowserHistoryLocation as any;
+    router.navigation.location = mockBrowserHistoryLocation as any;
+
+    container.register(Foo, Bar, Baz, Qux);
 
     await au.start().wait();
 
-    await router.activate();
+    // await router.activate();
+    // await router.loadUrl();
 
     async function tearDown() {
       await au.stop().wait();

--- a/packages/__tests__/router/nav.spec.ts
+++ b/packages/__tests__/router/nav.spec.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { IRouter, NavCustomElement, RouterConfiguration, ViewportCustomElement } from '@aurelia/router';
+import { IRouter, RouterConfiguration } from '@aurelia/router';
 import { Aurelia, CustomElement } from '@aurelia/runtime';
 import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 
@@ -28,10 +28,6 @@ describe('Nav', function () {
       }
     });
 
-    // container.register(IRouter);
-    // container.register(ViewportCustomElement, NavCustomElement);
-    // container.register(Foo, Bar, Baz, Qux);
-
     const host = ctx.doc.createElement('div');
     ctx.doc.body.appendChild(host);
 
@@ -49,9 +45,6 @@ describe('Nav', function () {
 
     await au.start().wait();
 
-    // await router.activate();
-    // await router.loadUrl();
-
     async function tearDown() {
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
@@ -59,7 +52,7 @@ describe('Nav', function () {
     }
 
     return { au, container, host, router, ctx, tearDown };
-  };
+  }
 
   it('generates nav with a link', async function () {
     this.timeout(5000);
@@ -93,7 +86,6 @@ describe('Nav', function () {
     await tearDown();
   });
 });
-
 
 const wait = async (time = 500) => {
   await new Promise((resolve) => {

--- a/packages/__tests__/router/queue.spec.ts
+++ b/packages/__tests__/router/queue.spec.ts
@@ -1,5 +1,5 @@
-import { assert, TestContext } from '@aurelia/testing';
 import { Queue, QueueItem } from '@aurelia/router';
+import { assert, TestContext } from '@aurelia/testing';
 
 class Animal {
   constructor(public type: string, public name: string) { }

--- a/packages/__tests__/router/route-recognizer.spec.ts
+++ b/packages/__tests__/router/route-recognizer.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigurableRoute, RouteRecognizer } from '@aurelia/router';
-import { eachCartesianJoin, assert } from '@aurelia/testing';
+import { assert, eachCartesianJoin } from '@aurelia/testing';
 
 const staticRoute = {'path': 'static', 'handler': {'name': 'static'}};
 const dynamicRoute = {'path': 'dynamic/:id', 'handler': {'name': 'dynamic'}};

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -1,6 +1,6 @@
 import { DebugConfiguration } from '@aurelia/debug';
 import { Aurelia, CustomElement, LifecycleFlags, ILifecycle } from '@aurelia/runtime';
-import { Router, ViewportCustomElement } from '@aurelia/router';
+import { IRouter, RouterConfiguration, ViewportCustomElement } from '@aurelia/router';
 import { MockBrowserHistoryLocation, TestContext, assert } from '@aurelia/testing';
 import { PLATFORM } from '@aurelia/kernel';
 
@@ -82,27 +82,26 @@ describe('Router', function () {
         }
       });
 
+    const host = ctx.doc.createElement('div');
+    ctx.doc.body.appendChild(host as any);
 
-    container.register(Router as any);
-    container.register(ViewportCustomElement as any);
+    const au = ctx.wnd['au'] = new Aurelia(container)
+      .register(DebugConfiguration, RouterConfiguration)
+      .app({ host: host, component: App });
+
+    // container.register(Router as any);
+    // container.register(ViewportCustomElement as any);
     container.register(Foo, Bar, Baz, Qux, Quux, Corge, Uier, Grault, Garply, Waldo, Plugh);
 
-    const router = container.get(Router);
+    const router = container.get(IRouter);
     const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
     mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
     router.navigation.history = mockBrowserHistoryLocation as any;
     router.navigation.location = mockBrowserHistoryLocation as any;
 
-    const host = ctx.doc.createElement('div');
-    ctx.doc.body.appendChild(host as any);
-
-    const au = ctx.wnd['au'] = new Aurelia(container)
-      .register(DebugConfiguration)
-      .app({ host: host, component: App });
-
     await au.start().wait();
 
-    await router.activate();
+    // await router.activate();
 
     async function tearDown() {
       await au.stop().wait();
@@ -747,26 +746,31 @@ describe('Router', function () {
 
       const { container, lifecycle } = ctx;
 
-      container.register(ViewportCustomElement);
+      // container.register(ViewportCustomElement);
       const App = CustomElement.define({ name: 'app', template: '<au-viewport></au-viewport>', dependencies }, null);
 
       const host = ctx.doc.createElement('div');
       ctx.doc.body.appendChild(host as any);
       const component = new App();
 
-      const au = ctx.wnd['au'] = new Aurelia(container);
+      const au = ctx.wnd['au'] = new Aurelia(container)
+      .register(DebugConfiguration, RouterConfiguration)
+      .app({ host: host, component: App });
 
-      au.app({ host, component });
-      await au.start().wait();
+      // const au = ctx.wnd['au'] = new Aurelia(container);
 
-      const router = container.get(Router);
+      // au.app({ host, component });
+
+      const router = container.get(IRouter);
       const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
       mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
       router.navigation.history = mockBrowserHistoryLocation as any;
       router.navigation.location = mockBrowserHistoryLocation as any;
 
-      await router.activate();
-      await Promise.resolve();
+      await au.start().wait();
+
+      // await router.activate();
+      // await Promise.resolve();
 
       async function $teardown() {
         await au.stop().wait();
@@ -998,7 +1002,7 @@ describe('Router', function () {
 let quxCantLeave = 2;
 let plughReentryBehavior = 'default';
 
-const $goto = async (path: string, router: Router, lifecycle: ILifecycle) => {
+const $goto = async (path: string, router: IRouter, lifecycle: ILifecycle) => {
   await router.goto(path);
   lifecycle.processRAFQueue(LifecycleFlags.none);
 }

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -1,8 +1,8 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { Aurelia, CustomElement, LifecycleFlags, ILifecycle } from '@aurelia/runtime';
-import { IRouter, RouterConfiguration, ViewportCustomElement } from '@aurelia/router';
-import { MockBrowserHistoryLocation, TestContext, assert } from '@aurelia/testing';
 import { PLATFORM } from '@aurelia/kernel';
+import { IRouter, RouterConfiguration } from '@aurelia/router';
+import { Aurelia, CustomElement, ILifecycle, LifecycleFlags } from '@aurelia/runtime';
+import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 
 describe('Router', function () {
   async function setup() {
@@ -89,8 +89,6 @@ describe('Router', function () {
       .register(DebugConfiguration, RouterConfiguration)
       .app({ host: host, component: App });
 
-    // container.register(Router as any);
-    // container.register(ViewportCustomElement as any);
     container.register(Foo, Bar, Baz, Qux, Quux, Corge, Uier, Grault, Garply, Waldo, Plugh);
 
     const router = container.get(IRouter);
@@ -101,16 +99,14 @@ describe('Router', function () {
 
     await au.start().wait();
 
-    // await router.activate();
-
     async function tearDown() {
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
       router.deactivate();
-    };
+    }
 
     return { au, container, lifecycle, host, router, ctx, tearDown };
-  };
+  }
 
   it('can be created', async function () {
     this.timeout(5000);
@@ -746,7 +742,6 @@ describe('Router', function () {
 
       const { container, lifecycle } = ctx;
 
-      // container.register(ViewportCustomElement);
       const App = CustomElement.define({ name: 'app', template: '<au-viewport></au-viewport>', dependencies }, null);
 
       const host = ctx.doc.createElement('div');
@@ -757,10 +752,6 @@ describe('Router', function () {
       .register(DebugConfiguration, RouterConfiguration)
       .app({ host: host, component: App });
 
-      // const au = ctx.wnd['au'] = new Aurelia(container);
-
-      // au.app({ host, component });
-
       const router = container.get(IRouter);
       const mockBrowserHistoryLocation = new MockBrowserHistoryLocation();
       mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
@@ -768,9 +759,6 @@ describe('Router', function () {
       router.navigation.location = mockBrowserHistoryLocation as any;
 
       await au.start().wait();
-
-      // await router.activate();
-      // await Promise.resolve();
 
       async function $teardown() {
         await au.stop().wait();
@@ -1019,4 +1007,3 @@ const waitForNavigation = async (router) => {
     await wait(100);
   }
 };
-

--- a/packages/__tests__/router/viewport-content.spec.ts
+++ b/packages/__tests__/router/viewport-content.spec.ts
@@ -1,6 +1,6 @@
 import { IRenderContext } from '@aurelia/runtime';
 import { CustomElement } from '@aurelia/runtime';
-import { Router, ViewportContent } from '@aurelia/router';
+import { IRouter, ViewportContent } from '@aurelia/router';
 import { assert, TestContext } from '@aurelia/testing';
 
 const define = (CustomElement as any).define;
@@ -16,7 +16,7 @@ describe('ViewportContent', function () {
     async function $setup(dependencies: any[] = []) {
       const ctx = TestContext.createHTMLTestContext();
       const container = ctx.container;
-      const router = container.get(Router);
+      const router = container.get(IRouter);
       return { container, router };
     }
 

--- a/packages/__tests__/router/viewport-content.spec.ts
+++ b/packages/__tests__/router/viewport-content.spec.ts
@@ -1,6 +1,6 @@
+import { IRouter, ViewportContent } from '@aurelia/router';
 import { IRenderContext } from '@aurelia/runtime';
 import { CustomElement } from '@aurelia/runtime';
-import { IRouter, ViewportContent } from '@aurelia/router';
 import { assert, TestContext } from '@aurelia/testing';
 
 const define = (CustomElement as any).define;

--- a/packages/__tests__/router/viewport.spec.ts
+++ b/packages/__tests__/router/viewport.spec.ts
@@ -1,5 +1,5 @@
-import { CustomElement } from '@aurelia/runtime';
 import { Viewport } from '@aurelia/router';
+import { CustomElement } from '@aurelia/runtime';
 
 const define = (CustomElement as any).define;
 

--- a/packages/router/src/browser-navigation.ts
+++ b/packages/router/src/browser-navigation.ts
@@ -14,7 +14,7 @@ export interface INavigationStore {
 }
 
 export interface INavigationViewer {
-  activate(callback: (ev?: INavigationViewerEvent) => void): Promise<void>;
+  activate(callback: (ev?: INavigationViewerEvent) => void): void;
   deactivate(): void;
 }
 
@@ -79,7 +79,7 @@ export class BrowserNavigation implements INavigationStore, INavigationViewer {
     this.forwardedState = {};
   }
 
-  public activate(callback: (ev?: INavigationViewerEvent) => void): Promise<void> {
+  public activate(callback: (ev?: INavigationViewerEvent) => void): void {
     if (this.isActive) {
       throw new Error('Browser navigation has already been activated');
     }
@@ -87,8 +87,6 @@ export class BrowserNavigation implements INavigationStore, INavigationViewer {
     this.callback = callback;
     this.pendingCalls.activate({ lifecycle: this.lifecycle, allowedExecutionCostWithinTick: this.allowedExecutionCostWithinTick });
     this.window.addEventListener('popstate', this.handlePopstate);
-
-    return Promise.resolve();
   }
 
   public loadUrl(): Promise<void> {

--- a/packages/router/src/browser-navigation.ts
+++ b/packages/router/src/browser-navigation.ts
@@ -79,7 +79,7 @@ export class BrowserNavigation implements INavigationStore, INavigationViewer {
     this.forwardedState = {};
   }
 
-  public async activate(callback: (ev?: INavigationViewerEvent) => void): Promise<void> {
+  public activate(callback: (ev?: INavigationViewerEvent) => void): Promise<void> {
     if (this.isActive) {
       throw new Error('Browser navigation has already been activated');
     }
@@ -88,8 +88,13 @@ export class BrowserNavigation implements INavigationStore, INavigationViewer {
     this.pendingCalls.activate({ lifecycle: this.lifecycle, allowedExecutionCostWithinTick: this.allowedExecutionCostWithinTick });
     this.window.addEventListener('popstate', this.handlePopstate);
 
+    return Promise.resolve();
+  }
+
+  public loadUrl(): Promise<void> {
     return this.handlePopstate(null);
   }
+
   public deactivate(): void {
     if (!this.isActive) {
       throw new Error('Browser navigation has not been activated');

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -3,7 +3,7 @@ import { StartTask } from '@aurelia/runtime';
 
 import { NavCustomElement } from './resources/nav';
 import { ViewportCustomElement } from './resources/viewport';
-import { IRouterOptions, Router, IRouter } from './router';
+import { IRouter, IRouterOptions, Router } from './router';
 
 export const RouterRegistration = Router as unknown as IRegistry;
 
@@ -43,7 +43,8 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeAttach().call(router => router.activate())
+      StartTask.with(IRouter).beforeBind().call(router => router.activate()),
+      StartTask.with(IRouter).beforeAttach().call(router => router.loadUrl()),
     );
   },
   /**

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -43,10 +43,7 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeBind().call(router => {
-        router.activate();
-        return Promise.resolve();
-      }),
+      StartTask.with(IRouter).beforeBind().call(router => router.activate()),
       StartTask.with(IRouter).beforeAttach().call(router => router.loadUrl()),
     );
   },

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -43,7 +43,10 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeBind().call(router => { router.activate(); return Promise.resolve(); }),
+      StartTask.with(IRouter).beforeBind().call(router => {
+        router.activate();
+        return Promise.resolve();
+      }),
       StartTask.with(IRouter).beforeAttach().call(router => router.loadUrl()),
     );
   },

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -5,7 +5,7 @@ import { NavCustomElement } from './resources/nav';
 import { ViewportCustomElement } from './resources/viewport';
 import { IRouter, IRouterOptions, Router } from './router';
 
-export const RouterRegistration = Router as unknown as IRegistry;
+export const RouterRegistration = IRouter as unknown as IRegistry;
 
 /**
  * Default runtime/environment-agnostic implementations for the following interfaces:
@@ -43,7 +43,7 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeBind().call(router => router.activate()),
+      StartTask.with(IRouter).beforeBind().call(router => { router.activate(); return Promise.resolve(); }),
       StartTask.with(IRouter).beforeAttach().call(router => router.loadUrl()),
     );
   },

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,6 +1,6 @@
 import { ICustomElementType, IObserverLocator, IPropertyObserver, LifecycleFlags } from '@aurelia/runtime';
 import { INavRoute, IViewportComponent, Nav, NavInstruction } from './nav';
-import { Router } from './router';
+import { IRouter } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 export class NavRoute {
@@ -15,7 +15,7 @@ export class NavRoute {
   public active: string = '';
 
   private readonly observerLocator: IObserverLocator;
-  private readonly observer: IPropertyObserver<Router, 'activeComponents'>;
+  private readonly observer: IPropertyObserver<IRouter, 'activeComponents'>;
 
   constructor(nav: Nav, route?: INavRoute) {
     this.nav = nav;
@@ -29,7 +29,7 @@ export class NavRoute {
     this.link = this._link(this.instructions);
     this.linkActive = route.consideredActive ? this._link(this.parseRoute(route.consideredActive)) : this.link;
     this.observerLocator = this.nav.router.container.get(IObserverLocator);
-    this.observer = this.observerLocator.getObserver(LifecycleFlags.none, this.nav.router, 'activeComponents') as IPropertyObserver<Router, 'activeComponents'>;
+    this.observer = this.observerLocator.getObserver(LifecycleFlags.none, this.nav.router, 'activeComponents') as IPropertyObserver<IRouter, 'activeComponents'>;
     this.observer.subscribe(this);
   }
 

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -1,7 +1,7 @@
 import { ICustomElementType } from '@aurelia/runtime';
 import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';
-import { Router } from './router';
+import { IRouter } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IViewportComponent {
@@ -26,9 +26,9 @@ export class Nav {
   public routes: NavRoute[];
   public classes: INavClasses;
 
-  public router: Router;
+  public router: IRouter;
 
-  constructor(router: Router, name: string, routes: NavRoute[] = [], classes: INavClasses = {}) {
+  constructor(router: IRouter, name: string, routes: NavRoute[] = [], classes: INavClasses = {}) {
     this.router = router;
     this.name = name;
     this.routes = routes;

--- a/packages/router/src/resources/nav.ts
+++ b/packages/router/src/resources/nav.ts
@@ -1,7 +1,7 @@
 import { inject } from '@aurelia/kernel';
 import { bindable, customElement, INode } from '@aurelia/runtime';
 import { NavRoute } from '../nav-route';
-import { Router } from '../router';
+import { IRouter } from '../router';
 
 export interface INavClasses {
   nav?: string;
@@ -14,7 +14,7 @@ export interface INavClasses {
   aActive?: string;
 }
 
-@inject(Router, INode)
+@inject(IRouter, INode)
 @customElement({
   name: 'au-nav', template:
     `<template>
@@ -35,9 +35,9 @@ export class NavCustomElement {
   @bindable public level: number;
   @bindable public classes: INavClasses;
 
-  private readonly router: Router;
+  private readonly router: IRouter;
 
-  constructor(router: Router) {
+  constructor(router: IRouter) {
     this.router = router;
 
     this.name = null;

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -18,14 +18,17 @@ import {
   TemplateDefinition
 } from '@aurelia/runtime';
 
-import { Router } from '../router';
+import {
+  IRouter,
+  Router
+} from '../router';
 import {
   IViewportOptions,
   Viewport
 } from '../viewport';
 
 export class ViewportCustomElement {
-  public static readonly inject: readonly Key[] = [Router, INode, IRenderingEngine];
+  public static readonly inject: readonly Key[] = [IRouter, INode, IRenderingEngine];
 
   @bindable public name: string;
   @bindable public scope: boolean;

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -20,7 +20,6 @@ import {
 
 import {
   IRouter,
-  Router
 } from '../router';
 import {
   IViewportOptions,
@@ -43,11 +42,11 @@ export class ViewportCustomElement {
   // tslint:disable-next-line: prefer-readonly // This is set by the controller after this instance is constructed
   public $controller!: IController;
 
-  private readonly router: Router;
+  private readonly router: IRouter;
   private readonly element: Element;
   private readonly renderingEngine: IRenderingEngine;
 
-  constructor(router: Router, element: Element, renderingEngine: IRenderingEngine) {
+  constructor(router: IRouter, element: Element, renderingEngine: IRenderingEngine) {
     this.name = 'default';
     this.scope = null;
     this.usedBy = null;

--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -1,4 +1,4 @@
-import { IRouteTransformer, Router } from './router';
+import { IRouteTransformer, IRouter } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 /**
@@ -13,7 +13,7 @@ export class RouteTable implements IRouteTransformer {
    * @param router The application router.
    * @returns The viewport instructions for a found route or the route if not found.
    */
-  public transformFromUrl = (route: string, router: Router): string | ViewportInstruction[] => {
+  public transformFromUrl = (route: string, router: IRouter): string | ViewportInstruction[] => {
     // TODO: Implement route recognizing to transform a configured route to a set of viewport instructions
     return route;
   }
@@ -25,7 +25,7 @@ export class RouteTable implements IRouteTransformer {
    * @param router The application router.
    * @returns The route for a found set of viewport instructions or the viewport instructions if not found.
    */
-  public transformToUrl = (instructions: ViewportInstruction[], router: Router): string | ViewportInstruction[] => {
+  public transformToUrl = (instructions: ViewportInstruction[], router: IRouter): string | ViewportInstruction[] => {
     // TODO: Implement mapping from set of viewport instructions to a configured route
     return instructions;
   }

--- a/packages/router/src/route-table.ts
+++ b/packages/router/src/route-table.ts
@@ -1,4 +1,4 @@
-import { IRouteTransformer, IRouter } from './router';
+import { IRouter, IRouteTransformer } from './router';
 import { ViewportInstruction } from './viewport-instruction';
 
 /**

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -36,6 +36,7 @@ export interface IRouter {
   readonly isNavigating: boolean;
 
   activate(options?: IRouterOptions): Promise<void>;
+  loadUrl(): Promise<void>;
   deactivate(): void;
 
   linkCallback(info: AnchorEventInfo): void;
@@ -133,6 +134,10 @@ export class Router implements IRouter {
     });
     this.linkHandler.activate({ callback: this.linkCallback });
     return this.navigation.activate(this.navigationCallback);
+  }
+
+  public loadUrl(): Promise<void> {
+    return this.navigation.loadUrl();
   }
 
   public deactivate(): void {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -16,8 +16,8 @@ import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IRouteTransformer {
-  transformFromUrl?(route: string, router: Router): string | ViewportInstruction[];
-  transformToUrl?(instructions: ViewportInstruction[], router: Router): string | ViewportInstruction[];
+  transformFromUrl?(route: string, router: IRouter): string | ViewportInstruction[];
+  transformToUrl?(instructions: ViewportInstruction[], router: IRouter): string | ViewportInstruction[];
 }
 
 export const IRouteTransformer = DI.createInterface<IRouteTransformer>('IRouteTransformer').withDefault(x => x.singleton(RouteTable));
@@ -34,8 +34,16 @@ export interface IRouteViewport {
 
 export interface IRouter {
   readonly isNavigating: boolean;
+  activeComponents: string[];
+  readonly container: IContainer;
+  readonly scopes: Scope[];
+  readonly instructionResolver: InstructionResolver;
+  navigator: Navigator;
+  readonly navigation: BrowserNavigation;
+  readonly guardian: Guardian;
+  readonly navs: Record<string, Nav>;
 
-  activate(options?: IRouterOptions): Promise<void>;
+  activate(options?: IRouterOptions): void;
   loadUrl(): Promise<void>;
   deactivate(): void;
 
@@ -114,7 +122,7 @@ export class Router implements IRouter {
     return this.processingNavigation !== null;
   }
 
-  public activate(options?: IRouterOptions): Promise<void> {
+  public activate(options?: IRouterOptions): void {
     if (this.isActive) {
       throw new Error('Router has already been activated');
     }
@@ -133,7 +141,7 @@ export class Router implements IRouter {
       store: this.navigation,
     });
     this.linkHandler.activate({ callback: this.linkCallback });
-    return this.navigation.activate(this.navigationCallback);
+    this.navigation.activate(this.navigationCallback);
   }
 
   public loadUrl(): Promise<void> {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -41,7 +41,7 @@ export interface IRouter {
   navigator: Navigator;
   readonly navigation: BrowserNavigation;
   readonly guardian: Guardian;
-  readonly navs: Record<string, Nav>;
+  readonly navs: Readonly<Record<string, Nav>>;
 
   activate(options?: IRouterOptions): void;
   loadUrl(): Promise<void>;

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -1,6 +1,6 @@
 import { IContainer } from '@aurelia/kernel';
 import { IController, ICustomElementType, IRenderContext } from '@aurelia/runtime';
-import { Router } from './router';
+import { IRouter } from './router';
 import { IFindViewportsResult } from './scope';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
@@ -26,12 +26,12 @@ export class Scope {
   public children: Scope[];
   public viewports: Viewport[];
 
-  private readonly router: Router;
+  private readonly router: IRouter;
 
   private viewportInstructions: ViewportInstruction[];
   private availableViewports: Record<string, Viewport>;
 
-  constructor(router: Router, element: Element, context: IRenderContext | IContainer, parent: Scope) {
+  constructor(router: IRouter, element: Element, context: IRenderContext | IContainer, parent: Scope) {
     this.router = router;
     this.element = element;
     this.context = context;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
-import { Router } from './router';
+import { IRouter } from './router';
 import { Viewport } from './viewport';
 import { IRouteableCustomElementType } from './viewport-content';
 
@@ -84,7 +84,7 @@ export class ViewportInstruction {
     return null;
   }
 
-  public viewportInstance(router: Router): Viewport {
+  public viewportInstance(router: IRouter): Viewport {
     if (this.viewport !== null) {
       return this.viewport;
     }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,7 +1,7 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { ICustomElementType, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
 import { INavigationInstruction } from './navigator';
-import { Router } from './router';
+import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
 import { ReentryBehavior, ViewportContent } from './viewport-content';
@@ -30,7 +30,7 @@ export class Viewport {
 
   public enabled: boolean;
 
-  private readonly router: Router;
+  private readonly router: IRouter;
 
   private clear: boolean;
   private elementResolve?: ((value?: void | PromiseLike<void>) => void) | null;
@@ -39,7 +39,7 @@ export class Viewport {
 
   private cache: ViewportContent[];
 
-  constructor(router: Router, name: string, element: Element, context: IRenderContext | IContainer, owningScope: Scope, scope: Scope, options?: IViewportOptions) {
+  constructor(router: IRouter, name: string, element: Element, context: IRenderContext | IContainer, owningScope: Scope, scope: Scope, options?: IViewportOptions) {
     this.router = router;
     this.name = name;
     this.element = element;

--- a/packages/router/test/e2e/doc-example/app/src/components/login-special.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login-special.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
 import { customElement, ICustomElement } from '@aurelia/runtime';
-import { Router } from '../../../../../../src';
+import { IRouter } from '../../../../../../src';
 import { State } from '../state';
 
 @customElement({
@@ -9,9 +9,9 @@ import { State } from '../state';
   <p>You need to be logged in SPECIAL to continue.</p>
   <button data-test="login-button" click.trigger="login()">Okay, log me in SPECIAL</button>
 </div>` })
-@inject(State, Router)
+@inject(State, IRouter)
 export class LoginSpecial {
-  constructor(private readonly state: State, private readonly router: Router) { }
+  constructor(private readonly state: State, private readonly router: IRouter) { }
 
   public login() {
     this.state.loggedIn = true;

--- a/packages/router/test/e2e/doc-example/app/src/components/login.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/login.ts
@@ -1,6 +1,6 @@
 import { inject } from '@aurelia/kernel';
 import { customElement, ICustomElement } from '@aurelia/runtime';
-import { Router } from '../../../../../../src';
+import { IRouter } from '../../../../../../src';
 import { State } from '../state';
 import { ViewportInstruction } from '../../../../../../src/viewport-instruction';
 
@@ -10,9 +10,9 @@ import { ViewportInstruction } from '../../../../../../src/viewport-instruction'
   <p>You need to be logged in to continue.</p>
   <button data-test="login-button" click.trigger="login()">Okay, log me in</button>
 </div>` })
-@inject(State, Router)
+@inject(State, IRouter)
 export class Login {
-  constructor(private readonly state: State, private readonly router: Router) { }
+  constructor(private readonly state: State, private readonly router: IRouter) { }
 
   public login() {
     this.state.loggedIn = true;

--- a/packages/router/test/e2e/doc-example/app/src/components/main.ts
+++ b/packages/router/test/e2e/doc-example/app/src/components/main.ts
@@ -1,12 +1,12 @@
 import { inject } from '@aurelia/kernel';
 import { customElement } from '@aurelia/runtime';
-import { Router } from '../../../../../../../router/src/index';
+import { IRouter } from '../../../../../../../router/src/index';
 import { State } from '../state';
 import { About } from './about';
 import { Authors } from './authors/authors';
 import { Books } from './books/books';
 
-@inject(Router, State)
+@inject(IRouter, State)
 @customElement({
   name: 'main', template:
     `
@@ -40,7 +40,7 @@ import { Books } from './books/books';
   </div>
 ` })
 export class Main {
-  constructor(private readonly router: Router, private readonly state: State) {
+  constructor(private readonly router: IRouter, private readonly state: State) {
     this.router.setNav('main-menu', [
       {
         title: 'Authors',

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -309,11 +309,13 @@ export class ProviderTask implements ILifecycleTask {
   public wait(): Promise<unknown> {
     if (this.promise === void 0) {
       const instance = this.container.get(this.key);
-      const promiseOrTask = this.callback.call(void 0, instance);
+      const maybePromiseOrTask = this.callback.call(void 0, instance);
 
-      this.promise = (promiseOrTask as Promise<unknown>).then instanceof Function
-        ? promiseOrTask as Promise<unknown>
-        : (promiseOrTask as ILifecycleTask).wait();
+      this.promise = maybePromiseOrTask === void 0
+        ? Promise.resolve()
+        : (maybePromiseOrTask as Promise<unknown>).then instanceof Function
+          ? maybePromiseOrTask as Promise<unknown>
+          : (maybePromiseOrTask as ILifecycleTask).wait();
 
       this.promise = this.promise.then(() => {
         this.done = true;

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -52,7 +52,7 @@ export interface ICallbackSlotChooser<K extends Key> {
 }
 
 export interface ICallbackChooser<K extends Key> {
-  call<K1 extends Key = K>(fn: (instance: Resolved<K1>) => PromiseOrTask): IStartTask;
+  call<K1 extends Key = K>(fn: (instance: Resolved<K1>) => MaybePromiseOrTask): IStartTask;
 }
 
 const enum TaskType {

--- a/test/cypress/app/src/components/router/with-nav.ts
+++ b/test/cypress/app/src/components/router/with-nav.ts
@@ -1,14 +1,14 @@
 import { inject } from '@aurelia/kernel';
-import { Router } from '@aurelia/router';
+import { IRouter } from '@aurelia/router';
 import { customElement } from '@aurelia/runtime';
 
 import template from './with-nav.html';
 
-@inject(Router)
+@inject(IRouter)
 @customElement({
   name: 'routerWithNav',
   template
 })
 export class RouterWithNav {
-  constructor(private router: Router) { }
+  constructor(private router: IRouter) { }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR moves router initialization into RouterConfiguration and updates tests and test apps accordingly. It also switches injects from Router to IRouter.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working. 

## 📑 Test Plan

- Make sure tests still pass.

## ⏭ Next Steps

- Make RouterConfiguration customization work
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
