### PR TITLE
feat(focus): add focus attribute

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,5 +57,6 @@
     "statusBar.background": "#3f2e5e",
     "statusBarItem.hoverBackground": "#563f80",
     "statusBar.foreground": "#e7e7e7"
-  }
+  },
+  "workbench.tree.indent": 16
 }

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -150,17 +150,10 @@ describe('focus.spec.ts', function() {
           const isFocusable = ceProp && (typeof ceProp.tabIndex !== undefined || ceProp.contentEditable);
           // tslint:disable-next-line:insecure-random
           const ceName = `ce-${Math.random().toString().slice(-6)}`;
+          const CustomEl = defineCustomElement(ceName, ceTemplate, { tabIndex: 1 }, shadowMode);
 
           it(`works with ${isFocusable ? 'focusable' : ''} custom element ${ceName}, #shadowRoot: ${shadowMode}`, function() {
             let callCount = 0;
-
-            const { au, component, ctx } = setup<IApp>(
-              `<template><${ceName} focus.bind=hasFocus></${ceName}></template>`,
-              class App {
-                public hasFocus = true;
-              }
-            );
-            const CustomEl = defineCustomElement(ctx, ceName, ceTemplate, { tabIndex: 1 }, shadowMode);
             // only track call, virtually no different without this layer
             CustomEl.prototype['focus'] = function focus(options?: FocusOptions): void {
               callCount++;
@@ -178,6 +171,13 @@ describe('focus.spec.ts', function() {
                 return HTMLElement.prototype.focus.call(this, options);
               }
             };
+
+            const { au, component, ctx } = setup<IApp>(
+              `<template><${ceName} focus.bind=hasFocus></${ceName}></template>`,
+              class App {
+                public hasFocus = true;
+              }
+            );
 
             const activeElement = ctx.doc.activeElement;
             const ceEl = ctx.doc.querySelector(`app ${ceName}`);
@@ -348,7 +348,7 @@ describe('focus.spec.ts', function() {
     return { ctx, container, lifecycle, host, au, component, observerLocator };
   }
 
-  function defineCustomElement(ctx: HTMLTestContext, name: string, template: string, props: Record<string, any> = null, mode: 'open' | 'closed' | null = 'open') {
+  function defineCustomElement(name: string, template: string, props: Record<string, any> = null, mode: 'open' | 'closed' | null = 'open') {
     class CustomEl extends HTMLElement {
       constructor() {
         super();

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -1,9 +1,13 @@
-import { Constructable } from '@aurelia/kernel';
+import { Constructable, PLATFORM } from '@aurelia/kernel';
 import { Aurelia, CustomElement } from '@aurelia/runtime';
 import { Focus } from '@aurelia/runtime-html';
 import { assert, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
 
 describe('focus.spec.ts', function() {
+
+  if (!PLATFORM.isBrowserLike) {
+    return;
+  }
 
   interface IApp {
     hasFocus?: boolean;

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -345,7 +345,7 @@ describe('focus.spec.ts', function() {
   }
 
   function defineCustomElement(ctx: HTMLTestContext, name: string, template: string, props: Record<string, any> = null, mode: 'open' | 'closed' | null = 'open') {
-    class CustomEl extends ctx.dom.HTMLElement {
+    class CustomEl extends ctx.HTMLElement {
       constructor() {
         super();
         if (mode !== null) {

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -1,0 +1,375 @@
+import { Constructable } from '@aurelia/kernel';
+import { Aurelia, CustomElement } from '@aurelia/runtime';
+import { Focus } from '@aurelia/runtime-html';
+import { assert, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
+
+describe.only('focus.spec.ts', function() {
+
+  interface IApp {
+    hasFocus?: boolean;
+    isFocused?: boolean;
+    isFocused2?: boolean;
+    selectedOption?: string;
+  }
+
+  let $aurelia: Aurelia;
+  let $host: HTMLElement;
+
+  beforeEach(function() {
+    $aurelia = undefined;
+    $host = undefined;
+  });
+
+  afterEach(function() {
+    if ($aurelia) {
+      $aurelia.stop();
+      ($aurelia.root.host as Element).remove();
+    }
+    if ($host) {
+      $host.remove();
+    }
+  });
+
+  describe('basic scenarios', function() {
+
+    describe('with non-focusable element', function() {
+      it('focuses when there is tabindex attribute', function() {
+        const { au, component, ctx } = setup<IApp>(
+          `<template>
+            <div focus.bind="hasFocus" id="blurred" tabindex="-1"></div>
+          </template>`,
+          class App {
+            public hasFocus = true;
+          }
+        );
+
+        const activeElement = ctx.doc.activeElement;
+        const div = ctx.doc.querySelector('app div');
+        assert.notEqual(div, null, '<app/> <div/> not null');
+        assert.equal(activeElement.tagName, 'DIV', 'activeElement === <div/>');
+        assert.equal(activeElement, div, 'activeElement === <div/>');
+        assert.equal(component.hasFocus, true, 'It should not have affected component.hasFocus');
+      });
+    });
+
+    it('invokes focus when there is **NO** tabindex attribute', function() {
+      let callCount = 0;
+      HTMLDivElement.prototype.focus = function() {
+        callCount++;
+        return HTMLElement.prototype.focus.call(this);
+      };
+
+      const { au, component, ctx } = setup<IApp>(
+        `<template>
+          <div focus.bind="hasFocus" id="blurred"></div>
+        </template>`,
+        class App {
+          public hasFocus = true;
+        }
+      );
+
+      const activeElement = ctx.doc.activeElement;
+      const div = ctx.doc.querySelector('app div');
+      assert.equal(callCount, 1, 'It should have invoked focus on DIV element prototype');
+      assert.notEqual(div, null, '<app/> <div/> should not be null');
+      assert.notEqual(activeElement.tagName, 'DIV');
+      assert.notEqual(activeElement, div);
+      assert.equal(component.hasFocus, true, 'It should not have affected component.hasFocus');
+
+      // focus belongs to HTMLElement class
+      delete HTMLDivElement.prototype.focus;
+    });
+
+    for (const [desc, template] of [
+      ['<div/>', '<div contenteditable focus.bind=hasFocus id=blurred></div>'],
+      ['<input/>', `<input focus.bind=hasFocus id=blurred>`],
+      ['<select/>', `<select focus.bind=hasFocus id=blurred></select>`],
+      ['<button/>', '<button focus.bind=hasFocus id=blurred></button>'],
+      ['<video/>', '<video tabindex=1 focus.bind=hasFocus id=blurred></video>'],
+      ['<select/> + <option/>', `<select focus.bind=hasFocus id=blurred><option tabindex=1>Hello</option></select>`],
+      ['<textarea/>', `<textarea focus.bind=hasFocus id=blurred></textarea>`]
+    ]) {
+      describe(`with ${desc}`, function() {
+        it('Works in basic scenario', function() {
+          const { au, component, ctx } = setup<IApp>(
+            `<template>
+              ${template}
+            </template>`,
+            class App {
+              public hasFocus = true;
+            }
+          );
+
+          const elName = desc.replace(/^<|\/>.*$/g, '');
+          const activeElement = ctx.doc.activeElement;
+          const focusable = ctx.doc.querySelector(`app ${elName}`);
+          assert.notEqual(focusable, null, `focusable el (<${elName}/>) is not null`);
+          assert.equal(activeElement.tagName, elName.toUpperCase());
+          assert.equal(activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'It should not have affected component.hasFocus');
+        });
+      });
+    }
+
+    // For combination with native custom element, there needs to be tests based on several combinations
+    // Factors that need to be considered are: shadow root, shadow root with a focusable element,
+    //                  no shadow root, no shadow root with a focusable element
+    //                  tab-index/ content-editable attribute on custom element itself
+    //
+    // Assertion should at least focus on which active element is
+    //                  How the component will be affected by the start up
+    //                  Focus method on custom element has been invoked
+    describe('CustomElements -- Initialization only', function() {
+
+      // when shadowModes is null, custom element sets its innerHTML directly on it own
+      // instead of its shadow root
+      const shadowModes: ShadowRootMode[] = ['open', 'closed', null];
+      const ceTemplates = [
+        '<input />',
+        '<textarea></textarea>',
+        '<select><option></option><option></option></select>',
+        '<div contenteditable="true"></div>',
+        '<div tabindex="1"></div>'
+      ];
+      // controls tests of focusability of the native custom element
+      const ceProps: Record<string, any>[] = [
+        { tabIndex: 1 },
+        { contentEditable: true },
+        // Test case: CE itself is not focusable
+        {}
+      ];
+
+      eachCartesianJoin(
+        [shadowModes, ceTemplates, ceProps],
+        (shadowMode, ceTemplate, ceProp) => {
+          const hasShadowRoot = shadowMode !== null;
+          const isFocusable = ceProp && (typeof ceProp.tabIndex !== undefined || ceProp.contentEditable);
+          // tslint:disable-next-line:insecure-random
+          const ceName = `ce-${Math.random().toString().slice(-6)}`;
+          const CustomEl = defineCustomElement(ceName, ceTemplate, { tabIndex: 1 }, shadowMode);
+
+          it(`works with ${isFocusable ? 'focusable' : ''} custom element ${ceName}, #shadowRoot: ${shadowMode}`, function() {
+            let callCount = 0;
+            // only track call, virtually no different without this layer
+            CustomEl.prototype['focus'] = function focus(options?: FocusOptions): void {
+              callCount++;
+              if (hasShadowRoot) {
+                return HTMLElement.prototype.focus.call(this, options);
+              } else {
+                const focusableEl = this.querySelector('input')
+                  || this.querySelector('textarea')
+                  || this.querySelector('select')
+                  || this.querySelector('[contenteditable]')
+                  || this.querySelector('[tabindex]');
+                if (focusableEl) {
+                  return (focusableEl as HTMLElement).focus();
+                }
+                return HTMLElement.prototype.focus.call(this, options);
+              }
+            };
+
+            const { au, component, ctx } = setup<IApp>(
+              `<template><${ceName} focus.bind=hasFocus></${ceName}></template>`,
+              class App {
+                public hasFocus = true;
+              }
+            );
+
+            const activeElement = ctx.doc.activeElement;
+            const ceEl = ctx.doc.querySelector(`app ${ceName}`);
+            assert.equal(callCount, 1, 'It should have called focus()');
+            assert.notEqual(ceEl, null);
+            if (isFocusable) {
+              if (hasShadowRoot) {
+                assert.equal(activeElement.tagName, ceName.toUpperCase());
+                assert.equal(activeElement, ceEl);
+              } else {
+                assert.notEqual(
+                  activeElement,
+                  ceEl,
+                  'Custom element should NOT have focus when it has focusable light dom child'
+                );
+              }
+            }
+            assert.equal(component.hasFocus, true, 'It should not have affected component.hasFocus');
+          });
+        }
+      );
+    });
+  });
+
+  describe('Interactive scenarios', function() {
+    const focusAttrs = [
+      'focus.two-way=hasFocus',
+      // 'focus.bind=hasFocus',
+      // 'focus="value.two-way: hasFocus"',
+      // 'focus="value.bind: hasFocus"'
+    ];
+    const templates: IFocusTestCase[] = [
+      {
+        title: focusAttr => `Works when shifting focus away from <input/> [${focusAttr}]`,
+        template: (focusAttr) => `<template>
+          <input ${focusAttr} />
+          <div></div>
+          <button>Click me</button>
+        </template>`,
+        getFocusable: 'input',
+        app: class App {
+          public hasFocus = true;
+        },
+        assertionFn: async (ctx, component, focusable) => {
+          const doc = ctx.doc;
+          const win = ctx.wnd;
+          const button = doc.querySelector('button');
+          button.focus();
+          assert.equal(doc.activeElement, button);
+          assert.equal(component.hasFocus, false, '+ button@focus');
+
+          focusable.focus();
+          assert.equal(doc.activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'input@focus');
+
+          win.dispatchEvent(new CustomEvent('blur'));
+          assert.equal(doc.activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'window@blur');
+        }
+      },
+      {
+        title: focusAttr => `Works when shifting focus away from <select/> [${focusAttr}]`,
+        template: (focusAttr) => `<template>
+          <select ${focusAttr} value.bind="anyThing">
+            <option>1</option>
+            <option>2</option>
+          </select>
+          <button>Click me</button>
+        </template>`,
+        getFocusable: 'select',
+        app: class App {
+          public hasFocus = true;
+          public selectedOption: '1' | '2' = '1';
+        },
+        assertionFn: async (ctx, component, focusable) => {
+          const doc = ctx.doc;
+          const win = ctx.wnd;
+          const button = doc.querySelector('button');
+          button.focus();
+          await waitForDelay(50);
+          assert.equal(doc.activeElement, button);
+          assert.equal(component.hasFocus, false, '> button@focus');
+
+          focusable.focus();
+          assert.equal(doc.activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'select@focus');
+
+          win.dispatchEvent(new CustomEvent('blur'));
+          assert.equal(doc.activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'window@blur');
+
+          component.selectedOption = '2';
+          await waitForDelay();
+          assert.equal(doc.activeElement, focusable);
+          assert.equal(component.hasFocus, true, 'select@change');
+        }
+      },
+      {
+        title: focusAttr => `Multiple focus bindings and focus stealing between <input/> [${focusAttr}]`,
+        template: (focusAttr) => `<template>
+          <input ${focusAttr} id=input1>
+          <input focus.bind="isFocused2" id=input2>
+          <button>Click me</button>
+        </template>`,
+        getFocusable: 'input',
+        app: class App {
+          public hasFocus = true;
+          public isFocused2 = false;
+        },
+        async assertionFn(ctx, component, focusable) {
+          const input2 = ctx.doc.querySelector('#input2') as HTMLInputElement;
+          assert.notEqual(focusable, input2, '@setup: focusable === #input2');
+          input2.focus();
+          await waitForDelay(50);
+          assert.equal(document.activeElement, input2, '#input2@focus -> document.activeElement === #input2');
+          assert.equal(component.isFocused2, true, '#input2@focus -> component.isFocused2 === true');
+          assert.equal(component.hasFocus, false, '#input2@focus -> component.hasFocus === false');
+        }
+      }
+    ];
+
+    eachCartesianJoin(
+      [focusAttrs, templates],
+      (command, { title, template, getFocusable, app, assertionFn }: IFocusTestCase) => {
+        it(title(command), function() {
+          const { au, component, ctx } = setup<IApp>(
+            template(command),
+            app
+          );
+          const doc = ctx.doc;
+          const activeElement = doc.activeElement;
+          const focusable = typeof getFocusable === 'string'
+            ? doc.querySelector(getFocusable) as HTMLElement
+            : getFocusable(doc);
+          assert.notEqual(focusable, null);
+          if (typeof getFocusable === 'string') {
+            const parts = getFocusable.split(' ');
+            assert.equal(activeElement.tagName, parts[parts.length - 1].toUpperCase());
+          }
+          assert.equal(activeElement, focusable, '@setup -> document.activeElement === focusable');
+          assert.equal(component.hasFocus, true, 'It should not have affected component.hasFocus');
+          return assertionFn(ctx, component, focusable);
+        });
+      }
+    );
+
+    interface IFocusTestCase<T extends IApp = IApp> {
+      title: (focusAttr: string) => string;
+      template: TemplateFn;
+      app: Constructable<T>;
+      assertionFn: AssertionFn;
+      getFocusable: string | ((doc: Document) => HTMLElement);
+    }
+  });
+
+  function setup<T>(template: string | Node, $class: Constructable<T>, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    container.register(...registrations, Focus);
+    const host = $host = ctx.doc.body.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElement.define({ name: 'app', template }, $class);
+    const component = new App();
+
+    au.app({ host, component });
+    au.start();
+
+    return { ctx, container, lifecycle, host, au, component, observerLocator };
+  }
+
+  function defineCustomElement(name: string, template: string, props: Record<string, any> = null, mode: 'open' | 'closed' | null = 'open') {
+    class CustomEl extends HTMLElement {
+      constructor() {
+        super();
+        if (mode !== null) {
+          this.attachShadow({ mode }).innerHTML = template;
+        } else {
+          this.innerHTML = template;
+        }
+        for (const p in props) {
+          this[p] = props[p];
+        }
+      }
+    }
+    customElements.define(name, CustomEl);
+    return CustomEl;
+  }
+
+  function waitForDelay(time = 0): Promise<void> {
+    return new Promise(r => setTimeout(r, time));
+  }
+
+  type TemplateFn = (focusAttrBindingCommand: string) => string;
+
+  interface AssertionFn<T extends IApp = IApp> {
+    // tslint:disable-next-line:callable-types
+    (ctx: HTMLTestContext, component: T, focusable: HTMLElement): void | Promise<void>;
+  }
+});

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -349,7 +349,7 @@ describe('focus.spec.ts', function() {
   }
 
   function defineCustomElement(ctx: HTMLTestContext, name: string, template: string, props: Record<string, any> = null, mode: 'open' | 'closed' | null = 'open') {
-    class CustomEl extends ctx.HTMLElement {
+    class CustomEl extends HTMLElement {
       constructor() {
         super();
         if (mode !== null) {

--- a/packages/__tests__/jit-html/focus.spec.ts
+++ b/packages/__tests__/jit-html/focus.spec.ts
@@ -3,7 +3,7 @@ import { Aurelia, CustomElement } from '@aurelia/runtime';
 import { Focus } from '@aurelia/runtime-html';
 import { assert, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
 
-describe.only('focus.spec.ts', function() {
+describe('focus.spec.ts', function() {
 
   interface IApp {
     hasFocus?: boolean;

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -13,6 +13,7 @@ import { HTMLProjectorLocator } from './projectors';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
 import { UpdateTriggerBindingBehavior } from './resources/binding-behaviors/update-trigger';
+import { Focus } from './resources/custom-attributes/focus';
 import { Compose } from './resources/custom-elements/compose';
 
 export const IProjectorLocatorRegistration = HTMLProjectorLocator as IRegistry;
@@ -38,6 +39,7 @@ export const AttrBindingBehaviorRegistration = AttrBindingBehavior as IRegistry;
 export const SelfBindingBehaviorRegistration = SelfBindingBehavior as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as IRegistry;
 export const ComposeRegistration = Compose as IRegistry;
+export const FocusRegistration = Focus as unknown as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) resources:
@@ -49,6 +51,7 @@ export const DefaultResources = [
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
   ComposeRegistration,
+  FocusRegistration
 ];
 
 export const ListenerBindingRendererRegistration = ListenerBindingRenderer as IRegistry;

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -67,6 +67,10 @@ export {
 } from './resources/binding-behaviors/update-trigger';
 
 export {
+  Focus
+} from './resources/custom-attributes/focus';
+
+export {
   Subject,
   Compose
 } from './resources/custom-elements/compose';

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -1,0 +1,133 @@
+import {
+  bindable,
+  BindingMode,
+  customAttribute,
+  IController,
+  IDOM,
+  INode,
+  State
+} from '@aurelia/runtime';
+import { HTMLDOM } from '../../dom';
+import { addListener, removeListener } from './utils';
+
+/**
+ * Focus attribute for element focus binding
+ */
+@customAttribute('focus')
+export class Focus {
+
+  public static readonly inject: unknown = [INode, IDOM];
+
+  @bindable({ mode: BindingMode.twoWay })
+  public value: unknown;
+
+  private element: HTMLElement;
+  private dom: HTMLDOM;
+
+  /**
+   * Indicates whether `apply` should be called when `attached` callback is invoked
+   */
+  private needsApply: boolean;
+
+  // This is set by the controller after this instance is constructed
+  // tslint:disable-next-line: prefer-readonly
+  private $controller!: IController;
+
+  constructor(
+    element: HTMLElement,
+    dom: HTMLDOM
+  ) {
+    this.element = element;
+    this.dom = dom;
+    this.needsApply = false;
+  }
+
+  public binding(): void {
+    this.valueChanged();
+  }
+
+  /**
+   * Invoked everytime the bound value changes.
+   * @param newValue The new value.
+   */
+  public valueChanged(): void {
+    // In theory, we could/should react immediately
+    // but focus state of an element cannot be achieved
+    // while it's disconnected from the document
+    // thus, there neesd to be a check if it's currently connected or not
+    // before applying the value to the element
+    if (this.$controller.flags & State.isAttached) {
+      this.apply();
+    }
+    // If the element is not currently connect
+    // toggle the flag to add pending work for later
+    // in attached lifecycle
+    // tslint:disable-next-line:one-line
+    else {
+      this.needsApply = true;
+    }
+  }
+
+  /**
+   * Invoked when the attribute is attached to the DOM.
+   */
+  public attached(): void {
+    if (this.needsApply) {
+      this.needsApply = false;
+      this.apply();
+    }
+    // the following block is to help minification
+    // as addEventListener method name, together with element property
+    // adds quite a bit of munification unfriendly code
+    const el = this.element;
+    addListener(el, 'focus', this);
+    addListener(el, 'blur', this);
+  }
+
+  /**
+   * Invoked when the attribute is detached from the DOM.
+   */
+  public detached(): void {
+    // the following block is to help minification
+    // as addEventListener method name, together with element property
+    // adds quite a bit of munification unfriendly code
+    const el = this.element;
+    removeListener(el, 'focus', this);
+    removeListener(el, 'blur', this);
+  }
+
+  /**
+   * EventTarget interface handler for better memory usage
+   */
+  public handleEvent(e: FocusEvent): void {
+    // there are only two event listened to
+    // if the even is focus, it menans the element is focused
+    // only need to switch the value to true
+    if (e.type === 'focus') {
+      this.value = true;
+    }
+    // else, it's blur event
+    // when a blur event happens, there are two situations
+    // 1. the element itself lost the focus
+    // 2. window lost the focus
+    // To handle both (1) and (2), only need to check if
+    // current active element is still the same element of this focus custom attribute
+    // If it's not, it's a blur event happened on Window because the browser tab lost focus
+    // tslint:disable-next-line:one-line
+    else if (this.dom.document.activeElement !== this.element) {
+      this.value = false;
+    }
+  }
+
+  /**
+   * Focus/blur based on current value
+   */
+  private apply(): void {
+    const el = this.element;
+    if (this.value) {
+      el.focus();
+    } else {
+      el.blur();
+    }
+  }
+}

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -15,9 +15,6 @@ import { HTMLDOM } from '../../dom';
 @customAttribute('focus')
 export class Focus {
 
-  // tslint:disable-next-line
-  private static readonly inject = [INode, IDOM];
-
   @bindable({ mode: BindingMode.twoWay })
   public value: unknown;
 
@@ -27,12 +24,11 @@ export class Focus {
   private needsApply: boolean;
 
   // This is set by the controller after this instance is constructed
-  // tslint:disable-next-line: prefer-readonly
-  private $controller!: IController;
+  private readonly $controller!: IController;
 
   constructor(
-    private readonly element: HTMLElement,
-    private readonly dom: HTMLDOM
+    @INode private readonly element: HTMLElement,
+    @IDOM private readonly dom: HTMLDOM
   ) {
     this.element = element;
     this.dom = dom;

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -8,7 +8,6 @@ import {
   State
 } from '@aurelia/runtime';
 import { HTMLDOM } from '../../dom';
-import { addListener, removeListener } from './utils';
 
 /**
  * Focus attribute for element focus binding
@@ -16,13 +15,11 @@ import { addListener, removeListener } from './utils';
 @customAttribute('focus')
 export class Focus {
 
-  public static readonly inject: unknown = [INode, IDOM];
+  // tslint:disable-next-line
+  private static readonly inject = [INode, IDOM];
 
   @bindable({ mode: BindingMode.twoWay })
   public value: unknown;
-
-  private element: HTMLElement;
-  private dom: HTMLDOM;
 
   /**
    * Indicates whether `apply` should be called when `attached` callback is invoked
@@ -34,8 +31,8 @@ export class Focus {
   private $controller!: IController;
 
   constructor(
-    element: HTMLElement,
-    dom: HTMLDOM
+    private readonly element: HTMLElement,
+    private readonly dom: HTMLDOM
   ) {
     this.element = element;
     this.dom = dom;
@@ -56,7 +53,7 @@ export class Focus {
     // while it's disconnected from the document
     // thus, there neesd to be a check if it's currently connected or not
     // before applying the value to the element
-    if (this.$controller.flags & State.isAttached) {
+    if (this.$controller.state & State.isAttached) {
       this.apply();
     }
     // If the element is not currently connect
@@ -76,24 +73,18 @@ export class Focus {
       this.needsApply = false;
       this.apply();
     }
-    // the following block is to help minification
-    // as addEventListener method name, together with element property
-    // adds quite a bit of munification unfriendly code
     const el = this.element;
-    addListener(el, 'focus', this);
-    addListener(el, 'blur', this);
+    el.addEventListener('focus', this);
+    el.addEventListener('blur', this);
   }
 
   /**
    * Invoked when the attribute is detached from the DOM.
    */
   public detached(): void {
-    // the following block is to help minification
-    // as addEventListener method name, together with element property
-    // adds quite a bit of munification unfriendly code
     const el = this.element;
-    removeListener(el, 'focus', this);
-    removeListener(el, 'blur', this);
+    el.removeEventListener('focus', this);
+    el.removeEventListener('blur', this);
   }
 
   /**

--- a/packages/runtime-html/src/resources/custom-attributes/utils.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/utils.ts
@@ -1,7 +1,0 @@
-export const addListener = (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject): void => {
-  target.addEventListener(event, handler);
-};
-
-export const removeListener = (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject): void => {
-  target.removeEventListener(event, handler);
-};

--- a/packages/runtime-html/src/resources/custom-attributes/utils.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/utils.ts
@@ -1,0 +1,7 @@
+export const addListener = (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject): void => {
+  target.addEventListener(event, handler);
+};
+
+export const removeListener = (target: EventTarget, event: string, handler: EventListenerOrEventListenerObject): void => {
+  target.removeEventListener(event, handler);
+};


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add focus attribute, as one of core attributes in vCurrent

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

Need to re-enable multiple binding scenarios once the support is back:

```html
Working:
<input focus.two-way="hasFocus">
Not working:
<input focus="value.two-way: hasFocus">
```

## ⏭ Next Steps

Add more tests
