### PR TITLE
feat(attr-childlist): add childlist attribute

### DIFF
--- a/packages/__tests__/jit-html/childlist.integration.spec.ts
+++ b/packages/__tests__/jit-html/childlist.integration.spec.ts
@@ -1,0 +1,105 @@
+import { Constructable } from '@aurelia/kernel';
+import { Aurelia, CustomElement } from '@aurelia/runtime';
+import { ChildList } from '@aurelia/runtime-html';
+import { assert, TestContext } from '@aurelia/testing';
+
+describe('childist.integration.spec.ts', function() {
+
+  it('gets the right childist', function() {
+    const { dispose, ctx, component } = setup(
+      `<div childlist.bind="childrenOfTheWhale">
+        <div></div>
+        <button></button>
+        <input/>
+        <select></select>
+      </div>`,
+      class App {
+        public childrenOfTheWhale: HTMLElement[];
+      }
+    );
+
+    assert.instanceOf(component.childrenOfTheWhale, Array, 'should have been array');
+    assert.equal(component.childrenOfTheWhale.length, 4, 'should have had 4 elements');
+
+    const gbl = ctx.wnd as unknown as typeof globalThis;
+    assertElements(
+      component.childrenOfTheWhale,
+      [ctx.HTMLDivElement, gbl.HTMLButtonElement, gbl.HTMLInputElement, gbl.HTMLSelectElement]
+    );
+    dispose();
+  });
+
+  describe('with surrogate usage', function() {
+    it('works with basic usage', function() {
+      const { dispose, ctx, component } = setup(
+        `<template childlist.bind="childrenOfTheWhale">
+          <div></div>
+          <button></button>
+          <input/>
+          <select></select>
+        </template>`,
+        class App {
+          public childrenOfTheWhale: HTMLElement[];
+        }
+      );
+
+      debugger;
+      assert.instanceOf(component.childrenOfTheWhale, Array, 'should have been array');
+      assert.equal(component.childrenOfTheWhale.length, 4, 'should have had 4 elements');
+
+      const gbl = ctx.wnd as unknown as typeof globalThis;
+      assertElements(
+        component.childrenOfTheWhale,
+        [ctx.HTMLDivElement, gbl.HTMLButtonElement, gbl.HTMLInputElement, gbl.HTMLSelectElement]
+      );
+      dispose();
+    });
+  });
+
+  function assertElements(elements: HTMLElement[], elementTypes: Constructable<HTMLElement>[], assertionMsgPrefix: string = '') {
+    assert.equal(
+      elements.length,
+      elementTypes.length,
+      // tslint:disable-next-line:no-nested-template-literals
+      `${assertionMsgPrefix ? `${assertionMsgPrefix} ` : ''}Elements count should have been ${Math.max(elements.length, elementTypes.length)}`
+    );
+    elements.forEach((el, idx) =>
+      assert.equal(el instanceof elementTypes[idx], true, `expected <${el.tagName}/> at index [${idx}] to be instanceof ${elementTypes[idx].name}`)
+    );
+  }
+
+  function setup<T>(template: string | Node, $class: Constructable<T>, autoStart: boolean = true, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    container.register(...registrations, ChildList);
+    const host = ctx.doc.body.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElement.define({ name: 'app', template }, $class);
+    const component = new App();
+
+    let startPromise: Promise<unknown>;
+    if (autoStart) {
+      au.app({ host, component });
+      startPromise = au.start().wait();
+    }
+
+    return {
+      startPromise,
+      ctx,
+      container,
+      lifecycle,
+      host,
+      au,
+      component,
+      observerLocator,
+      start: async () => {
+        au.app({ host, component });
+        await au.start().wait();
+      },
+      dispose: async () => {
+        await au.stop().wait();
+        host.remove();
+      }
+    };
+  }
+});

--- a/packages/__tests__/jit-html/childlist.unit.spec.ts
+++ b/packages/__tests__/jit-html/childlist.unit.spec.ts
@@ -1,0 +1,3 @@
+describe('childlist.unit.spec.ts', function() {
+
+});

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -13,6 +13,7 @@ import { HTMLProjectorLocator } from './projectors';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
 import { UpdateTriggerBindingBehavior } from './resources/binding-behaviors/update-trigger';
+import { ChildList } from './resources/custom-attributes/childlist';
 import { Focus } from './resources/custom-attributes/focus';
 import { Compose } from './resources/custom-elements/compose';
 
@@ -40,6 +41,7 @@ export const SelfBindingBehaviorRegistration = SelfBindingBehavior as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as IRegistry;
 export const ComposeRegistration = Compose as IRegistry;
 export const FocusRegistration = Focus as unknown as IRegistry;
+export const ChildListRegistration = ChildList as unknown as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) resources:
@@ -51,7 +53,8 @@ export const DefaultResources = [
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
   ComposeRegistration,
-  FocusRegistration
+  FocusRegistration,
+  ChildListRegistration
 ];
 
 export const ListenerBindingRendererRegistration = ListenerBindingRenderer as IRegistry;

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -67,6 +67,10 @@ export {
 } from './resources/binding-behaviors/update-trigger';
 
 export {
+  ChildList
+} from './resources/custom-attributes/childlist';
+
+export {
   Focus
 } from './resources/custom-attributes/focus';
 

--- a/packages/runtime-html/src/resources/custom-attributes/childlist.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/childlist.ts
@@ -1,0 +1,82 @@
+import { Constructable, PLATFORM } from '@aurelia/kernel';
+import { bindable, BindingMode, customAttribute, IDOM, INode } from '@aurelia/runtime';
+import { HTMLDOM } from '../../dom';
+
+@customAttribute({
+  name: 'childlist',
+  hasDynamicOptions: true
+})
+export class ChildList {
+
+  @bindable({
+    mode: BindingMode.fromView
+  })
+  public value?: Element[];
+
+  @bindable()
+  public selector?: string;
+
+  private observer!: MutationObserver;
+
+  constructor(
+    @INode private readonly element: HTMLElement,
+    @IDOM private readonly dom: HTMLDOM
+  ) {
+  }
+
+  public binding(): void {
+    let observer = this.observer;
+    if (observer === void 0) {
+      observer = this.observer = this.createObserver();
+    }
+    observer.observe(this.element, { childList: true });
+  }
+
+  public attached(): void {
+    this.selectorChanged(this.selector || '');
+  }
+
+  public unbinding(): void {
+    this.observer.disconnect();
+    this.observer = (void 0)!;
+  }
+
+  public selectorChanged(selector: string): void {
+    const newChildList: Element[] = [];
+    this.collect(newChildList, this.element.children, selector);
+    this.value = newChildList;
+  }
+
+  private createObserver(): MutationObserver {
+    return new (this.dom.window as unknown as { MutationObserver: Constructable<MutationObserver> })
+      .MutationObserver((records: MutationRecord[]) => {
+        this.handleMutation(records[0]);
+      });
+  }
+
+  private handleMutation(record: MutationRecord): void {
+    if (record.type === 'childList') {
+      return;
+    }
+    const newChildList: Element[] = [];
+    this.collect(newChildList, this.element.children, this.selector || '');
+    this.value = newChildList;
+  }
+
+  private collect(list: Element[], children: ArrayLike<Element>, selector: string): void {
+    const shouldFilter = typeof selector === 'string' && selector !== '';
+    for (let i = 0, ii = children.length; ii > i; ++i) {
+      const node = children[i];
+      if (node.nodeType !== 1) {
+        continue;
+      }
+      if (shouldFilter) {
+        if (node.matches(selector) && list.indexOf(node) !== -1) {
+          list.push(node);
+        }
+      } else {
+        list.push(node);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Ability to bind a childlist of any arbitrary element with default binding mode is from view. Example usage:

```html
<div childlist.bind="children_of_the_div">
  <div></div>
  <button></button>
  <input/>
  <select></select>
</div>
```

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

Should see how feasible this is, in conjunction with `@children` decorator, potentially some consolidation if this is usable?
Timing is another issue, `attaching` is enough in normal case, but if this supports surrogate element, it needs to be done initially during `attached`

## 📑 Test Plan

N/A

## ⏭ Next Steps

N/A