### PR TITLE
feat(attr-rectsize): add rectsize attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,12 @@
         }
       }
     },
+    "@juggle/resize-observer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-2.3.0.tgz",
+      "integrity": "sha512-vCS2dz1HAG760+vADa7Fol/NhrmdyDa58Nvq39TpdwYjCqTEDFmIFCDGRiKGSw4GPoDRcx/+xwOYlJdMeNUKRw==",
+      "dev": true
+    },
     "@lerna/add": {
       "version": "3.16.2",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.16.2.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "rxjs": "^6.5.2"
   },
   "devDependencies": {
+    "@juggle/resize-observer": "^2.3.0",
     "@types/acorn": "^4.0.5",
     "@types/fancy-log": "^1.3.1",
     "@types/jsdom": "^12.2.4",

--- a/packages/__tests__/jit-html/rectsize.integration.spec.ts
+++ b/packages/__tests__/jit-html/rectsize.integration.spec.ts
@@ -1,0 +1,85 @@
+import { Constructable } from '@aurelia/kernel';
+import { Aurelia, CustomElement } from '@aurelia/runtime';
+import { RectSize } from '@aurelia/runtime-html';
+import { assert, HTMLTestContext, TestContext } from '@aurelia/testing';
+// tslint:disable-next-line:import-name
+import ResizeObserver from '@juggle/resize-observer';
+import { ResizeObserverSize } from './resize-observer-typings-test';
+
+describe('rectsize.integration.spec.ts', function() {
+
+  it('works in basic scenario', async function() {
+    RectSize.ResizeObserver = ResizeObserver;
+    const { dispose, ctx, host, component } = setup(
+      `<form style="width: 100px">
+        <div id=formField1 rectsize.bind="firstnameFieldSize" style="height: 60px">
+          <label>First name</label>
+          <input name=firstname />
+        </div>
+      </form>`,
+      class App {
+        public firstnameFieldSize: ResizeObserverSize;
+      }
+    );
+
+    await waitForFrames(ctx, 1);
+    assert.deepEqual(component.firstnameFieldSize, { inlineSize: 100, blockSize: 60 }, 'Should have been 100x60 (1)');
+
+    host.querySelector('form').style.width = '200px';
+    assert.deepEqual(component.firstnameFieldSize, { inlineSize: 100, blockSize: 60 }, 'Should have been 100x60 still (2)');
+    await waitForFrames(ctx, 1);
+    assert.deepEqual(component.firstnameFieldSize, { inlineSize: 200, blockSize: 60 }, 'Should have been 200x60');
+
+    dispose();
+  });
+
+  function setup<T>(template: string | Node, $class: Constructable<T>, autoStart: boolean = true, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    container.register(...registrations, RectSize);
+    const host = ctx.doc.body.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElement.define({ name: 'app', template }, $class);
+    const component = new App();
+
+    let startPromise: Promise<unknown>;
+    if (autoStart) {
+      au.app({ host, component });
+      startPromise = au.start().wait();
+    }
+
+    return {
+      startPromise,
+      ctx,
+      container,
+      lifecycle,
+      host,
+      au,
+      component,
+      observerLocator,
+      start: async () => {
+        au.app({ host, component });
+        await au.start().wait();
+      },
+      dispose: async () => {
+        await au.stop().wait();
+        host.remove();
+      }
+    };
+  }
+
+  function waitForFrames(ctx: HTMLTestContext, frameCount: number) {
+    // tslint:disable-next-line:promise-must-complete
+    return new Promise<void>(r => {
+      const next = () => {
+        if (frameCount > 0) {
+          frameCount--;
+          ctx.wnd.requestAnimationFrame(next);
+        } else {
+          r();
+        }
+      };
+      next();
+    });
+  }
+});

--- a/packages/__tests__/jit-html/rectsize.unit.spec.ts
+++ b/packages/__tests__/jit-html/rectsize.unit.spec.ts
@@ -1,0 +1,3 @@
+describe('rectsize.unit.spec.ts', function() {
+
+});

--- a/packages/__tests__/jit-html/resize-observer-typings-test.d.ts
+++ b/packages/__tests__/jit-html/resize-observer-typings-test.d.ts
@@ -1,0 +1,98 @@
+/**
+ * Copied from https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
+ */
+
+/**
+ * The ResizeObserver interface is used to observe changes to Element's content
+ * rect.
+ *
+ * It is modeled after MutationObserver and IntersectionObserver.
+ */
+export interface ResizeObserver {
+  new (callback: ResizeObserverCallback): ResizeObserver;
+
+  /**
+   * Adds target to the list of observed elements.
+   */
+  observe: (target: Element, options?: ResizeObserverOptions) => void;
+
+  /**
+   * Removes target from the list of observed elements.
+   */
+  unobserve: (target: Element) => void;
+
+  /**
+   * Clears both the observationTargets and activeTargets lists.
+   */
+  disconnect: () => void;
+}
+
+/**
+ * Options to be given to the resize observer,
+ * when oberving a new element.
+ *
+ * https://drafts.csswg.org/resize-observer-1/#dictdef-resizeobserveroptions
+ */
+export interface ResizeObserverOptions {
+  box: 'border-box' | 'content-box' | undefined;
+}
+
+
+/**
+ * This callback delivers ResizeObserver's notifications. It is invoked by a
+ * broadcast active observations algorithm.
+ */
+export interface ResizeObserverCallback {
+  (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
+
+export interface ResizeObserverEntry {
+  /**
+   * @param target The Element whose size has changed.
+   */
+  new (target: Element);
+
+  /**
+   * The Element whose size has changed.
+   */
+  readonly target: Element;
+
+  /**
+   * Element's content rect when ResizeObserverCallback is invoked.
+   */
+  readonly contentRect: DOMRectReadOnly;
+  
+  readonly borderBoxSize: ResizeObserverSize;
+  readonly contentBoxSize: ResizeObserverSize;
+}
+
+/**
+ * Size of a specific box.
+ * 
+ * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
+ */
+export interface ResizeObserverSize {
+  /**
+   * ~ width
+   */
+  readonly inlineSize: number;
+  /**
+   * ~ height
+   */
+  readonly blockSize: number;
+}
+
+declare class DOMRectReadOnly {
+  static fromRect(other: DOMRectInit | undefined): DOMRectReadOnly;
+
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+
+  toJSON: () => any;
+}

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -14,6 +14,7 @@ import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
 import { UpdateTriggerBindingBehavior } from './resources/binding-behaviors/update-trigger';
 import { Focus } from './resources/custom-attributes/focus';
+import { RectSize } from './resources/custom-attributes/rectsize';
 import { Compose } from './resources/custom-elements/compose';
 
 export const IProjectorLocatorRegistration = HTMLProjectorLocator as IRegistry;
@@ -40,6 +41,7 @@ export const SelfBindingBehaviorRegistration = SelfBindingBehavior as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as IRegistry;
 export const ComposeRegistration = Compose as IRegistry;
 export const FocusRegistration = Focus as unknown as IRegistry;
+export const RectsizeRegistration = RectSize as unknown as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) resources:
@@ -51,7 +53,8 @@ export const DefaultResources = [
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
   ComposeRegistration,
-  FocusRegistration
+  FocusRegistration,
+  RectsizeRegistration
 ];
 
 export const ListenerBindingRendererRegistration = ListenerBindingRenderer as IRegistry;

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -71,6 +71,10 @@ export {
 } from './resources/custom-attributes/focus';
 
 export {
+  RectSize
+} from './resources/custom-attributes/rectsize';
+
+export {
   Subject,
   Compose
 } from './resources/custom-elements/compose';

--- a/packages/runtime-html/src/resources/custom-attributes/rectsize.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/rectsize.ts
@@ -1,0 +1,60 @@
+import { bindable, BindingMode, customAttribute, IDOM, INode } from '@aurelia/runtime';
+import { HTMLDOM } from '../../dom';
+
+@customAttribute({
+  name: 'rectsize',
+  hasDynamicOptions: true
+})
+export class RectSize {
+
+  /**
+   * Allow user to ponyfill Resize observer via this static field
+   */
+  public static ResizeObserver: ResizeObserver;
+
+  @bindable({ mode: BindingMode.fromView })
+  public value!: ResizeObserverSize;
+
+  @bindable()
+  public boxSize!: 'border-box' | 'content-box';
+
+  private observer!: ResizeObserver;
+
+  constructor(
+    @INode private readonly element: HTMLElement,
+    @IDOM private readonly dom: HTMLDOM
+  ) {
+
+  }
+
+  public binding(): void {
+    let observer = this.observer;
+    if (observer === void 0) {
+      observer = this.observer = this.createObserver();
+    }
+    observer.observe(this.element, { box: 'border-box' });
+  }
+
+  public unbinding(): void {
+    this.observer.disconnect();
+    this.observer = (void 0)!;
+  }
+
+  private createObserver(): ResizeObserver {
+    const ResizeObserverCtor = this.getResizeObserver();
+    return new ResizeObserverCtor((entries) => {
+      this.handleResize(entries[0]);
+    });
+  }
+
+  /**
+   * @internal
+   */
+  private handleResize(entry: ResizeObserverEntry): void {
+    this.value = this.boxSize === 'content-box' ? entry.contentBoxSize : entry.borderBoxSize;
+  }
+
+  private getResizeObserver(): ResizeObserver {
+    return RectSize.ResizeObserver || this.dom.window.ResizeObserver;
+  }
+}

--- a/packages/runtime-html/src/resources/custom-attributes/resize-observer.d.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/resize-observer.d.ts
@@ -1,0 +1,102 @@
+/**
+ * Copied from https://gist.github.com/strothj/708afcf4f01dd04de8f49c92e88093c3
+ */
+
+interface Window {
+  ResizeObserver: ResizeObserver;
+}
+
+/**
+ * The ResizeObserver interface is used to observe changes to Element's content
+ * rect.
+ *
+ * It is modeled after MutationObserver and IntersectionObserver.
+ */
+interface ResizeObserver {
+  new (callback: ResizeObserverCallback): ResizeObserver;
+
+  /**
+   * Adds target to the list of observed elements.
+   */
+  observe: (target: Element, options?: ResizeObserverOptions) => void;
+
+  /**
+   * Removes target from the list of observed elements.
+   */
+  unobserve: (target: Element) => void;
+
+  /**
+   * Clears both the observationTargets and activeTargets lists.
+   */
+  disconnect: () => void;
+}
+
+/**
+ * Options to be given to the resize observer,
+ * when oberving a new element.
+ *
+ * https://drafts.csswg.org/resize-observer-1/#dictdef-resizeobserveroptions
+ */
+interface ResizeObserverOptions {
+  box: 'border-box' | 'content-box' | undefined;
+}
+
+
+/**
+ * This callback delivers ResizeObserver's notifications. It is invoked by a
+ * broadcast active observations algorithm.
+ */
+interface ResizeObserverCallback {
+  (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
+
+interface ResizeObserverEntry {
+  /**
+   * @param target The Element whose size has changed.
+   */
+  new (target: Element);
+
+  /**
+   * The Element whose size has changed.
+   */
+  public readonly target: Element;
+
+  /**
+   * Element's content rect when ResizeObserverCallback is invoked.
+   */
+  public readonly contentRect: DOMRectReadOnly;
+  
+  public readonly borderBoxSize: ResizeObserverSize;
+  public readonly contentBoxSize: ResizeObserverSize;
+}
+
+/**
+ * Size of a specific box.
+ * 
+ * https://drafts.csswg.org/resize-observer-1/#resizeobserversize 
+ */
+interface ResizeObserverSize {
+  /**
+   * ~ width
+   */
+  readonly inlineSize: number;
+  /**
+   * ~ height
+   */
+  readonly blockSize: number;
+}
+
+interface DOMRectReadOnly {
+  static fromRect(other: DOMRectInit | undefined): DOMRectReadOnly;
+
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+
+  toJSON: () => any;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add new attribute `rectsize` to provide automatic element sizing binding. Example:
```html
<form style="width: 100px">
  <div id=formField1 rectsize.bind="firstnameFieldSize" style="height: 60px">
    <label>First name</label>
    <input name=firstname />
  </div>
</form>
```
```ts
/**
 * Editor’s Draft, 7 June 2019 at https://drafts.csswg.org/resize-observer-1/#resizeobserversize
 */
firstnameFieldSize === { inlineSize: 100, blockSize: 60 }
```

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

Test many combinations with template controllers
Test with element in Shadow DOM (probably hard without native support)
Test with containerless element

## ⏭ Next Steps

N/A