### PR TITLE
Runtime Support for Styles

### DIFF
--- a/packages/__tests__/kernel/di.integration.spec.ts
+++ b/packages/__tests__/kernel/di.integration.spec.ts
@@ -772,3 +772,37 @@ describe('DI.createInterface() -> container.get()', function () {
     });
   });
 });
+
+describe('defer registration', () => {
+  class FakeCSSService {
+    constructor(public data: any) {}
+  }
+
+  class FakeCSSHandler {
+    public register(container: IContainer, data) {
+      container.register(
+        Registration.instance(
+          FakeCSSService,
+          new FakeCSSService(data)
+        )
+      );
+    }
+  }
+
+  it(`enables the handler class to provide registrations for data`, () => {
+    const container = DI.createContainer();
+    const data = {};
+
+    container.register(
+      Registration.singleton('.css', FakeCSSHandler)
+    );
+
+    container.register(
+      Registration.defer('.css', data)
+    );
+
+    const service = container.get(FakeCSSService);
+
+    assert.strictEqual(service.data, data);
+  });
+});

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -1,5 +1,5 @@
-import { DI, PLATFORM, Registration } from '@aurelia/kernel';
-import { Controller, CustomAttribute, CustomElement, INode, Aurelia } from '@aurelia/runtime';
+import { DI, Registration } from '@aurelia/kernel';
+import { Aurelia, Controller, CustomAttribute, CustomElement, INode } from '@aurelia/runtime';
 import {
   AdoptedStyleSheetsStyles,
   CSSModulesProcessorRegistry,

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -1,0 +1,69 @@
+import { DI, PLATFORM, Registration } from '@aurelia/kernel';
+import { CustomAttribute, INode } from '@aurelia/runtime';
+import { CSSModulesRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
+import { assert } from '@aurelia/testing';
+
+describe('styles', () => {
+  describe('CSS Modules', () => {
+    it('config adds correct registry for css', () => {
+      const container = DI.createContainer();
+
+      container.register(
+        StyleConfiguration.cssModules()
+      );
+
+      const registry = container.get('.css');
+      assert.instanceOf(registry, CSSModulesRegistry);
+    });
+
+    it ('registry overrides class attribute', () => {
+      const element = { className: '' };
+      const container = DI.createContainer();
+      container.register(Registration.instance(INode, element));
+      const registry = new CSSModulesRegistry();
+      const cssModulesLookup = {};
+
+      registry.register(container, cssModulesLookup);
+
+      const attr = container.get(CustomAttribute.keyFrom('class'));
+
+      assert.equal(CustomAttribute.isType(attr.constructor), true);
+    });
+
+    it ('class attribute maps class names', () => {
+      const element = { className: '' };
+      const container = DI.createContainer();
+      container.register(Registration.instance(INode, element));
+      const cssModulesLookup = {
+        'foo': 'bar',
+        'baz': 'qux'
+      };
+
+      const registry = new CSSModulesRegistry();
+      registry.register(container, cssModulesLookup);
+
+      const attr = container.get(CustomAttribute.keyFrom('class')) as any;
+      attr.value = 'foo baz';
+      attr.valueChanged();
+
+      assert.equal(element.className, 'bar qux');
+    });
+  });
+
+  describe('Shadow DOM', () => {
+    if (!PLATFORM.isBrowserLike) {
+      return;
+    }
+
+    it('config adds correct registry for css', () => {
+      const container = DI.createContainer();
+
+      container.register(
+        StyleConfiguration.shadowDOM()
+      );
+
+      const registry = container.get('.css');
+      assert.instanceOf(registry, ShadowDOMRegistry);
+    });
+  });
+});

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -1,26 +1,26 @@
 import { DI, PLATFORM, Registration } from '@aurelia/kernel';
 import { CustomAttribute, INode } from '@aurelia/runtime';
-import { AdoptedStyleSheetsStyles, CSSModulesRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
+import { AdoptedStyleSheetsStyles, CSSModulesProcessorRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 
-describe.only('styles', () => {
-  describe('CSS Modules', () => {
+describe('styles', () => {
+  describe('CSS Modules Processor', () => {
     it('config adds correct registry for css', () => {
       const container = DI.createContainer();
 
       container.register(
-        StyleConfiguration.cssModules()
+        StyleConfiguration.cssModulesProcessor()
       );
 
       const registry = container.get('.css');
-      assert.instanceOf(registry, CSSModulesRegistry);
+      assert.instanceOf(registry, CSSModulesProcessorRegistry);
     });
 
     it('registry overrides class attribute', () => {
       const element = { className: '' };
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
-      const registry = new CSSModulesRegistry();
+      const registry = new CSSModulesProcessorRegistry();
       const cssModulesLookup = {};
 
       registry.register(container, cssModulesLookup);
@@ -39,7 +39,7 @@ describe.only('styles', () => {
         'baz': 'qux'
       };
 
-      const registry = new CSSModulesRegistry();
+      const registry = new CSSModulesProcessorRegistry();
       registry.register(container, cssModulesLookup);
 
       const attr = container.get(CustomAttribute.keyFrom('class')) as any;

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -1,9 +1,9 @@
 import { DI, PLATFORM, Registration } from '@aurelia/kernel';
 import { CustomAttribute, INode } from '@aurelia/runtime';
-import { CSSModulesRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
+import { AdoptedStyleSheetsStyles, CSSModulesRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 
-describe('styles', () => {
+describe.only('styles', () => {
   describe('CSS Modules', () => {
     it('config adds correct registry for css', () => {
       const container = DI.createContainer();
@@ -16,7 +16,7 @@ describe('styles', () => {
       assert.instanceOf(registry, CSSModulesRegistry);
     });
 
-    it ('registry overrides class attribute', () => {
+    it('registry overrides class attribute', () => {
       const element = { className: '' };
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
@@ -30,7 +30,7 @@ describe('styles', () => {
       assert.equal(CustomAttribute.isType(attr.constructor), true);
     });
 
-    it ('class attribute maps class names', () => {
+    it('class attribute maps class names', () => {
       const element = { className: '' };
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
@@ -65,5 +65,13 @@ describe('styles', () => {
       const registry = container.get('.css');
       assert.instanceOf(registry, ShadowDOMRegistry);
     });
+
+    // TODO: style element style tests
+
+    if (!AdoptedStyleSheetsStyles.supported()) {
+      return;
+    }
+
+    // TODO: adopted styles tests
   });
 });

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -1,16 +1,23 @@
 import { DI, PLATFORM, Registration } from '@aurelia/kernel';
-import { CustomAttribute, INode } from '@aurelia/runtime';
-import { AdoptedStyleSheetsStyles, CSSModulesProcessorRegistry, ShadowDOMRegistry, StyleConfiguration } from '@aurelia/runtime-html';
-import { assert } from '@aurelia/testing';
+import { Controller, CustomAttribute, CustomElement, INode } from '@aurelia/runtime';
+import {
+  AdoptedStyleSheetsStyles,
+  CSSModulesProcessorRegistry,
+  IShadowDOMStyles,
+  ShadowDOMProjector,
+  ShadowDOMRegistry,
+  StyleConfiguration,
+  StyleElementStyles,
+  styles
+} from '@aurelia/runtime-html';
+import { assert, TestContext } from '@aurelia/testing';
 
-describe('styles', () => {
+describe('Styles', () => {
   describe('CSS Modules Processor', () => {
     it('config adds correct registry for css', () => {
       const container = DI.createContainer();
 
-      container.register(
-        StyleConfiguration.cssModulesProcessor()
-      );
+      container.register(StyleConfiguration.cssModulesProcessor());
 
       const registry = container.get('.css');
       assert.instanceOf(registry, CSSModulesProcessorRegistry);
@@ -48,6 +55,28 @@ describe('styles', () => {
 
       assert.equal(element.className, 'bar qux');
     });
+
+    it('style function uses correct registry', () => {
+      const container = DI.createContainer();
+      const childContainer = container.createChild();
+
+      container.register(StyleConfiguration.cssModulesProcessor());
+
+      const element = { className: '' };
+      const cssModulesLookup = {
+        'foo': 'bar',
+        'baz': 'qux'
+      };
+
+      childContainer.register(Registration.instance(INode, element));
+      styles(cssModulesLookup).register(childContainer);
+
+      const attr = childContainer.get(CustomAttribute.keyFrom('class')) as any;
+      attr.value = 'foo baz';
+      attr.valueChanged();
+
+      assert.equal(element.className, 'bar qux');
+    });
   });
 
   describe('Shadow DOM', () => {
@@ -58,20 +87,165 @@ describe('styles', () => {
     it('config adds correct registry for css', () => {
       const container = DI.createContainer();
 
-      container.register(
-        StyleConfiguration.shadowDOM()
-      );
+      container.register(StyleConfiguration.shadowDOM());
 
       const registry = container.get('.css');
       assert.instanceOf(registry, ShadowDOMRegistry);
     });
 
-    // TODO: style element style tests
+    it('registry provides root shadow dom styles', () => {
+      const container = DI.createContainer();
+      const childContainer = container.createChild();
+
+      container.register(StyleConfiguration.shadowDOM());
+
+      const s = childContainer.get(IShadowDOMStyles);
+
+      assert.instanceOf(s, Object);
+      assert.equal(typeof s.applyTo, 'function');
+    });
+
+    it('config passes root styles to container', () => {
+      const container = DI.createContainer();
+      const childContainer = container.createChild();
+      const rootStyles = '.my-class { color: red }';
+
+      container.register(
+        StyleConfiguration.shadowDOM({
+          sharedStyles: [rootStyles]
+        })
+      );
+
+      const s = childContainer.get(IShadowDOMStyles);
+
+      if (AdoptedStyleSheetsStyles.supported()) {
+        assert.instanceOf(s, AdoptedStyleSheetsStyles);
+        assert.equal(s['styleSheets'].length, 1);
+      } else {
+        assert.instanceOf(s, StyleElementStyles);
+        assert.equal(s['localStyles'].length, 1);
+      }
+    });
+
+    it('element styles apply parent styles', () => {
+      const root = { prepend() {} };
+      const fake = {
+        wasCalled: false,
+        applyTo() { this.wasCalled = true; }
+      };
+
+      const s = new StyleElementStyles([], fake);
+      s.applyTo(root as any);
+
+      assert.equal(fake.wasCalled, true);
+    });
+
+    it('element styles apply by prepending style elements to shadow root', () => {
+      const css = '.my-class { color: red }';
+      const root = {
+        element: null,
+        prepend(styleElement) {
+          this.element = styleElement;
+        }
+      };
+
+      const s = new StyleElementStyles([css], null);
+      s.applyTo(root as any);
+
+      assert.equal(root.element.tagName, 'STYLE');
+      assert.equal(root.element.innerHTML, css);
+    });
+
+    it('adopted styles apply parent styles', () => {
+      const root = { adoptedStyleSheets: [] };
+      const fake = {
+        wasCalled: false,
+        applyTo() { this.wasCalled = true; }
+      };
+
+      const s = new AdoptedStyleSheetsStyles([], new Map(), fake);
+      s.applyTo(root as any);
+
+      assert.equal(fake.wasCalled, true);
+    });
+
+    it('projector applies styles during projection', () => {
+      const ctx = TestContext.createHTMLTestContext();
+      const host = ctx.createElement('foo-bar');
+      const FooBar = CustomElement.define(
+        {
+          name: 'foo-bar',
+          shadowOptions: { mode: 'open' }
+        }
+      );
+      const css = '.my-class { color: red }';
+      const context = ctx.container.createChild();
+      context.register(
+        Registration.instance(
+          IShadowDOMStyles,
+          new StyleElementStyles([css], null)
+        )
+      );
+
+      const component = new FooBar();
+      const controller = Controller.forCustomElement(component, ctx.container, host);
+      controller.context = context;
+
+      const seq = { appendTo() {} };
+      const projector = controller.projector!;
+
+      projector.project(seq as any);
+
+      const root = projector.provideEncapsulationSource() as ShadowRoot;
+      assert.strictEqual(root.firstElementChild.innerHTML, css);
+    });
 
     if (!AdoptedStyleSheetsStyles.supported()) {
       return;
     }
 
-    // TODO: adopted styles tests
+    it('adopted styles apply by setting adopted style sheets on shadow root', () => {
+      const css = '.my-class { color: red }';
+      const root = { adoptedStyleSheets: [] };
+
+      const s = new AdoptedStyleSheetsStyles([css], new Map(), null);
+      s.applyTo(root as any);
+
+      assert.equal(root.adoptedStyleSheets.length, 1);
+      assert.instanceOf(root.adoptedStyleSheets[0], CSSStyleSheet);
+    });
+
+    it('adopted styles use cached style sheets', () => {
+      const css = '.my-class { color: red }';
+      const root = { adoptedStyleSheets: [] };
+      const cache = new Map();
+      const sheet = new CSSStyleSheet();
+      cache.set(css, sheet);
+
+      const s = new AdoptedStyleSheetsStyles([css], cache, null);
+      s.applyTo(root as any);
+
+      assert.equal(root.adoptedStyleSheets.length, 1);
+      assert.strictEqual(root.adoptedStyleSheets[0], sheet);
+    });
+
+    it('adopted styles merge sheets from parent', () => {
+      const sharedCSS = '.my-class { color: red }';
+      const localCSS = '.something-else { color: blue }';
+      const root = { adoptedStyleSheets: [] };
+      const cache = new Map();
+      const sharedSheet = new CSSStyleSheet();
+      const localSheet = new CSSStyleSheet();
+      cache.set(sharedCSS, sharedSheet);
+      cache.set(localCSS, localSheet);
+
+      const p = new AdoptedStyleSheetsStyles([sharedCSS], cache, null);
+      const s = new AdoptedStyleSheetsStyles([localCSS], cache, p);
+      s.applyTo(root as any);
+
+      assert.equal(root.adoptedStyleSheets.length, 2);
+      assert.strictEqual(root.adoptedStyleSheets[0], sharedSheet);
+      assert.strictEqual(root.adoptedStyleSheets[1], localSheet);
+    });
   });
 });

--- a/packages/__tests__/runtime-html/styles.spec.ts
+++ b/packages/__tests__/runtime-html/styles.spec.ts
@@ -4,7 +4,6 @@ import {
   AdoptedStyleSheetsStyles,
   CSSModulesProcessorRegistry,
   IShadowDOMStyles,
-  ShadowDOMProjector,
   ShadowDOMRegistry,
   StyleConfiguration,
   StyleElementStyles,

--- a/packages/__tests__/setup-browser-router.ts
+++ b/packages/__tests__/setup-browser-router.ts
@@ -25,7 +25,9 @@ function createBrowserTestContext(): HTMLTestContext {
     HTMLDivElement,
     Text,
     Comment,
-    DOMParser
+    DOMParser,
+    CSSStyleSheet,
+    ShadowRoot
   );
 }
 

--- a/packages/__tests__/setup-browser.ts
+++ b/packages/__tests__/setup-browser.ts
@@ -25,7 +25,9 @@ function createBrowserTestContext(): HTMLTestContext {
     HTMLDivElement,
     Text,
     Comment,
-    DOMParser
+    DOMParser,
+    CSSStyleSheet,
+    ShadowRoot
   );
 }
 

--- a/packages/__tests__/setup-node.ts
+++ b/packages/__tests__/setup-node.ts
@@ -28,7 +28,9 @@ function createJSDOMTestContext(): HTMLTestContext {
     jsdom.window.HTMLDivElement,
     jsdom.window.Text,
     jsdom.window.Comment,
-    jsdom.window.DOMParser
+    jsdom.window.DOMParser,
+    jsdom.window.CSSStyleSheet,
+    class ShadowRoot {} as any
   );
 }
 

--- a/packages/__tests__/setup-node.ts
+++ b/packages/__tests__/setup-node.ts
@@ -30,7 +30,7 @@ function createJSDOMTestContext(): HTMLTestContext {
     jsdom.window.Comment,
     jsdom.window.DOMParser,
     jsdom.window.CSSStyleSheet,
-    class ShadowRoot {} as any
+    (jsdom.window as unknown as { ShadowRoot: typeof ShadowRoot }).ShadowRoot
   );
 }
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -45,7 +45,7 @@ export interface IServiceLocator {
 }
 
 export interface IRegistry {
-  register(container: IContainer, ...params: any[]): void;
+  register(container: IContainer, ...params: unknown[]): void;
 }
 
 export interface IContainer extends IServiceLocator {
@@ -766,6 +766,23 @@ export class Container implements IContainer {
   }
 }
 
+/**
+ * An implementation of IRegistry that delegates registration to a
+ * separately registered class. The ParameterizedRegistry facilitates the
+ * passing of parameters to the final registry.
+ */
+export class ParameterizedRegistry implements IRegistry {
+  constructor(
+    private readonly key: Key,
+    private readonly params: unknown[]
+  ) {}
+
+  public register(container: IContainer): void {
+    const registry = container.get<IRegistry>(this.key);
+    registry.register(container, ...this.params);
+  }
+}
+
 export const Registration = Object.freeze({
   instance<T>(key: Key, value: T): IRegistration<T> {
     return new Resolver(key, ResolverStrategy.instance, value);
@@ -782,13 +799,8 @@ export const Registration = Object.freeze({
   alias<T>(originalKey: T, aliasKey: Key): IRegistration<Resolved<T>> {
     return new Resolver(aliasKey, ResolverStrategy.alias, originalKey);
   },
-  defer(key: Key, ...params: any[]): IRegistry {
-    return {
-      register(container: IContainer) {
-        const r = container.get<IRegistry>(key);
-        r.register(container, ...params);
-      }
-    };
+  defer(key: Key, ...params: unknown[]): IRegistry {
+    return new ParameterizedRegistry(key, params);
   }
 });
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -45,7 +45,7 @@ export interface IServiceLocator {
 }
 
 export interface IRegistry {
-  register(container: IContainer): void;
+  register(container: IContainer, ...params: any[]): void;
 }
 
 export interface IContainer extends IServiceLocator {
@@ -782,6 +782,14 @@ export const Registration = Object.freeze({
   alias<T>(originalKey: T, aliasKey: Key): IRegistration<Resolved<T>> {
     return new Resolver(aliasKey, ResolverStrategy.alias, originalKey);
   },
+  defer(key: Key, ...params: any[]): IRegistry {
+    return {
+      register(container: IContainer) {
+        const r = container.get<IRegistry>(key);
+        r.register(container, ...params);
+      }
+    };
+  }
 });
 
 export class InstanceProvider<K extends Key> implements IResolver<K | null> {

--- a/packages/runtime-html-browser/src/index.ts
+++ b/packages/runtime-html-browser/src/index.ts
@@ -30,7 +30,9 @@ class BrowserDOMInitializer implements IDOMInitializer {
           Node,
           Element,
           HTMLElement,
-          CustomEvent
+          CustomEvent,
+          CSSStyleSheet,
+          ShadowRoot
         );
       } else {
         dom = new HTMLDOM(
@@ -39,7 +41,9 @@ class BrowserDOMInitializer implements IDOMInitializer {
           Node,
           Element,
           HTMLElement,
-          CustomEvent
+          CustomEvent,
+          CSSStyleSheet,
+          ShadowRoot
         );
       }
     } else {
@@ -49,7 +53,9 @@ class BrowserDOMInitializer implements IDOMInitializer {
         Node,
         Element,
         HTMLElement,
-        CustomEvent
+        CustomEvent,
+        CSSStyleSheet,
+        ShadowRoot
       );
     }
     Registration.instance(IDOM, dom).register(this.container);

--- a/packages/runtime-html-jsdom/src/index.ts
+++ b/packages/runtime-html-jsdom/src/index.ts
@@ -33,7 +33,9 @@ class JSDOMInitializer implements IDOMInitializer {
           this.jsdom.window.Node,
           this.jsdom.window.Element,
           this.jsdom.window.HTMLElement,
-          this.jsdom.window.CustomEvent
+          this.jsdom.window.CustomEvent,
+          this.jsdom.window.CSSStyleSheet,
+          class ShadowRoot {} as any
         );
       } else {
         if (config.host !== undefined) {
@@ -45,7 +47,9 @@ class JSDOMInitializer implements IDOMInitializer {
           this.jsdom.window.Node,
           this.jsdom.window.Element,
           this.jsdom.window.HTMLElement,
-          this.jsdom.window.CustomEvent
+          this.jsdom.window.CustomEvent,
+          this.jsdom.window.CSSStyleSheet,
+          class ShadowRoot {} as any
         );
       }
     } else {
@@ -55,7 +59,9 @@ class JSDOMInitializer implements IDOMInitializer {
         this.jsdom.window.Node,
         this.jsdom.window.Element,
         this.jsdom.window.HTMLElement,
-        this.jsdom.window.CustomEvent
+        this.jsdom.window.CustomEvent,
+        this.jsdom.window.CSSStyleSheet,
+        class ShadowRoot {} as any
       );
     }
     Registration.instance(IDOM, dom).register(this.container);

--- a/packages/runtime-html-jsdom/src/index.ts
+++ b/packages/runtime-html-jsdom/src/index.ts
@@ -35,7 +35,7 @@ class JSDOMInitializer implements IDOMInitializer {
           this.jsdom.window.HTMLElement,
           this.jsdom.window.CustomEvent,
           this.jsdom.window.CSSStyleSheet,
-          class ShadowRoot {} as any
+          (this.jsdom.window as unknown as { ShadowRoot: typeof ShadowRoot }).ShadowRoot
         );
       } else {
         if (config.host !== undefined) {
@@ -49,7 +49,7 @@ class JSDOMInitializer implements IDOMInitializer {
           this.jsdom.window.HTMLElement,
           this.jsdom.window.CustomEvent,
           this.jsdom.window.CSSStyleSheet,
-          class ShadowRoot {} as any
+          (this.jsdom.window as unknown as { ShadowRoot: typeof ShadowRoot }).ShadowRoot
         );
       }
     } else {
@@ -61,7 +61,7 @@ class JSDOMInitializer implements IDOMInitializer {
         this.jsdom.window.HTMLElement,
         this.jsdom.window.CustomEvent,
         this.jsdom.window.CSSStyleSheet,
-        class ShadowRoot {} as any
+        (this.jsdom.window as unknown as { ShadowRoot: typeof ShadowRoot }).ShadowRoot
       );
     }
     Registration.instance(IDOM, dom).register(this.container);

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -50,6 +50,8 @@ export class HTMLDOM implements IDOM {
   public readonly Element: typeof Element;
   public readonly HTMLElement: typeof HTMLElement;
   public readonly CustomEvent: typeof CustomEvent;
+  public readonly CSSStyleSheet: typeof CSSStyleSheet;
+  public readonly ShadowRoot: typeof ShadowRoot;
   public readonly window: Window;
   public readonly document: Document;
 
@@ -59,7 +61,9 @@ export class HTMLDOM implements IDOM {
     TNode: typeof Node,
     TElement: typeof Element,
     THTMLElement: typeof HTMLElement,
-    TCustomEvent: typeof CustomEvent
+    TCustomEvent: typeof CustomEvent,
+    TCSSStyleSheet: typeof CSSStyleSheet,
+    TShadowRoot: typeof ShadowRoot
   ) {
     this.window = window;
     this.document = document;
@@ -67,6 +71,8 @@ export class HTMLDOM implements IDOM {
     this.Element = TElement;
     this.HTMLElement = THTMLElement;
     this.CustomEvent = TCustomEvent;
+    this.CSSStyleSheet = TCSSStyleSheet;
+    this.ShadowRoot = TShadowRoot;
     if (DOM.isInitialized) {
       Reporter.write(1001); // TODO: create reporters code // DOM already initialized (just info)
       DOM.destroy();

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -146,7 +146,7 @@ export {
   IShadowDOMConfiguration
 } from './styles/style-configuration';
 export {
-  CSSModulesRegistry
+  CSSModulesProcessorRegistry
 } from './styles/css-modules-registry';
 export {
   ShadowDOMRegistry

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -145,3 +145,9 @@ export {
   styles,
   IShadowDOMConfiguration
 } from './styles/style-configuration';
+export {
+  CSSModulesRegistry
+} from './styles/css-modules-registry';
+export {
+  ShadowDOMRegistry
+} from './styles/shadow-dom-registry';

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -151,3 +151,7 @@ export {
 export {
   ShadowDOMRegistry
 } from './styles/shadow-dom-registry';
+export {
+  AdoptedStyleSheetsStyles,
+  StyleElementStyles
+} from './styles/shadow-dom-styles';

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -139,3 +139,9 @@ export {
   HTMLProjectorLocator,
   ShadowDOMProjector
 } from './projectors';
+
+export {
+  StyleConfiguration,
+  styles,
+  IShadowDOMConfiguration
+} from './styles/style-configuration';

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -153,5 +153,6 @@ export {
 } from './styles/shadow-dom-registry';
 export {
   AdoptedStyleSheetsStyles,
-  StyleElementStyles
+  StyleElementStyles,
+  IShadowDOMStyles
 } from './styles/shadow-dom-styles';

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -17,6 +17,7 @@ import {
   IProjectorLocator,
   TemplateDefinition
 } from '@aurelia/runtime';
+import { IShadowDOMStyleManager } from './styles/shadow-dom-styles';
 
 const slice = Array.prototype.slice;
 
@@ -53,10 +54,12 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
   public host: CustomElementHost<Node>;
   public shadowRoot: CustomElementHost<ShadowRoot>;
   public dom: IDOM<Node>;
+  private $controller: IController<Node>;
 
   constructor(dom: IDOM<Node>, $controller: IController<Node>, host: CustomElementHost<HTMLElement>, definition: TemplateDefinition) {
     this.dom = dom;
     this.host = host;
+    this.$controller = $controller;
 
     let shadowOptions: ShadowRootInit;
     if (
@@ -86,6 +89,9 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
   }
 
   public project(nodes: INodeSequence<Node>): void {
+    const context = this.$controller.context!;
+    const manager = context.get(IShadowDOMStyleManager);
+    manager.applyTo(this.shadowRoot);
     nodes.appendTo(this.shadowRoot);
   }
 

--- a/packages/runtime-html/src/projectors.ts
+++ b/packages/runtime-html/src/projectors.ts
@@ -17,7 +17,7 @@ import {
   IProjectorLocator,
   TemplateDefinition
 } from '@aurelia/runtime';
-import { IShadowDOMStyleManager } from './styles/shadow-dom-styles';
+import { IShadowDOMStyles } from './styles/shadow-dom-styles';
 
 const slice = Array.prototype.slice;
 
@@ -90,8 +90,8 @@ export class ShadowDOMProjector implements IElementProjector<Node> {
 
   public project(nodes: INodeSequence<Node>): void {
     const context = this.$controller.context!;
-    const manager = context.get(IShadowDOMStyleManager);
-    manager.applyTo(this.shadowRoot);
+    const styles = context.get(IShadowDOMStyles);
+    styles.applyTo(this.shadowRoot);
     nodes.appendTo(this.shadowRoot);
   }
 

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -3,7 +3,7 @@ import { bindable, customAttribute, INode } from '@aurelia/runtime';
 
 export class CSSModulesProcessorRegistry {
   public register(container: IContainer, ...params: (Record<string, string>)[]) {
-    const classLookup = Object.assign({}, ...params) as Record<string, string>;
+    const classLookup = { ...params } as Record<string, string>;
 
     @customAttribute('class')
     class ClassCustomAttribute {

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -1,9 +1,9 @@
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, IRegistry } from '@aurelia/kernel';
 import { bindable, customAttribute, INode } from '@aurelia/runtime';
 
-export class CSSModulesProcessorRegistry {
+export class CSSModulesProcessorRegistry implements IRegistry {
   public register(container: IContainer, ...params: (Record<string, string>)[]) {
-    const classLookup = { ...params } as Record<string, string>;
+    const classLookup = Object.assign({}, ...params) as Record<string, string>;
 
     @customAttribute('class')
     class ClassCustomAttribute {

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -1,5 +1,5 @@
 import { IContainer } from '@aurelia/kernel';
-import { bindable, customAttribute } from '@aurelia/runtime';
+import { bindable, customAttribute, INode } from '@aurelia/runtime';
 
 export class CSSModulesRegistry {
   public register(container: IContainer, ...params: (Record<string, string>)[]) {
@@ -9,7 +9,7 @@ export class CSSModulesRegistry {
     class ClassCustomAttribute {
       @bindable public value!: string;
 
-      constructor(private element: HTMLElement) {}
+      constructor(@INode private element: HTMLElement) {}
 
       public binding() {
         this.valueChanged();

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -1,7 +1,7 @@
 import { IContainer } from '@aurelia/kernel';
 import { bindable, customAttribute, INode } from '@aurelia/runtime';
 
-export class CSSModulesRegistry {
+export class CSSModulesProcessorRegistry {
   public register(container: IContainer, ...params: (Record<string, string>)[]) {
     const classLookup = Object.assign({}, ...params) as Record<string, string>;
 

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -1,0 +1,32 @@
+import { IContainer } from '@aurelia/kernel';
+import { bindable, customAttribute } from '@aurelia/runtime';
+
+export class CSSModulesRegistry {
+  public register(container: IContainer, ...params: (Record<string, string>)[]) {
+    const classLookup = Object.assign({}, ...params) as Record<string, string>;
+
+    @customAttribute('class')
+    class ClassCustomAttribute {
+      @bindable public value!: string;
+
+      constructor(private element: HTMLElement) {}
+
+      public binding() {
+        this.valueChanged();
+      }
+
+      public valueChanged() {
+        if (!this.value) {
+          this.element.className = '';
+          return;
+        }
+
+        this.element.className = this.value.split(' ')
+          .map(x => classLookup[x] || x)
+          .join(' ');
+      }
+    }
+
+    container.register(ClassCustomAttribute);
+  }
+}

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -2,7 +2,7 @@ import { IContainer, Registration } from '@aurelia/kernel';
 import {  IShadowDOMStyles } from './shadow-dom-styles';
 
 export type ShadowDOMStylesFactory =
-  (styles: string[], shared: IShadowDOMStyles | null) => IShadowDOMStyles;
+  (localStyles: string[], sharedStyles: IShadowDOMStyles | null) => IShadowDOMStyles;
 
 export class ShadowDOMRegistry {
   constructor(

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -1,25 +1,20 @@
 import { IContainer, Registration } from '@aurelia/kernel';
-import {  IShadowDOMStyleManager } from './shadow-dom-styles';
+import {  IShadowDOMStyles } from './shadow-dom-styles';
 
-export function adoptedStyleSheetsSupported(): boolean {
-  return 'adoptedStyleSheets' in ShadowRoot.prototype;
-}
-
-export type ShadowDOMStyleManagerFactory =
-  (styles: string[], parent: IShadowDOMStyleManager | null) => IShadowDOMStyleManager;
+export type ShadowDOMStylesFactory =
+  (styles: string[], shared: IShadowDOMStyles | null) => IShadowDOMStyles;
 
 export class ShadowDOMRegistry {
   constructor(
-    private parent: IShadowDOMStyleManager,
-    private factory: ShadowDOMStyleManagerFactory
-  ) {
-  }
+    private sharedStyles: IShadowDOMStyles,
+    private createStyles: ShadowDOMStylesFactory
+  ) { }
 
   public register(container: IContainer, ...params: any[]) {
     container.register(
       Registration.instance(
-        IShadowDOMStyleManager,
-        this.factory(params, this.parent)
+        IShadowDOMStyles,
+        this.createStyles(params, this.sharedStyles)
       )
     );
   }

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -2,7 +2,7 @@ import { IContainer, Registration } from '@aurelia/kernel';
 import {  IShadowDOMStyles } from './shadow-dom-styles';
 
 export type ShadowDOMStylesFactory =
-  (localStyles: string[], sharedStyles: IShadowDOMStyles | null) => IShadowDOMStyles;
+  (localStyles: (string | CSSStyleSheet)[], sharedStyles: IShadowDOMStyles | null) => IShadowDOMStyles;
 
 export class ShadowDOMRegistry {
   constructor(

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -1,16 +1,16 @@
-import { IContainer, Registration } from '@aurelia/kernel';
+import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
 import {  IShadowDOMStyles } from './shadow-dom-styles';
 
 export type ShadowDOMStylesFactory =
   (localStyles: (string | CSSStyleSheet)[], sharedStyles: IShadowDOMStyles | null) => IShadowDOMStyles;
 
-export class ShadowDOMRegistry {
+export class ShadowDOMRegistry implements IRegistry {
   constructor(
     private sharedStyles: IShadowDOMStyles,
     private createStyles: ShadowDOMStylesFactory
   ) { }
 
-  public register(container: IContainer, ...params: any[]) {
+  public register(container: IContainer, ...params: (string | CSSStyleSheet)[]) {
     container.register(
       Registration.instance(
         IShadowDOMStyles,

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -1,28 +1,25 @@
 import { IContainer, Registration } from '@aurelia/kernel';
-import {
-  AdoptedStyleSheetsStyleManager,
-  IShadowDOMStyleManager,
-  StyleElementStyleManager
-} from './shadow-dom-styles';
+import {  IShadowDOMStyleManager } from './shadow-dom-styles';
 
 export function adoptedStyleSheetsSupported(): boolean {
   return 'adoptedStyleSheets' in ShadowRoot.prototype;
 }
 
-export class ShadowDOMRegistry {
-  private useAdoptedStyleSheets: boolean;
+export type ShadowDOMStyleManagerFactory =
+  (styles: string[], parent: IShadowDOMStyleManager | null) => IShadowDOMStyleManager;
 
-  constructor(private parent: IShadowDOMStyleManager) {
-    this.useAdoptedStyleSheets = adoptedStyleSheetsSupported();
+export class ShadowDOMRegistry {
+  constructor(
+    private parent: IShadowDOMStyleManager,
+    private factory: ShadowDOMStyleManagerFactory
+  ) {
   }
 
   public register(container: IContainer, ...params: any[]) {
     container.register(
       Registration.instance(
         IShadowDOMStyleManager,
-        this.useAdoptedStyleSheets
-          ? new AdoptedStyleSheetsStyleManager(params, this.parent)
-          : new StyleElementStyleManager(params, this.parent)
+        this.factory(params, this.parent)
       )
     );
   }

--- a/packages/runtime-html/src/styles/shadow-dom-registry.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-registry.ts
@@ -1,0 +1,29 @@
+import { IContainer, Registration } from '@aurelia/kernel';
+import {
+  AdoptedStyleSheetsStyleManager,
+  IShadowDOMStyleManager,
+  StyleElementStyleManager
+} from './shadow-dom-styles';
+
+export function adoptedStyleSheetsSupported(): boolean {
+  return 'adoptedStyleSheets' in ShadowRoot.prototype;
+}
+
+export class ShadowDOMRegistry {
+  private useAdoptedStyleSheets: boolean;
+
+  constructor(private parent: IShadowDOMStyleManager) {
+    this.useAdoptedStyleSheets = adoptedStyleSheetsSupported();
+  }
+
+  public register(container: IContainer, ...params: any[]) {
+    container.register(
+      Registration.instance(
+        IShadowDOMStyleManager,
+        this.useAdoptedStyleSheets
+          ? new AdoptedStyleSheetsStyleManager(params, this.parent)
+          : new StyleElementStyleManager(params, this.parent)
+      )
+    );
+  }
+}

--- a/packages/runtime-html/src/styles/shadow-dom-styles.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-styles.ts
@@ -1,0 +1,56 @@
+import { DI, PLATFORM } from '@aurelia/kernel';
+
+type HasAdoptedStyleSheets = ShadowRoot & {
+  adoptedStyleSheets: CSSStyleSheet[];
+};
+
+export const IShadowDOMStyleManager =
+  DI.createInterface<IShadowDOMStyleManager>('IShadowDOMStyleManager')
+    .withDefault(x => x.instance({ applyTo: PLATFORM.noop }));
+
+export interface IShadowDOMStyleManager {
+  applyTo(shadowRoot: ShadowRoot): void;
+}
+
+export class AdoptedStyleSheetsStyleManager implements IShadowDOMStyleManager {
+  private readonly styleSheets: CSSStyleSheet[];
+
+  constructor(styles: string[], private parent: IShadowDOMStyleManager | null = null) {
+    this.styleSheets = styles.map(x => {
+      const sheet = new CSSStyleSheet();
+      (sheet as any).replaceSync(x);
+      return sheet;
+    });
+  }
+
+  public applyTo(shadowRoot: HasAdoptedStyleSheets) {
+    if (this.parent !== null) {
+      this.parent.applyTo(shadowRoot);
+    }
+
+    // https://wicg.github.io/construct-stylesheets/
+    // https://developers.google.com/web/updates/2019/02/constructable-stylesheets
+    shadowRoot.adoptedStyleSheets = [
+      ...shadowRoot.adoptedStyleSheets,
+      ...this.styleSheets
+    ];
+  }
+}
+
+export class StyleElementStyleManager implements IShadowDOMStyleManager {
+  constructor(private styles: string[], private parent: IShadowDOMStyleManager | null = null) {}
+
+  public applyTo(shadowRoot: ShadowRoot) {
+    const styles = this.styles;
+
+    for (let i = styles.length - 1; i > -1; --i) {
+      const element = document.createElement('style');
+      element.innerHTML = styles[i];
+      shadowRoot.prepend(element);
+    }
+
+    if (this.parent !== null) {
+      this.parent.applyTo(shadowRoot);
+    }
+  }
+}

--- a/packages/runtime-html/src/styles/shadow-dom-styles.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-styles.ts
@@ -1,4 +1,4 @@
-import { DI, PLATFORM } from '@aurelia/kernel';
+import { DI, PLATFORM, Reporter } from '@aurelia/kernel';
 
 type HasAdoptedStyleSheets = ShadowRoot & {
   adoptedStyleSheets: CSSStyleSheet[];
@@ -63,23 +63,16 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
 
 export class StyleElementStyles implements IShadowDOMStyles {
   constructor(
-    private localStyles: (string | CSSStyleSheet)[],
+    private localStyles: string[],
     private sharedStyles: IShadowDOMStyles | null = null
-  ) {}
+  ) { }
 
   public applyTo(shadowRoot: ShadowRoot) {
     const styles = this.localStyles;
 
     for (let i = styles.length - 1; i > -1; --i) {
       const element = document.createElement('style');
-      const style = styles[i];
-
-      if (style instanceof CSSStyleSheet) {
-        element.innerHTML = style.cssText;
-      } else {
-        element.innerHTML = style;
-      }
-
+      element.innerHTML = styles[i];
       shadowRoot.prepend(element);
     }
 

--- a/packages/runtime-html/src/styles/shadow-dom-styles.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-styles.ts
@@ -1,4 +1,5 @@
 import { DI, PLATFORM } from '@aurelia/kernel';
+import { HTMLDOM } from '../dom';
 
 type HasAdoptedStyleSheets = ShadowRoot & {
   adoptedStyleSheets: CSSStyleSheet[];
@@ -20,6 +21,7 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
   private readonly styleSheets: CSSStyleSheet[];
 
   constructor(
+    dom: HTMLDOM,
     localStyles: (string | CSSStyleSheet)[],
     styleSheetCache: Map<string, CSSStyleSheet>,
     private sharedStyles: IShadowDOMStyles | null = null
@@ -27,13 +29,13 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
     this.styleSheets = localStyles.map(x => {
       let sheet: CSSStyleSheet | undefined;
 
-      if (x instanceof CSSStyleSheet) {
+      if (x instanceof dom.CSSStyleSheet) {
         sheet = x;
       } else {
         sheet = styleSheetCache.get(x);
 
         if (!sheet) {
-          sheet = new CSSStyleSheet();
+          sheet = new dom.CSSStyleSheet();
           (sheet as any).replaceSync(x);
           styleSheetCache.set(x, sheet);
         }
@@ -43,8 +45,8 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
     });
   }
 
-  public static supported(): boolean {
-    return 'adoptedStyleSheets' in ShadowRoot.prototype;
+  public static supported(dom: HTMLDOM): boolean {
+    return 'adoptedStyleSheets' in dom.ShadowRoot.prototype;
   }
 
   public applyTo(shadowRoot: HasAdoptedStyleSheets) {
@@ -63,15 +65,17 @@ export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
 
 export class StyleElementStyles implements IShadowDOMStyles {
   constructor(
+    private dom: HTMLDOM,
     private localStyles: string[],
     private sharedStyles: IShadowDOMStyles | null = null
   ) { }
 
   public applyTo(shadowRoot: ShadowRoot) {
     const styles = this.localStyles;
+    const dom = this.dom;
 
     for (let i = styles.length - 1; i > -1; --i) {
-      const element = document.createElement('style');
+      const element = dom.createElement('style');
       element.innerHTML = styles[i];
       shadowRoot.prepend(element);
     }

--- a/packages/runtime-html/src/styles/shadow-dom-styles.ts
+++ b/packages/runtime-html/src/styles/shadow-dom-styles.ts
@@ -1,4 +1,4 @@
-import { DI, PLATFORM, Reporter } from '@aurelia/kernel';
+import { DI, PLATFORM } from '@aurelia/kernel';
 
 type HasAdoptedStyleSheets = ShadowRoot & {
   adoptedStyleSheets: CSSStyleSheet[];

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -64,6 +64,13 @@ export const StyleConfiguration = {
 
         container.register(
           Registration.instance(
+            IShadowDOMStyles,
+            globalSharedStyles
+          )
+        );
+
+        container.register(
+          Registration.instance(
             ext,
             new ShadowDOMRegistry(
               globalSharedStyles,

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -45,7 +45,12 @@ export const StyleConfiguration = {
           };
         } else {
           createStyles = (localStyles, sharedStyles) => {
-            return new StyleElementStyles(localStyles, sharedStyles);
+            if (localStyles.find(x => typeof x !== 'string')) {
+              // TODO: use reporter
+              throw new Error('Shadow DOM CSS must be a string.');
+            }
+
+            return new StyleElementStyles(localStyles as string[], sharedStyles);
           };
         }
 

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -16,7 +16,7 @@ export interface IShadowDOMConfiguration {
   sharedStyles?: (string | CSSStyleSheet)[];
 }
 
-export function styles(...styles: any[]) {
+export function styles(...styles: unknown[]) {
   return Registration.defer(ext, ...styles);
 }
 

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -49,19 +49,19 @@ export const StyleConfiguration = {
           };
         }
 
-        let parent: IShadowDOMStyleManager;
+        let rootManager: IShadowDOMStyleManager;
 
         if (config && config.sharedStyles) {
-          parent = factory(config.sharedStyles, null);
+          rootManager = factory(config.sharedStyles, null);
         } else {
-          parent = noopShadowDOMStyleManager;
+          rootManager = noopShadowDOMStyleManager;
         }
 
         container.register(
           Registration.instance(
             ext,
             new ShadowDOMRegistry(
-              parent,
+              rootManager,
               factory
             )
           )

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -1,5 +1,5 @@
 import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
-import { CSSModulesRegistry } from './css-modules-registry';
+import { CSSModulesProcessorRegistry } from './css-modules-registry';
 import { ShadowDOMRegistry, ShadowDOMStylesFactory } from './shadow-dom-registry';
 import {
   AdoptedStyleSheetsStyles,
@@ -19,11 +19,11 @@ export function styles(...styles: any[]) {
 }
 
 export const StyleConfiguration = {
-  cssModules(): IRegistry {
+  cssModulesProcessor(): IRegistry {
     return {
       register(container: IContainer) {
         container.register(
-          Registration.singleton(ext, CSSModulesRegistry)
+          Registration.singleton(ext, CSSModulesProcessorRegistry)
         );
       }
     };

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -1,9 +1,10 @@
 import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
 import { CSSModulesRegistry } from './css-modules-registry';
-import { adoptedStyleSheetsSupported, ShadowDOMRegistry } from './shadow-dom-registry';
+import { adoptedStyleSheetsSupported, ShadowDOMRegistry, ShadowDOMStyleManagerFactory } from './shadow-dom-registry';
 import {
   AdoptedStyleSheetsStyleManager,
   IShadowDOMStyleManager,
+  noopShadowDOMStyleManager,
   StyleElementStyleManager
 } from './shadow-dom-styles';
 
@@ -31,19 +32,39 @@ export const StyleConfiguration = {
   shadowDOM(config?: IShadowDOMConfiguration): IRegistry {
     return {
       register(container: IContainer) {
+        let factory: ShadowDOMStyleManagerFactory;
+
+        if (adoptedStyleSheetsSupported()) {
+          const cache = new Map();
+          factory = (s, parent) => {
+            return new AdoptedStyleSheetsStyleManager(
+              s,
+              cache,
+              parent
+            );
+          };
+        } else {
+          factory = (s, parent) => {
+            return new StyleElementStyleManager(s, parent);
+          };
+        }
+
+        let parent: IShadowDOMStyleManager;
+
         if (config && config.sharedStyles) {
-          container.register(
-            Registration.instance(
-              IShadowDOMStyleManager,
-              adoptedStyleSheetsSupported()
-                ? new AdoptedStyleSheetsStyleManager(config.sharedStyles, null)
-                : new StyleElementStyleManager(config.sharedStyles, null)
-            )
-          );
+          parent = factory(config.sharedStyles, null);
+        } else {
+          parent = noopShadowDOMStyleManager;
         }
 
         container.register(
-          Registration.singleton(ext, ShadowDOMRegistry)
+          Registration.instance(
+            ext,
+            new ShadowDOMRegistry(
+              parent,
+              factory
+            )
+          )
         );
       }
     };

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -1,0 +1,51 @@
+import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
+import { CSSModulesRegistry } from './css-modules-registry';
+import { adoptedStyleSheetsSupported, ShadowDOMRegistry } from './shadow-dom-registry';
+import {
+  AdoptedStyleSheetsStyleManager,
+  IShadowDOMStyleManager,
+  StyleElementStyleManager
+} from './shadow-dom-styles';
+
+const ext = '.css';
+
+export interface IShadowDOMConfiguration {
+  sharedStyles?: string[];
+}
+
+export function styles(...styles: any[]) {
+  return Registration.defer(ext, ...styles);
+}
+
+export const StyleConfiguration = {
+  cssModules(): IRegistry {
+    return {
+      register(container: IContainer) {
+        container.register(
+          Registration.singleton(ext, CSSModulesRegistry)
+        );
+      }
+    };
+  },
+
+  shadowDOM(config?: IShadowDOMConfiguration): IRegistry {
+    return {
+      register(container: IContainer) {
+        if (config && config.sharedStyles) {
+          container.register(
+            Registration.instance(
+              IShadowDOMStyleManager,
+              adoptedStyleSheetsSupported()
+                ? new AdoptedStyleSheetsStyleManager(config.sharedStyles, null)
+                : new StyleElementStyleManager(config.sharedStyles, null)
+            )
+          );
+        }
+
+        container.register(
+          Registration.singleton(ext, ShadowDOMRegistry)
+        );
+      }
+    };
+  }
+};

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -11,7 +11,7 @@ import {
 const ext = '.css';
 
 export interface IShadowDOMConfiguration {
-  sharedStyles?: string[];
+  sharedStyles?: (string | CSSStyleSheet)[];
 }
 
 export function styles(...styles: any[]) {

--- a/packages/testing/src/html-test-context.ts
+++ b/packages/testing/src/html-test-context.ts
@@ -111,7 +111,9 @@ export class HTMLTestContext {
     HTMLDivElementType: typeof HTMLDivElement,
     TextType: typeof Text,
     CommentType: typeof Comment,
-    DOMParserType: typeof DOMParser
+    DOMParserType: typeof DOMParser,
+    CSSStyleSheetType: typeof CSSStyleSheet,
+    ShadowRootType: typeof ShadowRoot
   ) {
     this.config = config;
     this.wnd = wnd;
@@ -126,7 +128,7 @@ export class HTMLTestContext {
     this.Comment = CommentType;
     this.DOMParser = DOMParserType;
     this.doc = wnd.document;
-    this.dom = new HTMLDOM(this.wnd, this.doc, NodeType, ElementType, HTMLElementType, CustomEventType);
+    this.dom = new HTMLDOM(this.wnd, this.doc, NodeType, ElementType, HTMLElementType, CustomEventType, CSSStyleSheetType, ShadowRootType);
     this._container = void 0;
     this._templateCompiler = void 0;
     this._observerLocator = void 0;
@@ -149,7 +151,9 @@ export class HTMLTestContext {
     HTMLDivElementType: typeof HTMLDivElement,
     TextType: typeof Text,
     CommentType: typeof Comment,
-    DOMParserType: typeof DOMParser
+    DOMParserType: typeof DOMParser,
+    CSSStyleSheetType: typeof CSSStyleSheet,
+    ShadowRootType: typeof ShadowRoot
   ): HTMLTestContext {
     return new HTMLTestContext(
       config,
@@ -163,7 +167,9 @@ export class HTMLTestContext {
       HTMLDivElementType,
       TextType,
       CommentType,
-      DOMParserType
+      DOMParserType,
+      CSSStyleSheetType,
+      ShadowRootType
     );
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR implements the necessary infrastructure to support both CSS Modules Preprocessing and Shadow DOM CSS styles in the HTML runtime. The Shadow DOM styles implementation supports using adoptedStyleSheets if present, and falling back to style elements if not. When using adoptedStyleSheets, it can handle both strings and CSSStyleSheet instances, providing support for the upcoming CSS Modules spec as well.

### 🎫 Issues

* #524 

## 👩‍💻 Reviewer Notes

The basic idea is that "styles" are a dependency of the template. So, the infrastructure is based around plugging in different ways to handle CSS, based on application preference. Depending on configuration, when styles are added to a component dependency list, a different registry will be used to register the correct set of services within the component's render context. For CSS Modules, a custom class attribute is registered. For Shadow DOM CSS, a style manager is configured, which is later used by the ShadowDOMProjector. Two different style managers for Shadow DOM have been implemented, with the best implementation being chosen based on the runtime capabilities of the browser.

## ⏭ Next Steps

* Get conventions and template build-time support to use this.
