### PR TITLE
Dynamic routing: default to scoped viewports

### DIFF
--- a/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/main.ts
@@ -45,12 +45,12 @@ export class Main {
       {
         title: 'Authors',
         route: [Authors, About],
-        consideredActive: [Authors],
+        consideredActive: ['authors'],
       },
       {
         title: 'Books',
         route: [Books, About],
-        consideredActive: Books,
+        consideredActive: 'books',
       },
       {
         route: About,

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -76,8 +76,8 @@ describe('InstructionResolver', function () {
     { instruction: 'foo@left', viewportInstruction: new ViewportInstruction('foo', 'left') },
     { instruction: 'foo(123)@left', viewportInstruction: new ViewportInstruction('foo', 'left', '123') },
     { instruction: 'foo(123)', viewportInstruction: new ViewportInstruction('foo', undefined, '123') },
-    { instruction: 'foo/bar', viewportInstruction: new ViewportInstruction('foo', undefined, undefined, false, new ViewportInstruction('bar')) },
-    { instruction: 'foo(123)/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', false, new ViewportInstruction('bar', 'left', undefined, false, new ViewportInstruction('baz'))) },
+    { instruction: 'foo/bar', viewportInstruction: new ViewportInstruction('foo', undefined, undefined, true, new ViewportInstruction('bar')) },
+    { instruction: 'foo(123)/bar@left/baz', viewportInstruction: new ViewportInstruction('foo', undefined, '123', true, new ViewportInstruction('bar', 'left', undefined, true, new ViewportInstruction('baz'))) },
   ];
 
   for (const instructionTest of instructions) {

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -10,7 +10,7 @@ describe('Router', function () {
     const { container, lifecycle } = ctx;
 
     const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-    const Foo = CustomElement.define({ name: 'foo', template: '<template>Viewport: foo <a href="#baz@foo"><span>baz</span></a><au-viewport name="foo"></au-viewport></template>' });
+    const Foo = CustomElement.define({ name: 'foo', template: '<template>Viewport: foo <a href="baz@foo"><span>baz</span></a><au-viewport name="foo"></au-viewport></template>' });
     const Bar = CustomElement.define({ name: 'bar', template: '<template>Viewport: bar Parameter id: [${id}] Parameter name: [${name}] <au-viewport name="bar"></au-viewport></template>' }, class {
       public static parameters = ['id', 'name'];
       public id = 'no id';
@@ -443,10 +443,8 @@ describe('Router', function () {
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('corge@left', router, lifecycle);
+    await $goto('corge@left/baz(123)', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: corge', `host.textContent`);
-
-    await $goto('baz(123)', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: baz', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
 
@@ -458,10 +456,9 @@ describe('Router', function () {
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('corge@left', router, lifecycle);
-    assert.includes(host.textContent, 'Viewport: corge', `host.textContent`);
+    await $goto('corge@left/baz(id=123)', router, lifecycle);
 
-    await $goto('baz(id=123)', router, lifecycle);
+    assert.includes(host.textContent, 'Viewport: corge', `host.textContent`);
     assert.includes(host.textContent, 'Viewport: baz', `host.textContent`);
     assert.includes(host.textContent, 'Parameter id: [123]', `host.textContent`);
 
@@ -656,12 +653,12 @@ describe('Router', function () {
 
       (host as any).getElementsByTagName('INPUT')[1].value = 'asdf';
 
-      await $goto('corge@grault', router, lifecycle);
+      await $goto('grault@left/corge@grault', router, lifecycle);
 
       assert.notIncludes(host.textContent, 'garply', `host.textContent`);
       assert.includes(host.textContent, 'Viewport: corge', `host.textContent`);
 
-      await $goto('garply@grault', router, lifecycle);
+      await $goto('grault@left/garply@grault', router, lifecycle);
 
       assert.notIncludes(host.textContent, 'Viewport: corge', `host.textContent`);
       assert.includes(host.textContent, 'garply', `host.textContent`);
@@ -691,12 +688,12 @@ describe('Router', function () {
 
     (host as any).getElementsByTagName('INPUT')[1].value = 'asdf';
 
-    await $goto('foo@waldo', router, lifecycle);
+    await $goto('waldo@left/foo@waldo', router, lifecycle);
 
     assert.notIncludes(host.textContent, 'Viewport: grault', `host.textContent`);
     assert.includes(host.textContent, 'Viewport: foo', `host.textContent`);
 
-    await $goto('grault@waldo', router, lifecycle);
+    await $goto('waldo@left/grault@waldo', router, lifecycle);
 
     assert.notIncludes(host.textContent, 'Viewport: corge', `host.textContent`);
     assert.includes(host.textContent, 'Viewport: grault', `host.textContent`);
@@ -800,7 +797,7 @@ describe('Router', function () {
       const Local1 = CustomElement.define({ name: 'local1', template: 'local1<au-viewport name="one"></au-viewport>', dependencies: [Local2] }, null);
       const { lifecycle, host, router, $teardown } = await $setup([Local1]);
 
-      await $goto('local1+local2', router, lifecycle);
+      await $goto('local1/local2', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*local2.*/, `host.textContent`);
 
@@ -814,7 +811,7 @@ describe('Router', function () {
       const { lifecycle, host, router, container, $teardown } = await $setup([Local1]);
       container.register(Global3);
 
-      await $goto('local1+local2+global3', router, lifecycle);
+      await $goto('local1/local2/global3', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*local2.*global3.*/, `host.textContent`);
 
@@ -828,7 +825,7 @@ describe('Router', function () {
       const { lifecycle, host, router, container, $teardown } = await $setup([Local1]);
       container.register(Global2);
 
-      await $goto('local1+global2+local3', router, lifecycle);
+      await $goto('local1/global2/local3', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*global2.*local3.*/, `host.textContent`);
 
@@ -842,7 +839,7 @@ describe('Router', function () {
       const { lifecycle, host, router, container, $teardown } = await $setup();
       container.register(Global1);
 
-      await $goto('global1+local2+local3', router, lifecycle);
+      await $goto('global1/local2/local3', router, lifecycle);
 
       assert.match(host.textContent, /.*global1.*local2.*local3.*/, `host.textContent`);
 
@@ -855,7 +852,7 @@ describe('Router', function () {
       const Local1 = CustomElement.define({ name: 'local1', template: 'local1<au-viewport name="one" used-by="local2"></au-viewport>', dependencies: [Local2] }, null);
       const { lifecycle, host, router, $teardown } = await $setup([Local1]);
 
-      await $goto('local1+local2+local3', router, lifecycle);
+      await $goto('local1/local2/local3', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*local2.*local3.*/, `host.textContent`);
 
@@ -869,11 +866,11 @@ describe('Router', function () {
       const Local2 = CustomElement.define({ name: 'local2', template: 'local2<au-viewport name="two"></au-viewport>', dependencies: [Conflict2] }, null);
       const { lifecycle, host, router, $teardown } = await $setup([Local1, Local2]);
 
-      await $goto('local1@default+conflict@one', router, lifecycle);
+      await $goto('local1@default/conflict@one', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*conflict1.*/, `host.textContent`);
 
-      await $goto('local2@default+conflict@two', router, lifecycle);
+      await $goto('local2@default/conflict@two', router, lifecycle);
 
       assert.match(host.textContent, /.*local2.*conflict2.*/, `host.textContent`);
 
@@ -888,11 +885,11 @@ describe('Router', function () {
       const { lifecycle, host, router, container, $teardown } = await $setup();
       container.register(Global1, Global2);
 
-      await $goto('global1@default+conflict@one', router, lifecycle);
+      await $goto('global1@default/conflict@one', router, lifecycle);
 
       assert.match(host.textContent, /.*global1.*conflict1.*/, `host.textContent`);
 
-      await $goto('global2@default+conflict@two', router, lifecycle);
+      await $goto('global2@default/conflict@two', router, lifecycle);
 
       assert.match(host.textContent, /.*global2.*conflict2.*/, `host.textContent`);
 
@@ -907,11 +904,11 @@ describe('Router', function () {
       const { lifecycle, host, router, container, $teardown } = await $setup([Local1]);
       container.register(Global2);
 
-      await $goto('local1@default+conflict@one', router, lifecycle);
+      await $goto('local1@default/conflict@one', router, lifecycle);
 
       assert.match(host.textContent, /.*local1.*conflict1.*/, `host.textContent`);
 
-      await $goto('global2@default+conflict@two', router, lifecycle);
+      await $goto('global2@default/conflict@two', router, lifecycle);
 
       assert.match(host.textContent, /.*global2.*conflict2.*/, `host.textContent`);
 

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -10,7 +10,7 @@ describe('Router', function () {
     const { container, lifecycle } = ctx;
 
     const App = CustomElement.define({ name: 'app', template: '<template><au-viewport name="left"></au-viewport><au-viewport name="right"></au-viewport></template>' });
-    const Foo = CustomElement.define({ name: 'foo', template: '<template>Viewport: foo <a href="#/baz@foo"><span>baz</span></a><au-viewport name="foo"></au-viewport></template>' });
+    const Foo = CustomElement.define({ name: 'foo', template: '<template>Viewport: foo <a href="#baz@foo"><span>baz</span></a><au-viewport name="foo"></au-viewport></template>' });
     const Bar = CustomElement.define({ name: 'bar', template: '<template>Viewport: bar Parameter id: [${id}] Parameter name: [${name}] <au-viewport name="bar"></au-viewport></template>' }, class {
       public static parameters = ['id', 'name'];
       public id = 'no id';
@@ -39,7 +39,7 @@ describe('Router', function () {
       public leave() { return true; }
     });
     const Quux = CustomElement.define({ name: 'quux', template: '<template>Viewport: quux<au-viewport name="quux" scope></au-viewport></template>' });
-    const Corge = CustomElement.define({ name: 'corge', template: '<template>Viewport: corge<au-viewport name="corge" used-by="baz"></au-viewport></template>' });
+    const Corge = CustomElement.define({ name: 'corge', template: '<template>Viewport: corge<au-viewport name="corge" used-by="baz"></au-viewport>Viewport: dummy<au-viewport name="dummy"></au-viewport></template>' });
 
     const Uier = CustomElement.define({ name: 'uier', template: '<template>Viewport: uier</template>' }, class {
       public async canEnter() {
@@ -371,7 +371,7 @@ describe('Router', function () {
     await $goto('corge@left', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: corge', `host.textContent`);
 
-    await $goto('baz', router, lifecycle);
+    await $goto('corge@left/baz', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: baz', `host.textContent`);
 
     await tearDown();

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -334,7 +334,8 @@ describe('Router', function () {
 
     const { lifecycle, host, router, tearDown } = await setup();
 
-    await $goto('foo@left+bar@right+baz@foo+qux@bar', router, lifecycle);
+    // await $goto('foo@left+bar@right+baz@foo+qux@bar', router, lifecycle);
+    await $goto('foo@left/baz@foo+bar@right/qux@bar', router, lifecycle);
     assert.includes(host.textContent, 'Viewport: foo', `host.textContent`);
     assert.includes(host.textContent, 'Viewport: bar', `host.textContent`);
     assert.includes(host.textContent, 'Viewport: baz', `host.textContent`);

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -8,7 +8,7 @@ export interface IRouteSeparators {
   viewport?: string;
   sibling?: string;
   scope?: string;
-  ownsScope?: string;
+  noScope?: string;
   parameters?: string;
   parametersEnd?: string;
   parameter?: string;
@@ -27,7 +27,7 @@ export class InstructionResolver {
         viewport: '@', // ':',
         sibling: '+', // '/',
         scope: '/', // '+',
-        ownsScope: '!',
+        noScope: '!',
         parameters: '(', // '='
         parametersEnd: ')', // ''
         parameter: '&',
@@ -155,12 +155,12 @@ export class InstructionResolver {
   }
 
   private parseAViewportInstruction(instruction: string): ViewportInstruction {
-    let scope: boolean;
+    let scope: boolean = true;
 
-    // Scope is always at the end, regardless of anything else
-    if (instruction.endsWith(this.separators.ownsScope)) {
-      scope = true;
-      instruction = instruction.slice(0, -this.separators.ownsScope.length);
+    // No scope is always at the end, regardless of anything else
+    if (instruction.endsWith(this.separators.noScope)) {
+      scope = false;
+      instruction = instruction.slice(0, -this.separators.noScope.length);
     }
 
     const [componentPart, viewport] = instruction.split(this.separators.viewport);
@@ -187,8 +187,8 @@ export class InstructionResolver {
       if (instruction.viewportName !== null && !excludeViewport) {
         instructionString += this.separators.viewport + instruction.viewportName;
       }
-      if (instruction.ownsScope) {
-        instructionString += this.separators.ownsScope;
+      if (!instruction.ownsScope) {
+        instructionString += this.separators.noScope;
       }
       return instructionString;
     }

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -30,9 +30,9 @@ export class ViewportCustomElement {
   public static readonly inject: readonly Key[] = [IRouter, INode, IRenderingEngine];
 
   @bindable public name: string;
-  @bindable public scope: boolean;
   @bindable public usedBy: string;
   @bindable public default: string;
+  @bindable public noScope: boolean;
   @bindable public noLink: boolean;
   @bindable public noHistory: boolean;
   @bindable public stateful: boolean;
@@ -48,9 +48,9 @@ export class ViewportCustomElement {
 
   constructor(router: IRouter, element: Element, renderingEngine: IRenderingEngine) {
     this.name = 'default';
-    this.scope = null;
     this.usedBy = null;
     this.default = null;
+    this.noScope = null;
     this.noLink = null;
     this.noHistory = null;
     this.stateful = null;
@@ -105,7 +105,7 @@ export class ViewportCustomElement {
   }
 
   public connect(): void {
-    const options: IViewportOptions = { scope: this.element.hasAttribute('scope') };
+    const options: IViewportOptions = { scope: !this.element.hasAttribute('no-scope') };
     if (this.usedBy && this.usedBy.length) {
       options.usedBy = this.usedBy;
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -162,25 +162,24 @@ export class Router implements IRouter {
     let href = info.href;
     if (href.startsWith('#')) {
       href = href.slice(1);
+      // '#' === '/' === '#/'
+      if (!href.startsWith('/')) {
+        href = `/${href}`;
+      }
     }
     // If it's not from scope root, figure out which scope
     if (!href.startsWith('/')) {
       let scope = this.closestScope(info.anchor);
-      // No scope modifications, default to include current scope
-      // and replace content (by moving start one scope up)
-      if (!href.startsWith('.')) {
-        scope = scope.parent || scope;
-      } else {
-        // Start in current scope and look down (don't replace content)
+      // Scope modifications
+      if (href.startsWith('.')) {
+        // The same as no scope modification
         if (href.startsWith('./')) {
           href = href.slice(2);
-        } else { // Find out how many scopes upwards we should move
-          // First move up to include the current scope
+        }
+        // Find out how many scopes upwards we should move
+        while (href.startsWith('../')) {
           scope = scope.parent || scope;
-          while (href.startsWith('../')) {
-            scope = scope.parent || scope;
-            href = href.slice(3);
-          }
+          href = href.slice(3);
         }
       }
       const context = scope.scopeContext();

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -161,10 +161,28 @@ export class Router implements IRouter {
   public linkCallback = (info: AnchorEventInfo): void => {
     let href = info.href;
     if (href.startsWith('#')) {
-      href = href.substring(1);
+      href = href.slice(1);
     }
+    // If it's not from scope root, figure out which scope
     if (!href.startsWith('/')) {
-      const scope = this.closestScope(info.anchor);
+      let scope = this.closestScope(info.anchor);
+      // No scope modifications, default to include current scope
+      // and replace content (by moving start one scope up)
+      if (!href.startsWith('.')) {
+        scope = scope.parent || scope;
+      } else {
+        // Start in current scope and look down (don't replace content)
+        if (href.startsWith('./')) {
+          href = href.slice(2);
+        } else { // Find out how many scopes upwards we should move
+          // First move up to include the current scope
+          scope = scope.parent || scope;
+          while (href.startsWith('../')) {
+            scope = scope.parent || scope;
+            href = href.slice(3);
+          }
+        }
+      }
       const context = scope.scopeContext();
       href = this.instructionResolver.buildScopedLink(context, href);
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -52,7 +52,10 @@ export interface IRouter {
   processNavigations(qInstruction: QueueItem<INavigationInstruction>): Promise<void>;
   addProcessingViewport(componentOrInstruction: string | Partial<ICustomElementType> | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void;
 
-  // Called from the viewport custom element in attached()
+  // External API to get viewport by name
+  getViewport(name: string): Viewport;
+
+    // Called from the viewport custom element in attached()
   addViewport(name: string, element: Element, context: IRenderContext, options?: IViewportOptions): Viewport;
   // Called from the viewport custom element
   removeViewport(viewport: Viewport, element: Element, context: IRenderContext): void;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -15,7 +15,7 @@ export class ViewportInstruction {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = false, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -43,7 +43,7 @@ export class App implements IViewModel {
     this.message = 'Hello World!'; // just for unit testing ;)
   }
 
-  public async bound() {
+  public async binding() {
     this.router.guardian.addGuard(
       () => {
         if (this.state.isAuthenticated) { return true; }

--- a/test/realworld/src/components/article/article-meta.html
+++ b/test/realworld/src/components/article/article-meta.html
@@ -2,13 +2,13 @@
 <import from="../../shared/buttons/follow-button"></import>
 
 <div class="article-meta">
-  <a href="profile(${article.author.username})"><img src.bind="article.author.image" /></a>
+  <a href="/profile(${article.author.username})"><img src.bind="article.author.image" /></a>
   <div class="info">
-    <a href="profile(${article.author.username})" class="author">${article.author.username}</a>
+    <a href="/profile(${article.author.username})" class="author">${article.author.username}</a>
     <span class="date">${article.createdAt | date}</span>
   </div>
   <span if.bind="canModify">
-    <a class="btn btn-outline-secondary btn-sm" href="editor(slug=${article.slug})">
+    <a class="btn btn-outline-secondary btn-sm" href="/editor(slug=${article.slug})">
       <i class="ion-edit"></i>&nbsp;Edit Article
     </a>
     &nbsp;&nbsp;

--- a/test/realworld/src/components/article/comment.html
+++ b/test/realworld/src/components/article/comment.html
@@ -3,11 +3,11 @@
     <p class="card-text">${comment.body}</p>
   </div>
   <div class="card-footer">
-    <a href="profile(${comment.author.username})" class="comment-author">
+    <a href="/profile(${comment.author.username})" class="comment-author">
       <img src.bind="comment.author.image" class="comment-author-img" />
     </a>
     &nbsp;
-    <a href="profile(${comment.author.username})" class="comment-author">${comment.author.username}</a>
+    <a href="/profile(${comment.author.username})" class="comment-author">${comment.author.username}</a>
     <span class="date-posted">${comment.createdAt | date}</span>
     <span class="mod-options" if.bind="canModify">
       <i class="ion-trash-a" click.delegate="deleteCb({commentId: comment.id})"></i>

--- a/test/realworld/src/components/auth/auth.html
+++ b/test/realworld/src/components/auth/auth.html
@@ -5,8 +5,8 @@
       <div class="col-md-6 offset-md-3 col-xs-12">
         <h1 class="text-xs-center">Sign ${type === 'login' ? 'in' : 'up'}</h1>
         <p class="text-xs-center">
-          <a href="auth(type=login)" if.bind="type === 'register'">Have an account?</a>
-          <a href="auth(type=register)" if.bind="type === 'login'">Need an account?</a>
+          <a href="/auth(type=login)" if.bind="type === 'register'">Have an account?</a>
+          <a href="/auth(type=register)" if.bind="type === 'login'">Need an account?</a>
         </p>
 
         <ul class="error-messages" if.bind="controller.errors">

--- a/test/realworld/src/components/profile/profile.html
+++ b/test/realworld/src/components/profile/profile.html
@@ -17,7 +17,7 @@
             &nbsp;
             ${profile.following ? 'Unfollow' : 'Follow'} ${profile.username}
           </button>
-          <a href="settings" class="btn btn-sm btn-outline-secondary action-btn" if.bind="isUser">
+          <a href="/settings" class="btn btn-sm btn-outline-secondary action-btn" if.bind="isUser">
             <i class="ion-gear-a"></i> Edit Profile Settings
           </a>
         </div>

--- a/test/realworld/src/components/profile/profile.ts
+++ b/test/realworld/src/components/profile/profile.ts
@@ -35,7 +35,7 @@ export class Profile {
         a: 'nav-link',
         aActive: 'active',
       });
-    this.router.goto(`profile-article(${this.username})`);
+    this.router.goto(`/profile(${this.username})/profile-article(${this.username})`);
     return this.profile = profile;
   }
 

--- a/test/realworld/src/resources/elements/article-preview.html
+++ b/test/realworld/src/resources/elements/article-preview.html
@@ -2,10 +2,10 @@
 
 <div class="article-preview">
   <div class="article-meta">
-    <a href="profile(${article.author.username})">
+    <a href="/profile(${article.author.username})">
       <img src.bind="article.author.image" /></a>
     <div class="info">
-      <a href="profile(${article.author.username})" class="author">
+      <a href="/profile(${article.author.username})" class="author">
         ${article.author.username}</a>
       <span class="date">${article.createdAt | date}</span>
     </div>
@@ -15,7 +15,7 @@
       </template>
     </favorite-button>
   </div>
-  <a href="article(slug=${article.slug })" class="preview-link">
+  <a href="/article(slug=${article.slug })" class="preview-link">
     <h1>${article.title}</h1>
     <p>${article.description}</p>
     <span>Read more...</span>

--- a/test/realworld/src/shared/layouts/header-layout.html
+++ b/test/realworld/src/shared/layouts/header-layout.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light">
   <div class="container">
-    <a class="navbar-brand" href="home">conduit</a>
+    <a class="navbar-brand" href="/home">conduit</a>
     <au-nav name="main"></au-nav>
   </div>
 </nav>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes viewports scoped by default. This means that viewports by default will create a new scope/hierarchical segment. The difference being

Unscoped viewports, current default
```html
<host>
  <a href="products">Product list, relative</a> <!-- works -->
  <a href="/products">Product list, absolute</a> <!-- works -->
  <a href="product(123)">Show product 123, relative</a> <!-- works if "products" is already shown -->
  <a href="/product(456)">Show product 456, absolute</a> <!-- works if "products" is already shown -->

  <au-viewport name="master" used-by="products"></au-viewport>

    <a href="products">Product list, relative</a> <!-- works -->
    <a href="/products">Product list, absolute</a> <!-- works -->
    <a href="product(123)">Show product 123, relative</a> <!-- works -->
    <a href="/product(456)">Show product 456, absolute</a> <!-- works -->

    <au-viewport name="detail" used-by="product">

      <a href="products">Product list, relative</a> <!-- works -->
      <a href="/products">Product list, absolute</a> <!-- works -->
      <a href="product(123)">Show product 123, relative</a> <!-- works -->
      <a href="/product(456)">Show product 456, absolute</a> <!-- works -->
    </au-viewport>
  </au-viewport>
</host>
```

Scoped viewports, NEW default
```html
<host>
  <a href="products">Product list, relative</a> <!-- works -->
  <a href="/products">Product list, absolute</a> <!-- works -->
  <a href="product(123)">Show product 123, relative</a> <!-- doesn't work, needs to be "products/product(123)" -->
  <a href="/product(456)">Show product 456, absolute</a> <!-- doesn't work, needs to be "/products/product(456)" -->

  <au-viewport name="master" used-by="products">

    <a href="products">Product list, relative</a> <!-- doesn't work, needs to be "../products" -->
    <a href="/products">Product list, absolute</a> <!-- works -->
    <a href="product(123)">Show product 123, relative</a> <!-- works -->
    <a href="/product(456)">Show product 456, absolute</a> <!-- doesn't work, needs to be "/products/product(456)" -->

    <au-viewport name="detail" used-by="product"></au-viewport>

      <a href="products">Product list, relative</a> <!-- doesn't work, needs to be "../../products" -->
      <a href="/products">Product list, absolute</a> <!-- works -->
      <a href="product(123)">Show product 123, relative</a> <!-- doesn't work, needs to be "../product(123)" -->
      <a href="/product(456)">Show product 456, absolute</a> <!-- doesn't work, needs to be "/products/product(456) -->
    </au-viewport>
  </au-viewport>
</host>
```

As a result, the `scope` attribute on `au-viewport` is replaced by an opposite attribute, `no-scope`.

Note that this is a BREAKING CHANGE for applications with more than one viewport who hasn't explicitly made the viewports scoped by adding the `scope` attribute.

This PR also implements support for the `../` prefix in `href` for upwards traversal in the scope tree.

It follows https://github.com/aurelia/aurelia/pull/575.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working. 

## 📑 Test Plan

- Make sure existing tests pass.

## ⏭ Next Steps

- Implement scope traversal to Router's `goto` method
- Add tests for the new au-nav options
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->