### PR TITLE
refactor(router): refactor interfaces and types

### DIFF
--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,7 +1,7 @@
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
+import { GuardFunction, GuardTarget, IGuardTarget, INavigatorInstruction, IRouteableComponentType } from './interfaces';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-import { INavigatorInstruction, IRouteableComponentType, GuardTarget, IGuardTarget, GuardFunction } from './interfaces';
 
 export class Guard {
   public type: GuardTypes;

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -7,8 +7,8 @@ import { ViewportInstruction } from './viewport-instruction';
 
 export class Guard {
   public type: GuardTypes;
-  public includeTargets: Target<Constructable>[];
-  public excludeTargets: Target<Constructable>[];
+  public includeTargets: Target[];
+  public excludeTargets: Target[];
   public guard: GuardFunction;
   public id: GuardIdentity;
 
@@ -42,8 +42,8 @@ export class Guard {
   }
 }
 
-class Target<C extends Constructable> {
-  public component?: IRouteableComponentType<C>;
+class Target {
+  public component?: IRouteableComponentType;
   public componentName?: string;
   public viewport?: Viewport;
   public viewportName?: string;
@@ -51,9 +51,9 @@ class Target<C extends Constructable> {
   constructor(target: GuardTarget) {
     if (typeof target === 'string') {
       this.componentName = target;
-    } else if (ComponentAppellationResolver.isType(target as IRouteableComponentType<C>)) {
-      this.component = target as IRouteableComponentType<C>;
-      this.componentName = ComponentAppellationResolver.getName(target as IRouteableComponentType<C>);
+    } else if (ComponentAppellationResolver.isType(target as IRouteableComponentType)) {
+      this.component = target as IRouteableComponentType;
+      this.componentName = ComponentAppellationResolver.getName(target as IRouteableComponentType);
     } else {
       const cvTarget = target as IComponentAndOrViewportOrNothing;
       this.component = ComponentAppellationResolver.isType(cvTarget.component) ? ComponentAppellationResolver.getType(cvTarget.component as Constructable) : null;

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,6 +1,6 @@
 import { Constructable } from '@aurelia/kernel';
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
-import { GuardFunction, GuardTarget, IGuardTarget, INavigatorInstruction, IRouteableComponentType, ComponentAppellationResolver, ViewportAppellationResolver, IComponentAndOrViewportOrNothing } from './interfaces';
+import { GuardFunction, GuardTarget, INavigatorInstruction, IRouteableComponentType, ComponentAppellationResolver, ViewportAppellationResolver, IComponentAndOrViewportOrNothing } from './interfaces';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -56,7 +56,7 @@ class Target<C extends Constructable> {
       this.componentName = ComponentHandleResolver.getName(target as IRouteableComponentType<C>);
     } else {
       const cvTarget = target as IComponentAndOrViewportOrNothing;
-      this.component = ComponentHandleResolver.isType(cvTarget.component) ? ComponentHandleResolver.getType(cvTarget.component as IRouteableComponentType<C>) : null;
+      this.component = ComponentHandleResolver.isType(cvTarget.component) ? ComponentHandleResolver.getType(cvTarget.component as Constructable) : null;
       this.componentName = ComponentHandleResolver.getName(cvTarget.component)
       this.viewport = ViewportHandleResolver.isInstance(cvTarget.viewport) ? cvTarget.viewport as Viewport : null;
       this.viewportName = ViewportHandleResolver.getName(cvTarget.viewport);

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,6 +1,6 @@
 import { Constructable } from '@aurelia/kernel';
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
-import { ComponentAppellationResolver, GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType, ViewportAppellationResolver } from './interfaces';
+import { ComponentHandleResolver, GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType, ViewportHandleResolver } from './interfaces';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -50,15 +50,15 @@ class Target<C extends Constructable> {
   constructor(target: GuardTarget) {
     if (typeof target === 'string') {
       this.componentName = target;
-    } else if (ComponentAppellationResolver.isType(target as IRouteableComponentType<C>)) {
+    } else if (ComponentHandleResolver.isType(target as IRouteableComponentType<C>)) {
       this.component = target as IRouteableComponentType<C>;
-      this.componentName = ComponentAppellationResolver.getName(target as IRouteableComponentType<C>);
+      this.componentName = ComponentHandleResolver.getName(target as IRouteableComponentType<C>);
     } else {
       const cvTarget = target as IComponentAndOrViewportOrNothing;
-      this.component = ComponentAppellationResolver.isType(cvTarget.component) ? ComponentAppellationResolver.getType(cvTarget.component as IRouteableComponentType<C>) : null;
-      this.componentName = ComponentAppellationResolver.getName(cvTarget.component)
-      this.viewport = ViewportAppellationResolver.isInstance(cvTarget.viewport) ? cvTarget.viewport as Viewport : null;
-      this.viewportName = ViewportAppellationResolver.getName(cvTarget.viewport);
+      this.component = ComponentHandleResolver.isType(cvTarget.component) ? ComponentHandleResolver.getType(cvTarget.component as IRouteableComponentType<C>) : null;
+      this.componentName = ComponentHandleResolver.getName(cvTarget.component)
+      this.viewport = ViewportHandleResolver.isInstance(cvTarget.viewport) ? cvTarget.viewport as Viewport : null;
+      this.viewportName = ViewportHandleResolver.getName(cvTarget.viewport);
     }
   }
 

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,6 +1,7 @@
 import { Constructable } from '@aurelia/kernel';
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
-import { ComponentHandleResolver, GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType, ViewportHandleResolver } from './interfaces';
+import { GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType } from './interfaces';
+import { ComponentHandleResolver, ViewportHandleResolver } from './type-resolvers';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,7 +1,7 @@
 import { Constructable } from '@aurelia/kernel';
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
 import { GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType } from './interfaces';
-import { ComponentHandleResolver, ViewportHandleResolver } from './type-resolvers';
+import { ComponentAppellationResolver, ViewportHandleResolver } from './type-resolvers';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -51,13 +51,13 @@ class Target<C extends Constructable> {
   constructor(target: GuardTarget) {
     if (typeof target === 'string') {
       this.componentName = target;
-    } else if (ComponentHandleResolver.isType(target as IRouteableComponentType<C>)) {
+    } else if (ComponentAppellationResolver.isType(target as IRouteableComponentType<C>)) {
       this.component = target as IRouteableComponentType<C>;
-      this.componentName = ComponentHandleResolver.getName(target as IRouteableComponentType<C>);
+      this.componentName = ComponentAppellationResolver.getName(target as IRouteableComponentType<C>);
     } else {
       const cvTarget = target as IComponentAndOrViewportOrNothing;
-      this.component = ComponentHandleResolver.isType(cvTarget.component) ? ComponentHandleResolver.getType(cvTarget.component as Constructable) : null;
-      this.componentName = ComponentHandleResolver.getName(cvTarget.component)
+      this.component = ComponentAppellationResolver.isType(cvTarget.component) ? ComponentAppellationResolver.getType(cvTarget.component as Constructable) : null;
+      this.componentName = ComponentAppellationResolver.getName(cvTarget.component)
       this.viewport = ViewportHandleResolver.isInstance(cvTarget.viewport) ? cvTarget.viewport as Viewport : null;
       this.viewportName = ViewportHandleResolver.getName(cvTarget.viewport);
     }

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,7 +1,7 @@
-import { GuardFunction, GuardIdentity, GuardTarget, GuardTypes, IGuardOptions, IGuardTarget } from './guardian';
+import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
+import { INavigatorInstruction, IRouteableComponentType, GuardTarget, IGuardTarget, GuardFunction } from './interfaces';
 
 export class Guard {
   public type: GuardTypes;

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,8 +1,7 @@
 import { GuardFunction, GuardIdentity, GuardTarget, GuardTypes, IGuardOptions, IGuardTarget } from './guardian';
-import { INavigatorInstruction } from './navigator';
 import { Viewport } from './viewport';
-import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
 
 export class Guard {
   public type: GuardTypes;

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,6 +1,6 @@
 import { Constructable } from '@aurelia/kernel';
 import { GuardIdentity, GuardTypes, IGuardOptions, } from './guardian';
-import { GuardFunction, GuardTarget, INavigatorInstruction, IRouteableComponentType, ComponentAppellationResolver, ViewportAppellationResolver, IComponentAndOrViewportOrNothing } from './interfaces';
+import { ComponentAppellationResolver, GuardFunction, GuardTarget, IComponentAndOrViewportOrNothing, INavigatorInstruction, IRouteableComponentType, ViewportAppellationResolver } from './interfaces';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 

--- a/packages/router/src/guard.ts
+++ b/packages/router/src/guard.ts
@@ -1,8 +1,7 @@
-import { ICustomElementType } from '@aurelia/runtime';
-
 import { GuardFunction, GuardIdentity, GuardTarget, GuardTypes, IGuardOptions, IGuardTarget } from './guardian';
 import { INavigatorInstruction } from './navigator';
 import { Viewport } from './viewport';
+import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
 
 export class Guard {
@@ -43,7 +42,7 @@ export class Guard {
 }
 
 class Target {
-  public component?: Partial<ICustomElementType>;
+  public component?: IRouteableComponentType;
   public componentName?: string;
   public viewport?: Viewport;
   public viewportName?: string;
@@ -58,7 +57,7 @@ class Target {
       this.viewport = viewport;
       this.viewportName = viewportName;
     } else {
-      this.component = target as Partial<ICustomElementType>;
+      this.component = target as IRouteableComponentType;
     }
   }
 

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,12 +1,11 @@
-import { ICustomElementType } from '@aurelia/runtime';
-
 import { Guard } from './guard';
 import { INavigatorInstruction } from './navigator';
 import { Viewport } from './viewport';
+import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IGuardTarget {
-  component?: Partial<ICustomElementType>;
+  component?: IRouteableComponentType;
   componentName?: string;
   viewport?: Viewport;
   viewportName?: string;
@@ -18,7 +17,7 @@ export const enum GuardTypes {
 }
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget = IGuardTarget | Partial<ICustomElementType> | string;
+export type GuardTarget = IGuardTarget | IRouteableComponentType | string;
 export type GuardIdentity = number;
 
 export interface IGuardOptions {

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,7 +1,6 @@
 import { Guard } from './guard';
-import { Viewport } from './viewport';
+import { GuardFunction, GuardTarget, INavigatorInstruction } from './interfaces';
 import { ViewportInstruction } from './viewport-instruction';
-import { INavigatorInstruction, IRouteableComponentType, GuardTarget, GuardFunction } from './interfaces';
 
 // Only one so far, but it's easier to support more from the start
 export const enum GuardTypes {

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,8 +1,7 @@
 import { Guard } from './guard';
-import { INavigatorInstruction } from './navigator';
 import { Viewport } from './viewport';
-import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
 
 export interface IGuardTarget {
   component?: IRouteableComponentType;

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -1,22 +1,13 @@
 import { Guard } from './guard';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
-
-export interface IGuardTarget {
-  component?: IRouteableComponentType;
-  componentName?: string;
-  viewport?: Viewport;
-  viewportName?: string;
-}
+import { INavigatorInstruction, IRouteableComponentType, GuardTarget, GuardFunction } from './interfaces';
 
 // Only one so far, but it's easier to support more from the start
 export const enum GuardTypes {
   Before = 'before',
 }
 
-export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget = IGuardTarget | IRouteableComponentType | string;
 export type GuardIdentity = number;
 
 export interface IGuardOptions {

--- a/packages/router/src/guardian.ts
+++ b/packages/router/src/guardian.ts
@@ -10,8 +10,17 @@ export const enum GuardTypes {
 export type GuardIdentity = number;
 
 export interface IGuardOptions {
+  /**
+   * What event/when to guard. Defaults to Before
+   */
   type?: GuardTypes;
+  /**
+   * What to guard. If omitted, everything is included
+   */
   include?: GuardTarget[];
+  /**
+   * What not to guard. If omitted, nothing is excluded
+   */
   exclude?: GuardTarget[];
 }
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -23,7 +23,6 @@ export {
 export {
   GuardFunction,
   GuardTarget,
-  IGuardTarget,
   INavigatorInstruction,
   IRouteableComponent,
   IRouteableComponentType,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -14,19 +14,21 @@ export {
 } from './guard';
 
 export {
-  IGuardTarget,
   GuardTypes,
-  GuardFunction,
-  GuardTarget,
   GuardIdentity,
   IGuardOptions,
   Guardian,
 } from './guardian';
 
 export {
+  GuardFunction,
+  GuardTarget,
+  IGuardTarget,
   INavigatorInstruction,
   IRouteableComponent,
   IRouteableComponentType,
+  IViewportComponent,
+  NavigationInstruction,
   ReentryBehavior,
 } from './interfaces';
 
@@ -79,8 +81,6 @@ export {
   IRouteTransformer,
   IRouterOptions,
   IRouter,
-  IViewportComponent,
-  NavigationInstruction,
   Router,
 } from './router';
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -27,7 +27,7 @@ export {
   INavigatorInstruction,
   IRouteableComponent,
   IRouteableComponentType,
-  IViewportComponent,
+  IViewportInstruction,
   NavigationInstruction,
   ReentryBehavior,
 } from './interfaces';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -92,8 +92,8 @@ export {
 } from './viewport';
 
 export {
-  IRouteableCustomElement,
-  IRouteableCustomElementType,
+  IRouteableComponent,
+  IRouteableComponentType,
   ContentStatus,
   ReentryBehavior,
   ViewportContent,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -78,7 +78,6 @@ export {
 export {
   IRouteTransformer,
   IRouterOptions,
-  IRouteViewport,
   IRouter,
   IViewportComponent,
   NavigationInstruction,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -86,7 +86,6 @@ export {
 } from './router';
 
 export {
-  IViewportComponentType,
   IFindViewportsResult,
   ChildContainer,
   Scope,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -80,7 +80,7 @@ export {
 } from './router';
 
 export {
-  IViewportCustomElementType,
+  IViewportComponentType,
   IFindViewportsResult,
   ChildContainer,
   Scope,

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -24,6 +24,13 @@ export {
 } from './guardian';
 
 export {
+  INavigatorInstruction,
+  IRouteableComponent,
+  IRouteableComponentType,
+  ReentryBehavior,
+} from './interfaces';
+
+export {
   INavRoute,
   Nav,
 } from './nav';
@@ -37,7 +44,6 @@ export {
   INavigatorEntry,
   INavigatorOptions,
   INavigatorFlags,
-  INavigatorInstruction,
   INavigatorState,
   INavigatorStore,
   INavigatorViewer,
@@ -92,10 +98,7 @@ export {
 } from './viewport';
 
 export {
-  IRouteableComponent,
-  IRouteableComponentType,
   ContentStatus,
-  ReentryBehavior,
   ViewportContent,
 } from './viewport-content';
 

--- a/packages/router/src/instruction-resolver.ts
+++ b/packages/router/src/instruction-resolver.ts
@@ -146,6 +146,17 @@ export class InstructionResolver {
     return unique;
   }
 
+  public flattenViewportInstructions(instructions: ViewportInstruction[]): ViewportInstruction[] {
+    const flat: ViewportInstruction[] = [];
+    for (const instruction of instructions) {
+      flat.push(instruction);
+      if (instruction.nextScopeInstruction) {
+        flat.push(...this.flattenViewportInstructions([instruction.nextScopeInstruction]));
+      }
+    }
+    return flat;
+  }
+
   public stateStringsToString(stateStrings: string[], clear: boolean = false): string {
     const strings = stateStrings.slice();
     if (clear) {

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -17,10 +17,10 @@ export interface IRouteableComponentType<C extends Constructable = Constructable
 
 export interface IRouteableComponent<T extends INode = INode> extends IViewModel<T> {
   reentryBehavior?: ReentryBehavior;
-  canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
-  enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
-  canLeave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | Promise<boolean>;
-  leave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
+  canEnter?(parameters: string[] | Record<string, string>, nextInstruction: INavigatorInstruction, instruction: INavigatorInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
+  enter?(parameters: string[] | Record<string, string>, nextInstruction: INavigatorInstruction, instruction: INavigatorInstruction): void | Promise<void>;
+  canLeave?(nextInstruction: INavigatorInstruction, instruction: INavigatorInstruction): boolean | Promise<boolean>;
+  leave?(nextInstruction: INavigatorInstruction, instruction: INavigatorInstruction): void | Promise<void>;
 }
 
 export const enum ReentryBehavior {
@@ -49,7 +49,7 @@ export interface IComponentAndOrViewportOrNothing {
 
 export type NavigationInstruction = ComponentAppellation | IViewportInstruction | ViewportInstruction;
 
-export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
+export type GuardFunction = (viewportInstructions: ViewportInstruction[], navigationInstruction: INavigatorInstruction) => boolean | ViewportInstruction[];
 export type GuardTarget = ComponentAppellation | IComponentAndOrViewportOrNothing;
 
 export type ComponentAppellation = string | IRouteableComponentType | Constructable; // TODO: | IRouteableComponent;

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -53,7 +53,7 @@ export type NavigationInstruction<C extends Constructable = Constructable> = Com
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
 export type GuardTarget<C extends Constructable = Constructable> = ComponentAppellation<C> | IComponentAndOrViewportOrNothing;
 
-export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C>; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
+export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
 export type ViewportAppellation = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];
 

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -11,7 +11,7 @@ import { ViewportInstruction } from './viewport-instruction';
 * of the API.
 */
 
-export interface IRouteableComponentType<C extends Constructable> extends ICustomElementType<C> {
+export interface IRouteableComponentType<C extends Constructable = Constructable> extends ICustomElementType<C> {
   parameters?: string[];
 }
 
@@ -36,22 +36,22 @@ export interface INavigatorInstruction extends INavigatorEntry {
   repeating?: boolean;
 }
 
-export interface IViewportInstruction<C extends Constructable> {
-  component: ComponentAppellation<C>;
+export interface IViewportInstruction {
+  component: ComponentAppellation;
   viewport?: ViewportHandle;
   parameters?: ComponentParameters;
 }
 
-export interface IComponentAndOrViewportOrNothing<C extends Constructable = Constructable> {
-  component?: ComponentAppellation<C>;
+export interface IComponentAndOrViewportOrNothing {
+  component?: ComponentAppellation;
   viewport?: ViewportHandle;
 }
 
-export type NavigationInstruction<C extends Constructable = Constructable> = ComponentAppellation<C> | IViewportInstruction<C> | ViewportInstruction;
+export type NavigationInstruction = ComponentAppellation | IViewportInstruction | ViewportInstruction;
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget<C extends Constructable = Constructable> = ComponentAppellation<C> | IComponentAndOrViewportOrNothing;
+export type GuardTarget = ComponentAppellation | IComponentAndOrViewportOrNothing;
 
-export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
+export type ComponentAppellation = string | IRouteableComponentType | Constructable; // TODO: | IRouteableComponent;
 export type ViewportHandle = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,16 +1,16 @@
+import { Constructable } from '@aurelia/kernel';
+import { CustomElement, ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
 import { ComponentAppellation } from './interfaces';
+import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
+import { IRouter } from './router';
+import { Viewport } from './viewport';
+import { ViewportInstruction } from './viewport-instruction';
+
 /*
 * Contains interfaces and types that aren't strongly connected
 * to component(s) or that are considered an essential part
 * of the API.
 */
-
-import { Constructable } from '@aurelia/kernel';
-import { CustomElement, ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
-import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
-import { IRouter } from './router';
-import { Viewport } from './viewport';
-import { ViewportInstruction } from './viewport-instruction';
 
 export interface IRouteableComponentType<C extends Constructable> extends ICustomElementType<C> {
   parameters?: string[];
@@ -37,8 +37,8 @@ export interface INavigatorInstruction extends INavigatorEntry {
   repeating?: boolean;
 }
 
-export interface IViewportInstruction {
-  component: ComponentAppellation;
+export interface IViewportInstruction<C extends Constructable> {
+  component: ComponentAppellation<C>;
   viewport?: ViewportAppellation;
   parameters?: ComponentParameters;
 }
@@ -48,12 +48,12 @@ export interface IComponentAndOrViewportOrNothing<C extends Constructable = Cons
   viewport?: ViewportAppellation;
 }
 
-export type NavigationInstruction = ComponentAppellation | IViewportInstruction | ViewportInstruction;
+export type NavigationInstruction<C extends Constructable = Constructable> = ComponentAppellation<C> | IViewportInstruction<C> | ViewportInstruction;
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget = ComponentAppellation | IComponentAndOrViewportOrNothing;
+export type GuardTarget<C extends Constructable = Constructable> = ComponentAppellation<C> | IComponentAndOrViewportOrNothing;
 
-export type ComponentAppellation<C extends Constructable = Constructable, T extends INode = INode> = string | IRouteableComponentType<C>; // TODO: | IRouteableComponent<T>;
+export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C>; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
 export type ViewportAppellation = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];
 
@@ -97,7 +97,7 @@ export const ViewportAppellationResolver = {
     if (ViewportAppellationResolver.isName(viewport)) {
       return viewport as string;
     } else {
-      return (viewport as Viewport).name;
+      return viewport ? (viewport as Viewport).name : null;
     }
   }
 };
@@ -114,7 +114,7 @@ export const NavigationInstructionResolver = {
       } else if (instruction as ViewportInstruction instanceof ViewportInstruction) {
         instructions.push(instruction as ViewportInstruction);
       } else if (instruction['component']) {
-        const viewportComponent = instruction as IViewportInstruction;
+        const viewportComponent = instruction as IViewportInstruction<C>;
         instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
       } else {
         instructions.push(new ViewportInstruction(instruction as IRouteableComponentType<C>));

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -43,13 +43,6 @@ export interface IViewportInstruction {
   parameters?: ComponentParameters;
 }
 
-export interface IGuardTarget<C extends Constructable> {
-  component?: IRouteableComponentType<C>;
-  componentName?: string;
-  viewport?: Viewport;
-  viewportName?: string;
-}
-
 export interface IComponentAndOrViewportOrNothing<C extends Constructable = Constructable> {
   component?: ComponentAppellation<C>;
   viewport?: ViewportAppellation;

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,5 +1,12 @@
+/*
+* Contains interfaces and types that aren't strongly connected
+* to component(s) or that are considered an essential part
+* of the API.
+*/
+
 import { ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
 import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
+import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IComponent {
@@ -35,3 +42,21 @@ export interface INavigatorInstruction extends INavigatorEntry {
   repeating?: boolean;
 }
 
+export interface IViewportComponent {
+  component: string | IRouteableComponentType;
+  viewport?: string | Viewport;
+  parameters?: Record<string, unknown> | string; // TODO: Allow unknown[] for parameters
+}
+
+export interface IGuardTarget {
+  component?: IRouteableComponentType;
+  componentName?: string;
+  viewport?: Viewport;
+  viewportName?: string;
+}
+
+
+export type NavigationInstruction = string | IRouteableComponentType | IViewportComponent | ViewportInstruction;
+
+export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
+export type GuardTarget = IGuardTarget | IRouteableComponentType | string;

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,8 +1,7 @@
 import { Constructable } from '@aurelia/kernel';
-import { CustomElement, ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
+import { ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
 import { ComponentHandle } from './interfaces';
 import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
-import { IRouter } from './router';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -56,70 +55,3 @@ export type GuardTarget<C extends Constructable = Constructable> = ComponentHand
 export type ComponentHandle<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
 export type ViewportHandle = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];
-
-export const ComponentHandleResolver = {
-  isName: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
-    return typeof component === 'string';
-  },
-  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
-    return CustomElement.isType(component);
-  },
-  getName: function <T>(component: T & ComponentHandle<Constructable>): string {
-    if (ComponentHandleResolver.isName(component)) {
-      return component as string;
-    } else if (ComponentHandleResolver.isType(component)) {
-      return (component as ICustomElementType).description.name;
-    } else {
-      return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
-    }
-  },
-  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): ICustomElementType<T> {
-    if (ComponentHandleResolver.isName(component)) {
-      return null;
-    } else if (ComponentHandleResolver.isType(component)) {
-      return component;
-    }
-    // TODO: Fix resolve for instance
-    // else {
-    //   return (component as ICustomElementType).constructor;
-    // }
-  },
-};
-
-export const ViewportHandleResolver = {
-  isName: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
-    return typeof viewport === 'string';
-  },
-  isInstance: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
-    return viewport instanceof Viewport;
-  },
-  getName: function <T>(viewport: T & ViewportHandle): string {
-    if (ViewportHandleResolver.isName(viewport)) {
-      return viewport as string;
-    } else {
-      return viewport ? (viewport as Viewport).name : null;
-    }
-  }
-};
-
-export const NavigationInstructionResolver = {
-  toViewportInstructions: function <C extends Constructable>(router: IRouter, navigationInstructions: NavigationInstruction | NavigationInstruction[]): ViewportInstruction[] {
-    if (!Array.isArray(navigationInstructions)) {
-      return NavigationInstructionResolver.toViewportInstructions(router, [navigationInstructions]);
-    }
-    const instructions: ViewportInstruction[] = [];
-    for (const instruction of navigationInstructions) {
-      if (typeof instruction === 'string') {
-        instructions.push(router.instructionResolver.parseViewportInstruction(instruction));
-      } else if (instruction as ViewportInstruction instanceof ViewportInstruction) {
-        instructions.push(instruction as ViewportInstruction);
-      } else if (instruction['component']) {
-        const viewportComponent = instruction as IViewportInstruction<C>;
-        instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
-      } else {
-        instructions.push(new ViewportInstruction(instruction as IRouteableComponentType<C>));
-      }
-    }
-    return instructions;
-  },
-};

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { Constructable } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
-import { ComponentAppellation } from './interfaces';
+import { ComponentHandle } from './interfaces';
 import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
@@ -38,45 +38,45 @@ export interface INavigatorInstruction extends INavigatorEntry {
 }
 
 export interface IViewportInstruction<C extends Constructable> {
-  component: ComponentAppellation<C>;
-  viewport?: ViewportAppellation;
+  component: ComponentHandle<C>;
+  viewport?: ViewportHandle;
   parameters?: ComponentParameters;
 }
 
 export interface IComponentAndOrViewportOrNothing<C extends Constructable = Constructable> {
-  component?: ComponentAppellation<C>;
-  viewport?: ViewportAppellation;
+  component?: ComponentHandle<C>;
+  viewport?: ViewportHandle;
 }
 
-export type NavigationInstruction<C extends Constructable = Constructable> = ComponentAppellation<C> | IViewportInstruction<C> | ViewportInstruction;
+export type NavigationInstruction<C extends Constructable = Constructable> = ComponentHandle<C> | IViewportInstruction<C> | ViewportInstruction;
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget<C extends Constructable = Constructable> = ComponentAppellation<C> | IComponentAndOrViewportOrNothing;
+export type GuardTarget<C extends Constructable = Constructable> = ComponentHandle<C> | IComponentAndOrViewportOrNothing;
 
-export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
-export type ViewportAppellation = string | Viewport;
+export type ComponentHandle<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
+export type ViewportHandle = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];
 
-export const ComponentAppellationResolver = {
-  isName: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> {
+export const ComponentHandleResolver = {
+  isName: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
     return typeof component === 'string';
   },
-  isType: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> {
+  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
     return CustomElement.isType(component);
   },
-  getName: function <T>(component: T & ComponentAppellation<Constructable>): string {
-    if (ComponentAppellationResolver.isName(component)) {
+  getName: function <T>(component: T & ComponentHandle<Constructable>): string {
+    if (ComponentHandleResolver.isName(component)) {
       return component as string;
-    } else if (ComponentAppellationResolver.isType(component)) {
+    } else if (ComponentHandleResolver.isType(component)) {
       return (component as ICustomElementType).description.name;
     } else {
       return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
     }
   },
-  getType: function <T extends Constructable>(component: T & ComponentAppellation<Constructable>): ICustomElementType<T> {
-    if (ComponentAppellationResolver.isName(component)) {
+  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): ICustomElementType<T> {
+    if (ComponentHandleResolver.isName(component)) {
       return null;
-    } else if (ComponentAppellationResolver.isType(component)) {
+    } else if (ComponentHandleResolver.isType(component)) {
       return component;
     }
     // TODO: Fix resolve for instance
@@ -86,15 +86,15 @@ export const ComponentAppellationResolver = {
   },
 };
 
-export const ViewportAppellationResolver = {
-  isName: function <T>(viewport: T & ViewportAppellation): viewport is T & ViewportAppellation {
+export const ViewportHandleResolver = {
+  isName: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
     return typeof viewport === 'string';
   },
-  isInstance: function <T>(viewport: T & ViewportAppellation): viewport is T & ViewportAppellation {
+  isInstance: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
     return viewport instanceof Viewport;
   },
-  getName: function <T>(viewport: T & ViewportAppellation): string {
-    if (ViewportAppellationResolver.isName(viewport)) {
+  getName: function <T>(viewport: T & ViewportHandle): string {
+    if (ViewportHandleResolver.isName(viewport)) {
       return viewport as string;
     } else {
       return viewport ? (viewport as Viewport).name : null;

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -4,20 +4,13 @@
 * of the API.
 */
 
+import { Constructable } from '@aurelia/kernel';
 import { ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
 import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-export interface IComponent {
-
-}
-
-export interface IViewport {
-
-}
-
-export interface IRouteableComponentType extends Partial<ICustomElementType> {
+export interface IRouteableComponentType<C extends Constructable = Constructable> extends Partial<ICustomElementType<C>> {
   parameters?: string[];
 }
 
@@ -42,10 +35,10 @@ export interface INavigatorInstruction extends INavigatorEntry {
   repeating?: boolean;
 }
 
-export interface IViewportComponent {
-  component: string | IRouteableComponentType;
-  viewport?: string | Viewport;
-  parameters?: Record<string, unknown> | string; // TODO: Allow unknown[] for parameters
+export interface IViewportInstruction {
+  component: ComponentAppellation;
+  viewport?: ViewportAppellation;
+  parameters?: string | Record<string, unknown>; // TODO: | unknown[];
 }
 
 export interface IGuardTarget {
@@ -55,8 +48,15 @@ export interface IGuardTarget {
   viewportName?: string;
 }
 
-
-export type NavigationInstruction = string | IRouteableComponentType | IViewportComponent | ViewportInstruction;
+export type NavigationInstruction = ComponentAppellation | IViewportInstruction | ViewportInstruction;
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget = IGuardTarget | IRouteableComponentType | string;
+export type GuardTarget = ComponentAppellation | IComponentAndOrViewportOrNothing;
+
+export type ComponentAppellation<C extends Constructable = Constructable, T extends INode = INode> = string | IRouteableComponentType<C>; // TODO: | IRouteableComponent<T>;
+export type ViewportAppellation = string | Viewport;
+
+export interface IComponentAndOrViewportOrNothing<C extends Constructable = Constructable> {
+  component?: ComponentAppellation<C>;
+  viewport?: ViewportAppellation;
+}

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,6 +1,6 @@
 import { Constructable } from '@aurelia/kernel';
 import { ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
-import { ComponentHandle } from './interfaces';
+import { ComponentAppellation } from './interfaces';
 import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
@@ -37,21 +37,21 @@ export interface INavigatorInstruction extends INavigatorEntry {
 }
 
 export interface IViewportInstruction<C extends Constructable> {
-  component: ComponentHandle<C>;
+  component: ComponentAppellation<C>;
   viewport?: ViewportHandle;
   parameters?: ComponentParameters;
 }
 
 export interface IComponentAndOrViewportOrNothing<C extends Constructable = Constructable> {
-  component?: ComponentHandle<C>;
+  component?: ComponentAppellation<C>;
   viewport?: ViewportHandle;
 }
 
-export type NavigationInstruction<C extends Constructable = Constructable> = ComponentHandle<C> | IViewportInstruction<C> | ViewportInstruction;
+export type NavigationInstruction<C extends Constructable = Constructable> = ComponentAppellation<C> | IViewportInstruction<C> | ViewportInstruction;
 
 export type GuardFunction = (viewportInstructions?: ViewportInstruction[], navigationInstruction?: INavigatorInstruction) => boolean | ViewportInstruction[];
-export type GuardTarget<C extends Constructable = Constructable> = ComponentHandle<C> | IComponentAndOrViewportOrNothing;
+export type GuardTarget<C extends Constructable = Constructable> = ComponentAppellation<C> | IComponentAndOrViewportOrNothing;
 
-export type ComponentHandle<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
+export type ComponentAppellation<C extends Constructable = Constructable> = string | IRouteableComponentType<C> | Constructable; // TODO: , T extends INode = INode    | IRouteableComponent<T>;
 export type ViewportHandle = string | Viewport;
 export type ComponentParameters = string | Record<string, unknown>; // TODO: | unknown[];

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -1,0 +1,37 @@
+import { ICustomElementType, INode, IViewModel } from '@aurelia/runtime';
+import { INavigatorEntry, INavigatorFlags, IStoredNavigatorEntry } from './navigator';
+import { ViewportInstruction } from './viewport-instruction';
+
+export interface IComponent {
+
+}
+
+export interface IViewport {
+
+}
+
+export interface IRouteableComponentType extends Partial<ICustomElementType> {
+  parameters?: string[];
+}
+
+export interface IRouteableComponent<T extends INode = INode> extends IViewModel<T> {
+  reentryBehavior?: ReentryBehavior;
+  canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
+  enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
+  canLeave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | Promise<boolean>;
+  leave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
+}
+
+export const enum ReentryBehavior {
+  default = 'default',
+  disallow = 'disallow',
+  enter = 'enter',
+  refresh = 'refresh',
+}
+
+export interface INavigatorInstruction extends INavigatorEntry {
+  navigation?: INavigatorFlags;
+  previous?: IStoredNavigatorEntry;
+  repeating?: boolean;
+}
+

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,7 +1,8 @@
 import { Constructable } from '@aurelia/kernel';
-import { ComponentHandleResolver, IRouteableComponentType, NavigationInstruction, NavigationInstructionResolver } from './interfaces';
+import { IRouteableComponentType, NavigationInstruction } from './interfaces';
 import { INavRoute, Nav } from './nav';
 import { ViewportInstruction } from './viewport-instruction';
+import { ComponentHandleResolver, NavigationInstructionResolver } from './type-resolvers';
 
 
 export class NavRoute {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,7 +1,7 @@
 import { INavRoute, Nav } from './nav';
 import { IViewportComponent, NavigationInstruction } from './router';
-import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+import { IRouteableComponentType } from './interfaces';
 
 
 export class NavRoute {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,5 +1,5 @@
 import { Constructable } from '@aurelia/kernel';
-import { ComponentAppellationResolver, IRouteableComponentType, NavigationInstruction, NavigationInstructionResolver } from './interfaces';
+import { ComponentHandleResolver, IRouteableComponentType, NavigationInstruction, NavigationInstructionResolver } from './interfaces';
 import { INavRoute, Nav } from './nav';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -32,7 +32,7 @@ export class NavRoute {
       this.link = this.computeLink(this.instructions);
     }
     this.linkActive = route.consideredActive ? route.consideredActive : this.link;
-    if (!(this.linkActive instanceof Function) || ComponentAppellationResolver.isType(this.linkActive as IRouteableComponentType<Constructable>)) {
+    if (!(this.linkActive instanceof Function) || ComponentHandleResolver.isType(this.linkActive as IRouteableComponentType<Constructable>)) {
       this.linkActive = NavigationInstructionResolver.toViewportInstructions(this.nav.router, this.linkActive as NavigationInstruction | NavigationInstruction[]);
     }
     this.execute = route.execute;

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,6 +1,6 @@
+import { IRouteableComponentType, IViewportComponent, NavigationInstruction } from './interfaces';
 import { INavRoute, Nav } from './nav';
 import { ViewportInstruction } from './viewport-instruction';
-import { IRouteableComponentType, NavigationInstruction, IViewportComponent } from './interfaces';
 
 
 export class NavRoute {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,7 +1,8 @@
-import { ICustomElementType } from '@aurelia/runtime';
 import { INavRoute, Nav } from './nav';
 import { IViewportComponent, NavigationInstruction } from './router';
+import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+
 
 export class NavRoute {
   public nav: Nav;
@@ -77,7 +78,7 @@ export class NavRoute {
         const viewportComponent = route as IViewportComponent;
         instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
       } else {
-        instructions.push(new ViewportInstruction(route as Partial<ICustomElementType>));
+        instructions.push(new ViewportInstruction(route as IRouteableComponentType));
       }
     }
     return instructions;

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,4 +1,4 @@
-import { IRouteableComponentType, IViewportComponent, NavigationInstruction } from './interfaces';
+import { IRouteableComponentType, IViewportInstruction, NavigationInstruction } from './interfaces';
 import { INavRoute, Nav } from './nav';
 import { ViewportInstruction } from './viewport-instruction';
 
@@ -74,7 +74,7 @@ export class NavRoute {
       } else if (route as ViewportInstruction instanceof ViewportInstruction) {
         instructions.push(route as ViewportInstruction);
       } else if (route['component']) {
-        const viewportComponent = route as IViewportComponent;
+        const viewportComponent = route as IViewportInstruction;
         instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
       } else {
         instructions.push(new ViewportInstruction(route as IRouteableComponentType));

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -2,7 +2,7 @@ import { Constructable } from '@aurelia/kernel';
 import { IRouteableComponentType, NavigationInstruction } from './interfaces';
 import { INavRoute, Nav } from './nav';
 import { ViewportInstruction } from './viewport-instruction';
-import { ComponentHandleResolver, NavigationInstructionResolver } from './type-resolvers';
+import { ComponentAppellationResolver, NavigationInstructionResolver } from './type-resolvers';
 
 
 export class NavRoute {
@@ -33,7 +33,7 @@ export class NavRoute {
       this.link = this.computeLink(this.instructions);
     }
     this.linkActive = route.consideredActive ? route.consideredActive : this.link;
-    if (!(this.linkActive instanceof Function) || ComponentHandleResolver.isType(this.linkActive as IRouteableComponentType<Constructable>)) {
+    if (!(this.linkActive instanceof Function) || ComponentAppellationResolver.isType(this.linkActive as IRouteableComponentType<Constructable>)) {
       this.linkActive = NavigationInstructionResolver.toViewportInstructions(this.nav.router, this.linkActive as NavigationInstruction | NavigationInstruction[]);
     }
     this.execute = route.execute;

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -79,7 +79,8 @@ export class NavRoute {
       return (this.linkActive as ((route: NavRoute) => boolean))(this) ? 'nav-active' : '';
     }
     const components = this.linkActive as ViewportInstruction[];
-    const activeComponents = this.nav.router.activeComponents.map((state) => this.nav.router.instructionResolver.parseViewportInstruction(state));
+    let activeComponents = this.nav.router.activeComponents.map((state) => this.nav.router.instructionResolver.parseViewportInstruction(state));
+    activeComponents = this.nav.router.instructionResolver.flattenViewportInstructions(activeComponents);
     for (const component of components) {
       if (activeComponents.every((active) => !active.sameComponent(component, this.compareParameters && !!component.parametersString))) {
         return '';

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,7 +1,6 @@
 import { INavRoute, Nav } from './nav';
-import { IViewportComponent, NavigationInstruction } from './router';
 import { ViewportInstruction } from './viewport-instruction';
-import { IRouteableComponentType } from './interfaces';
+import { IRouteableComponentType, NavigationInstruction, IViewportComponent } from './interfaces';
 
 
 export class NavRoute {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -33,7 +33,7 @@ export class NavRoute {
       this.link = this.computeLink(this.instructions);
     }
     this.linkActive = route.consideredActive ? route.consideredActive : this.link;
-    if (!(this.linkActive instanceof Function) || ComponentAppellationResolver.isType(this.linkActive as IRouteableComponentType<Constructable>)) {
+    if (!(this.linkActive instanceof Function) || ComponentAppellationResolver.isType(this.linkActive as IRouteableComponentType)) {
       this.linkActive = NavigationInstructionResolver.toViewportInstructions(this.nav.router, this.linkActive as NavigationInstruction | NavigationInstruction[]);
     }
     this.execute = route.execute;
@@ -65,7 +65,7 @@ export class NavRoute {
   }
 
   private parseRoute<C extends Constructable>(routes: NavigationInstruction | NavigationInstruction[]): ViewportInstruction[] {
-    return NavigationInstructionResolver.toViewportInstructions<C>(this.nav.router, routes);
+    return NavigationInstructionResolver.toViewportInstructions(this.nav.router, routes);
   }
 
   private computeVisible(): boolean {

--- a/packages/router/src/nav-route.ts
+++ b/packages/router/src/nav-route.ts
@@ -1,9 +1,8 @@
 import { Constructable } from '@aurelia/kernel';
 import { IRouteableComponentType, NavigationInstruction } from './interfaces';
 import { INavRoute, Nav } from './nav';
-import { ViewportInstruction } from './viewport-instruction';
 import { ComponentAppellationResolver, NavigationInstructionResolver } from './type-resolvers';
-
+import { ViewportInstruction } from './viewport-instruction';
 
 export class NavRoute {
   public nav: Nav;

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -1,13 +1,14 @@
+import { Constructable } from '@aurelia/kernel';
 import { NavigationInstruction } from './interfaces';
 import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';
 import { IRouter } from './router';
 
-export interface INavRoute {
-  route?: NavigationInstruction | NavigationInstruction[];
+export interface INavRoute<C extends Constructable = Constructable> {
+  route?: NavigationInstruction<C> | NavigationInstruction<C>[];
   execute?: ((route: NavRoute) => void);
   condition?: boolean | ((route: NavRoute) => boolean);
-  consideredActive?: NavigationInstruction | NavigationInstruction[] | ((route: NavRoute) => boolean);
+  consideredActive?: NavigationInstruction<C> | NavigationInstruction<C>[] | ((route: NavRoute) => boolean);
   compareParameters?: boolean;
   link?: string;
   title: string;

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -1,6 +1,7 @@
 import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';
-import { IRouter, NavigationInstruction } from './router';
+import { IRouter } from './router';
+import { NavigationInstruction } from './interfaces';
 
 export interface INavRoute {
   route?: NavigationInstruction | NavigationInstruction[];

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -1,7 +1,7 @@
+import { NavigationInstruction } from './interfaces';
 import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';
 import { IRouter } from './router';
-import { NavigationInstruction } from './interfaces';
 
 export interface INavRoute {
   route?: NavigationInstruction | NavigationInstruction[];

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -4,11 +4,11 @@ import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';
 import { IRouter } from './router';
 
-export interface INavRoute<C extends Constructable = Constructable> {
-  route?: NavigationInstruction<C> | NavigationInstruction<C>[];
+export interface INavRoute {
+  route?: NavigationInstruction | NavigationInstruction[];
   execute?: ((route: NavRoute) => void);
   condition?: boolean | ((route: NavRoute) => boolean);
-  consideredActive?: NavigationInstruction<C> | NavigationInstruction<C>[] | ((route: NavRoute) => boolean);
+  consideredActive?: NavigationInstruction | NavigationInstruction[] | ((route: NavRoute) => boolean);
   compareParameters?: boolean;
   link?: string;
   title: string;

--- a/packages/router/src/nav.ts
+++ b/packages/router/src/nav.ts
@@ -1,4 +1,3 @@
-import { Constructable } from '@aurelia/kernel';
 import { NavigationInstruction } from './interfaces';
 import { NavRoute } from './nav-route';
 import { INavClasses } from './resources/nav';

--- a/packages/router/src/navigator.ts
+++ b/packages/router/src/navigator.ts
@@ -1,6 +1,6 @@
 import { Reporter } from '@aurelia/kernel';
-import { Queue, QueueItem } from './queue';
 import { INavigatorInstruction } from './interfaces';
+import { Queue, QueueItem } from './queue';
 
 export interface INavigatorStore {
   length: number;

--- a/packages/router/src/navigator.ts
+++ b/packages/router/src/navigator.ts
@@ -1,5 +1,6 @@
 import { Reporter } from '@aurelia/kernel';
 import { Queue, QueueItem } from './queue';
+import { INavigatorInstruction } from './interfaces';
 
 export interface INavigatorStore {
   length: number;
@@ -61,12 +62,6 @@ export interface INavigatorFlags {
   forward?: boolean;
   back?: boolean;
   replace?: boolean;
-}
-
-export interface INavigatorInstruction extends INavigatorEntry {
-  navigation?: INavigatorFlags;
-  previous?: IStoredNavigatorEntry;
-  repeating?: boolean;
 }
 
 export interface INavigatorState {

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -1,30 +1,7 @@
-import {
-  Key,
-  Writable
-} from '@aurelia/kernel';
-
-import {
-  bindable,
-  createRenderContext,
-  CustomElement,
-  IController,
-  ICustomElementType,
-  IDOM,
-  INode,
-  IRenderContext,
-  IRenderingEngine,
-  ITemplate,
-  LifecycleFlags,
-  TemplateDefinition
-} from '@aurelia/runtime';
-
-import {
-  IRouter,
-} from '../router';
-import {
-  IViewportOptions,
-  Viewport
-} from '../viewport';
+import { Key, Writable } from '@aurelia/kernel';
+import { bindable, createRenderContext, CustomElement, IController, ICustomElementType, IDOM, INode, IRenderContext, IRenderingEngine, ITemplate, LifecycleFlags, TemplateDefinition } from '@aurelia/runtime';
+import { IRouter } from '../router';
+import { IViewportOptions, Viewport } from '../viewport';
 
 export class ViewportCustomElement {
   public static readonly inject: readonly Key[] = [IRouter, INode, IRenderingEngine];

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -1,7 +1,30 @@
-import { Key, Writable } from '@aurelia/kernel';
-import { bindable, createRenderContext, CustomElement, IController, ICustomElementType, IDOM, INode, IRenderContext, IRenderingEngine, ITemplate, LifecycleFlags, TemplateDefinition } from '@aurelia/runtime';
-import { IRouter } from '../router';
-import { IViewportOptions, Viewport } from '../viewport';
+import {
+  Key,
+  Writable
+} from '@aurelia/kernel';
+
+import {
+  bindable,
+  createRenderContext,
+  CustomElement,
+  IController,
+  ICustomElementType,
+  IDOM,
+  INode,
+  IRenderContext,
+  IRenderingEngine,
+  ITemplate,
+  LifecycleFlags,
+  TemplateDefinition
+} from '@aurelia/runtime';
+
+import {
+  IRouter,
+} from '../router';
+import {
+  IViewportOptions,
+  Viewport
+} from '../viewport';
 
 export class ViewportCustomElement {
   public static readonly inject: readonly Key[] = [IRouter, INode, IRenderingEngine];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -3,7 +3,7 @@ import { Aurelia, IRenderContext } from '@aurelia/runtime';
 import { BrowserNavigator } from './browser-navigator';
 import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
-import { ComponentHandle, INavigatorInstruction, ViewportHandle } from './interfaces';
+import { ComponentAppellation, INavigatorInstruction, ViewportHandle } from './interfaces';
 import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
 import { INavigatorEntry, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
@@ -47,7 +47,7 @@ export interface IRouter {
   linkCallback(info: AnchorEventInfo): void;
 
   processNavigations(qInstruction: QueueItem<INavigatorInstruction>): Promise<void>;
-  addProcessingViewport(componentOrInstruction: ComponentHandle | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void;
+  addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void;
 
   // External API to get viewport by name
   getViewport(name: string): Viewport;
@@ -374,7 +374,7 @@ export class Router implements IRouter {
     await this.navigator.finalize(instruction);
   }
 
-  public addProcessingViewport(componentOrInstruction: ComponentHandle | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void {
+  public addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void {
     if (this.processingNavigation && (onlyIfProcessingStatus === undefined || onlyIfProcessingStatus)) {
       if (componentOrInstruction instanceof ViewportInstruction) {
         if (!componentOrInstruction.viewport) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -3,7 +3,7 @@ import { Aurelia, IRenderContext } from '@aurelia/runtime';
 import { BrowserNavigator } from './browser-navigator';
 import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
-import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
+import { ComponentAppellation, INavigatorInstruction, ViewportAppellation } from './interfaces';
 import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
 import { INavigatorEntry, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
@@ -46,7 +46,7 @@ export interface IRouter {
   linkCallback(info: AnchorEventInfo): void;
 
   processNavigations(qInstruction: QueueItem<INavigatorInstruction>): Promise<void>;
-  addProcessingViewport(componentOrInstruction: string | IRouteableComponentType | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void;
+  addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportAppellation, onlyIfProcessingStatus?: boolean): void;
 
   // External API to get viewport by name
   getViewport(name: string): Viewport;
@@ -373,7 +373,7 @@ export class Router implements IRouter {
     await this.navigator.finalize(instruction);
   }
 
-  public addProcessingViewport(componentOrInstruction: string | IRouteableComponentType | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void {
+  public addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportAppellation, onlyIfProcessingStatus?: boolean): void {
     if (this.processingNavigation && (onlyIfProcessingStatus === undefined || onlyIfProcessingStatus)) {
       if (componentOrInstruction instanceof ViewportInstruction) {
         if (!componentOrInstruction.viewport) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -3,6 +3,7 @@ import { Aurelia, IRenderContext } from '@aurelia/runtime';
 import { BrowserNavigator } from './browser-navigator';
 import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
+import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
 import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
 import { INavigatorEntry, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
@@ -14,7 +15,6 @@ import { Scope } from './scope';
 import { arrayRemove } from './utils';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
 
 export interface IRouteTransformer {
   transformFromUrl?(route: string, router: IRouter): string | ViewportInstruction[];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -28,11 +28,6 @@ export interface IRouterOptions extends INavigatorOptions, IRouteTransformer {
   reportCallback?(instruction: INavigatorInstruction): void;
 }
 
-export interface IRouteViewport {
-  name: string;
-  component: IRouteableComponentType | string;
-}
-
 export interface IViewportComponent {
   component: string | IRouteableComponentType;
   viewport?: string | Viewport;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -28,14 +28,6 @@ export interface IRouterOptions extends INavigatorOptions, IRouteTransformer {
   reportCallback?(instruction: INavigatorInstruction): void;
 }
 
-export interface IViewportComponent {
-  component: string | IRouteableComponentType;
-  viewport?: string | Viewport;
-  parameters?: Record<string, unknown> | string; // TODO: Allow unknown[] for parameters
-}
-
-export type NavigationInstruction = string | IRouteableComponentType | IViewportComponent | ViewportInstruction;
-
 export interface IRouter {
   readonly isNavigating: boolean;
   activeComponents: string[];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -5,7 +5,7 @@ import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
 import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
-import { INavigatorEntry, INavigatorInstruction, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
+import { INavigatorEntry, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
 import { IParsedQuery, parseQuery } from './parser';
 import { QueueItem } from './queue';
 import { INavClasses } from './resources/nav';
@@ -13,8 +13,8 @@ import { RouteTable } from './route-table';
 import { Scope } from './scope';
 import { arrayRemove } from './utils';
 import { IViewportOptions, Viewport } from './viewport';
-import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+import { INavigatorInstruction, IRouteableComponentType } from './interfaces';
 
 export interface IRouteTransformer {
   transformFromUrl?(route: string, router: IRouter): string | ViewportInstruction[];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -16,7 +16,6 @@ import { arrayRemove } from './utils';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-
 export interface IRouteTransformer {
   transformFromUrl?(route: string, router: IRouter): string | ViewportInstruction[];
   transformToUrl?(instructions: ViewportInstruction[], router: IRouter): string | ViewportInstruction[];
@@ -52,7 +51,7 @@ export interface IRouter {
   // External API to get viewport by name
   getViewport(name: string): Viewport;
 
-    // Called from the viewport custom element in attached()
+  // Called from the viewport custom element in attached()
   addViewport(name: string, element: Element, context: IRenderContext, options?: IViewportOptions): Viewport;
   // Called from the viewport custom element
   removeViewport(viewport: Viewport, element: Element, context: IRenderContext): void;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -16,6 +16,7 @@ import { arrayRemove } from './utils';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
+
 export interface IRouteTransformer {
   transformFromUrl?(route: string, router: IRouter): string | ViewportInstruction[];
   transformToUrl?(instructions: ViewportInstruction[], router: IRouter): string | ViewportInstruction[];

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, Key, Reporter } from '@aurelia/kernel';
-import { Aurelia, ICustomElementType, IRenderContext } from '@aurelia/runtime';
+import { Aurelia, IRenderContext } from '@aurelia/runtime';
 import { BrowserNavigator } from './browser-navigator';
 import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
@@ -13,6 +13,7 @@ import { RouteTable } from './route-table';
 import { Scope } from './scope';
 import { arrayRemove } from './utils';
 import { IViewportOptions, Viewport } from './viewport';
+import { IRouteableComponentType } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IRouteTransformer {
@@ -29,16 +30,16 @@ export interface IRouterOptions extends INavigatorOptions, IRouteTransformer {
 
 export interface IRouteViewport {
   name: string;
-  component: Partial<ICustomElementType> | string;
+  component: IRouteableComponentType | string;
 }
 
 export interface IViewportComponent {
-  component: string | Partial<ICustomElementType>;
+  component: string | IRouteableComponentType;
   viewport?: string | Viewport;
   parameters?: Record<string, unknown> | string; // TODO: Allow unknown[] for parameters
 }
 
-export type NavigationInstruction = string | Partial<ICustomElementType> | IViewportComponent | ViewportInstruction;
+export type NavigationInstruction = string | IRouteableComponentType | IViewportComponent | ViewportInstruction;
 
 export interface IRouter {
   readonly isNavigating: boolean;
@@ -58,7 +59,7 @@ export interface IRouter {
   linkCallback(info: AnchorEventInfo): void;
 
   processNavigations(qInstruction: QueueItem<INavigatorInstruction>): Promise<void>;
-  addProcessingViewport(componentOrInstruction: string | Partial<ICustomElementType> | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void;
+  addProcessingViewport(componentOrInstruction: string | IRouteableComponentType | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void;
 
   // External API to get viewport by name
   getViewport(name: string): Viewport;
@@ -385,7 +386,7 @@ export class Router implements IRouter {
     await this.navigator.finalize(instruction);
   }
 
-  public addProcessingViewport(componentOrInstruction: string | Partial<ICustomElementType> | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void {
+  public addProcessingViewport(componentOrInstruction: string | IRouteableComponentType | ViewportInstruction, viewport?: Viewport | string, onlyIfProcessingStatus?: boolean): void {
     if (this.processingNavigation && (onlyIfProcessingStatus === undefined || onlyIfProcessingStatus)) {
       if (componentOrInstruction instanceof ViewportInstruction) {
         if (!componentOrInstruction.viewport) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -3,7 +3,7 @@ import { Aurelia, IRenderContext } from '@aurelia/runtime';
 import { BrowserNavigator } from './browser-navigator';
 import { Guardian, GuardTypes } from './guardian';
 import { InstructionResolver, IRouteSeparators } from './instruction-resolver';
-import { ComponentAppellation, INavigatorInstruction, ViewportAppellation } from './interfaces';
+import { ComponentHandle, INavigatorInstruction, ViewportHandle } from './interfaces';
 import { AnchorEventInfo, LinkHandler } from './link-handler';
 import { INavRoute, Nav } from './nav';
 import { INavigatorEntry, INavigatorOptions, INavigatorViewerEvent, Navigator } from './navigator';
@@ -46,7 +46,7 @@ export interface IRouter {
   linkCallback(info: AnchorEventInfo): void;
 
   processNavigations(qInstruction: QueueItem<INavigatorInstruction>): Promise<void>;
-  addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportAppellation, onlyIfProcessingStatus?: boolean): void;
+  addProcessingViewport(componentOrInstruction: ComponentHandle | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void;
 
   // External API to get viewport by name
   getViewport(name: string): Viewport;
@@ -373,7 +373,7 @@ export class Router implements IRouter {
     await this.navigator.finalize(instruction);
   }
 
-  public addProcessingViewport(componentOrInstruction: ComponentAppellation | ViewportInstruction, viewport?: ViewportAppellation, onlyIfProcessingStatus?: boolean): void {
+  public addProcessingViewport(componentOrInstruction: ComponentHandle | ViewportInstruction, viewport?: ViewportHandle, onlyIfProcessingStatus?: boolean): void {
     if (this.processingNavigation && (onlyIfProcessingStatus === undefined || onlyIfProcessingStatus)) {
       if (componentOrInstruction instanceof ViewportInstruction) {
         if (!componentOrInstruction.viewport) {

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -5,7 +5,7 @@ import { IFindViewportsResult } from './scope';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-export interface IViewportCustomElementType extends ICustomElementType {
+export interface IViewportComponentType extends ICustomElementType {
   viewport?: string;
 }
 

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -5,10 +5,6 @@ import { IFindViewportsResult } from './scope';
 import { IViewportOptions, Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-export interface IViewportComponentType extends ICustomElementType {
-  viewport?: string;
-}
-
 export interface IFindViewportsResult {
   viewportInstructions?: ViewportInstruction[];
   viewportsRemaining?: boolean;

--- a/packages/router/src/scope.ts
+++ b/packages/router/src/scope.ts
@@ -1,5 +1,5 @@
 import { IContainer } from '@aurelia/kernel';
-import { IController, ICustomElementType, IRenderContext } from '@aurelia/runtime';
+import { IController, IRenderContext } from '@aurelia/runtime';
 import { IRouter } from './router';
 import { IFindViewportsResult } from './scope';
 import { IViewportOptions, Viewport } from './viewport';

--- a/packages/router/src/type-resolvers.ts
+++ b/packages/router/src/type-resolvers.ts
@@ -9,9 +9,13 @@ export const ComponentHandleResolver = {
   isName: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
     return typeof component === 'string';
   },
-  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
+  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> & IRouteableComponentType<Constructable> {
     return CustomElement.isType(component);
   },
+  isInstance: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> & IRouteableComponent<Constructable> {
+    return !ComponentHandleResolver.isName(component) && !ComponentHandleResolver.isType(component);
+  },
+
   getName: function <T>(component: T & ComponentHandle<Constructable>): string {
     if (ComponentHandleResolver.isName(component)) {
       return component as string;
@@ -21,16 +25,21 @@ export const ComponentHandleResolver = {
       return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
     }
   },
-  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): ICustomElementType<T> {
+  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): IRouteableComponentType<T> {
     if (ComponentHandleResolver.isName(component)) {
       return null;
     } else if (ComponentHandleResolver.isType(component)) {
       return component;
+    } else {
+      return ((component as IRouteableComponent).constructor as IRouteableComponentType<T>);
     }
-    // TODO: Fix resolve for instance
-    // else {
-    //   return (component as ICustomElementType).constructor;
-    // }
+  },
+  getInstance: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): IRouteableComponent<T> {
+    if (ComponentHandleResolver.isName(component) || ComponentHandleResolver.isType(component)) {
+      return null;
+    } else {
+      return component;
+    }
   },
 };
 

--- a/packages/router/src/type-resolvers.ts
+++ b/packages/router/src/type-resolvers.ts
@@ -1,0 +1,73 @@
+import { Constructable } from '@aurelia/kernel';
+import { CustomElement, ICustomElementType } from '@aurelia/runtime';
+import { ComponentHandle, IRouteableComponent, IRouteableComponentType, IViewportInstruction, NavigationInstruction, ViewportHandle } from './interfaces';
+import { IRouter } from './router';
+import { Viewport } from './viewport';
+import { ViewportInstruction } from './viewport-instruction';
+
+export const ComponentHandleResolver = {
+  isName: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
+    return typeof component === 'string';
+  },
+  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
+    return CustomElement.isType(component);
+  },
+  getName: function <T>(component: T & ComponentHandle<Constructable>): string {
+    if (ComponentHandleResolver.isName(component)) {
+      return component as string;
+    } else if (ComponentHandleResolver.isType(component)) {
+      return (component as ICustomElementType).description.name;
+    } else {
+      return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
+    }
+  },
+  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): ICustomElementType<T> {
+    if (ComponentHandleResolver.isName(component)) {
+      return null;
+    } else if (ComponentHandleResolver.isType(component)) {
+      return component;
+    }
+    // TODO: Fix resolve for instance
+    // else {
+    //   return (component as ICustomElementType).constructor;
+    // }
+  },
+};
+
+export const ViewportHandleResolver = {
+  isName: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
+    return typeof viewport === 'string';
+  },
+  isInstance: function <T>(viewport: T & ViewportHandle): viewport is T & ViewportHandle {
+    return viewport instanceof Viewport;
+  },
+  getName: function <T>(viewport: T & ViewportHandle): string {
+    if (ViewportHandleResolver.isName(viewport)) {
+      return viewport as string;
+    } else {
+      return viewport ? (viewport as Viewport).name : null;
+    }
+  }
+};
+
+export const NavigationInstructionResolver = {
+  toViewportInstructions: function <C extends Constructable>(router: IRouter, navigationInstructions: NavigationInstruction | NavigationInstruction[]): ViewportInstruction[] {
+    if (!Array.isArray(navigationInstructions)) {
+      return NavigationInstructionResolver.toViewportInstructions(router, [navigationInstructions]);
+    }
+    const instructions: ViewportInstruction[] = [];
+    for (const instruction of navigationInstructions) {
+      if (typeof instruction === 'string') {
+        instructions.push(router.instructionResolver.parseViewportInstruction(instruction));
+      } else if (instruction as ViewportInstruction instanceof ViewportInstruction) {
+        instructions.push(instruction as ViewportInstruction);
+      } else if (instruction['component']) {
+        const viewportComponent = instruction as IViewportInstruction<C>;
+        instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
+      } else {
+        instructions.push(new ViewportInstruction(instruction as IRouteableComponentType<C>));
+      }
+    }
+    return instructions;
+  },
+};

--- a/packages/router/src/type-resolvers.ts
+++ b/packages/router/src/type-resolvers.ts
@@ -1,41 +1,41 @@
 import { Constructable } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType } from '@aurelia/runtime';
-import { ComponentHandle, IRouteableComponent, IRouteableComponentType, IViewportInstruction, NavigationInstruction, ViewportHandle } from './interfaces';
+import { ComponentAppellation, IRouteableComponent, IRouteableComponentType, IViewportInstruction, NavigationInstruction, ViewportHandle } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-export const ComponentHandleResolver = {
-  isName: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> {
+export const ComponentAppellationResolver = {
+  isName: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> {
     return typeof component === 'string';
   },
-  isType: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> & IRouteableComponentType<Constructable> {
+  isType: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> & IRouteableComponentType<Constructable> {
     return CustomElement.isType(component);
   },
-  isInstance: function <T>(component: T & ComponentHandle<Constructable>): component is T & ComponentHandle<Constructable> & IRouteableComponent<Constructable> {
-    return !ComponentHandleResolver.isName(component) && !ComponentHandleResolver.isType(component);
+  isInstance: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> & IRouteableComponent<Constructable> {
+    return !ComponentAppellationResolver.isName(component) && !ComponentAppellationResolver.isType(component);
   },
 
-  getName: function <T>(component: T & ComponentHandle<Constructable>): string {
-    if (ComponentHandleResolver.isName(component)) {
+  getName: function <T>(component: T & ComponentAppellation<Constructable>): string {
+    if (ComponentAppellationResolver.isName(component)) {
       return component as string;
-    } else if (ComponentHandleResolver.isType(component)) {
+    } else if (ComponentAppellationResolver.isType(component)) {
       return (component as ICustomElementType).description.name;
     } else {
       return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
     }
   },
-  getType: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): IRouteableComponentType<T> {
-    if (ComponentHandleResolver.isName(component)) {
+  getType: function <T extends Constructable>(component: T & ComponentAppellation<Constructable>): IRouteableComponentType<T> {
+    if (ComponentAppellationResolver.isName(component)) {
       return null;
-    } else if (ComponentHandleResolver.isType(component)) {
+    } else if (ComponentAppellationResolver.isType(component)) {
       return component;
     } else {
       return ((component as IRouteableComponent).constructor as IRouteableComponentType<T>);
     }
   },
-  getInstance: function <T extends Constructable>(component: T & ComponentHandle<Constructable>): IRouteableComponent<T> {
-    if (ComponentHandleResolver.isName(component) || ComponentHandleResolver.isType(component)) {
+  getInstance: function <T extends Constructable>(component: T & ComponentAppellation<Constructable>): IRouteableComponent<T> {
+    if (ComponentAppellationResolver.isName(component) || ComponentAppellationResolver.isType(component)) {
       return null;
     } else {
       return component;

--- a/packages/router/src/type-resolvers.ts
+++ b/packages/router/src/type-resolvers.ts
@@ -6,17 +6,17 @@ import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
 export const ComponentAppellationResolver = {
-  isName: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> {
+  isName: function <T>(component: T & ComponentAppellation): component is T & ComponentAppellation {
     return typeof component === 'string';
   },
-  isType: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> & IRouteableComponentType<Constructable> {
+  isType: function <T>(component: T & ComponentAppellation): component is T & ComponentAppellation & IRouteableComponentType {
     return CustomElement.isType(component);
   },
-  isInstance: function <T>(component: T & ComponentAppellation<Constructable>): component is T & ComponentAppellation<Constructable> & IRouteableComponent<Constructable> {
+  isInstance: function <T>(component: T & ComponentAppellation): component is T & ComponentAppellation & IRouteableComponent {
     return !ComponentAppellationResolver.isName(component) && !ComponentAppellationResolver.isType(component);
   },
 
-  getName: function <T>(component: T & ComponentAppellation<Constructable>): string {
+  getName: function <T>(component: T & ComponentAppellation): string {
     if (ComponentAppellationResolver.isName(component)) {
       return component as string;
     } else if (ComponentAppellationResolver.isType(component)) {
@@ -25,16 +25,16 @@ export const ComponentAppellationResolver = {
       return ((component as IRouteableComponent).constructor as ICustomElementType).description.name;
     }
   },
-  getType: function <T extends Constructable>(component: T & ComponentAppellation<Constructable>): IRouteableComponentType<T> {
+  getType: function <T extends Constructable>(component: T & ComponentAppellation): IRouteableComponentType {
     if (ComponentAppellationResolver.isName(component)) {
       return null;
     } else if (ComponentAppellationResolver.isType(component)) {
       return component;
     } else {
-      return ((component as IRouteableComponent).constructor as IRouteableComponentType<T>);
+      return ((component as IRouteableComponent).constructor as IRouteableComponentType);
     }
   },
-  getInstance: function <T extends Constructable>(component: T & ComponentAppellation<Constructable>): IRouteableComponent<T> {
+  getInstance: function <T extends Constructable>(component: T & ComponentAppellation): IRouteableComponent {
     if (ComponentAppellationResolver.isName(component) || ComponentAppellationResolver.isType(component)) {
       return null;
     } else {
@@ -56,11 +56,18 @@ export const ViewportHandleResolver = {
     } else {
       return viewport ? (viewport as Viewport).name : null;
     }
-  }
+  },
+  getInstance: function <T>(viewport: T & ViewportHandle): Viewport {
+    if (ViewportHandleResolver.isName(viewport)) {
+      return null;
+    } else {
+      return viewport;
+    }
+  },
 };
 
 export const NavigationInstructionResolver = {
-  toViewportInstructions: function <C extends Constructable>(router: IRouter, navigationInstructions: NavigationInstruction | NavigationInstruction[]): ViewportInstruction[] {
+  toViewportInstructions: function (router: IRouter, navigationInstructions: NavigationInstruction | NavigationInstruction[]): ViewportInstruction[] {
     if (!Array.isArray(navigationInstructions)) {
       return NavigationInstructionResolver.toViewportInstructions(router, [navigationInstructions]);
     }
@@ -71,10 +78,10 @@ export const NavigationInstructionResolver = {
       } else if (instruction as ViewportInstruction instanceof ViewportInstruction) {
         instructions.push(instruction as ViewportInstruction);
       } else if (instruction['component']) {
-        const viewportComponent = instruction as IViewportInstruction<C>;
+        const viewportComponent = instruction as IViewportInstruction;
         instructions.push(new ViewportInstruction(viewportComponent.component, viewportComponent.viewport, viewportComponent.parameters));
       } else {
-        instructions.push(new ViewportInstruction(instruction as IRouteableComponentType<C>));
+        instructions.push(new ViewportInstruction(instruction as IRouteableComponentType));
       }
     }
     return instructions;

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
 import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { ComponentHandle, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
+import { ComponentAppellation, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
@@ -14,7 +14,7 @@ export const enum ContentStatus {
 }
 
 export class ViewportContent {
-  public content: ComponentHandle;
+  public content: ComponentAppellation;
   public parameters: string;
   public instruction: INavigatorInstruction;
   public component: IRouteableComponent;
@@ -23,7 +23,7 @@ export class ViewportContent {
   public fromCache: boolean;
   public reentry: boolean;
 
-  constructor(content: ComponentHandle = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
+  constructor(content: ComponentAppellation = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
     // Can be a (resolved) type or a string (to be resolved later)
     this.content = content;
     this.parameters = parameters;

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -5,11 +5,11 @@ import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
 
-export interface IRouteableCustomElementType extends Partial<ICustomElementType> {
+export interface IRouteableComponentType extends Partial<ICustomElementType> {
   parameters?: string[];
 }
 
-export interface IRouteableCustomElement<T extends INode = INode> extends IViewModel<T> {
+export interface IRouteableComponent<T extends INode = INode> extends IViewModel<T> {
   reentryBehavior?: ReentryBehavior;
   canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
   enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
@@ -33,10 +33,10 @@ export const enum ReentryBehavior {
 }
 
 export class ViewportContent {
-  public content: IRouteableCustomElementType | string;
+  public content: IRouteableComponentType | string;
   public parameters: string;
   public instruction: INavigatorInstruction;
-  public component: IRouteableCustomElement;
+  public component: IRouteableComponent;
   public contentStatus: ContentStatus;
   public entered: boolean;
   public fromCache: boolean;
@@ -108,7 +108,7 @@ export class ViewportContent {
       return Promise.resolve(true);
     }
 
-    const contentType: IRouteableCustomElementType = this.component !== null ? this.component.constructor : this.content as IRouteableCustomElementType;
+    const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor : this.content as IRouteableComponentType;
     const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
     this.instruction.parameters = merged.namedParameters;
     this.instruction.parameterList = merged.parameterList;
@@ -141,7 +141,7 @@ export class ViewportContent {
       return;
     }
     if (this.component.enter) {
-      const contentType: IRouteableCustomElementType = this.component !== null ? this.component.constructor : this.content as IRouteableCustomElementType;
+      const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor : this.content as IRouteableComponentType;
       const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
       this.instruction.parameters = merged.namedParameters;
       this.instruction.parameterList = merged.parameterList;
@@ -258,21 +258,21 @@ export class ViewportContent {
       return (this.content).description.name;
     }
   }
-  public componentType(context: IRenderContext | IContainer): IRouteableCustomElementType {
+  public componentType(context: IRenderContext | IContainer): IRouteableComponentType {
     if (this.content === null) {
       return null;
     } else if (typeof this.content !== 'string') {
       return this.content;
     } else {
       const container = context.get(IContainer);
-      const resolver = container.getResolver<Constructable & IRouteableCustomElementType>(CustomElement.keyFrom(this.content));
+      const resolver = container.getResolver<Constructable & IRouteableComponentType>(CustomElement.keyFrom(this.content));
       if (resolver !== null) {
         return resolver.getFactory(container).Type;
       }
       return null;
     }
   }
-  public componentInstance(context: IRenderContext | IContainer): IRouteableCustomElement {
+  public componentInstance(context: IRenderContext | IContainer): IRouteableComponent {
     if (this.content === null) {
       return null;
     }
@@ -280,9 +280,9 @@ export class ViewportContent {
     const component = this.componentName();
     const container = context.get(IContainer);
     if (typeof component !== 'string') {
-      return container.get<IRouteableCustomElement>(component);
+      return container.get<IRouteableComponent>(component);
     } else {
-      return container.get<IRouteableCustomElement>(CustomElement.keyFrom(component));
+      return container.get<IRouteableComponent>(CustomElement.keyFrom(component));
     }
   }
 }

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
 import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { ComponentAppellation, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
+import { ComponentHandle, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
@@ -14,7 +14,7 @@ export const enum ContentStatus {
 }
 
 export class ViewportContent {
-  public content: ComponentAppellation;
+  public content: ComponentHandle;
   public parameters: string;
   public instruction: INavigatorInstruction;
   public component: IRouteableComponent;
@@ -23,7 +23,7 @@ export class ViewportContent {
   public fromCache: boolean;
   public reentry: boolean;
 
-  constructor(content: ComponentAppellation = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
+  constructor(content: ComponentHandle = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
     // Can be a (resolved) type or a string (to be resolved later)
     this.content = content;
     this.parameters = parameters;

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,5 +1,5 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
-import { Controller, CustomElement, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
+import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
 import { ComponentAppellation, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
@@ -236,14 +236,14 @@ export class ViewportContent {
     } else if (typeof this.content === 'string') {
       return this.content;
     } else {
-      return (this.content).description.name;
+      return (this.content as ICustomElementType<Constructable>).description.name;
     }
   }
   public componentType(context: IRenderContext | IContainer): IRouteableComponentType<Constructable> {
     if (this.content === null) {
       return null;
     } else if (typeof this.content !== 'string') {
-      return this.content;
+      return this.content as IRouteableComponentType<Constructable>;
     } else {
       const container = context.get(IContainer);
       const resolver = container.getResolver<Constructable & IRouteableComponentType<Constructable>>(CustomElement.keyFrom(this.content));

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -89,7 +89,7 @@ export class ViewportContent {
       return Promise.resolve(true);
     }
 
-    const contentType: IRouteableComponentType<Constructable> = this.component !== null ? this.component.constructor as IRouteableComponentType<Constructable> : this.content as IRouteableComponentType<Constructable>;
+    const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor as IRouteableComponentType : this.content as IRouteableComponentType;
     const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
     this.instruction.parameters = merged.namedParameters;
     this.instruction.parameterList = merged.parameterList;
@@ -122,7 +122,7 @@ export class ViewportContent {
       return;
     }
     if (this.component.enter) {
-      const contentType: IRouteableComponentType<Constructable> = this.component !== null ? this.component.constructor as IRouteableComponentType<Constructable> : this.content as IRouteableComponentType<Constructable>;
+      const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor as IRouteableComponentType : this.content as IRouteableComponentType;
       const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
       this.instruction.parameters = merged.namedParameters;
       this.instruction.parameterList = merged.parameterList;
@@ -239,14 +239,14 @@ export class ViewportContent {
       return (this.content as ICustomElementType<Constructable>).description.name;
     }
   }
-  public componentType(context: IRenderContext | IContainer): IRouteableComponentType<Constructable> {
+  public componentType(context: IRenderContext | IContainer): IRouteableComponentType {
     if (this.content === null) {
       return null;
     } else if (typeof this.content !== 'string') {
-      return this.content as IRouteableComponentType<Constructable>;
+      return this.content as IRouteableComponentType;
     } else {
       const container = context.get(IContainer);
-      const resolver = container.getResolver<Constructable & IRouteableComponentType<Constructable>>(CustomElement.keyFrom(this.content));
+      const resolver = container.getResolver<Constructable & IRouteableComponentType>(CustomElement.keyFrom(this.content));
       if (resolver !== null) {
         return resolver.getFactory(container).Type;
       }

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
-import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, IViewModel, LifecycleFlags } from '@aurelia/runtime';
-import { INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
+import { Controller, CustomElement, INode, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
+import { ComponentAppellation, INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
@@ -14,7 +14,7 @@ export const enum ContentStatus {
 }
 
 export class ViewportContent {
-  public content: IRouteableComponentType | string;
+  public content: ComponentAppellation;
   public parameters: string;
   public instruction: INavigatorInstruction;
   public component: IRouteableComponent;
@@ -23,7 +23,7 @@ export class ViewportContent {
   public fromCache: boolean;
   public reentry: boolean;
 
-  constructor(content: IRouteableComponentType | string = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
+  constructor(content: ComponentAppellation = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
     // Can be a (resolved) type or a string (to be resolved later)
     this.content = content;
     this.parameters = parameters;
@@ -89,7 +89,7 @@ export class ViewportContent {
       return Promise.resolve(true);
     }
 
-    const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor : this.content as IRouteableComponentType;
+    const contentType: IRouteableComponentType<Constructable> = this.component !== null ? this.component.constructor as IRouteableComponentType<Constructable> : this.content as IRouteableComponentType<Constructable>;
     const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
     this.instruction.parameters = merged.namedParameters;
     this.instruction.parameterList = merged.parameterList;
@@ -122,7 +122,7 @@ export class ViewportContent {
       return;
     }
     if (this.component.enter) {
-      const contentType: IRouteableComponentType = this.component !== null ? this.component.constructor : this.content as IRouteableComponentType;
+      const contentType: IRouteableComponentType<Constructable> = this.component !== null ? this.component.constructor as IRouteableComponentType<Constructable> : this.content as IRouteableComponentType<Constructable>;
       const merged = mergeParameters(this.parameters, this.instruction.query, contentType.parameters);
       this.instruction.parameters = merged.namedParameters;
       this.instruction.parameterList = merged.parameterList;
@@ -239,14 +239,14 @@ export class ViewportContent {
       return (this.content).description.name;
     }
   }
-  public componentType(context: IRenderContext | IContainer): IRouteableComponentType {
+  public componentType(context: IRenderContext | IContainer): IRouteableComponentType<Constructable> {
     if (this.content === null) {
       return null;
     } else if (typeof this.content !== 'string') {
       return this.content;
     } else {
       const container = context.get(IContainer);
-      const resolver = container.getResolver<Constructable & IRouteableComponentType>(CustomElement.keyFrom(this.content));
+      const resolver = container.getResolver<Constructable & IRouteableComponentType<Constructable>>(CustomElement.keyFrom(this.content));
       if (resolver !== null) {
         return resolver.getFactory(container).Type;
       }

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -42,7 +42,7 @@ export class ViewportContent {
   public fromCache: boolean;
   public reentry: boolean;
 
-  constructor(content: Partial<ICustomElementType> | string = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
+  constructor(content: IRouteableComponentType | string = null, parameters: string = null, instruction: INavigatorInstruction = null, context: IRenderContext | IContainer = null) {
     // Can be a (resolved) type or a string (to be resolved later)
     this.content = content;
     this.parameters = parameters;

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,21 +1,9 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
 import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, IViewModel, LifecycleFlags } from '@aurelia/runtime';
-import { INavigatorInstruction } from './navigator';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-
-export interface IRouteableComponentType extends Partial<ICustomElementType> {
-  parameters?: string[];
-}
-
-export interface IRouteableComponent<T extends INode = INode> extends IViewModel<T> {
-  reentryBehavior?: ReentryBehavior;
-  canEnter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | string | ViewportInstruction[] | Promise<boolean | string | ViewportInstruction[]>;
-  enter?(parameters?: string[] | Record<string, string>, nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
-  canLeave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): boolean | Promise<boolean>;
-  leave?(nextInstruction?: INavigatorInstruction, instruction?: INavigatorInstruction): void | Promise<void>;
-}
+import { IRouteableComponentType, INavigatorInstruction, IRouteableComponent, ReentryBehavior } from './interfaces';
 
 export const enum ContentStatus {
   none = 0,
@@ -23,13 +11,6 @@ export const enum ContentStatus {
   loaded = 2,
   initialized = 3,
   added = 4,
-}
-
-export const enum ReentryBehavior {
-  default = 'default',
-  disallow = 'disallow',
-  enter = 'enter',
-  refresh = 'refresh',
 }
 
 export class ViewportContent {

--- a/packages/router/src/viewport-content.ts
+++ b/packages/router/src/viewport-content.ts
@@ -1,9 +1,9 @@
 import { Constructable, IContainer, Reporter } from '@aurelia/kernel';
 import { Controller, CustomElement, ICustomElementType, INode, IRenderContext, IViewModel, LifecycleFlags } from '@aurelia/runtime';
+import { INavigatorInstruction, IRouteableComponent, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { mergeParameters } from './parser';
 import { Viewport } from './viewport';
 import { ViewportInstruction } from './viewport-instruction';
-import { IRouteableComponentType, INavigatorInstruction, IRouteableComponent, ReentryBehavior } from './interfaces';
 
 export const enum ContentStatus {
   none = 0,

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,4 +1,4 @@
-import { Constructable, IContainer } from '@aurelia/kernel';
+import { IContainer } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
 import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportHandle } from './interfaces';
 import { IRouter } from './router';

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,8 +1,8 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, IRenderContext } from '@aurelia/runtime';
+import { IRouteableComponentType } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
-import { IRouteableComponentType } from './interfaces';
 
 export class ViewportInstruction {
   public component?: IRouteableComponentType;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -2,7 +2,7 @@ import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
-import { IRouteableCustomElementType } from './viewport-content';
+import { IRouteableComponentType } from './viewport-content';
 
 export class ViewportInstruction {
   public component?: Partial<ICustomElementType>;
@@ -72,12 +72,12 @@ export class ViewportInstruction {
     // TODO: Deal with parametersList
   }
 
-  public componentType(context: IRenderContext): IRouteableCustomElementType {
+  public componentType(context: IRenderContext): IRouteableComponentType {
     if (this.component !== null) {
       return this.component;
     }
     const container = context.get(IContainer);
-    const resolver = container.getResolver<Constructable & IRouteableCustomElementType>(CustomElement.keyFrom(this.componentName));
+    const resolver = container.getResolver<Constructable & IRouteableComponentType>(CustomElement.keyFrom(this.componentName));
     if (resolver !== null) {
       return resolver.getFactory(container).Type;
     }

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
-import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportAppellation } from './interfaces';
+import { ComponentHandle, ComponentParameters, IRouteableComponentType, ViewportHandle } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 
@@ -15,7 +15,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: ComponentAppellation<C>, viewport?: ViewportAppellation, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: ComponentHandle<C>, viewport?: ViewportHandle, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,7 +32,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: ComponentAppellation<C>): void {
+  public setComponent(component: ComponentHandle<C>): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;
@@ -42,7 +42,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
     }
   }
 
-  public setViewport(viewport: ViewportAppellation): void {
+  public setViewport(viewport: ViewportHandle): void {
     if (viewport === undefined || viewport === '') {
       viewport = null;
     }

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -2,7 +2,7 @@ import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, IRenderContext } from '@aurelia/runtime';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
-import { IRouteableComponentType } from './viewport-content';
+import { IRouteableComponentType } from './interfaces';
 
 export class ViewportInstruction {
   public component?: IRouteableComponentType;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,5 +1,6 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, IRenderContext } from '@aurelia/runtime';
+import { ICustomElementType } from './../../runtime/src/resources/custom-element';
 import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportAppellation } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
@@ -38,7 +39,7 @@ export class ViewportInstruction {
       this.component = null;
     } else {
       this.component = component;
-      this.componentName = component.description.name;
+      this.componentName = (component as ICustomElementType).description.name;
     }
   }
 

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -4,8 +4,8 @@ import { ComponentAppellation, ComponentParameters, IRouteableComponentType, Vie
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 
-export class ViewportInstruction<C extends Constructable = Constructable> {
-  public component?: IRouteableComponentType<Constructable>;
+export class ViewportInstruction {
+  public component?: IRouteableComponentType;
   public componentName?: string;
   public viewport?: Viewport;
   public viewportName?: string;
@@ -15,7 +15,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: ComponentAppellation<C>, viewport?: ViewportHandle, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: ComponentAppellation, viewport?: ViewportHandle, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,12 +32,12 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: ComponentAppellation<C>): void {
+  public setComponent(component: ComponentAppellation): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;
     } else {
-      this.component = component as IRouteableComponentType<C>;
+      this.component = component as IRouteableComponentType;
       this.componentName = (component as ICustomElementType).description.name;
     }
   }
@@ -72,12 +72,12 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
     // TODO: Deal with parametersList
   }
 
-  public componentType(context: IRenderContext): IRouteableComponentType<Constructable> {
+  public componentType(context: IRenderContext): IRouteableComponentType {
     if (this.component !== null) {
       return this.component;
     }
     const container = context.get(IContainer);
-    const resolver = container.getResolver<Constructable & IRouteableComponentType<Constructable>>(CustomElement.keyFrom(this.componentName));
+    const resolver = container.getResolver<IRouteableComponentType>(CustomElement.keyFrom(this.componentName));
     if (resolver !== null) {
       return resolver.getFactory(container).Type;
     }

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,11 +1,11 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, IRenderContext } from '@aurelia/runtime';
-import { IRouteableComponentType } from './interfaces';
+import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportAppellation } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 
 export class ViewportInstruction {
-  public component?: IRouteableComponentType;
+  public component?: IRouteableComponentType<Constructable>;
   public componentName?: string;
   public viewport?: Viewport;
   public viewportName?: string;
@@ -15,7 +15,7 @@ export class ViewportInstruction {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: IRouteableComponentType | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: ComponentAppellation, viewport?: ViewportAppellation, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,7 +32,7 @@ export class ViewportInstruction {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: IRouteableComponentType | string): void {
+  public setComponent(component: ComponentAppellation): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;
@@ -42,7 +42,7 @@ export class ViewportInstruction {
     }
   }
 
-  public setViewport(viewport: Viewport | string): void {
+  public setViewport(viewport: ViewportAppellation): void {
     if (viewport === undefined || viewport === '') {
       viewport = null;
     }
@@ -57,7 +57,7 @@ export class ViewportInstruction {
     }
   }
 
-  public setParameters(parameters: Record<string, unknown> | string): void {
+  public setParameters(parameters: ComponentParameters): void {
     if (parameters === undefined || parameters === '') {
       parameters = null;
     }
@@ -72,12 +72,12 @@ export class ViewportInstruction {
     // TODO: Deal with parametersList
   }
 
-  public componentType(context: IRenderContext): IRouteableComponentType {
+  public componentType(context: IRenderContext): IRouteableComponentType<Constructable> {
     if (this.component !== null) {
       return this.component;
     }
     const container = context.get(IContainer);
-    const resolver = container.getResolver<Constructable & IRouteableComponentType>(CustomElement.keyFrom(this.componentName));
+    const resolver = container.getResolver<Constructable & IRouteableComponentType<Constructable>>(CustomElement.keyFrom(this.componentName));
     if (resolver !== null) {
       return resolver.getFactory(container).Type;
     }

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,11 +1,11 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
-import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
+import { CustomElement, IRenderContext } from '@aurelia/runtime';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 import { IRouteableComponentType } from './viewport-content';
 
 export class ViewportInstruction {
-  public component?: Partial<ICustomElementType>;
+  public component?: IRouteableComponentType;
   public componentName?: string;
   public viewport?: Viewport;
   public viewportName?: string;
@@ -15,7 +15,7 @@ export class ViewportInstruction {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: Partial<ICustomElementType> | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: IRouteableComponentType | string, viewport?: Viewport | string, parameters?: Record<string, unknown> | string, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,7 +32,7 @@ export class ViewportInstruction {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: Partial<ICustomElementType> | string): void {
+  public setComponent(component: IRouteableComponentType | string): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,6 +1,5 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
-import { CustomElement, IRenderContext } from '@aurelia/runtime';
-import { ICustomElementType } from './../../runtime/src/resources/custom-element';
+import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
 import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportAppellation } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -4,7 +4,7 @@ import { ComponentAppellation, ComponentParameters, IRouteableComponentType, Vie
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 
-export class ViewportInstruction {
+export class ViewportInstruction<C extends Constructable = Constructable> {
   public component?: IRouteableComponentType<Constructable>;
   public componentName?: string;
   public viewport?: Viewport;
@@ -15,7 +15,7 @@ export class ViewportInstruction {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: ComponentAppellation, viewport?: ViewportAppellation, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: ComponentAppellation<C>, viewport?: ViewportAppellation, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,7 +32,7 @@ export class ViewportInstruction {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: ComponentAppellation): void {
+  public setComponent(component: ComponentAppellation<C>): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -37,7 +37,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
       this.componentName = component;
       this.component = null;
     } else {
-      this.component = component;
+      this.component = component as IRouteableComponentType<C>;
       this.componentName = (component as ICustomElementType).description.name;
     }
   }

--- a/packages/router/src/viewport-instruction.ts
+++ b/packages/router/src/viewport-instruction.ts
@@ -1,6 +1,6 @@
 import { Constructable, IContainer } from '@aurelia/kernel';
 import { CustomElement, ICustomElementType, IRenderContext } from '@aurelia/runtime';
-import { ComponentHandle, ComponentParameters, IRouteableComponentType, ViewportHandle } from './interfaces';
+import { ComponentAppellation, ComponentParameters, IRouteableComponentType, ViewportHandle } from './interfaces';
 import { IRouter } from './router';
 import { Viewport } from './viewport';
 
@@ -15,7 +15,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
   public ownsScope?: boolean;
   public nextScopeInstruction?: ViewportInstruction;
 
-  constructor(component: ComponentHandle<C>, viewport?: ViewportHandle, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
+  constructor(component: ComponentAppellation<C>, viewport?: ViewportHandle, parameters?: ComponentParameters, ownsScope: boolean = true, nextScopeInstruction: ViewportInstruction = null) {
     this.component = null;
     this.componentName = null;
     this.viewport = null;
@@ -32,7 +32,7 @@ export class ViewportInstruction<C extends Constructable = Constructable> {
     this.nextScopeInstruction = nextScopeInstruction;
   }
 
-  public setComponent(component: ComponentHandle<C>): void {
+  public setComponent(component: ComponentAppellation<C>): void {
     if (typeof component === 'string') {
       this.componentName = component;
       this.component = null;

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,10 +1,10 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
-import { ICustomElementType, IRenderContext, LifecycleFlags } from '@aurelia/runtime';
+import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
 import { INavigatorInstruction } from './navigator';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
-import { ReentryBehavior, ViewportContent } from './viewport-content';
+import { IRouteableComponentType, ReentryBehavior, ViewportContent } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
 
 export interface IViewportOptions {
@@ -58,7 +58,7 @@ export class Viewport {
     this.enabled = true;
   }
 
-  public setNextContent(content: Partial<ICustomElementType> | string, instruction: INavigatorInstruction): boolean {
+  public setNextContent(content: IRouteableComponentType | string, instruction: INavigatorInstruction): boolean {
     let parameters;
     this.clear = false;
     if (typeof content === 'string') {
@@ -279,7 +279,7 @@ export class Viewport {
   }
 
   // TODO: Deal with non-string components
-  public wantComponent(component: ICustomElementType | string): boolean {
+  public wantComponent(component: IRouteableComponentType | string): boolean {
     let usedBy = this.options.usedBy || [];
     if (typeof usedBy === 'string') {
       usedBy = usedBy.split(',');
@@ -287,7 +287,7 @@ export class Viewport {
     return usedBy.indexOf(component as string) >= 0;
   }
   // TODO: Deal with non-string components
-  public acceptComponent(component: ICustomElementType | string): boolean {
+  public acceptComponent(component: IRouteableComponentType | string): boolean {
     if (component === '-' || component === null) {
       return true;
     }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,11 +1,11 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { INavigatorInstruction } from './navigator';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
-import { IRouteableComponentType, ReentryBehavior, ViewportContent } from './viewport-content';
+import { ViewportContent } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
+import { IRouteableComponentType, INavigatorInstruction, ReentryBehavior } from './interfaces';
 
 export interface IViewportOptions {
   scope?: boolean;

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,6 +1,6 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { ComponentHandle, INavigatorInstruction, ReentryBehavior } from './interfaces';
+import { ComponentAppellation, INavigatorInstruction, ReentryBehavior } from './interfaces';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
@@ -58,7 +58,7 @@ export class Viewport {
     this.enabled = true;
   }
 
-  public setNextContent(content: ComponentHandle, instruction: INavigatorInstruction): boolean {
+  public setNextContent(content: ComponentAppellation, instruction: INavigatorInstruction): boolean {
     let parameters;
     this.clear = false;
     if (typeof content === 'string') {
@@ -279,7 +279,7 @@ export class Viewport {
   }
 
   // TODO: Deal with non-string components
-  public wantComponent(component: ComponentHandle): boolean {
+  public wantComponent(component: ComponentAppellation): boolean {
     let usedBy = this.options.usedBy || [];
     if (typeof usedBy === 'string') {
       usedBy = usedBy.split(',');
@@ -287,7 +287,7 @@ export class Viewport {
     return usedBy.indexOf(component as string) >= 0;
   }
   // TODO: Deal with non-string components
-  public acceptComponent(component: ComponentHandle): boolean {
+  public acceptComponent(component: ComponentAppellation): boolean {
     if (component === '-' || component === null) {
       return true;
     }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,11 +1,11 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
+import { INavigatorInstruction, IRouteableComponentType, ReentryBehavior } from './interfaces';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
 import { ViewportContent } from './viewport-content';
 import { ViewportInstruction } from './viewport-instruction';
-import { IRouteableComponentType, INavigatorInstruction, ReentryBehavior } from './interfaces';
 
 export interface IViewportOptions {
   scope?: boolean;

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,6 +1,6 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { INavigatorInstruction, IRouteableComponentType, ReentryBehavior } from './interfaces';
+import { ComponentAppellation, INavigatorInstruction, ReentryBehavior } from './interfaces';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
@@ -58,7 +58,7 @@ export class Viewport {
     this.enabled = true;
   }
 
-  public setNextContent(content: IRouteableComponentType | string, instruction: INavigatorInstruction): boolean {
+  public setNextContent(content: ComponentAppellation, instruction: INavigatorInstruction): boolean {
     let parameters;
     this.clear = false;
     if (typeof content === 'string') {
@@ -279,7 +279,7 @@ export class Viewport {
   }
 
   // TODO: Deal with non-string components
-  public wantComponent(component: IRouteableComponentType | string): boolean {
+  public wantComponent(component: ComponentAppellation): boolean {
     let usedBy = this.options.usedBy || [];
     if (typeof usedBy === 'string') {
       usedBy = usedBy.split(',');
@@ -287,7 +287,7 @@ export class Viewport {
     return usedBy.indexOf(component as string) >= 0;
   }
   // TODO: Deal with non-string components
-  public acceptComponent(component: IRouteableComponentType | string): boolean {
+  public acceptComponent(component: ComponentAppellation): boolean {
     if (component === '-' || component === null) {
       return true;
     }

--- a/packages/router/src/viewport.ts
+++ b/packages/router/src/viewport.ts
@@ -1,6 +1,6 @@
 import { IContainer, Reporter } from '@aurelia/kernel';
 import { IRenderContext, LifecycleFlags } from '@aurelia/runtime';
-import { ComponentAppellation, INavigatorInstruction, ReentryBehavior } from './interfaces';
+import { ComponentHandle, INavigatorInstruction, ReentryBehavior } from './interfaces';
 import { IRouter } from './router';
 import { Scope } from './scope';
 import { IViewportOptions } from './viewport';
@@ -58,7 +58,7 @@ export class Viewport {
     this.enabled = true;
   }
 
-  public setNextContent(content: ComponentAppellation, instruction: INavigatorInstruction): boolean {
+  public setNextContent(content: ComponentHandle, instruction: INavigatorInstruction): boolean {
     let parameters;
     this.clear = false;
     if (typeof content === 'string') {
@@ -279,7 +279,7 @@ export class Viewport {
   }
 
   // TODO: Deal with non-string components
-  public wantComponent(component: ComponentAppellation): boolean {
+  public wantComponent(component: ComponentHandle): boolean {
     let usedBy = this.options.usedBy || [];
     if (typeof usedBy === 'string') {
       usedBy = usedBy.split(',');
@@ -287,7 +287,7 @@ export class Viewport {
     return usedBy.indexOf(component as string) >= 0;
   }
   // TODO: Deal with non-string components
-  public acceptComponent(component: ComponentAppellation): boolean {
+  public acceptComponent(component: ComponentHandle): boolean {
     if (component === '-' || component === null) {
       return true;
     }

--- a/test/realworld/package-lock.json
+++ b/test/realworld/package-lock.json
@@ -13,18 +13,18 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         }
@@ -40,24 +40,24 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         },
         "@aurelia/runtime-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -65,18 +65,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -93,18 +93,18 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         }
@@ -121,7 +121,7 @@
       "dependencies": {
         "@aurelia/jit": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -129,18 +129,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -148,24 +148,24 @@
         },
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         },
         "@aurelia/runtime-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -173,18 +173,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -205,7 +205,7 @@
       "dependencies": {
         "@aurelia/jit": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -213,18 +213,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -232,7 +232,7 @@
         },
         "@aurelia/jit-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/jit": "0.3.0",
             "@aurelia/kernel": "0.3.0",
@@ -242,7 +242,7 @@
           "dependencies": {
             "@aurelia/jit": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0",
                 "@aurelia/runtime": "0.3.0"
@@ -250,37 +250,38 @@
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 },
                 "@aurelia/runtime": {
                   "version": "0.3.0",
-                  "resolved": false,
+                  "bundled": true,
                   "requires": {
                     "@aurelia/kernel": "0.3.0"
-                  }
+                  },
+                  "dependencies": {}
                 }
               }
             },
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             },
             "@aurelia/runtime-html": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0",
                 "@aurelia/runtime": "0.3.0"
@@ -288,18 +289,18 @@
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 },
                 "@aurelia/runtime": {
                   "version": "0.3.0",
-                  "resolved": false,
+                  "bundled": true,
                   "requires": {
                     "@aurelia/kernel": "0.3.0"
                   },
                   "dependencies": {
                     "@aurelia/kernel": {
                       "version": "0.3.0",
-                      "resolved": false
+                      "bundled": true
                     }
                   }
                 }
@@ -309,24 +310,24 @@
         },
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         },
         "@aurelia/runtime-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -334,20 +335,21 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
-              }
+              },
+              "dependencies": {}
             }
           }
         },
         "@aurelia/runtime-html-browser": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0",
@@ -356,24 +358,24 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             },
             "@aurelia/runtime-html": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0",
                 "@aurelia/runtime": "0.3.0"
@@ -381,14 +383,15 @@
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 },
                 "@aurelia/runtime": {
                   "version": "0.3.0",
-                  "resolved": false,
+                  "bundled": true,
                   "requires": {
                     "@aurelia/kernel": "0.3.0"
-                  }
+                  },
+                  "dependencies": {}
                 }
               }
             }
@@ -429,24 +432,24 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         },
         "@aurelia/runtime-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -454,18 +457,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -481,7 +484,7 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         }
       }
     },
@@ -494,18 +497,18 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         }
@@ -521,24 +524,24 @@
       "dependencies": {
         "@aurelia/kernel": {
           "version": "0.3.0",
-          "resolved": false
+          "bundled": true
         },
         "@aurelia/runtime": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0"
           },
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             }
           }
         },
         "@aurelia/runtime-html": {
           "version": "0.3.0",
-          "resolved": false,
+          "bundled": true,
           "requires": {
             "@aurelia/kernel": "0.3.0",
             "@aurelia/runtime": "0.3.0"
@@ -546,18 +549,18 @@
           "dependencies": {
             "@aurelia/kernel": {
               "version": "0.3.0",
-              "resolved": false
+              "bundled": true
             },
             "@aurelia/runtime": {
               "version": "0.3.0",
-              "resolved": false,
+              "bundled": true,
               "requires": {
                 "@aurelia/kernel": "0.3.0"
               },
               "dependencies": {
                 "@aurelia/kernel": {
                   "version": "0.3.0",
-                  "resolved": false
+                  "bundled": true
                 }
               }
             }
@@ -1530,15 +1533,6 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -2059,17 +2053,6 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "copy-descriptor": {
@@ -2135,9 +2118,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -2232,9 +2215,9 @@
       }
     },
     "date-fns": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0.tgz",
-      "integrity": "sha512-nGZDA64Ktq5uTWV4LEH3qX+foV4AguT5qxwRlJDzJtf57d4xLNwtwrfb7SzKCoikoae8Bvxf0zdaEG/xWssp/w=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -2342,17 +2325,6 @@
         "p-map": "^2.0.0",
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "delayed-stream": {
@@ -2759,8 +2731,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -3407,8 +3378,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3429,14 +3399,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3451,20 +3419,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3581,8 +3546,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3594,7 +3558,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3609,7 +3572,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3617,14 +3579,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3643,7 +3603,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3724,8 +3683,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3737,7 +3695,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3823,8 +3780,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3860,7 +3816,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3880,7 +3835,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3924,14 +3878,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4061,9 +4013,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
-      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
     "handle-thing": {
@@ -4674,9 +4626,9 @@
       "dev": true
     },
     "is-absolute-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
-      "integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
+      "integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -5178,9 +5130,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
+      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -5443,17 +5395,6 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "ms": {
@@ -5805,9 +5746,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -6068,9 +6009,9 @@
       }
     },
     "portfinder": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+      "integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -6667,9 +6608,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -6776,9 +6717,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
-      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true
     },
     "serve-index": {
@@ -7428,13 +7369,26 @@
       "dev": true
     },
     "style-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
-      "integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
+      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.0.1"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
       }
     },
     "supports-color": {
@@ -7673,9 +7627,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz",
-      "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
+      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -7983,9 +7937,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -74,20 +74,20 @@ export class App implements IViewModel {
 
   public get routes() {
     return [
-      // {
-      //   route: Home as unknown as  IRouteableComponentType<Constructable>,
-      //   title: 'Home',
-      // },
+      {
+        route: Home as unknown as IRouteableComponentType<Constructable>,
+        title: 'Home',
+      },
       {
         condition: this.authenticated,
         route: `editor(type=new)`,
         title: '<i class="ion-compose"></i>&nbsp;New Post',
       },
-      // {
-      //   condition: this.authenticated,
-      //   route: Settings,
-      //   title: '<i class="ion-gear-a"></i>&nbsp;Settings',
-      // },
+      {
+        condition: this.authenticated,
+        route: Settings as unknown as IRouteableComponentType<Constructable>,
+        title: '<i class="ion-gear-a"></i>&nbsp;Settings',
+      },
       {
         compareParameters: true,
         condition: this.notAuthenticated,

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -50,7 +50,7 @@ export class App implements IViewModel {
         this.router.goto(`auth(type=login)`);
         return [];
       }
-      , { include: [{ componentName: 'editor' }, { componentName: 'settings' }] },
+      , { include: [{ component: 'editor' }, { component: 'settings' }] },
     );
     const observerLocator = this.router.container.get(IObserverLocator);
     const observer = observerLocator.getObserver(LifecycleFlags.none, this.state, 'isAuthenticated') as any;

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -1,5 +1,5 @@
-import { inject } from '@aurelia/kernel';
-import { IRouter } from '@aurelia/router';
+import { Constructable, inject } from '@aurelia/kernel';
+import { IRouteableComponentType, IRouter } from '@aurelia/router';
 import { customElement, IObserverLocator, IViewModel, LifecycleFlags } from '@aurelia/runtime';
 import { UserService } from './shared/services/user-service';
 import { SharedState } from './shared/state/shared-state';
@@ -74,20 +74,20 @@ export class App implements IViewModel {
 
   public get routes() {
     return [
-      {
-        route: Home,
-        title: 'Home',
-      },
+      // {
+      //   route: Home as unknown as  IRouteableComponentType<Constructable>,
+      //   title: 'Home',
+      // },
       {
         condition: this.authenticated,
         route: `editor(type=new)`,
         title: '<i class="ion-compose"></i>&nbsp;New Post',
       },
-      {
-        condition: this.authenticated,
-        route: Settings,
-        title: '<i class="ion-gear-a"></i>&nbsp;Settings',
-      },
+      // {
+      //   condition: this.authenticated,
+      //   route: Settings,
+      //   title: '<i class="ion-gear-a"></i>&nbsp;Settings',
+      // },
       {
         compareParameters: true,
         condition: this.notAuthenticated,

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -75,7 +75,7 @@ export class App implements IViewModel {
   public get routes() {
     return [
       {
-        route: Home as unknown as IRouteableComponentType<Constructable>,
+        route: Home,
         title: 'Home',
       },
       {
@@ -85,7 +85,7 @@ export class App implements IViewModel {
       },
       {
         condition: this.authenticated,
-        route: Settings as unknown as IRouteableComponentType<Constructable>,
+        route: Settings,
         title: '<i class="ion-gear-a"></i>&nbsp;Settings',
       },
       {

--- a/test/realworld/src/app.ts
+++ b/test/realworld/src/app.ts
@@ -1,5 +1,5 @@
-import { Constructable, inject } from '@aurelia/kernel';
-import { IRouteableComponentType, IRouter } from '@aurelia/router';
+import { inject } from '@aurelia/kernel';
+import { INavRoute, IRouter } from '@aurelia/router';
 import { customElement, IObserverLocator, IViewModel, LifecycleFlags } from '@aurelia/runtime';
 import { UserService } from './shared/services/user-service';
 import { SharedState } from './shared/state/shared-state';
@@ -72,7 +72,7 @@ export class App implements IViewModel {
     this.router.updateNav();
   }
 
-  public get routes() {
+  public get routes(): INavRoute[] {
     return [
       {
         route: Home,

--- a/test/realworld/src/main.ts
+++ b/test/realworld/src/main.ts
@@ -23,10 +23,15 @@ const globalResources = [
 
   SharedState,
   HttpClient,
-] as unknown as IRegistry[];
+] as any;
 
 (global as any).au = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration, RouterConfiguration, ...globalResources)
+  .register(
+    BasicConfiguration,
+    DebugConfiguration,
+    RouterConfiguration,
+    ...globalResources,
+  )
   .app({
     component: App,
     host: document.querySelector('app')!,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR refactors and restructures interfaces and types, including renaming `IRouteableCustomElement*` to `IRouteableComponent*` and using them where appropriate. It also fixes a small bug in `au-nav`s active route.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working. 

## 📑 Test Plan

- Make sure existing tests pass.

## ⏭ Next Steps

- Implement scope traversal to Router's `goto` method
- Add tests for the new au-nav options
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->