### PR TITLE
WIP: View Locator

### DIFF
--- a/packages/runtime/src/configuration.ts
+++ b/packages/runtime/src/configuration.ts
@@ -39,6 +39,7 @@ import { Repeat } from './resources/custom-attributes/repeat';
 import { Replaceable } from './resources/custom-attributes/replaceable';
 import { With } from './resources/custom-attributes/with';
 import { SanitizeValueConverter } from './resources/value-converters/sanitize';
+import { ViewValueConverter } from './resources/value-converters/view';
 
 export const IObserverLocatorRegistration = ObserverLocator as IRegistry;
 export const ILifecycleRegistration = Lifecycle as IRegistry;
@@ -67,6 +68,7 @@ export const RepeatRegistration = Repeat as IRegistry;
 export const ReplaceableRegistration = Replaceable as unknown as IRegistry;
 export const WithRegistration = With as IRegistry;
 export const SanitizeValueConverterRegistration = SanitizeValueConverter as unknown as IRegistry;
+export const ViewValueConverterRegistration = ViewValueConverter as unknown as IRegistry;
 export const DebounceBindingBehaviorRegistration = DebounceBindingBehavior as unknown as IRegistry;
 export const OneTimeBindingBehaviorRegistration = OneTimeBindingBehavior as unknown as IRegistry;
 export const ToViewBindingBehaviorRegistration = ToViewBindingBehavior as unknown as IRegistry;
@@ -92,6 +94,7 @@ export const DefaultResources = [
   ReplaceableRegistration,
   WithRegistration,
   SanitizeValueConverterRegistration,
+  ViewValueConverterRegistration,
   DebounceBindingBehaviorRegistration,
   OneTimeBindingBehaviorRegistration,
   ToViewBindingBehaviorRegistration,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -290,6 +290,9 @@ export {
 } from './templating/controller';
 export {
   ViewFactory,
+  IViewLocator,
+  ViewLocator,
+  view
 } from './templating/view';
 
 export {

--- a/packages/runtime/src/resources/value-converters/view.ts
+++ b/packages/runtime/src/resources/value-converters/view.ts
@@ -1,0 +1,14 @@
+import { IViewLocator } from '../../templating/view';
+import { valueConverter } from '../value-converter';
+
+@valueConverter('view')
+export class ViewValueConverter {
+  constructor(@IViewLocator private viewLocator: IViewLocator) {}
+
+  public toView(subject: object, viewName?: string) {
+    return this.viewLocator.getViewComponentForModelInstance(
+      subject,
+      viewName
+    );
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR enables any class to have one or more associated views. With a view associated, the `au-compose` element can then render instances of the class by using the `view` value converter.

### 🎫 Issues

* #375 

## 👩‍💻 Reviewer Notes

The interesting part is the implementation of the ViewLocator, which creates (and caches) components on the fly to allow existing, non-component object instances to be rendered as components with their associated view.

## 📑 Test Plan

Tests coming in future commits to this PR...

## ⏭ Next Steps

We should add a new convention for associating views. Today, if you have a class in a file named `foo.js` and you have a view in `foo.html`, the convention is to create a component. We should add that if the html file has the "view" suffix, then the class should merely have the view associated rather than being made into a component. For example, `foo.js` and `foo-view.html` will not result in a component. The view will be compiled the same, but the `@view(template)` decorator will be added to the class in `foo.js` instead of the `@customElement(template)` decorator. This will enable robust, convention-based, dynamic composition of vanilla JS classes.
