### PR TITLE
chore: partially fix renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,10 @@
       "allowedVersions": "^3.3.6"
     },
     {
+      "packageNames": ["chromedriver"],
+      "allowedVersions": "^74.0.0"
+    },
+    {
       "packageNames": ["karma"],
       "allowedVersions": "~4.1.0"
     },

--- a/test/js-framework-benchmark/webdriver-ts-results/src/App.tsx
+++ b/test/js-framework-benchmark/webdriver-ts-results/src/App.tsx
@@ -94,8 +94,8 @@ class App extends React.Component<{}, State> {
                   frameworks,
                   frameworksKeyed: frameworks.filter(f => f.keyed === true),
                   frameworksNonKeyed: frameworks.filter(f => f.keyed === false),
-                  selectedBenchmarks: _allBenchmarks,
-                  selectedFrameworks: _allFrameworks,
+                  selectedBenchmarks: _allBenchmarks as Set<Benchmark>,
+                  selectedFrameworks: _allFrameworks as Set<Framework>,
                   separateKeyedAndNonKeyed: true,
                   resultTables: [],
                   sortKey: SORT_BY_GEOMMEAN_CPU,
@@ -111,18 +111,18 @@ class App extends React.Component<{}, State> {
     else set.add(benchmark);
     let sortKey = this.state.sortKey;
     let setIds = new Set();
-    set.forEach(b => setIds.add(b.id))
+    set.forEach((b: Benchmark) => setIds.add(b.id))
     if ((sortKey!=SORT_BY_NAME && sortKey!=SORT_BY_GEOMMEAN_CPU && sortKey!=SORT_BY_GEOMMEAN_MEM && sortKey!=SORT_BY_GEOMMEAN_STARTUP) && !setIds.has(sortKey)) sortKey = SORT_BY_NAME;
-    this.nextState.selectedBenchmarks = set;
-    this.setState({selectedBenchmarks: set, sortKey, resultTables: this.updateResultTable()});
+    this.nextState.selectedBenchmarks = set as Set<Benchmark>;
+    this.setState({selectedBenchmarks: set as Set<Benchmark>, sortKey, resultTables: this.updateResultTable()});
   }
   selectFramework = (framework: Framework, value: boolean): void => {
     let set = new Set();
     this.state.selectedFrameworks.forEach(framework => set.add(framework));
     if (set.has(framework)) set.delete(framework);
     else set.add(framework);
-    this.nextState.selectedFrameworks = set;
-    this.setState({selectedFrameworks: set, resultTables: this.updateResultTable()});
+    this.nextState.selectedFrameworks = set as Set<Framework>;
+    this.setState({selectedFrameworks: set as Set<Framework>, resultTables: this.updateResultTable()});
   }
   selectSeparateKeyedAndNonKeyed = (value: boolean): void => {
     this.nextState.separateKeyedAndNonKeyed = value;

--- a/test/js-framework-benchmark/webdriver-ts/package.json
+++ b/test/js-framework-benchmark/webdriver-ts/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "cross-env": "5.2.0",
-    "chromedriver": "75.0.0",
+    "chromedriver": "74.0.0",
     "dot": "1.1.2",
     "jstat": "1.8.3",
     "lighthouse": "5.1.0",


### PR DESCRIPTION
# Pull Request

## 📖 Description

This should (partially) get Renovate back in line.

### 🎫 Issues

* #551 

## 👩‍💻 Reviewer Notes

This PR fixes two separate issues related to dependency updates:
* There is a newer version of `chromedriver`. The problem is that that package is directly tied to the version of Chrome installed on the machine. In this case the version of Chrome installed on the Docker image used on CircleCI. My solution is to pin `chromedriver` to the currently used version `^74.0.0` across the board. Note that this is a temporary solution, because when CircleCI decides to update its version of Chrome stuff will start breaking again. This would happen with or without `renovate` though...
* `test/js-framework-benchmark/webdriver-ts-results` is using version `3.3.3333` of `typescript`. Once you upgrade it to the current `3.5.3` (that the rest of the repo is already using) the build breaks due to casting errors. This PR introduces the necessary casts to have it build again.

## 📑 Test Plan

Trust CircleCI

## ⏭ Next Steps

Fix the remaining issues (if any) that block #551.
