### PR TITLE
feat(default-replaceable): allow replace conv

### DIFF
--- a/packages/__tests__/jit-html/replaceable.spec.ts
+++ b/packages/__tests__/jit-html/replaceable.spec.ts
@@ -28,8 +28,8 @@ describe('replaceable', function () {
   ]) {
     it(`replaceable - ${title}`, function () {
 
-      const App = CustomElement.define({ name: 'app', template: `<template><foo>${appMarkup}</foo></template>` }, class {});
-      const Foo = CustomElement.define({ name: 'foo', template: `<template>${ceMarkup}</template>` }, class {});
+      const App = CustomElement.define({ name: 'app', template: `<template><foo>${appMarkup}</foo></template>` }, class { });
+      const Foo = CustomElement.define({ name: 'foo', template: `<template>${ceMarkup}</template>` }, class { });
 
       const ctx = TestContext.createHTMLTestContext();
       ctx.container.register(Foo);
@@ -64,6 +64,405 @@ describe('replaceable', function () {
     au.start();
 
     assert.strictEqual(host.textContent, 'abc', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless replace element full`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless replace element with part replaceable empty`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template part replaceable></replace></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless replace element short`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless template element no name short`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable></template></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless replace element full NO TEMPLATE WRAPPER`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<replace></replace>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless replace element short NO TEMPLATE WRAPPER`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<replace/>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  // TODO: run this case with more combinations
+  it(`replaceable - bind to parent scope when binding inside replace-part has multiple template controllers in between`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><div replace-part="bar"><div if.bind="true" repeat.for="i of 1">\${baz}</div></div></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { });
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to target containerless replace element full`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part='default'>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to target containerless replace element short`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to target containerless template element short`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable/></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
+
+  });
+
+
+  it(`replaceable - default bind to parent containerless no element short template`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable/></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element long template`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable></template></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element short template`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element long template`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element long replace NESTED`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element short replace NESTED`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace /></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to target containerless template element no name short replace NESTED`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo><template replace-part>\${baz}</template></foo></foo></foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace /></template>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element short template no wrapper`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<replace/>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
+
+  });
+
+  it(`replaceable - default bind to parent containerless no element long template no wrapper`, function () {
+
+    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<replace></replace>` }, class { public baz = 'abc'; });
+    Foo.containerless = true;
+
+    const ctx = TestContext.createHTMLTestContext();
+    ctx.container.register(Foo);
+    const au = new Aurelia(ctx.container);
+
+    const host = ctx.createElement('div');
+    const component = new App();
+
+    au.app({ host, component });
+
+    au.start();
+
+    assert.strictEqual(host.textContent, 'def', `host.textContent`);
 
   });
 
@@ -117,7 +516,7 @@ describe('replaceable', function () {
   it(`replaceable - bind to parent scope`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><div replace-part="bar">\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class {});
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><div replaceable part="bar"></div></template>` }, class { });
 
     const ctx = TestContext.createHTMLTestContext();
     ctx.container.register(Foo);
@@ -157,7 +556,7 @@ describe('replaceable', function () {
   it(`replaceable/template - bind to parent scope`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { });
 
     const ctx = TestContext.createHTMLTestContext();
     ctx.container.register(Foo);
@@ -177,7 +576,7 @@ describe('replaceable', function () {
   it(`replaceable/template - uses last on name conflict`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part="bar">\${qux}</template><template replace-part="bar">\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class {});
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable part="bar"></template></template>` }, class { });
 
     const ctx = TestContext.createHTMLTestContext();
     ctx.container.register(Foo);
@@ -295,8 +694,8 @@ describe('replaceable', function () {
 
   });
 
-  describe('Difficult cases', function() {
-    describe('with multiple nested replaceable from 1 -> 10 levels', function() {
+  describe('Difficult cases', function () {
+    describe('with multiple nested replaceable from 1 -> 10 levels', function () {
       const createReplaceableDiv = (level: number) => {
         let currentLevel = 0;
         let template = '';
@@ -324,14 +723,14 @@ describe('replaceable', function () {
       };
 
       for (let i = 1; 11 > i; ++i) {
-        it(`works with replaceable on normal <div/> with. Nesting level: ${i}`, function() {
+        it(`works with replaceable on normal <div/> with. Nesting level: ${i}`, function () {
           const App = CustomElement.define(
             { name: 'app', template: `<template><foo><template replace-part="p-${i}"><span>replace-part-p</span></template></foo></template>` },
-            class App {}
+            class App { }
           );
           const Foo = CustomElement.define(
             { name: 'foo', template: `<template>${createReplaceableDiv(i)}</template>` },
-            class Foo {}
+            class Foo { }
           );
 
           const ctx = TestContext.createHTMLTestContext();
@@ -351,7 +750,7 @@ describe('replaceable', function () {
       }
     });
 
-    describe('with multiple replaceables + all no nested replaceable + From 1 -> 10 siblings', function() {
+    describe('with multiple replaceables + all no nested replaceable + From 1 -> 10 siblings', function () {
       const buildReplacementTemplate = (count: number) => {
         let template = '';
         let i = 0;
@@ -371,16 +770,17 @@ describe('replaceable', function () {
         return template;
       };
       for (let i = 1; 11 > i; ++i) {
-        it(`works with replaceable on normal <div/>. Siblings count: ${i}`, function() {
+        it(`works with replaceable on normal <div/>. Siblings count: ${i}`, function () {
           const App = CustomElement.define(
-            { name: 'app', template:
-              `<template><foo>${buildReplacementTemplate(i)}</foo></template>`
+            {
+              name: 'app', template:
+                `<template><foo>${buildReplacementTemplate(i)}</foo></template>`
             },
-            class App {}
+            class App { }
           );
           const Foo = CustomElement.define(
             { name: 'foo', template: `<template>${buildReplaceableDiv(i)}</template>` },
-            class Foo {}
+            class Foo { }
           );
 
           const ctx = TestContext.createHTMLTestContext();

--- a/packages/__tests__/jit-html/replaceable.spec.ts
+++ b/packages/__tests__/jit-html/replaceable.spec.ts
@@ -1,5 +1,5 @@
 import { Aurelia, CustomElement, LifecycleFlags as LF } from '@aurelia/runtime';
-import { TestContext, assert } from '@aurelia/testing';
+import { assert, TestContext } from '@aurelia/testing';
 
 describe('replaceable', function () {
   for (const [title, appMarkup, ceMarkup, , , , , , expected] of [
@@ -67,116 +67,12 @@ describe('replaceable', function () {
 
   });
 
-  it(`replaceable - default bind to parent containerless replace element full`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless replace element with part replaceable empty`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><template part replaceable></au-replace></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless replace element short`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
   it(`replaceable - default bind to parent containerless template element no name short`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable></template></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless replace element full NO TEMPLATE WRAPPER`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace></au-replace>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless replace element short NO TEMPLATE WRAPPER`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace/>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
     const ctx = TestContext.createHTMLTestContext();
     ctx.container.register(Foo);
     const au = new Aurelia(ctx.container);
@@ -213,48 +109,6 @@ describe('replaceable', function () {
 
   });
 
-  it(`replaceable - default bind to target containerless replace element full`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part='default'>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to target containerless replace element short`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
-
-  });
-
   it(`replaceable - default bind to target containerless template element short`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
@@ -275,7 +129,6 @@ describe('replaceable', function () {
     assert.strictEqual(host.textContent, 'abc', `host.textContent`);
 
   });
-
 
   it(`replaceable - default bind to parent containerless no element short template`, function () {
 
@@ -302,153 +155,6 @@ describe('replaceable', function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
     const Foo = CustomElement.define({ name: 'foo', template: `<template><template replaceable></template></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element short template`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element long template`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element long replace NESTED`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element short replace NESTED`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace /></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to target containerless template element no name short replace NESTED`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo><template replace-part>\${baz}</template></foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace /></template>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'abc', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element short template no wrapper`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace/>` }, class { public baz = 'abc'; });
-    Foo.containerless = true;
-
-    const ctx = TestContext.createHTMLTestContext();
-    ctx.container.register(Foo);
-    const au = new Aurelia(ctx.container);
-
-    const host = ctx.createElement('div');
-    const component = new App();
-
-    au.app({ host, component });
-
-    au.start();
-
-    assert.strictEqual(host.textContent, 'def', `host.textContent`);
-
-  });
-
-  it(`replaceable - default bind to parent containerless no element long template no wrapper`, function () {
-
-    const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace></au-replace>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -508,7 +214,7 @@ describe('replaceable', function () {
 
     component.show = true;
 
-    ctx.lifecycle.processRAFQueue(LF.none)
+    ctx.lifecycle.processRAFQueue(LF.none);
 
     assert.strictEqual(host.textContent, 'def', `host.textContent`);
   });
@@ -798,103 +504,6 @@ describe('replaceable', function () {
         });
       }
     });
-
-    // describe('with multiple replaceables + with nested replaceables + from 1 -> 10 siblings + from 1 -> nesting levels', function() {
-    //   // in this part, we will test replacing a replaceable somewhere between 1 -> 10 levels of nesting replaceable
-    //   // with only 1 replacement
-    //   const maxReplaceableSiblingCount = 10;
-    //   const maxDepth = 10;
-    //   const buildNestedReplaceableDiv = (baseSiblingIndex: number, nestedDepth: number) => {
-    //     let template = '';
-    //     let currentBaseLevel = 0;
-    //     while (baseSiblingIndex > currentBaseLevel) {
-    //       let currentDepth = 0;
-    //       let $template = `<div replaceable part="p-${currentBaseLevel}-0">replaceable-p-${currentBaseLevel}-0`;
-    //       while (nestedDepth > currentDepth) {
-    //         $template += `<div replaceable part="p-${currentBaseLevel}-${currentDepth}">replaceable-p-${currentBaseLevel}-${currentDepth}`;
-    //         ++currentDepth;
-    //       }
-    //       while (currentDepth > 0) {
-    //         $template += '</div>';
-    //         --currentDepth;
-    //       }
-    //       $template += '<div>';
-    //       template += $template;
-    //       ++currentBaseLevel;
-    //     }
-    //     return template;
-    //   };
-    //   const buildNestedReplacementTemplate = (baseSiblingIndex: number, nestedDepth: number) => {
-    //     return `<template replace-part="p-${baseSiblingIndex}-${nestedDepth}">replace-part-p${baseSiblingIndex}-${nestedDepth}</template>`;
-    //   };
-    //   const buildExpectedTextContent = (baseSiblingIndex: number, nestedDepth: number) => {
-    //     let currentBaseIndex = 0;
-    //     let finalTextContent = '';
-    //     while (maxReplaceableSiblingCount > currentBaseIndex) {
-    //       if (baseSiblingIndex > currentBaseIndex) {
-    //         let i = 0;
-    //         while (maxDepth > i) {
-    //           finalTextContent += `replaceable-p-${currentBaseIndex}-${i}`;
-    //           ++i;
-    //         }
-    //       } else if (baseSiblingIndex === currentBaseIndex) {
-    //         let currentDepth = 0;
-    //         /**
-    //          * <template replaceable>
-    //          *   <template replaceable>
-    //          *      <template replaceable>  <----- replacement here won't affect any level above it
-    //          *        <template>            <--x-- but will terminate all replacement after it
-    //          */
-    //         while (nestedDepth > currentDepth) {
-    //           finalTextContent += `replaceable-p-${currentBaseIndex}-${currentDepth}`;
-    //         }
-    //         finalTextContent += `replace-part-p-${currentBaseIndex}-${nestedDepth}`;
-    //       } else {
-    //         let i = 0;
-    //         while (maxDepth > i) {
-    //           finalTextContent += `replaceable-p-${currentBaseIndex}-${i}`;
-    //           ++i;
-    //         }
-    //       }
-    //       ++currentBaseIndex;
-    //     }
-    //     return finalTextContent;
-    //   };
-
-    //   for (let baseReplaceableCount = 0; 10 > baseReplaceableCount; ++baseReplaceableCount) {
-    //     for (let nestedDepth = 0; 10 > nestedDepth; ++nestedDepth) {
-    //       it(`works with replaceable on normal <div/>. Siblings count: ${baseReplaceableCount}`, function() {
-    //         const App = CustomElement.define(
-    //           { name: 'app', template:
-    //             `<template><foo>${buildNestedReplacementTemplate(baseReplaceableCount, nestedDepth)}</foo></template>`
-    //           },
-    //           class App {}
-    //         );
-    //         const Foo = CustomElement.define(
-    //           { name: 'foo', template: `<template>${buildNestedReplaceableDiv(baseReplaceableCount, nestedDepth)}</template>` },
-    //           class Foo {}
-    //         );
-
-    //         const ctx = TestContext.createHTMLTestContext();
-    //         ctx.container.register(Foo);
-    //         const au = new Aurelia(ctx.container);
-
-    //         const host = ctx.createElement('div');
-    //         const component = new App();
-
-    //         au.app({ host, component });
-    //         au.start();
-
-    //         assert.strictEqual(
-    //           host.textContent,
-    //           buildExpectedTextContent(baseReplaceableCount, nestedDepth),
-    //           `[base=${baseReplaceableCount}, depth=${nestedDepth}]host.textContent`
-    //         );
-    //         tearDown(au);
-    //       });
-    //     }
-    //   }
-    // });
   });
 
   interface ITestItem {

--- a/packages/__tests__/jit-html/replaceable.spec.ts
+++ b/packages/__tests__/jit-html/replaceable.spec.ts
@@ -70,7 +70,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless replace element full`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -91,7 +91,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless replace element with part replaceable empty`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><template part replaceable></replace></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><template part replaceable></au-replace></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -112,7 +112,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless replace element short`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><div>\${baz}</div></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -154,7 +154,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless replace element full NO TEMPLATE WRAPPER`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<replace></replace>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace></au-replace>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -175,7 +175,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless replace element short NO TEMPLATE WRAPPER`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<foo><div>\${baz}</div></foo>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<replace/>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace/>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
     const ctx = TestContext.createHTMLTestContext();
     ctx.container.register(Foo);
@@ -216,7 +216,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to target containerless replace element full`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part='default'>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -237,7 +237,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to target containerless replace element short`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><template replace-part>\${baz}</template></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -322,7 +322,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element short template`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace/></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace/></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -343,7 +343,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element long template`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -364,7 +364,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element long replace NESTED`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace></replace></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace></au-replace></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -385,7 +385,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element short replace NESTED`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo>\${baz}</foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace /></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace /></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -406,7 +406,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to target containerless template element no name short replace NESTED`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo><foo><foo><template replace-part>\${baz}</template></foo></foo></foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<template><replace /></template>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<template><au-replace /></template>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -427,7 +427,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element short template no wrapper`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<replace/>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace/>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();
@@ -448,7 +448,7 @@ describe('replaceable', function () {
   it(`replaceable - default bind to parent containerless no element long template no wrapper`, function () {
 
     const App = CustomElement.define({ name: 'app', template: `<template><foo>\${baz}</foo></template>` }, class { public baz = 'def'; });
-    const Foo = CustomElement.define({ name: 'foo', template: `<replace></replace>` }, class { public baz = 'abc'; });
+    const Foo = CustomElement.define({ name: 'foo', template: `<au-replace></au-replace>` }, class { public baz = 'abc'; });
     Foo.containerless = true;
 
     const ctx = TestContext.createHTMLTestContext();

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -392,7 +392,7 @@ export class TemplateBinder {
     let childNode: ChildNode;
     if (node.nodeName === 'TEMPLATE') {
       childNode = (node as HTMLTemplateElement).content.firstChild!;
-    } else if (node.nodeName === 'REPLACE') {
+    } else if (node.nodeName === 'AU-REPLACE') {
       const parent = node.parentNode;
       if (parent === null) {
         childNode = node.firstChild!;
@@ -559,7 +559,7 @@ export class TemplateBinder {
     const name = node.getAttribute('replace-part');
     if (name == null) {
       const root = this.manifestRoot || this.parentManifestRoot;
-      if (root && root.flags & 16 /* isCustomElement */ && root.isTarget && root.isContainerless) {
+      if (root && root.flags & SymbolFlags.isCustomElement /* isCustomElement */ && root.isTarget && root.isContainerless) {
         const physicalNode = root.physicalNode as typeof node;
         if (physicalNode.childElementCount === 1) {
           return new ReplacePartSymbol('default');

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -392,17 +392,6 @@ export class TemplateBinder {
     let childNode: ChildNode;
     if (node.nodeName === 'TEMPLATE') {
       childNode = (node as HTMLTemplateElement).content.firstChild!;
-    } else if (node.nodeName === 'AU-REPLACE') {
-      const parent = node.parentNode;
-      if (parent === null) {
-        childNode = node.firstChild!;
-      } else {
-        const template = this.dom.createTemplate() as HTMLTemplateElement;
-        template.toggleAttribute('replaceable');
-        template.setAttribute('part', 'default');
-        parent.replaceChild(template, node);
-        childNode = template;
-      }
     } else {
       childNode = node.firstChild!;
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This allows projection of elements without defining default replacements when a containerless element is being used.

See below for usage examples.
```ts
@customElement({
    name: 'cool-button', containerless: true, template: `
<button>
<template replaceable />
</button
`})
export class CoolButton {
message = 'I am inside the coolest button on earth!';
}
```

```html
<template>

<!-- Straight content rendered inside button -->
<cool-button> I am still pretty cool since I live in some unknown realm
owned by the coolest button on earth </cool-button>
<!--
RENDERS
<button>I am still pretty cool since I live in some unknown realm
owned by the coolest button on earth</button>
-->

<!-- Render message from current controller-->
<cool-button>${message} </cool-button>
<!--
RENDERS
<button>I am the parent of the coolest button on earth!</button>
-->


<!-- Render message from within the cool button -->
<cool-button> <template>${message} </template> </cool-button>

<!--
RENDERS
<button>I am inside the coolest button on earth!</button>
-->

</template>
```


```ts

export class App{
message= 'I am the parent of the coolest button on earth!';
}


```






### 🎫 Issues

<!---
* List and link relevant issues here.
-->
N/A
## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Tests writen.
## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

E2E tests.

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
