### PR TITLE
feat(router): configure to not use url fragment hash

### DIFF
--- a/packages/__tests__/router/browser-navigator.spec.ts
+++ b/packages/__tests__/router/browser-navigator.spec.ts
@@ -69,7 +69,7 @@ describe('BrowserNavigator', function () {
   it('can be activated', async function () {
     const { sut, tearDown, callback } = setup();
 
-    await sut.activate(callback);
+    await sut.activate({ callback });
 
     assert.strictEqual(sut['isActive'], true, `sut.isActive`);
     // assert.strictEqual(addEventListener.calls.length, 1, `addEventListener.calls.length`);
@@ -82,7 +82,7 @@ describe('BrowserNavigator', function () {
   it('can be deactivated', async function () {
     const { sut, tearDown, callback } = setup();
 
-    await sut.activate(callback);
+    await sut.activate({ callback });
     assert.strictEqual(sut['isActive'], true, `sut.isActive`);
     // assert.strictEqual(addEventListener.calls.length, 1, `addEventListener.calls.length`);
 
@@ -97,12 +97,12 @@ describe('BrowserNavigator', function () {
   it('throws when activated while active', async function () {
     const { sut, tearDown, callback } = setup();
 
-    await sut.activate(callback);
+    await sut.activate({ callback });
     assert.strictEqual(sut['isActive'], true, `sut.isActive`);
 
     let err;
     try {
-      await sut.activate(callback);
+      await sut.activate({ callback });
     } catch (e) {
       err = e;
     }
@@ -117,11 +117,13 @@ describe('BrowserNavigator', function () {
     const { sut, tearDown, callback } = setup();
 
     let counter = 0;
-    await sut.activate(
-      // Called once for each url/location change (no longer in as part of activation)
-      function () {
-        counter++;
-      });
+    await sut.activate({
+      callback:
+        // Called once for each url/location change (no longer in as part of activation)
+        function () {
+          counter++;
+        }
+    });
 
     await sut.pushNavigatorState(toNavigatorState('one'));
     assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);
@@ -141,7 +143,7 @@ describe('BrowserNavigator', function () {
   it('queues consecutive calls', async function () {
     const { sut, tearDown, callback } = setup();
 
-    await sut.activate(callback);
+    await sut.activate({ callback });
     await wait();
 
     const length = sut['pendingCalls'].length;
@@ -163,11 +165,13 @@ describe('BrowserNavigator', function () {
     const { sut, tearDown, callback } = setup();
 
     let counter = 0;
-    await sut.activate(
-      // Called once for each url/location change (no longer in as part of activation)
-      function () {
-        counter++;
-      });
+    await sut.activate({
+      callback:
+        // Called once for each url/location change (no longer in as part of activation)
+        function () {
+          counter++;
+        }
+    });
 
     await sut.pushNavigatorState(toNavigatorState('one'));
     assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);

--- a/packages/__tests__/router/browser-navigator.spec.ts
+++ b/packages/__tests__/router/browser-navigator.spec.ts
@@ -187,6 +187,63 @@ describe('BrowserNavigator', function () {
 
     tearDown();
   });
+
+  it('defaults to using url fragment hash', async function () {
+    const { sut, tearDown, callback } = setup();
+
+    let instruction;
+    await sut.activate({
+      callback:
+        function (state) {
+          instruction = state;
+        }
+    });
+
+    await sut.pushNavigatorState(toNavigatorState('one'));
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);
+    await sut.pushNavigatorState(toNavigatorState('two'));
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'two', `sut.history.state.currentEntry.instruction`);
+    await sut.go(-1);
+    await Promise.resolve();
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);
+
+    assert.strictEqual(instruction.instruction, '/one', `instruction.instruction`);
+    assert.strictEqual(instruction.path, '/', `instruction.path`);
+    assert.strictEqual(instruction.hash, '#/one', `instruction.hash`);
+
+    sut.deactivate();
+
+    tearDown();
+  });
+
+  it('can be set to not using url fragment hash', async function () {
+    const { sut, tearDown, callback } = setup();
+
+    let instruction;
+    await sut.activate({
+      callback:
+        function (state) {
+          instruction = state;
+        },
+        useUrlFragmentHash: false,
+    });
+
+    await sut.pushNavigatorState(toNavigatorState('one'));
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);
+    await sut.pushNavigatorState(toNavigatorState('two'));
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'two', `sut.history.state.currentEntry.instruction`);
+    await sut.go(-1);
+    await Promise.resolve();
+    assert.strictEqual(sut.history.state.currentEntry.instruction, 'one', `sut.history.state.currentEntry.instruction`);
+
+    assert.strictEqual(instruction.instruction, '/one', `instruction.instruction`);
+    assert.strictEqual(instruction.path, '/one', `instruction.path`);
+    assert.strictEqual(instruction.hash, '', `instruction.hash`);
+
+    sut.deactivate();
+
+    tearDown();
+  });
 });
 
 const toNavigatorState = (instruction: string): INavigatorState => {

--- a/packages/router/src/browser-navigator.ts
+++ b/packages/router/src/browser-navigator.ts
@@ -89,13 +89,13 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
 
   public pushNavigatorState(state: INavigatorState): Promise<void> {
     const { title, path } = state.currentEntry;
-    const fragment = this.options.useBrowserFragmentHash ? '#' : '';
+    const fragment = this.options.useBrowserFragmentHash ? '#/' : '';
     return this.enqueue(this.history, 'pushState', [state, title, `${fragment}${path}`]);
   }
 
   public replaceNavigatorState(state: INavigatorState): Promise<void> {
     const { title, path } = state.currentEntry;
-    const fragment = this.options.useBrowserFragmentHash ? '#' : '';
+    const fragment = this.options.useBrowserFragmentHash ? '#/' : '';
     return this.enqueue(this.history, 'replaceState', [state, title, `${fragment}${path}`]);
   }
 

--- a/packages/router/src/browser-navigator.ts
+++ b/packages/router/src/browser-navigator.ts
@@ -1,7 +1,7 @@
 import { Key, Reporter } from '@aurelia/kernel';
 import { IDOM, ILifecycle } from '@aurelia/runtime';
 import { HTMLDOM } from '@aurelia/runtime-html';
-import { INavigatorState, INavigatorStore, INavigatorViewer, INavigatorViewerEvent, INavigatorViewerOptions } from './navigator';
+import { INavigatorState, INavigatorStore, INavigatorViewer, INavigatorViewerOptions } from './navigator';
 import { Queue, QueueItem } from './queue';
 
 interface Call {
@@ -54,7 +54,10 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
       throw new Error('Browser navigation has already been activated');
     }
     this.isActive = true;
-    this.options = { ...this.options, ...options };
+    this.options.callback = options.callback;
+    if (options.useBrowserFragmentHash != void 0) {
+      this.options.useBrowserFragmentHash = options.useBrowserFragmentHash;
+    }
     this.pendingCalls.activate({ lifecycle: this.lifecycle, allowedExecutionCostWithinTick: this.allowedExecutionCostWithinTick });
     this.window.addEventListener('popstate', this.handlePopstate);
   }

--- a/packages/router/src/browser-navigator.ts
+++ b/packages/router/src/browser-navigator.ts
@@ -18,7 +18,7 @@ interface ForwardedState {
 }
 
 export interface IBrowserNavigatorOptions extends INavigatorViewerOptions {
-  useBrowserFragmentHash?: boolean;
+  useUrlFragmentHash?: boolean;
 }
 
 export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
@@ -33,7 +33,7 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
   private readonly pendingCalls: Queue<Call>;
   private isActive: boolean = false;
   private options: IBrowserNavigatorOptions = {
-    useBrowserFragmentHash: true,
+    useUrlFragmentHash: true,
     callback: () => { },
   };
 
@@ -55,8 +55,8 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
     }
     this.isActive = true;
     this.options.callback = options.callback;
-    if (options.useBrowserFragmentHash != void 0) {
-      this.options.useBrowserFragmentHash = options.useBrowserFragmentHash;
+    if (options.useUrlFragmentHash != void 0) {
+      this.options.useUrlFragmentHash = options.useUrlFragmentHash;
     }
     this.pendingCalls.activate({ lifecycle: this.lifecycle, allowedExecutionCostWithinTick: this.allowedExecutionCostWithinTick });
     this.window.addEventListener('popstate', this.handlePopstate);
@@ -72,7 +72,7 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
     }
     this.window.removeEventListener('popstate', this.handlePopstate);
     this.pendingCalls.deactivate();
-    this.options = { useBrowserFragmentHash: true, callback: () => { } };
+    this.options = { useUrlFragmentHash: true, callback: () => { } };
     this.isActive = false;
   }
 
@@ -89,13 +89,13 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
 
   public pushNavigatorState(state: INavigatorState): Promise<void> {
     const { title, path } = state.currentEntry;
-    const fragment = this.options.useBrowserFragmentHash ? '#/' : '';
+    const fragment = this.options.useUrlFragmentHash ? '#/' : '';
     return this.enqueue(this.history, 'pushState', [state, title, `${fragment}${path}`]);
   }
 
   public replaceNavigatorState(state: INavigatorState): Promise<void> {
     const { title, path } = state.currentEntry;
-    const fragment = this.options.useBrowserFragmentHash ? '#/' : '';
+    const fragment = this.options.useUrlFragmentHash ? '#/' : '';
     return this.enqueue(this.history, 'replaceState', [state, title, `${fragment}${path}`]);
   }
 
@@ -116,7 +116,7 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
         path: pathname,
         data: search,
         hash,
-        instruction: this.options.useBrowserFragmentHash ? hash.slice(1) : pathname,
+        instruction: this.options.useUrlFragmentHash ? hash.slice(1) : pathname,
       });
     }
     if (resolve) {

--- a/packages/router/src/navigator.ts
+++ b/packages/router/src/navigator.ts
@@ -12,8 +12,11 @@ export interface INavigatorStore {
 }
 
 export interface INavigatorViewer {
-  activate(callback: (ev?: INavigatorViewerEvent) => void): void;
+  activate(options: INavigatorViewerOptions): void;
   deactivate(): void;
+}
+export interface INavigatorViewerOptions {
+  callback(ev: INavigatorViewerEvent): void;
 }
 
 export interface INavigatorViewerEvent {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -25,6 +25,7 @@ export const IRouteTransformer = DI.createInterface<IRouteTransformer>('IRouteTr
 
 export interface IRouterOptions extends INavigatorOptions, IRouteTransformer {
   separators?: IRouteSeparators;
+  useBrowserFragmentHash?: boolean;
   reportCallback?(instruction: INavigatorInstruction): void;
 }
 
@@ -127,7 +128,10 @@ export class Router implements IRouter {
       store: this.navigation,
     });
     this.linkHandler.activate({ callback: this.linkCallback });
-    this.navigation.activate(this.browserNavigatorCallback);
+    this.navigation.activate({
+      callback: this.browserNavigatorCallback,
+      useBrowserFragmentHash: this.options.useBrowserFragmentHash
+    });
   }
 
   public loadUrl(): Promise<void> {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -219,6 +219,10 @@ export class Router implements IRouter {
         // TODO: Don't go via string here, use instructions as they are
         path = Array.isArray(routeOrInstructions) ? this.instructionResolver.stringifyViewportInstructions(routeOrInstructions) : routeOrInstructions;
       }
+      // TODO: Review this
+      if (path === '/') {
+        path = '';
+      }
 
       // TODO: Clean up clear viewports
       const { clear, newPath } = this.instructionResolver.shouldClearViewports(path);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -25,7 +25,7 @@ export const IRouteTransformer = DI.createInterface<IRouteTransformer>('IRouteTr
 
 export interface IRouterOptions extends INavigatorOptions, IRouteTransformer {
   separators?: IRouteSeparators;
-  useBrowserFragmentHash?: boolean;
+  useUrlFragmentHash?: boolean;
   reportCallback?(instruction: INavigatorInstruction): void;
 }
 
@@ -130,7 +130,7 @@ export class Router implements IRouter {
     this.linkHandler.activate({ callback: this.linkCallback });
     this.navigation.activate({
       callback: this.browserNavigatorCallback,
-      useBrowserFragmentHash: this.options.useBrowserFragmentHash
+      useUrlFragmentHash: this.options.useUrlFragmentHash
     });
   }
 

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -227,7 +227,11 @@ export class MockBrowserHistoryLocation {
   get pathname(): string {
     const parts = this.parts;
     // parts.shift();
-    return parts.shift()!;
+    let path = parts.shift()!;
+    if (!path.startsWith('/')) {
+      path = `/${path}`;
+    }
+    return path;
   }
   get search(): string {
     const parts = this.parts;

--- a/test/realworld/package-lock.json
+++ b/test/realworld/package-lock.json
@@ -403,21 +403,21 @@
       "version": "file:../../packages/kernel"
     },
     "@aurelia/plugin-conventions": {
-      "version": "0.4.0-dev.201908192330",
-      "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-0.4.0-dev.201908192330.tgz",
-      "integrity": "sha512-2A+nVrxnBWHbVZ73wQBYeeukkqdl0aOp2M+KDZU/anlZw8ZCgewkYQEitaIT1VNou3a5v/yfgcsmEoh8+B7pWA==",
+      "version": "0.4.0-dev.201908250007",
+      "resolved": "https://registry.npmjs.org/@aurelia/plugin-conventions/-/plugin-conventions-0.4.0-dev.201908250007.tgz",
+      "integrity": "sha512-HenR6sFAsneXgKRrC5qWAhe/FJKH34jI2s7rHw0SIvSMuxowFtZpFpl8CnN5PBrPHrzVS7G1QxVUFG9mM8LhSA==",
       "dev": true,
       "requires": {
-        "@aurelia/kernel": "^0.4.0-dev.201908192330",
+        "@aurelia/kernel": "^0.4.0-dev.201908250007",
         "modify-code": "^0.5.3",
         "parse5": "^5.1.0",
         "typescript": "^3.5.3"
       },
       "dependencies": {
         "@aurelia/kernel": {
-          "version": "0.4.0-dev.201908192330",
-          "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-0.4.0-dev.201908192330.tgz",
-          "integrity": "sha512-VjLkGJDgnttSkRXEz3wnrHMI5obJm1rjCaMWtvZlYbtjYOr8lnjQXUIFaSYqUxFJs3OSty1z3ELQXh6TKTlAfw==",
+          "version": "0.4.0-dev.201908250007",
+          "resolved": "https://registry.npmjs.org/@aurelia/kernel/-/kernel-0.4.0-dev.201908250007.tgz",
+          "integrity": "sha512-Rwn3OpaMhjU6QfYOxDPONm9XO6f42IQ0gXlftgQ1n+1dO8ZILE+/SN13RCJoy19HcjQGNInO2WEOTK0VIfPcDA==",
           "dev": true
         }
       }
@@ -569,12 +569,12 @@
       }
     },
     "@aurelia/webpack-loader": {
-      "version": "0.4.0-dev.201908192330",
-      "resolved": "https://registry.npmjs.org/@aurelia/webpack-loader/-/webpack-loader-0.4.0-dev.201908192330.tgz",
-      "integrity": "sha512-33w9V3oxHSstfznwHjy0llE+wNi2dZEi4D+4mYds0cE6MtzJOAzb0iwGJ81vsmJkvbHh51RJU2hSV0KCu0ehdQ==",
+      "version": "0.4.0-dev.201908250007",
+      "resolved": "https://registry.npmjs.org/@aurelia/webpack-loader/-/webpack-loader-0.4.0-dev.201908250007.tgz",
+      "integrity": "sha512-oeo8sgSN7niSbPsjkurbE5vnPIOQ8fcwmvlJMr0mdE9v1V7KmKY+/6tGEsfeM/bqYlxP/10Kz1KhtEZK2KMnIA==",
       "dev": true,
       "requires": {
-        "@aurelia/plugin-conventions": "^0.4.0-dev.201908192330",
+        "@aurelia/plugin-conventions": "^0.4.0-dev.201908250007",
         "loader-utils": "^1.2.3"
       }
     },
@@ -1533,6 +1533,15 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -1598,9 +1607,9 @@
       }
     },
     "chokidar": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
-      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -2053,6 +2062,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -2215,9 +2235,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.1.tgz",
+      "integrity": "sha512-C14oTzTZy8DH1Eq8N78owrCWvf3+cnJw88BTK/N3DYWVxDJuJzPaNdplzYxDYuuXXGvqBcO4Vy5SOrwAooXSWw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -2325,6 +2345,17 @@
         "p-map": "^2.0.0",
         "pify": "^4.0.1",
         "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "delayed-stream": {
@@ -5130,9 +5161,9 @@
       }
     },
     "marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -5395,6 +5426,17 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -6608,9 +6650,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -6717,9 +6759,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
+      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
       "dev": true
     },
     "serve-index": {
@@ -7369,26 +7411,13 @@
       "dev": true
     },
     "style-loader": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
-      "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.0.0.tgz",
+      "integrity": "sha512-B0dOCFwv7/eY31a5PCieNwMgMhVGFe9w+rh7s/Bx8kfFkrth9zfTZquoYvdw8URgiqxObQKcpW51Ugz1HjfdZw==",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
       }
     },
     "supports-color": {
@@ -7407,9 +7436,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.0.tgz",
-      "integrity": "sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.2.1.tgz",
+      "integrity": "sha512-cGbc5utAcX4a9+2GGVX4DsenG6v0x3glnDi5hx8816X1McEAwPlPgRtXPJzSBsbpILxZ8MQMT0KvArLuE0HP5A==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -7627,9 +7656,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.18.0.tgz",
-      "integrity": "sha512-Q3kXkuDEijQ37nXZZLKErssQVnwCV/+23gFEMROi8IlbaBG6tXqLPQJ5Wjcyt/yHPKBC+hD5SzuGaMora+ZS6w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz",
+      "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",

--- a/test/realworld/src/app.html
+++ b/test/realworld/src/app.html
@@ -1,3 +1,4 @@
 <header-layout></header-layout>
+<label style="display: block; padding-left: 40px;"><input type="checkbox" checked.two-way="router.navigation.options.useUrlFragmentHash">Use browser fragment (hash)</label>
 <au-viewport name="main" default="home"></au-viewport>
 <footer-layout></footer-layout>

--- a/test/realworld/src/app.html
+++ b/test/realworld/src/app.html
@@ -1,4 +1,3 @@
 <header-layout></header-layout>
-<label style="display: block; padding-left: 40px;"><input type="checkbox" checked.two-way="router.navigation.options.useUrlFragmentHash">Use browser fragment (hash)</label>
 <au-viewport name="main" default="home"></au-viewport>
 <footer-layout></footer-layout>

--- a/test/realworld/src/main.ts
+++ b/test/realworld/src/main.ts
@@ -29,7 +29,7 @@ const globalResources = [
   .register(
     BasicConfiguration,
     DebugConfiguration,
-    RouterConfiguration,
+    RouterConfiguration.customize({ useUrlFragmentHash: true }),
     ...globalResources,
   )
   .app({

--- a/test/realworld/src/main.ts
+++ b/test/realworld/src/main.ts
@@ -29,7 +29,7 @@ const globalResources = [
   .register(
     BasicConfiguration,
     DebugConfiguration,
-    RouterConfiguration.customize({ useUrlFragmentHash: true }),
+    RouterConfiguration.customize({ useUrlFragmentHash: false }),
     ...globalResources,
   )
   .app({

--- a/test/realworld/src/resources/value-converters/date.ts
+++ b/test/realworld/src/resources/value-converters/date.ts
@@ -8,9 +8,10 @@ export class DateValueConverter {
   * "July 27, 2017"
   */
   public toView(value: Date | string | number) {
-    return format(
-      value,
-      'MMMM D, YYYY',
-    );
+    return value;
+    //   return format(
+    //     value,
+    //     'MMMM D, YYYY',
+    //   );
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes it possible to configure the router to not use url fragment hash (to "use push state").

```typescript
au.register(
    RouterConfiguration.customize({ useUrlFragmentHash: false }),
  )
```

Note that the web server need to be configured to handle "redirects to the right application page" for deep links and other browser url manipulations to work. 

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Added two new tests that tests the configuration difference.
- Make sure existing tests pass.

## ⏭ Next Steps

- Implement scope traversal to Router's `goto` method
- Add tests for the new au-nav options
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->