### PR TITLE
fix(di): defer should not register primitives

### DIFF
--- a/packages/__tests__/kernel/di.integration.spec.ts
+++ b/packages/__tests__/kernel/di.integration.spec.ts
@@ -821,4 +821,26 @@ describe('defer registration', () => {
 
     assert.strictEqual(data.wasCalled, true);
   });
+
+  [
+    {
+      name: 'string',
+      value: 'some string value'
+    },
+    {
+      name: 'boolean',
+      value: true
+    },
+    {
+      name: 'number',
+      value: 42
+    }
+  ].forEach(x => {
+    it (`does not pass ${x.name} params to the container's register when no handler is found`, () => {
+      const container = DI.createContainer();
+      container.register(
+        Registration.defer('.css', x.value)
+      );
+    });
+  });
 });

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -781,8 +781,8 @@ export class ParameterizedRegistry implements IRegistry {
     if (container.has(this.key, true)) {
       const registry = container.get<IRegistry>(this.key);
       registry.register(container, ...this.params);
-    } else  {
-      container.register(...this.params);
+    } else {
+      container.register(...this.params.filter(x => typeof x === 'object'));
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

A basic fix to the `Registration.defer` implementation that prevents primitive data values from being passed to the container when there's no handler. This is specifically for CSS view build scenarios where no special CSS handling is needed at runtime.