### PR TITLE
refactor(router): make load url awaitable

### DIFF
--- a/packages/router/src/browser-navigator.ts
+++ b/packages/router/src/browser-navigator.ts
@@ -72,14 +72,14 @@ export class BrowserNavigator implements INavigatorStore, INavigatorViewer {
     this.isActive = false;
   }
 
-  get length(): number {
+  public get length(): number {
     return this.history.length;
   }
-  get state(): Record<string, unknown> {
+  public get state(): Record<string, unknown> {
     return this.history.state;
   }
 
-  get viewerState(): INavigatorViewerState {
+  public get viewerState(): INavigatorViewerState {
     const { pathname, search, hash } = this.location;
     return {
       path: pathname,

--- a/packages/router/src/navigator.ts
+++ b/packages/router/src/navigator.ts
@@ -19,13 +19,16 @@ export interface INavigatorViewerOptions {
   callback(ev: INavigatorViewerEvent): void;
 }
 
-export interface INavigatorViewerEvent {
-  event: PopStateEvent;
-  state?: INavigatorState;
+export interface INavigatorViewerState {
   path: string;
-  data: string;
+  query: string;
   hash: string;
   instruction: string;
+}
+
+export interface INavigatorViewerEvent extends INavigatorViewerState {
+  event: PopStateEvent;
+  state?: INavigatorState;
 }
 
 export interface IStoredNavigatorEntry {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -135,7 +135,15 @@ export class Router implements IRouter {
   }
 
   public loadUrl(): Promise<void> {
-    return this.navigation.loadUrl();
+    const entry: INavigatorEntry = {
+      ...this.navigation.viewerState,
+      ...{
+        fullStateInstruction: '',
+        replacing: true,
+        fromBrowser: false,
+      }
+    };
+    return this.navigator.navigate(entry);
   }
 
   public deactivate(): void {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the router's `loadUrl` method `await`able by returning a promise that's resolved when the url is loaded.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure existing tests pass.

## ⏭ Next Steps

- Implement scope traversal to Router's `goto` method
- Add tests for the new au-nav options
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->