### PR TITLE
Conventional view locator

### DIFF
--- a/packages/__tests__/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-html-template.spec.ts
@@ -317,5 +317,5 @@ export function getHTMLOnlyElement() {
       })
     );
     assert.equal(result.code, expected);
-  })
+  });
 });

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -46,6 +46,24 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
+  it('injects customElement decorator for loosely equal class name', function () {
+    const code = `export class UAFooBar {}\n`;
+    const expected = `import * as __au2ViewDef from './ua-foo-bar.html';
+import { customElement } from '@aurelia/runtime';
+@customElement(__au2ViewDef)
+export class UAFooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'ua-foo-bar.js'),
+        contents: code,
+        filePair: 'ua-foo-bar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects view decorator', function () {
     const code = `export class FooBar {}\n`;
     const expected = `import * as __au2ViewDef from './foo-bar-view.html';
@@ -58,6 +76,24 @@ export class FooBar {}
         path: path.join('bar', 'foo-bar.js'),
         contents: code,
         filePair: 'foo-bar-view.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects view decorator for loosely equal class name', function () {
+    const code = `export class UAFooBar {}\n`;
+    const expected = `import * as __au2ViewDef from './ua-foo-bar-view.html';
+import { view } from '@aurelia/runtime';
+@view(__au2ViewDef)
+export class UAFooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'ua-foo-bar.js'),
+        contents: code,
+        filePair: 'ua-foo-bar-view.html'
       },
       preprocessOptions()
     );

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -46,6 +46,24 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
+  it('injects view decorator', function () {
+    const code = `export class FooBar {}\n`;
+    const expected = `import * as __au2ViewDef from './foo-bar-view.html';
+import { view } from '@aurelia/runtime';
+@view(__au2ViewDef)
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar-view.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects customElement decorator for non-kebab case file name', function () {
     const code = `export class FooBar {}\n`;
     const expected = `import * as __au2ViewDef from './FooBar.html';
@@ -58,6 +76,24 @@ export class FooBar {}
         path: path.join('bar', 'FooBar.js'),
         contents: code,
         filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects view decorator for non-kebab case file name', function () {
+    const code = `export class FooBar {}\n`;
+    const expected = `import * as __au2ViewDef from './FooBarView.html';
+import { view } from '@aurelia/runtime';
+@view(__au2ViewDef)
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBarView.html'
       },
       preprocessOptions()
     );
@@ -88,6 +124,84 @@ function b() {}
         path: path.join('bar', 'foo-bar.js'),
         contents: code,
         filePair: 'foo-bar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('does not inject customElement decorator for decorated resource', function () {
+    const code = `import { customElement } from '@aurelia/runtime';
+import * as lorem from './lorem.html';
+
+@customElement(lorem)
+export class FooBar {}
+`;
+    const expected = `import { customElement } from '@aurelia/runtime';
+import * as lorem from './lorem.html';
+
+@customElement(lorem)
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects view decorator with existing runtime import', function () {
+    const code = `import { containerless } from '@aurelia/runtime';
+
+const A = 0;
+@containerless()
+export class FooBar {}
+
+function b() {}
+`;
+    const expected = `import * as __au2ViewDef from './foo-bar-view.html';
+import { containerless, view } from '@aurelia/runtime';
+
+const A = 0;
+@view(__au2ViewDef)
+@containerless()
+export class FooBar {}
+
+function b() {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar-view.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('does not inject view decorator for decorated resource', function () {
+    const code = `import { view } from '@aurelia/runtime';
+import * as lorem from './lorem.html';
+
+@view(lorem)
+export class FooBar {}
+`;
+    const expected = `import { view } from '@aurelia/runtime';
+import * as lorem from './lorem.html';
+
+@view(lorem)
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar-view.html'
       },
       preprocessOptions()
     );

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -77,8 +77,8 @@ function b() {}
 import { containerless, customElement } from '@aurelia/runtime';
 
 const A = 0;
-@containerless()
 @customElement(__au2ViewDef)
+@containerless()
 export class FooBar {}
 
 function b() {}
@@ -413,6 +413,45 @@ export class SomeValueConverter {
 }
 
 @customElement({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependencies, SomeValueConverter ] })
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.ts'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects new decorator before existing decorator', function () {
+    const code = `import { something } from '@aurelia/runtime';
+@something
+export class FooBar {}
+
+@something()
+export class SomeValueConverter {
+  toView(value: string): string {
+    return value;
+  }
+}
+`;
+    const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { something, customElement, valueConverter } from '@aurelia/runtime';
+
+
+@valueConverter('some')
+@something()
+export class SomeValueConverter {
+  toView(value: string): string {
+    return value;
+  }
+}
+
+@customElement({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependencies, SomeValueConverter ] })
+@something
 export class FooBar {}
 `;
     const result = preprocessResource(

--- a/packages/__tests__/plugin-conventions/preprocess.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess.spec.ts
@@ -129,6 +129,26 @@ export class FooBar {}
     assert.equal(result.map.version, 3);
   });
 
+  it('injects view decorator', function () {
+    const js = `export class FooBar {}\n`;
+    const expected = `import * as __au2ViewDef from './foo-bar-view.html';
+import { view } from '@aurelia/runtime';
+@view(__au2ViewDef)
+export class FooBar {}
+`;
+    const result = preprocess(
+      {
+        path: path.join('src', 'foo-bar.ts'),
+        contents: js,
+        base: 'base'
+      },
+      {},
+      (filePath: string) => filePath === path.join('base', 'src', 'foo-bar-view.html')
+    );
+    assert.equal(result.code, expected);
+    assert.equal(result.map.version, 3);
+  });
+
   it('injects various decorators when there is implicit custom element', function () {
     const js = `import {Foo} from './foo';
 import { valueConverter } from '@aurelia/runtime';

--- a/packages/plugin-conventions/src/options.ts
+++ b/packages/plugin-conventions/src/options.ts
@@ -1,4 +1,4 @@
-export type ResourceType = 'customElement' | 'customAttribute' | 'valueConverter' | 'bindingBehavior' | 'bindingCommand';
+export type ResourceType = 'view' | 'customElement' | 'customAttribute' | 'valueConverter' | 'bindingBehavior' | 'bindingCommand';
 
 export interface INameConvention {
   name: string;

--- a/packages/plugin-conventions/src/preprocess-resource.ts
+++ b/packages/plugin-conventions/src/preprocess-resource.ts
@@ -198,6 +198,10 @@ function findDecoratedResourceType(node: ts.Node): ResourceType | void {
   }
 }
 
+function isKindOfSame(name1: string, name2: string): boolean {
+  return name1.replace(/-/g, '') === name2.replace(/-/g, '');
+}
+
 function findResource(node: ts.Node, expectedResourceName: string, filePair: string | undefined, code: string): IFoundResource | void {
   if (!ts.isClassDeclaration(node)) return;
   if (!node.name) return;
@@ -206,7 +210,7 @@ function findResource(node: ts.Node, expectedResourceName: string, filePair: str
 
   const className = node.name.text;
   const {name, type} = nameConvention(className);
-  const isImplicitResource = name === expectedResourceName;
+  const isImplicitResource = isKindOfSame(name, expectedResourceName);
   const decoratedType = findDecoratedResourceType(node);
 
   if (decoratedType) {
@@ -220,7 +224,7 @@ function findResource(node: ts.Node, expectedResourceName: string, filePair: str
       if (isImplicitResource && filePair) {
         return {
           implicitStatement: { pos: pos, end: node.end },
-          runtimeImportName: kebabCase(filePair).startsWith(name + '-view') ? 'view' : 'customElement'
+          runtimeImportName: kebabCase(filePair).startsWith(expectedResourceName + '-view') ? 'view' : 'customElement'
         };
       }
     } else {

--- a/packages/plugin-conventions/src/preprocess.ts
+++ b/packages/plugin-conventions/src/preprocess.ts
@@ -39,6 +39,20 @@ export function preprocess(
       } else {
         unit.filePair = path.basename(filePair);
       }
+    } else {
+      // Try foo.js and foo-view.html convention.
+      // This convention is handled by @view(), not @customElement().
+      const possibleViewPair = allOptions.templateExtensions.map(e =>
+        path.join(base, unit.path.slice(0, - ext.length) + '-view' + e)
+      );
+      const viewPair = possibleViewPair.find(_fileExists);
+      if (viewPair) {
+        if (allOptions.useProcessedFilePairFilename) {
+          unit.filePair = basename  + '-view' + '.html';
+        } else {
+          unit.filePair = path.basename(viewPair);
+        }
+      }
     }
     return preprocessResource(unit, allOptions);
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

1. Implement conventional `@view` decorator for #584.
2. Fixed a compatibility issue on existing decorators. The injected decorator is now before existing decorators.
3. Improve compatibility with uppercase resource name
    - Convention now support ua-foo.js to match resource class name UAFoo.
### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ⏭ Next Steps
