### PR TITLE
refactor(plugin-conventions): simplify usage of html only element

### DIFF
--- a/packages/__tests__/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-html-template.spec.ts
@@ -11,11 +11,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate({ path: path.join('lo', 'foo-bar.html'), contents: html }, preprocessOptions());
@@ -32,11 +32,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ Registration.defer('.css', d0) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate({ path: path.join('lo', 'foo-bar.html'), contents: html, filePair: 'foo-bar.css' }, preprocessOptions());
@@ -53,11 +53,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ Registration.defer('.css', d0) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate({ path: path.join('lo', 'foo-bar.html'), contents: html, filePair: 'foo-bar.css' }, preprocessOptions());
@@ -67,8 +67,7 @@ export function getHTMLOnlyElement() {
   it('processes template with dependencies', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "./foo-bar.scss";
@@ -77,11 +76,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate({ path: path.join('lo', 'FooBar.html'), contents: html }, preprocessOptions());
@@ -91,8 +90,7 @@ export function getHTMLOnlyElement() {
   it('supports HTML-only dependency not in html format', function () {
     const html = '<import from="./hello-world.md" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.md";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.md";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "./foo-bar.scss";
@@ -101,11 +99,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate({ path: path.join('lo', 'FooBar.html'), contents: html }, preprocessOptions());
@@ -115,8 +113,7 @@ export function getHTMLOnlyElement() {
   it('processes template with dependencies, wrap css module id', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "./foo-bar.scss";
@@ -125,11 +122,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -142,8 +139,7 @@ export function getHTMLOnlyElement() {
   it('processes template with css dependencies in shadowDOM mode', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "!!raw-loader!./foo-bar.scss";
@@ -153,11 +149,11 @@ export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 export const shadowOptions = { mode: 'open' };
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, shadowOptions });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -173,8 +169,7 @@ export function getHTMLOnlyElement() {
   it('processes template with css dependencies in shadowDOM mode with string module wrap', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "!!raw-loader!./foo-bar.scss";
@@ -184,11 +179,11 @@ export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 export const shadowOptions = { mode: 'closed' };
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, shadowOptions });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -204,8 +199,7 @@ export function getHTMLOnlyElement() {
   it('processes template with css dependencies in shadowDOM mode with string module wrap and explicit shadow mode', function () {
     const html = '<import from="./hello-world.html"><use-shadow-dom><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "!!raw-loader!./foo-bar.scss";
@@ -215,11 +209,11 @@ export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 export const shadowOptions = { mode: 'open' };
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, shadowOptions });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -235,8 +229,7 @@ export function getHTMLOnlyElement() {
   it('processes template with css dependencies in per-file shadowDOM mode with string module wrap and explicit shadow mode', function () {
     const html = '<import from="./hello-world.html"><use-shadow-dom><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "!!raw-loader!./foo-bar.scss";
@@ -246,11 +239,11 @@ export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 export const shadowOptions = { mode: 'open' };
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, shadowOptions });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -266,8 +259,7 @@ export function getHTMLOnlyElement() {
     const html = '<import from="./hello-world.html"><use-shadow-dom><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
 console.warn("WARN: ShadowDOM is disabled for ${path.join('lo', 'foo.html')}. ShadowDOM requires element name to contain a dash (-), you have to refactor <foo> to something like <lorem-foo>.");
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "./foo-bar.scss";
@@ -276,11 +268,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(
@@ -303,11 +295,11 @@ export const dependencies = [  ];
 export const containerless = true;
 export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, containerless, bindables });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocessHtmlTemplate(

--- a/packages/__tests__/plugin-conventions/preprocess.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess.spec.ts
@@ -11,11 +11,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocess({ path: path.join('src', 'foo-bar.html'), contents: html }, {}, () => false);
@@ -33,11 +33,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ Registration.defer('.css', d0) ];
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocess(
@@ -57,8 +57,7 @@ export function getHTMLOnlyElement() {
   it('transforms html file with shadowOptions', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime';
-import * as h0 from "./hello-world.html";
-const d0 = h0.getHTMLOnlyElement();
+import * as d0 from "./hello-world.html";
 import * as d1 from "foo";
 import { Registration } from '@aurelia/kernel';
 import d2 from "!!raw-loader!./foo-bar.scss";
@@ -68,11 +67,11 @@ export default template;
 export const dependencies = [ d0, d1, Registration.defer('.css', d2) ];
 export const shadowOptions = { mode: 'open' };
 let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies, shadowOptions });
   }
-  return _e;
+  container.register(_e);
 }
 `;
     const result = preprocess(

--- a/packages/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages/plugin-conventions/src/preprocess-html-template.ts
@@ -45,10 +45,7 @@ export function preprocessHtmlTemplate(unit: IFileUnit, options: IPreprocessOpti
 
   deps.forEach((d, i) => {
     const ext = path.extname(d);
-    if (options.templateExtensions.includes(ext)) {
-      statements.push(`import * as h${i} from ${s(d)};\nconst d${i} = h${i}.getHTMLOnlyElement();\n`);
-      viewDeps.push(`d${i}`);
-    } else if (ext && ext !== '.js' && ext !== '.ts') {
+    if (ext && ext !== '.js' && ext !== '.ts' && !options.templateExtensions.includes(ext)) {
       // Wrap all other unknown resources (including .css, .scss) in defer.
       if (!registrationImported) {
         statements.push(`import { Registration } from '@aurelia/kernel';\n`);
@@ -91,11 +88,11 @@ export const dependencies = [ ${viewDeps.join(', ')} ];
   }
 
   m.append(`let _e;
-export function getHTMLOnlyElement() {
+export function register(container) {
   if (!_e) {
     _e = CustomElement.define({ name, template, dependencies${shadowMode ? ', shadowOptions' : ''}${containerless ? ', containerless' : ''}${Object.keys(bindables).length ? ', bindables' : ''} });
   }
-  return _e;
+  container.register(_e);
 }
 `);
   const { code, map } = m.transform();

--- a/packages/plugin-gulp/README.md
+++ b/packages/plugin-gulp/README.md
@@ -50,6 +50,7 @@ For apps in TypeScript, an extra typing definition is required for html module. 
 `html.d.ts`
 ```ts
 declare module '*.html' {
+  import { IContainer } from '@aurelia/kernel';
   import { IBindableDescription } from '@aurelia/runtime';
   export const name: string;
   export const template: string;
@@ -58,7 +59,7 @@ declare module '*.html' {
   export const containerless: boolean | undefined;
   export const bindables: Record<string, IBindableDescription>;
   export const shadowOptions: { mode: 'open' | 'closed'} | undefined;
-  export function getHTMLOnlyElement();
+  export function register(container: IContainer);
 }
 ```
 

--- a/packages/webpack-loader/README.md
+++ b/packages/webpack-loader/README.md
@@ -57,6 +57,7 @@ For apps in TypeScript, an extra typing definition is required for html module. 
 `html.d.ts`
 ```ts
 declare module '*.html' {
+  import { IContainer } from '@aurelia/kernel';
   import { IBindableDescription } from '@aurelia/runtime';
   export const name: string;
   export const template: string;
@@ -65,7 +66,7 @@ declare module '*.html' {
   export const containerless: boolean | undefined;
   export const bindables: Record<string, IBindableDescription>;
   export const shadowOptions: { mode: 'open' | 'closed'} | undefined;
-  export function getHTMLOnlyElement();
+  export function register(container: IContainer);
 }
 ```
 

--- a/test/realworld/src/html.d.ts
+++ b/test/realworld/src/html.d.ts
@@ -1,7 +1,12 @@
 declare module '*.html' {
+  import { IContainer } from '@aurelia/kernel';
+  import { IBindableDescription } from '@aurelia/runtime';
   export const name: string;
   export const template: string;
   export default template;
   export const dependencies: string[];
-  export function getHTMLOnlyElement();
+  export const containerless: boolean | undefined;
+  export const bindables: Record<string, IBindableDescription>;
+  export const shadowOptions: { mode: 'open' | 'closed'} | undefined;
+  export function register(container: IContainer);
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

As Rob suggested, simplified HTML only element by implementing `register(container)` method in html module.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

Passed manually tested in app.

## ⏭ Next Steps

Need to update makes skeleton after this release.
