### PR TITLE
refactor(debug): rename Tracer to DebugTracer

### DIFF
--- a/packages/__tests__/router/e2e/nav/src/tracing.ts
+++ b/packages/__tests__/router/e2e/nav/src/tracing.ts
@@ -1,5 +1,5 @@
 import { ITraceInfo, Tracer } from '@aurelia/kernel';
-import { Tracer as DebugTracer } from '../../../../../debug/src/tracer';
+import { DebugTracer } from '../../../../../debug/src/tracer';
 
 export const TraceWriter = {
   write(info: ITraceInfo): void {

--- a/packages/debug/src/configuration.ts
+++ b/packages/debug/src/configuration.ts
@@ -1,7 +1,7 @@
-import { IContainer, Reporter as RuntimeReporter, Tracer as RuntimeTracer } from '@aurelia/kernel';
+import { IContainer, Reporter as RuntimeReporter, Tracer } from '@aurelia/kernel';
 import { enableImprovedExpressionDebugging } from './binding/unparser';
 import { Reporter } from './reporter';
-import { Tracer } from './tracer';
+import { DebugTracer } from './tracer';
 
 export const DebugConfiguration = {
   register(container?: IContainer): void {
@@ -13,6 +13,6 @@ export const DebugConfiguration = {
 
 export const TraceConfiguration = {
   register(container?: IContainer): void {
-    Object.assign(RuntimeTracer, Tracer);
+    Object.assign(Tracer, DebugTracer);
   }
 };

--- a/packages/debug/src/index.ts
+++ b/packages/debug/src/index.ts
@@ -4,7 +4,7 @@ export {
 } from './configuration';
 
 export {
-  Tracer,
+  DebugTracer,
   stringifyLifecycleFlags,
 } from './tracer';
 

--- a/packages/debug/src/tracer.ts
+++ b/packages/debug/src/tracer.ts
@@ -1,4 +1,4 @@
-import { ILiveLoggingOptions, ITraceInfo, ITraceWriter, PLATFORM, Reporter, Tracer as RuntimeTracer } from '@aurelia/kernel';
+import { ILiveLoggingOptions, ITraceInfo, ITraceWriter, PLATFORM, Reporter, Tracer } from '@aurelia/kernel';
 import { IScope, LifecycleFlags } from '@aurelia/runtime';
 
 const marker: ITraceInfo = {
@@ -57,8 +57,8 @@ class TraceInfo implements ITraceInfo {
   }
 }
 
-export const Tracer: typeof RuntimeTracer = {
-  ...RuntimeTracer,
+export const DebugTracer: typeof Tracer = {
+  ...Tracer,
   /**
    * A convenience property for the user to conditionally call the tracer.
    * This saves unnecessary `noop` and `slice` calls in non-AOT scenarios even if debugging is disabled.
@@ -144,13 +144,13 @@ const defaultOptions: ILiveLoggingOptions = Object.freeze({
  * Writes out each trace info item as they are traced.
  * @param writer An object to write the output to.
  */
-function enableLiveLogging(this: typeof Tracer, writer: ITraceWriter): void;
+function enableLiveLogging(this: typeof DebugTracer, writer: ITraceWriter): void;
 /**
  * Writes out each trace info item as they are traced.
  * @param options Optional. Specify which logging categories to output. If omitted, all will be logged.
  */
-function enableLiveLogging(this: typeof Tracer, options?: ILiveLoggingOptions): void;
-function enableLiveLogging(this: typeof Tracer, optionsOrWriter?: ILiveLoggingOptions | ITraceWriter): void {
+function enableLiveLogging(this: typeof DebugTracer, options?: ILiveLoggingOptions): void;
+function enableLiveLogging(this: typeof DebugTracer, optionsOrWriter?: ILiveLoggingOptions | ITraceWriter): void {
   this.liveLoggingEnabled = true;
   if (optionsOrWriter && 'write' in optionsOrWriter) {
     this.liveWriter = optionsOrWriter;

--- a/packages/testing/src/tracing.ts
+++ b/packages/testing/src/tracing.ts
@@ -1,6 +1,6 @@
 import {
   stringifyLifecycleFlags,
-  Tracer as DebugTracer
+  DebugTracer
 } from '@aurelia/debug';
 import {
   ICustomAttributeSymbol,


### PR DESCRIPTION
This is part of #630, to avoid naming conflict with kernel Tracer.

BREAKING CHANGE: debug Tracer is renamed to DebugTracer
