### PR TITLE
feat(aurelia): single "aurelia" package to re-exports internals

### DIFF
--- a/docs/engineering-notes/specs.md
+++ b/docs/engineering-notes/specs.md
@@ -51,7 +51,7 @@ To start an Aurelia application, create a `new Aurelia()` object with a target `
 
 ```ts
 import { Aurelia } from '@aurelia/jit-html-browser';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { ThirdPartyPlugin } from 'third-party-plugin';
 
 // Object API.
@@ -59,7 +59,7 @@ const app = new Aurelia({
   host: 'my-host-element',
   component: MyRootComponent
   plugins: [
-    BasicCofiguration,
+    JitHtmlBrowserConfiguration,
     ThirdPartyPlugin
   ]
 }).start();
@@ -69,7 +69,7 @@ const app = new Aurelia()
   .host('my-host-element')
   .component(MyRootComponent)
   .plugins([
-    BasicCofiguration,
+    JitHtmlBrowserConfiguration,
     ThirdPartyPlugin
   ])
   .start();

--- a/docs/engineering-notes/specs.md
+++ b/docs/engineering-notes/specs.md
@@ -18,28 +18,30 @@ Note: The contents in this document may no longer apply or be out of date.
 ```ts
 import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
 import { MyRootComponent } from './my-root-component';
-au(MyRootComponent); // by default host to element name (<my-root-component> for MyRootComponent),
-                     // or <body> if <my-root-component> is absent.
+// By default host to element name (<my-root-component> for MyRootComponent),
+// or <body> if <my-root-component> is absent.
+au.app(MyRootComponent).start();
 
-// or load additional aurelia features
-au(MyRootComponent, {
-  deps: [ // deps or dependencies
+// Or load additional aurelia features
+au
+  .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
-  ]
-});
+  )
+  .app(MyRootComponent)
+  .start();
 
-// or host to <my-start-tag>
-au(MyRootComponent, {
-  host: 'my-start-tag'
-});
-au(MyRootComponent, {
-  host: document.querySelector('my-start-tag'),
-  deps: [
+// Or host to <my-start-tag>
+au
+  .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
-  ]
-});
+  )
+  .app({
+    component: MyRootComponent,
+    host: document.querySelector('my-start-tag')
+  })
+  .start();
 ```
 
 ## Verbose Startup

--- a/docs/engineering-notes/specs.md
+++ b/docs/engineering-notes/specs.md
@@ -11,6 +11,39 @@ Note: The contents in this document may no longer apply or be out of date.
 
 # Application Startup
 
+## New Quick Startup (recommended)
+*Spec: https://github.com/aurelia/aurelia/issues/630* <br />
+*Status: 0/Discussion*
+
+```ts
+import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
+import { MyRootComponent } from './my-root-component';
+au(MyRootComponent); // by default host to element name (<my-root-component> for MyRootComponent),
+                     // or <body> if <my-root-component> is absent.
+
+// or load additional aurelia features
+au(MyRootComponent, {
+  deps: [ // deps or dependencies
+    StyleConfiguration.shadowDOM(),
+    RouterConfiguration.customize({ useUrlFragmentHash: false })
+  ]
+});
+
+// or host to <my-start-tag>
+au(MyRootComponent, {
+  host: 'my-start-tag'
+});
+au(MyRootComponent, {
+  host: document.querySelector('my-start-tag'),
+  deps: [
+    StyleConfiguration.shadowDOM(),
+    RouterConfiguration.customize({ useUrlFragmentHash: false })
+  ]
+});
+```
+
+## Verbose Startup
+
 *Spec: https://github.com/aurelia/aurelia/issues/397* <br />
 *Status: 0/Discussion*
 

--- a/docs/engineering-notes/specs.md
+++ b/docs/engineering-notes/specs.md
@@ -16,14 +16,14 @@ Note: The contents in this document may no longer apply or be out of date.
 *Status: 0/Discussion*
 
 ```ts
-import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
+import Aurelia, { StyleConfiguration, RouterConfiguration } from 'aurelia';
 import { MyRootComponent } from './my-root-component';
 // By default host to element name (<my-root-component> for MyRootComponent),
 // or <body> if <my-root-component> is absent.
-au.app(MyRootComponent).start();
+Aurelia.app(MyRootComponent).start();
 
 // Or load additional aurelia features
-au
+Aurelia
   .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
@@ -32,7 +32,7 @@ au
   .start();
 
 // Or host to <my-start-tag>
-au
+Aurelia
   .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })

--- a/docs/user-docs/app-basics/app-configuration-and-startup.md
+++ b/docs/user-docs/app-basics/app-configuration-and-startup.md
@@ -37,12 +37,12 @@ To start an Aurelia application, create a `new Aurelia()` object with a target `
 
 ```typescript
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { ShellComponent } from './shell';
 
 new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('body'), component: ShellComponent })
   .start();
 ```

--- a/docs/user-docs/app-basics/app-configuration-and-startup.md
+++ b/docs/user-docs/app-basics/app-configuration-and-startup.md
@@ -7,28 +7,30 @@
 ```ts
 import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
 import { MyRootComponent } from './my-root-component';
-au(MyRootComponent); // by default host to element name (<my-root-component> for MyRootComponent),
-                     // or <body> if <my-root-component> is absent.
+// By default host to element name (<my-root-component> for MyRootComponent),
+// or <body> if <my-root-component> is absent.
+au.app(MyRootComponent).start();
 
-// or load additional aurelia features
-au(MyRootComponent, {
-  deps: [ // deps or dependencies
+// Or load additional aurelia features
+au
+  .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
-  ]
-});
+  )
+  .app(MyRootComponent)
+  .start();
 
-// or host to <my-start-tag>
-au(MyRootComponent, {
-  host: 'my-start-tag'
-});
-au(MyRootComponent, {
-  host: document.querySelector('my-start-tag'),
-  deps: [
+// Or host to <my-start-tag>
+au
+  .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
-  ]
-});
+  )
+  .app({
+    component: MyRootComponent,
+    host: document.querySelector('my-start-tag')
+  })
+  .start();
 ```
 
 ### Verbose Startup

--- a/docs/user-docs/app-basics/app-configuration-and-startup.md
+++ b/docs/user-docs/app-basics/app-configuration-and-startup.md
@@ -5,14 +5,14 @@
 ### New Quick Startup (recommended)
 
 ```ts
-import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
+import Aurelia, { StyleConfiguration, RouterConfiguration } from 'aurelia';
 import { MyRootComponent } from './my-root-component';
 // By default host to element name (<my-root-component> for MyRootComponent),
 // or <body> if <my-root-component> is absent.
-au.app(MyRootComponent).start();
+Aurelia.app(MyRootComponent).start();
 
 // Or load additional aurelia features
-au
+Aurelia
   .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
@@ -21,7 +21,7 @@ au
   .start();
 
 // Or host to <my-start-tag>
-au
+Aurelia
   .register(
     StyleConfiguration.shadowDOM(),
     RouterConfiguration.customize({ useUrlFragmentHash: false })
@@ -59,7 +59,11 @@ To make a custom element globally available to your application, pass the custom
 import { CardCustomElement } from './components/card';
 
 // When using quick startup
-au(..., <any>CardCustomElement);
+Aurelia
+  .register(...)
+  .register(<any>CardCustomElement);
+  .app({ ... })
+  .start();
 
 // When using verbose startup
 new Aurelia()
@@ -80,7 +84,11 @@ If you have a package that exports all your custom elements, you can pass the en
 import * as globalComponents from './components';
 
 // When using quick startup
-au(..., <any>globalComponents);
+Aurelia
+  .register(...)
+  .register(<any>globalComponents)
+  .app({ ... })
+  .start();
 
 // When using verbose startup
 new Aurelia()

--- a/docs/user-docs/app-basics/app-configuration-and-startup.md
+++ b/docs/user-docs/app-basics/app-configuration-and-startup.md
@@ -2,6 +2,37 @@
 
 ## Application Startup
 
+### New Quick Startup (recommended)
+
+```ts
+import au, { StyleConfiguration, RouterConfiguration } from 'aurelia';
+import { MyRootComponent } from './my-root-component';
+au(MyRootComponent); // by default host to element name (<my-root-component> for MyRootComponent),
+                     // or <body> if <my-root-component> is absent.
+
+// or load additional aurelia features
+au(MyRootComponent, {
+  deps: [ // deps or dependencies
+    StyleConfiguration.shadowDOM(),
+    RouterConfiguration.customize({ useUrlFragmentHash: false })
+  ]
+});
+
+// or host to <my-start-tag>
+au(MyRootComponent, {
+  host: 'my-start-tag'
+});
+au(MyRootComponent, {
+  host: document.querySelector('my-start-tag'),
+  deps: [
+    StyleConfiguration.shadowDOM(),
+    RouterConfiguration.customize({ useUrlFragmentHash: false })
+  ]
+});
+```
+
+### Verbose Startup
+
 To start an Aurelia application, create a `new Aurelia()` object with a target `host` and a root `component` and call `start()`.
 
 ```typescript
@@ -25,6 +56,10 @@ To make a custom element globally available to your application, pass the custom
 ```typescript
 import { CardCustomElement } from './components/card';
 
+// When using quick startup
+au(..., <any>CardCustomElement);
+
+// When using verbose startup
 new Aurelia()
   .register(...)
   .register(<any>CardCustomElement)
@@ -42,6 +77,10 @@ If you have a package that exports all your custom elements, you can pass the en
 ```TypeScript src/main.ts
 import * as globalComponents from './components';
 
+// When using quick startup
+au(..., <any>globalComponents);
+
+// When using verbose startup
 new Aurelia()
   .register(...)
   .register(<any>globalComponents)

--- a/docs/user-docs/getting-started/components.md
+++ b/docs/user-docs/getting-started/components.md
@@ -166,14 +166,14 @@ In practice, most people want to side-step this feature and make most of their g
 {% code-tabs-item title="mail.ts" %}
 ```typescript
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 import { NameTag } from './name-tag';
 
 new Aurelia()
   .register(
-    BasicConfiguration,
+    JitHtmlBrowserConfiguration,
     DebugConfiguration,
     NameTag // Here it is!
   ).app({ host: document.querySelector('app'), component: App })
@@ -195,14 +195,14 @@ export * from './name-tag';
 {% code-tabs-item title="main.ts" %}
 ```typescript
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 import * as globalComponents from './components/registry';
 
 new Aurelia()
   .register(
-    BasicConfiguration,
+    JitHtmlBrowserConfiguration,
     DebugConfiguration,
     globalComponents // This globalizes all the exports of our registry.
   ).app({ host: document.querySelector('app'), component: App })
@@ -214,7 +214,7 @@ new Aurelia()
 {% hint style="info" %}
 **Aurelia Architecture**
 
-Did you notice how the default Aurelia startup code involves importing and registering `BasicConfiguration`? The `BasicConfiguration` export is a type of `registry,` just like the one we described above. Since all of Aurelia's internals are pluggable and extensible, we provide this convenience registry to setup the standard options you would want in a typical application.
+Did you notice how the default Aurelia startup code involves importing and registering `JitHtmlBrowserConfiguration`? The `JitHtmlBrowserConfiguration` export is a type of `registry,` just like the one we described above. Since all of Aurelia's internals are pluggable and extensible, we provide this convenience registry to setup the standard options you would want in a typical application.
 {% endhint %}
 
 ### Working without Conventions

--- a/examples/jit-browserify-ts/package.json
+++ b/examples/jit-browserify-ts/package.json
@@ -12,14 +12,7 @@
     "serve": "http-server -c-1 -p 9000 ."
   },
   "dependencies": {
-    "@aurelia/debug": "dev",
-    "@aurelia/jit": "dev",
-    "@aurelia/jit-html": "dev",
-    "@aurelia/jit-html-browser": "dev",
-    "@aurelia/kernel": "dev",
-    "@aurelia/runtime": "dev",
-    "@aurelia/runtime-html": "dev",
-    "@aurelia/runtime-html-browser": "dev"
+    "aurelia": "dev"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/examples/jit-browserify-ts/src/app.ts
+++ b/examples/jit-browserify-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@aurelia/runtime';
+import { customElement } from 'aurelia';
 import * as template from './app.html';
 
 @customElement({ name: 'app', template })

--- a/examples/jit-browserify-ts/src/startup.ts
+++ b/examples/jit-browserify-ts/src/startup.ts
@@ -1,9 +1,6 @@
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 
-window['au'] = new Aurelia()
-  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
-  .app({ host: document.querySelector('app'), component: new App() })
+Aurelia
+  .app(App)
   .start();

--- a/examples/jit-browserify-ts/src/startup.ts
+++ b/examples/jit-browserify-ts/src/startup.ts
@@ -1,9 +1,9 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();

--- a/examples/jit-browserify-ts/src/startup.ts
+++ b/examples/jit-browserify-ts/src/startup.ts
@@ -1,6 +1,4 @@
 import Aurelia from 'aurelia';
 import { App } from './app';
 
-Aurelia
-  .app(App)
-  .start();
+Aurelia.app(App).start();

--- a/examples/jit-fuse-box-ts/package.json
+++ b/examples/jit-fuse-box-ts/package.json
@@ -12,14 +12,7 @@
     "serve": "http-server -c-1 -p 9000 dist"
   },
   "dependencies": {
-    "@aurelia/debug": "dev",
-    "@aurelia/jit-html": "dev",
-    "@aurelia/jit-html-browser": "dev",
-    "@aurelia/jit": "dev",
-    "@aurelia/kernel": "dev",
-    "@aurelia/runtime-html": "dev",
-    "@aurelia/runtime-html-browser": "dev",
-    "@aurelia/runtime": "dev"
+    "aurelia": "dev"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/examples/jit-fuse-box-ts/src/app.ts
+++ b/examples/jit-fuse-box-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@aurelia/runtime';
+import { customElement } from 'aurelia';
 import template from './app.html';
 
 @customElement({ name: 'app', template })

--- a/examples/jit-fuse-box-ts/src/startup.ts
+++ b/examples/jit-fuse-box-ts/src/startup.ts
@@ -1,9 +1,6 @@
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 
-window['au'] = new Aurelia()
-  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
-  .app({ host: document.querySelector('app'), component: new App() })
+Aurelia
+  .app(App)
   .start();

--- a/examples/jit-fuse-box-ts/src/startup.ts
+++ b/examples/jit-fuse-box-ts/src/startup.ts
@@ -1,9 +1,9 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();

--- a/examples/jit-fuse-box-ts/src/startup.ts
+++ b/examples/jit-fuse-box-ts/src/startup.ts
@@ -1,6 +1,4 @@
 import Aurelia from 'aurelia';
 import { App } from './app';
 
-Aurelia
-  .app(App)
-  .start();
+Aurelia.app(App).start();

--- a/examples/jit-iife-inline/index.html
+++ b/examples/jit-iife-inline/index.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <script src="./node_modules/@aurelia/jit-html-browser/dist/index.iife.full.js"></script>
+  <script src="./node_modules/aurelia/dist/index.iife.full.js"></script>
   <app>
     <template>
       <div>${message}</div>
@@ -19,10 +19,9 @@
       constructor() { this.message = 'Hello World!'; }
     }
     var host = document.querySelector('app');
-    au.runtime.customElement({ name: 'app', template: host.innerHTML })(App)
-    new au.runtime.Aurelia()
-      .register(au.jitHtmlBrowser.JitHtmlBrowserConfiguration)
-      .app({ host, component: new App() })
+    au.aurelia.customElement({ name: 'app', template: host.innerHTML })(App);
+    au.aurelia.Aurelia
+      .app(App)
       .start();
   </script>
 </body>

--- a/examples/jit-iife-inline/index.html
+++ b/examples/jit-iife-inline/index.html
@@ -21,7 +21,7 @@
     var host = document.querySelector('app');
     au.runtime.customElement({ name: 'app', template: host.innerHTML })(App)
     new au.runtime.Aurelia()
-      .register(au.jitHtmlBrowser.BasicConfiguration)
+      .register(au.jitHtmlBrowser.JitHtmlBrowserConfiguration)
       .app({ host, component: new App() })
       .start();
   </script>

--- a/examples/jit-iife-inline/package.json
+++ b/examples/jit-iife-inline/package.json
@@ -12,7 +12,7 @@
     "serve": "http-server -c-1 -p 9000 ."
   },
   "dependencies": {
-    "@aurelia/jit-html-browser": "dev"
+    "aurelia": "dev"
   },
   "devDependencies": {
     "http-server": "latest"

--- a/examples/jit-parcel-ts/package.json
+++ b/examples/jit-parcel-ts/package.json
@@ -12,14 +12,7 @@
     "serve": "http-server -c-1 -p 9000 dist"
   },
   "dependencies": {
-    "@aurelia/debug": "dev",
-    "@aurelia/jit-html": "dev",
-    "@aurelia/jit-html-browser": "dev",
-    "@aurelia/jit": "dev",
-    "@aurelia/kernel": "dev",
-    "@aurelia/runtime-html": "dev",
-    "@aurelia/runtime-html-browser": "dev",
-    "@aurelia/runtime": "dev"
+    "aurelia": "dev"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/examples/jit-parcel-ts/src/app.ts
+++ b/examples/jit-parcel-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@aurelia/runtime';
+import { customElement } from 'aurelia';
 import template from './app.html';
 
 @customElement({ name: 'app', template })

--- a/examples/jit-parcel-ts/src/startup.ts
+++ b/examples/jit-parcel-ts/src/startup.ts
@@ -1,9 +1,6 @@
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 
-window['au'] = new Aurelia()
-  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
-  .app({ host: document.querySelector('app'), component: new App() })
+Aurelia
+  .app(App)
   .start();

--- a/examples/jit-parcel-ts/src/startup.ts
+++ b/examples/jit-parcel-ts/src/startup.ts
@@ -1,9 +1,9 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();

--- a/examples/jit-parcel-ts/src/startup.ts
+++ b/examples/jit-parcel-ts/src/startup.ts
@@ -1,6 +1,4 @@
 import Aurelia from 'aurelia';
 import { App } from './app';
 
-Aurelia
-  .app(App)
-  .start();
+Aurelia.app(App).start();

--- a/examples/jit-pixi-webpack-ts/package.json
+++ b/examples/jit-pixi-webpack-ts/package.json
@@ -7,14 +7,8 @@
     "serve": "http-server -c-1 -p 9000 dist"
   },
   "dependencies": {
-    "@aurelia/jit-html-browser": "file:../../packages/jit-html-browser",
-    "@aurelia/jit-html": "file:../../packages/jit-html",
-    "@aurelia/jit": "file:../../packages/jit",
-    "@aurelia/kernel": "file:../../packages/kernel",
-    "@aurelia/plugin-pixi": "file:../../packages/plugin-pixi",
-    "@aurelia/runtime-html-browser": "file:../../packages/runtime-html-browser",
-    "@aurelia/runtime-html": "file:../../packages/runtime-html",
-    "@aurelia/runtime": "file:../../packages/runtime",
+    "aurelia": "dev",
+    "@aurelia/plugin-pixi": "dev",
     "pixi.js": "^4.8.8"
   },
   "devDependencies": {

--- a/examples/jit-pixi-webpack-ts/src/app.ts
+++ b/examples/jit-pixi-webpack-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@aurelia/runtime';
+import { customElement } from 'aurelia';
 import template from './app.html';
 import { loader } from 'pixi.js';
 

--- a/examples/jit-pixi-webpack-ts/src/startup.ts
+++ b/examples/jit-pixi-webpack-ts/src/startup.ts
@@ -1,10 +1,10 @@
 import { PixiConfiguration } from '@aurelia/plugin-pixi';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, PixiConfiguration)
+  .register(JitHtmlBrowserConfiguration, PixiConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();
 

--- a/examples/jit-pixi-webpack-ts/src/startup.ts
+++ b/examples/jit-pixi-webpack-ts/src/startup.ts
@@ -1,10 +1,9 @@
 import { PixiConfiguration } from '@aurelia/plugin-pixi';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 
-window['au'] = new Aurelia()
-  .register(JitHtmlBrowserConfiguration, PixiConfiguration)
-  .app({ host: document.querySelector('app'), component: new App() })
+Aurelia
+  .register(PixiConfiguration)
+  .app(App)
   .start();
 

--- a/examples/jit-webpack-ts/package.json
+++ b/examples/jit-webpack-ts/package.json
@@ -12,14 +12,7 @@
     "serve": "http-server -c-1 -p 9000 dist"
   },
   "dependencies": {
-    "@aurelia/debug": "dev",
-    "@aurelia/jit": "dev",
-    "@aurelia/jit-html": "dev",
-    "@aurelia/jit-html-browser": "dev",
-    "@aurelia/kernel": "dev",
-    "@aurelia/runtime-html": "dev",
-    "@aurelia/runtime-html-browser": "dev",
-    "@aurelia/runtime": "dev"
+    "aurelia": "dev"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/examples/jit-webpack-ts/src/app.ts
+++ b/examples/jit-webpack-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { customElement } from '@aurelia/runtime';
+import { customElement } from 'aurelia';
 import template from './app.html';
 
 @customElement({ name: 'app', template })

--- a/examples/jit-webpack-ts/src/startup.ts
+++ b/examples/jit-webpack-ts/src/startup.ts
@@ -1,9 +1,6 @@
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 
-window['au'] = new Aurelia()
-  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
-  .app({ host: document.querySelector('app'), component: new App() })
+Aurelia
+  .app(App)
   .start();

--- a/examples/jit-webpack-ts/src/startup.ts
+++ b/examples/jit-webpack-ts/src/startup.ts
@@ -1,9 +1,9 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitHtmlBrowserConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();

--- a/examples/jit-webpack-ts/src/startup.ts
+++ b/examples/jit-webpack-ts/src/startup.ts
@@ -1,6 +1,4 @@
 import Aurelia from 'aurelia';
 import { App } from './app';
 
-Aurelia
-  .app(App)
-  .start();
+Aurelia.app(App).start();

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
     "packages/__tests__",
     "packages/__tests__/e2e",
     "packages/aot",
+    "packages/aurelia",
     "packages/debug",
     "packages/fetch-client",
     "packages/i18n",

--- a/packages/__tests__/e2e/src/startup.ts
+++ b/packages/__tests__/e2e/src/startup.ts
@@ -1,6 +1,6 @@
 import { DebugConfiguration } from '@aurelia/debug';
 import { I18nConfiguration } from '@aurelia/i18n';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import Fetch from 'i18next-fetch-backend';
 import * as intervalPlural from 'i18next-intervalplural-postprocessor';
@@ -24,7 +24,7 @@ Intl['RelativeTimeFormat'] = Intl['RelativeTimeFormat'] || RelativeTimeFormat;
 
   const au = new Aurelia()
     .register(
-      BasicConfiguration,
+      JitHtmlBrowserConfiguration,
       DebugConfiguration,
       I18nConfiguration.customize((options) => {
         options.translationAttributeAliases = ['t', 'i18n'];

--- a/packages/__tests__/i18n/t/translation-parameters-render.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-render.spec.ts
@@ -2,7 +2,7 @@ import { I18nConfiguration, TranslationBinding, TranslationParametersAttributePa
 import { AttributePatternDefinition, AttrSyntax, BindingCommandResource, IAttributePattern, IBindingCommand, PlainAttributeSymbol } from '@aurelia/jit';
 import { AttrBindingCommand } from '@aurelia/jit-html';
 import { DI } from '@aurelia/kernel';
-import { AnyBindingExpression, BindingType, IController, IExpressionParser, IInstructionRenderer, IObserverLocator, IRenderContext, LifecycleFlags, RuntimeBasicConfiguration, ICallBindingInstruction } from '@aurelia/runtime';
+import { AnyBindingExpression, BindingType, IController, IExpressionParser, IInstructionRenderer, IObserverLocator, IRenderContext, LifecycleFlags, RuntimeConfiguration, ICallBindingInstruction } from '@aurelia/runtime';
 import { DOM } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 
@@ -71,7 +71,7 @@ describe('TranslationParametersBindingRenderer', function () {
 
   function setup() {
     const { container } = TestContext.createHTMLTestContext();
-    container.register(RuntimeBasicConfiguration, I18nConfiguration);
+    container.register(RuntimeConfiguration, I18nConfiguration);
     return container as unknown as IRenderContext;
   }
 

--- a/packages/__tests__/i18n/t/translation-render.spec.ts
+++ b/packages/__tests__/i18n/t/translation-render.spec.ts
@@ -2,7 +2,7 @@ import { I18nConfiguration, TranslationAttributePattern, TranslationBindAttribut
 import { AttributePatternDefinition, AttrSyntax, BindingCommandResource, IAttributePattern, PlainAttributeSymbol } from '@aurelia/jit';
 import { AttrBindingCommand } from '@aurelia/jit-html';
 import { DI } from '@aurelia/kernel';
-import { AnyBindingExpression, BindingType, ICallBindingInstruction, IController, IExpressionParser, IInstructionRenderer, IObserverLocator, IRenderContext, LifecycleFlags, RuntimeBasicConfiguration } from '@aurelia/runtime';
+import { AnyBindingExpression, BindingType, ICallBindingInstruction, IController, IExpressionParser, IInstructionRenderer, IObserverLocator, IRenderContext, LifecycleFlags, RuntimeConfiguration } from '@aurelia/runtime';
 import { DOM } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 
@@ -117,7 +117,7 @@ describe('TranslationBindingRenderer', function () {
 
   function setup() {
     const container = DI.createContainer();
-    container.register(RuntimeBasicConfiguration, I18nConfiguration);
+    container.register(RuntimeConfiguration, I18nConfiguration);
     return container;
   }
 
@@ -281,7 +281,7 @@ describe('TranslationBindBindingRenderer', function () {
 
   function setup() {
     const container = DI.createContainer();
-    container.register(RuntimeBasicConfiguration, I18nConfiguration);
+    container.register(RuntimeConfiguration, I18nConfiguration);
     return container;
   }
 

--- a/packages/__tests__/jit-html/binding-command.class.spec.ts
+++ b/packages/__tests__/jit-html/binding-command.class.spec.ts
@@ -1,7 +1,7 @@
 import { Constructable } from '@aurelia/kernel';
 import { Aurelia, BindingMode, CustomElement, ILifecycle, LifecycleFlags } from '@aurelia/runtime';
 import { IEventManager } from '@aurelia/runtime-html';
-import { BasicConfiguration } from '@aurelia/jit-html';
+import { JitHtmlConfiguration } from '@aurelia/jit-html';
 import { TestContext, eachCartesianJoin, eachCartesianJoinAsync, assert } from '@aurelia/testing';
 
 // TemplateCompiler - Binding Commands integration
@@ -133,7 +133,7 @@ describe('template-compiler.binding-commands.class', function() {
           class App {
             public value: unknown = true;
           },
-          BasicConfiguration,
+          JitHtmlConfiguration,
           CustomElement.define(
             {
               name: 'child',

--- a/packages/__tests__/jit-html/binding-command.style.spec.ts
+++ b/packages/__tests__/jit-html/binding-command.style.spec.ts
@@ -1,7 +1,7 @@
 import { PLATFORM, Constructable } from '@aurelia/kernel';
 import { Aurelia, CustomElement, ILifecycle, LifecycleFlags } from '@aurelia/runtime';
 import { IEventManager } from '@aurelia/runtime-html';
-import { BasicConfiguration } from '@aurelia/jit-html';
+import { JitHtmlConfiguration } from '@aurelia/jit-html';
 import { TestContext, eachCartesianJoin, assert } from '@aurelia/testing';
 
 // Remove certain defaults/fallbacks which are added by certain browsers to allow the assertion to pass
@@ -148,7 +148,7 @@ describe('template-compiler.binding-commands.style', () => {
           class App {
             public value: string = ruleValue;
           },
-          BasicConfiguration,
+          JitHtmlConfiguration,
           CustomElement.define(
             {
               name: 'child',

--- a/packages/__tests__/jit-html/kitchen-sink.spec.ts
+++ b/packages/__tests__/jit-html/kitchen-sink.spec.ts
@@ -223,7 +223,7 @@ describe('dependency injection', function () {
 //   it.skip('if', () => {
 //     enableTracing();
 //     Tracer.enableLiveLogging(SymbolTraceWriter);
-//     const container = BasicConfiguration.createContainer();
+//     const container = JitHtmlBrowserConfiguration.createContainer();
 //     const dom = new HTMLDOM(document);
 //     Registration.instance(IDOM, dom).register(container, IDOM);
 //     const host = document.createElement('div');

--- a/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/startup.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { RouterConfiguration } from '@aurelia/router';
 import { registerComponent } from './utils';
@@ -24,7 +24,7 @@ import { LoginSpecial } from './components/login-special';
 import { Main } from './components/main';
 import { State } from './state';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   App as any,

--- a/packages/__tests__/router/e2e/modules/src/startup.ts
+++ b/packages/__tests__/router/e2e/modules/src/startup.ts
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '../../../../../jit';
+import { JitConfiguration } from '../../../../../jit';
 import { DI } from '../../../../../kernel';
 import { NavCustomElement, ViewportCustomElement } from '../../../../../router';
 import { Aurelia, CustomElement } from '../../../../../runtime';
@@ -26,7 +26,7 @@ import { Beta } from './components/beta';
 import { Sub } from './components/sub';
 
 const container = DI.createContainer();
-container.register(BasicConfiguration,
+container.register(JitConfiguration,
                    ViewportCustomElement as any,
                    NavCustomElement as any,
                    GotoCustomElement as any,

--- a/packages/__tests__/router/e2e/navigation-skeleton/app/src/startup.ts
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/src/startup.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { RouterConfiguration } from '@aurelia/router';
 import { Aurelia } from '@aurelia/runtime';
 import { ChildRouter } from './child-router';
@@ -11,7 +11,7 @@ import { State } from './state';
 import { Users } from './users';
 import { UpperValueConverter, Welcome } from './welcome';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   App as any,

--- a/packages/__tests__/router/e2e/scope/src/startup.ts
+++ b/packages/__tests__/router/e2e/scope/src/startup.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { registerComponent } from './utils';
 
@@ -18,7 +18,7 @@ import { Inbox } from './components/inbox';
 import { Recursive } from './components/recursive';
 import { Schedule } from './components/schedule';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   ViewportCustomElement as any,

--- a/packages/__tests__/router/e2e/siblings/src/startup.ts
+++ b/packages/__tests__/router/e2e/siblings/src/startup.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { registerComponent } from './utils';
 
@@ -29,7 +29,7 @@ import { Alpha } from './components/alpha';
 import { Beta } from './components/beta';
 import { Sub } from './components/sub';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   ViewportCustomElement as any,

--- a/packages/__tests__/router/e2e/wizard/src/startup.ts
+++ b/packages/__tests__/router/e2e/wizard/src/startup.ts
@@ -1,5 +1,5 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { registerComponent } from './utils';
 
@@ -29,7 +29,7 @@ import { Alpha } from './components/alpha';
 import { Beta } from './components/beta';
 import { Sub } from './components/sub';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   ViewportCustomElement as any,

--- a/packages/__tests__/runtime/binding.spec.ts
+++ b/packages/__tests__/runtime/binding.spec.ts
@@ -14,7 +14,7 @@ import {
   ObjectLiteralExpression,
   PrimitiveLiteralExpression,
   PropertyAccessor,
-  RuntimeBasicConfiguration,
+  RuntimeConfiguration,
   Scope,
   SetterObserver,
   State
@@ -50,7 +50,7 @@ describe('PropertyBinding', function () {
   let dummyMode: BindingMode;
 
   function setup(sourceExpression: any = dummySourceExpression, target: any = dummyTarget, targetProperty: string = dummyTargetProperty, mode: BindingMode = dummyMode) {
-    const container = RuntimeBasicConfiguration.createContainer();
+    const container = RuntimeConfiguration.createContainer();
     const observerLocator = createObserverLocator(container);
     const lifecycle = container.get(ILifecycle);
     const sut = new PropertyBinding(sourceExpression, target, targetProperty, mode, observerLocator, container);
@@ -103,7 +103,7 @@ describe('PropertyBinding', function () {
         expr = new BinaryExpression('+', expr, new AccessScopeExpression(prop, 0));
       }
     }
-    const container = RuntimeBasicConfiguration.createContainer();
+    const container = RuntimeConfiguration.createContainer();
     const observerLocator = createObserverLocator(container);
     const target = {val: 0};
     const sut = new PropertyBinding(expr as any, target, 'val', BindingMode.toView, observerLocator, container);

--- a/packages/__tests__/runtime/call.spec.ts
+++ b/packages/__tests__/runtime/call.spec.ts
@@ -8,7 +8,7 @@ import {
   ILifecycle,
   IScope,
   LifecycleFlags as LF,
-  RuntimeBasicConfiguration,
+  RuntimeConfiguration,
   SetterObserver
 } from '@aurelia/runtime';
 import {
@@ -20,7 +20,7 @@ import {
 
 describe.skip('CallBinding', function () {
   function setup(sourceExpression: IExpression, target: any, targetProperty: string) {
-    const container = RuntimeBasicConfiguration.createContainer();
+    const container = RuntimeConfiguration.createContainer();
     const lifecycle = container.get(ILifecycle);
     const observerLocator = createObserverLocator(container);
     const sut = new CallBinding(sourceExpression as any, target, targetProperty, observerLocator, container);

--- a/packages/__tests__/runtime/computed-observer.spec.ts
+++ b/packages/__tests__/runtime/computed-observer.spec.ts
@@ -7,7 +7,7 @@ import {
   ITargetAccessorLocator,
   ITargetObserverLocator,
   LifecycleFlags as LF,
-  RuntimeBasicConfiguration,
+  RuntimeConfiguration,
   ComputedOverrides,
   createComputedObserver
 } from '@aurelia/runtime';
@@ -22,7 +22,7 @@ declare let document;
 
 describe.skip('ComputedObserver', function () {
   function setup() {
-    const container = RuntimeBasicConfiguration.createContainer();
+    const container = RuntimeConfiguration.createContainer();
     const innerLocator = {
       handles() { return false; }
     };

--- a/packages/__tests__/runtime/dirty-checker.spec.ts
+++ b/packages/__tests__/runtime/dirty-checker.spec.ts
@@ -3,7 +3,7 @@ import {
   DirtyCheckSettings,
   IDirtyChecker,
   LifecycleFlags,
-  RuntimeBasicConfiguration
+  RuntimeConfiguration
 } from '@aurelia/runtime';
 import { assert } from '@aurelia/testing';
 
@@ -13,7 +13,7 @@ describe.skip('DirtyChecker', function () {
   });
 
   function setup() {
-    const container = RuntimeBasicConfiguration.createContainer();
+    const container = RuntimeConfiguration.createContainer();
     const dirtyChecker = container.get(IDirtyChecker);
 
     return { dirtyChecker };

--- a/packages/__tests__/setup-browser-router.ts
+++ b/packages/__tests__/setup-browser-router.ts
@@ -3,7 +3,7 @@ import {
   TestContext,
 } from '@aurelia/testing';
 import {
-  BasicConfiguration as BasicBrowserConfiguration
+  JitHtmlBrowserConfiguration
 } from '@aurelia/jit-html-browser';
 import {
   Reporter,
@@ -14,7 +14,7 @@ Reporter.level = LogLevel.error;
 
 function createBrowserTestContext(): HTMLTestContext {
   return HTMLTestContext.create(
-    BasicBrowserConfiguration,
+    JitHtmlBrowserConfiguration,
     window,
     UIEvent,
     Event,

--- a/packages/__tests__/setup-browser.ts
+++ b/packages/__tests__/setup-browser.ts
@@ -3,7 +3,7 @@ import {
   TestContext,
 } from '@aurelia/testing';
 import {
-  BasicConfiguration as BasicBrowserConfiguration
+  JitHtmlBrowserConfiguration
 } from '@aurelia/jit-html-browser';
 import {
   Reporter,
@@ -14,7 +14,7 @@ Reporter.level = LogLevel.error;
 
 function createBrowserTestContext(): HTMLTestContext {
   return HTMLTestContext.create(
-    BasicBrowserConfiguration,
+    JitHtmlBrowserConfiguration,
     window,
     UIEvent,
     Event,

--- a/packages/__tests__/setup-node.ts
+++ b/packages/__tests__/setup-node.ts
@@ -3,7 +3,7 @@ import {
   TestContext,
 } from '@aurelia/testing';
 import {
-  BasicConfiguration as BasicJSDOMConfiguration
+  JitHtmlJsdomConfiguration
 } from '@aurelia/jit-html-jsdom';
 import {
   Reporter,
@@ -17,7 +17,7 @@ function createJSDOMTestContext(): HTMLTestContext {
   const jsdom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`);
 
   return HTMLTestContext.create(
-    BasicJSDOMConfiguration,
+    JitHtmlJsdomConfiguration,
     jsdom.window,
     jsdom.window.UIEvent,
     jsdom.window.Event,

--- a/packages/aurelia/.npmrc
+++ b/packages/aurelia/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/aurelia/CHANGELOG.md
+++ b/packages/aurelia/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/aurelia/LICENSE
+++ b/packages/aurelia/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2010 - 2018 Blue Spire Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/aurelia/README.md
+++ b/packages/aurelia/README.md
@@ -1,0 +1,21 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
+[![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
+[![CircleCI](https://circleci.com/gh/aurelia/aurelia.svg?style=shield)](https://circleci.com/gh/aurelia/aurelia)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/5ac0e13689735698073a/test_coverage)](https://codeclimate.com/github/aurelia/aurelia/test_coverage)
+[![npm](https://img.shields.io/npm/v/aurelia.svg?maxAge=3600)](https://www.npmjs.com/package/aurelia)
+# aurelia
+
+## Installing
+
+For the latest stable version:
+
+```bash
+npm install --save-dev aurelia
+```
+
+For our nightly builds:
+
+```bash
+npm install --save-dev aurelia@dev
+```

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "aurelia",
+  "version": "0.3.0",
+  "main": "dist/esnext/index.js",
+  "module": "dist/esnext/index.js",
+  "types": "dist/index.d.ts",
+  "typings": "dist/index.d.ts",
+  "license": "MIT",
+  "homepage": "https://aurelia.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aurelia/aurelia"
+  },
+  "bugs": {
+    "url": "https://github.com/aurelia/aurelia/issues"
+  },
+  "keywords": [
+    "aurelia"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "lint": "tslint --project tsconfig.json -t stylish",
+    "build": "tsc -b",
+    "bundle": "ts-node -P ../../scripts/tsconfig.json ../../scripts/bundle.ts umd,esm,system aurelia",
+    "dev": "tsc -b -w"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@aurelia/debug": "0.3.0",
+    "@aurelia/fetch-client": "0.3.0",
+    "@aurelia/jit": "0.3.0",
+    "@aurelia/jit-html": "0.3.0",
+    "@aurelia/jit-html-browser": "0.3.0",
+    "@aurelia/kernel": "0.3.0",
+    "@aurelia/router": "0.3.0",
+    "@aurelia/runtime": "0.3.0",
+    "@aurelia/runtime-html": "0.3.0",
+    "@aurelia/runtime-html-browser": "0.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^10.14.13",
+    "tslib": "^1.10.0",
+    "tslint": "^5.19.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "tslint-sonarts": "^1.9.0",
+    "typescript": "^3.5.3"
+  }
+}

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,0 +1,923 @@
+export {
+  quickStart as default
+} from './quick-start';
+
+export {
+  DebugConfiguration,
+  TraceConfiguration,
+
+  // DebugTracer,
+  // stringifyLifecycleFlags,
+
+  Unparser,
+  Serializer
+} from '@aurelia/debug';
+
+export {
+  Interceptor,
+  RetryConfiguration,
+  RetryableRequest,
+  ValidInterceptorMethodName,
+
+  json,
+
+  retryStrategy,
+  RetryInterceptor,
+
+  HttpClientConfiguration,
+
+  HttpClient
+} from '@aurelia/fetch-client';
+
+export {
+  // AttrSyntax,
+
+  // IAttributeParser,
+
+  attributePattern,
+  // AttributePatternDefinition,
+  // IAttributePattern,
+  // IAttributePatternHandler,
+  // Interpretation,
+  // ISyntaxInterpreter,
+
+  // AtPrefixedTriggerAttributePattern,
+  // ColonPrefixedBindAttributePattern,
+  // DotSeparatedAttributePattern,
+  // RefAttributePattern,
+
+  bindingCommand,
+  // BindingCommandResource,
+  // IBindingCommand,
+  // IBindingCommandDefinition,
+  // IBindingCommandResource,
+  // IBindingCommandType,
+  // getTarget,
+
+  // CallBindingCommand,
+  // DefaultBindingCommand,
+  // ForBindingCommand,
+  // FromViewBindingCommand,
+  // OneTimeBindingCommand,
+  // ToViewBindingCommand,
+  // TwoWayBindingCommand,
+
+  // IExpressionParserRegistration,
+
+  // DefaultComponents as JitDefaultComponents,
+
+  // RefAttributePatternRegistration,
+  // DotSeparatedAttributePatternRegistration,
+
+  // DefaultBindingSyntax,
+
+  // AtPrefixedTriggerAttributePatternRegistration,
+  // ColonPrefixedBindAttributePatternRegistration,
+
+  // ShortHandBindingSyntax,
+
+  // CallBindingCommandRegistration,
+  // DefaultBindingCommandRegistration,
+  // ForBindingCommandRegistration,
+  // FromViewBindingCommandRegistration,
+  // OneTimeBindingCommandRegistration,
+  // ToViewBindingCommandRegistration,
+  // TwoWayBindingCommandRegistration,
+
+  // DefaultBindingLanguage as JitDefaultBindingLanguage,
+
+  BasicConfiguration as JitBasicConfiguration,
+
+  // Access,
+  // Precedence,
+  // Char,
+  // These exports are temporary until we have a proper way to unit test them
+
+  parseExpression,
+  // parse,
+  // ParserState,
+
+  // ResourceModel,
+  // BindableInfo,
+  // ElementInfo,
+  // AttrInfo,
+
+  // BindingSymbol,
+  // CustomAttributeSymbol,
+  // CustomElementSymbol,
+  // ICustomAttributeSymbol,
+  // IPlainAttributeSymbol,
+  // IElementSymbol,
+  // INodeSymbol,
+  // IParentNodeSymbol,
+  // IResourceAttributeSymbol,
+  // ISymbol,
+  // ISymbolWithBindings,
+  // ISymbolWithMarker,
+  // ISymbolWithTemplate,
+  // LetElementSymbol,
+  // PlainAttributeSymbol,
+  // PlainElementSymbol,
+  // ReplacePartSymbol,
+  // SymbolFlags,
+  // TemplateControllerSymbol,
+  // TextSymbol
+} from '@aurelia/jit';
+
+export {
+  // IAttrSyntaxTransformer,
+
+  // TriggerBindingCommand,
+  // DelegateBindingCommand,
+  // CaptureBindingCommand,
+  // AttrBindingCommand,
+  // ClassBindingCommand,
+  // StyleBindingCommand,
+
+  // ITemplateCompilerRegistration,
+  // ITemplateElementFactoryRegistration,
+  // IAttrSyntaxTransformerRegistation,
+
+  // DefaultComponents as JitHtmlDefaultComponents,
+
+  // TriggerBindingCommandRegistration,
+  // DelegateBindingCommandRegistration,
+  // CaptureBindingCommandRegistration,
+  // AttrBindingCommandRegistration,
+  // ClassBindingCommandRegistration,
+  // StyleBindingCommandRegistration,
+
+  // DefaultBindingLanguage as JitHtmlDefaultBindingLanguage,
+
+  BasicConfiguration as JitHtmlBasicConfiguration,
+
+  // stringifyDOM,
+  // stringifyInstructions,
+  // stringifyTemplateDefinition,
+
+  // TemplateBinder,
+
+  // ITemplateElementFactory
+} from '@aurelia/jit-html';
+
+export {
+  BasicConfiguration as JitHtmlBrowserBasicConfiguration
+} from '@aurelia/jit-html-browser';
+
+export {
+  all,
+  DI,
+  IContainer,
+  IDefaultableInterfaceSymbol,
+  IFactory,
+  inject,
+  IRegistration,
+  IRegistry,
+  IResolver,
+  IServiceLocator,
+  Key,
+  lazy,
+  optional,
+  RegisterSelf,
+  Registration,
+  ResolveCallback,
+  singleton,
+  transient,
+  Injectable,
+  InterfaceSymbol,
+  InstanceProvider,
+  Resolved,
+
+  // Class,
+  // Constructable,
+  // ConstructableClass,
+  // Diff,
+  // ICallable,
+  // IDisposable,
+  // IFrameRequestCallback,
+  // IIndexable,
+  // IPerformance,
+  // ITimerHandler,
+  // IWindowOrWorkerGlobalScope,
+  // KnownKeys,
+  // NoInfer,
+  // Omit,
+  // OptionalKnownKeys,
+  // OptionalValuesOf,
+  // Overwrite,
+  // Param0,
+  // Param1,
+  // Param2,
+  // Param3,
+  // Pick2,
+  // Pick3,
+  // Primitive,
+  // Public,
+  // Purify,
+  // RequiredKnownKeys,
+  // RequiredValuesOf,
+  // StrictPrimitive,
+  // Unwrap,
+  // ValuesOf,
+  // Writable,
+  // IfEquals,
+  // ReadonlyKeys,
+  // WritableKeys,
+
+  relativeToFile,
+  join,
+  buildQueryString,
+  parseQueryString,
+  IQueryParams,
+
+  PLATFORM,
+
+  ITraceInfo,
+  ITraceWriter,
+  ILiveLoggingOptions,
+  Reporter,
+  Tracer,
+  LogLevel,
+
+  Profiler,
+
+  IResourceDefinition,
+  IResourceDescriptions,
+  IResourceKind,
+  IResourceType,
+  ResourceDescription,
+  ResourcePartDescription,
+  RuntimeCompilationResources,
+
+  EventAggregator,
+  EventAggregatorCallback,
+  IEventAggregator,
+
+  isNumeric,
+  camelCase,
+  kebabCase,
+  toArray,
+  nextId,
+  resetId,
+  compareNumber,
+  mergeDistinct,
+} from '@aurelia/kernel';
+
+export {
+  BrowserNavigator,
+
+  ILinkHandlerOptions,
+  AnchorEventInfo,
+
+  LinkHandler,
+
+  Guard,
+
+  GuardTypes,
+  GuardIdentity,
+  IGuardOptions,
+  Guardian,
+
+  GuardFunction,
+  GuardTarget,
+  INavigatorInstruction,
+  IRouteableComponent,
+  IRouteableComponentType,
+  IViewportInstruction,
+  NavigationInstruction,
+  ReentryBehavior,
+
+  INavRoute,
+  Nav,
+
+  NavRoute,
+
+  IStoredNavigatorEntry,
+  INavigatorEntry,
+  INavigatorOptions,
+  INavigatorFlags,
+  INavigatorState,
+  INavigatorStore,
+  INavigatorViewer,
+  INavigatorViewerEvent,
+  Navigator,
+
+  QueueItem,
+  IQueueOptions,
+  Queue,
+
+  RouteHandler,
+  ConfigurableRoute,
+  HandlerEntry,
+  RouteGenerator,
+  TypesRecord,
+  RecognizeResult,
+  RecognizeResults,
+  CharSpec,
+  // State as RouterState, // duplicated in @aurelia/runtime
+  StaticSegment,
+  DynamicSegment,
+  StarSegment,
+  EpsilonSegment,
+  Segment,
+  RouteRecognizer,
+
+  IRouteTransformer,
+  IRouterOptions,
+  IRouter,
+  Router,
+
+  IFindViewportsResult,
+  ChildContainer,
+  // Scope as RouterScope, // duplicated in @aurelia/runtime
+
+  IViewportOptions,
+  Viewport,
+
+  ContentStatus,
+  ViewportContent,
+
+  ViewportInstruction,
+
+  RouterConfiguration,
+  RouterRegistration,
+  // DefaultComponents as RouterDefaultComponents,
+  // DefaultResources as RouterDefaultResources,
+  // ViewportCustomElement,
+  // ViewportCustomElementRegistration,
+  // NavCustomElement,
+  // NavCustomElementRegistration,
+} from '@aurelia/router';
+
+export {
+  // CallFunctionExpression,
+  // connects,
+  // observes,
+  // callsFunction,
+  // hasAncestor,
+  // isAssignable,
+  // isLeftHandSide,
+  // isPrimary,
+  // isResource,
+  // hasBind,
+  // hasUnbind,
+  // isLiteral,
+  // arePureLiterals,
+  // isPureLiteral,
+  // CustomExpression,
+  // BindingBehaviorExpression,
+  // ValueConverterExpression,
+  // AssignExpression,
+  // ConditionalExpression,
+  // AccessThisExpression,
+  // AccessScopeExpression,
+  // AccessMemberExpression,
+  // AccessKeyedExpression,
+  // CallScopeExpression,
+  // CallMemberExpression,
+  // BinaryExpression,
+  // UnaryExpression,
+  // PrimitiveLiteralExpression,
+  // HtmlLiteralExpression,
+  // ArrayLiteralExpression,
+  // ObjectLiteralExpression,
+  // TemplateExpression,
+  // TaggedTemplateExpression,
+  // ArrayBindingPattern,
+  // ObjectBindingPattern,
+  // BindingIdentifier,
+  // ForOfStatement,
+  // Interpolation,
+
+  // AnyBindingExpression,
+  // IsPrimary,
+  // IsLiteral,
+  // IsLeftHandSide,
+  // IsUnary,
+  // IsBinary,
+  // IsConditional,
+  // IsAssign,
+  // IsValueConverter,
+  // IsBindingBehavior,
+  // IsAssignable,
+  // IsExpression,
+  // IsExpressionOrStatement,
+  // Connects,
+  // Observes,
+  // CallsFunction,
+  // IsResource,
+  // HasBind,
+  // HasUnbind,
+  // HasAncestor,
+  // IVisitor,
+  // IExpression,
+  // IAccessKeyedExpression,
+  // IAccessMemberExpression,
+  // IAccessScopeExpression,
+  // IAccessThisExpression,
+  // IArrayBindingPattern,
+  // IArrayLiteralExpression,
+  // IAssignExpression,
+  // IBinaryExpression,
+  // IBindingBehaviorExpression,
+  // IBindingIdentifier,
+  // ICallFunctionExpression,
+  // ICallMemberExpression,
+  // ICallScopeExpression,
+  // IConditionalExpression,
+  // IForOfStatement,
+  // IHtmlLiteralExpression,
+  // IInterpolationExpression,
+  // IObjectBindingPattern,
+  // IObjectLiteralExpression,
+  // IPrimitiveLiteralExpression,
+  // ITaggedTemplateExpression,
+  // ITemplateExpression,
+  // IUnaryExpression,
+  // IValueConverterExpression,
+  // BinaryOperator,
+  // BindingIdentifierOrPattern,
+  // UnaryOperator,
+
+  // PropertyBinding,
+
+  // CallBinding,
+
+  // IPartialConnectableBinding,
+  // IConnectableBinding,
+  // connectable,
+
+  // IExpressionParser,
+  // BindingType,
+
+  // MultiInterpolationBinding,
+  // InterpolationBinding,
+
+  // LetBinding,
+
+  // RefBinding,
+
+  // ArrayObserver,
+  // enableArrayObservation,
+  // disableArrayObservation,
+  // applyMutationsToIndices,
+  // synchronizeIndices,
+
+  // MapObserver,
+  // enableMapObservation,
+  // disableMapObservation,
+
+  // SetObserver,
+  // enableSetObservation,
+  // disableSetObservation,
+
+  // BindingContext,
+  // Scope,
+  // OverrideContext,
+
+  // CollectionLengthObserver,
+
+  // CollectionSizeObserver,
+
+  // ComputedOverrides,
+  // ComputedLookup,
+  computed,
+  // createComputedObserver,
+  // CustomSetterObserver,
+  // GetterObserver,
+
+  // IDirtyChecker,
+  // DirtyCheckProperty,
+  // DirtyCheckSettings,
+
+  // IObjectObservationAdapter,
+  // IObserverLocator,
+  // ITargetObserverLocator,
+  // ITargetAccessorLocator,
+  // getCollectionObserver,
+  // ObserverLocator,
+
+  // PrimitiveObserver,
+
+  // PropertyAccessor,
+
+  // ProxyObserver,
+
+  // SelfObserver,
+
+  // SetterObserver,
+
+  // ISignaler,
+
+  subscriberCollection,
+  collectionSubscriberCollection,
+  proxySubscriberCollection,
+
+  bindingBehavior,
+  BindingBehavior,
+  IBindingBehavior,
+  IBindingBehaviorDefinition,
+  IBindingBehaviorResource,
+  IBindingBehaviorType,
+
+  // BindingModeBehavior,
+  // OneTimeBindingBehavior,
+  // ToViewBindingBehavior,
+  // FromViewBindingBehavior,
+  // TwoWayBindingBehavior,
+
+  // DebounceableBinding,
+  // DebounceBindingBehavior,
+
+  // PriorityBindingBehavior,
+
+  // SignalableBinding,
+  // SignalBindingBehavior,
+
+  // ThrottleableBinding,
+  // ThrottleBindingBehavior,
+
+  customAttribute,
+  CustomAttributeConstructor,
+  CustomAttributeDecorator,
+  CustomAttribute,
+  dynamicOptions,
+  ICustomAttributeResource,
+  ICustomAttributeType,
+  templateController,
+
+  // FrequentMutations,
+  // InfrequentMutations,
+  // ObserveShallow,
+
+  // If,
+  // Else,
+
+  // Repeat,
+
+  // Replaceable,
+
+  // With,
+
+  containerless,
+  customElement,
+  CustomElementHost,
+  CustomElement,
+  ICustomElementDecorator,
+  ICustomElementResource,
+  ICustomElementType,
+  IElementProjector,
+  IProjectorLocator,
+  useShadowDOM,
+
+  IValueConverter,
+  IValueConverterDefinition,
+  IValueConverterResource,
+  IValueConverterType,
+  valueConverter,
+  ValueConverter,
+
+  ISanitizer,
+  // SanitizeValueConverter,
+
+  // ViewValueConverter,
+
+  bindable,
+  BindableDecorator,
+  WithBindables,
+  Bindable,
+
+  children,
+  ChildrenDecorator,
+  HasChildrenObservers,
+
+// These exports are temporary until we have a proper way to unit test them
+  Controller,
+
+  ViewFactory,
+  IViewLocator,
+  ViewLocator,
+  view,
+
+  Aurelia,
+  IDOMInitializer,
+  ISinglePageApp,
+  CompositionRoot,
+
+  // IfRegistration,
+  // ElseRegistration,
+  // RepeatRegistration,
+  // ReplaceableRegistration,
+  // WithRegistration,
+
+  // SanitizeValueConverterRegistration,
+
+  // DebounceBindingBehaviorRegistration,
+  // OneTimeBindingBehaviorRegistration,
+  // ToViewBindingBehaviorRegistration,
+  // FromViewBindingBehaviorRegistration,
+  // PriorityBindingBehaviorRegistration,
+  // SignalBindingBehaviorRegistration,
+  // ThrottleBindingBehaviorRegistration,
+  // TwoWayBindingBehaviorRegistration,
+
+  // RefBindingRendererRegistration,
+  // CallBindingRendererRegistration,
+  // CustomAttributeRendererRegistration,
+  // CustomElementRendererRegistration,
+  // InterpolationBindingRendererRegistration,
+  // IteratorBindingRendererRegistration,
+  // LetElementRendererRegistration,
+  // PropertyBindingRendererRegistration,
+  // SetPropertyRendererRegistration,
+  // TemplateControllerRendererRegistration,
+
+  // DefaultResources as RuntimeDefaultResources,
+  // IObserverLocatorRegistration,
+  // ILifecycleRegistration,
+  // IRendererRegistration,
+  // RuntimeBasicConfiguration,
+
+  // AttributeDefinition,
+  // AttributeInstruction,
+  // BindableDefinitions,
+  // BindableSource,
+  // buildTemplateDefinition,
+  // CustomElementConstructor,
+  // HooksDefinition,
+  // IAttributeDefinition,
+  // IBindableDescription,
+  // IBuildInstruction,
+  // ICallBindingInstruction,
+  // IElementHydrationOptions,
+  // IHydrateAttributeInstruction,
+  // IHydrateElementInstruction,
+  // IHydrateLetElementInstruction,
+  // IHydrateTemplateController,
+  // IInterpolationInstruction,
+  // IIteratorBindingInstruction,
+  // ILetBindingInstruction,
+  // InstructionRow,
+  // InstructionTypeName,
+  // IPropertyBindingInstruction,
+  // IRefBindingInstruction,
+  // ISetPropertyInstruction,
+  // isTargetedInstruction,
+  // ITargetedInstruction,
+  // ITemplateDefinition,
+  // NodeInstruction,
+  // TargetedInstruction,
+  // TargetedInstructionType,
+  // TemplateDefinition,
+  // TemplatePartDefinitions,
+  alias,
+  registerAliases,
+
+  // DOM, should expose the one exported in runtime-html
+  // INode,
+  // IRenderLocation,
+  // IDOM,
+  // NodeSequence,
+  // INodeSequence,
+  // INodeSequenceFactory,
+
+  BindingMode,
+  BindingStrategy,
+  ExpressionKind,
+  Hooks,
+  LifecycleFlags,
+  // State,
+
+  // CallBindingInstruction,
+  // FromViewBindingInstruction,
+  // HydrateAttributeInstruction,
+  // HydrateElementInstruction,
+  // HydrateTemplateController,
+  // InterpolationInstruction,
+  // IteratorBindingInstruction,
+  // LetBindingInstruction,
+  // LetElementInstruction,
+  // OneTimeBindingInstruction,
+  // RefBindingInstruction,
+  // SetPropertyInstruction,
+  // ToViewBindingInstruction,
+  // TwoWayBindingInstruction,
+
+  // ViewModelKind,
+  // IBinding,
+  // ILifecycle,
+  // IViewModel,
+  // IController,
+  // IRenderContext,
+  // IViewCache,
+  // IViewFactory,
+  // Priority,
+
+  // PromiseOrTask,
+  // MaybePromiseOrTask,
+  // AggregateContinuationTask,
+  // TerminalTask,
+  // AggregateTerminalTask,
+  // ContinuationTask,
+  // ILifecycleTask,
+  // LifecycleTask,
+  // PromiseTask,
+  // TaskSlot,
+  // StartTask,
+  // IStartTask,
+  // IStartTaskManager,
+  // ProviderTask,
+
+  // AccessorOrObserver,
+  // Collection,
+  // CollectionKind,
+  // DelegationStrategy,
+  // IAccessor,
+  // IBindingContext,
+  // IBindingTargetAccessor,
+  // IBindingTargetObserver,
+  // ICollectionChangeTracker,
+  // ICollectionObserver,
+  // ICollectionSubscriber,
+  // IndexMap,
+  // IObservable,
+  // IObservedArray,
+  // IObservedMap,
+  // IObservedSet,
+  // IOverrideContext,
+  // IPropertyChangeTracker,
+  // IPropertyObserver,
+  // IScope,
+  // ISubscribable,
+  // ISubscriberCollection,
+  // ObservedCollection,
+  // ObserversLookup,
+  // PropertyObserver,
+  // CollectionObserver,
+  // ICollectionSubscriberCollection,
+  // IProxyObserver,
+  // IProxy,
+  // IProxySubscribable,
+  // IProxySubscriber,
+  // IProxySubscriberCollection,
+  // ICollectionSubscribable,
+  // ISubscriber,
+  // isIndexMap,
+  // copyIndexMap,
+  // cloneIndexMap,
+  // createIndexMap,
+
+  // instructionRenderer,
+  // ensureExpression,
+  // addComponent,
+  // addBinding,
+
+  // CompiledTemplate,
+  // createRenderContext,
+  // ChildrenObserver,
+  // IInstructionRenderer,
+  // IInstructionTypeClassifier,
+  // IRenderer,
+  // IRenderingEngine,
+  // ITemplate,
+  // ITemplateCompiler,
+  // ITemplateFactory,
+  // ViewCompileFlags
+} from '@aurelia/runtime';
+
+export {
+  // Listener,
+
+  // AttributeBinding,
+
+  // AttributeNSAccessor,
+
+  // IInputElement,
+  // CheckedObserver,
+
+  // ClassAttributeAccessor,
+
+  // DataAttributeAccessor,
+
+  // ElementPropertyAccessor,
+
+  // IManagedEvent,
+  // ListenerTracker,
+  // DelegateOrCaptureSubscription,
+  // TriggerSubscription,
+  // IElementConfiguration,
+  // IEventManager,
+  // IEventSubscriber,
+  // IEventTargetWithLookups,
+  // EventSubscriber,
+  // EventSubscription,
+  // EventManager,
+
+  // TargetAccessorLocator,
+  // TargetObserverLocator,
+
+  // ISelectElement,
+  // IOptionElement,
+  // SelectValueObserver,
+
+  // StyleAttributeAccessor,
+
+  // ISVGAnalyzer,
+
+  // ValueAttributeObserver,
+
+  // AttrBindingBehavior,
+
+  // SelfableBinding,
+  // SelfBindingBehavior,
+
+  // UpdateTriggerBindingBehavior,
+  // UpdateTriggerableBinding,
+  // UpdateTriggerableObserver,
+
+  // Blur,
+  // BlurManager,
+
+  // Focus,
+
+  // Subject,
+  // Compose,
+
+  // IProjectorLocatorRegistration,
+  // ITargetAccessorLocatorRegistration,
+  // ITargetObserverLocatorRegistration,
+  // ITemplateFactoryRegistration,
+
+  // DefaultComponents as RuntimeHtmlDefaultComponents,
+
+  // AttrBindingBehaviorRegistration,
+  // SelfBindingBehaviorRegistration,
+  // UpdateTriggerBindingBehaviorRegistration,
+  // ComposeRegistration,
+
+  // DefaultResources as RuntimeHtmlDefaultResources,
+
+  // AttributeBindingRendererRegistration,
+  // ListenerBindingRendererRegistration,
+  // SetAttributeRendererRegistration,
+  // StylePropertyBindingRendererRegistration,
+  // TextBindingRendererRegistration,
+
+  // DefaultRenderers,
+
+  BasicConfiguration as RuntimeHtmlBasicConfiguration,
+
+  // createElement,
+  // RenderPlan,
+
+  // HTMLAttributeInstruction,
+  // HTMLInstructionRow,
+  // HTMLNodeInstruction,
+  // HTMLTargetedInstruction,
+  // HTMLTargetedInstructionType,
+  // IAttributeBindingInstruction,
+  // IListenerBindingInstruction,
+  // ISetAttributeInstruction,
+  // isHTMLTargetedInstruction,
+  // IStylePropertyBindingInstruction,
+  // ITextBindingInstruction,
+
+  // NodeType,
+  // HTMLDOM,
+  DOM, // on top of DOM in @aurelia/runtime
+  // NodeSequenceFactory,
+  // FragmentNodeSequence,
+
+  // AttributeBindingInstruction,
+  // CaptureBindingInstruction,
+  // DelegateBindingInstruction,
+  // SetAttributeInstruction,
+  // StylePropertyBindingInstruction,
+  // TextBindingInstruction,
+  // TriggerBindingInstruction,
+
+  // ContainerlessProjector,
+  // HostProjector,
+  // HTMLProjectorLocator,
+  // ShadowDOMProjector,
+
+  StyleConfiguration,
+  styles,
+  IShadowDOMConfiguration,
+
+  // CSSModulesProcessorRegistry,
+
+  // ShadowDOMRegistry,
+
+  // AdoptedStyleSheetsStyles,
+  // StyleElementStyles,
+  // IShadowDOMStyles,
+  // IShadowDOMGlobalStyles
+} from '@aurelia/runtime-html';
+
+export {
+  // IDOMInitializerRegistration,
+  // DefaultComponents as RuntimeHtmlBrowserDefaultComponents,
+  BasicConfiguration as RuntimeHtmlBrowserBasicConfiguration
+} from '@aurelia/runtime-html-browser';
+

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -9,20 +9,20 @@ export {
   // DebugTracer,
   // stringifyLifecycleFlags,
 
-  Unparser,
-  Serializer
+  // Unparser,
+  // Serializer
 } from '@aurelia/debug';
 
 export {
   Interceptor,
-  RetryConfiguration,
-  RetryableRequest,
-  ValidInterceptorMethodName,
+  // RetryConfiguration,
+  // RetryableRequest,
+  // ValidInterceptorMethodName,
 
-  json,
+  // json,
 
-  retryStrategy,
-  RetryInterceptor,
+  // retryStrategy,
+  // RetryInterceptor,
 
   HttpClientConfiguration,
 
@@ -36,7 +36,7 @@ export {
 
   attributePattern,
   // AttributePatternDefinition,
-  // IAttributePattern,
+  IAttributePattern,
   // IAttributePatternHandler,
   // Interpretation,
   // ISyntaxInterpreter,
@@ -48,11 +48,11 @@ export {
 
   bindingCommand,
   // BindingCommandResource,
-  // IBindingCommand,
+  IBindingCommand,
   // IBindingCommandDefinition,
   // IBindingCommandResource,
   // IBindingCommandType,
-  // getTarget,
+  getTarget,
 
   // CallBindingCommand,
   // DefaultBindingCommand,
@@ -74,7 +74,7 @@ export {
   // AtPrefixedTriggerAttributePatternRegistration,
   // ColonPrefixedBindAttributePatternRegistration,
 
-  // ShortHandBindingSyntax,
+  ShortHandBindingSyntax,
 
   // CallBindingCommandRegistration,
   // DefaultBindingCommandRegistration,
@@ -86,14 +86,14 @@ export {
 
   // DefaultBindingLanguage as JitDefaultBindingLanguage,
 
-  BasicConfiguration as JitBasicConfiguration,
+  // BasicConfiguration as JitBasicConfiguration,
 
   // Access,
   // Precedence,
   // Char,
   // These exports are temporary until we have a proper way to unit test them
 
-  parseExpression,
+  // parseExpression,
   // parse,
   // ParserState,
 
@@ -168,8 +168,8 @@ export {
   all,
   DI,
   IContainer,
-  IDefaultableInterfaceSymbol,
-  IFactory,
+  // IDefaultableInterfaceSymbol,
+  // IFactory,
   inject,
   IRegistration,
   IRegistry,
@@ -178,24 +178,24 @@ export {
   Key,
   lazy,
   optional,
-  RegisterSelf,
+  // RegisterSelf,
   Registration,
-  ResolveCallback,
+  // ResolveCallback,
   singleton,
   transient,
-  Injectable,
-  InterfaceSymbol,
+  // Injectable,
+  // InterfaceSymbol,
   InstanceProvider,
   Resolved,
 
-  // Class,
-  // Constructable,
-  // ConstructableClass,
+  Class,
+  Constructable,
+  ConstructableClass,
   // Diff,
-  // ICallable,
-  // IDisposable,
+  ICallable,
+  IDisposable,
   // IFrameRequestCallback,
-  // IIndexable,
+  IIndexable,
   // IPerformance,
   // ITimerHandler,
   // IWindowOrWorkerGlobalScope,
@@ -224,29 +224,29 @@ export {
   // ReadonlyKeys,
   // WritableKeys,
 
-  relativeToFile,
-  join,
-  buildQueryString,
-  parseQueryString,
-  IQueryParams,
+  // relativeToFile,
+  // join,
+  // buildQueryString,
+  // parseQueryString,
+  // IQueryParams,
 
   PLATFORM,
 
-  ITraceInfo,
-  ITraceWriter,
-  ILiveLoggingOptions,
+  // ITraceInfo,
+  // ITraceWriter,
+  // ILiveLoggingOptions,
   Reporter,
   Tracer,
   LogLevel,
 
   Profiler,
 
-  IResourceDefinition,
-  IResourceDescriptions,
-  IResourceKind,
-  IResourceType,
-  ResourceDescription,
-  ResourcePartDescription,
+  // IResourceDefinition,
+  // IResourceDescriptions,
+  // IResourceKind,
+  // IResourceType,
+  // ResourceDescription,
+  // ResourcePartDescription,
   RuntimeCompilationResources,
 
   EventAggregator,
@@ -257,85 +257,85 @@ export {
   camelCase,
   kebabCase,
   toArray,
-  nextId,
-  resetId,
-  compareNumber,
-  mergeDistinct,
+  // nextId,
+  // resetId,
+  // compareNumber,
+  // mergeDistinct,
 } from '@aurelia/kernel';
 
 export {
-  BrowserNavigator,
+  // BrowserNavigator,
 
-  ILinkHandlerOptions,
-  AnchorEventInfo,
+  // ILinkHandlerOptions,
+  // AnchorEventInfo,
 
-  LinkHandler,
+  // LinkHandler,
 
-  Guard,
+  // Guard,
 
-  GuardTypes,
-  GuardIdentity,
-  IGuardOptions,
-  Guardian,
+  // GuardTypes,
+  // GuardIdentity,
+  // IGuardOptions,
+  // Guardian,
 
-  GuardFunction,
-  GuardTarget,
-  INavigatorInstruction,
-  IRouteableComponent,
-  IRouteableComponentType,
-  IViewportInstruction,
-  NavigationInstruction,
-  ReentryBehavior,
+  // GuardFunction,
+  // GuardTarget,
+  // INavigatorInstruction,
+  // IRouteableComponent,
+  // IRouteableComponentType,
+  // IViewportInstruction,
+  // NavigationInstruction,
+  // ReentryBehavior,
 
-  INavRoute,
-  Nav,
+  // INavRoute,
+  // Nav,
 
-  NavRoute,
+  // NavRoute,
 
-  IStoredNavigatorEntry,
-  INavigatorEntry,
-  INavigatorOptions,
-  INavigatorFlags,
-  INavigatorState,
-  INavigatorStore,
-  INavigatorViewer,
-  INavigatorViewerEvent,
-  Navigator,
+  // IStoredNavigatorEntry,
+  // INavigatorEntry,
+  // INavigatorOptions,
+  // INavigatorFlags,
+  // INavigatorState,
+  // INavigatorStore,
+  // INavigatorViewer,
+  // INavigatorViewerEvent,
+  // Navigator,
 
-  QueueItem,
-  IQueueOptions,
-  Queue,
+  // QueueItem,
+  // IQueueOptions,
+  // Queue,
 
-  RouteHandler,
-  ConfigurableRoute,
-  HandlerEntry,
-  RouteGenerator,
-  TypesRecord,
-  RecognizeResult,
-  RecognizeResults,
-  CharSpec,
-  // State as RouterState, // duplicated in @aurelia/runtime
-  StaticSegment,
-  DynamicSegment,
-  StarSegment,
-  EpsilonSegment,
-  Segment,
-  RouteRecognizer,
+  // RouteHandler,
+  // ConfigurableRoute,
+  // HandlerEntry,
+  // RouteGenerator,
+  // TypesRecord,
+  // RecognizeResult,
+  // RecognizeResults,
+  // CharSpec,
+  // // State as RouterState, // duplicated in @aurelia/runtime
+  // StaticSegment,
+  // DynamicSegment,
+  // StarSegment,
+  // EpsilonSegment,
+  // Segment,
+  // RouteRecognizer,
 
   IRouteTransformer,
   IRouterOptions,
   IRouter,
   Router,
 
-  IFindViewportsResult,
-  ChildContainer,
+  // IFindViewportsResult,
+  // ChildContainer,
   // Scope as RouterScope, // duplicated in @aurelia/runtime
 
-  IViewportOptions,
-  Viewport,
+  // IViewportOptions,
+  // Viewport,
 
-  ContentStatus,
-  ViewportContent,
+  // ContentStatus,
+  // ViewportContent,
 
   ViewportInstruction,
 
@@ -516,9 +516,9 @@ export {
   bindingBehavior,
   BindingBehavior,
   IBindingBehavior,
-  IBindingBehaviorDefinition,
-  IBindingBehaviorResource,
-  IBindingBehaviorType,
+  // IBindingBehaviorDefinition,
+  // IBindingBehaviorResource,
+  // IBindingBehaviorType,
 
   // BindingModeBehavior,
   // OneTimeBindingBehavior,
@@ -538,12 +538,12 @@ export {
   // ThrottleBindingBehavior,
 
   customAttribute,
-  CustomAttributeConstructor,
-  CustomAttributeDecorator,
+  // CustomAttributeConstructor,
+  // CustomAttributeDecorator,
   CustomAttribute,
   dynamicOptions,
-  ICustomAttributeResource,
-  ICustomAttributeType,
+  // ICustomAttributeResource,
+  // ICustomAttributeType,
   templateController,
 
   // FrequentMutations,
@@ -563,45 +563,45 @@ export {
   customElement,
   CustomElementHost,
   CustomElement,
-  ICustomElementDecorator,
-  ICustomElementResource,
-  ICustomElementType,
-  IElementProjector,
-  IProjectorLocator,
+  // ICustomElementDecorator,
+  // ICustomElementResource,
+  // ICustomElementType,
+  // IElementProjector,
+  // IProjectorLocator,
   useShadowDOM,
 
   IValueConverter,
-  IValueConverterDefinition,
-  IValueConverterResource,
-  IValueConverterType,
+  // IValueConverterDefinition,
+  // IValueConverterResource,
+  // IValueConverterType,
   valueConverter,
   ValueConverter,
 
-  ISanitizer,
+  // ISanitizer,
   // SanitizeValueConverter,
 
   // ViewValueConverter,
 
   bindable,
-  BindableDecorator,
-  WithBindables,
+  // BindableDecorator,
+  // WithBindables,
   Bindable,
 
   children,
-  ChildrenDecorator,
-  HasChildrenObservers,
+  // ChildrenDecorator,
+  // HasChildrenObservers,
 
 // These exports are temporary until we have a proper way to unit test them
   Controller,
 
   ViewFactory,
-  IViewLocator,
-  ViewLocator,
-  view,
+  // IViewLocator,
+  // ViewLocator,
+  // view,
 
   Aurelia,
-  IDOMInitializer,
-  ISinglePageApp,
+  // IDOMInitializer,
+  // ISinglePageApp,
   CompositionRoot,
 
   // IfRegistration,
@@ -674,17 +674,17 @@ export {
   registerAliases,
 
   // DOM, should expose the one exported in runtime-html
-  // INode,
-  // IRenderLocation,
-  // IDOM,
+  INode,
+  IRenderLocation,
+  IDOM,
   // NodeSequence,
   // INodeSequence,
   // INodeSequenceFactory,
 
   BindingMode,
   BindingStrategy,
-  ExpressionKind,
-  Hooks,
+  // ExpressionKind,
+  // Hooks,
   LifecycleFlags,
   // State,
 
@@ -705,7 +705,7 @@ export {
 
   // ViewModelKind,
   // IBinding,
-  // ILifecycle,
+  ILifecycle,
   // IViewModel,
   // IController,
   // IRenderContext,
@@ -715,18 +715,18 @@ export {
 
   // PromiseOrTask,
   // MaybePromiseOrTask,
-  // AggregateContinuationTask,
-  // TerminalTask,
-  // AggregateTerminalTask,
-  // ContinuationTask,
-  // ILifecycleTask,
-  // LifecycleTask,
-  // PromiseTask,
-  // TaskSlot,
-  // StartTask,
-  // IStartTask,
-  // IStartTaskManager,
-  // ProviderTask,
+  AggregateContinuationTask,
+  TerminalTask,
+  AggregateTerminalTask,
+  ContinuationTask,
+  ILifecycleTask,
+  LifecycleTask,
+  PromiseTask,
+  TaskSlot,
+  StartTask,
+  IStartTask,
+  IStartTaskManager,
+  ProviderTask,
 
   // AccessorOrObserver,
   // Collection,
@@ -739,7 +739,7 @@ export {
   // ICollectionChangeTracker,
   // ICollectionObserver,
   // ICollectionSubscriber,
-  // IndexMap,
+  IndexMap,
   // IObservable,
   // IObservedArray,
   // IObservedMap,
@@ -767,10 +767,10 @@ export {
   // cloneIndexMap,
   // createIndexMap,
 
-  // instructionRenderer,
-  // ensureExpression,
-  // addComponent,
-  // addBinding,
+  instructionRenderer,
+  ensureExpression,
+  addComponent,
+  addBinding,
 
   // CompiledTemplate,
   // createRenderContext,
@@ -865,9 +865,9 @@ export {
 
   // DefaultRenderers,
 
-  BasicConfiguration as RuntimeHtmlBasicConfiguration,
+  // BasicConfiguration as RuntimeHtmlBasicConfiguration,
 
-  // createElement,
+  createElement,
   // RenderPlan,
 
   // HTMLAttributeInstruction,
@@ -915,9 +915,9 @@ export {
   // IShadowDOMGlobalStyles
 } from '@aurelia/runtime-html';
 
-export {
-  // IDOMInitializerRegistration,
-  // DefaultComponents as RuntimeHtmlBrowserDefaultComponents,
-  BasicConfiguration as RuntimeHtmlBrowserBasicConfiguration
-} from '@aurelia/runtime-html-browser';
-
+// tslint:disable-next-line:no-commented-code
+// export {
+//   IDOMInitializerRegistration,
+//   DefaultComponents as RuntimeHtmlBrowserDefaultComponents,
+//   BasicConfiguration as RuntimeHtmlBrowserBasicConfiguration
+// } from '@aurelia/runtime-html-browser';

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -86,7 +86,7 @@ export {
 
   // DefaultBindingLanguage as JitDefaultBindingLanguage,
 
-  // BasicConfiguration as JitBasicConfiguration,
+  // JitConfiguration,
 
   // Access,
   // Precedence,
@@ -149,7 +149,7 @@ export {
 
   // DefaultBindingLanguage as JitHtmlDefaultBindingLanguage,
 
-  BasicConfiguration as JitHtmlBasicConfiguration,
+  JitHtmlConfiguration,
 
   // stringifyDOM,
   // stringifyInstructions,
@@ -161,7 +161,7 @@ export {
 } from '@aurelia/jit-html';
 
 export {
-  BasicConfiguration as JitHtmlBrowserBasicConfiguration
+  JitHtmlBrowserConfiguration
 } from '@aurelia/jit-html-browser';
 
 export {
@@ -636,7 +636,7 @@ export {
   // IObserverLocatorRegistration,
   // ILifecycleRegistration,
   // IRendererRegistration,
-  // RuntimeBasicConfiguration,
+  // RuntimeConfiguration,
 
   // AttributeDefinition,
   // AttributeInstruction,
@@ -865,7 +865,7 @@ export {
 
   // DefaultRenderers,
 
-  // BasicConfiguration as RuntimeHtmlBasicConfiguration,
+  // RuntimeHtmlConfiguration,
 
   createElement,
   // RenderPlan,
@@ -919,5 +919,5 @@ export {
 // export {
 //   IDOMInitializerRegistration,
 //   DefaultComponents as RuntimeHtmlBrowserDefaultComponents,
-//   BasicConfiguration as RuntimeHtmlBrowserBasicConfiguration
+//   RuntimeHtmlBrowserConfiguration
 // } from '@aurelia/runtime-html-browser';

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -149,7 +149,7 @@ export {
 
   // DefaultBindingLanguage as JitHtmlDefaultBindingLanguage,
 
-  JitHtmlConfiguration,
+  // JitHtmlConfiguration,
 
   // stringifyDOM,
   // stringifyInstructions,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,6 @@
 export {
-  quickStart as default
+  Aurelia,
+  Aurelia as default
 } from './quick-start';
 
 export {
@@ -599,7 +600,7 @@ export {
   // ViewLocator,
   // view,
 
-  Aurelia,
+  // Aurelia, // Replaced by quick-start wrapper
   // IDOMInitializer,
   // ISinglePageApp,
   CompositionRoot,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -20,7 +20,7 @@ export {
   // RetryableRequest,
   // ValidInterceptorMethodName,
 
-  // json,
+  json,
 
   // retryStrategy,
   // RetryInterceptor,
@@ -288,10 +288,10 @@ export {
   // NavigationInstruction,
   // ReentryBehavior,
 
-  // INavRoute,
+  INavRoute,
   // Nav,
 
-  // NavRoute,
+  NavRoute,
 
   // IStoredNavigatorEntry,
   // INavigatorEntry,
@@ -492,7 +492,7 @@ export {
   // DirtyCheckSettings,
 
   // IObjectObservationAdapter,
-  // IObserverLocator,
+  IObserverLocator,
   // ITargetObserverLocator,
   // ITargetAccessorLocator,
   // getCollectionObserver,
@@ -707,7 +707,7 @@ export {
   // ViewModelKind,
   // IBinding,
   ILifecycle,
-  // IViewModel,
+  IViewModel,
   // IController,
   // IRenderContext,
   // IViewCache,

--- a/packages/aurelia/src/quick-start.ts
+++ b/packages/aurelia/src/quick-start.ts
@@ -1,11 +1,11 @@
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { IRegistry } from '@aurelia/kernel';
 import { Aurelia, ICustomElementType, INode } from '@aurelia/runtime';
 
 function start(component: unknown, host: INode, deps: IRegistry[]): Aurelia {
   const au = new Aurelia();
-  au.register(BasicConfiguration, ...deps);
+  au.register(JitHtmlBrowserConfiguration, ...deps);
 
   if (typeof process !== 'undefined' && typeof process.env === 'object') {
     // Just use NODE_ENV to control build process.

--- a/packages/aurelia/src/quick-start.ts
+++ b/packages/aurelia/src/quick-start.ts
@@ -1,0 +1,62 @@
+import { DebugConfiguration } from '@aurelia/debug';
+import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { IRegistry } from '@aurelia/kernel';
+import { Aurelia, ICustomElementType, INode } from '@aurelia/runtime';
+
+function start(component: unknown, host: INode, deps: IRegistry[]): Aurelia {
+  const au = new Aurelia();
+  au.register(BasicConfiguration, ...deps);
+
+  if (typeof process !== 'undefined' && typeof process.env === 'object') {
+    // Just use NODE_ENV to control build process.
+    // Bundlers (at least webpack/dumber/parcel) have feature to remove this branch in production.
+    // Then tree-shaking/minifier will remove unused DebugConfiguration import.
+    // tslint:disable-next-line:no-collapsible-if
+    if (process.env.NODE_ENV !== 'production') {
+      au.register(DebugConfiguration);
+    }
+  }
+
+  au.app({ host, component }).start();
+  return au;
+}
+
+interface IQuickStartOptions {
+  host?: string | Element | null;
+  dependencies?: unknown[];
+  // Support deps as an alias of dependencies
+  deps?: unknown[];
+}
+
+// TODO: SSR?? abstract HTMLElement and document.
+
+/**
+ * A wrapper to quick start an Aurelia app
+ */
+export function quickStart(component: unknown, options: IQuickStartOptions = {}): Aurelia {
+  let host = options.host;
+  const deps = (options.dependencies || options.deps || []) as IRegistry[];
+
+  // Try to get host from custom element name.
+  if (host === undefined || host === null) {
+    const comp = component as ICustomElementType;
+    // tslint:disable-next-line:no-collapsible-if
+    if (comp && comp.kind && comp.kind.name === 'custom-element') {
+      // Default to custom element element name
+      const elementName = comp.description && comp.description.name;
+      host = elementName;
+    }
+  }
+
+  if (typeof host === 'string') {
+    host = document.querySelector(host);
+  }
+
+  // When no target is found, default to body.
+  // For example, when user forgot to write <my-app></my-app> in html.
+  if (host === undefined || host === null) {
+    host = document.body;
+  }
+
+  return start(component, host, deps);
+}

--- a/packages/aurelia/tsconfig.json
+++ b/packages/aurelia/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "lib": ["dom"],
+    "rootDir": "src",
+    "declarationDir": "dist",
+    "outDir": "dist/esnext"
+  },
+  "include": ["src"]
+}

--- a/packages/examples/e2e-benchmark/vnext/src/startup.ts
+++ b/packages/examples/e2e-benchmark/vnext/src/startup.ts
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia, ILifecycle } from '@aurelia/runtime';
 import { App } from './app';
 import { Instrumenter } from './instrumenter';
@@ -6,7 +6,7 @@ declare var instrumenter: Instrumenter;
 
 instrumenter.markLifecycle('module-loaded');
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 const lifecycle = container.get(ILifecycle);
 instrumenter.lifecycle = lifecycle;
 const au = window['au'] = new Aurelia(container);

--- a/packages/examples/test-jit/startup.ts
+++ b/packages/examples/test-jit/startup.ts
@@ -1,9 +1,9 @@
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 import { DebugConfiguration } from '../debug/configuration';
-import { BasicConfiguration } from '../jit/configuration';
+import { JitConfiguration } from '../jit/configuration';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration, DebugConfiguration)
+  .register(JitConfiguration, DebugConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();

--- a/packages/jit-html-browser/src/index.ts
+++ b/packages/jit-html-browser/src/index.ts
@@ -8,25 +8,25 @@ import {
   DefaultComponents as JitHtmlDefaultComponents
 } from '@aurelia/jit-html';
 import { DI, IContainer, Profiler } from '@aurelia/kernel';
-import { BasicConfiguration as RuntimeHtmlBrowserBasicConfiguration } from '@aurelia/runtime-html-browser';
+import { RuntimeHtmlBrowserConfiguration } from '@aurelia/runtime-html-browser';
 
-const { enter, leave } = Profiler.createTimer('BasicConfiguration');
+const { enter, leave } = Profiler.createTimer('JitHtmlBrowserConfiguration');
 
 /**
  * A DI configuration object containing html-specific, browser-specific registrations:
- * - `BasicConfiguration` from `@aurelia/runtime-html-browser`
+ * - `RuntimeHtmlBrowserConfiguration` from `@aurelia/runtime-html-browser`
  * - `DefaultComponents` from `@aurelia/jit`
  * - `DefaultBindingSyntax` from `@aurelia/jit`
  * - `DefaultBindingLanguage` from `@aurelia/jit`
  * - `DefaultComponents` from `@aurelia/jit-html`
  * - `DefaultBindingLanguage` from `@aurelia/jit-html`
  */
-export const BasicConfiguration = {
+export const JitHtmlBrowserConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    RuntimeHtmlBrowserBasicConfiguration
+    RuntimeHtmlBrowserConfiguration
       .register(container)
       .register(
         ...JitDefaultBindingLanguage,

--- a/packages/jit-html-jsdom/src/index.ts
+++ b/packages/jit-html-jsdom/src/index.ts
@@ -8,25 +8,25 @@ import {
   DefaultComponents as JitHtmlDefaultComponents
 } from '@aurelia/jit-html';
 import { DI, IContainer, Profiler } from '@aurelia/kernel';
-import { BasicConfiguration as RuntimeJSDOMBrowserBasicConfiguration } from '@aurelia/runtime-html-jsdom';
+import { RuntimeHtmlJsdomConfiguration } from '@aurelia/runtime-html-jsdom';
 
-const { enter, leave } = Profiler.createTimer('BasicConfiguration');
+const { enter, leave } = Profiler.createTimer('JitHtmlJsdomConfiguration');
 
 /**
  * A DI configuration object containing html-specific, jsdom-specific registrations:
- * - `BasicConfiguration` from `@aurelia/runtime-html-jsdom`
+ * - `RuntimeHtmlJsdomConfiguration` from `@aurelia/runtime-html-jsdom`
  * - `DefaultComponents` from `@aurelia/jit`
  * - `DefaultBindingSyntax` from `@aurelia/jit`
  * - `DefaultBindingLanguage` from `@aurelia/jit`
  * - `DefaultComponents` from `@aurelia/jit-html`
  * - `DefaultBindingLanguage` from `@aurelia/jit-html`
  */
-export const BasicConfiguration = {
+export const JitHtmlJsdomConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    RuntimeJSDOMBrowserBasicConfiguration
+    RuntimeHtmlJsdomConfiguration
       .register(container)
       .register(
         ...JitDefaultBindingLanguage,

--- a/packages/jit-html/src/configuration.ts
+++ b/packages/jit-html/src/configuration.ts
@@ -4,7 +4,7 @@ import {
   DefaultComponents as JitDefaultComponents
 } from '@aurelia/jit';
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
-import { BasicConfiguration as RuntimeHtmlBasicConfiguration } from '@aurelia/runtime-html';
+import { RuntimeHtmlConfiguration } from '@aurelia/runtime-html';
 import {
   AttrAttributePattern,
   ClassAttributePattern,
@@ -71,19 +71,19 @@ export const DefaultBindingLanguage = [
 
 /**
  * A DI configuration object containing html-specific (but environment-agnostic) registrations:
- * - `BasicConfiguration` from `@aurelia/runtime-html`
+ * - `RuntimeHtmlConfiguration` from `@aurelia/runtime-html`
  * - `DefaultComponents` from `@aurelia/jit`
  * - `DefaultBindingSyntax` from `@aurelia/jit`
  * - `DefaultBindingLanguage` from `@aurelia/jit`
  * - `DefaultComponents`
  * - `DefaultBindingLanguage`
  */
-export const BasicConfiguration = {
+export const JitHtmlConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    return RuntimeHtmlBasicConfiguration
+    return RuntimeHtmlConfiguration
       .register(container)
       .register(
         ...JitDefaultComponents,

--- a/packages/jit-html/src/index.ts
+++ b/packages/jit-html/src/index.ts
@@ -25,7 +25,7 @@ export {
 
   DefaultBindingLanguage,
 
-  BasicConfiguration
+  JitHtmlConfiguration
 } from './configuration';
 export {
   stringifyDOM,

--- a/packages/jit/src/configuration.ts
+++ b/packages/jit/src/configuration.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
-import { IExpressionParser, RuntimeBasicConfiguration } from '@aurelia/runtime';
+import { IExpressionParser, RuntimeConfiguration } from '@aurelia/runtime';
 import {
   AtPrefixedTriggerAttributePattern,
   ColonPrefixedBindAttributePattern,
@@ -85,17 +85,17 @@ export const DefaultBindingLanguage = [
 
 /**
  * A DI configuration object containing runtime/environment-agnostic registrations:
- * - `BasicConfiguration` from `@aurelia/runtime`
+ * - `RuntimeConfiguration` from `@aurelia/runtime`
  * - `DefaultComponents`
  * - `DefaultBindingSyntax`
  * - `DefaultBindingLanguage`
  */
-export const BasicConfiguration = {
+export const JitConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    return RuntimeBasicConfiguration
+    return RuntimeConfiguration
       .register(container)
       .register(
         ...DefaultComponents,

--- a/packages/jit/src/index.ts
+++ b/packages/jit/src/index.ts
@@ -61,7 +61,7 @@ export {
 
   DefaultBindingLanguage,
 
-  BasicConfiguration
+  JitConfiguration
 } from './configuration';
 export {
   Access,

--- a/packages/runtime-html-browser/src/index.ts
+++ b/packages/runtime-html-browser/src/index.ts
@@ -1,6 +1,6 @@
 import { DI, IContainer, IRegistry, IResolver, Key, Registration } from '@aurelia/kernel';
 import { IDOM, IDOMInitializer, ISinglePageApp } from '@aurelia/runtime';
-import { BasicConfiguration as RuntimeHtmlConfiguration, HTMLDOM } from '@aurelia/runtime-html';
+import { RuntimeHtmlConfiguration, HTMLDOM } from '@aurelia/runtime-html';
 
 class BrowserDOMInitializer implements IDOMInitializer {
   public static readonly inject: readonly Key[] = [IContainer];
@@ -75,10 +75,10 @@ export const DefaultComponents = [
 
 /**
  * A DI configuration object containing html-specific, browser-specific registrations:
- * - `BasicConfiguration` from `@aurelia/runtime-html`
+ * - `RuntimeHtmlConfiguration` from `@aurelia/runtime-html`
  * - `DefaultComponents`
  */
-export const BasicConfiguration = {
+export const RuntimeHtmlBrowserConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */

--- a/packages/runtime-html-jsdom/src/index.ts
+++ b/packages/runtime-html-jsdom/src/index.ts
@@ -1,6 +1,6 @@
 import { DI, IContainer, IRegistry, IResolver, Key, Registration } from '@aurelia/kernel';
 import { IDOM, IDOMInitializer, ISinglePageApp } from '@aurelia/runtime';
-import { BasicConfiguration as RuntimeHtmlConfiguration, HTMLDOM } from '@aurelia/runtime-html';
+import { RuntimeHtmlConfiguration, HTMLDOM } from '@aurelia/runtime-html';
 import { JSDOM } from 'jsdom';
 
 class JSDOMInitializer implements IDOMInitializer {
@@ -81,10 +81,10 @@ export const DefaultComponents = [
 
 /**
  * A DI configuration object containing html-specific, jsdom-specific registrations:
- * - `BasicConfiguration` from `@aurelia/runtime-html`
+ * - `RuntimeHtmlConfiguration` from `@aurelia/runtime-html`
  * - `DefaultComponents`
  */
-export const BasicConfiguration = {
+export const RuntimeHtmlJsdomConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
-import { RuntimeBasicConfiguration } from '@aurelia/runtime';
+import { RuntimeConfiguration } from '@aurelia/runtime';
 import { HTMLTemplateFactory } from './dom';
 import {
   AttributeBindingRenderer,
@@ -80,17 +80,17 @@ export const DefaultRenderers = [
 
 /**
  * A DI configuration object containing html-specific (but environment-agnostic) registrations:
- * - `BasicConfiguration` from `@aurelia/runtime`
+ * - `RuntimeConfiguration` from `@aurelia/runtime`
  * - `DefaultComponents`
  * - `DefaultResources`
  * - `DefaultRenderers`
  */
-export const BasicConfiguration = {
+export const RuntimeHtmlConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */
   register(container: IContainer): IContainer {
-    return RuntimeBasicConfiguration
+    return RuntimeConfiguration
       .register(container)
       .register(
         ...DefaultComponents,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -103,7 +103,7 @@ export {
 
   DefaultRenderers,
 
-  BasicConfiguration
+  RuntimeHtmlConfiguration
 } from './configuration';
 export {
   createElement,

--- a/packages/runtime/src/configuration.ts
+++ b/packages/runtime/src/configuration.ts
@@ -152,7 +152,7 @@ export const DefaultRenderers = [
  * - `DefaultResources`
  * - `DefaultRenderers`
  */
-export const RuntimeBasicConfiguration = {
+export const RuntimeConfiguration = {
   /**
    * Apply this configuration to the provided container.
    */

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -340,7 +340,7 @@ export {
   IObserverLocatorRegistration,
   ILifecycleRegistration,
   IRendererRegistration,
-  RuntimeBasicConfiguration
+  RuntimeConfiguration
 } from './configuration';
 export {
   AttributeDefinition,

--- a/packages/testing/src/au-dom.ts
+++ b/packages/testing/src/au-dom.ts
@@ -49,7 +49,7 @@ import {
   LetElementInstruction,
   LifecycleFlags,
   PropertyBinding,
-  RuntimeBasicConfiguration,
+  RuntimeConfiguration,
   TargetedInstruction,
   TemplateDefinition,
   ToViewBindingInstruction
@@ -675,7 +675,7 @@ export class AuTextRenderer implements IInstructionRenderer {
 export const AuDOMConfiguration = {
   register(container: IContainer): void {
     container.register(
-      RuntimeBasicConfiguration,
+      RuntimeConfiguration,
       AuTextRenderer as unknown as IRegistry,
       Registration.singleton(IDOM, AuDOM),
       Registration.singleton(IDOMInitializer, AuDOMInitializer),

--- a/packages/testing/src/test-builder.ts
+++ b/packages/testing/src/test-builder.ts
@@ -1,5 +1,5 @@
 import { parseExpression } from '@aurelia/jit';
-import { BasicConfiguration } from '@aurelia/jit-html';
+import { JitHtmlConfiguration } from '@aurelia/jit-html';
 import {
   Class,
   Constructable,
@@ -350,7 +350,7 @@ import {
 //   private readonly Type: T;
 
 //   constructor(Type: T) {
-//     this.container = BasicConfiguration.createContainer();
+//     this.container = JitHtmlConfiguration.createContainer();
 //     this.container.register(Type as any);
 //     this.Type = Type;
 //   }

--- a/scripts/project.ts
+++ b/scripts/project.ts
@@ -94,7 +94,7 @@ export default {
     const name = {
       kebab: kebabName,
       camel: camelName,
-      npm: `@aurelia/${kebabName}`,
+      npm: kebabName === 'aurelia' ? 'aurelia' : `@aurelia/${kebabName}`,
       namespace: 'au',
       iife: `au.${camelName}`,
     }

--- a/test/1kcomponents/app-double.js
+++ b/test/1kcomponents/app-double.js
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia, CustomElementResource, ValueConverterResource, ILifecycle, Priority, LifecycleFlags } from '@aurelia/runtime';
 import { register } from '@aurelia/plugin-svg';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
@@ -257,14 +257,14 @@ function defineApp(fps, count) {
   );
 }
 
-new Aurelia().register(BasicConfiguration, { register }).app(
+new Aurelia().register(JitHtmlBrowserConfiguration, { register }).app(
   {
     host: document.getElementById('app-left'),
     component: defineApp(5, 2000)
   }
 ).start();
 
-new Aurelia().register(BasicConfiguration, { register }).app(
+new Aurelia().register(JitHtmlBrowserConfiguration, { register }).app(
   {
     host: document.getElementById('app-right'),
     component: defineApp(25, 1000)

--- a/test/1kcomponents/app.js
+++ b/test/1kcomponents/app.js
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia, CustomElementResource, ValueConverterResource, ILifecycle, Priority, LifecycleFlags } from '@aurelia/runtime';
 import { register } from '@aurelia/plugin-svg';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
@@ -255,7 +255,7 @@ const App = CustomElementResource.define(
   }
 );
 
-new Aurelia().register(BasicConfiguration, { register }).app(
+new Aurelia().register(JitHtmlBrowserConfiguration, { register }).app(
   {
     host: document.getElementById('app'),
     component: App,

--- a/test/browserstack/src/select/startup.ts
+++ b/test/browserstack/src/select/startup.ts
@@ -1,9 +1,9 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration)
+  .register(JitHtmlBrowserConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();
 

--- a/test/browserstack/src/todos/startup.ts
+++ b/test/browserstack/src/todos/startup.ts
@@ -1,9 +1,9 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 window['au'] = new Aurelia()
-  .register(BasicConfiguration)
+  .register(JitHtmlBrowserConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();
 

--- a/test/cypress/app/src/startup.ts
+++ b/test/cypress/app/src/startup.ts
@@ -1,6 +1,6 @@
 import { NavCustomElement, ViewportCustomElement } from '@aurelia/router';
 import { DebugConfiguration } from '@aurelia/debug';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 
 import { registerComponent } from './utils';
@@ -10,7 +10,7 @@ import { App } from './app';
 import { RouterHome } from './components/router/home';
 import { RouterWithNav } from './components/router/with-nav';
 
-const container = BasicConfiguration.createContainer();
+const container = JitHtmlBrowserConfiguration.createContainer();
 
 container.register(
   ViewportCustomElement as any,

--- a/test/fractals-tree/app.js
+++ b/test/fractals-tree/app.js
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { register } from '@aurelia/plugin-svg';
 import { Aurelia, CustomElementResource } from '@aurelia/runtime';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
@@ -11,7 +11,7 @@ startMemMonitor();
 try {
   new Aurelia()
     .register(
-      BasicConfiguration,
+      JitHtmlBrowserConfiguration,
       { register }
     )
     .app({
@@ -37,14 +37,14 @@ try {
           ]
         },
         (() => {
-          class App {        
+          class App {
             constructor(state) {
               this.state = state;
               const base = state.baseSize;
               this.totalNodes = 2 ** (10 + 1);
               this.baseTransform = `translate(50%, 100%) translate(-${base / 2}px, 0) scale(${base}, ${-base})`;
             }
-          
+
             onMouseMove({ clientX, clientY }) {
               this.state.mouseMoved(clientX, clientY);
             }

--- a/test/grid/src/startup.ts
+++ b/test/grid/src/startup.ts
@@ -1,14 +1,14 @@
 import * as faker from 'faker';
 
 import { Aurelia } from '@aurelia/runtime';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { App } from './app';
 import { DI } from '@aurelia/kernel';
 
 window['faker'] = faker;
 
 const container = DI.createContainer().register(
-  BasicConfiguration,
+  JitHtmlBrowserConfiguration,
 );
 
 const au = window['au'] = new Aurelia(container);

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
@@ -1,9 +1,9 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 global['Aurelia'] = new Aurelia()
-  .register(BasicConfiguration)
+  .register(JitHtmlBrowserConfiguration)
   .app({
     host: document.querySelector('app'),
     component: App

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-npm/src/main.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-npm/src/main.ts
@@ -1,9 +1,9 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia } from '@aurelia/runtime';
 import { App } from './app';
 
 new Aurelia()
-  .register(BasicConfiguration)
+  .register(JitHtmlBrowserConfiguration)
   .app({
     host: document.querySelector('app'),
     component: App

--- a/test/rainbow-spiral/app.js
+++ b/test/rainbow-spiral/app.js
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { register } from '@aurelia/plugin-svg';
 import { Aurelia, CustomElementResource } from '@aurelia/runtime';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
@@ -6,14 +6,14 @@ import { Cursor } from './cursor';
 
 startFPSMonitor();
 startMemMonitor();
-        
+
 const COUNT = 200;
 const LOOPS = 6;
 
 try {
   new Aurelia()
     .register(
-      BasicConfiguration,
+      JitHtmlBrowserConfiguration,
       { register }
     )
     .app({

--- a/test/realworld/src/main.ts
+++ b/test/realworld/src/main.ts
@@ -1,6 +1,6 @@
 import { DebugConfiguration } from '@aurelia/debug';
 import { HttpClient } from '@aurelia/fetch-client';
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { IRegistry } from '@aurelia/kernel';
 import { RouterConfiguration } from '@aurelia/router';
 import { Aurelia } from '@aurelia/runtime';
@@ -27,7 +27,7 @@ const globalResources = [
 
 (global as any).au = new Aurelia()
   .register(
-    BasicConfiguration,
+    JitHtmlBrowserConfiguration,
     DebugConfiguration,
     RouterConfiguration.customize({ useUrlFragmentHash: false }),
     ...globalResources,

--- a/test/sierpinski-triangle/app.js
+++ b/test/sierpinski-triangle/app.js
@@ -1,4 +1,4 @@
-import { BasicConfiguration } from '@aurelia/jit-html-browser';
+import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
 import { Aurelia, CustomElementResource, ValueConverterResource, ILifecycle, Priority } from '@aurelia/runtime';
 import { register } from '@aurelia/plugin-svg';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
@@ -14,7 +14,7 @@ export const clock = {
   },
 };
 
-new Aurelia().register(BasicConfiguration, { register }).app(
+new Aurelia().register(JitHtmlBrowserConfiguration, { register }).app(
   {
     host: document.getElementById('app'),
     component: CustomElementResource.define(


### PR DESCRIPTION
# Pull Request

## 📖 Description

Re-export all in a single "aurelia" package, and a wrapper to start app.

### 🎫 Issues

This is an implementation of RFC #630, more description in the RFC.

## 👩‍💻 Reviewer Notes

Our release and publish scripts seems ok to handle non-scoped package. I only did a minor update.

The re-exports only exported essentials from internal packages, lots of exports are commented out right now.

**Please review and make modification to the export list, especially on kernel, router, and runtime.**

Note fetch-client and router are in the re-exports list, as I think at least 90% of Aurelia 2 users will use them.

i18n, dialog, validation, store, are not in the list. We can change in future if needed.

The quick start wrapper is the default export of "aurelia" package. It followed @EisenbergEffect 's suggested API.

```ts
import Aurelia, { StyleConfiguration, RouterConfiguration } from 'aurelia';
import { MyRootComponent } from './my-root-component';
// By default host to element name (<my-root-component> for MyRootComponent),
// or <body> if <my-root-component> is absent.
Aurelia.app(MyRootComponent).start();

// Or load additional aurelia features
Aurelia
  .register(
    StyleConfiguration.shadowDOM(),
    RouterConfiguration.customize({ useUrlFragmentHash: false })
  )
  .app(MyRootComponent)
  .start();

// Or host to <my-start-tag>
Aurelia
  .register(
    StyleConfiguration.shadowDOM(),
    RouterConfiguration.customize({ useUrlFragmentHash: false })
  )
  .app({
    component: MyRootComponent,
    host: document.querySelector('my-start-tag')
  })
  .start();
```

The method returns Aurelia instance, not the task. User can wait on it. `au(MyApp).wait().then(() => ...);`.

## 📑 Test Plan

Tested manually in a local webpack app. The quick start wrapper worked as expected.

Similiar to existing Aurelia class, there is no unit tests for the quick start wrapper. I don't know how to do it. However it will be covered by e2e tests with various example apps.

## ⏭ Next Steps

- [ ] update conventions. (Let's do it in a separate PR.)
- [ ] update all example apps setup.
- [ ] update aurelia/new makes skeletons.
- [ ] update docs.
