### PR TITLE
docs: update doc to use latest "aurelia" package

### DIFF
--- a/docs/engineering-notes/specs.md
+++ b/docs/engineering-notes/specs.md
@@ -52,8 +52,7 @@ Aurelia
 To start an Aurelia application, create a `new Aurelia()` object with a target `host`, a root `component`, and an optional list of `plugins`, and call `start()`.
 
 ```ts
-import { Aurelia } from '@aurelia/jit-html-browser';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
+import Aurelia, { JitHtmlBrowserConfiguration } from 'aurelia';
 import { ThirdPartyPlugin } from 'third-party-plugin';
 
 // Object API.

--- a/docs/user-docs/app-basics/app-configuration-and-startup.md
+++ b/docs/user-docs/app-basics/app-configuration-and-startup.md
@@ -38,9 +38,7 @@ Aurelia
 To start an Aurelia application, create a `new Aurelia()` object with a target `host` and a root `component` and call `start()`.
 
 ```typescript
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia, { DebugConfiguration, JitHtmlBrowserConfiguration } from 'aurelia';
 import { ShellComponent } from './shell';
 
 new Aurelia()

--- a/docs/user-docs/app-basics/dependency-injection.md
+++ b/docs/user-docs/app-basics/dependency-injection.md
@@ -26,7 +26,7 @@ Fortunately, there is a battle-tested solution to this problem. We can use a Dep
 An application typically has a single root-level DI container. To create a root container, call the `DI.createContainer()` method:
 
 ```typescript
-import { DI } from '@aurelia/kernel';
+import { DI } from 'aurelia';
 
 const container = DI.createContainer();
 ```
@@ -57,7 +57,7 @@ In this case we have a class that is designed to import files. In order to do it
 Decorators are an upcoming feature of EcmaScript and an experimental feature in TypeScript. If you want to use decorators in your project, you must first opt into them by adding `"experimentalDecorators": true` in the `compilerOptions` section of your `tsconfig.json` file. Once enabled, you can import the `@inject` decorator from this library and use it to declare injected dependencies. Here's the same example from above, written with a decorator:
 
 ```typescript
-import { inject } from '@aurelia/kernel';
+import { inject } from 'aurelia';
 
 @inject(FileReader, Logger)
 export class FileImporter {
@@ -72,7 +72,7 @@ This decorator simply creates a static `inject` property on the decorated class,
 If you have already opted into using TypeScript and decorators, you have an additional option available to you: decorator metadata. It's possible for the TypeScript compiler to emit metadata about the types of the constructor parameters automatically, as part of the build process, if a decorator is present. If this metadata is present, the DI container can use it instead of an explicit injection list. To enable this feature for the compiler, add `"emitDecoratorMetadata": true` in the `compilerOptions` section of your `tsconfig.json` file. With that in place, you can write the above code like this:
 
 ```typescript
-import { inject } from '@aurelia/kernel';
+import { inject } from 'aurelia';
 
 @inject()
 export class FileImporter {
@@ -96,7 +96,7 @@ If you have either of the above scenarios, you'll want to be sure to use an expl
 Internally, the DI Container figures out how to locate each dependency using a Resolver. Which resolver is used depends on if or how the dependency was registered. \(See below for information on registration.\) However, you can specify a special resolver when you declare your dependencies. For example, perhaps your application has an Inspector that is composed of Panel instances. You may want to inject the panels into the inspector. However, there isn't just one Panel, there are multiple different types of panels that implement the Panel interface. In this case, you'd want to use the `all` resolver. Here's what that would look like with a plain class:
 
 ```typescript
-import { all } from '@aurelia/kernel';
+import { all } from 'aurelia';
 
 export class Inspector {
   static inject = [all(Panel)];
@@ -107,7 +107,7 @@ export class Inspector {
 And with a decorator...
 
 ```typescript
-import { all } from '@aurelia/kernel';
+import { all } from 'aurelia';
 
 @inject(all(Panel))
 export class Inspector {
@@ -118,7 +118,7 @@ export class Inspector {
 In another scenario, you might have a dependency on a service that is expensive to create and that isn't always required, depending on what the user is doing with the app. In this case, you may want to lazily resolve the dependency when it's needed. For this, use the `lazy` resolver:
 
 ```typescript
-import { lazy } from '@aurelia/kernel';
+import { lazy } from 'aurelia';
 
 export class MyClass {
   static inject = [lazy(ExpensiveToCreateService)];
@@ -129,7 +129,7 @@ export class MyClass {
 And with a decorator...
 
 ```typescript
-import { lazy } from '@aurelia/kernel';
+import { lazy } from 'aurelia';
 
 @inject(lazy(ExpensiveToCreateService))
 export class MyClass {
@@ -197,7 +197,7 @@ Auto-registration works if everything is a singleton and you're using classes fo
 The primary API for registration is called `register` and it can be used in combination with the `Registration` DSL. Here's an example:
 
 ```typescript
-import { DI, Registration } from '@aurelia/kernel';
+import { DI, Registration } from 'aurelia';
 
 const container = DI.createContainer();
 container.register(
@@ -257,7 +257,7 @@ export interface IProfileService { ... }
 When this technique is used, TypeScript, based on usage, can determine in which scenarios you want to use the interface and in which you want to use the Symbol. So, it can completely understand this code:
 
 ```typescript
-import { Registration } from '@aurelia/kernel';
+import { Registration } from 'aurelia';
 
 const IProfileService = Symbol('IProfileService');
 interface IProfileService { ... }
@@ -283,7 +283,7 @@ container.register(
 Because this is such a handy capability of the compiler, the DI API provides a helper method with some benefits. We can optionally rework the above code to use this API like so:
 
 ```typescript
-import { DI } from '@aurelia/kernel';
+import { DI } from 'aurelia';
 
 export const IProfileService = DI.createInterface<IProfileService>();
 export interface IProfileService {
@@ -298,7 +298,7 @@ This is slightly more verbose, but it has the advantage that the symbol created 
 In many front-end scenarios, it's common to have a single default implementation of your interface, which you provide "out of the box". To facilitate this scenario, the `DI.createInterface()` method returns an `IDefaultableInterfaceSymbol`, exposing a method named `withDefault` that you can call to associate a default implementation with your interface. The consumer who sets up the container can still specify their own implementation of the interface at runtime, but if one is not provided, it will fallback to the default implementation specified through this method. This allows the container to use auto-registration with the symbols created by the `DI.createInterface()` helper.
 
 ```typescript
-import { DI } from '@aurelia/kernel';
+import { DI } from 'aurelia';
 
 export interface ITaskQueue {
     // ...api...

--- a/docs/user-docs/app-basics/internationalization.md
+++ b/docs/user-docs/app-basics/internationalization.md
@@ -60,9 +60,9 @@ npm i @aurelia/i18n
 
 ```typescript
 import { I18nConfiguration } from '@aurelia/i18n';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 
-new Aurelia()
+Aurelia
   .register(
     I18nConfiguration.customize((options) => {
       options.initOptions = {
@@ -73,7 +73,7 @@ new Aurelia()
       };
     })
   )
-  .app({ host, component })
+  .app(component)
   .start();
 ```
 
@@ -376,7 +376,7 @@ The example sets the `[title]` attribute of the `span`. A useful example would b
 
 The same syntax of attribute translation also works for translating `@bindable`s of custom elements.
 
-\`\`\`typescript custom-message.ts import { bindable, customElement } from '@aurelia/runtime';. import template from './custom-message.html';
+\`\`\`typescript custom-message.ts import { bindable, customElement } from 'aurelia';. import template from './custom-message.html';
 
 @customElement\({ name: 'custom-message', template }\) export class CustomMessage { @bindable public message: string; }
 
@@ -680,7 +680,7 @@ export class MyDemoVm {
 }
 ```
 
-\`\`\`html my-demo-vm.html  ${ date \| rt }   ${ date & rt : { style: 'short' } : 'de' } 
+\`\`\`html my-demo-vm.html  ${ date \| rt }   ${ date & rt : { style: 'short' } : 'de' }
 
 ```text
 The `rt` ValueConverter and BindingBehavior can be used to relatively format dates in a declarative way from the view.
@@ -701,7 +701,7 @@ See the example below.
 
 ```typescript my-demo-vm.ts
 import { Signals } from '@aurelia/i18n';
-import { ISignaler } from '@aurelia/runtime';
+import { ISignaler } from 'aurelia';
 
 export class MyDemoVm {
 

--- a/docs/user-docs/examples/custom-attributes/binding-to-element-size.md
+++ b/docs/user-docs/examples/custom-attributes/binding-to-element-size.md
@@ -3,8 +3,7 @@
 ## Basic implementation
 
 ```typescript
-import { bindable, BindingMode, customAttribute, IDOM, INode } from '@aurelia/runtime';
-import { HTMLDOM } from '@aurelia/runtime-html';
+import { bindable, BindingMode, customAttribute, HTMLDOM, IDOM, INode } from 'aurelia';
 
 @customAttribute({
   name: 'rectsize',

--- a/docs/user-docs/getting-started/components.md
+++ b/docs/user-docs/getting-started/components.md
@@ -55,7 +55,7 @@ The `say-hello` custom element we've created isn't very interesting yet, so lets
 {% code-tabs %}
 {% code-tabs-item title="say-hello.ts" %}
 ```typescript
-import { bindable } from '@aurelia/runtime';
+import { bindable } from 'aurelia';
 
 export class SayHello {
   @bindable to = 'World';
@@ -89,7 +89,7 @@ Now, what if we want our component to do something in response to user interacti
 {% code-tabs %}
 {% code-tabs-item title="say-hello.ts" %}
 ```typescript
-import { bindable } from '@aurelia/runtime';
+import { bindable } from 'aurelia';
 
 export class SayHello {
   @bindable to = 'World';
@@ -140,7 +140,7 @@ By default, components you create aren't global. What that means is that you can
 
 {% code-tabs-item title="say-hello.ts" %}
 ```typescript
-import { bindable } from '@aurelia/runtime';
+import { bindable } from 'aurelia';
 
 export class SayHello {
   @bindable to = 'World';
@@ -165,19 +165,16 @@ In practice, most people want to side-step this feature and make most of their g
 {% code-tabs %}
 {% code-tabs-item title="mail.ts" %}
 ```typescript
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 import { NameTag } from './name-tag';
 
-new Aurelia()
+Aurelia
   .register(
-    JitHtmlBrowserConfiguration,
-    DebugConfiguration,
     NameTag // Here it is!
-  ).app({ host: document.querySelector('app'), component: App })
-   .start();
+  )
+  .app(App)
+  .start();
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -194,19 +191,16 @@ export * from './name-tag';
 
 {% code-tabs-item title="main.ts" %}
 ```typescript
-import { DebugConfiguration } from '@aurelia/debug';
-import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { Aurelia } from '@aurelia/runtime';
+import Aurelia from 'aurelia';
 import { App } from './app';
 import * as globalComponents from './components/registry';
 
-new Aurelia()
+Aurelia
   .register(
-    JitHtmlBrowserConfiguration,
-    DebugConfiguration,
     globalComponents // This globalizes all the exports of our registry.
-  ).app({ host: document.querySelector('app'), component: App })
-   .start();
+  )
+  .app(App)
+  .start();
 ```
 {% endcode-tabs-item %}
 {% endcode-tabs %}
@@ -224,7 +218,7 @@ So far, we've described how components are created by simply naming your JavaScr
 {% code-tabs %}
 {% code-tabs-item title="say-hello.ts" %}
 ```typescript
-import { customElement, bindable } from '@aurelia/runtime';
+import { customElement, bindable } from 'aurelia';
 import template from './say-hello.html';
 
 @customElement({
@@ -291,7 +285,7 @@ To tap into any of these hooks, simply implement the method on your class:
 {% code-tabs %}
 {% code-tabs-item title="say-hello.ts" %}
 ```typescript
-import { bindable } from '@aurelia/runtime';
+import { bindable } from 'aurelia';
 
 export class SayHello {
   @bindable to = 'World';

--- a/packages/aurelia/README.md
+++ b/packages/aurelia/README.md
@@ -6,6 +6,25 @@
 [![npm](https://img.shields.io/npm/v/aurelia.svg?maxAge=3600)](https://www.npmjs.com/package/aurelia)
 # aurelia
 
+This is the umbrella package for Aurelia 2. It re-exports selected internals from following Aurelia 2 packages:
+
+```
+@aurelia/debug
+@aurelia/fetch-client
+@aurelia/jit
+@aurelia/jit-html
+@aurelia/jit-html-browser
+@aurelia/kernel
+@aurelia/router
+@aurelia/runtime
+@aurelia/runtime-html
+@aurelia/runtime-html-browser
+```
+
+It's designed to simplify app development, and we recommend all app authors to use this package. Ideally, unused Aurelia 2 features will be tree-shaken off by JavaScript bundlers.
+
+Note plugin authors should instead use individual scoped `@aurelia/*` packages in order to avoid bringing in unnecessary dependencies.
+
 ## Installing
 
 For the latest stable version:

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -508,7 +508,7 @@ export {
 
   // SetterObserver,
 
-  // ISignaler,
+  ISignaler,
 
   subscriberCollection,
   collectionSubscriberCollection,
@@ -884,7 +884,7 @@ export {
   // ITextBindingInstruction,
 
   // NodeType,
-  // HTMLDOM,
+  HTMLDOM,
   DOM, // on top of DOM in @aurelia/runtime
   // NodeSequenceFactory,
   // FragmentNodeSequence,


### PR DESCRIPTION
Also added two re-exports `ISignaler` and `HTMLDOM` in "aurelia" package because i18n sample code uses them.