### PR TITLE
fix(let): to-view-model -> to-binding-context

### DIFF
--- a/packages/__tests__/jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/jit-html/custom-elements.spec.ts
@@ -62,9 +62,9 @@ describe('custom-elements', function () {
 
   });
 
-  // //<let [to-view-model] />
+  // //<let [to-binding-context] />
   it('04.', async function () {
-    const { tearDown, lifecycle, appHost, component } = setup<Person>('<template><let to-view-model full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', class implements Person { });
+    const { tearDown, lifecycle, appHost, component } = setup<Person>('<template><let to-binding-context full-name.bind="firstName + ` ` + lastName"></let><div>\${fullName}</div></template>', class implements Person { });
     component.firstName = 'bi';
     assert.strictEqual(component.fullName, 'bi undefined', `component.fullName`);
     component.lastName = 'go';

--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -365,17 +365,17 @@ describe('template-compiler.spec.ts\n  [TemplateCompiler]', function () {
         describe('[to-view-model]', function () {
           it('understands [to-view-model]', function () {
             const { instructions } = compileWith(`<template><let to-view-model></let></template>`);
-            assert.strictEqual((instructions[0][0]).toViewModel, true, `(instructions[0][0]).toViewModel`);
+            assert.strictEqual((instructions[0][0]).toBindingContext, true, `(instructions[0][0]).toBindingContext`);
           });
 
           it('ignores [to-view-model] order', function () {
             let instructions = compileWith(`<template><let a.bind="a" to-view-model></let></template>`).instructions[0];
             verifyInstructions(instructions, [
-              { toVerify: ['type', 'toViewModel'], type: TT.hydrateLetElement, toViewModel: true }
+              { toVerify: ['type', 'toBindingContext'], type: TT.hydrateLetElement, toBindingContext: true }
             ]);
             instructions = compileWith(`<template><let to-view-model a.bind="a"></let></template>`).instructions[0];
             verifyInstructions(instructions, [
-              { toVerify: ['type', 'toViewModel'], type: TT.hydrateLetElement, toViewModel: true }
+              { toVerify: ['type', 'toBindingContext'], type: TT.hydrateLetElement, toBindingContext: true }
             ]);
           });
         });

--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -362,18 +362,18 @@ describe('template-compiler.spec.ts\n  [TemplateCompiler]', function () {
           ]);
         });
 
-        describe('[to-view-model]', function () {
-          it('understands [to-view-model]', function () {
-            const { instructions } = compileWith(`<template><let to-view-model></let></template>`);
+        describe('[to-binding-context]', function () {
+          it('understands [to-binding-context]', function () {
+            const { instructions } = compileWith(`<template><let to-binding-context></let></template>`);
             assert.strictEqual((instructions[0][0]).toBindingContext, true, `(instructions[0][0]).toBindingContext`);
           });
 
-          it('ignores [to-view-model] order', function () {
-            let instructions = compileWith(`<template><let a.bind="a" to-view-model></let></template>`).instructions[0];
+          it('ignores [to-binding-context] order', function () {
+            let instructions = compileWith(`<template><let a.bind="a" to-binding-context></let></template>`).instructions[0];
             verifyInstructions(instructions, [
               { toVerify: ['type', 'toBindingContext'], type: TT.hydrateLetElement, toBindingContext: true }
             ]);
-            instructions = compileWith(`<template><let to-view-model a.bind="a"></let></template>`).instructions[0];
+            instructions = compileWith(`<template><let to-binding-context a.bind="a"></let></template>`).instructions[0];
             verifyInstructions(instructions, [
               { toVerify: ['type', 'toBindingContext'], type: TT.hydrateLetElement, toBindingContext: true }
             ]);

--- a/packages/__tests__/runtime/let-binding.spec.ts
+++ b/packages/__tests__/runtime/let-binding.spec.ts
@@ -46,7 +46,7 @@
 //       assert.strictEqual(sut.target, target, 'It should have not recreated target');
 //     });
 
-//     it('creates right target with toViewModel === true', function () {
+//     it('creates right target with toBindingContext === true', function () {
 //       const vm = { vm: 5 };
 //       const sourceExpression = new MockExpression();
 //       sut = new LetBinding(<any>sourceExpression, 'foo', observerLocator, container, true);
@@ -54,7 +54,7 @@
 //       assert.strictEqual(sut.target, vm, 'It should have used bindingContext to create target.');
 //     });
 
-//     it('creates right target with toViewModel === false', function () {
+//     it('creates right target with toBindingContext === false', function () {
 //       const vm = { vm: 5 };
 //       const view = { view: 6 };
 //       const sourceExpression = new MockExpression();

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -221,9 +221,9 @@ export class TemplateBinder {
     let i = 0;
     while (i < attributes.length) {
       const attr = attributes[i];
-      if (attr.name === 'to-view-model') {
-        node.removeAttribute('to-view-model');
-        symbol.toViewModel = true;
+      if (attr.name === 'to-binding-context') {
+        node.removeAttribute('to-binding-context');
+        symbol.toBindingContext = true;
         continue;
       }
       const attrSyntax = this.attrParser.parse(attr.name, attr.value);

--- a/packages/jit-html/src/template-compiler.ts
+++ b/packages/jit-html/src/template-compiler.ts
@@ -173,7 +173,7 @@ export class TemplateCompiler implements ITemplateCompiler {
             binding = bindings[j];
             instructions[j] = new LetBindingInstruction(binding.expression as IsBindingBehavior, binding.target);
           }
-          this.instructionRows.push([new LetElementInstruction(instructions, (childNode as LetElementSymbol).toViewModel)]);
+          this.instructionRows.push([new LetElementInstruction(instructions, (childNode as LetElementSymbol).toBindingContext)]);
         } else {
           this.compileParentNode(childNode as IParentNodeSymbol);
         }

--- a/packages/jit/src/semantic-model.ts
+++ b/packages/jit/src/semantic-model.ts
@@ -311,7 +311,7 @@ export class CustomElementSymbol implements IElementSymbol, ISymbolWithBindings,
 export class LetElementSymbol implements INodeSymbol, ISymbolWithBindings, ISymbolWithMarker {
   public flags: SymbolFlags;
   public physicalNode: INode;
-  public toViewModel: boolean;
+  public toBindingContext: boolean;
   public marker: INode;
 
   private _bindings: BindingSymbol[] | null;
@@ -326,7 +326,7 @@ export class LetElementSymbol implements INodeSymbol, ISymbolWithBindings, ISymb
   constructor(dom: IDOM, node: INode) {
     this.flags = SymbolFlags.isLetElement | SymbolFlags.hasMarker;
     this.physicalNode = node;
-    this.toViewModel = false;
+    this.toBindingContext = false;
     this.marker = createMarker(dom);
     this._bindings = null;
   }

--- a/packages/runtime/src/binding/let-binding.ts
+++ b/packages/runtime/src/binding/let-binding.ts
@@ -41,14 +41,14 @@ export class LetBinding implements IPartialConnectableBinding {
   public target: (IObservable & IIndexable) | null;
   public targetProperty: string;
 
-  private readonly toViewModel: boolean;
+  private readonly toBindingContext: boolean;
 
   constructor(
     sourceExpression: IExpression,
     targetProperty: string,
     observerLocator: IObserverLocator,
     locator: IServiceLocator,
-    toViewModel: boolean = false,
+    toBindingContext: boolean = false,
   ) {
     connectable.assignIdTo(this);
     this.$state = State.none;
@@ -61,7 +61,7 @@ export class LetBinding implements IPartialConnectableBinding {
     this.target = null;
     this.targetProperty = targetProperty;
 
-    this.toViewModel = toViewModel;
+    this.toBindingContext = toBindingContext;
   }
 
   public handleChange(_newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
@@ -94,7 +94,7 @@ export class LetBinding implements IPartialConnectableBinding {
 
     this.$scope = scope;
     this.part = part;
-    this.target = (this.toViewModel ? scope.bindingContext : scope.overrideContext) as IIndexable;
+    this.target = (this.toBindingContext ? scope.bindingContext : scope.overrideContext) as IIndexable;
 
     const sourceExpression = this.sourceExpression;
     if (sourceExpression.bind) {

--- a/packages/runtime/src/definitions.ts
+++ b/packages/runtime/src/definitions.ts
@@ -114,7 +114,7 @@ export type AttributeDefinition = Required<IAttributeDefinition>;
 
 export type InstructionTypeName = string;
 
-export const ITargetedInstruction = DI.createInterface<ITargetedInstruction>('createInterface').noDefault();
+export const ITargetedInstruction = DI.createInterface<ITargetedInstruction>('ITargetedInstruction').noDefault();
 export interface ITargetedInstruction {
   type: InstructionTypeName;
 }
@@ -207,7 +207,7 @@ export interface IHydrateTemplateController extends ITargetedInstruction {
 export interface IHydrateLetElementInstruction extends ITargetedInstruction {
   type: TargetedInstructionType.hydrateLetElement;
   instructions: ILetBindingInstruction[];
-  toViewModel: boolean;
+  toBindingContext: boolean;
 }
 
 export interface ILetBindingInstruction extends ITargetedInstruction {

--- a/packages/runtime/src/instructions.ts
+++ b/packages/runtime/src/instructions.ts
@@ -220,13 +220,13 @@ export class LetElementInstruction implements IHydrateLetElementInstruction {
   public type: TargetedInstructionType.hydrateLetElement;
 
   public instructions: ILetBindingInstruction[];
-  public toViewModel: boolean;
+  public toBindingContext: boolean;
 
-  constructor(instructions: ILetBindingInstruction[], toViewModel: boolean) {
+  constructor(instructions: ILetBindingInstruction[], toBindingContext: boolean) {
     this.type = TargetedInstructionType.hydrateLetElement;
 
     this.instructions = instructions;
-    this.toViewModel = toViewModel;
+    this.toBindingContext = toBindingContext;
   }
 }
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -344,7 +344,7 @@ export class LetElementRenderer implements IInstructionRenderer {
   public render(flags: LifecycleFlags, dom: IDOM, context: IRenderContext, renderable: IController, target: INode, instruction: IHydrateLetElementInstruction): void {
     dom.remove(target);
     const childInstructions = instruction.instructions;
-    const toViewModel = instruction.toViewModel;
+    const toBindingContext = instruction.toBindingContext;
 
     let childInstruction: ILetBindingInstruction;
     let expr: AnyBindingExpression;
@@ -352,7 +352,7 @@ export class LetElementRenderer implements IInstructionRenderer {
     for (let i = 0, ii = childInstructions.length; i < ii; ++i) {
       childInstruction = childInstructions[i];
       expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
-      binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toViewModel);
+      binding = new LetBinding(expr, childInstruction.to, this.observerLocator, context, toBindingContext);
       addBinding(renderable, binding);
     }
   }

--- a/packages/testing/src/au-dom.ts
+++ b/packages/testing/src/au-dom.ts
@@ -767,11 +767,11 @@ export const AuDOMTest = {
       parts
     );
   },
-  createLetInstruction(bindings: [string, string][], toViewModel: boolean = false): LetElementInstruction {
+  createLetInstruction(bindings: [string, string][], toBindingContext: boolean = false): LetElementInstruction {
     return new LetElementInstruction(
       // @ts-ignore
       bindings.map(([from, to]) => new LetBindingInstruction(parseExpression(from), to)),
-      toViewModel
+      toBindingContext
     );
   }
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description

Let in v2 was developed at during the finalization of v1 let, so it carried some old naming. Change from `to-view-model` to `to-binding-context`

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ⏭ Next Steps

N/A