### PR TITLE
refactor(jit-html): cleanup template-binder and improve semantic-model types

### DIFF
--- a/packages/jit-html/src/semantic-model.ts
+++ b/packages/jit-html/src/semantic-model.ts
@@ -1,0 +1,56 @@
+import {
+  AnySymbol as $AnySymbol,
+  BindingSymbol,
+  CustomAttributeSymbol,
+  CustomElementSymbol as $CustomElementSymbol,
+  ElementSymbol as $ElementSymbol,
+  LetElementSymbol as $LetElementSymbol,
+  NodeSymbol as $NodeSymbol,
+  ParentNodeSymbol as $ParentNodeSymbol,
+  PlainAttributeSymbol,
+  PlainElementSymbol as $PlainElementSymbol,
+  ReplacePartSymbol as $ReplacePartSymbol,
+  ResourceAttributeSymbol as $ResourceAttributeSymbol,
+  SymbolWithBindings as $SymbolWithBindings,
+  SymbolWithMarker as $SymbolWithMarker,
+  SymbolWithTemplate as $SymbolWithTemplate,
+  TemplateControllerSymbol as $TemplateControllerSymbol,
+  TextSymbol as $TextSymbol,
+} from '@aurelia/jit';
+
+export type AnySymbol = $AnySymbol<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type ElementSymbol = $ElementSymbol<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type NodeSymbol = $NodeSymbol<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type ParentNodeSymbol = $ParentNodeSymbol<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type ResourceAttributeSymbol = $ResourceAttributeSymbol<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type SymbolWithBindings = $SymbolWithBindings<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type SymbolWithMarker = $SymbolWithMarker<Text, HTMLTemplateElement | HTMLElement, Comment>;
+export type SymbolWithTemplate = $SymbolWithTemplate<Text, HTMLTemplateElement | HTMLElement, Comment>;
+
+/* eslint-disable @typescript-eslint/class-name-casing */
+declare class $$CustomElementSymbol extends $CustomElementSymbol<Text, HTMLTemplateElement | HTMLElement, Comment> {}
+declare class $$LetElementSymbol extends $LetElementSymbol<HTMLTemplateElement | HTMLElement, Comment> {}
+declare class $$PlainElementSymbol extends $PlainElementSymbol<Text, HTMLTemplateElement | HTMLElement, Comment> {}
+declare class $$ReplacePartSymbol extends $ReplacePartSymbol<Text, HTMLTemplateElement | HTMLElement, Comment> {}
+declare class $$TemplateControllerSymbol extends $TemplateControllerSymbol<Text, HTMLTemplateElement | HTMLElement, Comment> {}
+declare class $$TextSymbol extends $TextSymbol<Text, Comment> {}
+
+export const CustomElementSymbol = $CustomElementSymbol as typeof $$CustomElementSymbol;
+export const LetElementSymbol = $LetElementSymbol as typeof $$LetElementSymbol;
+export const PlainElementSymbol = $PlainElementSymbol as typeof $$PlainElementSymbol;
+export const ReplacePartSymbol = $ReplacePartSymbol as typeof $$ReplacePartSymbol;
+export const TemplateControllerSymbol = $TemplateControllerSymbol as typeof $$TemplateControllerSymbol;
+export const TextSymbol = $TextSymbol as typeof $$TextSymbol;
+
+export interface CustomElementSymbol extends $$CustomElementSymbol {}
+export interface LetElementSymbol extends $$LetElementSymbol {}
+export interface PlainElementSymbol extends $$PlainElementSymbol {}
+export interface ReplacePartSymbol extends $$ReplacePartSymbol {}
+export interface TemplateControllerSymbol extends $$TemplateControllerSymbol {}
+export interface TextSymbol extends $$TextSymbol {}
+
+export {
+  BindingSymbol,
+  CustomAttributeSymbol,
+  PlainAttributeSymbol,
+};

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -1,29 +1,17 @@
+/* eslint-disable compat/compat */
+
 import {
   AttrInfo,
   AttrSyntax,
   BindableInfo,
-  BindingSymbol,
-  CustomAttributeSymbol,
-  CustomElementSymbol,
   IAttributeParser,
   IBindingCommand,
-  IElementSymbol,
-  IParentNodeSymbol,
-  IResourceAttributeSymbol,
-  ISymbolWithMarker,
-  LetElementSymbol,
-  PlainAttributeSymbol,
-  PlainElementSymbol,
-  ReplacePartSymbol,
   ResourceModel,
   SymbolFlags,
-  TemplateControllerSymbol,
-  TextSymbol
+  Char,
 } from '@aurelia/jit';
 import {
   camelCase,
-  Profiler,
-  Tracer,
 } from '@aurelia/kernel';
 import {
   AnyBindingExpression,
@@ -36,74 +24,135 @@ import {
   NodeType,
 } from '@aurelia/runtime-html';
 import { IAttrSyntaxTransformer } from './attribute-syntax-transformer';
+import {
+  BindingSymbol,
+  CustomAttributeSymbol,
+  CustomElementSymbol,
+  ElementSymbol,
+  LetElementSymbol,
+  ParentNodeSymbol,
+  PlainAttributeSymbol,
+  PlainElementSymbol,
+  ReplacePartSymbol,
+  ResourceAttributeSymbol,
+  SymbolWithMarker,
+  TemplateControllerSymbol,
+  TextSymbol,
+} from './semantic-model';
 
-const slice = Array.prototype.slice;
-
-const { enter, leave } = Profiler.createTimer('TemplateBinder');
-
-const invalidSurrogateAttribute = {
+const invalidSurrogateAttribute = Object.assign(Object.create(null), {
   'id': true,
   'part': true,
   'replace-part': true
-};
+}) as Record<string, boolean | undefined>;
 
-const attributesToIgnore = {
+const attributesToIgnore = Object.assign(Object.create(null), {
   'as-element': true,
   'part': true,
   'replace-part': true
-};
+}) as Record<string, boolean | undefined>;
+
+function hasInlineBindings(rawValue: string): boolean {
+  const len = rawValue.length;
+  let ch = 0;
+  for (let i = 0; i < len; ++i) {
+    ch = rawValue.charCodeAt(i);
+    if (ch === Char.Backslash) {
+      ++i;
+      // Ignore whatever comes next because it's escaped
+    } else if (ch === Char.Colon) {
+      return true;
+    } else if (ch === Char.Dollar && rawValue.charCodeAt(i + 1) === Char.OpenBrace) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function processInterpolationText(symbol: TextSymbol): void {
+  const node = symbol.physicalNode;
+  const parentNode = node.parentNode!;
+  while (node.nextSibling !== null && node.nextSibling.nodeType === NodeType.Text) {
+    parentNode.removeChild(node.nextSibling);
+  }
+  node.textContent = '';
+  parentNode.insertBefore(symbol.marker, node);
+}
+
+function isTemplateControllerOf(proxy: ParentNodeSymbol, manifest: ElementSymbol): proxy is TemplateControllerSymbol {
+  return proxy !== manifest;
+}
+
+/**
+ * A (temporary) standalone function that purely does the DOM processing (lifting) related to template controllers.
+ * It's a first refactoring step towards separating DOM parsing/binding from mutations.
+ */
+function processTemplateControllers(dom: IDOM, manifestProxy: ParentNodeSymbol, manifest: ElementSymbol): void {
+  const manifestNode = manifest.physicalNode as HTMLElement;
+  let current = manifestProxy;
+  let currentTemplate: HTMLTemplateElement;
+  while (isTemplateControllerOf(current, manifest)) {
+    if (current.template === manifest) {
+      // the DOM linkage is still in its original state here so we can safely assume the parentNode is non-null
+      manifestNode.parentNode!.replaceChild(current.marker, manifestNode);
+
+      // if the manifest is a template element (e.g. <template repeat.for="...">) then we can skip one lift operation
+      // and simply use the template directly, saving a bit of work
+      if (manifestNode.nodeName === 'TEMPLATE') {
+        current.physicalNode = manifestNode as HTMLTemplateElement;
+        // the template could safely stay without affecting anything visible, but let's keep the DOM tidy
+        manifestNode.remove();
+      } else {
+        // the manifest is not a template element so we need to wrap it in one
+        currentTemplate = current.physicalNode = dom.createTemplate() as HTMLTemplateElement;
+        currentTemplate.content.appendChild(manifestNode);
+      }
+    } else {
+      currentTemplate = current.physicalNode = dom.createTemplate() as HTMLTemplateElement;
+      currentTemplate.content.appendChild(current.marker);
+    }
+    manifestNode.removeAttribute(current.syntax.rawName);
+    current = current.template!;
+  }
+}
+
+function processReplacePart(
+  dom: IDOM,
+  replacePart: ReplacePartSymbol,
+  manifestProxy: ParentNodeSymbol | SymbolWithMarker,
+): void {
+  let proxyNode: HTMLElement;
+  let currentTemplate: HTMLTemplateElement;
+  if ((manifestProxy.flags & SymbolFlags.hasMarker) > 0) {
+    proxyNode = (manifestProxy as SymbolWithMarker).marker as unknown as HTMLElement;
+  } else {
+    proxyNode = manifestProxy.physicalNode as HTMLElement;
+  }
+  if (proxyNode.nodeName === 'TEMPLATE') {
+    // if it's a template element, no need to do anything special, just assign it to the replacePart
+    replacePart.physicalNode = proxyNode as HTMLTemplateElement;
+  } else {
+    // otherwise wrap the replace-part in a template
+    currentTemplate = replacePart.physicalNode = dom.createTemplate() as HTMLTemplateElement;
+    currentTemplate.content.appendChild(proxyNode);
+  }
+}
 
 /**
  * TemplateBinder. Todo: describe goal of this class
  */
 export class TemplateBinder {
-  public dom: IDOM;
-  public resources: ResourceModel;
-  public attrParser: IAttributeParser;
-  public exprParser: IExpressionParser;
-  public attrSyntaxTransformer: IAttrSyntaxTransformer;
-
-  private surrogate: PlainElementSymbol | null;
-
-  // This is any "original" (as in, not a template created for a template controller) element.
-  // It collects all attribute symbols except for template controllers and replace-parts.
-  private manifest: IElementSymbol | null;
-
-  // This is the nearest wrapping custom element.
-  // It only collects replace-parts (and inherently everything that the manifest collects, if they are the same instance)
-  private manifestRoot: CustomElementSymbol | null;
-
-  // This is the nearest wrapping custom element relative to the current manifestRoot (the manifestRoot "one level up").
-  // It exclusively collects replace-parts that are placed on the current manifestRoot.
-  private parentManifestRoot: CustomElementSymbol | null;
-
-  private partName: string | null;
-
   public constructor(
-    dom: IDOM,
-    resources: ResourceModel,
-    attrParser: IAttributeParser,
-    exprParser: IExpressionParser,
-    attrSyntaxModifier: IAttrSyntaxTransformer
-  ) {
-    this.dom = dom;
-    this.resources = resources;
-    this.attrParser = attrParser;
-    this.exprParser = exprParser;
-    this.attrSyntaxTransformer = attrSyntaxModifier;
-    this.surrogate = null;
-    this.manifest = null;
-    this.manifestRoot = null;
-    this.parentManifestRoot = null;
-    this.partName = null;
-  }
+    public readonly dom: IDOM,
+    public readonly resources: ResourceModel,
+    public readonly attrParser: IAttributeParser,
+    public readonly exprParser: IExpressionParser,
+    public readonly attrSyntaxTransformer: IAttrSyntaxTransformer
+  ) {}
 
   public bind(node: HTMLTemplateElement): PlainElementSymbol {
-    const surrogateSave = this.surrogate;
-    const parentManifestRootSave = this.parentManifestRoot;
-    const manifestRootSave = this.manifestRoot;
-    const manifestSave = this.manifest;
-    const manifest = this.surrogate = this.manifest = new PlainElementSymbol(node);
+    const surrogate = new PlainElementSymbol(this.dom, node);
+
     const resources = this.resources;
     const attrSyntaxTransformer = this.attrSyntaxTransformer;
 
@@ -113,107 +162,136 @@ export class TemplateBinder {
       const attr = attributes[i];
       const attrSyntax = this.attrParser.parse(attr.name, attr.value);
 
-      if (invalidSurrogateAttribute[attrSyntax.target as keyof typeof invalidSurrogateAttribute] === true) {
+      if (invalidSurrogateAttribute[attrSyntax.target] === true) {
         throw new Error(`Invalid surrogate attribute: ${attrSyntax.target}`);
         // TODO: use reporter
       }
       const bindingCommand = resources.getBindingCommand(attrSyntax, true);
-      if (bindingCommand == null || (bindingCommand.bindingType & BindingType.IgnoreCustomAttr) === 0) {
+      if (bindingCommand === null || (bindingCommand.bindingType & BindingType.IgnoreCustomAttr) === 0) {
         const attrInfo = resources.getAttributeInfo(attrSyntax);
 
-        if (attrInfo == null) {
+        if (attrInfo === null) {
           // map special html attributes to their corresponding properties
           attrSyntaxTransformer.transform(node, attrSyntax);
           // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-          this.bindPlainAttribute(attrSyntax, attr);
+          this.bindPlainAttribute(
+            /* attrSyntax */ attrSyntax,
+            /* attr       */ attr,
+            /* surrogate  */ surrogate,
+            /* manifest   */ surrogate,
+          );
         } else if (attrInfo.isTemplateController) {
           throw new Error('Cannot have template controller on surrogate element.');
           // TODO: use reporter
         } else {
-          this.bindCustomAttribute(attrSyntax, attrInfo, bindingCommand);
+          this.bindCustomAttribute(
+            /* attrSyntax */ attrSyntax,
+            /* attrInfo   */ attrInfo,
+            /* command    */ bindingCommand,
+            /* manifest   */ surrogate,
+          );
         }
       } else {
         // map special html attributes to their corresponding properties
         attrSyntaxTransformer.transform(node, attrSyntax);
         // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-        this.bindPlainAttribute(attrSyntax, attr);
+        this.bindPlainAttribute(
+          /* attrSyntax */ attrSyntax,
+          /* attr       */ attr,
+          /* surrogate  */ surrogate,
+          /* manifest   */ surrogate,
+        );
       }
       ++i;
     }
 
-    this.bindChildNodes(node);
+    this.bindChildNodes(
+      /* node               */ node,
+      /* surrogate          */ surrogate,
+      /* manifest           */ surrogate,
+      /* manifestRoot       */ null,
+      /* parentManifestRoot */ null,
+      /* partName           */ null,
+    );
 
-    this.surrogate = surrogateSave;
-    this.parentManifestRoot = parentManifestRootSave;
-    this.manifestRoot = manifestRootSave;
-    this.manifest = manifestSave;
-
-    return manifest;
+    return surrogate;
   }
 
-  private bindManifest(parentManifest: IElementSymbol, node: HTMLTemplateElement | HTMLElement): void {
-
+  private bindManifest(
+    node: HTMLTemplateElement | HTMLElement,
+    surrogate: PlainElementSymbol,
+    manifest: ElementSymbol,
+    manifestRoot: CustomElementSymbol | null,
+    parentManifestRoot: CustomElementSymbol | null,
+    partName: string | null,
+  ): void {
     switch (node.nodeName) {
       case 'LET':
         // let cannot have children and has some different processing rules, so return early
-        this.bindLetElement(parentManifest, node);
+        this.bindLetElement(
+          /* manifest */ manifest,
+          /* node     */ node,
+        );
         return;
       case 'SLOT':
-        this.surrogate!.hasSlots = true;
+        surrogate.hasSlots = true;
     }
-
-    // nodes are processed bottom-up so we need to store the manifests before traversing down and
-    // restore them again afterwards
-    const parentManifestRootSave = this.parentManifestRoot;
-    const manifestRootSave = this.manifestRoot;
-    const manifestSave = this.manifest;
-    const partNameSave = this.partName;
 
     // get the part name to override the name of the compiled definition
-    this.partName = node.getAttribute('part');
-    if (this.partName === '' || (this.partName === null && node.hasAttribute('replaceable'))) {
-      this.partName = 'default';
+    partName = node.getAttribute('part');
+    if (partName === '' || (partName === null && node.hasAttribute('replaceable'))) {
+      partName = 'default';
     }
 
-    let manifestRoot: CustomElementSymbol = (void 0)!;
     let name = node.getAttribute('as-element');
-    if (name == null) {
+    if (name === null) {
       name = node.nodeName.toLowerCase();
     }
+
     const elementInfo = this.resources.getElementInfo(name);
-    if (elementInfo == null) {
+    if (elementInfo === null) {
       // there is no registered custom element with this name
-      this.manifest = new PlainElementSymbol(node);
+      manifest = new PlainElementSymbol(this.dom, node);
     } else {
       // it's a custom element so we set the manifestRoot as well (for storing replace-parts)
-      this.parentManifestRoot = this.manifestRoot;
-      manifestRoot = this.manifestRoot = this.manifest = new CustomElementSymbol(this.dom, node, elementInfo);
+      parentManifestRoot = manifestRoot;
+      manifestRoot = manifest = new CustomElementSymbol(this.dom, node, elementInfo);
     }
 
     // lifting operations done by template controllers and replace-parts effectively unlink the nodes, so start at the bottom
-    this.bindChildNodes(node);
+    this.bindChildNodes(
+      /* node               */ node,
+      /* surrogate          */ surrogate,
+      /* manifest           */ manifest,
+      /* manifestRoot       */ manifestRoot,
+      /* parentManifestRoot */ parentManifestRoot,
+      /* partName           */ partName,
+    );
 
     // the parentManifest will receive either the direct child nodes, or the template controllers / replace-parts
     // wrapping them
-    this.bindAttributes(node, parentManifest);
+    this.bindAttributes(
+      /* node               */ node,
+      /* surrogate          */ surrogate,
+      /* manifest           */ manifest,
+      /* manifestRoot       */ manifestRoot,
+      /* parentManifestRoot */ parentManifestRoot,
+      /* partName           */ partName,
+    );
 
-    if (manifestRoot != null && manifestRoot.isContainerless) {
-      node.parentNode!.replaceChild(manifestRoot.marker as Node, node);
-    } else if (this.manifest.isTarget) {
+    if (manifestRoot !== null && manifestRoot.isContainerless) {
+      node.parentNode!.replaceChild(manifestRoot.marker, node);
+    } else if (manifest.isTarget) {
       node.classList.add('au');
     }
-
-    // restore the stored manifests so the attributes are processed on the correct lavel
-    this.parentManifestRoot = parentManifestRootSave;
-    this.manifestRoot = manifestRootSave;
-    this.manifest = manifestSave;
-    this.partName = partNameSave;
-
   }
 
-  private bindLetElement(parentManifest: IElementSymbol, node: HTMLElement): void {
+  private bindLetElement(
+    manifest: ElementSymbol,
+    node: HTMLElement,
+  ): void {
     const symbol = new LetElementSymbol(this.dom, node);
-    parentManifest.childNodes.push(symbol);
+    manifest.childNodes.push(symbol);
 
     const attributes = node.attributes;
     let i = 0;
@@ -226,7 +304,7 @@ export class TemplateBinder {
       }
       const attrSyntax = this.attrParser.parse(attr.name, attr.value);
       const command = this.resources.getBindingCommand(attrSyntax, false);
-      const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
+      const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
       const expr = this.exprParser.parse(attrSyntax.rawValue, bindingType);
       const to = camelCase(attrSyntax.target);
       const info = new BindableInfo(to, BindingMode.toView);
@@ -234,18 +312,27 @@ export class TemplateBinder {
 
       ++i;
     }
-    node.parentNode!.replaceChild(symbol.marker as Node, node);
+    node.parentNode!.replaceChild(symbol.marker, node);
   }
 
-  private bindAttributes(node: HTMLTemplateElement | HTMLElement, parentManifest: IElementSymbol): void {
-
-    const { parentManifestRoot, manifestRoot, manifest } = this;
+  private bindAttributes(
+    node: HTMLTemplateElement | HTMLElement,
+    surrogate: PlainElementSymbol,
+    manifest: ElementSymbol,
+    manifestRoot: CustomElementSymbol | null,
+    parentManifestRoot: CustomElementSymbol | null,
+    partName: string | null,
+  ): void {
     // This is the top-level symbol for the current depth.
     // If there are no template controllers or replace-parts, it is always the manifest itself.
     // If there are template controllers, then this will be the outer-most TemplateControllerSymbol.
-    let manifestProxy: IParentNodeSymbol = manifest!;
+    let manifestProxy: ParentNodeSymbol = manifest;
 
-    let replacePart = this.declareReplacePart(node);
+    const replacePart = this.declareReplacePart(
+      /* node               */ node,
+      /* manifestRoot       */ manifestRoot,
+      /* parentManifestRoot */ parentManifestRoot,
+    );
 
     let previousController: TemplateControllerSymbol = (void 0)!;
     let currentController: TemplateControllerSymbol = (void 0)!;
@@ -255,7 +342,7 @@ export class TemplateBinder {
     while (i < attributes.length) {
       const attr = attributes[i];
       ++i;
-      if (attributesToIgnore[attr.name as keyof typeof attributesToIgnore] === true) {
+      if (attributesToIgnore[attr.name] === true) {
         continue;
       }
 
@@ -265,15 +352,24 @@ export class TemplateBinder {
       if (bindingCommand === null || (bindingCommand.bindingType & BindingType.IgnoreCustomAttr) === 0) {
         const attrInfo = this.resources.getAttributeInfo(attrSyntax);
 
-        if (attrInfo == null) {
+        if (attrInfo === null) {
           // map special html attributes to their corresponding properties
           this.attrSyntaxTransformer.transform(node, attrSyntax);
           // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-          this.bindPlainAttribute(attrSyntax, attr);
+          this.bindPlainAttribute(
+            /* attrSyntax */ attrSyntax,
+            /* attr       */ attr,
+            /* surrogate  */ surrogate,
+            /* manifest   */ manifest,
+          );
         } else if (attrInfo.isTemplateController) {
           // the manifest is wrapped by the inner-most template controller (if there are multiple on the same element)
           // so keep setting manifest.templateController to the latest template controller we find
-          currentController = manifest!.templateController = this.declareTemplateController(attrSyntax, attrInfo);
+          currentController = manifest.templateController = this.declareTemplateController(
+            /* attrSyntax */ attrSyntax,
+            /* attrInfo   */ attrInfo,
+            /* partName   */ partName,
+          );
 
           // the proxy and the manifest are only identical when we're at the first template controller (since the controller
           // is assigned to the proxy), so this evaluates to true at most once per node
@@ -288,21 +384,31 @@ export class TemplateBinder {
           previousController = currentController;
         } else {
           // a regular custom attribute
-          this.bindCustomAttribute(attrSyntax, attrInfo, bindingCommand);
+          this.bindCustomAttribute(
+            /* attrSyntax */ attrSyntax,
+            /* attrInfo   */ attrInfo,
+            /* command    */ bindingCommand,
+            /* manifest   */ manifest,
+          );
         }
       } else {
         // map special html attributes to their corresponding properties
         this.attrSyntaxTransformer.transform(node, attrSyntax);
         // it's not a custom attribute but might be a regular bound attribute or interpolation (it might also be nothing)
-        this.bindPlainAttribute(attrSyntax, attr);
+        this.bindPlainAttribute(
+          /* attrSyntax */ attrSyntax,
+          /* attr       */ attr,
+          /* surrogate  */ surrogate,
+          /* manifest   */ manifest,
+        );
       }
     }
 
-    processTemplateControllers(this.dom, manifestProxy, manifest!);
+    processTemplateControllers(this.dom, manifestProxy, manifest);
 
-    if (replacePart == null) {
+    if (replacePart === null) {
       // the proxy is either the manifest itself or the outer-most controller; add it directly to the parent
-      parentManifest.childNodes.push(manifestProxy);
+      manifest.childNodes.push(manifestProxy);
     } else {
 
       // if the current manifest is also the manifestRoot, it means the replace-part sits on a custom
@@ -310,94 +416,122 @@ export class TemplateBinder {
       const partOwner = manifest === manifestRoot ? parentManifestRoot : manifestRoot;
 
       // Tried a replace part with place to put it (process normal)
-      if (!partOwner) {
-        replacePart = (void 0)!;
-        parentManifest.childNodes.push(manifestProxy);
+      if (partOwner === null) {
+        manifest.childNodes.push(manifestProxy);
         return;
       }
 
       // there is a replace-part attribute on this node, so add it to the parts collection of the manifestRoot
       // instead of to the childNodes
-      replacePart.parent = parentManifest;
+      replacePart.parent = manifest;
       replacePart.template = manifestProxy;
       partOwner.parts.push(replacePart);
 
-      if (parentManifest.templateController != null) {
-        parentManifest.templateController.parts.push(replacePart);
+      if (manifest.templateController !== null) {
+        manifest.templateController.parts.push(replacePart);
       }
 
       processReplacePart(this.dom, replacePart, manifestProxy);
     }
   }
 
-  private bindChildNodes(node: HTMLTemplateElement | HTMLElement): void {
-    let childNode: ChildNode;
+  private bindChildNodes(
+    node: HTMLTemplateElement | HTMLElement,
+    surrogate: PlainElementSymbol,
+    manifest: ElementSymbol,
+    manifestRoot: CustomElementSymbol | null,
+    parentManifestRoot: CustomElementSymbol | null,
+    partName: string | null,
+  ): void {
+    let childNode: ChildNode | null;
     if (node.nodeName === 'TEMPLATE') {
-      childNode = (node as HTMLTemplateElement).content.firstChild!;
+      childNode = (node as HTMLTemplateElement).content.firstChild;
     } else {
-      childNode = node.firstChild!;
+      childNode = node.firstChild;
     }
 
-    let nextChild: ChildNode;
-    while (childNode != null) {
+    let nextChild: ChildNode | null;
+    while (childNode !== null) {
       switch (childNode.nodeType) {
         case NodeType.Element:
-          nextChild = childNode.nextSibling as ChildNode;
-          this.bindManifest(this.manifest!, childNode as HTMLElement);
+          nextChild = childNode.nextSibling;
+          this.bindManifest(
+            /* node               */ childNode as HTMLElement,
+            /* surrogate          */ surrogate,
+            /* manifest           */ manifest,
+            /* manifestRoot       */ manifestRoot,
+            /* parentManifestRoot */ parentManifestRoot,
+            /* partName           */ partName,
+          );
           childNode = nextChild;
           break;
         case NodeType.Text:
-          childNode = this.bindText(childNode as Text).nextSibling as ChildNode;
+          childNode = this.bindText(
+            /* textNode */ childNode as Text,
+            /* manifest */ manifest,
+          ).nextSibling;
           break;
         case NodeType.CDATASection:
         case NodeType.ProcessingInstruction:
         case NodeType.Comment:
         case NodeType.DocumentType:
-          childNode = childNode.nextSibling as ChildNode;
+          childNode = childNode.nextSibling;
           break;
         case NodeType.Document:
         case NodeType.DocumentFragment:
-          childNode = childNode.firstChild!;
+          childNode = childNode.firstChild;
       }
     }
 
   }
 
-  private bindText(node: Text): ChildNode {
-    const interpolation = this.exprParser.parse(node.wholeText, BindingType.Interpolation);
-    if (interpolation != null) {
-      const symbol = new TextSymbol(this.dom, node, interpolation);
-      this.manifest!.childNodes.push(symbol);
+  private bindText(
+    textNode: Text,
+    manifest: ElementSymbol,
+  ): ChildNode {
+    const interpolation = this.exprParser.parse(textNode.wholeText, BindingType.Interpolation);
+    if (interpolation !== null) {
+      const symbol = new TextSymbol(this.dom, textNode, interpolation);
+      manifest.childNodes.push(symbol);
       processInterpolationText(symbol);
     }
-    while (node.nextSibling != null && node.nextSibling.nodeType === NodeType.Text) {
-      node = node.nextSibling as Text;
+    let next: ChildNode = textNode;
+    while (next.nextSibling !== null && next.nextSibling.nodeType === NodeType.Text) {
+      next = next.nextSibling;
     }
-    return node;
+    return next;
   }
 
-  private declareTemplateController(attrSyntax: AttrSyntax, attrInfo: AttrInfo): TemplateControllerSymbol {
-
+  private declareTemplateController(
+    attrSyntax: AttrSyntax,
+    attrInfo: AttrInfo,
+    partName: string | null,
+  ): TemplateControllerSymbol {
     let symbol: TemplateControllerSymbol;
     const attrRawValue = attrSyntax.rawValue;
     const command = this.resources.getBindingCommand(attrSyntax, false);
     // multi-bindings logic here is similar to (and explained in) bindCustomAttribute
-    const isMultiBindings = command == null && hasInlineBindings(attrRawValue);
+    const isMultiBindings = command === null && hasInlineBindings(attrRawValue);
 
     if (isMultiBindings) {
-      symbol = new TemplateControllerSymbol(this.dom, attrSyntax, attrInfo, this.partName);
+      symbol = new TemplateControllerSymbol(this.dom, attrSyntax, attrInfo, partName);
       this.bindMultiAttribute(symbol, attrInfo, attrRawValue);
     } else {
-      symbol = new TemplateControllerSymbol(this.dom, attrSyntax, attrInfo, this.partName);
-      const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
+      symbol = new TemplateControllerSymbol(this.dom, attrSyntax, attrInfo, partName);
+      const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
       const expr = this.exprParser.parse(attrRawValue, bindingType);
-      symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable, expr, attrRawValue, attrSyntax.target));
+      symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable!, expr, attrRawValue, attrSyntax.target));
     }
 
     return symbol;
   }
 
-  private bindCustomAttribute(attrSyntax: AttrSyntax, attrInfo: AttrInfo, command: IBindingCommand | null): void {
+  private bindCustomAttribute(
+    attrSyntax: AttrSyntax,
+    attrInfo: AttrInfo,
+    command: IBindingCommand | null,
+    manifest: ElementSymbol,
+  ): void {
     let symbol: CustomAttributeSymbol;
     const attrRawValue = attrSyntax.rawValue;
     // Custom attributes are always in multiple binding mode,
@@ -407,7 +541,7 @@ export class TemplateBinder {
     //          In this scenario, the value of the custom attributes is required to be a valid expression
     //        * has no colon: ie: <div my-attr="abcd">
     //          In this scenario, it's simply invalid syntax. Consider style attribute rule-value pair: <div style="rule: ruleValue">
-    const isMultiBindings = command == null && hasInlineBindings(attrRawValue);
+    const isMultiBindings = command === null && hasInlineBindings(attrRawValue);
 
     if (isMultiBindings) {
       // a multiple-bindings attribute usage (semicolon separated binding) is only valid without a binding command;
@@ -416,16 +550,15 @@ export class TemplateBinder {
       this.bindMultiAttribute(symbol, attrInfo, attrRawValue);
     } else {
       symbol = new CustomAttributeSymbol(attrSyntax, attrInfo);
-      const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
+      const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
       const expr = this.exprParser.parse(attrRawValue, bindingType);
-      symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable, expr, attrRawValue, attrSyntax.target));
+      symbol.bindings.push(new BindingSymbol(command, attrInfo.bindable!, expr, attrRawValue, attrSyntax.target));
     }
-    const manifest = this.manifest!;
     manifest.customAttributes.push(symbol);
     manifest.isTarget = true;
   }
 
-  private bindMultiAttribute(symbol: IResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
+  private bindMultiAttribute(symbol: ResourceAttributeSymbol, attrInfo: AttrInfo, value: string): void {
     const bindables = attrInfo.bindables;
     const valueLength = value.length;
 
@@ -468,7 +601,7 @@ export class TemplateBinder {
         const attrSyntax = this.attrParser.parse(attrName, attrValue);
         const attrTarget = attrSyntax.target;
         const command = this.resources.getBindingCommand(attrSyntax, false);
-        const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
+        const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
         const expr = this.exprParser.parse(attrValue, bindingType);
         let bindable = bindables[attrTarget];
         if (bindable === undefined) {
@@ -490,10 +623,14 @@ export class TemplateBinder {
     }
   }
 
-  private bindPlainAttribute(attrSyntax: AttrSyntax, attr: Attr): void {
+  private bindPlainAttribute(
+    attrSyntax: AttrSyntax,
+    attr: Attr,
+    surrogate: PlainElementSymbol,
+    manifest: ElementSymbol,
+  ): void {
     const command = this.resources.getBindingCommand(attrSyntax, false);
-    const bindingType = command == null ? BindingType.Interpolation : command.bindingType;
-    const manifest = this.manifest!;
+    const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
     const attrTarget = attrSyntax.target;
     const attrRawValue = attrSyntax.rawValue;
     let expr: AnyBindingExpression;
@@ -511,7 +648,7 @@ export class TemplateBinder {
       expr = this.exprParser.parse(attrRawValue, bindingType);
     }
 
-    if (manifest.flags & SymbolFlags.isCustomElement) {
+    if ((manifest.flags & SymbolFlags.isCustomElement) > 0) {
       const bindable = (manifest as CustomElementSymbol).bindables[attrTarget];
       if (bindable != null) {
         // if the attribute name matches a bindable property name, add it regardless of whether it's a command, interpolation, or just a plain string;
@@ -527,7 +664,7 @@ export class TemplateBinder {
       // either a binding command, an interpolation, or a ref
       manifest.plainAttributes.push(new PlainAttributeSymbol(attrSyntax, command, expr));
       manifest.isTarget = true;
-    } else if (manifest === this.surrogate) {
+    } else if (manifest === surrogate) {
       // any attributes, even if they are plain (no command/interpolation etc), should be added if they
       // are on the surrogate element
       manifest.plainAttributes.push(new PlainAttributeSymbol(attrSyntax, command, expr));
@@ -537,14 +674,31 @@ export class TemplateBinder {
       // if it's an interpolation, clear the attribute value
       attr.value = '';
     }
-
   }
 
-  private declareReplacePart(node: HTMLTemplateElement | HTMLElement): ReplacePartSymbol | null {
+  private declareReplacePart(
+    node: HTMLTemplateElement | HTMLElement,
+    manifestRoot: CustomElementSymbol | null,
+    parentManifestRoot: CustomElementSymbol | null,
+  ): ReplacePartSymbol | null {
     const name = node.getAttribute('replace-part');
-    if (name == null) {
-      const root = this.manifestRoot || this.parentManifestRoot;
-      if (root && root.flags & SymbolFlags.isCustomElement /* isCustomElement */ && root.isTarget && root.isContainerless) {
+    if (name === null) {
+      let root: CustomElementSymbol | null = null;
+      if (
+        manifestRoot !== null
+        && (manifestRoot.flags & SymbolFlags.isCustomElement) > 0
+        && manifestRoot.isContainerless
+      ) {
+        root = manifestRoot;
+      } else if (
+        parentManifestRoot !== null
+        && (parentManifestRoot.flags & SymbolFlags.isCustomElement) > 0
+        && parentManifestRoot.isContainerless
+      ) {
+        root = parentManifestRoot;
+      }
+
+      if (root !== null) {
         const physicalNode = root.physicalNode as typeof node;
         if (physicalNode.childElementCount === 1) {
           return new ReplacePartSymbol('default');
@@ -552,96 +706,6 @@ export class TemplateBinder {
       }
       return null;
     }
-    return name === '' ? new ReplacePartSymbol('default') : new ReplacePartSymbol(name);
+    return new ReplacePartSymbol(name === '' ? 'default' : name);
   }
-}
-
-function hasInlineBindings(rawValue: string): boolean {
-  const len = rawValue.length;
-  let ch = 0;
-  for (let i = 0; i < len; ++i) {
-    ch = rawValue.charCodeAt(i);
-    if (ch === Char.Backslash) {
-      ++i;
-      // Ignore whatever comes next because it's escaped
-    } else if (ch === Char.Colon) {
-      return true;
-    } else if (ch === Char.Dollar && rawValue.charCodeAt(i + 1) === Char.OpenBrace) {
-      return false;
-    }
-  }
-  return false;
-}
-
-function processInterpolationText(symbol: TextSymbol): void {
-  const node = symbol.physicalNode as Text;
-  const parentNode = node.parentNode;
-  while (node.nextSibling != null && node.nextSibling.nodeType === NodeType.Text) {
-    parentNode!.removeChild(node.nextSibling);
-  }
-  node.textContent = '';
-  parentNode!.insertBefore(symbol.marker as Node, node);
-}
-
-/**
- * A (temporary) standalone function that purely does the DOM processing (lifting) related to template controllers.
- * It's a first refactoring step towards separating DOM parsing/binding from mutations.
- */
-function processTemplateControllers(dom: IDOM, manifestProxy: IParentNodeSymbol, manifest: IElementSymbol): void {
-  const manifestNode = manifest.physicalNode as HTMLElement;
-  let current = manifestProxy as TemplateControllerSymbol;
-  let currentTemplate: HTMLTemplateElement;
-  while ((current as IParentNodeSymbol) !== manifest) {
-    if (current.template === manifest) {
-      // the DOM linkage is still in its original state here so we can safely assume the parentNode is non-null
-      manifestNode.parentNode!.replaceChild(current.marker as Node, manifestNode);
-
-      // if the manifest is a template element (e.g. <template repeat.for="...">) then we can skip one lift operation
-      // and simply use the template directly, saving a bit of work
-      if (manifestNode.nodeName === 'TEMPLATE') {
-        current.physicalNode = manifestNode as HTMLTemplateElement;
-        // the template could safely stay without affecting anything visible, but let's keep the DOM tidy
-        manifestNode.remove();
-      } else {
-        // the manifest is not a template element so we need to wrap it in one
-        currentTemplate = current.physicalNode = dom.createTemplate() as HTMLTemplateElement;
-        currentTemplate.content.appendChild(manifestNode);
-      }
-    } else {
-      currentTemplate = current.physicalNode = dom.createTemplate() as HTMLTemplateElement;
-      currentTemplate.content.appendChild(current.marker as Node);
-    }
-    manifestNode.removeAttribute(current.syntax.rawName);
-    current = current.template as TemplateControllerSymbol;
-  }
-}
-
-function processReplacePart(dom: IDOM, replacePart: ReplacePartSymbol, manifestProxy: IParentNodeSymbol | ISymbolWithMarker): void {
-  let proxyNode: HTMLElement;
-  let currentTemplate: HTMLTemplateElement;
-  if (manifestProxy.flags & SymbolFlags.hasMarker) {
-    proxyNode = (manifestProxy as ISymbolWithMarker).marker as HTMLElement;
-  } else {
-    proxyNode = manifestProxy.physicalNode as HTMLElement;
-  }
-  if (proxyNode.nodeName === 'TEMPLATE') {
-    // if it's a template element, no need to do anything special, just assign it to the replacePart
-    replacePart.physicalNode = proxyNode as HTMLTemplateElement;
-  } else {
-    // otherwise wrap the replace-part in a template
-    currentTemplate = replacePart.physicalNode = dom.createTemplate() as HTMLTemplateElement;
-    currentTemplate.content.appendChild(proxyNode);
-  }
-}
-
-const enum Char {
-  Space       = 0x20,
-  DoubleQuote = 0x22,
-  Dollar      = 0x24,
-  SingleQuote = 0x27,
-  Slash       = 0x2F,
-  Semicolon   = 0x3B,
-  Colon       = 0x3A,
-  Backslash   = 0x5C,
-  OpenBrace   = 0x7B,
 }

--- a/packages/jit-html/src/template-compiler.ts
+++ b/packages/jit-html/src/template-compiler.ts
@@ -1,31 +1,14 @@
 import {
-  BindingSymbol,
-  CustomAttributeSymbol,
-  CustomElementSymbol,
   IAttributeParser,
-  ICustomAttributeSymbol,
-  IElementSymbol,
-  INodeSymbol,
-  IParentNodeSymbol,
-  IPlainAttributeSymbol,
-  ISymbolWithBindings,
-  LetElementSymbol,
-  PlainAttributeSymbol,
-  PlainElementSymbol,
-  ReplacePartSymbol,
   ResourceModel,
   SymbolFlags,
-  TemplateControllerSymbol,
-  TextSymbol
 } from '@aurelia/jit';
 import {
   IContainer,
   IResolver,
   IResourceDescriptions,
-  Key,
   mergeDistinct,
   PLATFORM,
-  Profiler,
   Registration,
 } from '@aurelia/kernel';
 import {
@@ -44,7 +27,6 @@ import {
   ITemplateDefinition,
   LetBindingInstruction,
   LetElementInstruction,
-  RefBindingInstruction,
   SetPropertyInstruction,
   TemplateDefinition
 } from '@aurelia/runtime';
@@ -57,13 +39,26 @@ import {
 import { IAttrSyntaxTransformer } from './attribute-syntax-transformer';
 import { TemplateBinder } from './template-binder';
 import { ITemplateElementFactory } from './template-element-factory';
+import {
+  BindingSymbol,
+  CustomElementSymbol,
+  CustomAttributeSymbol,
+  ElementSymbol,
+  NodeSymbol,
+  ParentNodeSymbol,
+  SymbolWithBindings,
+  LetElementSymbol,
+  PlainAttributeSymbol,
+  PlainElementSymbol,
+  ReplacePartSymbol,
+  TemplateControllerSymbol,
+  TextSymbol
+} from './semantic-model';
 
 const buildNotRequired: IBuildInstruction = Object.freeze({
   required: false,
   compiler: 'default'
 });
-
-const { enter, leave } = Profiler.createTimer('TemplateCompiler');
 
 /**
  * Default (runtime-agnostic) implementation for `ITemplateCompiler`.
@@ -155,16 +150,16 @@ export class TemplateCompiler implements ITemplateCompiler {
     return definition as TemplateDefinition;
   }
 
-  private compileChildNodes(parent: IElementSymbol): void {
-    if (parent.flags & SymbolFlags.hasChildNodes) {
+  private compileChildNodes(parent: ElementSymbol): void {
+    if ((parent.flags & SymbolFlags.hasChildNodes) > 0) {
       const { childNodes } = parent;
-      let childNode: INodeSymbol;
+      let childNode: NodeSymbol;
       const ii = childNodes.length;
       for (let i = 0; i < ii; ++i) {
         childNode = childNodes[i];
-        if (childNode.flags & SymbolFlags.isText) {
+        if ((childNode.flags & SymbolFlags.isText) > 0) {
           this.instructionRows.push([new TextBindingInstruction((childNode as TextSymbol).interpolation)]);
-        } else if (childNode.flags & SymbolFlags.isLetElement) {
+        } else if ((childNode.flags & SymbolFlags.isLetElement) > 0) {
           const bindings = (childNode as LetElementSymbol).bindings;
           const instructions: ILetBindingInstruction[] = [];
           let binding: BindingSymbol;
@@ -175,7 +170,7 @@ export class TemplateCompiler implements ITemplateCompiler {
           }
           this.instructionRows.push([new LetElementInstruction(instructions, (childNode as LetElementSymbol).toBindingContext)]);
         } else {
-          this.compileParentNode(childNode as IParentNodeSymbol);
+          this.compileParentNode(childNode as ParentNodeSymbol);
         }
       }
     }
@@ -204,7 +199,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     this.compileChildNodes(symbol);
   }
 
-  private compileParentNode(symbol: IParentNodeSymbol): void {
+  private compileParentNode(symbol: ParentNodeSymbol): void {
     switch (symbol.flags & SymbolFlags.type) {
       case SymbolFlags.isCustomElement:
         this.compileCustomElement(symbol as CustomElementSymbol);
@@ -223,13 +218,13 @@ export class TemplateCompiler implements ITemplateCompiler {
     const scopePartsSave = this.scopeParts;
     const controllerInstructions = this.instructionRows = [];
     const scopeParts = this.scopeParts = [];
-    this.compileParentNode(symbol.template);
+    this.compileParentNode(symbol.template!);
     this.instructionRows = instructionRowsSave;
     this.scopeParts = mergeDistinct(scopePartsSave, scopeParts, false);
 
     const def: ITemplateDefinition = {
       scopeParts,
-      name: symbol.partName == null ? symbol.res : symbol.partName,
+      name: symbol.partName === null ? symbol.res : symbol.partName,
       template: symbol.physicalNode,
       instructions: controllerInstructions,
       build: buildNotRequired
@@ -246,9 +241,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     this.instructionRows.push([new HydrateTemplateController(def, symbol.res, bindings, symbol.res === 'else', parts)]);
   }
 
-  private compileBindings(symbol: ISymbolWithBindings): HTMLAttributeInstruction[] {
+  private compileBindings(symbol: SymbolWithBindings): HTMLAttributeInstruction[] {
     let bindingInstructions: HTMLAttributeInstruction[];
-    if (symbol.flags & SymbolFlags.hasBindings) {
+    if ((symbol.flags & SymbolFlags.hasBindings) > 0) {
       // either a custom element with bindings, a custom attribute / template controller with dynamic options,
       // or a single value custom attribute binding
       const { bindings } = symbol;
@@ -265,9 +260,9 @@ export class TemplateCompiler implements ITemplateCompiler {
   }
 
   private compileBinding(symbol: BindingSymbol): HTMLAttributeInstruction {
-    if (symbol.command == null) {
+    if (symbol.command === null) {
       // either an interpolation or a normal string value assigned to an element or attribute binding
-      if (symbol.expression == null) {
+      if (symbol.expression === null) {
         // the template binder already filtered out non-bindables, so we know we need a setProperty here
         return new SetPropertyInstruction(symbol.rawValue, symbol.bindable.propName);
       } else {
@@ -281,9 +276,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     }
   }
 
-  private compileAttributes(symbol: IElementSymbol, offset: number): HTMLAttributeInstruction[] {
+  private compileAttributes(symbol: ElementSymbol, offset: number): HTMLAttributeInstruction[] {
     let attributeInstructions: HTMLAttributeInstruction[];
-    if (symbol.flags & SymbolFlags.hasAttributes) {
+    if ((symbol.flags & SymbolFlags.hasAttributes) > 0) {
       // any attributes on a custom element (which are not bindables) or a plain element
       const customAttributes = symbol.customAttributes;
       const plainAttributes = symbol.plainAttributes;
@@ -313,8 +308,8 @@ export class TemplateCompiler implements ITemplateCompiler {
   }
 
   private compilePlainAttribute(symbol: PlainAttributeSymbol): HTMLAttributeInstruction {
-    if (symbol.command == null) {
-      if (symbol.expression == null) {
+    if (symbol.command === null) {
+      if (symbol.expression === null) {
         // a plain attribute on a surrogate
         return new SetAttributeInstruction(symbol.syntax.rawValue, symbol.syntax.target);
       } else {
@@ -338,7 +333,7 @@ export class TemplateCompiler implements ITemplateCompiler {
 
   private compileParts(symbol: CustomElementSymbol): Record<string, ITemplateDefinition> {
     let parts: Record<string, ITemplateDefinition>;
-    if (symbol.flags & SymbolFlags.hasParts) {
+    if ((symbol.flags & SymbolFlags.hasParts) > 0) {
       parts = {};
       const replaceParts = symbol.parts;
       const ii = replaceParts.length;
@@ -356,7 +351,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         }
         scopeParts = this.scopeParts = [];
         partInstructions = this.instructionRows = [];
-        this.compileParentNode(replacePart.template);
+        this.compileParentNode(replacePart.template!);
         this.parts[replacePart.name] = parts[replacePart.name] = {
           scopeParts,
           name: replacePart.name,

--- a/packages/jit/src/index.ts
+++ b/packages/jit/src/index.ts
@@ -81,24 +81,22 @@ export {
   AttrInfo
 } from './resource-model';
 export {
+  AnySymbol,
   BindingSymbol,
   CustomAttributeSymbol,
   CustomElementSymbol,
-  ICustomAttributeSymbol,
-  IPlainAttributeSymbol,
-  IElementSymbol,
-  INodeSymbol,
-  IParentNodeSymbol,
-  IResourceAttributeSymbol,
-  ISymbol,
-  ISymbolWithBindings,
-  ISymbolWithMarker,
-  ISymbolWithTemplate,
+  ElementSymbol,
   LetElementSymbol,
+  NodeSymbol,
+  ParentNodeSymbol,
   PlainAttributeSymbol,
   PlainElementSymbol,
   ReplacePartSymbol,
+  ResourceAttributeSymbol,
   SymbolFlags,
+  SymbolWithBindings,
+  SymbolWithMarker,
+  SymbolWithTemplate,
   TemplateControllerSymbol,
-  TextSymbol
+  TextSymbol,
 } from './semantic-model';

--- a/packages/jit/src/resource-model.ts
+++ b/packages/jit/src/resource-model.ts
@@ -1,7 +1,6 @@
 import {
   IResourceDescriptions,
   kebabCase,
-  Reporter,
 } from '@aurelia/kernel';
 import {
   AttributeDefinition,
@@ -9,27 +8,171 @@ import {
   CustomAttribute,
   CustomElement,
   IBindableDescription,
-  TemplateDefinition
+  TemplateDefinition,
 } from '@aurelia/runtime';
 import { AttrSyntax } from './ast';
 import { BindingCommandResource, IBindingCommand } from './binding-command';
+
+/**
+ * A pre-processed piece of information about a defined bindable property on a custom
+ * element or attribute, optimized for consumption by the template compiler.
+ */
+export class BindableInfo {
+  public constructor(
+    /**
+     * The pre-processed *property* (not attribute) name of the bindable, which is
+     * (in order of priority):
+     *
+     * 1. The `property` from the description (if defined)
+     * 2. The name of the property of the bindable itself
+     */
+    public propName: string,
+    /**
+     * The pre-processed (default) bindingMode of the bindable, which is (in order of priority):
+     *
+     * 1. The `mode` from the bindable (if defined and not bindingMode.default)
+     * 2. The `defaultBindingMode` (if it's an attribute, defined, and not bindingMode.default)
+     * 3. `bindingMode.toView`
+     */
+    public mode: BindingMode,
+  ) {}
+}
+
+/**
+ * Pre-processed information about a custom element resource, optimized
+ * for consumption by the template compiler.
+ */
+export class ElementInfo {
+  /**
+   * A lookup of the bindables of this element, indexed by the (pre-processed)
+   * attribute names as they would be found in parsed markup.
+   */
+  public bindables: Record<string, BindableInfo | undefined> = Object.create(null);
+
+  public constructor(
+    public name: string,
+    public containerless: boolean,
+  ) {}
+
+  public static from(def: TemplateDefinition): ElementInfo {
+    const info = new ElementInfo(def.name, def.containerless);
+    const bindables = def.bindables as Record<string, IBindableDescription>;
+    const defaultBindingMode = BindingMode.toView;
+
+    let bindable: IBindableDescription;
+    let prop: string;
+    let attr: string;
+    let mode: BindingMode;
+
+    for (prop in bindables) {
+      bindable = bindables[prop];
+      // explicitly provided property name has priority over the implicit property name
+      if (bindable.property !== void 0) {
+        prop = bindable.property;
+      }
+      // explicitly provided attribute name has priority over the derived implicit attribute name
+      if (bindable.attribute !== void 0) {
+        attr = bindable.attribute;
+      } else {
+        // derive the attribute name from the resolved property name
+        attr = kebabCase(prop);
+      }
+      if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
+        mode = bindable.mode;
+      } else {
+        mode = defaultBindingMode;
+      }
+      info.bindables[attr] = new BindableInfo(prop, mode);
+    }
+    return info;
+  }
+}
+
+/**
+ * Pre-processed information about a custom attribute resource, optimized
+ * for consumption by the template compiler.
+ */
+export class AttrInfo {
+  /**
+   * A lookup of the bindables of this attribute, indexed by the (pre-processed)
+   * bindable names as they would be found in the attribute value.
+   *
+   * Only applicable to multi attribute bindings (semicolon-separated).
+   */
+  public bindables: Record<string, BindableInfo | undefined> = Object.create(null);
+  /**
+   * The single or first bindable of this attribute, or a default 'value'
+   * bindable if no bindables were defined on the attribute.
+   *
+   * Only applicable to single attribute bindings (where the attribute value
+   * contains no semicolons)
+   */
+  public bindable: BindableInfo | null = null;
+
+  public constructor(
+    public name: string,
+    public isTemplateController: boolean,
+  ) {}
+
+  public static from(def: AttributeDefinition): AttrInfo {
+    const info = new AttrInfo(def.name, def.isTemplateController);
+    const bindables = def.bindables as Record<string, IBindableDescription>;
+    const defaultBindingMode = def.defaultBindingMode !== void 0 && def.defaultBindingMode !== BindingMode.default
+      ? def.defaultBindingMode
+      : BindingMode.toView;
+
+    let bindable: IBindableDescription;
+    let prop: string;
+    let mode: BindingMode;
+    let hasPrimary: boolean = false;
+    let isPrimary: boolean = false;
+    let bindableInfo: BindableInfo;
+
+    for (prop in bindables) {
+      bindable = bindables[prop];
+      // explicitly provided property name has priority over the implicit property name
+      if (bindable.property !== void 0) {
+        prop = bindable.property;
+      }
+      if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
+        mode = bindable.mode;
+      } else {
+        mode = defaultBindingMode;
+      }
+      isPrimary = bindable.primary === true;
+      bindableInfo = info.bindables[prop] = new BindableInfo(prop, mode);
+      if (isPrimary) {
+        if (hasPrimary) {
+          throw new Error('primary already exists');
+        }
+        hasPrimary = true;
+        info.bindable = bindableInfo;
+      }
+      // set to first bindable by convention
+      if (info.bindable === null) {
+        info.bindable = bindableInfo;
+      }
+    }
+    // if no bindables are present, default to "value"
+    if (info.bindable === null) {
+      info.bindable = new BindableInfo('value', defaultBindingMode);
+    }
+    return info;
+  }
+}
 
 /**
  * A pre-processed piece of information about declared custom elements, attributes and
  * binding commands, optimized for consumption by the template compiler.
  */
 export class ResourceModel {
-  private readonly resources: IResourceDescriptions;
-  private readonly elementLookup: Record<string, ElementInfo>;
-  private readonly attributeLookup: Record<string, AttrInfo>;
-  private readonly commandLookup: Record<string, IBindingCommand>;
+  private readonly elementLookup: Record<string, ElementInfo | null | undefined> = Object.create(null);
+  private readonly attributeLookup: Record<string, AttrInfo | null | undefined> = Object.create(null);
+  private readonly commandLookup: Record<string, IBindingCommand | null | undefined> = Object.create(null);
 
-  public constructor(resources: IResourceDescriptions) {
-    this.resources = resources;
-    this.elementLookup = {};
-    this.attributeLookup = {};
-    this.commandLookup = {};
-  }
+  public constructor(
+    private readonly resources: IResourceDescriptions,
+  ) {}
 
   /**
    * Retrieve information about a custom element resource.
@@ -42,12 +185,7 @@ export class ResourceModel {
     let result = this.elementLookup[name];
     if (result === void 0) {
       const def = this.resources.find(CustomElement, name);
-      if (def == null) {
-        result = null!;
-      } else {
-        result = createElementInfo(def);
-      }
-      this.elementLookup[name] = result;
+      this.elementLookup[name] = result = def === null ? null : ElementInfo.from(def);
     }
     return result;
   }
@@ -63,12 +201,7 @@ export class ResourceModel {
     let result = this.attributeLookup[syntax.target];
     if (result === void 0) {
       const def = this.resources.find(CustomAttribute, syntax.target);
-      if (def == null) {
-        result = null!;
-      } else {
-        result = createAttributeInfo(def);
-      }
-      this.attributeLookup[syntax.target] = result;
+      this.attributeLookup[syntax.target] = result = def === null ? null : AttrInfo.from(def);
     }
     return result;
   }
@@ -87,179 +220,15 @@ export class ResourceModel {
     }
     let result = this.commandLookup[name];
     if (result === void 0) {
-      result = this.resources.create(BindingCommandResource, name)!;
-      if (result == null) {
-        // unknown binding command
+      result = this.resources.create(BindingCommandResource, name);
+      if (result === null) {
         if (optional) {
           return null;
         }
-        throw Reporter.error(0); // TODO: create error code
+        throw new Error(`Unknown binding command: ${name}`);
       }
       this.commandLookup[name] = result;
     }
     return result;
-  }
-}
-
-function createElementInfo(def: TemplateDefinition): ElementInfo {
-  const info = new ElementInfo(def.name, def.containerless);
-  const bindables = def.bindables as Record<string, IBindableDescription>;
-  const defaultBindingMode = BindingMode.toView;
-
-  let bindable: IBindableDescription;
-  let prop: string;
-  let attr: string;
-  let mode: BindingMode;
-
-  for (prop in bindables) {
-    bindable = bindables[prop];
-    // explicitly provided property name has priority over the implicit property name
-    if (bindable.property !== void 0) {
-      prop = bindable.property;
-    }
-    // explicitly provided attribute name has priority over the derived implicit attribute name
-    if (bindable.attribute !== void 0) {
-      attr = bindable.attribute;
-    } else {
-      // derive the attribute name from the resolved property name
-      attr = kebabCase(prop);
-    }
-    if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
-      mode = bindable.mode;
-    } else {
-      mode = defaultBindingMode;
-    }
-    info.bindables[attr] = new BindableInfo(prop, mode);
-  }
-  return info;
-}
-
-function createAttributeInfo(def: AttributeDefinition): AttrInfo {
-  const info = new AttrInfo(def.name, def.isTemplateController);
-  const bindables = def.bindables as Record<string, IBindableDescription>;
-  const defaultBindingMode = def.defaultBindingMode !== void 0 && def.defaultBindingMode !== BindingMode.default
-    ? def.defaultBindingMode
-    : BindingMode.toView;
-
-  let bindable: IBindableDescription;
-  let prop: string;
-  let mode: BindingMode;
-  let bindableCount: number = 0;
-  let hasPrimary: boolean = false;
-  let isPrimary: boolean = false;
-  let bindableInfo: BindableInfo;
-
-  for (prop in bindables) {
-    ++bindableCount;
-    bindable = bindables[prop];
-    // explicitly provided property name has priority over the implicit property name
-    if (bindable.property !== void 0) {
-      prop = bindable.property;
-    }
-    if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
-      mode = bindable.mode;
-    } else {
-      mode = defaultBindingMode;
-    }
-    isPrimary = bindable.primary === true;
-    bindableInfo = info.bindables[prop] = new BindableInfo(prop, mode);
-    if (isPrimary) {
-      if (hasPrimary) {
-        throw Reporter.error(0); // todo: error code: primary already exists
-      }
-      hasPrimary = true;
-      info.bindable = bindableInfo;
-    }
-    // set to first bindable by convention
-    if (info.bindable === null) {
-      info.bindable = bindableInfo;
-    }
-  }
-  // if no bindables are present, default to "value"
-  if (info.bindable === null) {
-    info.bindable = new BindableInfo('value', defaultBindingMode);
-  }
-  return info;
-}
-
-/**
- * A pre-processed piece of information about a defined bindable property on a custom
- * element or attribute, optimized for consumption by the template compiler.
- */
-export class BindableInfo {
-  /**
-   * The pre-processed *property* (not attribute) name of the bindable, which is
-   * (in order of priority):
-   *
-   * 1. The `property` from the description (if defined)
-   * 2. The name of the property of the bindable itself
-   */
-  public propName: string;
-  /**
-   * The pre-processed (default) bindingMode of the bindable, which is (in order of priority):
-   *
-   * 1. The `mode` from the bindable (if defined and not bindingMode.default)
-   * 2. The `defaultBindingMode` (if it's an attribute, defined, and not bindingMode.default)
-   * 3. `bindingMode.toView`
-   */
-  public mode: BindingMode;
-
-  public constructor(propName: string, mode: BindingMode) {
-    this.propName = propName;
-    this.mode = mode;
-  }
-}
-
-/**
- * Pre-processed information about a custom element resource, optimized
- * for consumption by the template compiler.
- */
-export class ElementInfo {
-  public name: string;
-  public containerless: boolean;
-
-  /**
-   * A lookup of the bindables of this element, indexed by the (pre-processed)
-   * attribute names as they would be found in parsed markup.
-   */
-  public bindables: Record<string, BindableInfo>;
-
-  public constructor(name: string, containerless: boolean) {
-    this.name = name;
-    this.containerless = containerless;
-    this.bindables = {};
-  }
-}
-
-/**
- * Pre-processed information about a custom attribute resource, optimized
- * for consumption by the template compiler.
- */
-export class AttrInfo {
-  public name: string;
-
-  /**
-   * A lookup of the bindables of this attribute, indexed by the (pre-processed)
-   * bindable names as they would be found in the attribute value.
-   *
-   * Only applicable to multi attribute bindings (semicolon-separated).
-   */
-  public bindables: Record<string, BindableInfo>;
-  /**
-   * The single or first bindable of this attribute, or a default 'value'
-   * bindable if no bindables were defined on the attribute.
-   *
-   * Only applicable to single attribute bindings (where the attribute value
-   * contains no semicolons)
-   */
-  public bindable: BindableInfo;
-
-  public isTemplateController: boolean;
-
-  public constructor(name: string, isTemplateController: boolean) {
-    this.name = name;
-    this.bindables = {};
-    this.bindable = null!;
-    this.isTemplateController = isTemplateController;
   }
 }

--- a/packages/testing/src/tracing.ts
+++ b/packages/testing/src/tracing.ts
@@ -3,10 +3,10 @@ import {
   DebugTracer
 } from '@aurelia/debug';
 import {
-  ICustomAttributeSymbol,
-  INodeSymbol,
-  IPlainAttributeSymbol,
-  ISymbol,
+  CustomAttributeSymbol,
+  NodeSymbol,
+  PlainAttributeSymbol,
+  AnySymbol,
   AttrSyntax,
 } from '@aurelia/jit';
 import {
@@ -47,14 +47,14 @@ export const SymbolTraceWriter = {
           if (p === null) {
             output += 'null';
           } else {
-            if ((p as ISymbol).flags !== undefined) {
-              const symbol = p as INodeSymbol | IPlainAttributeSymbol | ICustomAttributeSymbol;
+            if ((p as AnySymbol).flags !== undefined) {
+              const symbol = p as NodeSymbol | PlainAttributeSymbol | CustomAttributeSymbol;
               if ('target' in symbol) {
                 output += `attr: ${(symbol as AttrSyntax).target}=${(symbol as AttrSyntax).rawValue}`;
               } else if ('interpolation' in symbol) {
-                output += `text: "${((symbol as INodeSymbol).physicalNode as HTMLElement).textContent}"`;
+                output += `text: "${((symbol as NodeSymbol).physicalNode as HTMLElement).textContent}"`;
               } else {
-                output += `element: ${((symbol as INodeSymbol).physicalNode as HTMLElement).outerHTML}`;
+                output += `element: ${((symbol as NodeSymbol).physicalNode as HTMLElement).outerHTML}`;
               }
             } else {
               if ('outerHTML' in (p as HTMLElement)) {


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Simplified the `TemplateBinder` by passing the `manifest`, `manifestRoot`, etc via method parameters rather than storing&restoring them as class instance properties. Data flow should be easier to understand now. Also added some comments.
- Removed the symbol interfaces from the semantic model, using type unions of the classes instead. Also introduced node generic type arguments to make the types more accurate and require a little bit less casting.
- Cleaned up the resource model classes.
- Fixed a number of linting issues along the way.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Fixes https://github.com/aurelia/aurelia/issues/677
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

The semantic-model in `jit-html` looks a bit hacky, but this structure is needed to provide html-specific defaults for the generic type arguments. We might opt to get rid of those generics entirely and simply move the semantic model to jit-html at some point.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

No functional changes. Existing tests should still pass.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

We could look into merging `TemplateBinder` and `TemplateCompiler` (@bigopon ran into some difficulties with `@processContent` caused by the separation of these concerns). No concrete plans for that yet, though. Perhaps it's not needed.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
