### PR TITLE
refactor(router): rename au-href to goto

### DIFF
--- a/packages/__tests__/router/e2e/doc-example/app/src/components/authors/authors.ts
+++ b/packages/__tests__/router/e2e/doc-example/app/src/components/authors/authors.ts
@@ -10,7 +10,7 @@ import { Author } from './author';
 <h3>Authors</h3>
 <ul>
   <li data-test="authors-element-item" repeat.for="author of authors">
-    <a data-test="authors-element-author-link" href="\${author.name}" au-href.bind="{ component: Author, parameters: \`\${author.id}\` }">\${author.name}</a>
+    <a data-test="authors-element-author-link" href="\${author.name}" goto.bind="{ component: Author, parameters: \`\${author.id}\` }">\${author.name}</a>
     <ul><li data-test="authors-element-book-name" repeat.for="book of author.books">\${book.title}</li></ul>
   </li>
 </ul>

--- a/packages/__tests__/router/link-handler.spec.ts
+++ b/packages/__tests__/router/link-handler.spec.ts
@@ -1,4 +1,4 @@
-import { AnchorEventInfo, LinkHandler, AuHrefCustomAttribute } from '@aurelia/router';
+import { AnchorEventInfo, LinkHandler, GotoCustomAttribute } from '@aurelia/router';
 import { assert, createSpy, TestContext } from '@aurelia/testing';
 import { Writable, IRegistry, PLATFORM } from '@aurelia/kernel';
 import { CustomElement, Aurelia } from '@aurelia/runtime';
@@ -21,7 +21,7 @@ describe('LinkHandler', function () {
     doc.body.appendChild(host as any);
 
     const au = new Aurelia(container)
-      .register(AuHrefCustomAttribute as unknown as IRegistry)
+      .register(GotoCustomAttribute as unknown as IRegistry)
       .app({ host, component: App });
 
     await au.start().wait();
@@ -122,21 +122,21 @@ describe('LinkHandler', function () {
     // TODO: figure out why it doesn't work in nodejs and fix it
     it('returns the right instruction', async function () {
       const tests = [
-        { useHref: true, href: true, auHref: true, result: 'au-href' },
-        { useHref: true, href: false, auHref: true, result: 'au-href' },
-        { useHref: true, href: true, auHref: false, result: 'href' },
-        { useHref: true, href: false, auHref: false, result: null },
+        { useHref: true, href: true, goto: true, result: 'goto' },
+        { useHref: true, href: false, goto: true, result: 'goto' },
+        { useHref: true, href: true, goto: false, result: 'href' },
+        { useHref: true, href: false, goto: false, result: null },
 
-        { useHref: false, href: true, auHref: true, result: 'au-href' },
-        { useHref: false, href: false, auHref: true, result: 'au-href' },
-        { useHref: false, href: true, auHref: false, result: null },
-        { useHref: false, href: false, auHref: false, result: null },
+        { useHref: false, href: true, goto: true, result: 'goto' },
+        { useHref: false, href: false, goto: true, result: 'goto' },
+        { useHref: false, href: true, goto: false, result: null },
+        { useHref: false, href: false, goto: false, result: null },
       ];
 
       for (const test of tests) {
         const App = CustomElement.define({
           name: 'app',
-          template: `<a ${test.href ? 'href="href"' : ''} ${test.auHref ? 'au-href="au-href"' : ''}>Link</a>`
+          template: `<a ${test.href ? 'href="href"' : ''} ${test.goto ? 'goto="goto"' : ''}>Link</a>`
         });
 
         const { sut, tearDown, ctx } = await setupApp(App);

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -394,7 +394,7 @@ describe('Router', function () {
     await tearDown();
   });
 
-  it('handles anchor click with au-href', async function () {
+  it('handles anchor click with goto', async function () {
     this.timeout(5000);
 
     const tests = [
@@ -417,7 +417,7 @@ describe('Router', function () {
       name: 'app',
       dependencies: [IdName],
       template: `
-      ${tests.map(test => `<a au-href${test.bind ? '.bind' : ''}="${test.value}">${test.value}</a>`).join('<br>')}
+      ${tests.map(test => `<a goto${test.bind ? '.bind' : ''}="${test.value}">${test.value}</a>`).join('<br>')}
       <br>
       <au-viewport></au-viewport>
       `}) class App {

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -1,4 +1,4 @@
-import { AuHrefCustomAttribute } from './resources/au-href';
+import { GotoCustomAttribute } from './resources/goto';
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
 import { StartTask } from '@aurelia/runtime';
 import { NavCustomElement } from './resources/nav';
@@ -18,22 +18,22 @@ export const DefaultComponents = [
 export {
   ViewportCustomElement,
   NavCustomElement,
-  AuHrefCustomAttribute,
+  GotoCustomAttribute,
 };
 
 export const ViewportCustomElementRegistration = ViewportCustomElement as unknown as IRegistry;
 export const NavCustomElementRegistration = NavCustomElement as unknown as IRegistry;
-export const AuHrefCustomAttributeRegistration = AuHrefCustomAttribute as unknown as IRegistry;
+export const GotoCustomAttributeRegistration = GotoCustomAttribute as unknown as IRegistry;
 
 /**
  * Default router resources:
  * - Custom Elements: `au-viewport`, `au-nav`
- * - Custom Attributes: `au-href`
+ * - Custom Attributes: `goto`
  */
 export const DefaultResources: IRegistry[] = [
   ViewportCustomElement as unknown as IRegistry,
   NavCustomElement as unknown as IRegistry,
-  AuHrefCustomAttribute as unknown as IRegistry,
+  GotoCustomAttribute as unknown as IRegistry,
 ];
 
 let configurationOptions: IRouterOptions = {};

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -115,6 +115,6 @@ export {
   ViewportCustomElementRegistration,
   NavCustomElement,
   NavCustomElementRegistration,
-  AuHrefCustomAttribute,
-  AuHrefCustomAttributeRegistration,
+  GotoCustomAttribute,
+  GotoCustomAttributeRegistration,
 } from './configuration';

--- a/packages/router/src/link-handler.ts
+++ b/packages/router/src/link-handler.ts
@@ -7,8 +7,8 @@ import { Key } from '@aurelia/kernel';
  */
 export interface ILinkHandlerOptions {
   /**
-   * Attribute href should be used for route if present and
-   * attribute au-href is not present
+   * Attribute href should be used for instruction if present and
+   * attribute goto is not present
    */
   useHref?: boolean;
   /**
@@ -84,14 +84,14 @@ export class LinkHandler {
       return info;
     }
 
-    const auHref: string | null = (target as any).$au !== void 0 && (target as any).$au['au-href'] !== void 0 ? (target as any).$au['au-href'].viewModel.value : null;
+    const goto: string | null = (target as any).$au !== void 0 && (target as any).$au['goto'] !== void 0 ? (target as any).$au['goto'].viewModel.value : null;
     const href: string | null = options.useHref && target.hasAttribute('href') ? target.getAttribute('href') : null;
-    if ((auHref === null || auHref.length === 0) && (href === null || href.length === 0)) {
+    if ((goto === null || goto.length === 0) && (href === null || href.length === 0)) {
       return info;
     }
 
     info.anchor = target;
-    info.instruction = auHref || href;
+    info.instruction = goto || href;
 
     const leftButtonClicked: boolean = event.button === 0;
 

--- a/packages/router/src/resources/goto.ts
+++ b/packages/router/src/resources/goto.ts
@@ -1,7 +1,7 @@
 import { customAttribute, INode, bindable, BindingMode } from '@aurelia/runtime';
 
-@customAttribute('au-href')
-export class AuHrefCustomAttribute {
+@customAttribute('goto')
+export class GotoCustomAttribute {
   @bindable({ mode: BindingMode.toView })
   public value: unknown;
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR renames the `au-href` attribute to `goto`.

```html
<a goto="foo(bar)">foo with bar</a>
<a goto.bind="'foo(bar)'">foo with bar</a>
<a goto.bind="{ component: 'foo', parameters: 'bar' }">foo with bar</a>
<a goto.bind="{ component: Foo, parameters: 'bar' }">foo with bar</a>
```
The last example currently requires that the `Foo constructor` is known within the view model. For example
```typescript
import { Foo } from './foo';

export class MyComponent {
  private readonly Foo = Foo;
}
```

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure existing tests pass.

## ⏭ Next Steps

- Make `goto` use local click handler (trigger)
- Add first version of configuration
- Review parameters in viewport instructions
- Fix `realworld`
- Fix proper sync/async for lifecycle hooks
- Add tests for the new au-nav options
- Add tests for the before navigation guard
- Finish navigation skeleton
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->

