### PR TITLE
Support templateController in conventions.

### DIFF
--- a/packages/__tests__/plugin-conventions/name-convention.spec.ts
+++ b/packages/__tests__/plugin-conventions/name-convention.spec.ts
@@ -60,4 +60,16 @@ describe('nameConvention', function () {
       type: 'bindingCommand'
     });
   });
+
+  it('gets template controller like resource', function() {
+    assert.deepEqual(nameConvention('FooBarTemplateController'), {
+      name: 'foo-bar',
+      type: 'templateController'
+    });
+
+    assert.deepEqual(nameConvention('FOOBarTemplateController'), {
+      name: 'foo-bar',
+      type: 'templateController'
+    });
+  });
 });

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -334,11 +334,11 @@ export class FooBarTemplateController {}
   it('skips existing templateController decorator', function () {
     const code = `import { templateController } from '@aurelia/runtime';
 @templateController('some-thing')
-export class FooBar {}
+export class FooBarCustomAttribute {}
 `;
     const expected = `import { templateController } from '@aurelia/runtime';
 @templateController('some-thing')
-export class FooBar {}
+export class FooBarCustomAttribute {}
 `;
     const result = preprocessResource(
       {

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -278,6 +278,26 @@ export class FooBarCustomAttribute {}
     assert.equal(result.code, expected);
   });
 
+  it('skips existing customAttribute decorator', function () {
+    const code = `import { customAttribute } from 'aurelia';
+@customAttribute('some-thing')
+export class FooBar {}
+`;
+    const expected = `import { customAttribute } from 'aurelia';
+@customAttribute('some-thing')
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects templateController decorator', function () {
     const code = `export class FooBarTemplateController {}\n`;
     const expected = `import { templateController } from '@aurelia/runtime';
@@ -299,6 +319,26 @@ export class FooBarTemplateController {}
     const expected = `import { templateController } from '@aurelia/runtime';
 @templateController('foo-bar')
 export class FooBarTemplateController {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('skips existing templateController decorator', function () {
+    const code = `import { templateController } from '@aurelia/runtime';
+@templateController('some-thing')
+export class FooBar {}
+`;
+    const expected = `import { templateController } from '@aurelia/runtime';
+@templateController('some-thing')
+export class FooBar {}
 `;
     const result = preprocessResource(
       {
@@ -344,6 +384,26 @@ export class FooBarValueConverter {}
     assert.equal(result.code, expected);
   });
 
+  it('skips existing valueConverter decorator', function () {
+    const code = `import { valueConverter } from '@aurelia/runtime';
+@valueConverter('fooBar')
+export class FooBar {}
+`;
+    const expected = `import { valueConverter } from '@aurelia/runtime';
+@valueConverter('fooBar')
+export class FooBar {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects bindingBehavior decorator', function () {
     const code = `export class FooBarBindingBehavior {}\n`;
     const expected = `import { bindingBehavior } from '@aurelia/runtime';
@@ -365,6 +425,26 @@ export class FooBarBindingBehavior {}
     const expected = `import { bindingBehavior } from '@aurelia/runtime';
 @bindingBehavior('fooBar')
 export class FooBarBindingBehavior {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('skips existing bindingBehavior decorator', function () {
+    const code = `import { bindingBehavior } from 'aurelia';
+@bindingBehavior('fooBar')
+export class FooBar {}
+`;
+    const expected = `import { bindingBehavior } from 'aurelia';
+@bindingBehavior('fooBar')
+export class FooBar {}
 `;
     const result = preprocessResource(
       {
@@ -409,13 +489,33 @@ export class FooBarBindingCommand {}
     );
     assert.equal(result.code, expected);
   });
+
+  it('skips existing bindingCommand decorator', function () {
+    const code = `import { bindingCommand } from '@aurelia/jit';
+@bindingCommand('lorem')
+export class FooBarBindingCommand {}
+`;
+    const expected = `import { bindingCommand } from '@aurelia/jit';
+@bindingCommand('lorem')
+export class FooBarBindingCommand {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
 });
 
 describe('preprocessResource for complex resource', function () {
 
   it('injects various decorators when there is no implicit custom element', function () {
     const code = `import {Foo} from './foo';
-import { valueConverter } from '@aurelia/runtime';
+import Aurelia, { valueConverter } from 'aurelia';
 
 export class LeaveMeAlone {}
 
@@ -444,9 +544,10 @@ export class AbcBindingCommand {
 
 }
 `;
-    const expected = `import { bindingCommand } from '@aurelia/jit';
+    const expected = `import { customAttribute, bindingBehavior } from '@aurelia/runtime';
+import { bindingCommand } from '@aurelia/jit';
 import {Foo} from './foo';
-import { valueConverter, customAttribute, bindingBehavior } from '@aurelia/runtime';
+import Aurelia, { valueConverter } from 'aurelia';
 
 export class LeaveMeAlone {}
 

--- a/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages/__tests__/plugin-conventions/preprocess-resource.spec.ts
@@ -278,6 +278,39 @@ export class FooBarCustomAttribute {}
     assert.equal(result.code, expected);
   });
 
+  it('injects templateController decorator', function () {
+    const code = `export class FooBarTemplateController {}\n`;
+    const expected = `import { templateController } from '@aurelia/runtime';
+@templateController('foo-bar')
+export class FooBarTemplateController {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('injects templateController decorator for non-kebab case file name', function () {
+    const code = `export class FooBarTemplateController {}\n`;
+    const expected = `import { templateController } from '@aurelia/runtime';
+@templateController('foo-bar')
+export class FooBarTemplateController {}
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'FooBar.js'),
+        contents: code,
+        filePair: 'FooBar.html'
+      },
+      preprocessOptions()
+    );
+    assert.equal(result.code, expected);
+  });
+
   it('injects valueConverter decorator', function () {
     const code = `export class FooBarValueConverter {}\n`;
     const expected = `import { valueConverter } from '@aurelia/runtime';
@@ -459,7 +492,7 @@ export class AbcBindingCommand {
 
   it('injects various decorators when there is implicit custom element', function () {
     const code = `import {Foo} from './foo';
-import { valueConverter } from '@aurelia/runtime';
+import { templateController } from '@aurelia/runtime';
 import { other } from '@aurelia/jit';
 
 export class LeaveMeAlone {}
@@ -470,11 +503,8 @@ export class LoremCustomAttribute {
 
 }
 
-@valueConverter('one')
+@templateController('one')
 export class ForOne {
-  toView(value: number): string {
-    return '' + value;
-  }
 }
 
 export class TheSecondValueConverter {
@@ -493,7 +523,7 @@ export class AbcBindingCommand {
 `;
     const expected = `import * as __au2ViewDef from './foo-bar.html';
 import {Foo} from './foo';
-import { valueConverter, customElement, customAttribute, bindingBehavior } from '@aurelia/runtime';
+import { templateController, customElement, customAttribute, valueConverter, bindingBehavior } from '@aurelia/runtime';
 import { other, bindingCommand } from '@aurelia/jit';
 
 export class LeaveMeAlone {}
@@ -505,11 +535,8 @@ export class LoremCustomAttribute {
 
 }
 
-@valueConverter('one')
+@templateController('one')
 export class ForOne {
-  toView(value: number): string {
-    return '' + value;
-  }
 }
 
 @valueConverter('theSecond')

--- a/packages/plugin-conventions/src/name-convention.ts
+++ b/packages/plugin-conventions/src/name-convention.ts
@@ -2,7 +2,7 @@ import { camelCase, kebabCase } from '@aurelia/kernel';
 import { INameConvention, ResourceType } from './options';
 
 export function nameConvention(className: string): INameConvention {
-  const m = /^(.+?)(CustomAttribute|ValueConverter|BindingBehavior|BindingCommand)?$/.exec(className);
+  const m = /^(.+?)(CustomAttribute|ValueConverter|BindingBehavior|BindingCommand|TemplateController)?$/.exec(className);
   if (!m) {
     throw new Error(`No convention found for class name ${className}`);
   }

--- a/packages/plugin-conventions/src/options.ts
+++ b/packages/plugin-conventions/src/options.ts
@@ -1,4 +1,4 @@
-export type ResourceType = 'view' | 'customElement' | 'customAttribute' | 'valueConverter' | 'bindingBehavior' | 'bindingCommand';
+export type ResourceType = 'view' | 'customElement' | 'customAttribute' | 'valueConverter' | 'bindingBehavior' | 'bindingCommand' | 'templateController';
 
 export interface INameConvention {
   name: string;

--- a/packages/plugin-conventions/src/preprocess-resource.ts
+++ b/packages/plugin-conventions/src/preprocess-resource.ts
@@ -38,6 +38,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
   const expectedResourceName = kebabCase(basename);
   const sf = ts.createSourceFile(unit.path, unit.contents, ts.ScriptTarget.Latest);
 
+  let auImport: ICapturedImport = { names: [], start: 0, end: 0 };
   let runtimeImport: ICapturedImport = { names: [], start: 0, end: 0 };
   let jitImport: ICapturedImport = { names: [], start: 0, end: 0 };
 
@@ -49,6 +50,14 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
   const conventionalDecorators: [number, string][] = [];
 
   sf.statements.forEach(s => {
+    // Find existing import Aurelia, {customElement, templateController} from 'aurelia';
+    const au = captureImport(s, 'aurelia', unit.contents);
+    if (au) {
+      // Assumes only one import statement for @aurelia/runtime
+      auImport = au;
+      return;
+    }
+
     // Find existing import {customElement} from '@aurelia/runtime';
     const runtime = captureImport(s, '@aurelia/runtime', unit.contents);
     if (runtime) {
@@ -82,8 +91,12 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     if (localDep) localDeps.push(localDep);
     if (needDecorator) conventionalDecorators.push(needDecorator);
     if (implicitStatement) implicitElement = implicitStatement;
-    if (runtimeImportName) ensureTypeIsExported(runtimeImport.names, runtimeImportName);
-    if (jitImportName) ensureTypeIsExported(jitImport.names, jitImportName);
+    if (runtimeImportName && !auImport.names.includes(runtimeImportName)) {
+      ensureTypeIsExported(runtimeImport.names, runtimeImportName);
+    }
+    if (jitImportName && !auImport.names.includes(jitImportName)) {
+      ensureTypeIsExported(jitImport.names, jitImportName);
+    }
   });
 
   return modifyResource(unit, {

--- a/packages/plugin-conventions/src/preprocess-resource.ts
+++ b/packages/plugin-conventions/src/preprocess-resource.ts
@@ -182,7 +182,7 @@ function isExported(node: ts.Node): boolean {
   return false;
 }
 
-const KNOWN_DECORATORS = ['view', 'customElement', 'customAttribute', 'valueConverter', 'bindingBehavior', 'bindingCommand'];
+const KNOWN_DECORATORS = ['view', 'customElement', 'customAttribute', 'valueConverter', 'bindingBehavior', 'bindingCommand', 'templateController'];
 
 function findDecoratedResourceType(node: ts.Node): ResourceType | void {
   if (!node.decorators) return;


### PR DESCRIPTION
# Pull Request

## 📖 Description

1. Add support of `@templateController` in conventions.
    * If you already decorated class with `@templateController`, conventions will skip the resource (even if there is `CustomAttribute` suffix in class name).
    * If you name resource as `export class FooBarTemplateController` without decorator, conventions will inject `@templateController('foo-bar')`.

2. Add check on existing import statement on new "aurelia" package to avoid double import.

### 🎫 Issues

#657
#630 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

Manually tested in a webpack app.

## ⏭ Next Steps

To be tested in user apps.
