### PR TITLE
test: require node >= 12.0.0

### DIFF
--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": ">=10.16.0",
+    "node": ">=12.0.0",
     "npm": ">=6.1.0"
   },
   "scripts": {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Set the `node` engine requirement to `>=12.0.0` in `__tests__/package.json` as the tests for `i18n` make use of `RelativeTimeFormat`, which is only available in [Node 12 and up](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat).

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Self explanatory imho.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a