### PR TITLE
chore: move inline eslint disables to .eslintrc.js for generated tests

### DIFF
--- a/packages/__tests__/.eslintrc.js
+++ b/packages/__tests__/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   rules: {
     '@typescript-eslint/class-name-casing': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'compat/compat': 'off',
     'import/no-nodejs-modules': 'off',
     'jsdoc/require-jsdoc': 'off',
     'mocha/no-async-describe': 'error',
@@ -34,5 +35,14 @@ module.exports = {
     'mocha/no-hooks': 'off',
     'mocha/no-setup-in-describe': 'off',
     'mocha/no-synchronous-tests': 'off'
-  }
+  },
+  overrides: [{ // Specific overrides for JS files as some TS rules don't make sense there.
+    files: ['jit-html/generated/**'],
+    rules: {
+      '@typescript-eslint/quotes': 'off',
+      '@typescript-eslint/explicit-member-accessibility': 'off',
+      '@typescript-eslint/indent': 'off',
+      'no-template-curly-in-string': 'off'
+    }
+  }]
 };

--- a/packages/__tests__/jit-html/generated/template-compiler.mutations.basic.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.mutations.basic.spec.ts
@@ -1,4 +1,3 @@
-// /* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, sonarjs/no-all-duplicated-branches, no-template-curly-in-string */
 // import { Aurelia, CustomElement, INode } from "@aurelia/runtime";
 // import { expect } from "chai";
 // import { TestContext } from "@aurelia/testing";

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.double.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.double.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */
 import { Profiler } from "@aurelia/kernel";
 import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */
 import { Profiler } from "@aurelia/kernel";
 import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */
 import { Profiler } from "@aurelia/kernel";
 import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */
 import { Profiler } from "@aurelia/kernel";
 import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";

--- a/packages/__tests__/jit-html/generated/template-compiler.static.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */
 import { Profiler } from "@aurelia/kernel";
 import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";

--- a/scripts/generate-tests/util.ts
+++ b/scripts/generate-tests/util.ts
@@ -67,7 +67,7 @@ export function emit(path: string, ...nodes: Node[]): void {
       content += `${printer.printNode(EmitHint.Unspecified, node, emptyFile)}\n`;
     }
   }
-  writeFileSync(path, `/* eslint-disable @typescript-eslint/quotes, @typescript-eslint/explicit-member-accessibility, @typescript-eslint/indent, no-template-curly-in-string */\r\n${content.slice(0, -1)}\r\n`, { encoding: 'utf8' });
+  writeFileSync(path, `${content.slice(0, -1)}\r\n`, { encoding: 'utf8' });
 }
 
 export function addRange(start: number, end: number, ...records: Record<string, boolean>[]): void {


### PR DESCRIPTION

# Pull Request

## 📖 Description

Move the `eslint-disable` statements that are at the top of the generated tests (and are put there by the npm `generate-tests:template-compiler.*` scripts) to `.eslintrc.js`. This increases maintainability as the list keeps increasing and is now in a single location instead of in each file.

Also switched off `compat/compat` within tests as it doesn't make sense there.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Just moving some stuff around.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a