### PR TITLE
chore: switch to no-hooks

### DIFF
--- a/packages/__tests__/.eslintrc.js
+++ b/packages/__tests__/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'jsdoc/require-jsdoc': 'off',
     'mocha/no-async-describe': 'error',
     'mocha/no-exclusive-tests': 'warn',
+    'mocha/no-hooks': 'error',
     'mocha/no-hooks-for-single-case': 'off', // Disabled to avoid duplicates, because 'no-hooks' is enabled
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',
@@ -31,7 +32,6 @@ module.exports = {
 
     // Things we maybe need to fix some day, so are marked as off for now as they're quite noisy:
     'mocha/max-top-level-suites': 'off',
-    'mocha/no-hooks': 'off',
     'mocha/no-setup-in-describe': 'off',
     'mocha/no-synchronous-tests': 'off'
   }

--- a/packages/__tests__/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/i18n/t/translation-integration.spec.ts
@@ -4,6 +4,7 @@ import { Aurelia, bindable, customElement, DOM, INode, LifecycleFlags, ISignaler
 import { assert, TestContext } from '@aurelia/testing';
 
 describe('translation-integration', function () {
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     TranslationBindingCommand.aliases = ['t'];
     TranslationAttributePattern.aliases = ['t'];

--- a/packages/__tests__/i18n/t/translation-render.spec.ts
+++ b/packages/__tests__/i18n/t/translation-render.spec.ts
@@ -8,6 +8,7 @@ import { assert } from '@aurelia/testing';
 
 describe('TranslationAttributePattern', function () {
   let originalAliases: string[];
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     TranslationAttributePattern.aliases = originalAliases;
   });
@@ -61,6 +62,7 @@ describe('TranslationAttributePattern', function () {
 
 describe('TranslationBindingCommand', function () {
   let originalAliases: string[];
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     TranslationBindingCommand.aliases = originalAliases;
   });
@@ -171,6 +173,7 @@ describe('TranslationBindingRenderer', function () {
 
 describe('TranslationBindAttributePattern', function () {
   let originalAliases: string[];
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     TranslationBindAttributePattern.aliases = originalAliases;
   });
@@ -228,6 +231,7 @@ describe('TranslationBindAttributePattern', function () {
 
 describe('TranslationBindBindingCommand', function () {
   let originalAliases: string[];
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     TranslationBindBindingCommand.aliases = originalAliases;
   });

--- a/packages/__tests__/jit-html/blur.integration.spec.ts
+++ b/packages/__tests__/jit-html/blur.integration.spec.ts
@@ -13,13 +13,6 @@ describe('blur.integration.spec.ts', function() {
     hasFocus: boolean;
   }
 
-  before(async function () {
-    await waitForFrames(2);
-  });
-  after(async function () {
-    await waitForFrames(2);
-  });
-
   describe('>> with mouse', function() {
     describe('>> Basic scenarios', function() {
       // Note that from-view binding are not working at the moment

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.double.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.double.spec.ts
@@ -4,9 +4,11 @@ import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";
 
 describe("generated.template-compiler.static.if-else.double", function () {
+    // eslint-disable-next-line mocha/no-hooks
     before(function () {
         Profiler.enable();
     });
+    // eslint-disable-next-line mocha/no-hooks
     after(function () {
         Profiler.disable();
         writeProfilerReport("static.if-else.double");

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
@@ -4,9 +4,11 @@ import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";
 
 describe("generated.template-compiler.static.if-else.repeat.double", function () {
+    // eslint-disable-next-line mocha/no-hooks
     before(function () {
         Profiler.enable();
     });
+    // eslint-disable-next-line mocha/no-hooks
     after(function () {
         Profiler.disable();
         writeProfilerReport("static.if-else.repeat.double");

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.repeat.spec.ts
@@ -4,9 +4,11 @@ import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";
 
 describe("generated.template-compiler.static.if-else.repeat", function () {
+    // eslint-disable-next-line mocha/no-hooks
     before(function () {
         Profiler.enable();
     });
+    // eslint-disable-next-line mocha/no-hooks
     after(function () {
         Profiler.disable();
         writeProfilerReport("static.if-else.repeat");

--- a/packages/__tests__/jit-html/generated/template-compiler.static.if-else.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.if-else.spec.ts
@@ -4,9 +4,11 @@ import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";
 
 describe("generated.template-compiler.static.if-else", function () {
+    // eslint-disable-next-line mocha/no-hooks
     before(function () {
         Profiler.enable();
     });
+    // eslint-disable-next-line mocha/no-hooks
     after(function () {
         Profiler.disable();
         writeProfilerReport("static.if-else");

--- a/packages/__tests__/jit-html/generated/template-compiler.static.spec.ts
+++ b/packages/__tests__/jit-html/generated/template-compiler.static.spec.ts
@@ -4,9 +4,11 @@ import { Aurelia, CustomElement } from "@aurelia/runtime";
 import { TestContext, writeProfilerReport, assert } from "@aurelia/testing";
 
 describe("generated.template-compiler.static", function () {
+    // eslint-disable-next-line mocha/no-hooks
     before(function () {
         Profiler.enable();
     });
+    // eslint-disable-next-line mocha/no-hooks
     after(function () {
         Profiler.disable();
         writeProfilerReport("static");

--- a/packages/__tests__/jit-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.harmony.spec.ts
@@ -24,13 +24,6 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
     assertFn(ctx: HTMLTestContext, host: HTMLElement, comp: any): void | Promise<void>;
   }
 
-  before(async function() {
-    await new Promise(PLATFORM.requestAnimationFrame);
-  });
-  after(async function() {
-    await new Promise(PLATFORM.requestAnimationFrame);
-  });
-
   const testCases: IHarmoniousCompilationTestCase[] = [
     {
       title: 'basic surrogate working example with 1 pair of custom attr + event same name',

--- a/packages/__tests__/jit-html/template-compiler.ref.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.ref.spec.ts
@@ -18,13 +18,6 @@ import {
 
 describe('templating-compiler.ref.spec.ts', function() {
 
-  before(async function() {
-    await waitForFrames(2);
-  });
-  after(async function() {
-    await waitForFrames(2);
-  });
-
   interface IRefIntegrationTestCase {
     title: string;
     template: string | HTMLElement;

--- a/packages/__tests__/jit-html/template-compiler.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.spec.ts
@@ -56,6 +56,7 @@ describe('template-compiler.spec.ts\n  [TemplateCompiler]', function () {
   let container: IContainer;
   let dom: IDOM;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
     container = ctx.container;

--- a/packages/__tests__/jit-html/template-element-factory.spec.ts
+++ b/packages/__tests__/jit-html/template-element-factory.spec.ts
@@ -6,6 +6,7 @@ describe('HTMLTemplateElementFactory', function () {
   let sut: ITemplateElementFactory<HTMLElement>;
   let ctx: HTMLTestContext;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     ctx = TestContext.createHTMLTestContext();
     ctx.container.register(ITemplateElementFactoryRegistration);

--- a/packages/__tests__/kernel/di.integration.spec.ts
+++ b/packages/__tests__/kernel/di.integration.spec.ts
@@ -30,6 +30,7 @@ describe('DI.createInterface() -> container.get()', function () {
   let callback: ISpy<() => ICallback>;
   let get: ISpy<IContainer['get']>;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
     ITransient = DI.createInterface<ITransient>('ITransient').withDefault(x => x.transient(Transient));
@@ -41,6 +42,7 @@ describe('DI.createInterface() -> container.get()', function () {
     get = createSpy(container, 'get', true);
   });
 
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     get.restore();
   });

--- a/packages/__tests__/kernel/di.spec.ts
+++ b/packages/__tests__/kernel/di.spec.ts
@@ -318,9 +318,11 @@ describe(`The DI object`, function () {
   describe(`getDependencies()`, function () {
     let getDesignParamTypes: ISpy<typeof DI.getDesignParamTypes>;
 
+    // eslint-disable-next-line mocha/no-hooks
     beforeEach(function () {
       getDesignParamTypes = createSpy(DI, 'getDesignParamTypes', true);
     });
+    // eslint-disable-next-line mocha/no-hooks
     afterEach(function () {
       getDesignParamTypes.restore();
     });
@@ -479,12 +481,14 @@ describe(`The DI object`, function () {
 
       let registerResolver: ISpy<IContainer['registerResolver']>;
 
+      // eslint-disable-next-line mocha/no-hooks
       beforeEach(function () {
         sut = DI.createInterface();
         container = DI.createContainer();
         registerResolver = createSpy(container, 'registerResolver', true);
       });
 
+      // eslint-disable-next-line mocha/no-hooks
       afterEach(function () {
         registerResolver.restore();
       });

--- a/packages/__tests__/runtime-html/attr-binding-behavior.spec.ts
+++ b/packages/__tests__/runtime-html/attr-binding-behavior.spec.ts
@@ -10,6 +10,7 @@ describe('AttrBindingBehavior', function () {
   let sut: AttrBindingBehavior;
   let binding: PropertyBinding;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     const ctx = TestContext.createHTMLTestContext();
     target = ctx.createElement('div');

--- a/packages/__tests__/runtime-html/checked-observer.spec.ts
+++ b/packages/__tests__/runtime-html/checked-observer.spec.ts
@@ -17,6 +17,7 @@ const eventDefaults = { bubbles: true };
 
 describe.skip('CheckedObserver', function () {
 
+  // eslint-disable-next-line mocha/no-hooks
   before(function () {
     enableArrayObservation();
   });

--- a/packages/__tests__/runtime-html/dom.spec.ts
+++ b/packages/__tests__/runtime-html/dom.spec.ts
@@ -116,6 +116,7 @@ describe('dom', function () {
     Object.assign(ctx.doc, DocumentBackup);
   }
 
+  // eslint-disable-next-line mocha/no-hooks
   before(function () {
     Object.assign(DOMBackup, ctx.dom);
     for (const propName in ctx.doc) {
@@ -126,6 +127,7 @@ describe('dom', function () {
     }
   });
 
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     restoreBackups();
   });

--- a/packages/__tests__/runtime-html/self-binding-behavior.spec.ts
+++ b/packages/__tests__/runtime-html/self-binding-behavior.spec.ts
@@ -9,6 +9,7 @@ describe('SelfBindingBehavior', function () {
   let binding: PropertyBinding;
   let originalCallSource: () => void;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     sut = new SelfBindingBehavior();
     binding = new PropertyBinding(undefined, undefined, undefined, undefined, undefined, container as any);

--- a/packages/__tests__/runtime/array-observer.spec.ts
+++ b/packages/__tests__/runtime/array-observer.spec.ts
@@ -58,6 +58,7 @@ export class SynchronizingCollectionSubscriber implements ICollectionSubscriber 
 describe(`ArrayObserver`, function () {
   let sut: ArrayObserver;
 
+  // eslint-disable-next-line mocha/no-hooks
   before(function () {
     disableArrayObservation();
     enableArrayObservation();

--- a/packages/__tests__/runtime/ast.spec.ts
+++ b/packages/__tests__/runtime/ast.spec.ts
@@ -853,6 +853,7 @@ describe('AST', function () {
 describe('AccessKeyedExpression', function () {
   let expression: AccessKeyedExpression;
 
+  // eslint-disable-next-line mocha/no-hooks
   before(function () {
     expression = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), new PrimitiveLiteralExpression('bar'));
   });

--- a/packages/__tests__/runtime/binding-behavior.spec.ts
+++ b/packages/__tests__/runtime/binding-behavior.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@aurelia/testing';
 describe(`@bindingBehavior('foo')`, function () {
   let container: IContainer;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
   });

--- a/packages/__tests__/runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/runtime/binding-mode-behaviors.spec.ts
@@ -29,6 +29,7 @@ describe('BindingModeBehavior', function () {
 
     for (const initMode of initModeArr) {
       describe(Behavior.name, function () {
+        // eslint-disable-next-line mocha/no-hooks
         beforeEach(function () {
           sut = new Behavior();
           binding = new PropertyBinding(undefined, undefined, undefined, initMode, undefined, container as any);

--- a/packages/__tests__/runtime/binding.spec.ts
+++ b/packages/__tests__/runtime/binding.spec.ts
@@ -58,6 +58,7 @@ describe('PropertyBinding', function () {
     return { sut, lifecycle, container, observerLocator };
   }
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     dummySourceExpression = {} as any;
     dummyTarget = {foo: 'bar'};

--- a/packages/__tests__/runtime/debounce-binding-behavior.spec.ts
+++ b/packages/__tests__/runtime/debounce-binding-behavior.spec.ts
@@ -15,6 +15,7 @@ describe('DebounceBindingBehavior', function () {
   let binding: PropertyBinding;
   let originalFn: (newValue: unknown, previousValue: unknown, flags: LifecycleFlags) => void;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     sut = new DebounceBindingBehavior();
     binding = new PropertyBinding(undefined, undefined, undefined, undefined, undefined, container);

--- a/packages/__tests__/runtime/dirty-checker.spec.ts
+++ b/packages/__tests__/runtime/dirty-checker.spec.ts
@@ -8,6 +8,7 @@ import {
 import { assert } from '@aurelia/testing';
 
 describe.skip('DirtyChecker', function () {
+  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     DirtyCheckSettings.resetToDefault();
   });

--- a/packages/__tests__/runtime/throttle-binding-behavior.spec.ts
+++ b/packages/__tests__/runtime/throttle-binding-behavior.spec.ts
@@ -15,6 +15,7 @@ describe('ThrottleBindingBehavior', function () {
   let binding: PropertyBinding;
   let originalFn: (value: unknown, flags: LifecycleFlags) => void;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     sut = new ThrottleBindingBehavior();
     binding = new PropertyBinding(undefined, undefined, undefined, undefined, undefined, container);

--- a/packages/__tests__/runtime/value-converter.spec.ts
+++ b/packages/__tests__/runtime/value-converter.spec.ts
@@ -5,6 +5,7 @@ import { assert } from '@aurelia/testing';
 describe(`@valueConverter('foo')`, function () {
   let container: IContainer;
 
+  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
   });

--- a/scripts/generate-tests/template-compiler.static.ts
+++ b/scripts/generate-tests/template-compiler.static.ts
@@ -4,6 +4,7 @@ import { kebabCase } from '../../packages/kernel/src/index';
 import project from '../project';
 import {
   $$call,
+  $$comment,
   $$const,
   $$functionDecl,
   $$functionExpr,
@@ -1038,17 +1039,21 @@ function generateAndEmit(): void {
       $$functionExpr('describe', [
         $expression(`generated.template-compiler.${suffix}`),
         $functionExpr([
-          $$functionExpr('before', [
-            $functionExpr([
-              $$call('Profiler.enable')
+          $$comment('eslint-disable-next-line mocha/no-hooks',
+            $$functionExpr('before', [
+              $functionExpr([
+                $$call('Profiler.enable')
+              ])
             ])
-          ]),
-          $$functionExpr('after', [
-            $functionExpr([
-              $$call('Profiler.disable'),
-              $$call('writeProfilerReport', [$expression(suffix)])
+          ),
+          $$comment('eslint-disable-next-line mocha/no-hooks',
+            $$functionExpr('after', [
+              $functionExpr([
+                $$call('Profiler.disable'),
+                $$call('writeProfilerReport', [$expression(suffix)])
+              ])
             ])
-          ]),
+          ),
           $$functionDecl(
             'setup',
             [

--- a/scripts/generate-tests/util.ts
+++ b/scripts/generate-tests/util.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'fs';
 import {
+  addSyntheticLeadingComment,
   ArrayLiteralExpression,
   ClassElement,
   ClassExpression,
@@ -200,6 +201,10 @@ export function $$new(variable: string, path: [string | Expression | Identifier,
 export function $$new(variable: string, nameOrPath: string | [string | Expression | Identifier, ...(string | Identifier)[]], variablesOrExpressions?: (string | Expression | Identifier)[]): Statement;
 export function $$new(variable: string, nameOrPath: string | [string | Expression | Identifier, ...(string | Identifier)[]], variablesOrExpressions: (string | Expression | Identifier)[] = []): Statement {
   return $$const(variable, $new(nameOrPath, variablesOrExpressions));
+}
+
+export function $$comment(comment: string, arg: Statement): Statement {
+  return addSyntheticLeadingComment(arg, SyntaxKind.SingleLineCommentTrivia, ` ${comment}`, true);
 }
 
 export function $$const(name: string, initializer: Expression): VariableStatement;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Enable the `no-hooks` linting rule and disable the violations for now. This ensures we get no new global hooks, while being able to easily find the remaining ones and slowly refactor those away.

I did already remove a couple of global `before` and `after ` hooks that didn't seem necessary (anymore).

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

A spot check on the changes made would be appreciated.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

More linting