### PR TITLE
Fix multi binding compilation

### DIFF
--- a/packages/__tests__/jit-html/portal.spec.tsx
+++ b/packages/__tests__/jit-html/portal.spec.tsx
@@ -281,47 +281,100 @@ describe('portal.spec.tsx 🚪-🔁-🚪', function () {
           );
         }
       },
-      // todo: re-enable the test after fixing the parser
-      // {
-      //   title: 'it works with funny movement, with render context',
-      //   rootVm: CustomElement.define(
-      //     {
-      //       name: 'app',
-      //       template: <template>
-      //         <div ref='divdiv' portal='target.bind: target; render-context: #mock-render-context' class='divdiv'>{'${message}'}</div>
-      //         <div ref='localDiv'></div>
-      //         <div id="mock-render-context0">
-      //           <div id="mock-1-0" class="mock-target"></div>
-      //           <div id="mock-2-0" class="mock-target"></div>
-      //           <div id="mock-3-0" class="mock-target"></div>
-      //         </div>
-      //         <div id="mock-render-context">
-      //           <div id="mock-1-1" class="mock-target"></div>
-      //           <div id="mock-2-1" class="mock-target"></div>
-      //           <div id="mock-3-1" class="mock-target"></div>
-      //         </div>
-      //       </template>
-      //     },
-      //     class App {
-      //       public localDiv: HTMLElement;
-      //       public items: any[];
-      //       public $if: boolean;
-      //     }
-      //   ),
-      //   assertionFn: (ctx, host, comp: { target: any; divdiv: HTMLDivElement }) => {
-      //     assert.notStrictEqual(
-      //       childrenQuerySelector(ctx.doc.body, '.divdiv'),
-      //       null,
-      //       'it should have been moved to body'
-      //     );
+      {
+        title: 'it works with funny movement, with render context string',
+        rootVm: CustomElement.define(
+          {
+            name: 'app',
+            template: <template>
+              <div ref='divdiv' portal='target.bind: target; render-context: #mock-render-context' class='divdiv'>{'${message}'}</div>
+              <div ref='localDiv'></div>
+              <div id="mock-render-context0">
+                <div id="mock-1-0" class="mock-target"></div>
+                <div id="mock-2-0" class="mock-target"></div>
+                <div id="mock-3-0" class="mock-target"></div>
+              </div>
+              <div id="mock-render-context">
+                <div id="mock-1-1" class="mock-target"></div>
+                <div id="mock-2-1" class="mock-target"></div>
+                <div id="mock-3-1" class="mock-target"></div>
+              </div>
+            </template>
+          },
+          class App {
+            public localDiv: HTMLElement;
+            public items: any[];
+            public $if: boolean;
+          }
+        ),
+        assertionFn: (ctx, host, comp: { target: any; divdiv: HTMLDivElement }) => {
+          assert.notStrictEqual(
+            childrenQuerySelector(ctx.doc.body, '.divdiv'),
+            null,
+            'it should have been moved to body'
+          );
 
-      //     comp.target = '.mock-target';
-      //     assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-1');
+          comp.target = '.mock-target';
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-1');
 
-      //     comp.target = null;
-      //     assert.strictEqual(comp.divdiv.parentElement, ctx.doc.body);
-      //   }
-      // }
+          comp.target = null;
+          assert.strictEqual(comp.divdiv.parentElement, ctx.doc.body);
+        }
+      },
+      {
+        title: 'it works with funny movement, with render context element',
+        rootVm: CustomElement.define(
+          {
+            name: 'app',
+            template: <template>
+              <div ref='divdiv' portal='target.bind: target; render-context.bind: renderContext' class='divdiv'>{'${message}'}</div>
+              <div ref='localDiv'></div>
+              <div id="mock-render-context0">
+                <div id="mock-1-0" class="mock-target"></div>
+                <div id="mock-2-0" class="mock-target"></div>
+                <div id="mock-3-0" class="mock-target"></div>
+              </div>
+              <div id="mock-render-context">
+                <div id="mock-1-1" class="mock-target"></div>
+                <div id="mock-2-1" class="mock-target"></div>
+                <div id="mock-3-1" class="mock-target"></div>
+              </div>
+            </template>
+          },
+          class App {
+            public localDiv: HTMLElement;
+            public items: any[];
+            public renderContext: HTMLElement;
+          }
+        ),
+        assertionFn: (ctx, host, comp: { target: any; divdiv: HTMLDivElement; renderContext: HTMLElement }) => {
+          assert.notStrictEqual(
+            childrenQuerySelector(ctx.doc.body, '.divdiv'),
+            null,
+            'it should have been moved to body'
+          );
+
+          comp.target = '.mock-target';
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-0');
+
+          comp.target = null;
+          assert.strictEqual(comp.divdiv.parentElement, ctx.doc.body);
+
+          comp.target = '.mock-target';
+          // still not #mock-1-1 yet, because render context is unclear, so #mock-1-0 comes first for .mock-target
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-0');
+
+          comp.renderContext = host.querySelector('#mock-render-context');
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-1');
+
+          comp.renderContext = undefined;
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-0');
+
+          comp.renderContext = null;
+          assert.strictEqual(comp.divdiv.parentElement.id, 'mock-1-0');
+        }
+      },
+      // todo: add activating/deactivating + async + timing tests
     ];
 
     eachCartesianJoin(
@@ -366,6 +419,7 @@ describe('portal.spec.tsx 🚪-🔁-🚪', function () {
   interface IPortalTestRootVm {
     items?: any[];
     localDiv?: HTMLElement;
+    renderContext?: HTMLElement;
   }
 
   function setup<T>(options: { root: Constructable<T>; resources?: IRegistry[] }) {

--- a/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
@@ -557,7 +557,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       au.app({ component: App, host });
       await au.start().wait();
 
-      assert.includes(host.querySelector('a').search, `?route=home.main`);
+      if (PLATFORM.isBrowserLike) {
+        assert.includes(host.querySelector('a').search, `?route=home.main`);
+      } else {
+        assert.strictEqual(host.querySelector('a').href, `/?route=home.main`);
+      }
 
       await au.stop().wait();
       host.remove();
@@ -579,7 +583,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       au.app({ component: App, host });
       await au.start().wait();
 
-      assert.strictEqual(host.querySelector('a').search, '?route=home--main');
+      if (PLATFORM.isBrowserLike) {
+        assert.strictEqual(host.querySelector('a').search, '?route=home--main');
+      } else {
+        assert.strictEqual(host.querySelector('a').href, '/?route=home--main');
+      }
 
       await au.stop().wait();
       host.remove();
@@ -615,7 +623,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       const app = au.root.controller.viewModel as any;
 
       app.appId = 'appId-appId';
-      assert.strictEqual(anchorEl.search, `?params=[object%20Object]`);
+      if (PLATFORM.isBrowserLike) {
+        assert.strictEqual(anchorEl.search, `?params=[object%20Object]`);
+      } else {
+        assert.strictEqual(anchorEl.href, '/?params=[object%20Object]');
+      }
 
       await au.stop().wait();
       host.remove();

--- a/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
@@ -618,7 +618,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
 
       const anchorEl = host.querySelector('a');
 
-      assert.strictEqual(anchorEl.search, '?route=home.main');
+      if (PLATFORM.isBrowserLike) {
+        assert.strictEqual(anchorEl.search, '?route=home.main');
+      } else {
+        assert.strictEqual(anchorEl.href, '/?route=home.main');
+      }
 
       const app = au.root.controller.viewModel as any;
 

--- a/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/jit-html/template-compiler.primary-bindable.spec.ts
@@ -630,7 +630,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       if (PLATFORM.isBrowserLike) {
         assert.strictEqual(anchorEl.search, `?params=[object%20Object]`);
       } else {
-        assert.strictEqual(anchorEl.href, '/?params=[object%20Object]');
+        assert.strictEqual(anchorEl.href, '/?params=[object Object]');
       }
 
       await au.stop().wait();

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -601,7 +601,7 @@ export class TemplateBinder {
         }
 
         const attrSyntax = this.attrParser.parse(attrName, attrValue);
-        const attrTarget = attrSyntax.target;
+        const attrTarget = camelCase(attrSyntax.target);
         const command = this.resources.getBindingCommand(attrSyntax, false);
         const bindingType = command === null ? BindingType.Interpolation : command.bindingType;
         const expr = this.exprParser.parse(attrValue, bindingType);


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, multi binding attributes usage does not camel-case-ize the target attribute-property, making the following not working:
```html
<div square="border-radius: 5"></div>
```
But the following work;
```html
<div square="borderRadius: 5"></div>
```
Fix that by always convert target attribute-property to camel case

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

Should there be a warning in case an upper case character is detected in attribute name?

## 📑 Test Plan

N/A

## ⏭ Next Steps

N/A