### PR TITLE
Fix ce ca compilation

### DIFF
--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -127,7 +127,7 @@ describe('custom-attributes', function () {
 
   });
 
-  describe('with multiple bindings', function () {
+  describe('0.2 Multiple bindings', function () {
 
     @customAttribute('multi')
     class Multi {
@@ -201,4 +201,63 @@ describe('custom-attributes', function () {
     });
   });
 
+  describe('03. Change Handler', function() {
+    interface IChangeHandlerTestViewModel {
+      prop: any;
+      propChangedCallCount: number;
+      propChanged(newValue: any): void;
+    }
+
+    @customAttribute('foo')
+    class Foo implements IChangeHandlerTestViewModel {
+      @bindable()
+      public prop: any;
+      public propChangedCallCount: number = 0;
+      public propChanged(): void {
+        this.propChangedCallCount++;
+      }
+    }
+
+    it('does not invoke change handler when starts with plain usage', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest('<div foo="prop"></div>');
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with commands', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest('<div foo.bind="prop"></foo>');
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with interpolation', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo="\${prop}"></foo>`);
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with two way binding', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo.two-way="prop"></foo>`);
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    function setupChangeHandlerTest(template: string) {
+      const options = setup(template, class {}, [Foo]);
+      const fooEl = options.appHost.querySelector('div') as INode;
+      const fooVm = fooEl.$au.foo.viewModel as Foo;
+      return {
+        fooVm: fooVm,
+        tearDown: () => options.au.stop()
+      };
+    }
+  });
 });

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -4,7 +4,6 @@ import {
   CustomElement,
   LifecycleFlags,
   alias,
-  CustomAttribute,
   CustomElementHost
 } from '@aurelia/runtime';
 import { TestConfiguration, assert, setup } from '@aurelia/testing';

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -3,7 +3,9 @@ import {
   customElement,
   CustomElement,
   LifecycleFlags,
-  alias
+  alias,
+  CustomAttribute,
+  CustomElementHost
 } from '@aurelia/runtime';
 import { TestConfiguration, assert, setup } from '@aurelia/testing';
 import { Registration } from '@aurelia/kernel';
@@ -393,5 +395,68 @@ describe('custom-elements', function () {
       await options.tearDown();
     });
 
+  });
+
+  describe('08. Change Handler', function() {
+    interface IChangeHandlerTestViewModel {
+      prop: any;
+      propChangedCallCount: number;
+      propChanged(newValue: any): void;
+    }
+
+    @customElement({
+      name: 'foo',
+      template: ''
+    })
+    class Foo implements IChangeHandlerTestViewModel {
+      @bindable()
+      public prop: any;
+      public propChangedCallCount: number = 0;
+      public propChanged(): void {
+        this.propChangedCallCount++;
+      }
+    }
+
+    it('does not invoke change handler when starts with plain usage', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with commands', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with interpolation', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    it('does not invoke chane handler when starts with two way binding', function() {
+      const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
+      assert.strictEqual(fooVm.propChangedCallCount, 0);
+      fooVm.prop = '5';
+      assert.strictEqual(fooVm.propChangedCallCount, 1);
+      tearDown();
+    });
+
+    function setupChangeHandlerTest(template: string) {
+      const options = setup(template, app, [Foo]);
+      const fooEl = options.appHost.querySelector('foo') as CustomElementHost;
+      const fooVm = fooEl.$controller.viewModel as Foo;
+      return {
+        fooVm: fooVm,
+        tearDown: () => options.au.stop()
+      };
+    }
   });
 });

--- a/packages/runtime-html/src/html-renderer.ts
+++ b/packages/runtime-html/src/html-renderer.ts
@@ -159,6 +159,7 @@ export class AttributeBindingRenderer implements IInstructionRenderer {
   }
 }
 
+// http://jsben.ch/7n5Kt
 function addClasses(classList: DOMTokenList, className: string): void {
   const len = className.length;
   let start = 0;

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -56,6 +56,7 @@ import {
 import {
   Controller,
 } from './templating/controller';
+import { SelfObserver } from './observation/self-observer';
 
 type DecoratableInstructionRenderer<TType extends string, TProto, TClass> = Class<TProto & Partial<IInstructionTypeClassifier<TType> & Pick<IInstructionRenderer, 'render'>>, TClass> & Partial<IRegistry>;
 type DecoratedInstructionRenderer<TType extends string, TProto, TClass> =  Class<TProto & IInstructionTypeClassifier<TType> & Pick<IInstructionRenderer, 'render'>, TClass> & IRegistry;
@@ -239,10 +240,10 @@ export class SetPropertyRenderer implements IInstructionRenderer {
     target: IController,
     instruction: ISetPropertyInstruction,
   ): void {
-    context
+    const observer = context
       .get(IObserverLocator)
-      .getObserver(flags, target.bindingContext!, instruction.to)
-      .setValue(instruction.value === '' ? true : instruction.value, flags | LifecycleFlags.fromBind);
+      .getObserver(flags, target.bindingContext!, instruction.to) as SelfObserver;
+    observer.currentValue = instruction.value === '' ? true : instruction.value;
   }
 }
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -8,6 +8,7 @@ import {
   Registration,
   Reporter,
   Metadata,
+  IIndexable,
 } from '@aurelia/kernel';
 import { AnyBindingExpression } from './ast';
 import { CallBinding } from './binding/call-binding';
@@ -56,7 +57,7 @@ import {
 import {
   Controller,
 } from './templating/controller';
-import { SelfObserver } from './observation/self-observer';
+import { ObserversLookup } from './observation';
 
 type DecoratableInstructionRenderer<TType extends string, TProto, TClass> = Class<TProto & Partial<IInstructionTypeClassifier<TType> & Pick<IInstructionRenderer, 'render'>>, TClass> & Partial<IRegistry>;
 type DecoratedInstructionRenderer<TType extends string, TProto, TClass> =  Class<TProto & IInstructionTypeClassifier<TType> & Pick<IInstructionRenderer, 'render'>, TClass> & IRegistry;
@@ -240,10 +241,12 @@ export class SetPropertyRenderer implements IInstructionRenderer {
     target: IController,
     instruction: ISetPropertyInstruction,
   ): void {
-    const observer = context
-      .get(IObserverLocator)
-      .getObserver(flags, target.bindingContext!, instruction.to) as SelfObserver;
-    observer.currentValue = instruction.value === '' ? true : instruction.value;
+    const obj = getTarget(target) as IIndexable & { $observers: ObserversLookup };
+    if (obj.$observers !== void 0 && obj.$observers[instruction.to] !== void 0) {
+      obj.$observers[instruction.to].setValue(instruction.value, LifecycleFlags.fromBind);
+    } else {
+      obj[instruction.to] = instruction.value;
+    }
   }
 }
 

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -239,7 +239,10 @@ export class SetPropertyRenderer implements IInstructionRenderer {
     target: IController,
     instruction: ISetPropertyInstruction,
   ): void {
-    getTarget(target)[instruction.to as keyof object] = (instruction.value === '' ? true : instruction.value) as never; // Yeah, yeah..
+    context
+      .get(IObserverLocator)
+      .getObserver(flags, target.bindingContext!, instruction.to)
+      .setValue(instruction.value === '' ? true : instruction.value, flags | LifecycleFlags.fromBind);
   }
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently, `SetPropertyRenderer` simply does an assignment in the form of `object[prop] = value`. This causes change handler to fire prematurely. Simply set `currentValue` of the observer to avoid this

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ⏭ Next Steps

N/A