### PR TITLE
fix(runtime): remove stray semicolon triggering Terser error

### DIFF
--- a/packages/runtime/src/binding/property-binding.ts
+++ b/packages/runtime/src/binding/property-binding.ts
@@ -42,7 +42,7 @@ export class PropertyBinding implements IPartialConnectableBinding {
   public id!: number;
   public $state: State = State.none;
   public $lifecycle: ILifecycle;
-  public $scope?: IScope = void 0;;
+  public $scope?: IScope = void 0;
   public part?: string;
 
   public targetObserver?: AccessorOrObserver = void 0;;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Removed a spurious semicolon, which resulted in a Terser error when running `npm run-script build` with `npx makes`. See #735 for details.

### 🎫 Issues

Fixes #735 

## 👩‍💻 Reviewer Notes

I verified this removes the extra semicolon in `runtime/dist/esnext/binding/property-binding.js` after an `npm run build`

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

Figure out why the eslint `no-extra-semi` rule didn't notify us of this.
