### PR TITLE
chore(aurelia): fix the startup api types

### DIFF
--- a/packages/aurelia/src/quick-start.ts
+++ b/packages/aurelia/src/quick-start.ts
@@ -1,6 +1,6 @@
 import { DebugConfiguration } from '@aurelia/debug';
 import { JitHtmlBrowserConfiguration } from '@aurelia/jit-html-browser';
-import { DI, IContainer, IRegistry } from '@aurelia/kernel';
+import { DI, IContainer } from '@aurelia/kernel';
 import { Aurelia as $Aurelia, CompositionRoot, CustomElementType, ILifecycleTask, ISinglePageApp, CustomElement } from '@aurelia/runtime';
 
 // TODO: SSR?? abstract HTMLElement and document.
@@ -31,15 +31,15 @@ export class Aurelia extends $Aurelia<HTMLElement> {
     return createAurelia().start(root);
   }
 
-  public static app(config: ISinglePageApp<HTMLElement> | unknown): Aurelia {
+  public static app(config: ISinglePageApp<HTMLElement> | unknown): Omit<Aurelia, 'register' | 'app'> {
     return createAurelia().app(config);
   }
 
-  public static register(...params: (IRegistry | Record<string, Partial<IRegistry>>)[]): Aurelia {
+  public static register(...params: readonly unknown[]): Aurelia {
     return createAurelia().register(...params);
   }
 
-  public app(config: ISinglePageApp<HTMLElement> | unknown): this {
+  public app(config: ISinglePageApp<HTMLElement> | unknown): Omit<this, 'register' | 'app'> {
     if (CustomElement.isType(config as CustomElementType)) {
       // Default to custom element element name
       const definition = CustomElement.getDefinition(config as CustomElementType);

--- a/packages/runtime/src/aurelia.ts
+++ b/packages/runtime/src/aurelia.ts
@@ -214,7 +214,7 @@ export class Aurelia<TNode extends INode = INode> {
     return this;
   }
 
-  public app(config: ISinglePageApp<TNode>): this {
+  public app(config: ISinglePageApp<TNode>): Omit<this, 'register' | 'app'> {
     this.next = new CompositionRoot(config, this.container);
 
     if (this.isRunning) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- `Aurelia.register` in the quick-start had the wrong parameter type (`IRegistry`). This is now changed to `unknown` so it accepts anything (we may want to constrain it a bit more before going alpha though)
- Modified the `.app` signature on both the static and instance methods of `Aurelia` to return a type that omits `app` and `register`, so that the type system will not allow users to perform those invalid operations. `register` has to come before `app` and there is now no other way to do it.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Fixes https://github.com/aurelia/aurelia/issues/736
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

This is the effect:

![image](https://user-images.githubusercontent.com/9655331/68063985-0ebebd80-fd16-11e9-8240-fdcedad20a2e.png)

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
