### PR TITLE
Metadata fixes

### DIFF
--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -536,3 +536,14 @@ export function toLookup(...objs: {}[]): Readonly<{}> {
 export function isObject<T extends object = Object | Function>(value: unknown): value is T {
   return typeof value === 'object' && value !== null || typeof value === 'function';
 }
+
+/**
+ * Determine whether a value is `null` or `undefined`.
+ *
+ * @param value - The value to test.
+ * @returns `true` if the value is `null` or `undefined`, otherwise `false`.
+ * Also performs a type assertion that ensures TypeScript treats the value appropriately in the `if` and `else` branches after this check.
+ */
+export function isNullOrUndefined(value: unknown): value is null | undefined {
+  return value === null || value === void 0;
+}

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -481,3 +481,58 @@ export function toLookup<
 export function toLookup(...objs: {}[]): Readonly<{}> {
   return Object.assign(Object.create(null) as {}, ...objs);
 }
+
+/**
+ * Determine whether a value is an object.
+ *
+ * Uses `typeof` to guarantee this works cross-realm, which is where `instanceof Object` might fail.
+ *
+ * Some environments where these issues are known to arise:
+ * - same-origin iframes (accessing the other realm via `window.top`)
+ * - `jest`.
+ *
+ * The exact test is:
+ * ```ts
+ * typeof value === 'object' && value !== null || typeof value === 'function'
+ * ```
+ *
+ * @param value - The value to test.
+ * @returns `true` if the value is an object, otherwise `false`.
+ * Also performs a type assertion that defaults to `value is Object | Function` which, if the input type is a union with an object type, will infer the correct type.
+ * This can be overridden with the generic type argument.
+ *
+ * @example
+ *
+ * ```ts
+ * class Foo {
+ *   bar = 42;
+ * }
+ *
+ * function doStuff(input?: Foo | null) {
+ *   input.bar; // Object is possibly 'null' or 'undefined'
+ *
+ *   // input has an object type in its union (Foo) so that type will be extracted for the 'true' condition
+ *   if (isObject(input)) {
+ *     input.bar; // OK (input is now typed as Foo)
+ *   }
+ * }
+ *
+ * function doOtherStuff(input: unknown) {
+ *   input.bar; // Object is of type 'unknown'
+ *
+ *   // input is 'unknown' so there is no union type to match and it will default to 'Object | Function'
+ *   if (isObject(input)) {
+ *     input.bar; // Property 'bar' does not exist on type 'Object | Function'
+ *   }
+ *
+ *   // if we know for sure that, if input is an object, it must be a specific type, we can explicitly tell the function to assert that for us
+ *   if (isObject<Foo>(input)) {
+ *    input.bar; // OK (input is now typed as Foo)
+ *   }
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isObject<T extends object = Object | Function>(value: unknown): value is T {
+  return typeof value === 'object' && value !== null || typeof value === 'function';
+}

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -132,4 +132,5 @@ export {
   mergeObjects,
   firstDefined,
   getPrototypeChain,
+  isObject,
 } from './functions';

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -133,4 +133,5 @@ export {
   firstDefined,
   getPrototypeChain,
   isObject,
+  isNullOrUndefined,
 } from './functions';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Fixes an issue where a certain decorator usage type in monaco would cause metadata to throw
- Improves general error messages
- Exposes new functions `isObject` and `isNullOrUndefined` (used by metadata in this PR) from the kernel, to use in the framework and/or by end users for convenience
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
