### PR TITLE
Bindable observer

### DIFF
--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -2,7 +2,7 @@ import { PLATFORM, Primitive, IIndexable } from '@aurelia/kernel';
 import {
   LifecycleFlags as LF,
   PrimitiveObserver,
-  SelfObserver,
+  BindableObserver,
   SetterObserver
 } from '@aurelia/runtime';
 import { SpySubscriber, assert, TestContext, ChangeSet } from '@aurelia/testing';
@@ -180,11 +180,11 @@ describe('SetterObserver', function () {
   });
 });
 
-describe('SelfObserver', function () {
+describe('BindableObserver', function () {
   function setup(flags: LF, obj: IIndexable, key: string) {
     const ctx = TestContext.createHTMLTestContext();
     const lifecycle = ctx.lifecycle;
-    const sut = new SelfObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`);
+    const sut = new BindableObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`);
 
     return { sut };
   }

--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -184,7 +184,7 @@ describe('BindableObserver', function () {
   function setup(flags: LF, obj: IIndexable, key: string) {
     const ctx = TestContext.createHTMLTestContext();
     const lifecycle = ctx.lifecycle;
-    const sut = new BindableObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`);
+    const sut = new BindableObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`, PLATFORM.noop, PLATFORM.noop);
 
     return { sut };
   }

--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -184,7 +184,7 @@ describe('BindableObserver', function () {
   function setup(flags: LF, obj: IIndexable, key: string) {
     const ctx = TestContext.createHTMLTestContext();
     const lifecycle = ctx.lifecycle;
-    const sut = new BindableObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`, PLATFORM.noop, PLATFORM.noop);
+    const sut = new BindableObserver(lifecycle, flags, obj, key, `${key ? key.toString() : `${key}`}Changed`, PLATFORM.noop);
 
     return { sut };
   }

--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -229,36 +229,36 @@ describe('custom-attributes', function () {
       }
     }
 
-    it('does not invoke change handler when starts with plain usage', function () {
+    it('does not invoke change handler when starts with plain usage', async function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<div foo="prop"></div>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
       assert.strictEqual(fooVm.propChangedCallCount, 1);
-      tearDown();
+      await tearDown();
     });
 
-    it('does not invoke chane handler when starts with commands', function () {
+    it('does not invoke chane handler when starts with commands', async function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<div foo.bind="prop"></foo>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
       assert.strictEqual(fooVm.propChangedCallCount, 1);
-      tearDown();
+      await tearDown();
     });
 
-    it('does not invoke chane handler when starts with interpolation', function () {
+    it('does not invoke chane handler when starts with interpolation', async function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo="\${prop}"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
       assert.strictEqual(fooVm.propChangedCallCount, 1);
-      tearDown();
+      await tearDown();
     });
 
-    it('does not invoke chane handler when starts with two way binding', function () {
+    it('does not invoke chane handler when starts with two way binding', async function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo.two-way="prop"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0, '#1 should have had 0 calls at start');
       fooVm.prop = '5';
       assert.strictEqual(fooVm.propChangedCallCount, 1, '#2 shoulda had 1 call after mutation');
-      tearDown();
+      await tearDown();
     });
 
     function setupChangeHandlerTest(template: string) {
@@ -267,10 +267,7 @@ describe('custom-attributes', function () {
       const fooVm = CustomAttribute.for(fooEl, 'foo').viewModel as Foo;
       return {
         fooVm: fooVm,
-        tearDown: () => {
-          options.au.stop();
-          options.appHost.remove();
-        }
+        tearDown: () => options.tearDown()
       };
     }
   });
@@ -371,7 +368,7 @@ describe('custom-attributes', function () {
     eachCartesianJoin(
       [templateUsages, testCases],
       ([usageDesc, usageSyntax], testCase) => {
-        it(`does not invoke change handler when starts with ${usageDesc} usage`, function () {
+        it(`does not invoke change handler when starts with ${usageDesc} usage`, async function () {
           const template = `<div foo1${usageSyntax} foo2${usageSyntax} foo3${usageSyntax}></div>`;
           const { foos, tearDown } = setupChangeHandlerTest(template);
           const callCounts = testCase.callCounts;
@@ -394,13 +391,13 @@ describe('custom-attributes', function () {
             }
           });
 
-          tearDown();
+          await tearDown();
         });
       }
     );
 
     describe('04.1 + with two-way', function () {
-      it('does not invoke change handler when starts with two-way usage', function () {
+      it('does not invoke change handler when starts with two-way usage', async function () {
         const template = `<div foo1.two-way="prop"></div>`;
         const options = setup(
           template,
@@ -431,7 +428,7 @@ describe('custom-attributes', function () {
         assert.strictEqual(foo1Vm.prop, 6);
         assert.strictEqual(rootVm['prop'], 6);
 
-        options.au.stop();
+        await options.tearDown();
       });
 
       // Foo1 should cover both Foo2, and Foo3
@@ -451,15 +448,14 @@ describe('custom-attributes', function () {
         foo2Vm,
         foo3Vm,
         foos: [foo1Vm, foo2Vm, foo3Vm] as [IChangeHandlerTestViewModel, IChangeHandlerTestViewModel, IChangeHandlerTestViewModel],
-        tearDown: () => {
-          options.au.stop();
-          options.appHost.remove();
-        }
+        tearDown: () => options.tearDown()
       };
     }
   });
 
   describe('05. with setter/getter', function () {
+    this.afterEach(assert.isSchedulerEmpty);
+
     /**
      * Specs:
      * - with setter coercing to string for "prop" property
@@ -589,7 +585,7 @@ describe('custom-attributes', function () {
     eachCartesianJoin(
       [templateUsages, testCases],
       ([usageType, usageSyntax], [mutationValue, ...getFooVmProps]) => {
-        it(`does not invoke change handler when starts with ${UsageType[usageType]} usage`, function () {
+        it(`does not invoke change handler when starts with ${UsageType[usageType]} usage`, async function () {
           const template =
             `<div
               foo1${usageSyntax}
@@ -615,7 +611,7 @@ describe('custom-attributes', function () {
             );
           });
 
-          tearDown();
+          await tearDown();
         });
       }
     );
@@ -644,15 +640,12 @@ describe('custom-attributes', function () {
         foo3Vm,
         foo4Vm,
         foos: [foo1Vm, foo2Vm, foo3Vm, foo4Vm] as IChangeHandlerTestViewModel[],
-        tearDown: () => {
-          options.au.stop();
-          options.appHost.remove();
-        }
+        tearDown: () => options.tearDown()
       };
     }
 
     describe('05.1 + with two-way', function () {
-      it('works properly when two-way binding with number setter interceptor', function () {
+      it('works properly when two-way binding with number setter interceptor', async function () {
         const template = `<div foo1.two-way="prop">\${prop}</div>`;
         const options = setup(
           template,
@@ -682,11 +675,10 @@ describe('custom-attributes', function () {
         options.scheduler.getRenderTaskQueue().flush();
         assert.strictEqual(options.appHost.textContent, date.toString());
 
-        options.au.stop();
-        options.appHost.remove();
+        await options.tearDown();
       });
 
-      it('does not result in overflow error when dealing with NaN', function () {
+      it('does not result in overflow error when dealing with NaN', async function () {
         /**
          * Specs:
          * - With bindable with getter coerce to string, setter coerce to number for "prop" property
@@ -735,8 +727,7 @@ describe('custom-attributes', function () {
         options.scheduler.getRenderTaskQueue().flush();
         assert.strictEqual(options.appHost.textContent, 'NaN');
 
-        options.au.stop();
-        options.appHost.remove();
+        await options.tearDown();
       });
     });
   });

--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -280,7 +280,7 @@ describe('custom-attributes', function () {
   // foo1: has both normal change handler and all properties change handler
   // foo2: has only normal change handler
   // foo3: has only all properties change handler
-  describe('04. Change handler with "propertyChanged" callback', function() {
+  describe('04. Change handler with "propertyChanged" callback', function () {
     interface IChangeHandlerTestViewModel {
       prop: any;
       propChangedCallCount: number;
@@ -371,7 +371,7 @@ describe('custom-attributes', function () {
     eachCartesianJoin(
       [templateUsages, testCases],
       ([usageDesc, usageSyntax], testCase) => {
-        it(`does not invoke change handler when starts with ${usageDesc} usage`, function() {
+        it(`does not invoke change handler when starts with ${usageDesc} usage`, function () {
           const template = `<div foo1${usageSyntax} foo2${usageSyntax} foo3${usageSyntax}></div>`;
           const { foos, tearDown } = setupChangeHandlerTest(template);
           const callCounts = testCase.callCounts;
@@ -399,8 +399,8 @@ describe('custom-attributes', function () {
       }
     );
 
-    describe('04.1 + with two-way', function() {
-      it('does not invoke change handler when starts with two-way usage', function() {
+    describe('04.1 + with two-way', function () {
+      it('does not invoke change handler when starts with two-way usage', function () {
         const template = `<div foo1.two-way="prop"></div>`;
         const options = setup(
           template,
@@ -411,7 +411,7 @@ describe('custom-attributes', function () {
         );
 
         const fooEl = options.appHost.querySelector('div') as INode;
-        const foo1Vm = fooEl.$au.foo1.viewModel as Foo1;
+        const foo1Vm = CustomAttribute.for(fooEl, 'foo1').viewModel as Foo1;
 
         assert.strictEqual(foo1Vm.propChangedCallCount, 0, `#1 Foo1 count`);
         assert.strictEqual(foo1Vm.propertyChangedCallCount, 0, `#2 Foo1 count`);
@@ -442,9 +442,9 @@ describe('custom-attributes', function () {
     function setupChangeHandlerTest(template: string) {
       const options = setup(template, class {}, [Foo1, Foo2, Foo3]);
       const fooEl = options.appHost.querySelector('div') as INode;
-      const foo1Vm = fooEl.$au.foo1.viewModel as Foo1;
-      const foo2Vm = fooEl.$au.foo2.viewModel as Foo2;
-      const foo3Vm = fooEl.$au.foo3.viewModel as Foo3;
+      const foo1Vm = CustomAttribute.for(fooEl, 'foo1').viewModel as Foo1;
+      const foo2Vm = CustomAttribute.for(fooEl, 'foo2').viewModel as Foo2;
+      const foo3Vm = CustomAttribute.for(fooEl, 'foo3').viewModel as Foo3;
       return {
         rootVm: options.component,
         fooVm: foo1Vm,
@@ -459,7 +459,7 @@ describe('custom-attributes', function () {
     }
   });
 
-  describe('05. with setter/getter', function() {
+  describe('05. with setter/getter', function () {
     /**
      * Specs:
      * - with setter coercing to string for "prop" property
@@ -590,7 +590,7 @@ describe('custom-attributes', function () {
     eachCartesianJoin(
       [templateUsages, testCases],
       ([usageType, usageSyntax], [mutationValue, ...getFooVmProps]) => {
-        it(`does not invoke change handler when starts with ${UsageType[usageType]} usage`, function() {
+        it(`does not invoke change handler when starts with ${UsageType[usageType]} usage`, function () {
           const template =
             `<div
               foo1${usageSyntax}
@@ -634,10 +634,10 @@ describe('custom-attributes', function () {
     function setupChangeHandlerTest(template: string) {
       const options = setup(template, class { public prop: string = 'prop'; }, [Foo1, Foo2, Foo3, Foo4]);
       const fooEl = options.appHost.querySelector('div') as INode;
-      const foo1Vm = fooEl.$au.foo1.viewModel as Foo1;
-      const foo2Vm = fooEl.$au.foo2.viewModel as Foo2;
-      const foo3Vm = fooEl.$au.foo3.viewModel as Foo3;
-      const foo4Vm = fooEl.$au.foo4.viewModel as Foo4;
+      const foo1Vm = CustomAttribute.for(fooEl, 'foo1').viewModel as Foo1;
+      const foo2Vm = CustomAttribute.for(fooEl, 'foo2').viewModel as Foo2;
+      const foo3Vm = CustomAttribute.for(fooEl, 'foo3').viewModel as Foo3;
+      const foo4Vm = CustomAttribute.for(fooEl, 'foo4').viewModel as Foo4;
       return {
         rootVm: options.component,
         foo1Vm,
@@ -652,8 +652,8 @@ describe('custom-attributes', function () {
       };
     }
 
-    describe('05.1 + with two-way', function() {
-      it('works properly when two-way binding with number setter interceptor', function() {
+    describe('05.1 + with two-way', function () {
+      it('works properly when two-way binding with number setter interceptor', function () {
         const template = `<div foo1.two-way="prop">\${prop}</div>`;
         const options = setup(
           template,
@@ -662,8 +662,9 @@ describe('custom-attributes', function () {
           },
           [Foo1, Foo2, Foo3, Foo4]
         );
+        const fooEl = options.appHost.querySelector('div');
         const rootVm = options.au.root.viewModel as any;
-        const foo1Vm = (options.appHost.querySelector('div') as INode).$au.foo1.viewModel as Foo1;
+        const foo1Vm = CustomAttribute.for(fooEl, 'foo1').viewModel as Foo1;
 
         assert.strictEqual(foo1Vm.prop, 'prop', '#1 <-> Foo1 initial');
         assert.strictEqual(rootVm.prop, 'prop', '#1 <-> RootVm initial');
@@ -686,7 +687,7 @@ describe('custom-attributes', function () {
         options.appHost.remove();
       });
 
-      it('does not result in overflow error when getter/setter are different, but getter convert to primitive value', function() {
+      it('does not result in overflow error when getter/setter are different, but getter convert to primitive value', function () {
         /**
          * Specs:
          * - With bindable with getter coerce to string, setter coerce to number for "prop" property
@@ -708,8 +709,9 @@ describe('custom-attributes', function () {
           },
           [Foo5]
         );
+        const fooEl = options.appHost.querySelector('div');
         const rootVm = options.au.root.viewModel as any;
-        const foo5Vm = (options.appHost.querySelector('div') as INode).$au.foo5.viewModel as Foo5;
+        const foo5Vm = CustomAttribute.for(fooEl, 'foo1').viewModel as Foo5;
 
         assert.strictEqual(foo5Vm.prop, 'NaN', '#1 <-> Foo1 initial');
         assert.strictEqual(rootVm.prop, 'prop', '#1 <-> RootVm initial');

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -620,7 +620,7 @@ describe('custom-elements', function () {
     interface IBindableSetterHtmlInputTestCase {
       title: string;
       template: string;
-      setter: InterceptorFunc,
+      setter: InterceptorFunc;
       assertionFn: (ctx: HTMLTestContext, rootVm: IIndexable, inputEl: HTMLElement) => void;
     }
 
@@ -735,9 +735,9 @@ describe('custom-elements', function () {
         title: 'works with model binding + <select />',
         template: [
           '<select value.bind="value">',
-            '<option model.bind="1">Neutral',
-            '<option model.bind="2">Female',
-            '<option model.bind="3">Male'
+          '<option model.bind="1">Neutral',
+          '<option model.bind="2">Female',
+          '<option model.bind="3">Male'
         ].join(''),
         setter: Number,
         assertionFn: (ctx, rootVm, host) => {
@@ -775,7 +775,7 @@ describe('custom-elements', function () {
         assertionFn
       } = testCase;
 
-      it(title, function() {
+      it(title, function () {
         const ctx = TestContext.createHTMLTestContext();
         const au = new Aurelia(ctx.container);
         const host = ctx.createElement('app');

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -6,7 +6,7 @@ import {
   CustomElementHost,
   Aurelia
 } from '@aurelia/runtime';
-import { TestConfiguration, assert, setup, TestContext, HTMLTestContext, eachCartesianJoin } from '@aurelia/testing';
+import { TestConfiguration, assert, setup, TestContext, HTMLTestContext } from '@aurelia/testing';
 import { Registration, IIndexable } from '@aurelia/kernel';
 import { InterceptorFunc } from '@aurelia/runtime/dist/templating/bindable';
 

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -7,7 +7,7 @@ import {
   Aurelia
 } from '@aurelia/runtime';
 import { TestConfiguration, assert, setup, TestContext, HTMLTestContext } from '@aurelia/testing';
-import { Registration, IIndexable } from '@aurelia/kernel';
+import { Registration, IIndexable, PLATFORM } from '@aurelia/kernel';
 import { InterceptorFunc } from '@aurelia/runtime/dist/templating/bindable';
 
 interface Person { firstName?: string; lastName?: string; fullName?: string }
@@ -398,6 +398,7 @@ describe('custom-elements', function () {
   });
 
   describe('08. Change Handler', function () {
+    this.afterEach(assert.isSchedulerEmpty);
 
     describe('+ with only [prop]Changed()', function () {
       interface IChangeHandlerTestViewModel {
@@ -419,36 +420,36 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function () {
+      it('does not invoke change handler when starts with plain usage', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function () {
+      it('does not invoke change handler when starts with commands', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function () {
+      it('does not invoke change handler when starts with interpolation', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function () {
+      it('does not invoke change handler when starts with two way binding', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
       function setupChangeHandlerTest(template: string) {
@@ -457,10 +458,7 @@ describe('custom-elements', function () {
         const fooVm = CustomElement.for(fooEl).viewModel as Foo;
         return {
           fooVm: fooVm,
-          tearDown: () => {
-            options.au.stop();
-            options.appHost.remove();
-          }
+          tearDown: () => options.tearDown()
         };
       }
     });
@@ -485,37 +483,37 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function () {
+      it('does not invoke change handler when starts with plain usage', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function () {
+      it('does not invoke change handler when starts with commands', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function () {
+      it('does not invoke change handler when starts with interpolation', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function () {
+      it('does not invoke change handler when starts with two way binding', async function () {
         const { fooVm, rootVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
         assert.strictEqual(rootVm.prop, '5');
-        tearDown();
+        await tearDown();
       });
 
       function setupChangeHandlerTest(template: string) {
@@ -525,10 +523,7 @@ describe('custom-elements', function () {
         return {
           fooVm: fooVm,
           rootVm: options.au.root.viewModel as any,
-          tearDown: () => {
-            options.au.stop();
-            options.appHost.remove();
-          }
+          tearDown: () => options.tearDown()
         };
       }
     });
@@ -559,37 +554,37 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function () {
+      it('does not invoke change handler when starts with plain usage', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function () {
+      it('does not invoke change handler when starts with commands', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function () {
+      it('does not invoke change handler when starts with interpolation', async function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
         assert.strictEqual(fooVm.propChangedCallCount, 1);
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
-        tearDown();
+        await tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function () {
+      it('does not invoke change handler when starts with two way binding', async function () {
         const { fooVm, rootVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
@@ -597,7 +592,7 @@ describe('custom-elements', function () {
         assert.strictEqual(fooVm.propChangedCallCount, 1);
         assert.strictEqual(fooVm.propertyChangedCallCount, 1);
         assert.strictEqual(rootVm.prop, '5');
-        tearDown();
+        await tearDown();
       });
 
       function setupChangeHandlerTest(template: string) {
@@ -607,16 +602,14 @@ describe('custom-elements', function () {
         return {
           fooVm: fooVm,
           rootVm: options.au.root.viewModel as any,
-          tearDown: () => {
-            options.au.stop();
-            options.appHost.remove();
-          }
+          tearDown: () => options.tearDown()
         };
       }
     });
   });
 
   describe('09. with setter', function () {
+    this.afterEach(assert.isSchedulerEmpty);
     interface IBindableSetterHtmlInputTestCase {
       title: string;
       template: string;
@@ -671,14 +664,14 @@ describe('custom-elements', function () {
           // emulate input 1
           inputEl.value = '5';
           inputEl.dispatchEvent(new ctx.CustomEvent('input'));
-          assert.strictEqual(inputEl.value, '100');
-          assert.strictEqual(rootVm.value, 100);
+          assert.strictEqual(inputEl.value, PLATFORM.isBrowserLike ? '100' : '5');
+          assert.strictEqual(rootVm.value, PLATFORM.isBrowserLike ? 100 : 5);
 
           // emulate input 2
           inputEl.value = '5555';
           inputEl.dispatchEvent(new ctx.CustomEvent('input'));
-          assert.strictEqual(inputEl.value, '1000');
-          assert.strictEqual(rootVm.value, 1000);
+          assert.strictEqual(inputEl.value, PLATFORM.isBrowserLike ? '1000' : '5555');
+          assert.strictEqual(rootVm.value, PLATFORM.isBrowserLike ? 1000 : 5555);
 
           // emulate input 3
           inputEl.value = '555';
@@ -702,7 +695,7 @@ describe('custom-elements', function () {
           assert.strictEqual(rootVm.value, 11);
           assert.strictEqual(inputEl.value, '444');
           ctx.scheduler.getRenderTaskQueue().flush();
-          assert.strictEqual(inputEl.value, '100');
+          assert.strictEqual(inputEl.value, PLATFORM.isBrowserLike ? '100' : '11');
         }
       },
       {

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -454,7 +454,7 @@ describe('custom-elements', function () {
       function setupChangeHandlerTest(template: string) {
         const options = setup(template, app, [Foo]);
         const fooEl = options.appHost.querySelector('foo') as CustomElementHost;
-        const fooVm = fooEl.$controller.viewModel as Foo;
+        const fooVm = CustomElement.for(fooEl).viewModel as Foo;
         return {
           fooVm: fooVm,
           tearDown: () => {
@@ -521,7 +521,7 @@ describe('custom-elements', function () {
       function setupChangeHandlerTest(template: string) {
         const options = setup(template, app, [Foo]);
         const fooEl = options.appHost.querySelector('foo') as CustomElementHost;
-        const fooVm = fooEl.$controller.viewModel as Foo;
+        const fooVm = CustomElement.for(fooEl).viewModel as Foo;
         return {
           fooVm: fooVm,
           rootVm: options.au.root.viewModel as any,
@@ -603,7 +603,7 @@ describe('custom-elements', function () {
       function setupChangeHandlerTest(template: string) {
         const options = setup(template, app, [Foo]);
         const fooEl = options.appHost.querySelector('foo') as CustomElementHost;
-        const fooVm = fooEl.$controller.viewModel as Foo;
+        const fooVm = CustomElement.for(fooEl).viewModel as Foo;
         return {
           fooVm: fooVm,
           rootVm: options.au.root.viewModel as any,

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -397,9 +397,9 @@ describe('custom-elements', function () {
 
   });
 
-  describe('08. Change Handler', function() {
+  describe('08. Change Handler', function () {
 
-    describe('+ with only [prop]Changed()', function() {
+    describe('+ with only [prop]Changed()', function () {
       interface IChangeHandlerTestViewModel {
         prop: any;
         propChangedCallCount: number;
@@ -419,7 +419,7 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function() {
+      it('does not invoke change handler when starts with plain usage', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
@@ -427,7 +427,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function() {
+      it('does not invoke change handler when starts with commands', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
@@ -435,7 +435,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function() {
+      it('does not invoke change handler when starts with interpolation', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
@@ -443,7 +443,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function() {
+      it('does not invoke change handler when starts with two way binding', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         fooVm.prop = '5';
@@ -465,7 +465,7 @@ describe('custom-elements', function () {
       }
     });
 
-    describe('+ with only propertyChanged(name, newValue, oldValue)', function() {
+    describe('+ with only propertyChanged(name, newValue, oldValue)', function () {
       interface IChangeHandlerTestViewModel {
         prop: any;
         propertyChangedCallCount: number;
@@ -485,7 +485,7 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function() {
+      it('does not invoke change handler when starts with plain usage', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
@@ -493,7 +493,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function() {
+      it('does not invoke change handler when starts with commands', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
@@ -501,7 +501,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function() {
+      it('does not invoke change handler when starts with interpolation', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
@@ -509,7 +509,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function() {
+      it('does not invoke change handler when starts with two way binding', function () {
         const { fooVm, rootVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
         fooVm.prop = '5';
@@ -533,7 +533,7 @@ describe('custom-elements', function () {
       }
     });
 
-    describe('+ with both [prop]Changed() + propertyChanged(name, newValue, oldValue)', function() {
+    describe('+ with both [prop]Changed() + propertyChanged(name, newValue, oldValue)', function () {
       interface IChangeHandlerTestViewModel {
         prop: any;
         propChangedCallCount: number;
@@ -559,7 +559,7 @@ describe('custom-elements', function () {
         }
       }
 
-      it('does not invoke change handler when starts with plain usage', function() {
+      it('does not invoke change handler when starts with plain usage', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
@@ -569,7 +569,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with commands', function() {
+      it('does not invoke change handler when starts with commands', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
@@ -579,7 +579,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with interpolation', function() {
+      it('does not invoke change handler when starts with interpolation', function () {
         const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
@@ -589,7 +589,7 @@ describe('custom-elements', function () {
         tearDown();
       });
 
-      it('does not invoke change handler when starts with two way binding', function() {
+      it('does not invoke change handler when starts with two way binding', function () {
         const { fooVm, rootVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
         assert.strictEqual(fooVm.propChangedCallCount, 0);
         assert.strictEqual(fooVm.propertyChangedCallCount, 0);
@@ -616,8 +616,8 @@ describe('custom-elements', function () {
     });
   });
 
-  describe('09. with setter', function() {
-    it('works with direct input binding', function() {
+  describe('09. with setter', function () {
+    it('works with direct input binding', function () {
       const ctx = TestContext.createHTMLTestContext();
       const au = new Aurelia(ctx.container);
       const host = ctx.createElement('app');

--- a/packages/__tests__/5-jit-html/deep-bindables.spec.ts
+++ b/packages/__tests__/5-jit-html/deep-bindables.spec.ts
@@ -96,7 +96,7 @@
 //       const calls = {
 //         'ProxyObserver': [] as ITraceInfo[],
 //         'ProxySubscriberCollection': [] as ITraceInfo[],
-//         'SelfObserver': [] as ITraceInfo[],
+//         'BindableObserver': [] as ITraceInfo[],
 //         'SetterObserver': [] as ITraceInfo[]
 //       };
 //       if (trace) {
@@ -139,7 +139,7 @@
 //         assert.strictEqual(calls['ProxyObserver'].length, 0, 'calls[\'ProxyObserver\'].length', `calls['ProxyObserver'].length`);
 //       }
 //       // TODO: deeply verify observer call counts
-//       // const names = ['ProxyObserver', 'ProxySubscriberCollection', 'SelfObserver', 'SetterObserver'];
+//       // const names = ['ProxyObserver', 'ProxySubscriberCollection', 'BindableObserver', 'SetterObserver'];
 //       // for (const {} of names) {
 //       //   calls[`${name}.constructor`].sort((a, b) => a.depth < b.depth ? -1 : b.depth < a.depth ? 1 : 0);
 //       //   for (const call of calls[`${name}.constructor`]) {

--- a/packages/__tests__/tasks/copy-html.js
+++ b/packages/__tests__/tasks/copy-html.js
@@ -71,7 +71,7 @@ function handleChange(eventName, src) {
   }
 }
 
-const watched = sourceDirs.flatMap((dir) => [path.join(cwd, dir, '**/*.html'), path.join(cwd, dir, '**/*.css')]);
+const watched = sourceDirs.reduce((allDirs, dir) => allDirs.concat([path.join(cwd, dir, '**/*.html'), path.join(cwd, dir, '**/*.css')]), []);
 
 const watcher = chokidar.watch(watched, {
   awaitWriteFinish: true

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -534,7 +534,7 @@ export {
 
   // ProxyObserver,
 
-  // SelfObserver,
+  // BindableObserver,
 
   // SetterObserver,
 

--- a/packages/debug/src/tracer.ts
+++ b/packages/debug/src/tracer.ts
@@ -278,7 +278,7 @@ const BindingArgsProcessor = {
       case 'SetObserver':
         return flagsText(info);
       case 'SetterObserver':
-      case 'SelfObserver':
+      case 'BindableObserver':
         return `${flagsText(info)},${ctorName(info, 1)},${primitive(info, 2)}`;
       case 'ProxyObserver':
         return ctorName(info);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -174,8 +174,8 @@ export {
   ProxyObserver
 } from './observation/proxy-observer';
 export {
-  SelfObserver
-} from './observation/self-observer';
+  BindableObserver
+} from './observation/bindable-observer';
 export {
   SetterObserver
 } from './observation/setter-observer';

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -7,7 +7,7 @@ import { subscriberCollection } from './subscriber-collection';
 
 export interface BindableObserver extends IPropertyObserver<IIndexable, string> {}
 
-export interface IMayHavePropertyChangedCallback {
+interface IMayHavePropertyChangedCallback {
   propertyChanged?(name: string, newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void;
 }
 
@@ -29,7 +29,7 @@ export class BindableObserver {
   public constructor(
     public readonly lifecycle: ILifecycle,
     flags: LifecycleFlags,
-    public readonly obj: IIndexable & IMayHavePropertyChangedCallback,
+    public readonly obj: IIndexable,
     public readonly propertyKey: string,
     cbName: string,
   ) {
@@ -45,7 +45,7 @@ export class BindableObserver {
     this.callback = this.obj[cbName] as typeof BindableObserver.prototype.callback;
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const propertyChangedCallback = this.propertyChangedCallback = this.obj.propertyChanged;
+    const propertyChangedCallback = this.propertyChangedCallback = (this.obj as IMayHavePropertyChangedCallback).propertyChanged;
     const hasPropertyChangedCallback = this.hasPropertyChangedCallback = typeof propertyChangedCallback === 'function';
 
     if (this.callback === void 0 && !hasPropertyChangedCallback) {

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -5,7 +5,7 @@ import { IPropertyObserver, ISubscriber } from '../observation';
 import { ProxyObserver } from './proxy-observer';
 import { subscriberCollection } from './subscriber-collection';
 
-export interface SelfObserver extends IPropertyObserver<IIndexable, string> {}
+export interface BindableObserver extends IPropertyObserver<IIndexable, string> {}
 
 export interface IMayHavePropertyChangedCallback {
   propertyChanged?(name: string, newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void;
@@ -14,7 +14,7 @@ export interface IMayHavePropertyChangedCallback {
 type HasPropertyChangedCallback = Required<IMayHavePropertyChangedCallback>;
 
 @subscriberCollection()
-export class SelfObserver {
+export class BindableObserver {
   public currentValue: unknown = void 0;
   public oldValue: unknown = void 0;
 
@@ -41,7 +41,7 @@ export class SelfObserver {
       this.obj = obj;
     }
 
-    this.callback = this.obj[cbName] as typeof SelfObserver.prototype.callback;
+    this.callback = this.obj[cbName] as typeof BindableObserver.prototype.callback;
     const hasPropertyChangedCallback = this.hasPropertyChangedCallback = typeof this.obj.propertyChanged === 'function';
 
     if (this.callback === void 0 || !hasPropertyChangedCallback) {

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -86,7 +86,7 @@ export class BindableObserver {
       // example: two way binding
       //    - setter: Number
       //    - getter: String
-      //    someVm.prop = '5' <-- triggers setter      
+      //    someVm.prop = '5' <-- triggers setter
       ? this.getterInterceptor(currentValue)
       : currentValue;
   }

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -81,6 +81,12 @@ export class BindableObserver {
   public getValue(): unknown {
     const currentValue = this.currentValue;
     return this.shouldInterceptGet
+      // only intercepting getValue() call means there are cases where incoming value in setValue()
+      // is not the same with out going value in getValue(), but the assignment wont be considered a change
+      // example: two way binding
+      //    - setter: Number
+      //    - getter: String
+      //    someVm.prop = '5' <-- triggers setter      
       ? this.getterInterceptor(currentValue)
       : currentValue;
   }
@@ -125,7 +131,10 @@ export class BindableObserver {
   public subscribe(subscriber: ISubscriber): void {
     if (this.observing === false) {
       this.observing = true;
-      this.currentValue = this.obj[this.propertyKey];
+      const currentValue = this.obj[this.propertyKey];
+      this.currentValue = this.shouldInterceptSet
+        ? this.setterInterceptor(currentValue)
+        : currentValue;
       this.createGetterSetter();
     }
 

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -14,7 +14,6 @@ interface IMayHavePropertyChangedCallback {
 
 type HasPropertyChangedCallback = Required<IMayHavePropertyChangedCallback>;
 
-/* eslint-disable @typescript-eslint/unbound-method */
 @subscriberCollection()
 export class BindableObserver {
   public currentValue: unknown = void 0;
@@ -44,8 +43,6 @@ export class BindableObserver {
       isProxy = true;
       obj.$observer.subscribe(this, propertyKey);
       this.obj = obj.$raw;
-    } else {
-      this.obj = obj;
     }
 
     this.callback = this.obj[cbName] as typeof BindableObserver.prototype.callback;
@@ -95,6 +92,10 @@ export class BindableObserver {
 
     if (this.observing) {
       const currentValue = this.currentValue;
+      // eslint-disable-next-line compat/compat
+      if (Object.is(newValue, currentValue)) {
+        return;
+      }
       this.currentValue = newValue;
       if (this.lifecycle.batch.depth === 0) {
         this.callSubscribers(newValue, currentValue, this.persistentFlags | flags);
@@ -139,6 +140,7 @@ export class BindableObserver {
         {
           enumerable: true,
           configurable: true,
+          // todo: opt memory usage?
           get: () => this.getValue(),
           set: (value: unknown) => {
             this.setValue(value, LifecycleFlags.none);

--- a/packages/runtime/src/templating/bindable.ts
+++ b/packages/runtime/src/templating/bindable.ts
@@ -20,7 +20,6 @@ export type PartialBindableDefinition = {
   attribute?: string;
   property?: string;
   primary?: boolean;
-  get?: InterceptorFunc;
   set?: InterceptorFunc;
 };
 
@@ -94,7 +93,7 @@ function isBindableAnnotation(key: string): boolean {
 
 type BFluent = {
   add(config: PartialBindableDefinitionPropertyRequired): BFluent;
-  add(property: string): BFluent & B123456;
+  add(property: string): BFluent & B12345;
 };
 
 type B1<T = {}> = {
@@ -114,20 +113,15 @@ type B4<T = {}> = {
 };
 
 type B5<T = {}> = {
-  get(getterFn: InterceptorFunc): BFluent & T;
-};
-
-type B6<T = {}> = {
   set(setterFn: InterceptorFunc): BFluent & T;
 };
 
 // An important self-imposed limitation for this to be viable (e.g. avoid exponential combination growth),
 // is to keep the fluent API invocation order in a single direction.
-type B56 = B6 & B5<B6>;
-type B456 = B56 & B4<B56>;
-type B3456 = B456 & B3<B456>;
-type B23456 = B3456 & B2<B3456>;
-type B123456 = B23456 & B1<B23456>;
+type B45 = B5 & B4<B5>;
+type B345 = B45 & B3<B45>;
+type B2345 = B345 & B2<B345>;
+type B12345 = B2345 & B1<B2345>;
 
 export const Bindable = {
   name: Protocol.annotation.keyFor('bindable'),
@@ -165,8 +159,8 @@ export const Bindable = {
   for(Type: Constructable): BFluent {
     let def: Writable<BindableDefinition>;
 
-    const builder: BFluent & B123456 = {
-      add(configOrProp: string | PartialBindableDefinitionPropertyRequired): BFluent & B123456 {
+    const builder: BFluent & B12345 = {
+      add(configOrProp: string | PartialBindableDefinitionPropertyRequired): BFluent & B12345 {
         let prop: string;
         let config: PartialBindableDefinitionPropertyRequired;
         if (typeof configOrProp === 'string') {
@@ -185,32 +179,27 @@ export const Bindable = {
 
         return builder;
       },
-      mode(mode: BindingMode): BFluent & B123456 {
+      mode(mode: BindingMode): BFluent & B12345 {
         def.mode = mode;
 
         return builder;
       },
-      callback(callback: string): BFluent & B123456 {
+      callback(callback: string): BFluent & B12345 {
         def.callback = callback;
 
         return builder;
       },
-      attribute(attribute: string): BFluent & B123456 {
+      attribute(attribute: string): BFluent & B12345 {
         def.attribute = attribute;
 
         return builder;
       },
-      primary(): BFluent & B123456 {
+      primary(): BFluent & B12345 {
         def.primary = true;
 
         return builder;
       },
-      get(getInterpreter: InterceptorFunc): BFluent & B123456 {
-        def.get = getInterpreter;
-
-        return builder;
-      },
-      set(setInterpreter: InterceptorFunc): BFluent & B123456 {
+      set(setInterpreter: InterceptorFunc): BFluent & B12345 {
         def.set = setInterpreter;
 
         return builder;
@@ -248,7 +237,6 @@ export class BindableDefinition {
     public readonly mode: BindingMode,
     public readonly primary: boolean,
     public readonly property: string,
-    public readonly get: InterceptorFunc,
     public readonly set: InterceptorFunc,
   ) { }
 
@@ -259,10 +247,7 @@ export class BindableDefinition {
       firstDefined(def.mode, BindingMode.toView),
       firstDefined(def.primary, false),
       firstDefined(def.property, prop),
-      /* eslint-disable @typescript-eslint/unbound-method */
-      firstDefined(def.get, PLATFORM.noop),
       firstDefined(def.set, PLATFORM.noop),
-      /* eslint-enable @typescript-eslint/unbound-method */
     );
   }
 }
@@ -291,15 +276,13 @@ function apiTypeCheck() {
     @bindable({ attribute: 'prop' })
     @bindable({ primary: true })
     @bindable({ set: value => String(value) })
-    @bindable({ get: value => Number(value) })
-    @bindable({ get: value => Number(value), set: value => Number(value) })
+    @bindable({ set: value => Number(value) })
     @bindable({
       mode: BindingMode.twoWay,
       callback: 'propChanged',
       attribute: 'prop',
       primary: true,
-      set: value => String(value),
-      get: value => Number(value),
+      set: value => String(value)
     })
     public prop: unknown;
   }
@@ -332,9 +315,7 @@ function apiTypeCheck() {
     .add('prop').mode(BindingMode.twoWay).callback('propChanged')
     .add('prop').mode(BindingMode.twoWay).callback('propChanged').attribute('prop')
     .add('prop').mode(BindingMode.twoWay).callback('propChanged').attribute('prop').primary()
-    .add('prop').mode(BindingMode.twoWay).get(value => Number(value)).set(value => Number(value))
-    .add('prop').mode(BindingMode.twoWay).set(value => Number(value))
-    .add('prop').mode(BindingMode.twoWay).callback('propChanged').get(value => Number(value))
+    .add('prop').mode(BindingMode.twoWay).set((value: unknown) => Number(value))
     .add('prop').mode(BindingMode.twoWay).callback('propChanged').set(value => Number(value))
     .add('prop').callback('propChanged')
     .add('prop').callback('propChanged').attribute('prop')

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -1037,7 +1037,6 @@ function createObservers(
         useProxy ? ProxyObserver.getOrCreate(instance).proxy : instance as IIndexable,
         name,
         bindable.callback,
-        bindable.get,
         bindable.set,
       );
     }

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -57,8 +57,8 @@ import {
   ProxyObserver,
 } from '../observation/proxy-observer';
 import {
-  SelfObserver,
-} from '../observation/self-observer';
+  BindableObserver,
+} from '../observation/bindable-observer';
 import {
   ChildrenObserver,
   IRenderingEngine,
@@ -1013,7 +1013,7 @@ function createObservers(
   instance: object,
 ): void {
   const hasLookup = (instance as IIndexable).$observers != void 0;
-  const observers: Record<string, SelfObserver | ChildrenObserver> = hasLookup ? (instance as IIndexable).$observers as Record<string, SelfObserver> : {};
+  const observers: Record<string, BindableObserver | ChildrenObserver> = hasLookup ? (instance as IIndexable).$observers as Record<string, BindableObserver> : {};
   const bindables = description.bindables;
   const observableNames = Object.getOwnPropertyNames(bindables);
   const useProxy = (flags & LifecycleFlags.proxyStrategy) > 0 ;
@@ -1026,7 +1026,7 @@ function createObservers(
     name = observableNames[i];
 
     if (observers[name] == void 0) {
-      observers[name] = new SelfObserver(
+      observers[name] = new BindableObserver(
         lifecycle,
         flags,
         useProxy ? ProxyObserver.getOrCreate(instance).proxy : instance as IIndexable,

--- a/packages/runtime/src/templating/controller.ts
+++ b/packages/runtime/src/templating/controller.ts
@@ -71,6 +71,7 @@ import {
   CustomElement
 } from '../resources/custom-element';
 import { CustomAttributeDefinition, CustomAttribute } from '../resources/custom-attribute';
+import { BindableDefinition } from './bindable';
 
 type Definition = CustomAttributeDefinition | CustomElementDefinition;
 type Kind = { name: string };
@@ -1022,16 +1023,22 @@ function createObservers(
 
   const length = observableNames.length;
   let name: string;
+  let bindable: BindableDefinition;
+
   for (let i = 0; i < length; ++i) {
     name = observableNames[i];
 
     if (observers[name] == void 0) {
+      bindable = bindables[name];
+
       observers[name] = new BindableObserver(
         lifecycle,
         flags,
         useProxy ? ProxyObserver.getOrCreate(instance).proxy : instance as IIndexable,
         name,
-        bindables[name].callback
+        bindable.callback,
+        bindable.get,
+        bindable.set,
       );
     }
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Provide the ability to config bindable with getter/setter interceptors. Note that those config are purely interceptors, and expected to be pure functions. Usage example would be:

Defining a setter for altering incoming value:
```ts
export class MyEl {
  @bindable({ set: Number })
  public value: number

  @bindable({ set: val => Number(val) || 0 })
  public credit: number
}
```
Then in template, the scenarios like following will work as expected:
```html
<input type="number" value.bind="value">
<input type="number" value.bind="credit">
```
Or in code:
```ts
myEl.value = '5';
// myEl.value === 5

myEl.value = 'a';
// myEl.value === NaN

myEl.credit = '1';
// myEl.credit === 1;

myEl.credit = 'a';
// myEl.credit === NaN
```

Defining a getter:
```ts
export class MyEl {

  @bindable({ get: val => Number(val) || 0 })
  public age: number
}
```


### 🎫 Issues

Closes #368 

## 👩‍💻 Reviewer Notes

Is getter necessary?

## 📑 Test Plan

TBU

## ⏭ Next Steps

N/A