### PR TITLE
Emit decorator metadata

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -243,7 +243,9 @@ module.exports = {
       'Promise',
       'Map',
       'Set',
-      'Object.assign'
+      'Object.assign',
+      'WeakMap',
+      'WeakSet'
     ]
   }
 };

--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -1057,7 +1057,7 @@ describe(`The Container class`, function () {
   // });
 
   describe(`registerTransformer()`, function () {
-    for (const key of [null, undefined, Object]) {
+    for (const key of [null, undefined]) {
       it(_`throws on invalid key ${key}`, function () {
         const { sut } = setup();
         assert.throws(() => sut.registerTransformer(key, null as any), /5/, `() => sut.registerTransformer(key, null as any)`);
@@ -1074,7 +1074,7 @@ describe(`The Container class`, function () {
   });
 
   describe(`getResolver()`, function () {
-    for (const key of [null, undefined, Object]) {
+    for (const key of [null, undefined]) {
       it(_`throws on invalid key ${key}`, function () {
         const { sut } = setup();
         assert.throws(() => sut.getResolver(key, null as any), /5/, `() => sut.getResolver(key, null as any)`);
@@ -1097,7 +1097,7 @@ describe(`The Container class`, function () {
   // });
 
   describe(`get()`, function () {
-    for (const key of [null, undefined, Object]) {
+    for (const key of [null, undefined]) {
       it(_`throws on invalid key ${key}`, function () {
         const { sut } = setup();
         assert.throws(() => sut.get(key), /5/, `() => sut.get(key)`);
@@ -1107,7 +1107,7 @@ describe(`The Container class`, function () {
   });
 
   describe(`getAll()`, function () {
-    for (const key of [null, undefined, Object]) {
+    for (const key of [null, undefined]) {
       it(_`throws on invalid key ${key}`, function () {
         const { sut } = setup();
         assert.throws(() => sut.getAll(key), /5/, `() => sut.getAll(key)`);

--- a/packages/__tests__/5-jit-html/binding-behaviors.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-behaviors.spec.ts
@@ -50,7 +50,9 @@ describe('binding-behaviors', function () {
     class FooAttr5 {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(@INode element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {
@@ -63,7 +65,9 @@ describe('binding-behaviors', function () {
     class FooAttr4 {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(@INode element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {

--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -15,7 +15,9 @@ describe('custom-attributes', function () {
     class Fooatt5 {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(@INode element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {
@@ -28,7 +30,9 @@ describe('custom-attributes', function () {
     class Fooatt4 {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(@INode element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {
@@ -42,7 +46,9 @@ describe('custom-attributes', function () {
     class FooMultipleAlias {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(@INode element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {
@@ -135,7 +141,9 @@ describe('custom-attributes', function () {
         @bindable public b: string;
         public aResult: boolean;
         public bResult: string;
-        public constructor(@INode private readonly element: Element) {
+        private readonly element: Element;
+        public constructor(@INode element: INode) {
+          this.element = element as Element;
           this.element.innerHTML = 'Created';
         }
         public bound() {
@@ -160,7 +168,9 @@ describe('custom-attributes', function () {
         @bindable({ primary: true }) public b: string;
         public aResult: boolean;
         public bResult: string;
-        public constructor(@INode private readonly element: Element) {
+        private readonly element: Element;
+        public constructor(@INode element: INode) {
+          this.element = element as Element;
           this.element.innerHTML = 'Created';
         }
         public bound() {

--- a/packages/__tests__/5-jit-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.harmony.spec.ts
@@ -136,9 +136,10 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
             class Ce {
               public static inject = [INode];
               public lvl: number;
-              public constructor(
-                private readonly el: HTMLElement
-              ) {}
+              private readonly el: HTMLElement;
+              public constructor(el: INode) {
+                this.el = el as HTMLElement;
+              }
 
               public binding() {
                 this.el.setAttribute('lvl', `lvl-${this.lvl}`);
@@ -200,7 +201,10 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
           public static inject = [INode];
 
           public value: any;
-          public constructor(private readonly element: HTMLElement) {}
+          private readonly element: Element;
+          public constructor(element: INode) {
+            this.element = element as Element;
+          }
           public binding(): void {
             this.valueChanged();
           }
@@ -274,7 +278,10 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
           class Click {
             public static inject = [INode];
             public value: any;
-            public constructor(private readonly element: HTMLElement) {}
+            private readonly element: Element;
+            public constructor(element: INode) {
+              this.element = element as Element;
+            }
             public binding(): void {
               this.valueChanged();
             }

--- a/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
@@ -44,7 +44,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -69,7 +72,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public diameter: number;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -95,7 +101,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable({ primary: true })
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -120,7 +129,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -147,7 +159,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public diameter: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -175,7 +190,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable({ primary: true })
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -202,7 +220,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding() {
             this.el.style.background = this.color;
@@ -224,7 +245,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
         @customAttribute({ name: 'square' })
         class Square {
           public value: string;
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
+
           public binding() {
             this.el.style.background = this.value;
           }
@@ -247,7 +272,11 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @customAttribute({ name: 'square' })
           class Square {
             public value: string;
-            public constructor(@INode private readonly el: HTMLElement) {}
+            private readonly el: HTMLElement;
+            public constructor(el: INode) {
+              this.el = el as HTMLElement;
+            }
+
             public binding() {
               const value = this.value === 'literal:literal' ? 'red' : this.value;
               this.el.style.background = value;
@@ -293,7 +322,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
         }
         return [Square];
       },
@@ -316,7 +348,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable({ primary: true })
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
         }
         return [Square];
       },
@@ -342,7 +377,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;
@@ -369,7 +407,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;
@@ -399,7 +440,10 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           @bindable()
           public color: string;
 
-          public constructor(@INode private readonly el: HTMLElement) {}
+          private readonly el: HTMLElement;
+          public constructor(el: INode) {
+            this.el = el as HTMLElement;
+          }
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;

--- a/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
@@ -45,7 +45,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -73,7 +73,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public diameter: number;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -102,7 +102,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -130,7 +130,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -160,7 +160,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public diameter: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -191,7 +191,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -221,7 +221,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -246,7 +246,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
         class Square {
           public value: string;
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -273,7 +273,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           class Square {
             public value: string;
             private readonly el: HTMLElement;
-            public constructor(el: INode) {
+            public constructor(@INode el: INode) {
               this.el = el as HTMLElement;
             }
 
@@ -323,7 +323,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
         }
@@ -349,7 +349,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
         }
@@ -378,7 +378,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -408,7 +408,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 
@@ -441,7 +441,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
           public color: string;
 
           private readonly el: HTMLElement;
-          public constructor(el: INode) {
+          public constructor(@INode el: INode) {
             this.el = el as HTMLElement;
           }
 

--- a/packages/__tests__/5-jit-html/template-compiler.ref.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.ref.spec.ts
@@ -179,7 +179,10 @@ describe('templating-compiler.ref.spec.ts', function() {
         public unbindingCalls = 0;
         public unboundCalls = 0;
 
-        public constructor(public readonly el: HTMLElement) {}
+        private readonly el: Element;
+        public constructor(el: INode) {
+          this.el = el as Element;
+        }
 
         public binding(): void {
           this.bindingCalls++;

--- a/packages/__tests__/5-jit-html/value-converters.spec.ts
+++ b/packages/__tests__/5-jit-html/value-converters.spec.ts
@@ -33,7 +33,9 @@ describe('value-converters', function () {
     class FooAttribute {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {
@@ -46,7 +48,9 @@ describe('value-converters', function () {
     class FooAttribute2 {
       @bindable({ primary: true })
       public value: any;
-      public constructor(@INode private readonly element: Element) {
+      private readonly element: Element;
+      public constructor(element: INode) {
+        this.element = element as Element;
       }
 
       public bound() {

--- a/packages/__tests__/5-jit-html/value-converters.spec.ts
+++ b/packages/__tests__/5-jit-html/value-converters.spec.ts
@@ -34,7 +34,7 @@ describe('value-converters', function () {
       @bindable({ primary: true })
       public value: any;
       private readonly element: Element;
-      public constructor(element: INode) {
+      public constructor(@INode element: INode) {
         this.element = element as Element;
       }
 
@@ -49,7 +49,7 @@ describe('value-converters', function () {
       @bindable({ primary: true })
       public value: any;
       private readonly element: Element;
-      public constructor(element: INode) {
+      public constructor(@INode element: INode) {
         this.element = element as Element;
       }
 

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -19,7 +19,8 @@ import {
   IScope,
   IsExpression,
   LifecycleFlags,
-  State
+  State,
+  INode
 } from '@aurelia/runtime';
 import i18next from 'i18next';
 import { I18N } from '../i18n';
@@ -59,11 +60,14 @@ export class TranslationBinding implements IPartialConnectableBinding {
   private isInterpolatedSourceExpr!: boolean;
   private readonly targetObservers: Set<IBindingTargetAccessor>;
 
+  public readonly target: HTMLElement;
+
   public constructor(
-    public readonly target: HTMLElement,
+    target: INode,
     public observerLocator: IObserverLocator,
     public locator: IServiceLocator,
   ) {
+    this.target = target as HTMLElement;
     this.$state = State.none;
     this.i18n = this.locator.get(I18N);
     const ea: IEventAggregator = this.locator.get(IEventAggregator);

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -5,7 +5,7 @@ import { PLATFORM } from './platform';
 import { Reporter } from './reporter';
 import { ResourceType, Protocol } from './resource';
 import { Metadata } from './metadata';
-import { isNumeric } from './functions';
+import { isNumeric, isNativeFunction } from './functions';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -646,6 +646,9 @@ const createFactory = (function() {
   };
 
   return function <T extends Constructable>(Type: T): Factory<T> {
+    if (isNativeFunction(Type)) {
+      Reporter.write(5, Type.name);
+    }
     const dependencies = DI.getDependencies(Type);
     const invoker = classInvokers.length > dependencies.length ? classInvokers[dependencies.length] : fallbackInvoker;
     return new Factory<T>(Type, invoker, dependencies);
@@ -1013,9 +1016,7 @@ export class InstanceProvider<K extends Key> implements IResolver<K | null> {
 
 /** @internal */
 export function validateKey(key: any): void {
-  // note: design:paramTypes which will default to Object if the param types cannot be statically analyzed by tsc
-  // this check is intended to properly report on that problem - under no circumstance should Object be a valid key anyway
-  if (key == null || key === Object) {
+  if (key === null || key === void 0) {
     throw Reporter.error(5);
   }
 }

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -556,7 +556,7 @@ export function isNullOrUndefined(value: unknown): value is null | undefined {
  */
 export const isNativeFunction = (function () {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  const lookup: Map<Function, boolean> = new Map();
+  const lookup: WeakMap<Function, boolean> = new WeakMap();
 
   let isNative = false as boolean | undefined;
   let sourceText = '';

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -547,3 +547,55 @@ export function isObject<T extends object = Object | Function>(value: unknown): 
 export function isNullOrUndefined(value: unknown): value is null | undefined {
   return value === null || value === void 0;
 }
+
+/**
+ * Determine whether the value is a native function.
+ *
+ * @param fn - The function to check.
+ * @returns `true` is the function is a native function, otherwise `false`
+ */
+export const isNativeFunction = (function () {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  const lookup: Map<Function, boolean> = new Map();
+
+  let isNative = false as boolean | undefined;
+  let sourceText = '';
+  let i = 0;
+
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  return function (fn: Function) {
+    isNative = lookup.get(fn);
+    if (isNative === void 0) {
+      sourceText = fn.toString();
+      i = sourceText.length;
+
+      // http://www.ecma-international.org/ecma-262/#prod-NativeFunction
+      isNative = (
+        // 29 is the length of 'function () { [native code] }' which is the smallest length of a native function string
+        i >= 29 &&
+        // 100 seems to be a safe upper bound of the max length of a native function. In Chrome and FF it's 56, in Edge it's 61.
+        i <= 100 &&
+        // This whole heuristic *could* be tricked by a comment. Do we need to care about that?
+        sourceText.charCodeAt(i -  1) === 0x7D && // }
+        // TODO: the spec is a little vague about the precise constraints, so we do need to test this across various browsers to make sure just one whitespace is a safe assumption.
+        sourceText.charCodeAt(i -  2)  <= 0x20 && // whitespace
+        sourceText.charCodeAt(i -  3) === 0x5D && // ]
+        sourceText.charCodeAt(i -  4) === 0x65 && // e
+        sourceText.charCodeAt(i -  5) === 0x64 && // d
+        sourceText.charCodeAt(i -  6) === 0x6F && // o
+        sourceText.charCodeAt(i -  7) === 0x63 && // c
+        sourceText.charCodeAt(i -  8) === 0x20 && //
+        sourceText.charCodeAt(i -  9) === 0x65 && // e
+        sourceText.charCodeAt(i - 10) === 0x76 && // v
+        sourceText.charCodeAt(i - 11) === 0x69 && // i
+        sourceText.charCodeAt(i - 12) === 0x74 && // t
+        sourceText.charCodeAt(i - 13) === 0x61 && // a
+        sourceText.charCodeAt(i - 14) === 0x6E && // n
+        sourceText.charCodeAt(i - 15) === 0x58    // [
+      );
+
+      lookup.set(fn, isNative);
+    }
+    return isNative;
+  };
+})();

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -134,4 +134,5 @@ export {
   getPrototypeChain,
   isObject,
   isNullOrUndefined,
+  isNativeFunction,
 } from './functions';

--- a/packages/router/src/resources/goto.ts
+++ b/packages/router/src/resources/goto.ts
@@ -6,9 +6,14 @@ export class GotoCustomAttribute {
   public value: unknown;
 
   private hasHref: boolean | null = null;
+
+  private readonly element: HTMLElement;
+
   public constructor(
-    @INode private readonly element: HTMLElement,
-  ) { }
+    @INode element: INode,
+  ) {
+    this.element = element as HTMLElement;
+  }
 
   public binding(): void {
     this.updateValue();

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -32,10 +32,14 @@ export class ViewportCustomElement {
 
   public $controller!: IController; // This is set by the controller after this instance is constructed
 
+  private readonly element: Element;
+
   public constructor(
     @IRouter private readonly router: IRouter,
-    @INode private readonly element: Element,
-  ) {}
+    @INode element: INode,
+  ) {
+    this.element = element as HTMLElement;
+  }
 
   // public created(...rest): void {
   //   console.log('Created', rest);

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -19,6 +19,7 @@ import {
   LifecycleFlags,
   State,
   IScheduler,
+  INode,
 } from '@aurelia/runtime';
 import {
   AttributeObserver,
@@ -52,9 +53,11 @@ export class AttributeBinding implements IPartialConnectableBinding {
 
   public persistentFlags: LifecycleFlags = LifecycleFlags.none;
 
+  public target: Element;
+
   public constructor(
     public sourceExpression: IsBindingBehavior | IForOfStatement,
-    public target: Element,
+    target: INode,
     // some attributes may have inner structure
     // such as class -> collection of class names
     // such as style -> collection of style rules
@@ -66,6 +69,7 @@ export class AttributeBinding implements IPartialConnectableBinding {
     public observerLocator: IObserverLocator,
     public locator: IServiceLocator
   ) {
+    this.target = target as Element;
     connectable.assignIdTo(this);
     this.$scheduler = locator.get(IScheduler);
   }

--- a/packages/runtime-html/src/observation/attribute-ns-accessor.ts
+++ b/packages/runtime-html/src/observation/attribute-ns-accessor.ts
@@ -3,6 +3,7 @@ import {
   LifecycleFlags,
   IScheduler,
   ITask,
+  INode,
 } from '@aurelia/runtime';
 
 /**
@@ -10,6 +11,7 @@ import {
  * Wraps [`getAttributeNS`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttributeNS).
  */
 export class AttributeNSAccessor implements IAccessor<string | null> {
+  public readonly obj: HTMLElement;
   public currentValue: string | null = null;
   public oldValue: string | null = null;
 
@@ -21,10 +23,11 @@ export class AttributeNSAccessor implements IAccessor<string | null> {
   public constructor(
     public readonly scheduler: IScheduler,
     flags: LifecycleFlags,
-    public readonly obj: HTMLElement,
+    obj: INode,
     public readonly propertyKey: string,
     public readonly namespace: string,
   ) {
+    this.obj = obj as HTMLElement;
     this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -3,10 +3,12 @@ import {
   LifecycleFlags,
   IScheduler,
   ITask,
+  INode,
 } from '@aurelia/runtime';
 import { PLATFORM } from '@aurelia/kernel';
 
 export class ClassAttributeAccessor implements IAccessor<unknown> {
+  public readonly obj: HTMLElement;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
 
@@ -23,8 +25,9 @@ export class ClassAttributeAccessor implements IAccessor<unknown> {
   public constructor(
     public readonly scheduler: IScheduler,
     flags: LifecycleFlags,
-    public readonly obj: HTMLElement,
+    obj: INode,
   ) {
+    this.obj = obj as HTMLElement;
     this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 

--- a/packages/runtime-html/src/observation/data-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/data-attribute-accessor.ts
@@ -3,6 +3,7 @@ import {
   LifecycleFlags,
   IScheduler,
   ITask,
+  INode,
 } from '@aurelia/runtime';
 
 /**
@@ -13,6 +14,7 @@ import {
  * @see ElementPropertyAccessor
  */
 export class DataAttributeAccessor implements IAccessor<string | null> {
+  public readonly obj: HTMLElement;
   public currentValue: string | null = null;
   public oldValue: string | null = null;
 
@@ -24,9 +26,10 @@ export class DataAttributeAccessor implements IAccessor<string | null> {
   public constructor(
     public readonly scheduler: IScheduler,
     flags: LifecycleFlags,
-    public readonly obj: HTMLElement,
+    obj: INode,
     public readonly propertyKey: string,
   ) {
+    this.obj = obj as HTMLElement;
     this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -3,10 +3,12 @@ import {
   LifecycleFlags,
   IScheduler,
   ITask,
+  INode,
 } from '@aurelia/runtime';
 import { PLATFORM, kebabCase } from '@aurelia/kernel';
 
 export class StyleAttributeAccessor implements IAccessor<unknown> {
+  public readonly obj: HTMLElement;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
 
@@ -21,8 +23,9 @@ export class StyleAttributeAccessor implements IAccessor<unknown> {
   public constructor(
     public readonly scheduler: IScheduler,
     flags: LifecycleFlags,
-    public readonly obj: HTMLElement,
+    obj: INode,
   ) {
+    this.obj = obj as HTMLElement;
     this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 

--- a/packages/runtime-html/src/resources/custom-attributes/blur.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/blur.ts
@@ -136,11 +136,14 @@ export class Blur {
    */
   private readonly manager: BlurManager;
 
+  private readonly element: HTMLElement;
+
   public constructor(
-    @INode private readonly element: HTMLElement,
+    @INode element: INode,
     @IDOM private readonly dom: HTMLDOM,
     @IScheduler scheduler: IScheduler
   ) {
+    this.element = element as HTMLElement;
     /**
      * By default, the behavior should be least surprise possible, that:
      *

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -26,10 +26,14 @@ export class Focus {
   // This is set by the controller after this instance is constructed
   private readonly $controller!: IController;
 
+  private readonly element: HTMLElement;
+
   public constructor(
-    @INode private readonly element: HTMLElement,
+    @INode element: INode,
     @IDOM private readonly dom: HTMLDOM
-  ) {}
+  ) {
+    this.element = element as HTMLElement;
+  }
 
   public binding(): void {
     this.valueChanged();

--- a/packages/runtime-html/src/styles/css-modules-registry.ts
+++ b/packages/runtime-html/src/styles/css-modules-registry.ts
@@ -10,9 +10,13 @@ export class CSSModulesProcessorRegistry implements IRegistry {
     class ClassCustomAttribute {
       @bindable public value!: string;
 
+      private element: HTMLElement;
+
       public constructor(
-        @INode private element: HTMLElement,
-      ) {}
+        @INode element: INode,
+      ) {
+        this.element = element as HTMLElement;
+      }
 
       public binding() {
         this.valueChanged();

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "rootDir": ".",
 
     "declaration": true,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Previously we threw an error when the container gets `Object` as a key, but that turned out to have a few unintended side effect, such as not being able to do partial dependency resolution.

So, now we just report a warning instead, and we also do this on other natives (e.g. `Array`, `HTMLElement`, etc)

There is also a new exported helper function `isNativeFunction`, used by the container for the above, that will be useful in other parts of the framework and possibly also for end users.

Furthermore, there are a few issues with `emitDecoratorMetadata` in nodejs that I'm addressing now, because they're making things difficult in AOT.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
