### PR TITLE
chore: update fibers to 4.0.2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
   },
   "ignoreDeps": [
     "i18next",
-    "pixi.js"
+    "pixi.js",
+    "@types/pixi.js"
   ],
   "packageRules": [
     {
@@ -38,7 +39,7 @@
     },
     {
       "packageNames": ["chromedriver"],
-      "allowedVersions": "^74.0.0"
+      "allowedVersions": "^77.0.0"
     },
     {
       "packageNames": ["karma"],
@@ -51,10 +52,6 @@
     {
       "packageNames": ["mocha"],
       "allowedVersions": "~6.1.4"
-    },
-    {
-      "packageNames": ["pixi.js", "@types/pixi.js"],
-      "allowedVersions": "~4.8.8"
     }
   ]
 }

--- a/test/wdio/package-lock.json
+++ b/test/wdio/package-lock.json
@@ -343,9 +343,8 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "78.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
-      "integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
+      "version": "77.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-77.0.0.tgz",
       "dev": true,
       "requires": {
         "del": "^4.1.1",

--- a/test/wdio/package-lock.json
+++ b/test/wdio/package-lock.json
@@ -28,9 +28,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+      "version": "12.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
       "dev": true
     },
     "ajv": {
@@ -343,9 +343,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "76.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.1.tgz",
-      "integrity": "sha512-+8BCemJLKPF2w/UpzA1uNgLWQrg1IgIO4ZYcsAjYYgqD8zUcvQ+RfwA/0TR1Zwv9Mkd8fdzTe21eZ2FyZ83DAg==",
+      "version": "78.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-78.0.1.tgz",
+      "integrity": "sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==",
       "dev": true,
       "requires": {
         "del": "^4.1.1",
@@ -742,9 +742,9 @@
       }
     },
     "fibers": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
-      "integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
+      "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3"
@@ -2179,16 +2179,15 @@
       "integrity": "sha512-veHLIB3cQ76qqmUPda6QJQOh7SGmpD+sK5ANuLCeA1xYSJg0Y26SVLYJTtIkXF3dR1xDUfIYtSBDIhbmoXtMsQ==",
       "dev": true,
       "requires": {
-        "fibers": "^3.0.0",
         "selenium-standalone": "^6.15.4",
         "tcp-port-used": "^1.0.1",
         "webdriverio": "^4.12.0"
       },
       "dependencies": {
         "fibers": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
-          "integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
+          "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
           "dev": true,
           "requires": {
             "detect-libc": "^1.0.3"
@@ -2285,14 +2284,13 @@
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
-        "fibers": "^3.0.0",
         "object.assign": "^4.0.3"
       },
       "dependencies": {
         "fibers": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.1.tgz",
-          "integrity": "sha512-H79EJn7DMWXk48ygmC82bMP8KNcFBZF1CPfwBpYF6cO85hGWoIrlu7eyX9ayxfjP9Nsl0JXxdI6fpYU4DWVw2w==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/fibers/-/fibers-4.0.2.tgz",
+          "integrity": "sha512-FhICi1K4WZh9D6NC18fh2ODF3EWy1z0gzIdV9P7+s2pRjfRBnCkMDJ6x3bV1DkVymKH8HGrQa/FNOBjYvnJ/tQ==",
           "dev": true,
           "requires": {
             "detect-libc": "^1.0.3"

--- a/test/wdio/package.json
+++ b/test/wdio/package.json
@@ -2,7 +2,7 @@
   "name": "examples-e2e",
   "version": "0.3.0",
   "devDependencies": {
-    "chromedriver": "^78.0.1",
+    "chromedriver": "^77.0.0",
     "fibers": "^4.0.2",
     "mocha": "~6.1.4",
     "wdio": "^3.0.3",

--- a/test/wdio/package.json
+++ b/test/wdio/package.json
@@ -2,8 +2,8 @@
   "name": "examples-e2e",
   "version": "0.3.0",
   "devDependencies": {
-    "chromedriver": "^76.0.1",
-    "fibers": "^4.0.1",
+    "chromedriver": "^78.0.1",
+    "fibers": "^4.0.2",
     "mocha": "~6.1.4",
     "wdio": "^3.0.3",
     "wdio-mocha-framework": "^0.6.4"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Update `fibers` in `test/wdio/package.json`. This is a partial fix for #756. 

### 🎫 Issues

- #756 

## 👩‍💻 Reviewer Notes

The `wdio` package depends on `fibers@^3` which fails to install on Node 12. I've managed to update the dependencies with a `package-lock.json` tweak, fooling npm into using `fibers@^4`.

So `npm ci` works and will install the currently newest versions. `npm install` will still fail though.

I also had to only partially upgrade and pin `chromedriver` to `77.0.0` as updating CircleCI to use `78.0.1` resulted in a single failing test in Chrome.

And lastly I merged the two `pixi` exclusions in `renovate.json` to a single one.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

- Create a PR on the `wdio` package to have them update it to `fibers@^4`, to have a more permanent solution.
- Fix the underlying issue causing the test to fail on when updating CircleCI and `chromedriver`.
