### PR TITLE
perf(collection-observation): store observers in weakmaps

### DIFF
--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -121,7 +121,6 @@ export type PropertyObserver = IPropertyObserver<IIndexable, string>;
  */
 export type Collection = unknown[] | Set<unknown> | Map<unknown, unknown>;
 interface IObservedCollection<T extends CollectionKind = CollectionKind> {
-  $observer?: ICollectionObserver<T>;
   $raw?: this;
 }
 
@@ -184,7 +183,6 @@ export interface IProxyObserver<TObj extends {} = {}> extends IProxySubscriberCo
 
 export type IProxy<TObj extends {} = {}> = TObj & {
   $raw: TObj;
-  $observer: IProxyObserver<TObj>;
 };
 
 /**

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -10,6 +10,8 @@ import {
 import { CollectionLengthObserver } from './collection-length-observer';
 import { collectionSubscriberCollection } from './subscriber-collection';
 
+const observerLookup = new WeakMap<unknown[], ArrayObserver>();
+
 // https://tc39.github.io/ecma262/#sec-sortcompare
 function sortCompare(x: unknown, y: unknown): number {
   if (x === y) {
@@ -161,7 +163,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       return $push.apply($this, args);
     }
@@ -186,7 +188,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       return $unshift.apply($this, args);
     }
@@ -207,7 +209,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       return $pop.call($this);
     }
@@ -228,7 +230,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       return $shift.call($this);
     }
@@ -250,7 +252,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       return $splice.apply($this, args);
     }
@@ -291,7 +293,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       $reverse.call($this);
       return this;
@@ -317,7 +319,7 @@ const observe = {
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
     }
-    const o = $this.$observer;
+    const o = observerLookup.get($this);
     if (o === void 0) {
       $sort.call($this, compareFn);
       return this;
@@ -394,17 +396,7 @@ export class ArrayObserver {
     this.lifecycle = lifecycle;
     this.lengthObserver = (void 0)!;
 
-    Reflect.defineProperty(
-      array,
-      '$observer',
-      {
-        value: this,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-      },
-    );
-
+    observerLookup.set(array, this);
   }
 
   public notify(): void {
@@ -438,10 +430,11 @@ export class ArrayObserver {
 }
 
 export function getArrayObserver(flags: LifecycleFlags, lifecycle: ILifecycle, array: IObservedArray): ArrayObserver {
-  if (array.$observer === void 0) {
-    array.$observer = new ArrayObserver(flags, lifecycle, array);
+  const observer = observerLookup.get(array);
+  if (observer === void 0) {
+    return new ArrayObserver(flags, lifecycle, array);
   }
-  return array.$observer;
+  return observer;
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Stores collection observers in module-scoped weakmaps instead of as a property on the collections themselves.
This should help the garbage collector out a bit and reduce the chances of accidental memory leaks

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
