### PR TITLE
chore(browserstack): no unneeded npm i on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,6 @@ jobs:
           name: "Install e2e tests"
           command: |
             cd test/browserstack
-            npm i
             npm run build
       - run:
           name: "Serve e2e app in the background"


### PR DESCRIPTION
# Pull Request

## 📖 Description

`test/browserstack` is now a `lerna` managed package, so it doesn't need its own `npm i` anymore, as it uses the hoisted packages.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Self explanatory imho.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a