### PR TITLE
chore: update and unpin http-server

### DIFF
--- a/examples/jit-browserify-ts/package.json
+++ b/examples/jit-browserify-ts/package.json
@@ -20,7 +20,7 @@
     "browserify": "latest",
     "fancy-log": "^1.3.3",
     "gulp": "^4.0.2",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "stringify": "latest",
     "tsify": "latest",

--- a/examples/jit-fuse-box-ts/package.json
+++ b/examples/jit-fuse-box-ts/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^12.12.7",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.2",
     "fuse-box": "latest",

--- a/examples/jit-iife-inline/package.json
+++ b/examples/jit-iife-inline/package.json
@@ -15,6 +15,6 @@
     "aurelia": "dev"
   },
   "devDependencies": {
-    "http-server": "0.9.0"
+    "http-server": "^0.11.1"
   }
 }

--- a/examples/jit-parcel-ts/package.json
+++ b/examples/jit-parcel-ts/package.json
@@ -19,7 +19,7 @@
     "babel-core": "latest",
     "babel-plugin-transform-class-properties": "latest",
     "babel-plugin-transform-decorators-legacy": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "parcel-bundler": "latest",
     "parcel-plugin-typescript": "latest",
     "rimraf": "^3.0.0",

--- a/examples/jit-pixi-webpack-ts/package.json
+++ b/examples/jit-pixi-webpack-ts/package.json
@@ -18,7 +18,7 @@
     "file-loader": "^4.2.0",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/examples/jit-webpack-ts/package.json
+++ b/examples/jit-webpack-ts/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^12.12.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5711,23 +5711,15 @@
       }
     },
     "ecstatic": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-1.4.1.tgz",
-      "integrity": "sha1-Mst7b6LikNWGaGdNEV6PDD1WfWo=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.2.tgz",
+      "integrity": "sha512-fLf9l1hnwrHI2xn9mEDT7KIi22UDqA2jaCwyCbSUJh9a1V+LEUSL/JO/6TIz/QyuBURWUHrFL5Kg2TtO1bkkog==",
       "dev": true,
       "requires": {
-        "he": "^0.5.0",
-        "mime": "^1.2.11",
+        "he": "^1.1.1",
+        "mime": "^1.6.0",
         "minimist": "^1.1.0",
-        "url-join": "^1.0.0"
-      },
-      "dependencies": {
-        "he": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-          "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI=",
-          "dev": true
-        }
+        "url-join": "^2.0.5"
       }
     },
     "ee-first": {
@@ -8951,18 +8943,18 @@
       }
     },
     "http-server": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.9.0.tgz",
-      "integrity": "sha1-jxsGvcczYY1NxCgxx7oa/04GABo=",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.11.1.tgz",
+      "integrity": "sha512-6JeGDGoujJLmhjiRGlt8yK8Z9Kl0vnl/dQoQZlc4oeqaUoAKQg94NILLfrY3oWzSyFaQCVNTcKE5PZ3cH8VP9w==",
       "dev": true,
       "requires": {
         "colors": "1.0.3",
         "corser": "~2.0.0",
-        "ecstatic": "^1.4.0",
+        "ecstatic": "^3.0.0",
         "http-proxy": "^1.8.1",
         "opener": "~1.4.0",
         "optimist": "0.6.x",
-        "portfinder": "0.4.x",
+        "portfinder": "^1.0.13",
         "union": "~0.4.3"
       },
       "dependencies": {
@@ -13220,20 +13212,24 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
     },
     "portfinder": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz",
-      "integrity": "sha1-o/+t/6/k+5jgYBqF7aJ8J86Eyh4=",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+      "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
       "dev": true,
       "requires": {
-        "async": "0.9.0",
-        "mkdirp": "0.5.x"
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "async": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-          "integrity": "sha1-rDYTsdqb7RtHUQu0ZRuJMeRxRsc=",
-          "dev": true
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
         }
       }
     },
@@ -16174,9 +16170,9 @@
       }
     },
     "url-join": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
+      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
       "dev": true
     },
     "url-parse": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "htmlhint": "^0.11.0",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "husky": "^3.0.9",
     "ignore-loader": "^0.1.2",
     "istanbul": "^0.4.5",

--- a/packages/__e2e__/package.json
+++ b/packages/__e2e__/package.json
@@ -37,7 +37,7 @@
     "cypress": "^3.6.1",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "start-server-and-test": "^1.10.6",
     "ts-loader": "^6.2.1",

--- a/packages/__tests__/router/e2e/doc-example/app/package.json
+++ b/packages/__tests__/router/e2e/doc-example/app/package.json
@@ -30,7 +30,7 @@
     "cypress": "^3.6.1",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.6.0",
-    "http-server": "0.9.0"
+    "http-server": "^0.11.1"
   },
   "scripts": {
     "lint:html": "htmlhint -c .htmlhintrc src",

--- a/packages/__tests__/router/e2e/layouts/package.json
+++ b/packages/__tests__/router/e2e/layouts/package.json
@@ -16,7 +16,7 @@
     "browser-sync": "latest",
     "browserify": "latest",
     "gulp": "^4.0.2",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "stringify": "latest",
     "tsify": "latest",

--- a/packages/__tests__/router/e2e/modules/package.json
+++ b/packages/__tests__/router/e2e/modules/package.json
@@ -16,7 +16,7 @@
     "browser-sync": "latest",
     "browserify": "latest",
     "gulp": "^4.0.2",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "stringify": "latest",
     "tsify": "latest",

--- a/packages/__tests__/router/e2e/nav/package.json
+++ b/packages/__tests__/router/e2e/nav/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^12.12.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/packages/__tests__/router/e2e/navigation-skeleton/app/package.json
+++ b/packages/__tests__/router/e2e/navigation-skeleton/app/package.json
@@ -26,7 +26,7 @@
     "file-loader": "^4.2.0",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.2.1",

--- a/packages/__tests__/router/e2e/scope/package.json
+++ b/packages/__tests__/router/e2e/scope/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^12.12.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/packages/__tests__/router/e2e/siblings/package.json
+++ b/packages/__tests__/router/e2e/siblings/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^12.12.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/packages/__tests__/router/e2e/wizard/package.json
+++ b/packages/__tests__/router/e2e/wizard/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^12.12.7",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.2",

--- a/renovate.json
+++ b/renovate.json
@@ -46,10 +46,6 @@
       "allowedVersions": "~4.1.0"
     },
     {
-      "packageNames": ["http-server"],
-      "allowedVersions": "0.9.0"
-    },
-    {
       "packageNames": ["mocha"],
       "allowedVersions": "~6.1.4"
     }

--- a/test/1kcomponents/package.json
+++ b/test/1kcomponents/package.json
@@ -24,7 +24,7 @@
     "d3-scale-chromatic": "latest"
   },
   "devDependencies": {
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "webpack-cli": "^3.3.10",
     "webpack": "^4.41.2"
   }

--- a/test/browserstack/package.json
+++ b/test/browserstack/package.json
@@ -36,7 +36,7 @@
     "cross-env": "^6.0.3",
     "fancy-log": "^1.3.3",
     "html-loader": "^0.5.5",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "mocha": "~6.1.4",
     "npm-run-all": "^4.1.5",
     "path": "^0.12.7",

--- a/test/cypress/app/package.json
+++ b/test/cypress/app/package.json
@@ -29,7 +29,7 @@
     "css-loader": "latest",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "latest",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "rimraf": "^3.0.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.2.1",

--- a/test/fractals-tree/package.json
+++ b/test/fractals-tree/package.json
@@ -23,7 +23,7 @@
     "perf-monitor": "latest"
   },
   "devDependencies": {
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "webpack-cli": "^3.3.10",
     "webpack": "^4.41.2"
   }

--- a/test/grid/package.json
+++ b/test/grid/package.json
@@ -28,7 +28,7 @@
     "@types/faker": "latest",
     "autoprefixer": "latest",
     "html-loader": "^0.5.5",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "node-sass": "latest",
     "postcss-loader": "latest",
     "rimraf": "^3.0.0",

--- a/test/kitchen-sink/package.json
+++ b/test/kitchen-sink/package.json
@@ -31,7 +31,7 @@
     "@types/faker": "latest",
     "autoprefixer": "latest",
     "html-loader": "^0.5.5",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "node-sass": "latest",
     "postcss-loader": "latest",
     "rimraf": "^3.0.0",

--- a/test/rainbow-spiral/package.json
+++ b/test/rainbow-spiral/package.json
@@ -23,7 +23,7 @@
     "perf-monitor": "latest"
   },
   "devDependencies": {
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "webpack-cli": "^3.3.10",
     "webpack": "^4.41.2"
   }

--- a/test/sierpinski-triangle/package.json
+++ b/test/sierpinski-triangle/package.json
@@ -23,7 +23,7 @@
     "perf-monitor": "latest"
   },
   "devDependencies": {
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "webpack-cli": "^3.3.10",
     "webpack": "^4.41.2"
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Update and unpin `http-server`.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

<https://www.npmjs.com/advisories/830/versions> was fixed and `http-server` updated to the fixed version, so no more need for pinning.

## 📑 Test Plan

CircleCI.

## ⏭ Next Steps

n/a