### PR TITLE
chore: lint space-before-function-paren

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -175,6 +175,11 @@ module.exports = {
     'quotes': ['off'],
     'radix': 'error',
     'sort-keys': ['off'],
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always'
+    }],
     'space-in-parens': 'error',
     'spaced-comment': ['error', 'always', {
       line: { markers: ['/'], exceptions: ['-', '+'] },

--- a/examples/jit-pixi-webpack-ts/webpack.config.js
+++ b/examples/jit-pixi-webpack-ts/webpack.config.js
@@ -1,7 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     mode: production ? 'production' : 'development',

--- a/examples/jit-webpack-ts/webpack.config.js
+++ b/examples/jit-webpack-ts/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     mode: production ? 'production' : 'development',

--- a/packages/__tests__/1-kernel/di.integration.spec.ts
+++ b/packages/__tests__/1-kernel/di.integration.spec.ts
@@ -775,7 +775,7 @@ describe('DI.createInterface() -> container.get()', function () {
   });
 });
 
-describe('defer registration', function() {
+describe('defer registration', function () {
   class FakeCSSService {
     public constructor(public data: any) {}
   }
@@ -791,7 +791,7 @@ describe('defer registration', function() {
     }
   }
 
-  it(`enables the handler class to provide registrations for data`, function() {
+  it(`enables the handler class to provide registrations for data`, function () {
     const container = DI.createContainer();
     const data = {};
 
@@ -808,7 +808,7 @@ describe('defer registration', function() {
     assert.strictEqual(service.data, data);
   });
 
-  it(`passes the params to the container's register method if no handler is found`, function() {
+  it(`passes the params to the container's register method if no handler is found`, function () {
     const container = DI.createContainer();
     const data = {
       wasCalled: false,
@@ -838,7 +838,7 @@ describe('defer registration', function() {
       value: 42
     }
   ].forEach(x => {
-    it(`does not pass ${x.name} params to the container's register when no handler is found`, function() {
+    it(`does not pass ${x.name} params to the container's register when no handler is found`, function () {
       const container = DI.createContainer();
       container.register(
         Registration.defer('.css', x.value)

--- a/packages/__tests__/2-runtime/dirty-checker.spec.ts
+++ b/packages/__tests__/2-runtime/dirty-checker.spec.ts
@@ -94,7 +94,7 @@ describe('DirtyChecker', function () {
   ];
 
   for (const spec of specs) {
-    it(`updates after ${spec.framesPerCheck} RAF call`, function(done) {
+    it(`updates after ${spec.framesPerCheck} RAF call`, function (done) {
       const { framesPerCheck, frameChecks } = spec;
       DirtyCheckSettings.framesPerCheck = framesPerCheck;
       const { dirtyChecker, taskQueue } = setup();
@@ -253,7 +253,7 @@ describe('DirtyChecker', function () {
     });
   }
 
-  it('does nothing if disabled', function(done) {
+  it('does nothing if disabled', function (done) {
     const framesPerCheck: number = 1;
     DirtyCheckSettings.framesPerCheck = framesPerCheck;
     DirtyCheckSettings.disabled = true;
@@ -312,7 +312,7 @@ describe('DirtyChecker', function () {
   it.skip('warns by default', function () {
     let warnCalled = false;
     const writeBackup = Reporter.write;
-    Reporter.write = function(code) {
+    Reporter.write = function (code) {
       if (code === 801) {
         warnCalled = true;
       }
@@ -329,7 +329,7 @@ describe('DirtyChecker', function () {
     let warnCalled = false;
     DirtyCheckSettings.warn = false;
     const writeBackup = Reporter.write;
-    Reporter.write = function(code) {
+    Reporter.write = function (code) {
       if (code === 801) {
         warnCalled = true;
       }

--- a/packages/__tests__/2-runtime/view-location.spec.ts
+++ b/packages/__tests__/2-runtime/view-location.spec.ts
@@ -1,8 +1,8 @@
 import { view, ViewLocator, ViewValueConverter, CustomElement, Views, CustomElementDefinition } from '@aurelia/runtime';
 import { assert } from '@aurelia/testing';
 
-describe('the view value converter', function() {
-  it('delegates view location to the view locator service', function() {
+describe('the view value converter', function () {
+  it('delegates view location to the view locator service', function () {
     const fakeResult = class Component {};
     const fakeViewLocator = {
       object: null,
@@ -26,8 +26,8 @@ describe('the view value converter', function() {
   });
 });
 
-describe('the view decorator', function() {
-  it('can associate a view with a class', function() {
+describe('the view decorator', function () {
+  it('can associate a view with a class', function () {
     const template = { name: 'name' };
     @view(template)
     class MyModel {}
@@ -36,7 +36,7 @@ describe('the view decorator', function() {
     assert.equal(associated.name, template.name);
   });
 
-  it('can associate multiple views with a class', function() {
+  it('can associate multiple views with a class', function () {
     const template1 = { name: 'view-1' };
     const template2 = { name: 'view-2' };
 
@@ -51,8 +51,8 @@ describe('the view decorator', function() {
   });
 });
 
-describe('the view locator', function() {
-  it('returns a component class bound to the requested model', function() {
+describe('the view locator', function () {
+  it('returns a component class bound to the requested model', function () {
     const template = { name: 'name' };
     @view(template)
     class MyModel {}
@@ -67,7 +67,7 @@ describe('the view locator', function() {
     assert.equal(instance.viewModel, model);
   });
 
-  it('returns the same component class for the same model instance', function() {
+  it('returns the same component class for the same model instance', function () {
     const template = { name: 'name' };
     @view(template)
     class MyModel {}
@@ -83,7 +83,7 @@ describe('the view locator', function() {
     assert.equal(Component1, Component2);
   });
 
-  it('returns the same component base for two different instance of the same model', function() {
+  it('returns the same component base for two different instance of the same model', function () {
     const template = { name: 'name' };
     @view(template)
     class MyModel {}
@@ -104,7 +104,7 @@ describe('the view locator', function() {
     assert.instanceOf(Component2, BaseComponent);
   });
 
-  it('returns a component with the only view', function() {
+  it('returns a component with the only view', function () {
     const template1 = { name: 'view-1' };
 
     @view(template1)
@@ -120,7 +120,7 @@ describe('the view locator', function() {
     assert.equal('view-1', template.name);
   });
 
-  it('returns a component with the specified view', function() {
+  it('returns a component with the specified view', function () {
     const template1 = { name: 'view-1' };
     const template2 = { name: 'view-2' };
 
@@ -138,7 +138,7 @@ describe('the view locator', function() {
     assert.equal('view-2', template.name);
   });
 
-  it('returns a component with the view named "default-view" if no name specified', function() {
+  it('returns a component with the view named "default-view" if no name specified', function () {
     const template1 = { name: 'view-1' };
     const template2 = { name: 'default-view' };
 
@@ -156,7 +156,7 @@ describe('the view locator', function() {
     assert.equal('default-view', template.name);
   });
 
-  it('returns a component with the view based on a selector function', function() {
+  it('returns a component with the view based on a selector function', function () {
     const template1 = { name: 'view-1' };
     const template2 = { name: 'view-2' };
 
@@ -185,7 +185,7 @@ describe('the view locator', function() {
     assert.equal(receivedViews, Views.get(MyModel));
   });
 
-  it('can return a component based on a dynamic view when selector used with model without associated views', function() {
+  it('can return a component based on a dynamic view when selector used with model without associated views', function () {
     const template1 = { name: 'view-1' };
     class MyModel {}
 
@@ -204,7 +204,7 @@ describe('the view locator', function() {
     assert.equal(template1.name, template.name);
   });
 
-  it('locates views that are defined statically, without a decorator', function() {
+  it('locates views that are defined statically, without a decorator', function () {
     class MyModel {
       public static readonly $views = [{
         name: 'view-1'
@@ -233,14 +233,14 @@ describe('the view locator', function() {
     'unbinding',
     'unbound'
   ].forEach(lifecycleHook => {
-    it(`returns a component that implements lifecycle '${lifecycleHook}' if present on the model`, function() {
+    it(`returns a component that implements lifecycle '${lifecycleHook}' if present on the model`, function () {
       const template = { name: 'name' };
       @view(template)
       class MyModel {
         public invoked: boolean = false;
       }
 
-      MyModel.prototype[lifecycleHook] = function(this: MyModel) {
+      MyModel.prototype[lifecycleHook] = function (this: MyModel) {
         this.invoked = true;
       };
 

--- a/packages/__tests__/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/children-observer.spec.ts
@@ -2,9 +2,9 @@ import { children, Aurelia, CustomElement, PartialChildrenDefinition } from '@au
 import { TestContext, assert } from '@aurelia/testing';
 import { IContainer, PLATFORM } from '@aurelia/kernel';
 
-describe('ChildrenObserver', function() {
-  describe('populates', function() {
-    it('children array with child view models', function() {
+describe('ChildrenObserver', function () {
+  describe('populates', function () {
+    it('children array with child view models', function () {
       const { au, viewModel, ChildOne, ChildTwo } = createAppAndStart();
       assert.equal(viewModel.children.length, 2);
       assert.instanceOf(viewModel.children[0], ChildOne);
@@ -13,7 +13,7 @@ describe('ChildrenObserver', function() {
       au.stop();
     });
 
-    it('children array with by custom query', function() {
+    it('children array with by custom query', function () {
       const { au, viewModel, ChildOne } = createAppAndStart({
         query: p => (p.host as HTMLElement).querySelectorAll('.child-one')
       });
@@ -24,7 +24,7 @@ describe('ChildrenObserver', function() {
       au.stop();
     });
 
-    it('children array with by custom query, filter, and map', function() {
+    it('children array with by custom query, filter, and map', function () {
       const { au, viewModel, ChildOne } = createAppAndStart({
         query: p => (p.host as HTMLElement).querySelectorAll('.child-one'),
         filter: (node) => !!node,
@@ -38,12 +38,12 @@ describe('ChildrenObserver', function() {
     });
   });
 
-  describe('updates', function() {
+  describe('updates', function () {
     if (!PLATFORM.isBrowserLike) {
       return;
     }
 
-    it('children array with child view models', function(done) {
+    it('children array with child view models', function (done) {
       const { au, viewModel, ChildOne, ChildTwo, hostViewModel } = createAppAndStart();
 
       assert.equal(viewModel.children.length, 2);
@@ -64,7 +64,7 @@ describe('ChildrenObserver', function() {
       });
     });
 
-    it('children array with by custom query', function(done) {
+    it('children array with by custom query', function (done) {
       const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
         query: p => (p.host as HTMLElement).querySelectorAll('.child-two')
       });
@@ -86,7 +86,7 @@ describe('ChildrenObserver', function() {
       });
     });
 
-    it('children array with by custom query, filter, and map', function(done) {
+    it('children array with by custom query, filter, and map', function (done) {
       const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
         query: p => (p.host as HTMLElement).querySelectorAll('.child-two'),
         filter: (node) => !!node,

--- a/packages/__tests__/3-runtime-html/dom.spec.ts
+++ b/packages/__tests__/3-runtime-html/dom.spec.ts
@@ -280,7 +280,7 @@ describe('dom', function () {
   });
 
   describe('addEventListener', function () {
-    it('should add the specified eventListener to the node if the node is specified', function(done) {
+    it('should add the specified eventListener to the node if the node is specified', function (done) {
       const node = ctx.dom.createElement('div');
       const eventListener = createSpy();
       ctx.dom.addEventListener('click', eventListener, node);
@@ -295,7 +295,7 @@ describe('dom', function () {
       );
     });
 
-    it('should add the specified eventListener to the document if the node is NOT specified', function(done) {
+    it('should add the specified eventListener to the document if the node is NOT specified', function (done) {
       const eventListener = createSpy();
       ctx.dom.addEventListener('click', eventListener);
       ctx.doc.dispatchEvent(new ctx.CustomEvent('click', { bubbles: true }));
@@ -311,7 +311,7 @@ describe('dom', function () {
   });
 
   describe('removeEventListener', function () {
-    it('should remove the specified eventListener from the node if the node is specified', function(done) {
+    it('should remove the specified eventListener from the node if the node is specified', function (done) {
       const node = ctx.dom.createElement('div');
       const eventListener = createSpy();
       node.addEventListener('click', eventListener);
@@ -327,7 +327,7 @@ describe('dom', function () {
       );
     });
 
-    it('should remove the specified eventListener from the document if the node is NOT specified', function(done) {
+    it('should remove the specified eventListener from the document if the node is NOT specified', function (done) {
       const eventListener = createSpy();
       ctx.doc.addEventListener('click', eventListener);
       ctx.dom.removeEventListener('click', eventListener);

--- a/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
@@ -311,7 +311,7 @@ describe('SelectValueObserver', function () {
       }
 
       function select(...options: SelectValidChild[]): (ctx: HTMLTestContext) => HTMLSelectElement {
-        return function(ctx: HTMLTestContext) {
+        return function (ctx: HTMLTestContext) {
           return h(
             'select',
             { multiple: true },
@@ -323,13 +323,13 @@ describe('SelectValueObserver', function () {
   });
 
   function option(attributes: Record<string, any>) {
-    return function(ctx: HTMLTestContext) {
+    return function (ctx: HTMLTestContext) {
       return h('option', attributes);
     };
   }
 
   function optgroup(attributes: Record<string, any>, ...optionFactories: ((ctx: HTMLTestContext) => HTMLOptionElement)[]) {
-    return function(ctx: HTMLTestContext) {
+    return function (ctx: HTMLTestContext) {
       return h('optgroup', attributes, ...optionFactories.map(create => create(ctx)));
     };
   }

--- a/packages/__tests__/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 
-describe('Styles', function() {
+describe('Styles', function () {
   async function startApp(configure: (au: Aurelia) => void) {
     const ctx = TestContext.createHTMLTestContext();
     const au = new Aurelia(ctx.container);
@@ -25,8 +25,8 @@ describe('Styles', function() {
     return { au, ctx, host, container: au.container };
   }
 
-  describe('CSS Modules Processor', function() {
-    it('config adds correct registry for css', async function() {
+  describe('CSS Modules Processor', function () {
+    it('config adds correct registry for css', async function () {
       const { container } = await startApp(au => {
         au.register(StyleConfiguration.cssModulesProcessor());
       });
@@ -35,7 +35,7 @@ describe('Styles', function() {
       assert.instanceOf(registry, CSSModulesProcessorRegistry);
     });
 
-    it('registry overrides class attribute', function() {
+    it('registry overrides class attribute', function () {
       const element = { className: '' };
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
@@ -49,7 +49,7 @@ describe('Styles', function() {
       assert.equal(CustomAttribute.isType(attr.constructor), true);
     });
 
-    it('class attribute maps class names', function() {
+    it('class attribute maps class names', function () {
       const element = { className: '' };
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
@@ -68,7 +68,7 @@ describe('Styles', function() {
       assert.equal(element.className, 'bar qux');
     });
 
-    it('style function uses correct registry', function() {
+    it('style function uses correct registry', function () {
       const container = DI.createContainer();
       const childContainer = container.createChild();
 
@@ -90,7 +90,7 @@ describe('Styles', function() {
       assert.equal(element.className, 'bar qux');
     });
 
-    it('components do not inherit parent component styles', function() {
+    it('components do not inherit parent component styles', function () {
       const rootContainer = DI.createContainer();
       const parentContainer = rootContainer.createChild();
 
@@ -110,8 +110,8 @@ describe('Styles', function() {
     });
   });
 
-  describe('Shadow DOM', function() {
-    it('config adds correct registry for css', async function() {
+  describe('Shadow DOM', function () {
+    it('config adds correct registry for css', async function () {
       const { container } = await startApp(au => {
         au.register(StyleConfiguration.shadowDOM());
       });
@@ -120,7 +120,7 @@ describe('Styles', function() {
       assert.instanceOf(registry, ShadowDOMRegistry);
     });
 
-    it('registry provides root shadow dom styles', async function() {
+    it('registry provides root shadow dom styles', async function () {
       const { container } = await startApp(au => {
         au.register(StyleConfiguration.shadowDOM());
       });
@@ -132,7 +132,7 @@ describe('Styles', function() {
       assert.equal(typeof s.applyTo, 'function');
     });
 
-    it('config passes root styles to container', async function() {
+    it('config passes root styles to container', async function () {
       const rootStyles = '.my-class { color: red }';
       const { container, ctx } = await startApp(au => {
         au.register(StyleConfiguration.shadowDOM({
@@ -152,7 +152,7 @@ describe('Styles', function() {
       }
     });
 
-    it('element styles apply parent styles', function() {
+    it('element styles apply parent styles', function () {
       const ctx = TestContext.createHTMLTestContext();
       const root = { prepend() { return; } };
       const fake = {
@@ -166,7 +166,7 @@ describe('Styles', function() {
       assert.equal(fake.wasCalled, true);
     });
 
-    it('element styles apply by prepending style elements to shadow root', function() {
+    it('element styles apply by prepending style elements to shadow root', function () {
       const ctx = TestContext.createHTMLTestContext();
       const css = '.my-class { color: red }';
       const root = {
@@ -183,7 +183,7 @@ describe('Styles', function() {
       assert.equal(root.element.innerHTML, css);
     });
 
-    it('adopted styles apply parent styles', function() {
+    it('adopted styles apply parent styles', function () {
       const ctx = TestContext.createHTMLTestContext();
       const root = { adoptedStyleSheets: [] };
       const fake = {
@@ -197,7 +197,7 @@ describe('Styles', function() {
       assert.equal(fake.wasCalled, true);
     });
 
-    it('projector applies styles during projection', function() {
+    it('projector applies styles during projection', function () {
       const ctx = TestContext.createHTMLTestContext();
       const host = ctx.createElement('foo-bar');
       const FooBar = CustomElement.define(
@@ -232,7 +232,7 @@ describe('Styles', function() {
       return;
     }
 
-    it('adopted styles apply by setting adopted style sheets on shadow root', function() {
+    it('adopted styles apply by setting adopted style sheets on shadow root', function () {
       const css = '.my-class { color: red }';
       const root = { adoptedStyleSheets: [] };
       const ctx = TestContext.createHTMLTestContext();
@@ -244,7 +244,7 @@ describe('Styles', function() {
       assert.instanceOf(root.adoptedStyleSheets[0], ctx.dom.CSSStyleSheet);
     });
 
-    it('adopted styles use cached style sheets', function() {
+    it('adopted styles use cached style sheets', function () {
       const ctx = TestContext.createHTMLTestContext();
       const css = '.my-class { color: red }';
       const root = { adoptedStyleSheets: [] };
@@ -259,7 +259,7 @@ describe('Styles', function() {
       assert.strictEqual(root.adoptedStyleSheets[0], sheet);
     });
 
-    it('adopted styles merge sheets from parent', function() {
+    it('adopted styles merge sheets from parent', function () {
       const ctx = TestContext.createHTMLTestContext();
       const sharedCSS = '.my-class { color: red }';
       const localCSS = '.something-else { color: blue }';

--- a/packages/__tests__/5-jit-html/binding-command.class.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-command.class.spec.ts
@@ -6,10 +6,10 @@ import { TestContext, eachCartesianJoin, eachCartesianJoinAsync, assert } from '
 import { ClassAttributePattern } from './attribute-pattern';
 
 // TemplateCompiler - Binding Commands integration
-describe('template-compiler.binding-commands.class', function() {
+describe('template-compiler.binding-commands.class', function () {
 
   const falsyValues = [0, false, null, undefined, ''];
-  const truthyValues = [1, '1', true, {}, [], Symbol(), function() {/**/}, Number, new Proxy({}, {})];
+  const truthyValues = [1, '1', true, {}, [], Symbol(), function () {/**/}, Number, new Proxy({}, {})];
 
   const classNameTests: string[] = [
     'background',
@@ -130,7 +130,7 @@ describe('template-compiler.binding-commands.class', function() {
   eachCartesianJoin(
     [classNameTests, testCases],
     (className, testCase, callIndex) => {
-      it(testCase.title(className, callIndex), async function() {
+      it(testCase.title(className, callIndex), async function () {
         const { ctx, au, scheduler, host, component, tearDown } = setup(
           testCase.template(className),
           class App {

--- a/packages/__tests__/5-jit-html/binding-command.style.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-command.style.spec.ts
@@ -18,7 +18,7 @@ function getNormalizedStyle(el: HTMLElement, ruleName: string): string {
 }
 
 // TemplateCompiler - Binding Commands integration
-describe('template-compiler.binding-commands.style', function() {
+describe('template-compiler.binding-commands.style', function () {
 
   /** [ruleName, ruleValue, defaultValue, isInvalid, valueOnInvalid] */
   const rulesTests: [string, string, string, boolean?, string?][] = [
@@ -142,7 +142,7 @@ describe('template-compiler.binding-commands.style', function() {
   eachCartesianJoin(
     [rulesTests, testCases],
     ([ruleName, ruleValue, ruleDefaultValue, isInvalid, valueOnInvalid], testCase, callIndex) => {
-      it(testCase.title(ruleName, ruleValue, callIndex), async function() {
+      it(testCase.title(ruleName, ruleValue, callIndex), async function () {
         const { ctx, au, scheduler, host, component, tearDown } = setup(
           testCase.template(ruleName),
           class App {

--- a/packages/__tests__/5-jit-html/blur.integration.spec.ts
+++ b/packages/__tests__/5-jit-html/blur.integration.spec.ts
@@ -3,7 +3,7 @@ import { Aurelia, CustomElement, CustomElementHost } from '@aurelia/runtime';
 import { Blur, Focus } from '@aurelia/runtime-html';
 import { assert, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
 
-describe('blur.integration.spec.ts', function() {
+describe('blur.integration.spec.ts', function () {
 
   if (!PLATFORM.isBrowserLike) {
     return;
@@ -13,8 +13,8 @@ describe('blur.integration.spec.ts', function() {
     hasFocus: boolean;
   }
 
-  describe('>> with mouse', function() {
-    describe('>> Basic scenarios', function() {
+  describe('>> with mouse', function () {
+    describe('>> Basic scenarios', function () {
       // Note that from-view binding are not working at the moment
       // as blur has a guard to prevent unnecessary work,
       // it checks if value is already false and short circuit all checks
@@ -108,7 +108,7 @@ describe('blur.integration.spec.ts', function() {
       eachCartesianJoin(
         [blurAttrs, normalUsageTestCases],
         (command, { title, template, getFocusable, app, assertFn }: IBlurTestCase) => {
-          it(title(command), async function() {
+          it(title(command), async function () {
             const { ctx, component, testHost, dispose } = await setup<IApp>(
               template(command),
               app
@@ -122,7 +122,7 @@ describe('blur.integration.spec.ts', function() {
       );
     });
 
-    describe.skip('Abnormal scenarios', function() {
+    describe.skip('Abnormal scenarios', function () {
       const blurAttrs = [
         // 'blur.bind=hasFocus',
         'blur.two-way=hasFocus',
@@ -200,7 +200,7 @@ describe('blur.integration.spec.ts', function() {
         [blurAttrs, abnormalCases],
         (command, abnormalCase, callIndex) => {
           const { title, template, app, assertFn } = abnormalCase;
-          it(title(callIndex, command), async function() {
+          it(title(callIndex, command), async function () {
             const { component, testHost, ctx, dispose } = await setup<IApp>(
               template(command),
               app,
@@ -221,7 +221,7 @@ describe('blur.integration.spec.ts', function() {
     });
   });
 
-  describe('with shadowDOM', function() {
+  describe('with shadowDOM', function () {
     const testCases: IBlurTestCase[] = [
       {
         title: (...args) => `works with event originating inside shadow dom`,
@@ -301,7 +301,7 @@ describe('blur.integration.spec.ts', function() {
     eachCartesianJoin(
       [testCases],
       ({ title, template, dependencies = [], app, assertFn }: IBlurTestCase) => {
-        it(title(), async function() {
+        it(title(), async function () {
           const { ctx, component, testHost, dispose } = await setup<IApp>(
             template(''),
             app,

--- a/packages/__tests__/5-jit-html/blur.unit.spec.ts
+++ b/packages/__tests__/5-jit-html/blur.unit.spec.ts
@@ -3,7 +3,7 @@ import { ILifecycle } from '@aurelia/runtime';
 import { Blur } from '@aurelia/runtime-html';
 import { assert, createSpy, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
 
-describe('[UNIT] blur.unit.spec.ts', function() {
+describe('[UNIT] blur.unit.spec.ts', function () {
 
   if (!PLATFORM.isBrowserLike) {
     return;
@@ -11,14 +11,14 @@ describe('[UNIT] blur.unit.spec.ts', function() {
 
   const falsyPansyValues = [false, 0, '', undefined, null];
 
-  describe('contains()', function() {
+  describe('contains()', function () {
     for (const value of falsyPansyValues) {
-      it(`bails when value is already falsy: "${value}"`, function() {
+      it(`bails when value is already falsy: "${value}"`, function () {
         const { ctx, sut, dispose } = setup();
         const accessed: Record<string, number> = {};
         sut.value = value as unknown as boolean;
         sut.contains = (originalFn => {
-          return function(...args: unknown[]) {
+          return function (...args: unknown[]) {
             const proxy = new Proxy(this, {
               get(obj: Blur, propertyName: string): unknown {
                 accessed[propertyName] = (accessed[propertyName] || 0) + 1;
@@ -38,7 +38,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       });
     }
 
-    it('returns true when invoked on child element', function() {
+    it('returns true when invoked on child element', function () {
       const { ctx, target, sut, dispose } = setup();
       const child = target.appendChild(ctx.createElement('div'));
       sut.value = true;
@@ -47,19 +47,19 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       dispose();
     });
 
-    it('returns true when invoked on the its own element', function() {
+    it('returns true when invoked on the its own element', function () {
       const { target, sut, dispose } = setup();
       sut.value = true;
       assert.equal(sut.contains(target), true);
       dispose();
     });
 
-    it('bails when there is no thing linked and the hosting element does not contain the target', function() {
+    it('bails when there is no thing linked and the hosting element does not contain the target', function () {
       const { ctx, sut, dispose } = setup();
       let accessed: Record<string, number> = {};
       sut.value = true;
       sut.contains = (originalFn => {
-        return function(...args: unknown[]) {
+        return function (...args: unknown[]) {
           const proxy = new Proxy(this, {
             get(obj: Blur, propertyName: string): unknown {
               accessed[propertyName] = (accessed[propertyName] || 0) + 1;
@@ -99,7 +99,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       dispose();
     });
 
-    it('throws when given anything not a Node but also not null/undefined', function() {
+    it('throws when given anything not a Node but also not null/undefined', function () {
       const { sut } = setup();
       sut.value = true;
       for (const imcompatValue of [true, false, 'a', 5, Symbol(), Number, new Date(), {}, [], new Proxy({}, {})]) {
@@ -107,7 +107,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       }
     });
 
-    it('returns "true" when checking contains with element in different tree', function() {
+    it('returns "true" when checking contains with element in different tree', function () {
       const { target, sut, dispose } = setup();
       target
         .attachShadow({ mode: 'open' })
@@ -126,7 +126,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
     });
 
     for (let i = 1; 10 > i; ++i) {
-      it(`returns "true" when checking contains with element in ${i} deeply nested shadow root`, function() {
+      it(`returns "true" when checking contains with element in ${i} deeply nested shadow root`, function () {
         const { ctx, target, sut, dispose } = setup();
         const { rootShadowRoot, lastShadowRoot } = createNestingShadowRoot(ctx, i, target);
         assert.notEqual(rootShadowRoot, lastShadowRoot, 'root #ShadowRoot !== leaf #ShadowRoot');
@@ -152,8 +152,8 @@ describe('[UNIT] blur.unit.spec.ts', function() {
     }
   });
 
-  describe('.triggerBlur()', function() {
-    it('sets value to false', function() {
+  describe('.triggerBlur()', function () {
+    it('sets value to false', function () {
       const { dispose, sut } = setup();
       for (const value of [true, 'a', 5, Symbol(), Number, new Date(), null, undefined, {}, [], new Proxy({}, {})]) {
         sut.value = value as unknown as boolean;
@@ -163,14 +163,14 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       dispose();
     });
 
-    it('calls onBlur() if present', function() {
+    it('calls onBlur() if present', function () {
       const { dispose, sut } = setup();
       let count = 0;
-      const onBlurSpy = createSpy(function() {
+      const onBlurSpy = createSpy(function () {
         count++;
       });
       sut.onBlur = onBlurSpy;
-      const testValues = [true, 'a', 5, Symbol(), function() {/***/}, Number, new Date(), null, undefined, {}, [], new Proxy({}, {})];
+      const testValues = [true, 'a', 5, Symbol(), function () {/***/}, Number, new Date(), null, undefined, {}, [], new Proxy({}, {})];
       for (const value of testValues) {
         sut.value = value as unknown as boolean;
         sut.triggerBlur();
@@ -182,7 +182,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       dispose();
     });
 
-    it('does not call onBlur if value is not a function', function() {
+    it('does not call onBlur if value is not a function', function () {
       const { sut, dispose } = setup();
       const testValues = [true, 'a', 5, Symbol(), new Date(), null, undefined, {}, [], new Proxy({}, {})];
       let onBlurValue: any;
@@ -204,8 +204,8 @@ describe('[UNIT] blur.unit.spec.ts', function() {
     });
   });
 
-  describe('\n\t+ [linkedWith]', function() {
-    describe('object/object[] scenarios', function() {
+  describe('\n\t+ [linkedWith]', function () {
+    describe('object/object[] scenarios', function () {
       const { doc } = TestContext.createHTMLTestContext();
       const fakeEl = doc.body.appendChild(doc.createElement('fake'));
       const linkedWithValues: (HasContains | HasContains[])[] = [
@@ -236,7 +236,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
         ]
       ];
       for (const linkedWith of linkedWithValues) {
-        it('invokes contains on linkedWith object', function() {
+        it('invokes contains on linkedWith object', function () {
           const { sut, dispose } = setup();
           sut.linkedWith = linkedWith;
           assert.equal(
@@ -249,7 +249,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       }
     });
 
-    describe('string/string[] scenarios', function() {
+    describe('string/string[] scenarios', function () {
       const template = `
         <some-el><div data-query="some-el"></div></some-el>,
         <div class="some-css-class">
@@ -271,7 +271,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
         '#some-complex-selector > .some-nested-complex-selector + button'
       ];
       for (const linkWith of linkedWithValues) {
-        it(`works when linkedWith is a string: ${linkWith}`, function() {
+        it(`works when linkedWith is a string: ${linkWith}`, function () {
           const { sut, ctx: { doc }, dispose } = setup();
           sut.linkedWith = linkWith;
           const linkedWithTargetsCt = doc.body.insertAdjacentElement('afterbegin', doc.createElement('div'));
@@ -288,7 +288,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
         });
       }
 
-      it('works when linkedWith is an array of string', function() {
+      it('works when linkedWith is an array of string', function () {
         const { sut, ctx: { doc }, dispose } = setup();
         sut.linkedWith = linkedWithValues;
         const linkedWithTargetsCt = doc.body.insertAdjacentElement('afterbegin', doc.createElement('div'));
@@ -358,7 +358,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
             assert.equal(sut.contains(input), true);
           }
 
-          for (const truthyValue of [{}, [], 1, new Date(), function() {/*  */}, Symbol()]) {
+          for (const truthyValue of [{}, [], 1, new Date(), function () {/*  */}, Symbol()]) {
             sut.linkingContext = truthyValue as any;
             assert.throws(
               () => {
@@ -432,7 +432,7 @@ describe('[UNIT] blur.unit.spec.ts', function() {
       [testCases],
       (testCase) => {
         const { linkedWith, linkingContext, template, title, assertFn, blurHost } = testCase;
-        it(title(), async function() {
+        it(title(), async function () {
           const ctx = TestContext.createHTMLTestContext();
           const host = ctx.doc.body.appendChild(ctx.createElement('div'));
           host.innerHTML = template();

--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -211,7 +211,7 @@ describe('custom-attributes', function () {
     });
   });
 
-  describe('03. Change Handler', function() {
+  describe('03. Change Handler', function () {
     interface IChangeHandlerTestViewModel {
       prop: any;
       propChangedCallCount: number;
@@ -228,7 +228,7 @@ describe('custom-attributes', function () {
       }
     }
 
-    it('does not invoke change handler when starts with plain usage', function() {
+    it('does not invoke change handler when starts with plain usage', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<div foo="prop"></div>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -236,7 +236,7 @@ describe('custom-attributes', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with commands', function() {
+    it('does not invoke chane handler when starts with commands', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<div foo.bind="prop"></foo>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -244,7 +244,7 @@ describe('custom-attributes', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with interpolation', function() {
+    it('does not invoke chane handler when starts with interpolation', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo="\${prop}"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -252,7 +252,7 @@ describe('custom-attributes', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with two way binding', function() {
+    it('does not invoke chane handler when starts with two way binding', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<div foo.two-way="prop"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';

--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -396,7 +396,7 @@ describe('custom-elements', function () {
 
   });
 
-  describe('08. Change Handler', function() {
+  describe('08. Change Handler', function () {
     interface IChangeHandlerTestViewModel {
       prop: any;
       propChangedCallCount: number;
@@ -416,7 +416,7 @@ describe('custom-elements', function () {
       }
     }
 
-    it('does not invoke change handler when starts with plain usage', function() {
+    it('does not invoke change handler when starts with plain usage', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop="prop"></foo>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -424,7 +424,7 @@ describe('custom-elements', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with commands', function() {
+    it('does not invoke chane handler when starts with commands', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest('<foo prop.bind="prop"></foo>');
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -432,7 +432,7 @@ describe('custom-elements', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with interpolation', function() {
+    it('does not invoke chane handler when starts with interpolation', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop="\${prop}"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';
@@ -440,7 +440,7 @@ describe('custom-elements', function () {
       tearDown();
     });
 
-    it('does not invoke chane handler when starts with two way binding', function() {
+    it('does not invoke chane handler when starts with two way binding', function () {
       const { fooVm, tearDown } = setupChangeHandlerTest(`<foo prop.two-way="prop"></foo>`);
       assert.strictEqual(fooVm.propChangedCallCount, 0);
       fooVm.prop = '5';

--- a/packages/__tests__/5-jit-html/focus.spec.ts
+++ b/packages/__tests__/5-jit-html/focus.spec.ts
@@ -3,7 +3,7 @@ import { Aurelia, CustomElement } from '@aurelia/runtime';
 import { Focus } from '@aurelia/runtime-html';
 import { assert, eachCartesianJoin, HTMLTestContext, TestContext } from '@aurelia/testing';
 
-describe('focus.spec.ts', function() {
+describe('focus.spec.ts', function () {
 
   if (!PLATFORM.isBrowserLike) {
     return;
@@ -16,10 +16,10 @@ describe('focus.spec.ts', function() {
     selectedOption?: string;
   }
 
-  describe('basic scenarios', function() {
+  describe('basic scenarios', function () {
 
-    describe('with non-focusable element', function() {
-      it('focuses when there is tabindex attribute', async function() {
+    describe('with non-focusable element', function () {
+      it('focuses when there is tabindex attribute', async function () {
         const { startPromise, testHost, dispose, component, ctx } = setup<IApp>(
           `<template>
             <div focus.two-way="hasFocus" id="blurred" tabindex="-1"></div>
@@ -41,9 +41,9 @@ describe('focus.spec.ts', function() {
       });
     });
 
-    it('invokes focus when there is **NO** tabindex attribute', async function() {
+    it('invokes focus when there is **NO** tabindex attribute', async function () {
       let callCount = 0;
-      HTMLDivElement.prototype.focus = function() {
+      HTMLDivElement.prototype.focus = function () {
         callCount++;
         return HTMLElement.prototype.focus.call(this);
       };
@@ -81,8 +81,8 @@ describe('focus.spec.ts', function() {
       ['<select/> + <option/>', `<select focus.two-way=hasFocus id=blurred><option tabindex=1>Hello</option></select>`],
       ['<textarea/>', `<textarea focus.two-way=hasFocus id=blurred></textarea>`]
     ]) {
-      describe(`with ${desc}`, function() {
-        it('Works in basic scenario', async function() {
+      describe(`with ${desc}`, function () {
+        it('Works in basic scenario', async function () {
           const { startPromise, testHost, dispose, component, ctx } = setup<IApp>(
             `<template>
               ${template}
@@ -114,7 +114,7 @@ describe('focus.spec.ts', function() {
     // Assertion should at least focus on which active element is
     //                  How the component will be affected by the start up
     //                  Focus method on custom element has been invoked
-    describe('CustomElements -- Initialization only', function() {
+    describe('CustomElements -- Initialization only', function () {
 
       // when shadowModes is null, custom element sets its innerHTML directly on it own
       // instead of its shadow root
@@ -141,7 +141,7 @@ describe('focus.spec.ts', function() {
           const isFocusable = ceProp && (typeof ceProp.tabIndex !== 'undefined' || ceProp.contentEditable);
           const ceName = `ce-${Math.random().toString().slice(-6)}`;
 
-          it(`works with ${isFocusable ? 'focusable' : ''} custom element ${ceName}, #shadowRoot: ${shadowMode}`, async function() {
+          it(`works with ${isFocusable ? 'focusable' : ''} custom element ${ceName}, #shadowRoot: ${shadowMode}`, async function () {
             const { testHost, start, dispose, component, ctx } = setup<IApp>(
               `<template><${ceName} focus.two-way=hasFocus></${ceName}></template>`,
               class App {
@@ -198,7 +198,7 @@ describe('focus.spec.ts', function() {
     });
   });
 
-  describe('Interactive scenarios', function() {
+  describe('Interactive scenarios', function () {
     const focusAttrs = [
       'focus.two-way=hasFocus',
       // 'focus.two-way=hasFocus',
@@ -302,7 +302,7 @@ describe('focus.spec.ts', function() {
     eachCartesianJoin(
       [focusAttrs, templates],
       (command, { title, template, getFocusable, app, assertionFn }: IFocusTestCase) => {
-        it(title(command), async function() {
+        it(title(command), async function () {
           const { testHost, start, dispose, component, ctx } = setup<IApp>(
             template(command),
             app,

--- a/packages/__tests__/5-jit-html/repeat.contextual-props.spec.ts
+++ b/packages/__tests__/5-jit-html/repeat.contextual-props.spec.ts
@@ -370,7 +370,7 @@ describe(`[repeat.contextual-prop.spec.ts]`, function () {
 
     for (const bindingStrategy of [BindingStrategy.getterSetter, BindingStrategy.proxies]) {
 
-      suit(title, async function(): Promise<void> {
+      suit(title, async function (): Promise<void> {
         const ctx = TestContext.createHTMLTestContext();
 
         let body: HTMLElement;

--- a/packages/__tests__/5-jit-html/template-compiler.ce_and_surrogate.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.ce_and_surrogate.spec.ts
@@ -1,7 +1,7 @@
 import { HTMLTestContext, TestContext, assert } from '@aurelia/testing';
 import { CustomElement, Aurelia } from '@aurelia/runtime';
 
-describe('template-compiler.ce_and_surrogate.spec.ts', function() {
+describe('template-compiler.ce_and_surrogate.spec.ts', function () {
 
   interface ISurrogateIntegrationTestCase {
     title: string;
@@ -163,7 +163,7 @@ describe('template-compiler.ce_and_surrogate.spec.ts', function() {
       assertFn
     } = testCase;
 
-    it(title, async function() {
+    it(title, async function () {
       let host: HTMLElement;
       try {
         const ctx = TestContext.createHTMLTestContext();

--- a/packages/__tests__/5-jit-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.harmony.spec.ts
@@ -318,7 +318,7 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
     if (!PLATFORM.isBrowserLike && browserOnly) {
       return;
     }
-    it(`\n\t(${idx + 1}). ${title}\n\t`, async function() {
+    it(`\n\t(${idx + 1}). ${title}\n\t`, async function () {
       let host: HTMLElement;
       let body: HTMLElement;
       try {

--- a/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.primary-bindable.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '@aurelia/testing';
 import { HTMLDOM } from '../../runtime-html/dist';
 
-describe('template-compiler.primary-bindable.spec.ts', function() {
+describe('template-compiler.primary-bindable.spec.ts', function () {
 
   interface IPrimaryBindableTestCase {
     title: string;
@@ -479,7 +479,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       ? it.only(_title, fn)
       : it(_title, fn);
 
-    suit(title, async function() {
+    suit(title, async function () {
       let body: HTMLElement;
       let host: HTMLElement;
       try {
@@ -529,7 +529,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
     });
   }
 
-  describe('mimic vCurrent route-href', function() {
+  describe('mimic vCurrent route-href', function () {
     class $RouteHref$ {
 
       public static readonly inject = [INode, IDOM];
@@ -584,7 +584,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       }
     );
 
-    it('works correctly when binding only route name', async function() {
+    it('works correctly when binding only route name', async function () {
       const ctx = TestContext.createHTMLTestContext();
 
       const App = CustomElement.define({
@@ -610,7 +610,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
       host.remove();
     });
 
-    it('works correctly when using with value converter and a colon', async function() {
+    it('works correctly when using with value converter and a colon', async function () {
       const ctx = TestContext.createHTMLTestContext();
 
       const App = CustomElement.define({
@@ -638,7 +638,7 @@ describe('template-compiler.primary-bindable.spec.ts', function() {
 
     // todo: fix:
     //      + timing issue (change handler is invoked before binding)
-    it('works correctly when using multi binding syntax', async function() {
+    it('works correctly when using multi binding syntax', async function () {
       const ctx = TestContext.createHTMLTestContext();
 
       const App = CustomElement.define(

--- a/packages/__tests__/5-jit-html/template-compiler.ref.spec.ts
+++ b/packages/__tests__/5-jit-html/template-compiler.ref.spec.ts
@@ -16,7 +16,7 @@ import {
   TestContext
 } from '@aurelia/testing';
 
-describe('templating-compiler.ref.spec.ts', function() {
+describe('templating-compiler.ref.spec.ts', function () {
 
   interface IRefIntegrationTestCase {
     title: string;
@@ -463,7 +463,7 @@ describe('templating-compiler.ref.spec.ts', function() {
       ? it.only(_title, fn)
       : it(_title, fn);
 
-    suit(title, async function() {
+    suit(title, async function () {
       let body: HTMLElement;
       let host: HTMLElement;
       try {

--- a/packages/__tests__/plugin-conventions/name-convention.spec.ts
+++ b/packages/__tests__/plugin-conventions/name-convention.spec.ts
@@ -2,11 +2,11 @@ import { nameConvention } from '@aurelia/plugin-conventions';
 import { assert } from '@aurelia/testing';
 
 describe('nameConvention', function () {
-  it('complains about empty input', function() {
+  it('complains about empty input', function () {
     assert.throws(() => nameConvention(''));
   });
 
-  it('gets custom element like resource', function() {
+  it('gets custom element like resource', function () {
     assert.deepEqual(nameConvention('FooBar'), {
       name: 'foo-bar',
       type: 'customElement'
@@ -23,7 +23,7 @@ describe('nameConvention', function () {
     });
   });
 
-  it('gets custom attribute like resource', function() {
+  it('gets custom attribute like resource', function () {
     assert.deepEqual(nameConvention('FooBarCustomAttribute'), {
       name: 'foo-bar',
       type: 'customAttribute'
@@ -35,7 +35,7 @@ describe('nameConvention', function () {
     });
   });
 
-  it('gets value converter like resource', function() {
+  it('gets value converter like resource', function () {
     assert.deepEqual(nameConvention('FooBarValueConverter'), {
       name: 'fooBar',
       type: 'valueConverter'
@@ -47,21 +47,21 @@ describe('nameConvention', function () {
     });
   });
 
-  it('gets binding behavior like resource', function() {
+  it('gets binding behavior like resource', function () {
     assert.deepEqual(nameConvention('FooBarBindingBehavior'), {
       name: 'fooBar',
       type: 'bindingBehavior'
     });
   });
 
-  it('gets binding command like resource', function() {
+  it('gets binding command like resource', function () {
     assert.deepEqual(nameConvention('FooBarBindingCommand'), {
       name: 'foo-bar',
       type: 'bindingCommand'
     });
   });
 
-  it('gets template controller like resource', function() {
+  it('gets template controller like resource', function () {
     assert.deepEqual(nameConvention('FooBarTemplateController'), {
       name: 'foo-bar',
       type: 'templateController'

--- a/packages/__tests__/plugin-conventions/options.spec.ts
+++ b/packages/__tests__/plugin-conventions/options.spec.ts
@@ -2,7 +2,7 @@ import { preprocessOptions } from '@aurelia/plugin-conventions';
 import { assert } from '@aurelia/testing';
 
 describe('preprocessOptions', function () {
-  it('returns default options', function() {
+  it('returns default options', function () {
     assert.deepEqual(
       preprocessOptions(),
       {
@@ -14,7 +14,7 @@ describe('preprocessOptions', function () {
     );
   });
 
-  it('merges optional extensions', function() {
+  it('merges optional extensions', function () {
     assert.deepEqual(
       preprocessOptions({
         cssExtensions: ['.css', '.some'],
@@ -30,7 +30,7 @@ describe('preprocessOptions', function () {
     );
   });
 
-  it('merges optional options', function() {
+  it('merges optional options', function () {
     const wrap = (id: string) => `text!${id}`;
 
     assert.deepEqual(
@@ -52,7 +52,7 @@ describe('preprocessOptions', function () {
     );
   });
 
-  it('merges optional options, turn off stringModuleWrap if uses CSSModule', function() {
+  it('merges optional options, turn off stringModuleWrap if uses CSSModule', function () {
     const wrap = (id: string) => `text!${id}`;
 
     assert.deepEqual(

--- a/packages/__tests__/plugin-gulp/index.spec.ts
+++ b/packages/__tests__/plugin-gulp/index.spec.ts
@@ -67,7 +67,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms html file', function(done) {
+  it('transforms html file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.html content';
 
@@ -95,7 +95,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms html file in shadowDOM mode', function(done) {
+  it('transforms html file in shadowDOM mode', function (done) {
     const content = 'content';
     const expected = 'processed {"mode":"open"} text!src/foo-bar.html content';
 
@@ -130,7 +130,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms html file in CSSModule mode', function(done) {
+  it('transforms html file in CSSModule mode', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.html content';
 
@@ -159,7 +159,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms html file in shadowDOM mode + CSSModule mode', function(done) {
+  it('transforms html file in shadowDOM mode + CSSModule mode', function (done) {
     const content = 'content';
     const expected = 'processed {"mode":"open"} src/foo-bar.html content';
 
@@ -195,7 +195,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms js file', function(done) {
+  it('transforms js file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.js content';
 
@@ -223,7 +223,7 @@ describe('plugin-gulp', function () {
     }));
   });
 
-  it('transforms ts file', function(done) {
+  it('transforms ts file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.ts content';
 

--- a/packages/__tests__/router/route-recognizer.spec.ts
+++ b/packages/__tests__/router/route-recognizer.spec.ts
@@ -168,7 +168,7 @@ describe('route sut', function () {
     assert.strictEqual(!!sut.recognize('/b'), true, `!!sut.recognize('/b')`);
   });
 
-  eachCartesianJoin([routeSpecs], function(routeSpec) {
+  eachCartesianJoin([routeSpecs], function (routeSpec) {
     it(`should recognize - ${routeSpec.t}`, function () {
       const { route, path, isDynamic, params } = routeSpec;
       const sut = new RouteRecognizer();

--- a/packages/__tests__/setup-browser.ts
+++ b/packages/__tests__/setup-browser.ts
@@ -43,7 +43,7 @@ function initializeBrowserTestContext(): void {
 
 initializeBrowserTestContext();
 
-function importAll (r) {
+function importAll(r) {
   r.keys().forEach(r);
 }
 

--- a/packages/__tests__/webpack-loader/loader.spec.ts
+++ b/packages/__tests__/webpack-loader/loader.spec.ts
@@ -14,12 +14,12 @@ function preprocess(unit: IFileUnit, options: IOptionalPreprocessOptions) {
 }
 
 describe('webpack-loader', function () {
-  it('transforms html file', function(done) {
+  it('transforms html file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.html content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -34,12 +34,12 @@ describe('webpack-loader', function () {
     loader.call(context, content, preprocess);
   });
 
-  it('transforms html file in shadowDOM mode', function(done) {
+  it('transforms html file in shadowDOM mode', function (done) {
     const content = 'content';
     const expected = 'processed {"mode":"open"} !!raw-loader!src/foo-bar.html content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -55,12 +55,12 @@ describe('webpack-loader', function () {
     loader.call(context, content, preprocess);
   });
 
-  it('transforms html file in CSSModule mode', function(done) {
+  it('transforms html file in CSSModule mode', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.html content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -75,12 +75,12 @@ describe('webpack-loader', function () {
 
     loader.call(context, content, preprocess);
   });
-  it('transforms html file in shadowDOM mode + CSSModule mode', function(done) {
+  it('transforms html file in shadowDOM mode + CSSModule mode', function (done) {
     const content = 'content';
     const expected = 'processed {"mode":"open"} src/foo-bar.html content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -96,12 +96,12 @@ describe('webpack-loader', function () {
     loader.call(context, content, preprocess);
   });
 
-  it('transforms js file', function(done) {
+  it('transforms js file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.js content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -116,12 +116,12 @@ describe('webpack-loader', function () {
     loader.call(context, content, preprocess);
   });
 
-  it('transforms ts file', function(done) {
+  it('transforms ts file', function (done) {
     const content = 'content';
     const expected = 'processed src/foo-bar.ts content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;
@@ -136,12 +136,12 @@ describe('webpack-loader', function () {
     loader.call(context, content, preprocess);
   });
 
-  it('bypass other file', function(done) {
+  it('bypass other file', function (done) {
     const content = 'content';
     const notExpected = 'processed src/foo-bar.css content';
 
     const context = {
-      async: () => function(err, code, map) {
+      async: () => function (err, code, map) {
         if (err) {
           done(err);
           return;

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -210,7 +210,7 @@ export class DI {
   }
 
   public static createInterface<K extends Key>(friendlyName?: string): IDefaultableInterfaceSymbol<K> {
-    const Interface: InternalDefaultableInterfaceSymbol<K> = function(target: Injectable<K>, property: string, index: number): any {
+    const Interface: InternalDefaultableInterfaceSymbol<K> = function (target: Injectable<K>, property: string, index: number): any {
       if (target == null) {
         throw Reporter.error(16, Interface.friendlyName, Interface); // TODO: add error (trying to resolve an InterfaceSymbol that has no registrations)
       }
@@ -224,12 +224,12 @@ export class DI {
       return Interface;
     };
 
-    Interface.withDefault = function(configure: (builder: IResolverBuilder<K>) => IResolver<K>): InterfaceSymbol<K> {
+    Interface.withDefault = function (configure: (builder: IResolverBuilder<K>) => IResolver<K>): InterfaceSymbol<K> {
       Interface.withDefault = function (): InterfaceSymbol<K> {
         throw Reporter.error(17, Interface);
       };
 
-      Interface.register = function(container: IContainer, key?: Key): IResolver<K> {
+      Interface.register = function (container: IContainer, key?: Key): IResolver<K> {
         const trueKey = key == null ? Interface : key;
         return configure({
           instance(value: K): IResolver<K> {
@@ -257,7 +257,7 @@ export class DI {
   }
 
   public static inject(...dependencies: Key[]): (target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number) => void {
-    return function(target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number): void {
+    return function (target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number): void {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         const annotationParamtypes = DI.getOrCreateAnnotationParamTypes(target);
         const dep = dependencies[0];
@@ -354,7 +354,7 @@ function createResolver(getter: (key: any, handler: IContainer, requestor: ICont
       DI.inject(resolver)(target, property, descriptor);
     };
 
-    resolver.resolve = function(handler: IContainer, requestor: IContainer): any {
+    resolver.resolve = function (handler: IContainer, requestor: IContainer): any {
       return getter(key, handler, requestor);
     };
 
@@ -562,7 +562,7 @@ export class Factory<T extends Constructable = any> implements IFactory<T> {
   }
 }
 
-const createFactory = (function() {
+const createFactory = (function () {
   function invokeWithDynamicDependencies<T>(
     container: IContainer,
     Type: Constructable<T>,
@@ -645,7 +645,7 @@ const createFactory = (function() {
     invokeWithDynamicDependencies
   };
 
-  return function <T extends Constructable>(Type: T): Factory<T> {
+  return function <T extends Constructable> (Type: T): Factory<T> {
     if (isNativeFunction(Type)) {
       Reporter.write(5, Type.name);
     }

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -420,7 +420,7 @@ export const getPrototypeChain = (function () {
   let i = 0;
   let chain: [Constructable, ...Constructable[]] | undefined = void 0;
 
-  return function <T extends Constructable>(Type: T): readonly [T, ...Constructable[]] {
+  return function <T extends Constructable> (Type: T): readonly [T, ...Constructable[]] {
     chain = cache.get(Type);
     if (chain === void 0) {
       cache.set(Type, chain = [proto = Type]);

--- a/packages/plugin-gulp/src/index.ts
+++ b/packages/plugin-gulp/src/index.ts
@@ -2,7 +2,7 @@ import { Transform } from 'stream';
 import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aurelia/plugin-conventions';
 import * as Vinyl from 'vinyl';
 
-export default function(options: IOptionalPreprocessOptions = {}) {
+export default function (options: IOptionalPreprocessOptions = {}) {
   return plugin({
     ...options,
     useProcessedFilePairFilename: true,
@@ -17,7 +17,7 @@ export function plugin(
   const allOptions = preprocessOptions(options);
   return new Transform({
     objectMode: true,
-    transform: function(file: Vinyl, enc, cb) {
+    transform: function (file: Vinyl, enc, cb) {
       if (file.isStream()) {
         this.emit('error', new Error('@aurelia/plugin-gulp: Streaming is not supported'));
       } else if (file.isBuffer()) {

--- a/packages/plugin-pixi/src/resources/custom-elements/pixi-sprite.ts
+++ b/packages/plugin-pixi/src/resources/custom-elements/pixi-sprite.ts
@@ -179,19 +179,19 @@ export class PixiSprite {
 }
 
 for (const prop of directProps) {
-  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}Changed`] = function(this: PixiSprite, newValue: unknown): void {
+  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}Changed`] = function (this: PixiSprite, newValue: unknown): void {
     if ((this.$controller.state & State.isBound) > 0 && this.sprite != null) {
       this.sprite[prop] = newValue;
     }
   };
 }
 for (const prop of pointProps) {
-  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}XChanged`] = function(this: PixiSprite, newValue: unknown): void {
+  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}XChanged`] = function (this: PixiSprite, newValue: unknown): void {
     if ((this.$controller.state & State.isBound) > 0 && this.sprite != null) {
       (this.sprite[prop] as { x: unknown }).x = newValue;
     }
   };
-  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}YChanged`] = function(this: PixiSprite, newValue: unknown): void {
+  (PixiSprite.prototype as PixiSprite & { [key: string]: unknown })[`${prop}YChanged`] = function (this: PixiSprite, newValue: unknown): void {
     if ((this.$controller.state & State.isBound) > 0 && this.sprite != null) {
       (this.sprite[prop] as { y: unknown }).y = newValue;
     }

--- a/packages/runtime/src/dom.ts
+++ b/packages/runtime/src/dom.ts
@@ -92,7 +92,7 @@ export interface IDOM<T extends INode = INode> {
   setAttribute(node: T, name: string, value: unknown): void;
 }
 
-const ni = function(...args: unknown[]): unknown {
+const ni = function (...args: unknown[]): unknown {
   throw Reporter.error(1000); // TODO: create error code (not implemented exception)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any; // this function doesn't need typing because it is never directly called

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -158,7 +158,7 @@ const methods: ['push', 'unshift', 'pop', 'shift', 'splice', 'reverse', 'sort'] 
 
 const observe = {
   // https://tc39.github.io/ecma262/#sec-array.prototype.push
-  push: function(this: IObservedArray, ...args: unknown[]): ReturnType<typeof Array.prototype.push> {
+  push: function (this: IObservedArray, ...args: unknown[]): ReturnType<typeof Array.prototype.push> {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
@@ -183,7 +183,7 @@ const observe = {
     return $this.length;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.unshift
-  unshift: function(this: IObservedArray, ...args: unknown[]): ReturnType<typeof Array.prototype.unshift>  {
+  unshift: function (this: IObservedArray, ...args: unknown[]): ReturnType<typeof Array.prototype.unshift>  {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
@@ -204,7 +204,7 @@ const observe = {
     return len;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.pop
-  pop: function(this: IObservedArray): ReturnType<typeof Array.prototype.pop> {
+  pop: function (this: IObservedArray): ReturnType<typeof Array.prototype.pop> {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
@@ -225,7 +225,7 @@ const observe = {
     return element;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.shift
-  shift: function(this: IObservedArray): ReturnType<typeof Array.prototype.shift> {
+  shift: function (this: IObservedArray): ReturnType<typeof Array.prototype.shift> {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
@@ -245,7 +245,7 @@ const observe = {
     return element;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.splice
-  splice: function(this: IObservedArray, ...args: [number, number, ...unknown[]]): ReturnType<typeof Array.prototype.splice> {
+  splice: function (this: IObservedArray, ...args: [number, number, ...unknown[]]): ReturnType<typeof Array.prototype.splice> {
     const start: number = args[0];
     const deleteCount: number|undefined = args[1];
     let $this = this;
@@ -288,7 +288,7 @@ const observe = {
     return deleted;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.reverse
-  reverse: function(this: IObservedArray): ReturnType<typeof Array.prototype.reverse> {
+  reverse: function (this: IObservedArray): ReturnType<typeof Array.prototype.reverse> {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;
@@ -314,7 +314,7 @@ const observe = {
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.sort
   // https://github.com/v8/v8/blob/master/src/js/array.js
-  sort: function(this: IObservedArray, compareFn?: (a: unknown, b: unknown) => number): IObservedArray {
+  sort: function (this: IObservedArray, compareFn?: (a: unknown, b: unknown) => number): IObservedArray {
     let $this = this;
     if ($this.$raw !== void 0) {
       $this = $this.$raw;

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -25,7 +25,7 @@ const methods: ['set', 'clear', 'delete'] = ['set', 'clear', 'delete'];
 
 const observe = {
   // https://tc39.github.io/ecma262/#sec-map.prototype.map
-  set: function(this: IObservedMap, key: unknown, value: unknown): ReturnType<typeof $set> {
+  set: function (this: IObservedMap, key: unknown, value: unknown): ReturnType<typeof $set> {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;
@@ -59,7 +59,7 @@ const observe = {
     return this;
   },
   // https://tc39.github.io/ecma262/#sec-map.prototype.clear
-  clear: function(this: IObservedMap): ReturnType<typeof $clear>  {
+  clear: function (this: IObservedMap): ReturnType<typeof $clear>  {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;
@@ -85,7 +85,7 @@ const observe = {
     return undefined;
   },
   // https://tc39.github.io/ecma262/#sec-map.prototype.delete
-  delete: function(this: IObservedMap, value: unknown): ReturnType<typeof $delete> {
+  delete: function (this: IObservedMap, value: unknown): ReturnType<typeof $delete> {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -20,7 +20,7 @@ const methods: ['add', 'clear', 'delete'] = ['add', 'clear', 'delete'];
 
 const observe = {
   // https://tc39.github.io/ecma262/#sec-set.prototype.add
-  add: function(this: IObservedSet, value: unknown): ReturnType<typeof $add> {
+  add: function (this: IObservedSet, value: unknown): ReturnType<typeof $add> {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;
@@ -41,7 +41,7 @@ const observe = {
     return this;
   },
   // https://tc39.github.io/ecma262/#sec-set.prototype.clear
-  clear: function(this: IObservedSet): ReturnType<typeof $clear>  {
+  clear: function (this: IObservedSet): ReturnType<typeof $clear>  {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;
@@ -67,7 +67,7 @@ const observe = {
     return undefined;
   },
   // https://tc39.github.io/ecma262/#sec-set.prototype.delete
-  delete: function(this: IObservedSet, value: unknown): ReturnType<typeof $delete> {
+  delete: function (this: IObservedSet, value: unknown): ReturnType<typeof $delete> {
     let $this = this;
     if ($this.$raw !== undefined) {
       $this = $this.$raw;

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -14,7 +14,7 @@ import {
 
 export function subscriberCollection(): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return function(target: Function): void { // ClassDecorator expects it to be derived from Function
+  return function (target: Function): void { // ClassDecorator expects it to be derived from Function
     const proto = target.prototype as ISubscriberCollection;
 
     proto._subscriberFlags = SF.None;
@@ -32,7 +32,7 @@ export function subscriberCollection(): ClassDecorator {
 
 export function proxySubscriberCollection(): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return function(target: Function): void { // ClassDecorator expects it to be derived from Function
+  return function (target: Function): void { // ClassDecorator expects it to be derived from Function
     const proto = target.prototype as IProxySubscriberCollection;
 
     proto._proxySubscriberFlags = SF.None;
@@ -50,7 +50,7 @@ export function proxySubscriberCollection(): ClassDecorator {
 
 export function collectionSubscriberCollection(): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return function(target: Function): void { // ClassDecorator expects it to be derived from Function
+  return function (target: Function): void { // ClassDecorator expects it to be derived from Function
     const proto = target.prototype as ICollectionSubscriberCollection;
 
     proto._collectionSubscriberFlags = SF.None;

--- a/packages/runtime/src/renderer.ts
+++ b/packages/runtime/src/renderer.ts
@@ -67,7 +67,7 @@ type InstructionRendererDecorator<TType extends string> = <TProto, TClass>(targe
 export function instructionRenderer<TType extends string>(instructionType: TType): InstructionRendererDecorator<TType> {
   return function decorator<TProto, TClass>(target: DecoratableInstructionRenderer<TType, TProto, TClass>): DecoratedInstructionRenderer<TType, TProto, TClass> {
     // wrap the constructor to set the instructionType to the instance (for better performance than when set on the prototype)
-    const decoratedTarget = function(...args: unknown[]): TProto {
+    const decoratedTarget = function (...args: unknown[]): TProto {
       const instance = new target(...args);
       instance.instructionType = instructionType;
       return instance;

--- a/packages/runtime/src/resources/custom-element.ts
+++ b/packages/runtime/src/resources/custom-element.ts
@@ -363,7 +363,7 @@ export const CustomElement: CustomElementKind = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultProto = {} as any;
 
-    return function <P extends {} = {}>(
+    return function <P extends {} = {}> (
       name: string,
       proto: P = defaultProto,
     ): CustomElementType<Constructable<P>> {

--- a/packages/runtime/src/scheduler.ts
+++ b/packages/runtime/src/scheduler.ts
@@ -157,7 +157,7 @@ const createPromise = (function () {
     $reject = reject;
   }
 
-  return function <T>(): ExposedPromise<T> {
+  return function <T> (): ExposedPromise<T> {
     const p = new Promise(executor) as ExposedPromise<T>;
     p.resolve = $resolve!;
     p.reject = $reject!;

--- a/packages/runtime/src/templating/view.ts
+++ b/packages/runtime/src/templating/view.ts
@@ -135,7 +135,7 @@ export const Views = {
 };
 
 export function view(v: PartialCustomElementDefinition) {
-  return function<T extends Constructable>(target: T) {
+  return function<T extends Constructable> (target: T) {
     Views.add(target, v);
   };
 }

--- a/packages/testing/src/h.ts
+++ b/packages/testing/src/h.ts
@@ -54,7 +54,7 @@ const eventCmds = { delegate: 1, capture: 1, call: 1 };
 /**
  * jsx with aurelia binding command friendly version of h
  */
-export const hJsx = function(name: string, attrs: Record<string, string> | null, ...children: (Node | string | (Node | string)[])[]) {
+export const hJsx = function (name: string, attrs: Record<string, string> | null, ...children: (Node | string | (Node | string)[])[]) {
   const el = DOM.createElement(name === 'let$' ? 'let' : name);
   if (attrs != null) {
     let value: string | string[];

--- a/packages/testing/src/string-manipulation.ts
+++ b/packages/testing/src/string-manipulation.ts
@@ -66,7 +66,7 @@ export function stringify(value: any): string {
 export function jsonStringify(o: unknown): string {
   try {
     let cache: string[] = [];
-    const result = JSON.stringify(o, function(_key: string, value: any): string {
+    const result = JSON.stringify(o, function (_key: string, value: any): string {
       if (typeof value === 'object' && value !== null) {
         if (value.nodeType > 0) {
           return htmlStringify(value);

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -2,7 +2,7 @@ import { IOptionalPreprocessOptions, preprocess, preprocessOptions } from '@aure
 import { getOptions } from 'loader-utils';
 import * as webpack from 'webpack';
 
-export default function(
+export default function (
   this: webpack.loader.LoaderContext,
   contents: string,
   sourceMap?: object, // ignore existing source map for now

--- a/scripts/benchmarks/src/container.ts
+++ b/scripts/benchmarks/src/container.ts
@@ -10,22 +10,22 @@ const log = createLogger('container');
 const suites = {
   ['register']() {
     const suite = new Benchmark.Suite('register', {
-      onCycle: function(event) {
+      onCycle: function (event) {
         log(`[${c.cyan(name)}] ${event.target}`);
       }
     });
 
-    suite.add(`local runtime-html BasicConfiguration`, function() {
+    suite.add(`local runtime-html BasicConfiguration`, function () {
       local.kernel.DI.createContainer().register(local.runtimeHtml.BasicConfiguration);
     });
-    suite.add(`local jit-html     BasicConfiguration`, function() {
+    suite.add(`local jit-html     BasicConfiguration`, function () {
       local.kernel.DI.createContainer().register(local.jitHtml.BasicConfiguration);
     });
 
-    suite.add(`  dev runtime-html BasicConfiguration`, function() {
+    suite.add(`  dev runtime-html BasicConfiguration`, function () {
       dev.kernel.DI.createContainer().register(dev.runtimeHtml.HTMLRuntimeConfiguration);
     });
-    suite.add(`  dev jit-html     BasicConfiguration`, function() {
+    suite.add(`  dev jit-html     BasicConfiguration`, function () {
       dev.kernel.DI.createContainer().register(dev.jitHtml.HTMLJitConfiguration);
     });
 
@@ -59,31 +59,31 @@ const suites = {
     devContainer.register(DevSingleton, DevTransient);
 
     const suite = new Benchmark.Suite('resolve', {
-      setup: function() {
+      setup: function () {
         return;
       },
-      onCycle: function(event) {
+      onCycle: function (event) {
         log(`[${c.cyan(name)}] ${event.target}`);
       }
     });
 
-    suite.add(`local transient x ${count}`, function() {
+    suite.add(`local transient x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         localContainer.get(LocalTransient);
       }
     });
-    suite.add(`  dev transient x ${count}`, function() {
+    suite.add(`  dev transient x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         devContainer.get(DevTransient);
       }
     });
 
-    suite.add(`local singleton x ${count}`, function() {
+    suite.add(`local singleton x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         localContainer.get(LocalSingleton);
       }
     });
-    suite.add(`  dev singleton x ${count}`, function() {
+    suite.add(`  dev singleton x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         devContainer.get(DevSingleton);
       }

--- a/scripts/benchmarks/src/lifecycle.ts
+++ b/scripts/benchmarks/src/lifecycle.ts
@@ -47,12 +47,12 @@ const suites = {
     const devFoos = Array(count).fill(0).map(() => devContainer.get(DevFoo));
 
     const suite = new Benchmark.Suite('bind', {
-      onCycle: function(event) {
+      onCycle: function (event) {
         log(`[${c.cyan(name)}] ${event.target}`);
       }
     });
 
-    suite.add(`local beginBind+enqueueBound+endBind x ${count}`, function() {
+    suite.add(`local beginBind+enqueueBound+endBind x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         localLifecycle.beginBind();
         localLifecycle.enqueueBound(localFoos[i]);
@@ -61,7 +61,7 @@ const suites = {
         localLifecycle.endBind(0);
       }
     });
-    suite.add(`  dev beginBind+enqueueBound+endBind x ${count}`, function() {
+    suite.add(`  dev beginBind+enqueueBound+endBind x ${count}`, function () {
       for (let i = 0; i < count; ++i) {
         devLifecycle.beginBind();
         devLifecycle.enqueueBound(devFoos[i]);

--- a/test/1kcomponents/webpack.config.js
+++ b/test/1kcomponents/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-module.exports = function() {
+module.exports = function () {
   return {
     mode: 'none',
     devtool: false,

--- a/test/browserstack/browserstack.conf.ts
+++ b/test/browserstack/browserstack.conf.ts
@@ -108,10 +108,10 @@ exports.config = {
    */
   onPrepare: function (config, capabilities) {
     console.log('Connecting local');
-    return new Promise(function(resolve, reject){
+    return new Promise(function (resolve, reject){
       // eslint-disable-next-line @typescript-eslint/camelcase
       exports.bs_local = new browserstack.Local();
-      exports.bs_local.start({'key': exports.config.key }, function(error) {
+      exports.bs_local.start({'key': exports.config.key }, function (error) {
         if (error) return reject(error);
         console.log('Connected. Now testing...');
 
@@ -253,7 +253,7 @@ exports.config = {
    * Gets executed when an error happens, good place to take a screenshot
    * @ {String} error message
    */
-  onError: function(message) {
+  onError: function (message) {
     console.log(`Error - marking session ${browser.sessionId} as failed - ${message}`);
     CIEnv.browserstackPut(`sessions/${browser.sessionId}.json`, { status: 'failed', reason: message })
       .catch((error: Error) => { throw error; });

--- a/test/browserstack/specs/todos/app.spec.ts
+++ b/test/browserstack/specs/todos/app.spec.ts
@@ -10,17 +10,17 @@ describe(`Todos App - `, () => {
     const descriptionText = 'Hello World';
     const countValue = 1;
 
-    it(`description interpolation text: "${descriptionText}"`, function() {
+    it(`description interpolation text: "${descriptionText}"`, function () {
       const actual = AppPage.getDescriptionInterpolationText();
       expect(actual).to.equal(descriptionText);
     });
 
-    it(`count input value: ${countValue}`, function() {
+    it(`count input value: ${countValue}`, function () {
       const actual = AppPage.getCountInputValue();
       expect(actual).to.equal(countValue);
     });
 
-    it(`description input value: "${descriptionText}"`, function() {
+    it(`description input value: "${descriptionText}"`, function () {
       const actual = AppPage.getDescriptionInputValue();
       expect(actual).to.equal(descriptionText);
     });
@@ -38,31 +38,31 @@ describe(`Todos App - `, () => {
   }
 
   describe(`Add/remove todos`, () => {
-    it(`adds 1 todo`, function() {
+    it(`adds 1 todo`, function () {
       AppPage.addTodo();
       verifyTodos(1, 'Hello World', 'Hello World', false);
     });
 
-    it(`adds 1 todo and removes it`, function() {
+    it(`adds 1 todo and removes it`, function () {
       AppPage.addTodo();
       AppPage.clearTodos();
       verifyTodos(0, null, null, false);
     });
 
-    it(`adds 10 todos one by one`, function() {
+    it(`adds 10 todos one by one`, function () {
       for (let i = 0; i < 10; ++i) {
         AppPage.addTodo();
       }
       verifyTodos(10, 'Hello World', 'Hello World', false);
     });
 
-    it(`adds 10 todos at once`, function() {
+    it(`adds 10 todos at once`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       verifyTodos(10, 'Hello World', 'Hello World', false);
     });
 
-    it(`adds 10 todos at once and removes them`, function() {
+    it(`adds 10 todos at once and removes them`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       AppPage.clearTodos();
@@ -72,13 +72,13 @@ describe(`Todos App - `, () => {
 
   describe(`Change todo text`, () => {
 
-    it(`adds 1 todo with different text beforehand`, function() {
+    it(`adds 1 todo with different text beforehand`, function () {
       AppPage.setDescriptionInputValue('foo');
       AppPage.addTodo();
       verifyTodos(1, 'foo', 'foo', false);
     });
 
-    it(`adds 10 todos with different text beforehand one by one`, function() {
+    it(`adds 10 todos with different text beforehand one by one`, function () {
       AppPage.setDescriptionInputValue('foo');
       for (let i = 0; i < 10; ++i) {
         AppPage.addTodo();
@@ -86,20 +86,20 @@ describe(`Todos App - `, () => {
       verifyTodos(10, 'foo', 'foo', false);
     });
 
-    it(`adds 10 todos with different text beforehand at once`, function() {
+    it(`adds 10 todos with different text beforehand at once`, function () {
       AppPage.setDescriptionInputValue('foo');
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       verifyTodos(10, 'foo', 'foo', false);
     });
 
-    it(`adds 1 todo with different text afterwards`, function() {
+    it(`adds 1 todo with different text afterwards`, function () {
       AppPage.addTodo();
       AppPage.setDescriptionInputValue('foo');
       verifyTodos(1, 'foo', 'Hello World', false);
     });
 
-    it(`adds 10 todos with different text afterwards one by one`, function() {
+    it(`adds 10 todos with different text afterwards one by one`, function () {
       for (let i = 0; i < 10; ++i) {
         AppPage.addTodo();
       }
@@ -107,7 +107,7 @@ describe(`Todos App - `, () => {
       verifyTodos(10, 'foo', 'Hello World', false);
     });
 
-    it(`adds 10 todos with different text afterwards at once`, function() {
+    it(`adds 10 todos with different text afterwards at once`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       AppPage.setDescriptionInputValue('foo');
@@ -116,7 +116,7 @@ describe(`Todos App - `, () => {
   });
 
   describe(`Toggle todos`, () => {
-    it(`adds 10 todos and toggles them one by one`, function() {
+    it(`adds 10 todos and toggles them one by one`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       for (let i = 0; i < 10; ++i) {
@@ -125,7 +125,7 @@ describe(`Todos App - `, () => {
       verifyTodos(10, 'Hello World', 'Hello World', true);
     });
 
-    it(`adds 10 todos and toggles them one by one and back off again`, function() {
+    it(`adds 10 todos and toggles them one by one and back off again`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       for (let i = 0; i < 10; ++i) {
@@ -135,14 +135,14 @@ describe(`Todos App - `, () => {
       verifyTodos(10, 'Hello World', 'Hello World', false);
     });
 
-    it(`adds 10 todos and toggles them all at once`, function() {
+    it(`adds 10 todos and toggles them all at once`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       AppPage.toggleTodos();
       verifyTodos(10, 'Hello World', 'Hello World', true);
     });
 
-    it(`adds 10 todos and toggles them on all at once and back off again`, function() {
+    it(`adds 10 todos and toggles them on all at once and back off again`, function () {
       AppPage.setCountInputValue(10);
       AppPage.addTodo();
       AppPage.toggleTodos();

--- a/test/browserstack/webpack.config.js
+++ b/test/browserstack/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-module.exports = function(env, { app }) {
+module.exports = function (env, { app }) {
   return {
     mode: 'development',
     entry: `./src/${app}/startup.ts`,

--- a/test/cypress/app/webpack.config.js
+++ b/test/cypress/app/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     mode: production ? 'production' : 'development',

--- a/test/cypress/integration/router/default.spec.js
+++ b/test/cypress/integration/router/default.spec.js
@@ -1,9 +1,9 @@
 /// <reference types="Cypress" />
 
 // Tests the router and default route screen renders
-describe('Router Default', function() {
+describe('Router Default', function () {
 
-  it('contains an au-viewport tag', function() {
+  it('contains an au-viewport tag', function () {
     cy.visit('http://localhost:9001/');
 
     cy.get('au-viewport')
@@ -13,7 +13,7 @@ describe('Router Default', function() {
       .and('have.attr', 'name', 'app');
   });
 
-  it('contains an empty au-nav tag', function() {
+  it('contains an empty au-nav tag', function () {
     cy.visit('http://localhost:9001/');
 
     cy.get('au-nav')
@@ -22,7 +22,7 @@ describe('Router Default', function() {
       .should('not.exist');
   });
 
-  it('default route displays', function() {
+  it('default route displays', function () {
     cy.visit('http://localhost:9001/');
 
     cy.contains('Viewport: app').should('exist');

--- a/test/fractals-tree/webpack.config.js
+++ b/test/fractals-tree/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-module.exports = function() {
+module.exports = function () {
   return {
     target: 'web',
     mode: 'development',

--- a/test/grid/webpack.config.js
+++ b/test/grid/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-const loadPostCssPlugins = function() {
+const loadPostCssPlugins = function () {
   return [
     require("autoprefixer")({ browsers: ["last 2 versions"] })
   ];
@@ -14,7 +14,7 @@ const load = {
   ts: { loader: "ts-loader" }
 };
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     target: 'web',

--- a/test/js-framework-benchmark/build.js
+++ b/test/js-framework-benchmark/build.js
@@ -38,7 +38,7 @@ const relevant = args.skipIrrelevant && !_.some(core, isDifferent)
 
 _.each(skippable, ([dir,name]) => console.log(`*** Skipping ${dir}${name}`));
 
-_.each([].concat(relevant, core), function([dir,name]) {
+_.each([].concat(relevant, core), function ([dir,name]) {
   const fullname = dir + name;
   if(fs.statSync(fullname).isDirectory() && fs.existsSync(path.join(fullname, "package.json"))) {
     console.log(`*** Executing npm i in ${fullname}`);
@@ -55,7 +55,7 @@ _.each([].concat(relevant, core), function([dir,name]) {
 });
 
 const testable = args.check ? relevant : [];
-_.each(testable, function([dir,name]) {
+_.each(testable, function ([dir,name]) {
   const fullname = dir + name;
   if(fs.statSync(fullname).isDirectory() && fs.existsSync(path.join(fullname, "package.json"))) {
     console.log(`*** Executing npm run selenium for ${fullname}`);

--- a/test/js-framework-benchmark/copy.js
+++ b/test/js-framework-benchmark/copy.js
@@ -64,7 +64,7 @@ function copyFolderRecursiveSync(source, target) {
   }
 }
 
-_.each(fs.readdirSync('.'), function(name) {
+_.each(fs.readdirSync('.'), function (name) {
   if(fs.statSync(name).isDirectory() && name[0] !== '.' && !excludedDirectories.includes(name)) {
     console.log(`dist${path.sep}${name}`);
     fs.mkdirSync(`dist${path.sep}${name}`);

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia/aurelia_project/tasks/build.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia/aurelia_project/tasks/build.ts
@@ -1,6 +1,6 @@
 import { NPM } from 'aurelia-cli';
 
-export default function() {
+export default function () {
   console.log('`au build` is an alias of the `npm run build`, you may use either of those; see README for more details.');
 
   const args = process.argv.slice(3);

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia/src/app.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia/src/app.ts
@@ -2,12 +2,12 @@ import {Store} from './store';
 
 let startTime: number;
 let lastMeasure: string;
-const startMeasure = function(name) {
+const startMeasure = function (name) {
   startTime = performance.now();
   lastMeasure = name;
 };
-const stopMeasure = function() {
-  window.setTimeout(function() {
+const stopMeasure = function () {
+  window.setTimeout(function () {
     const stop = performance.now();
     console.log(`${lastMeasure} took ${stop-startTime}`);
   }, 0);

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/remove-tracer.js
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/remove-tracer.js
@@ -14,7 +14,7 @@ async function* walk(dir) {
   }
 }
 
-(async function() {
+(async function () {
   const aurelia = path.resolve(__dirname, "node_modules", "@aurelia");
 
   for await (const file of walk(aurelia)) {

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-npm/remove-tracer.js
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-npm/remove-tracer.js
@@ -14,7 +14,7 @@ async function* walk(dir) {
   }
 }
 
-(async function() {
+(async function () {
   const aurelia = path.resolve(__dirname, "node_modules", "@aurelia");
 
   for await (const file of walk(aurelia)) {

--- a/test/js-framework-benchmark/frameworks/keyed/vanillajs/src/Main.js
+++ b/test/js-framework-benchmark/frameworks/keyed/vanillajs/src/Main.js
@@ -2,11 +2,11 @@
 
 let startTime;
 let lastMeasure;
-const startMeasure = function(name) {
+const startMeasure = function (name) {
   startTime = performance.now();
   lastMeasure = name;
 };
-const stopMeasure = function() {
+const stopMeasure = function () {
   const last = lastMeasure;
   if (lastMeasure) {
     window.setTimeout(function () {
@@ -94,7 +94,7 @@ class Store {
   }
 }
 
-const getParentId = function(elem) {
+const getParentId = function (elem) {
   while (elem) {
     if (elem.tagName==="TR") {
       return elem.dataId;

--- a/test/js-framework-benchmark/webdriver-ts/src/webdriverAccess.ts
+++ b/test/js-framework-benchmark/webdriver-ts/src/webdriverAccess.ts
@@ -58,7 +58,7 @@ function elemNull(v: any) {
 }
 
 function waitForCondition(driver: WebDriver) {
-  return async function(text: string, fn: (driver: WebDriver) => Promise<boolean>, timeout: number): Promise<boolean> {
+  return async function (text: string, fn: (driver: WebDriver) => Promise<boolean>, timeout: number): Promise<boolean> {
     // eslint-disable-next-line no-return-await
     return await driver.wait(new Condition<Promise<boolean>>(text, fn), timeout);
   };
@@ -69,7 +69,7 @@ function waitForCondition(driver: WebDriver) {
 export async function testTextContains(driver: WebDriver, xpath: string, text: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testTextContains ${xpath} ${text}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await findByXPath(elem, xpath);
@@ -87,7 +87,7 @@ export async function testTextContains(driver: WebDriver, xpath: string, text: s
 export function testTextNotContained(driver: WebDriver, xpath: string, text: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testTextNotContained ${xpath} ${text}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await findByXPath(elem, xpath);
@@ -105,7 +105,7 @@ export function testTextNotContained(driver: WebDriver, xpath: string, text: str
 export function testClassContains(driver: WebDriver, xpath: string, text: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testClassContains ${xpath} ${text}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await findByXPath(elem, xpath);
@@ -123,7 +123,7 @@ export function testClassContains(driver: WebDriver, xpath: string, text: string
 export function testElementLocatedByXpath(driver: WebDriver, xpath: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testElementLocatedByXpath ${xpath}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await findByXPath(elem, xpath);
@@ -139,7 +139,7 @@ export function testElementLocatedByXpath(driver: WebDriver, xpath: string, time
 export function testElementNotLocatedByXPath(driver: WebDriver, xpath: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testElementNotLocatedByXPath ${xpath}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await findByXPath(elem, xpath);
@@ -155,7 +155,7 @@ export function testElementNotLocatedByXPath(driver: WebDriver, xpath: string, t
 export function testElementLocatedById(driver: WebDriver, id: string, timeout = config.TIMEOUT) {
   return waitForCondition(driver)(
     `testElementLocatedById ${id}`,
-    async function(driver) {
+    async function (driver) {
       try {
         let elem = await shadowRoot(driver);
         elem = await elem.findElement(By.id(id));
@@ -189,7 +189,7 @@ export function clickElementById(driver: WebDriver, id: string) {
 }
 
 export function clickElementByXPath(driver: WebDriver, xpath: string) {
-  return retry(5, driver, async function(driver, count) {
+  return retry(5, driver, async function (driver, count) {
     if (count>1 && config.LOG_DETAILS) console.log("clickElementByXPath ",xpath," attempt #",count);
     let elem = await shadowRoot(driver);
     elem = await findByXPath(elem, xpath);
@@ -200,7 +200,7 @@ export function clickElementByXPath(driver: WebDriver, xpath: string) {
 }
 
 export async function getTextByXPath(driver: WebDriver, xpath: string): Promise<string> {
-  return retry(5, driver, async function(driver, count) {
+  return retry(5, driver, async function (driver, count) {
     if (count>1 && config.LOG_DETAILS) console.log("getTextByXPath ",xpath," attempt #",count);
     let elem = await shadowRoot(driver);
     elem = await findByXPath(elem, xpath);

--- a/test/kitchen-sink/webpack.config.js
+++ b/test/kitchen-sink/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-const loadPostCssPlugins = function() {
+const loadPostCssPlugins = function () {
   return [
     require("autoprefixer")({ browsers: ["last 2 versions"] })
   ];
@@ -14,7 +14,7 @@ const load = {
   ts: { loader: "ts-loader" }
 };
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     target: 'web',

--- a/test/rainbow-spiral/webpack.config.js
+++ b/test/rainbow-spiral/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-module.exports = function() {
+module.exports = function () {
   return {
     target: 'web',
     mode: 'development',

--- a/test/realworld/webpack.config.js
+++ b/test/realworld/webpack.config.js
@@ -1,6 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = function(env, { mode }) {
+module.exports = function (env, { mode }) {
   const production = mode === 'production';
   return {
     mode: production ? 'production' : 'development',

--- a/test/sierpinski-triangle/webpack.config.js
+++ b/test/sierpinski-triangle/webpack.config.js
@@ -1,6 +1,6 @@
 const { resolve } = require('path');
 
-module.exports = function() {
+module.exports = function () {
   return {
     target: 'web',
     mode: 'development',

--- a/test/wdio/specs/examples.spec.js
+++ b/test/wdio/specs/examples.spec.js
@@ -1,8 +1,8 @@
 const { equal } = require('assert');
 
-describe('aurelia example', function() {
+describe('aurelia example', function () {
   this.timeout(20000);
-  it('should display "Hello World!"', function() {
+  it('should display "Hello World!"', function () {
     browser.url('/');
     console.log(`[browser logs]: ${JSON.stringify(browser.log('browser'), null, 2)}`);
     browser.waitForExist('app>div', 10000);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Require a space between `function` and the `()` with anonymous functions. And disallow the space with named functions.

Quoting @fkleuver:

> The idea is so that you don't need to add or remove spaces when switching between the two:
> ```js
> function () {}
> function foo() {}
> ```

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Switched on the rule and used the eslint `--fix` option to fix the codebase.

## 📑 Test Plan

CircleCI

## ⏭ Next Steps

n/a