### PR TITLE
fix(webpack-loader): canot use raw-loader on scss or less

### DIFF
--- a/packages/__tests__/webpack-loader/loader.spec.ts
+++ b/packages/__tests__/webpack-loader/loader.spec.ts
@@ -36,7 +36,7 @@ describe('webpack-loader', function () {
 
   it('transforms html file in shadowDOM mode', function (done) {
     const content = 'content';
-    const expected = 'processed {"mode":"open"} !!raw-loader!src/foo-bar.html content';
+    const expected = 'processed {"mode":"open"} src/foo-bar.html content';
 
     const context = {
       async: () => function (err, code, map) {

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -25,7 +25,7 @@ export function loader(
   try {
     const result = _preprocess(
       { path: filePath, contents },
-      preprocessOptions({ ...options, stringModuleWrap })
+      preprocessOptions(options || {})
     );
     // webpack uses source-map 0.6.1 typings for RawSourceMap which
     // contains typing error version: string (should be number).
@@ -40,8 +40,4 @@ export function loader(
   } catch (e) {
     cb(e);
   }
-}
-
-function stringModuleWrap(id: string) {
-  return `!!raw-loader!${id}`;
 }


### PR DESCRIPTION
For webpack, conditional loader (in webpack.config) is needed for shadow-dom css processing.

closes #776
