### PR TITLE
fix(repeat): initialize module-scoped index eagerly to fix reference error

### DIFF
--- a/packages/runtime/src/resources/custom-attributes/repeat.ts
+++ b/packages/runtime/src/resources/custom-attributes/repeat.ts
@@ -527,9 +527,9 @@ export class Repeat<C extends ObservedCollection = IObservedArray, T extends INo
   }
 }
 
-let prevIndices: Int32Array;
-let tailIndices: Int32Array;
-let maxLen = 0;
+let maxLen = 16;
+let prevIndices = new Int32Array(maxLen);
+let tailIndices = new Int32Array(maxLen);
 
 // Based on inferno's lis_algorithm @ https://github.com/infernojs/inferno/blob/master/packages/inferno/src/DOM/patching.ts#L732
 // with some tweaks to make it just a bit faster + account for IndexMap (and some names changes for readability)


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes a specific edge case where removing the only item of an array as the first array mutation for a repeater causes a ReferenceError due to module-scoped variable not yet being initialized. (the `if (len > maxLen)` logic that would initialize it, doesn't evaluate to true when the apparent initial length is 0)

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Pending e2e test for this scenario: https://github.com/aurelia/aurelia/issues/781
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Verified the fix locally. Needs e2e test to prevent future regression.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
