### PR TITLE
fix(container): ignore primitive values in register

### DIFF
--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -1006,6 +1006,43 @@ describe(`The Container class`, function () {
         `register.calls`,
       );
     });
+
+    describe(`does NOT throw when attempting to register primitive values`, function () {
+      for (const value of [
+        void 0,
+        null,
+        true,
+        false,
+        '',
+        'asdf',
+        NaN,
+        Infinity,
+        0,
+        42,
+        Symbol(),
+        Symbol('a'),
+      ]) {
+        it(`{foo:${String(value)}}`, function () {
+          const { sut } = setup();
+          sut.register({foo:value});
+        });
+
+        it(`{foo:{bar:${String(value)}}}`, function () {
+          const { sut } = setup();
+          sut.register({foo:{bar:value}});
+        });
+
+        it(`[${String(value)}]`, function () {
+          const { sut } = setup();
+          sut.register([value]);
+        });
+
+        it(`${String(value)}`, function () {
+          const { sut } = setup();
+          sut.register(value);
+        });
+      }
+    });
   });
 
   // describe(`registerResolver()`, function () {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -735,6 +735,9 @@ export class Container implements IContainer {
     let jj: number;
     for (let i = 0, ii = params.length; i < ii; ++i) {
       current = params[i];
+      if (typeof current !== 'object' && typeof current !== 'function' || current === null) {
+        continue;
+      }
       if (isRegistry(current)) {
         current.register(this);
       } else if (Protocol.resource.has(current)) {
@@ -756,6 +759,9 @@ export class Container implements IContainer {
         jj = keys.length;
         for (; j < jj; ++j) {
           value = current[keys[j]];
+          if (typeof value !== 'object' && typeof value !== 'function' || value === null) {
+            continue;
+          }
           // note: we could remove this if-branch and call this.register directly
           // - the extra check is just a perf tweak to create fewer unnecessary arrays by the spread operator
           if (isRegistry(value)) {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -5,7 +5,7 @@ import { PLATFORM } from './platform';
 import { Reporter } from './reporter';
 import { ResourceType, Protocol } from './resource';
 import { Metadata } from './metadata';
-import { isNumeric, isNativeFunction } from './functions';
+import { isNumeric, isNativeFunction, isObject } from './functions';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -735,7 +735,7 @@ export class Container implements IContainer {
     let jj: number;
     for (let i = 0, ii = params.length; i < ii; ++i) {
       current = params[i];
-      if (typeof current !== 'object' && typeof current !== 'function' || current === null) {
+      if (!isObject(current)) {
         continue;
       }
       if (isRegistry(current)) {
@@ -759,7 +759,7 @@ export class Container implements IContainer {
         jj = keys.length;
         for (; j < jj; ++j) {
           value = current[keys[j]];
-          if (typeof value !== 'object' && typeof value !== 'function' || value === null) {
+          if (!isObject(value)) {
             continue;
           }
           // note: we could remove this if-branch and call this.register directly


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

When primitive values are passed into `register()` this may cause unpredictable results, such as `Metadata` throwing an error, even when the end user has no control over that (such as when passing in a synthetically created module object by a bundler).

This PR causes the DI container to simply ignore those invalid values. I chose to do this in the top-level registration loop (as opposed to only in the inner `Object.keys` loop) so as to also make the container a bit more forgiving when passing in an array of registrations where one or more values is invalid. Being the most front-facing surface api, it should probably be forgiving in these scenarios.

We may want to let the reporter log a warning in this case in the future for good measure.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

Added tests for all primitive values shapes in the different ways they can be passed in

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
