### PR TITLE
Fix arr index observation

### DIFF
--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -902,14 +902,14 @@ describe('AccessKeyedExpression', function () {
     assert.strictEqual(binding.calls.length, 2, 'binding.calls.length');
   });
 
-  it('does not observe property in keyed array access when key is number', function () {
+  it('observes property in keyed array access when key is number', function () {
     const scope = createScopeForTest({ foo: ['hello world'] });
     const expression3 = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), new PrimitiveLiteralExpression(0));
     assert.strictEqual(expression3.evaluate(LF.none, scope, null), 'hello world', `expression3.evaluate(LF.none, scope, null)`);
     const binding = new MockBinding();
     expression3.connect(LF.none, scope, binding);
     assert.deepStrictEqual(binding.calls[0], ['observeProperty', LF.none, scope.bindingContext, 'foo'], 'binding.calls[0]');
-    assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
+    assert.strictEqual(binding.calls.length, 2, 'binding.calls.length');
   });
 
   describe('does not attempt to observe property when object is primitive', function () {

--- a/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
@@ -1,0 +1,41 @@
+import { TestContext, assert } from '@aurelia/testing';
+import { IInputElement, ValueAttributeObserver } from '@aurelia/runtime-html';
+import { LifecycleFlags, ArrayIndexObserver, ISubscriber } from '@aurelia/runtime';
+
+describe('3-runtime-html/array-index-observer.spec.ts', function() {
+  it('observer array index correctly', function() {
+    const { observerLocator } = createFixture();
+    const arr = [1, 2, 3];
+    const index_0_observer = observerLocator.getObserver(LifecycleFlags.none, arr, '0') as ArrayIndexObserver;
+    
+    let callcount = 0;
+    const index_0_subscriber: ISubscriber = {
+      handleChange() {
+        callcount++;
+      }
+    }
+    index_0_observer.subscribe(index_0_subscriber);
+    assert.instanceOf(index_0_observer, ArrayIndexObserver);
+    arr[0] = 5;
+    assert.strictEqual(index_0_observer.currentValue, 1);
+    arr.splice(0, 1, 4);
+    assert.strictEqual(index_0_observer.currentValue, 4);
+    assert.strictEqual(callcount, 1);
+
+    index_0_observer.setValue(0, LifecycleFlags.none);
+    assert.strictEqual(callcount, 2);
+    assert.strictEqual(arr[0], 0);
+  });
+
+  function createFixture() {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator, scheduler } = ctx;
+    const el = ctx.createElementFromMarkup(`<input />`) as IInputElement;
+    ctx.doc.body.appendChild(el);
+
+    const sut = ctx.observerLocator.getObserver(LifecycleFlags.none, el, 'value') as ValueAttributeObserver;
+    ctx.observerLocator.getObserver(LifecycleFlags.none, el, 'value');
+
+    return { ctx, container, lifecycle, observerLocator, el, sut, scheduler };
+  }
+});

--- a/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
@@ -2,27 +2,27 @@ import { TestContext, assert } from '@aurelia/testing';
 import { IInputElement, ValueAttributeObserver } from '@aurelia/runtime-html';
 import { LifecycleFlags, ArrayIndexObserver, ISubscriber } from '@aurelia/runtime';
 
-describe('3-runtime-html/array-index-observer.spec.ts', function() {
-  it('observer array index correctly', function() {
+describe('3-runtime-html/array-index-observer.spec.ts', function () {
+  it('observer array index correctly', function () {
     const { observerLocator } = createFixture();
     const arr = [1, 2, 3];
-    const index_0_observer = observerLocator.getObserver(LifecycleFlags.none, arr, '0') as ArrayIndexObserver;
-    
+    const indexZeroObserver = observerLocator.getObserver(LifecycleFlags.none, arr, '0') as ArrayIndexObserver;
+
     let callcount = 0;
-    const index_0_subscriber: ISubscriber = {
+    const indexZeroSubscriber: ISubscriber = {
       handleChange() {
         callcount++;
       }
-    }
-    index_0_observer.subscribe(index_0_subscriber);
-    assert.instanceOf(index_0_observer, ArrayIndexObserver);
+    };
+    indexZeroObserver.subscribe(indexZeroSubscriber);
+    assert.instanceOf(indexZeroObserver, ArrayIndexObserver);
     arr[0] = 5;
-    assert.strictEqual(index_0_observer.currentValue, 1);
+    assert.strictEqual(indexZeroObserver.currentValue, 1);
     arr.splice(0, 1, 4);
-    assert.strictEqual(index_0_observer.currentValue, 4);
+    assert.strictEqual(indexZeroObserver.currentValue, 4);
     assert.strictEqual(callcount, 1);
 
-    index_0_observer.setValue(0, LifecycleFlags.none);
+    indexZeroObserver.setValue(0, LifecycleFlags.none);
     assert.strictEqual(callcount, 2);
     assert.strictEqual(arr[0], 0);
   });

--- a/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
@@ -15,7 +15,7 @@ describe('3-runtime-html/array-index-observer.spec.ts', function () {
       }
     };
     indexZeroObserver.subscribe(indexZeroSubscriber);
-    assert.instanceOf(indexZeroObserver, ArrayIndexObserver);
+    assert.strictEqual(indexZeroObserver instanceof ArrayIndexObserver, true, 'index zero observer is ArrayIndexObserver');
     arr[0] = 5;
     assert.strictEqual(indexZeroObserver.currentValue, 1);
     arr.splice(0, 1, 4);

--- a/packages/__tests__/5-jit-html/array-index-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/array-index-observer.spec.ts
@@ -1,14 +1,8 @@
 import {
-  IObserverLocator,
   IScheduler,
-  LifecycleFlags,
   CustomElement,
   Aurelia,
   BindingStrategy,
-  GetterObserver,
-  SetterObserver,
-  MapObserver,
-  CustomSetterObserver,
   IDirtyChecker
 } from '@aurelia/runtime';
 import {
@@ -173,28 +167,5 @@ describe('simple Computed Observer test case', function () {
         testHost.remove();
       }
     };
-  }
-
-  class Property {
-    private _value: string;
-    public readonly valueChanged: any;
-
-    public constructor(public readonly name: string, value: string) {
-      this._value = value;
-      this.valueChanged = {
-        publish: () => {
-          // todo
-        }
-      };
-    }
-
-    public get value(): string {
-      return this._value;
-    }
-
-    public set value(value: string) {
-      this._value = value;
-      this.valueChanged.publish();
-    }
   }
 });

--- a/packages/__tests__/5-jit-html/array-index-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/array-index-observer.spec.ts
@@ -75,6 +75,50 @@ describe('simple Computed Observer test case', function () {
       }
     },
     {
+      title: 'works in checkbox scenario',
+      template: '<input type="checkbox" checked.bind="itemNames[0]" >',
+      ViewModel: TestClass,
+      assertFn: (ctx, host, component) => {
+        const inputEl = host.querySelector('input');
+        // only care about true boolean
+        assert.strictEqual(inputEl.checked, false);
+
+        component.itemNames.splice(0, 1, true as any);
+        ctx.container.get(IScheduler).getRenderTaskQueue().flush();
+        assert.strictEqual(inputEl.checked, true, 'should have been checked');
+
+        inputEl.checked = false;
+        inputEl.dispatchEvent(new ctx.CustomEvent('change'));
+
+        assert.strictEqual(component.itemNames[0], false);
+
+        const dirtyChecker = ctx.container.get(IDirtyChecker) as any;
+        assert.strictEqual(dirtyChecker['tracked'].length, 0);
+      }
+    },
+    {
+      title: 'works in select scenario',
+      template:
+        `<select value.bind="itemNames[0]">
+          <option repeat.for="item of items">\${item.name}
+        `,
+      ViewModel: TestClass,
+      assertFn: (ctx, host, component) => {
+        const selectEl = host.querySelector('select');
+        assert.strictEqual(selectEl.value, 'i-0');
+        assert.strictEqual(selectEl.options[0].selected, true);
+
+        selectEl.options[1].selected = true;
+        selectEl.dispatchEvent(new ctx.CustomEvent('change'));
+        assert.strictEqual(component.itemNames[0], 'i-1');
+
+        component.itemNames.splice(0, 1, 'i-2');
+        assert.strictEqual(selectEl.value, 'i-1');
+        ctx.container.get(IScheduler).getRenderTaskQueue().flush();
+        assert.strictEqual(selectEl.value, 'i-2');
+      }
+    },
+    {
       title: 'works in repeat scenario',
       template:
         `<input

--- a/packages/__tests__/5-jit-html/array-index-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/array-index-observer.spec.ts
@@ -49,7 +49,6 @@ describe('simple Computed Observer test case', function () {
     isDone?: boolean;
   }
 
-  
   class TestClass implements IApp {
     public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
       return { name: `i-${idx}`, value: idx + 1 };
@@ -110,7 +109,7 @@ describe('simple Computed Observer test case', function () {
     },
     {
       title: 'works in basic one way scenario without dirty checking',
-      template: '${itemNames[0]}',
+      template: `\${itemNames[0]}`,
       ViewModel: TestClass,
       assertFn: (ctx, host, component) => {
         assert.html.textContent(host, 'i-0');

--- a/packages/__tests__/5-jit-html/array-index-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/array-index-observer.spec.ts
@@ -1,0 +1,193 @@
+import {
+  IObserverLocator,
+  IScheduler,
+  LifecycleFlags,
+  CustomElement,
+  Aurelia,
+  BindingStrategy,
+  GetterObserver,
+  SetterObserver,
+  MapObserver,
+  CustomSetterObserver,
+  IDirtyChecker
+} from '@aurelia/runtime';
+import {
+  Constructable
+} from '@aurelia/kernel';
+import {
+  TestContext,
+  assert,
+  eachCartesianJoin,
+  HTMLTestContext
+} from '@aurelia/testing';
+
+describe('simple Computed Observer test case', function () {
+
+  interface IArrayIndexObserverTestCase<T extends IApp = IApp> {
+    title: string;
+    template: string;
+    ViewModel?: Constructable<T>;
+    assertFn: AssertionFn;
+    only?: boolean;
+  }
+
+  interface AssertionFn<T extends IApp = IApp> {
+    // eslint-disable-next-line @typescript-eslint/prefer-function-type
+    (ctx: HTMLTestContext, testHost: HTMLElement, component: T): void | Promise<void>;
+  }
+
+  interface IApp {
+    [key: string]: any;
+    items: IAppItem[];
+    itemNames: string[];
+    readonly total: number;
+  }
+
+  interface IAppItem {
+    name: string;
+    value: number;
+    isDone?: boolean;
+  }
+
+  const computedObserverTestCases: IArrayIndexObserverTestCase[] = [
+    {
+      title: 'works in basic scenario',
+      template: `<input value.bind="itemNames[0]" input.trigger="items[0].name = $event.target.value" />`,
+      ViewModel: class TestClass implements IApp {
+        public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
+          return { name: `i-${idx}`, value: idx + 1 };
+        });
+
+        public itemNames: string[] = this.items.map(i => i.name);
+
+        public get total(): number {
+          return this.items.reduce((total, item) => total + (item.value > 5 ? item.value : 0), 0);
+        }
+      },
+      assertFn: (ctx, host, component) => {
+        const inputEl = host.querySelector('input');
+        assert.html.value(inputEl, 'i-0');
+
+        inputEl.value = '00';
+        inputEl.dispatchEvent(new ctx.CustomEvent('input'));
+
+        assert.strictEqual(component.itemNames[0], '00');
+        assert.strictEqual(component.items[0].name, '00');
+
+        const dirtyChecker = ctx.container.get(IDirtyChecker) as any;
+        assert.strictEqual(dirtyChecker['tracked'].length, 0);
+      }
+    },
+    {
+      title: 'works in repeat scenario',
+      template:
+        `<input
+          repeat.for="itemName of itemNames"
+          value.bind="itemNames[$index]"
+          input.trigger="items[$index].name = itemNames[$index]"
+        />`,
+      ViewModel: class TestClass implements IApp {
+        public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
+          return { name: `i-${idx}`, value: idx + 1 };
+        });
+
+        public itemNames: string[] = this.items.map(i => i.name);
+
+        public get total(): number {
+          return this.items.reduce((total, item) => total + (item.value > 5 ? item.value : 0), 0);
+        }
+      },
+      assertFn: (ctx, host, component) => {
+        const inputEls = host.querySelectorAll('input');
+
+        inputEls.forEach((inputEl, idx) => {
+          assert.html.value(inputEl, `i-${idx}`);
+
+          const newValue = `00-${idx}`;
+          inputEl.value = newValue;
+          inputEl.dispatchEvent(new ctx.CustomEvent('input'));
+
+          assert.strictEqual(component.itemNames[idx], newValue);
+          assert.strictEqual(component.items[idx].name, newValue);
+        });
+
+        const dirtyChecker = ctx.container.get(IDirtyChecker) as any;
+        assert.strictEqual(dirtyChecker['tracked'].length, 0);
+      }
+    },
+  ];
+
+  eachCartesianJoin(
+    [computedObserverTestCases],
+    ({ only, title, template, ViewModel, assertFn }: IArrayIndexObserverTestCase) => {
+      // eslint-disable-next-line mocha/no-exclusive-tests
+      const $it = (title_: string, fn: Mocha.Func) => only ? it.only(title_, fn) : it(title_, fn);
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      $it(title, async function () {
+        const { ctx, component, testHost, tearDown } = await createFixture<any>(
+          template,
+          ViewModel
+        );
+        await assertFn(ctx, testHost, component);
+        // test cases could be sharing the same context document
+        // so wait a bit before running the next test
+        await tearDown();
+
+        assert.isSchedulerEmpty();
+      });
+    }
+  );
+
+  async function createFixture<T>(template: string | Node, $class: Constructable | null, ...registrations: any[]) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, lifecycle, observerLocator } = ctx;
+    registrations = Array.from(new Set([...registrations]));
+    container.register(...registrations);
+    const testHost = ctx.doc.body.appendChild(ctx.createElement('div'));
+    const appHost = testHost.appendChild(ctx.createElement('app'));
+    const au = new Aurelia(container);
+    const App = CustomElement.define({ name: 'app', template, strategy: BindingStrategy.proxies }, $class);
+    const component = new App();
+
+    au.app({ host: appHost, component });
+    await au.start().wait();
+
+    return {
+      ctx: ctx,
+      au,
+      container,
+      lifecycle,
+      testHost: testHost,
+      appHost,
+      component: component as T,
+      observerLocator,
+      tearDown: async () => {
+        await au.stop().wait();
+        testHost.remove();
+      }
+    };
+  }
+
+  class Property {
+    private _value: string;
+    public readonly valueChanged: any;
+
+    public constructor(public readonly name: string, value: string) {
+      this._value = value;
+      this.valueChanged = {
+        publish: () => {
+          // todo
+        }
+      };
+    }
+
+    public get value(): string {
+      return this._value;
+    }
+
+    public set value(value: string) {
+      this._value = value;
+      this.valueChanged.publish();
+    }
+  }
+});

--- a/packages/__tests__/5-jit-html/computed-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/computed-observer.spec.ts
@@ -243,7 +243,7 @@ describe('simple Computed Observer test case', function () {
         public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
           return { name: `i-${idx}`, value: idx + 1, isDone: idx % 2 === 0 };
         });
-    
+
         public get total(): number {
           return this.items[0].value;
         }

--- a/packages/__tests__/5-jit-html/computed-observer.spec.ts
+++ b/packages/__tests__/5-jit-html/computed-observer.spec.ts
@@ -8,7 +8,8 @@ import {
   GetterObserver,
   SetterObserver,
   MapObserver,
-  CustomSetterObserver
+  CustomSetterObserver,
+  IDirtyChecker
 } from '@aurelia/runtime';
 import {
   Constructable
@@ -233,6 +234,28 @@ describe('simple Computed Observer test case', function () {
         assert.strictEqual(host.textContent, '30');
         ctx.container.get(IScheduler).getRenderTaskQueue().flush();
         assert.strictEqual(host.textContent, '31');
+      }
+    },
+    {
+      title: 'works with array index',
+      template: `\${total}`,
+      ViewModel: class AppBase implements IApp {
+        public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
+          return { name: `i-${idx}`, value: idx + 1, isDone: idx % 2 === 0 };
+        });
+    
+        public get total(): number {
+          return this.items[0].value;
+        }
+      },
+      assertFn: (ctx, host, component) => {
+        const dirtyChecker = ctx.container.get(IDirtyChecker) as any;
+        assert.strictEqual((dirtyChecker.tracked as any[]).length, 0, 'Should have had no dirty checking');
+        assert.html.textContent(host, '1');
+        component.items.splice(0, 1, { name: 'mock', value: 1000 });
+        assert.html.textContent(host, '1');
+        ctx.container.get(IScheduler).getRenderTaskQueue().flush();
+        assert.html.textContent(host, '1000');
       }
     },
     {

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -272,7 +272,7 @@ export {
   EventAggregatorCallback,
   IEventAggregator,
 
-  isNumeric,
+  isArrayIndex,
   camelCase,
   kebabCase,
   pascalCase,

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -5,7 +5,7 @@ import { PLATFORM } from './platform';
 import { Reporter } from './reporter';
 import { ResourceType, Protocol } from './resource';
 import { Metadata } from './metadata';
-import { isNumeric, isNativeFunction, isObject } from './functions';
+import { isArrayIndex, isNativeFunction, isObject } from './functions';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -99,7 +99,7 @@ function cloneArrayWithPossibleProps<T>(source: readonly T[]): T[] {
   let key: string;
   for (let i = 0; i < len; ++i) {
     key = keys[i];
-    if (!isNumeric(key)) {
+    if (!isArrayIndex(key)) {
       clone[key] = source[key];
     }
   }
@@ -190,7 +190,7 @@ export class DI {
           let key: string;
           for (let i = 0; i < len; ++i) {
             key = keys[i];
-            if (!isNumeric(key)) {
+            if (!isArrayIndex(key)) {
               dependencies[key] = annotationParamtypes[key];
             }
           }

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -29,7 +29,7 @@ export function isArrayIndex(value: unknown): value is number | string {
       let ch = 0;
       for (let i = 0; i < length; ++i) {
         ch = value.charCodeAt(i);
-        if (i === 0 && ch === 0x30 /* must not start with 0 */ || ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
+        if (i === 0 && ch === 0x30 && length > 1 /* must not start with 0 */ || ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
           return isNumericLookup[value] = false;
         }
       }

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -13,23 +13,23 @@ const isNumericLookup: Record<string, boolean> = {};
  *
  * Results are cached.
  */
-export function isNumeric(value: unknown): value is number | string {
+export function isArrayIndex(value: unknown): value is number | string {
   switch (typeof value) {
     case 'number':
-      return true;
+      return value >= 0 && (value | 0) === value;
     case 'string': {
       const result = isNumericLookup[value];
       if (result !== void 0) {
         return result;
       }
-      const { length } = value;
+      const length = value.length;
       if (length === 0) {
         return isNumericLookup[value] = false;
       }
       let ch = 0;
       for (let i = 0; i < length; ++i) {
         ch = value.charCodeAt(i);
-        if (ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
+        if (i === 0 && ch === 0x30 /* must not start with 0 */ || ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
           return isNumericLookup[value] = false;
         }
       }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -115,7 +115,7 @@ export {
   IEventAggregator,
 } from './eventaggregator';
 export {
-  isNumeric,
+  isArrayIndex,
   camelCase,
   kebabCase,
   pascalCase,

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -75,7 +75,7 @@ export class CheckedObserver implements IAccessor {
   public flushChanges(flags: LifecycleFlags): void {
     if (this.hasChanges) {
       this.hasChanges = false;
-      const { currentValue } = this;
+      const currentValue = this.currentValue;
       this.oldValue = currentValue;
 
       if (this.valueObserver === void 0) {
@@ -135,7 +135,8 @@ export class CheckedObserver implements IAccessor {
   }
 
   public synchronizeElement(): void {
-    const { currentValue, obj } = this;
+    const currentValue = this.currentValue;
+    const obj = this.obj;
     const elementValue = Object.prototype.hasOwnProperty.call(obj, 'model') ? obj.model : obj.value;
     const isRadio = obj.type === 'radio';
     const matcher = obj.matcher !== void 0 ? obj.matcher : defaultMatcher;

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1,7 +1,6 @@
 import {
   IIndexable,
   IServiceLocator,
-  isNumeric,
   PLATFORM,
   Reporter,
   StrictPrimitive,

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -547,17 +547,8 @@ export class AccessKeyedExpression implements IAccessKeyedExpression {
     if (obj instanceof Object) {
       this.key.connect(flags, scope, binding, part);
       const key = this.key.evaluate(flags, scope, null, part);
-
-      if (Array.isArray(obj) && isNumeric(key)) {
-        // Only observe array indexers in proxy mode
-        if (flags & LifecycleFlags.proxyStrategy) {
-          binding.observeProperty(flags, obj, key as unknown as string);
-        }
-      } else {
-        // observe the property represented by the key as long as it's not an array indexer
-        // (note: string indexers behave the same way as numeric indexers as long as they represent numbers)
-        binding.observeProperty(flags, obj, key as string);
-      }
+      // (note: string indexers behave the same way as numeric indexers as long as they represent numbers)
+      binding.observeProperty(flags, obj, key as string);
     }
   }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -117,6 +117,7 @@ export {
 
 export {
   ArrayObserver,
+  ArrayIndexObserver,
   enableArrayObservation,
   disableArrayObservation,
   applyMutationsToIndices,
@@ -478,6 +479,7 @@ export {
   IBindingTargetObserver,
   ICollectionChangeTracker,
   ICollectionObserver,
+  ICollectionIndexObserver,
   ICollectionSubscriber,
   IndexMap,
   IObservable,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -290,6 +290,10 @@ export interface ICollectionSizeObserver extends IAccessor<number>, IPropertyCha
   currentValue: number;
 }
 
+export interface ICollectionIndexObserver extends ICollectionSubscriber, IPropertyObserver<IIndexable, string> {
+  owner: ICollectionObserver<CollectionKind.array>;
+}
+
 /**
  * Describes a type that specifically tracks changes in a collection (map, set or array)
  */
@@ -311,6 +315,7 @@ export interface ICollectionObserver<T extends CollectionKind> extends
   collection: ObservedCollectionKindToType<T>;
   lengthObserver: T extends CollectionKind.array ? ICollectionLengthObserver : ICollectionSizeObserver;
   getLengthObserver(): T extends CollectionKind.array ? ICollectionLengthObserver : ICollectionSizeObserver;
+  getIndexObserver(index: number): ICollectionIndexObserver;
   notify(): void;
 }
 export type CollectionObserver = ICollectionObserver<CollectionKind>;

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -388,7 +388,7 @@ export interface ArrayObserver extends ICollectionObserver<CollectionKind.array>
 export class ArrayObserver {
   public inBatch: boolean;
 
-  private indexObservers: Record<string | number, ArrayIndexObserver | undefined>;
+  private readonly indexObservers: Record<string | number, ArrayIndexObserver | undefined>;
 
   public constructor(flags: LifecycleFlags, lifecycle: ILifecycle, array: IObservedArray) {
 
@@ -509,13 +509,13 @@ export class ArrayIndexObserver implements ICollectionIndexObserver {
     }
   }
 
-  public subscribe(subscriber: ISubscriber<unknown>): void {
+  public subscribe(subscriber: ISubscriber): void {
     if (this.addSubscriber(subscriber) && ++this.subscriberCount === 1) {
       this.owner.addIndexObserver(this);
     }
   }
 
-  public unsubscribe(subscriber: ISubscriber<unknown>): void {
+  public unsubscribe(subscriber: ISubscriber): void {
     if (this.removeSubscriber(subscriber) && --this.subscriberCount === 0) {
       this.owner.removeIndexObserver(this);
     }

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -485,11 +485,23 @@ export class ArrayIndexObserver implements ICollectionIndexObserver {
   }
 
   public getValue(): unknown {
-    return (this.owner.collection as IObservedArray)[this.index];
+    return this.owner.collection[this.index];
   }
 
   public setValue(newValue: unknown, flags: LifecycleFlags): void {
-    (this.owner.collection as IObservedArray).splice(this.index, 1, newValue);
+    if (newValue === this.getValue()) {
+      return;
+    }
+    const arrayObserver = this.owner;
+    const index = this.index;
+    const indexMap = arrayObserver.indexMap;
+
+    if (indexMap[index] > -1) {
+      indexMap.deletedItems.push(indexMap[index]);
+    }
+    indexMap[index] = -2;
+    this.currentValue = arrayObserver.collection[index] = newValue;
+    arrayObserver.notify();
   }
 
   /**

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -500,7 +500,9 @@ export class ArrayIndexObserver implements ICollectionIndexObserver {
       indexMap.deletedItems.push(indexMap[index]);
     }
     indexMap[index] = -2;
-    this.currentValue = arrayObserver.collection[index] = newValue;
+    // do not need to update current value here
+    // as it will be updated inside handle collection change
+    arrayObserver.collection[index] = newValue;
     arrayObserver.notify();
   }
 

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -4,7 +4,7 @@ import {
   IIndexable,
   PLATFORM,
   Reporter,
-  isNumeric
+  isArrayIndex
 } from '@aurelia/kernel';
 import { LifecycleFlags } from '../flags';
 import { ILifecycle } from '../lifecycle';
@@ -264,7 +264,7 @@ function createGetterTraps(flags: LifecycleFlags, observerLocator: IObserverLoca
       // (for Map and Set at least) or they will throw.
       switch (toStringTag.call(target)) {
         case '[object Array]':
-          if (key === 'length' || isNumeric(key)) {
+          if (key === 'length' || isArrayIndex(key)) {
             observer.addCollectionDep(observerLocator.getArrayObserver(flags, target as unknown[]));
             return proxyOrValue(flags, target, key, observerLocator, observer);
           }

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -4,7 +4,8 @@ import {
   CollectionKind,
   createIndexMap,
   ICollectionObserver,
-  IObservedMap
+  IObservedMap,
+  ICollectionIndexObserver
 } from '../observation';
 import { CollectionSizeObserver } from './collection-size-observer';
 import { collectionSubscriberCollection } from './subscriber-collection';
@@ -190,6 +191,10 @@ export class MapObserver {
       this.lengthObserver = new CollectionSizeObserver(this.collection);
     }
     return this.lengthObserver;
+  }
+
+  public getIndexObserver(index: number): ICollectionIndexObserver {
+    throw new Error('Map index observation not supported');
   }
 
   public flushBatch(flags: LifecycleFlags): void {

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -5,7 +5,7 @@ import {
   Primitive,
   Registration,
   Reporter,
-  isNumeric,
+  isArrayIndex,
 } from '@aurelia/kernel';
 import { LifecycleFlags } from '../flags';
 import { ILifecycle } from '../lifecycle';
@@ -211,12 +211,8 @@ export class ObserverLocator implements IObserverLocator {
           return this.getArrayObserver(flags, obj as IObservedArray).getLengthObserver();
         }
         // is numer only returns true for integer
-        if (isNumeric(propertyName)) {
-          const index = parseInt(propertyName, 10);
-          // anything that is not integer will be treated like normal obj property
-          if (index.toString() === propertyName.toString()) {
-            return this.getArrayObserver(flags, obj as IObservedArray).getIndexObserver(index);
-          }
+        if (isArrayIndex(propertyName)) {
+          return this.getArrayObserver(flags, obj as IObservedArray).getIndexObserver(Number(propertyName));
         }
         break;
       case '[object Map]':

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -210,8 +210,13 @@ export class ObserverLocator implements IObserverLocator {
         if (propertyName === 'length') {
           return this.getArrayObserver(flags, obj as IObservedArray).getLengthObserver();
         }
+        // is numer only returns true for integer
         if (isNumeric(propertyName)) {
-          return this.dirtyChecker.createProperty(obj, propertyName);
+          const index = parseInt(propertyName, 10);
+          // anything that is not integer will be treated like normal obj property
+          if (index.toString() === propertyName) {
+            return this.getArrayObserver(flags, obj as IObservedArray).getIndexObserver(index);
+          }
         }
         break;
       case '[object Map]':

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -214,7 +214,7 @@ export class ObserverLocator implements IObserverLocator {
         if (isNumeric(propertyName)) {
           const index = parseInt(propertyName, 10);
           // anything that is not integer will be treated like normal obj property
-          if (index.toString() === propertyName) {
+          if (index.toString() === propertyName.toString()) {
             return this.getArrayObserver(flags, obj as IObservedArray).getIndexObserver(index);
           }
         }

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -1,6 +1,6 @@
 import { LifecycleFlags } from '../flags';
 import { ILifecycle } from '../lifecycle';
-import { CollectionKind, createIndexMap, ICollectionObserver, IObservedSet } from '../observation';
+import { CollectionKind, createIndexMap, ICollectionObserver, IObservedSet, ICollectionIndexObserver } from '../observation';
 import { CollectionSizeObserver } from './collection-size-observer';
 import { collectionSubscriberCollection } from './subscriber-collection';
 
@@ -172,6 +172,10 @@ export class SetObserver {
       this.lengthObserver = new CollectionSizeObserver(this.collection);
     }
     return this.lengthObserver;
+  }
+
+  public getIndexObserver(index: number): ICollectionIndexObserver {
+    throw new Error('Set index observation not supported');
   }
 
   public flushBatch(flags: LifecycleFlags): void {

--- a/packages/testing/src/inspect.ts
+++ b/packages/testing/src/inspect.ts
@@ -31,7 +31,7 @@ import {
 } from '@aurelia/jit';
 import {
   Constructable,
-  isNumeric,
+  isArrayIndex,
   Primitive,
 } from '@aurelia/kernel';
 import {
@@ -1066,7 +1066,7 @@ export function formatSpecialArray(
       break;
     }
     if (`${index}` !== key) {
-      if (!isNumeric(key)) {
+      if (!isArrayIndex(key)) {
         break;
       }
       const emptyItems = tmp - index;

--- a/packages/testing/src/util.ts
+++ b/packages/testing/src/util.ts
@@ -24,7 +24,7 @@
  */
 
 import {
-  isNumeric,
+  isArrayIndex,
   PLATFORM,
   Primitive,
 } from '@aurelia/kernel';
@@ -269,9 +269,9 @@ export function getOwnNonIndexProperties(
   showHidden: boolean,
 ): string[] {
   if (showHidden) {
-    return getOwnPropertyNames(val).filter(k => !isNumeric(k));
+    return getOwnPropertyNames(val).filter(k => !isArrayIndex(k));
   } else {
-    return Object_keys(val).filter(k => !isNumeric(k));
+    return Object_keys(val).filter(k => !isArrayIndex(k));
   }
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add ability to observe array index

### 🎫 Issues

Supports the scenario described at https://github.com/aurelia/binding/issues/444
with slightly modified templating syntax

Instead of
```html
  <ul>
    <li repeat.for="item of items">${item}</li>
  </ul>

  <p repeat.for="item of items">
    <input value.two-way="item"
  </p>
```
It can work with:
```html
  <ul>
    <li repeat.for="item of items">${item}</li>
  </ul>

  <p repeat.for="item of items">
    <input value.two-way="items[$index]"
  </p>
```

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ⏭ Next Steps

N/A