### PR TITLE
disable two counter-productive lint rules + update extensions.json

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
     'import/no-unassigned-import': 'error',
     'import/no-useless-path-segments': ['error'],
     'import/order': ['error', { 'groups': [], 'newlines-between': 'ignore' }],
-    'import/no-deprecated': 'error',
+    'import/no-deprecated': 'off', // this rule is extremely slow (takes 95% of the time of the full lint operation) so we disable it for that reason only
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-indentation': 'error',
     'jsdoc/check-tag-names': ['error', {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
   rules: {
     // Opinionated overrides of the default recommended rules:
     '@typescript-eslint/ban-ts-ignore': 'warn',
-    '@typescript-eslint/indent': ['error', 2],
+    '@typescript-eslint/indent': 'off', // Disabled until typescript-eslint properly fixes indentation (see https://github.com/typescript-eslint/typescript-eslint/issues/1232) - there are recurring issues and breaking changes, and this rule usually isn't violated due to autoformatting anyway.
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-empty-interface': 'off',

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens"
+  ]
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- `import/no-deprecated` turns out to be among the primary causes for eslint to be slow in our repository, so we're disabling it:
![image](https://user-images.githubusercontent.com/9655331/71647985-88672d80-2cfe-11ea-8be0-431cc334692c.png)

- `@typescript-eslint/indent` has recurring issues, in particular with parameter decorators (see https://github.com/typescript-eslint/typescript-eslint/issues/1232). There seems to be no indicator of anyone being invested in fixing that anytime soon. Since indentation is not much of a problem in our repo with all the autofixing available in-editor, I'm disabling this rule for now.

- Also adding back in `extensions.json` to make clearer to contributors which extensions they will probably want to install when working on the repo.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
