### PR TITLE
feat(custom-attr): add no multi bindings cfg

### DIFF
--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -8,6 +8,7 @@ import {
 import { assert, eachCartesianJoin, createFixture } from '@aurelia/testing';
 
 describe('custom-attributes', function () {
+  this.afterEach(assert.isSchedulerEmpty);
   // custom elements
   describe('01. Aliases', function () {
 
@@ -209,6 +210,26 @@ describe('custom-attributes', function () {
       const options = createFixture('<template> <div multi2.bind="value">Initial</div> </template>', app, [Multi2]);
       assert.strictEqual(options.appHost.firstElementChild.textContent, 'a: undefined, b: afterBind');
       await options.tearDown();
+    });
+
+    describe('with noMultiBindings: true', function () {
+      @customAttribute({
+        name: 'multi3',
+        noMultiBindings: true,
+      })
+      class Multi3 extends Multi2 {}
+      it('works with multi binding syntax', async function () {
+
+        const options = createFixture('<template> <div multi3="a.bind: 5; b.bind: 6">Initial</div> </template>', app, [Multi3]);
+        assert.strictEqual(options.appHost.firstElementChild.textContent, 'a: undefined, b: a.bind: 5; b.bind: 6');
+        await options.tearDown();
+      });
+
+      it('works with URL value', async function () {
+        const options = createFixture('<template> <div multi3="http://google.com">Initial</div> </template>', app, [Multi3]);
+        assert.strictEqual(options.appHost.firstElementChild.textContent, 'a: undefined, b: http://google.com');
+        await options.tearDown();
+      });
     });
   });
 
@@ -454,7 +475,6 @@ describe('custom-attributes', function () {
   });
 
   describe('05. with setter/getter', function () {
-    this.afterEach(assert.isSchedulerEmpty);
 
     /**
      * Specs:

--- a/packages/__tests__/5-jit-html/custom-attributes.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-attributes.spec.ts
@@ -230,6 +230,12 @@ describe('custom-attributes', function () {
         assert.strictEqual(options.appHost.firstElementChild.textContent, 'a: undefined, b: http://google.com');
         await options.tearDown();
       });
+
+      it('works with escaped colon', async function () {
+        const options = createFixture('<template> <div multi3="http\\://google.com">Initial</div> </template>', app, [Multi3]);
+        assert.strictEqual(options.appHost.firstElementChild.textContent, 'a: undefined, b: http\\://google.com');
+        await options.tearDown();
+      });
     });
   });
 

--- a/packages/jit-html/src/template-binder.ts
+++ b/packages/jit-html/src/template-binder.ts
@@ -535,7 +535,7 @@ export class TemplateBinder {
     const attrRawValue = attrSyntax.rawValue;
     const command = this.resources.getBindingCommand(attrSyntax, false);
     // multi-bindings logic here is similar to (and explained in) bindCustomAttribute
-    const isMultiBindings = command === null && hasInlineBindings(attrRawValue);
+    const isMultiBindings = attrInfo.noMultiBindings === false && command === null && hasInlineBindings(attrRawValue);
 
     if (isMultiBindings) {
       symbol = new TemplateControllerSymbol(this.dom, attrSyntax, attrInfo, partName);
@@ -561,11 +561,12 @@ export class TemplateBinder {
     // Custom attributes are always in multiple binding mode,
     // except when they can't be
     // When they cannot be:
+    //        * has explicit configuration noMultiBindings: false
     //        * has binding command, ie: <div my-attr.bind="...">.
     //          In this scenario, the value of the custom attributes is required to be a valid expression
     //        * has no colon: ie: <div my-attr="abcd">
     //          In this scenario, it's simply invalid syntax. Consider style attribute rule-value pair: <div style="rule: ruleValue">
-    const isMultiBindings = command === null && hasInlineBindings(attrRawValue);
+    const isMultiBindings = attrInfo.noMultiBindings === false && command === null && hasInlineBindings(attrRawValue);
 
     if (isMultiBindings) {
       // a multiple-bindings attribute usage (semicolon separated binding) is only valid without a binding command;

--- a/packages/jit/src/resource-model.ts
+++ b/packages/jit/src/resource-model.ts
@@ -117,10 +117,11 @@ export class AttrInfo {
   public constructor(
     public name: string,
     public isTemplateController: boolean,
+    public noMultiBindings: boolean,
   ) {}
 
   public static from(def: CustomAttributeDefinition): AttrInfo {
-    const info = new AttrInfo(def.name, def.isTemplateController);
+    const info = new AttrInfo(def.name, def.isTemplateController, def.noMultiBindings);
     const bindables = def.bindables;
     const defaultBindingMode = def.defaultBindingMode !== void 0 && def.defaultBindingMode !== BindingMode.default
       ? def.defaultBindingMode

--- a/packages/runtime/src/resources/custom-attribute.ts
+++ b/packages/runtime/src/resources/custom-attribute.ts
@@ -33,6 +33,20 @@ export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
   readonly bindables?: Record<string, PartialBindableDefinition> | readonly string[];
   readonly strategy?: BindingStrategy;
   readonly hooks?: HooksDefinition;
+  /**
+   * A config that can be used by template compliler to change attr value parsing mode
+   * `true` to always parse as a single value, mostly will be string in URL scenario
+   * Example:
+   * ```html
+   * <div goto="http://bla.bla.com">
+   * ```
+   * With `noMultiBinding: true`, user does not need to escape the `:` with `\`
+   * or use binding command to escape it.
+   *
+   * With `noMultiBinding: false (default)`, the above will be parsed as it's binding
+   * to a property name `http`, with value equal to literal string `//bla.bla.com`
+   */
+  readonly noMultiBindings?: boolean;
 }>;
 
 export type CustomAttributeType<T extends Constructable = Constructable> = ResourceType<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition>;
@@ -91,6 +105,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
     public readonly bindables: Record<string, BindableDefinition>,
     public readonly strategy: BindingStrategy,
     public readonly hooks: HooksDefinition,
+    public readonly noMultiBindings: boolean,
   ) {}
 
   public static create<T extends Constructable = Constructable>(
@@ -118,6 +133,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
       Bindable.from(...Bindable.getAll(Type), CustomAttribute.getAnnotation(Type, 'bindables'), Type.bindables, def.bindables),
       firstDefined(CustomAttribute.getAnnotation(Type, 'strategy'), def.strategy, Type.strategy, BindingStrategy.getterSetter),
       firstDefined(CustomAttribute.getAnnotation(Type, 'hooks'), def.hooks, Type.hooks, new HooksDefinition(Type.prototype)),
+      firstDefined(CustomAttribute.getAnnotation(Type, 'noMultiBindings'), def.noMultiBindings, Type.noMultiBindings, false),
     );
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add a new config for custom attribute to have ability to always parse their value as single binding. An example for this would be `goto` attribute:
```html
<a goto="http://outside.com"></a>
```

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ⏭ Next Steps

Plan to spec dynamic options properly to complete custom attribute features