### PR TITLE
fix(bindable-observer): reverse set interceptor

### DIFF
--- a/packages/__tests__/5-jit-html/custom-elements.spec.ts
+++ b/packages/__tests__/5-jit-html/custom-elements.spec.ts
@@ -13,7 +13,7 @@ import { InterceptorFunc } from '@aurelia/runtime/dist/templating/bindable';
 interface Person { firstName?: string; lastName?: string; fullName?: string }
 const app = class { public value: string = 'wOOt'; };
 
-describe('custom-elements', function () {
+describe('5-jit-html/custom-elements/custom-elements.spec.ts', function () {
 
   const registrations = [TestConfiguration];
 

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -59,7 +59,7 @@ export class BindableObserver {
       this.observing = true;
 
       const currentValue = obj[propertyKey];
-      this.currentValue = shouldInterceptSet && currentValue !== undefined
+      this.currentValue = shouldInterceptSet && currentValue !== void 0
         ? $set(currentValue)
         : currentValue;
       if (!isProxy) {

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -59,7 +59,7 @@ export class BindableObserver {
       this.observing = true;
 
       const currentValue = obj[propertyKey];
-      this.currentValue = shouldInterceptSet
+      this.currentValue = shouldInterceptSet && currentValue !== undefined
         ? $set(currentValue)
         : currentValue;
       if (!isProxy) {

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -60,8 +60,8 @@ export class BindableObserver {
 
       const currentValue = obj[propertyKey];
       this.currentValue = shouldInterceptSet
-        ? currentValue
-        : $set(currentValue);
+        ? $set(currentValue)
+        : currentValue;
       if (!isProxy) {
         this.createGetterSetter();
       }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix the wrong initialization logic of bindable observer. Oops on me

### 🎫 Issues

Ternary logic is reverse

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

Maybe add a few tests that has view model with property value initialized before creating the observers?

## ⏭ Next Steps

N/A