### PR TITLE
fix(router): make goto-active consider parameters

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -641,7 +641,7 @@ export class Router implements IRouter {
   public checkActive(instructions: ViewportInstruction[]): boolean {
     for (const instruction of instructions) {
       const scopeInstructions: ViewportInstruction[] = this.instructionResolver.matchScope(this.activeComponents, instruction.scope!);
-      const matching: ViewportInstruction[] = scopeInstructions.filter(instr => instr.sameComponent(instruction));
+      const matching: ViewportInstruction[] = scopeInstructions.filter(instr => instr.sameComponent(instruction, true));
       if (matching.length === 0) {
         return false;
       }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the `goto` attribute's active link check take parameters into account.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure existing tests pass

## ⏭ Next Steps

- Continue with triage comments
- Continue with configuration api
- Move relevant parts to `Metadata`
- Fully implement guards/hooks
- Fully implement unknown routes/components
- Add navigation events
- Make `goto` listen to navigation events instead of observing
- Fix `realworld`
- Fix proper sync/async for lifecycle hooks
- Add tests for the new `au-nav` options
- Add tests for `au-viewport-scope`
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->

