### PR TITLE
feat(router): enable exist for viewport attributes

### DIFF
--- a/packages/__tests__/router/viewport.spec.ts
+++ b/packages/__tests__/router/viewport.spec.ts
@@ -1,10 +1,56 @@
-import { Viewport } from '@aurelia/router';
-import { CustomElement } from '@aurelia/runtime';
-
-const define = (CustomElement as any).define;
+import { Viewport, RouterConfiguration, IRouter } from '@aurelia/router';
+import { CustomElement, Aurelia } from '@aurelia/runtime';
+import { TestContext, assert } from '@aurelia/testing';
+import { DebugConfiguration } from '@aurelia/debug';
 
 describe('Viewport', function () {
+  async function createFixture(config?, App?) {
+    const ctx = TestContext.createHTMLTestContext();
+    const { container, scheduler, doc, wnd } = ctx;
+
+    let path = wnd.location.href;
+    const hash = path.indexOf('#');
+    if (hash >= 0) {
+      path = path.slice(0, hash);
+    }
+    wnd.history.replaceState({}, '', path);
+
+    const host = doc.createElement('div');
+    if (App === void 0) {
+      App = CustomElement.define({ name: 'app', template: '<au-viewport></au-viewport>' });
+    }
+    const au = new Aurelia(container)
+      .register(
+        DebugConfiguration,
+        config !== void 0 ? RouterConfiguration : RouterConfiguration.customize(config),
+        App)
+      .app({ host: host, component: App });
+
+    const router = container.get(IRouter);
+
+    await au.start().wait();
+
+    async function tearDown() {
+      router.deactivate();
+      RouterConfiguration.customize();
+      await au.stop().wait();
+    }
+
+    return { au, container, scheduler, host, router, tearDown };
+  }
+
   it('can be created', function () {
     const sut = new Viewport(null, null, null, null, null, null);
+  });
+
+  it('can understand exist attributes', async function () {
+    const App = CustomElement.define({ name: 'app', template: '<au-viewport no-link></au-viewport>' });
+
+    const { router, tearDown } = await createFixture(undefined, App);
+
+    const viewport: any = router.allViewports().filter(vp => vp.name === 'default')[0];
+    assert.strictEqual(viewport.options.noLink, true, `noLink === true`);
+
+    await tearDown();
   });
 });

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -126,7 +126,7 @@ export class ViewportCustomElement implements ICustomElementViewModel<Element> {
 
   private getAttribute(key: string, value: string | boolean, checkExists: boolean = false): string | boolean | undefined {
     const result: Record<string, string | boolean> = {};
-    if (this.isBound) {
+    if (this.isBound && !checkExists) {
       return value;
     } else {
       if (this.element.hasAttribute(key)) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the viewport attributes `no-link`, `no-history` and `stateful` to not require a value, only to exist, in order to be true.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure existing tests pass

## ⏭ Next Steps

- Continue with triage comments
- Continue with configuration api
- Move relevant parts to `Metadata`
- Fully implement guards/hooks
- Fully implement unknown routes/components
- Add navigation events
- Make `goto` listen to navigation events instead of observing
- Fix `realworld`
- Fix proper sync/async for lifecycle hooks
- Add tests for the new `au-nav` options
- Add tests for `au-viewport-scope`
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->

