### PR TITLE
docs: add a contributing file for cli developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+If you are interested in contributing to Aurelia, please see
+[our contributor documentation](https://docs.aurelia.io/community-contribution/joining-the-community) for more
+information. You'll learn how to build the code and run tests, how best to engage in our social channels, how to submit
+PRs, and even how to contribute to our documentation. We welcome you and thank you in advance for joining with us in
+this endeavor.


### PR DESCRIPTION
this will be easier to find than the reference in the README,
if you have only cloned the repo.

I had this problem, I basically never noticed the contributing docs, because I was just code hunting at first.