### PR TITLE
feat(router): set no multi bindings on href attribute

### DIFF
--- a/packages/router/src/resources/href.ts
+++ b/packages/router/src/resources/href.ts
@@ -4,7 +4,10 @@ import { GotoCustomAttribute } from '../configuration';
 import { IEventManager } from '@aurelia/runtime-html';
 import { IDisposable } from '@aurelia/kernel';
 
-@customAttribute('href')
+@customAttribute({
+  name: 'href',
+  noMultiBindings: true
+})
 export class HrefCustomAttribute implements ICustomAttributeViewModel<HTMLElement> {
   @bindable({ mode: BindingMode.toView })
   public value: string | undefined;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR sets no multi bindings on the `href` custom attribute.

### 🎫 Issues

Related to https://github.com/aurelia/aurelia/issues/307, https://github.com/aurelia/aurelia/issues/369 and https://github.com/aurelia/aurelia/issues/367. 

## 👩‍💻 Reviewer Notes

Ignore everything in `packages/router/test/e2e/**` since they are just my own test applications while working.

## 📑 Test Plan

- Make sure existing tests pass

## ⏭ Next Steps

- Continue with triage comments
- Continue with configuration api
- Move relevant parts to `Metadata`
- Fully implement guards/hooks
- Fully implement unknown routes/components
- Add navigation events
- Make `goto` listen to navigation events instead of observing
- Fix `realworld`
- Fix proper sync/async for lifecycle hooks
- Add tests for the new `au-nav` options
- Add tests for `au-viewport-scope`
- Finish scoped viewports review
- Add tests covering scoped viewports
- Review controller parent implementation
- Review the extension points

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
