### PR TITLE
Listener binding fix

### DIFF
--- a/packages/__tests__/5-jit-html/binding-resources.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-resources.spec.ts
@@ -1,55 +1,238 @@
-// import { HTMLTestContext, TestContext, setupAndStart, tearDown } from '@aurelia/testing';
+import { TestContext, assert } from '@aurelia/testing';
+import { Aurelia, customElement, bindable, BindingMode } from '@aurelia/runtime';
 
-// // TemplateCompiler - Binding Resources integration
-// describe('binding-resources', function () {
-//   let ctx: HTMLTestContext;
+async function wait(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
 
-//   beforeEach(function () {
-//     ctx = TestContext.createHTMLTestContext();
-//   });
+// TemplateCompiler - Binding Resources integration
+describe('binding-resources', function () {
+  function createFixture() {
+      const ctx = TestContext.createHTMLTestContext();
+      const au = new Aurelia(ctx.container);
+      const host = ctx.createElement("div");
+      return { au, host, scheduler: ctx.scheduler, doc: ctx.doc };
+  }
 
-//   // debounceBindingBehavior - input.value
-//   it('01.', done => {
-//     const { au, lifecycle, host, component } = setupAndStart(ctx, `<template><input value.to-view="message & debounce:50"></template>`, null);
-//     assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
-//     component.message = 'hello!';
-//     setTimeout(() => {
-//       assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
-//       component.message = 'hello!!';
-//     },         25);
-//     setTimeout(() => {
-//       assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
-//       component.message = 'hello!!!';
-//     },         50);
-//     setTimeout(() => {
-//       assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
-//     },         75);
-//     setTimeout(() => {
-//       assert.strictEqual(host.firstChild['value'], 'hello!!!', `host.firstChild['value']`);
-//       tearDown(au, lifecycle, host);
-//       done();
-//     },         175);
-//   });
+  describe('debounce', function () {
+    it('works with toView bindings to elements', async function () {
+      @customElement({
+        name: 'app',
+        template: `<input ref="receiver" value.to-view="value & debounce:25">`,
+      })
+      class App {
+        public value: string = '0';
+        public receiver: HTMLInputElement;
+      }
 
-//   // TODO: fix throttle
-//   // it(`throttleBindingBehavior - input.value`, done => {
-//   //   const { au, lifecycle, host, component } = createFixture(`<template><input value.to-view="message & throttle:50"></template>`);
-//   //   au.app({ host, component }).start();
-//   //   assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
-//   //   component.message = 'hello!';
-//   //   lifecycle.flush(LifecycleFlags.none);
-//   //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
-//   //   component.message = 'hello!!';
-//   //   lifecycle.flush(LifecycleFlags.none);
-//   //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
-//   //   component.message = 'hello!!!';
-//   //   lifecycle.flush(LifecycleFlags.none);
-//   //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
-//   //   setTimeout(() => {
-//   //     component.message = 'hello!!!!';
-//   //     lifecycle.flush(LifecycleFlags.none);
-//   //     assert.strictEqual(host.firstChild['value'], 'hello!!!!', `host.firstChild['value']`);
-//   //     done();
-//   //   }, 75);
-//   // });
-// });
+      const { au, host, scheduler } = createFixture();
+
+      const component = new App();
+      au.app({ component, host });
+      await au.start().wait();
+
+      const receiver = component.receiver;
+      component.value = '1';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 1 not yet propagated`);
+
+      component.value = '2';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 2 not yet propagated`);
+
+      component.value = '3';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
+
+      await scheduler.yieldAll();
+
+      assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+    });
+
+    it('works with toView bindings to other components', async function () {
+      @customElement({
+        name: 'au-receiver',
+        template: null,
+      })
+      class Receiver {
+        @bindable({ mode: BindingMode.toView })
+        public value: string = '0';
+      }
+
+      @customElement({
+        name: 'app',
+        template: `<au-receiver view-model.ref="receiver" value.bind="value & debounce:25"></au-receiver>`,
+        dependencies: [Receiver],
+      })
+      class App {
+        public value: string = '0';
+        public receiver: Receiver;
+      }
+
+      const { au, host, scheduler } = createFixture();
+
+      const component = new App();
+      au.app({ component, host });
+      await au.start().wait();
+
+      const receiver = component.receiver;
+      component.value = '1';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 1 not yet propagated`);
+
+      component.value = '2';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 2 not yet propagated`);
+
+      component.value = '3';
+
+      await wait(20);
+
+      assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
+
+      await scheduler.yieldAll();
+
+      assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+    });
+
+    it('works with twoWay bindings to other components', async function () {
+      @customElement({
+        name: 'au-receiver',
+        template: null,
+      })
+      class Receiver {
+        @bindable({ mode: BindingMode.twoWay })
+        public value: string = '0';
+      }
+
+      @customElement({
+        name: 'app',
+        template: `<au-receiver view-model.ref="receiver" value.bind="value & debounce:25"></au-receiver>`,
+        dependencies: [Receiver],
+      })
+      class App {
+        public value: string = '0';
+        public receiver: Receiver;
+      }
+
+      const { au, host, scheduler } = createFixture();
+
+      const component = new App();
+      au.app({ component, host });
+      await au.start().wait();
+
+      const receiver = component.receiver;
+      component.value = '1';
+
+      await wait(20);
+
+      assert.strictEqual(component.value, '1', `component keeps change 1`);
+      assert.strictEqual(receiver.value, '0', `change 1 not yet propagated to receiver`);
+
+      receiver.value = '2';
+
+      await wait(20);
+
+      assert.strictEqual(component.value, '1', `change 2 not yet propagated to component`);
+      assert.strictEqual(receiver.value, '2', `receiver keeps change 2`);
+
+      component.value = '3';
+
+      await wait(20);
+
+      assert.strictEqual(component.value, '3', `component keeps change 3`);
+      assert.strictEqual(receiver.value, '2', `change 3 not yet propagated to receiver`);
+
+      await scheduler.yieldAll();
+
+      assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+    });
+
+    for (const command of ['trigger', 'capture', 'delegate']) {
+      it(`works with ${command} bindings`, async function () {
+        @customElement({
+          name: 'app',
+          template: `<div ref="receiver" click.${command}="handleClick($event) & debounce:25"></div>`,
+        })
+        class App {
+          public receiver: HTMLDivElement;
+
+          public events: MouseEvent[] = [];
+          public handleClick($event: MouseEvent): void {
+            this.events.push($event);
+          }
+        }
+
+        const { au, host, scheduler, doc } = createFixture();
+
+        const component = new App();
+
+        doc.body.appendChild(host);
+        au.app({ component, host });
+        await au.start().wait();
+
+        const eventInit = { bubbles: true, cancelable: true };
+        const receiver = component.receiver;
+        const event1 = new MouseEvent('click', eventInit);
+        receiver.dispatchEvent(event1);
+
+        await wait(20);
+
+        assert.strictEqual(component.events.length, 0, `event 1 not yet propagated`);
+
+        const event2 = new MouseEvent('click', eventInit);
+        receiver.dispatchEvent(event2);
+
+        await wait(20);
+
+        assert.strictEqual(component.events.length, 0, `event 2 not yet propagated`);
+
+        const event3 = new MouseEvent('click', eventInit);
+        receiver.dispatchEvent(event3);
+
+        await wait(20);
+
+        assert.strictEqual(component.events.length, 0, `event 3 not yet propagated`);
+
+        await scheduler.yieldAll();
+
+        assert.strictEqual(component.events.length, 1, `event 3 propagated`);
+        assert.strictEqual(component.events[0], event3, `event 3 is the specific event that propagated`);
+
+        host.remove();
+      });
+    }
+  });
+
+  // TODO: fix throttle
+  // it(`throttleBindingBehavior - input.value`, done => {
+  //   const { au, lifecycle, host, component } = createFixture(`<template><input value.to-view="message & throttle:50"></template>`);
+  //   au.app({ host, component }).start();
+  //   assert.strictEqual(host.firstChild['value'], '', `host.firstChild['value']`);
+  //   component.message = 'hello!';
+  //   lifecycle.flush(LifecycleFlags.none);
+  //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
+  //   component.message = 'hello!!';
+  //   lifecycle.flush(LifecycleFlags.none);
+  //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
+  //   component.message = 'hello!!!';
+  //   lifecycle.flush(LifecycleFlags.none);
+  //   assert.strictEqual(host.firstChild['value'], 'hello!', `host.firstChild['value']`);
+  //   setTimeout(() => {
+  //     component.message = 'hello!!!!';
+  //     lifecycle.flush(LifecycleFlags.none);
+  //     assert.strictEqual(host.firstChild['value'], 'hello!!!!', `host.firstChild['value']`);
+  //     done();
+  //   }, 75);
+  // });
+});

--- a/packages/__tests__/5-jit-html/binding-resources.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-resources.spec.ts
@@ -10,8 +10,12 @@ describe('binding-resources', function () {
   function createFixture() {
       const ctx = TestContext.createHTMLTestContext();
       const au = new Aurelia(ctx.container);
-      const host = ctx.createElement("div");
-      return { au, host, scheduler: ctx.scheduler, doc: ctx.doc };
+      const host = ctx.createElement('div');
+      return {
+        au,
+        host,
+        ctx,
+      };
   }
 
   describe('debounce', function () {
@@ -25,7 +29,7 @@ describe('binding-resources', function () {
         public receiver: HTMLInputElement;
       }
 
-      const { au, host, scheduler } = createFixture();
+      const { au, host, ctx } = createFixture();
 
       const component = new App();
       au.app({ component, host });
@@ -50,7 +54,7 @@ describe('binding-resources', function () {
 
       assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
 
-      await scheduler.yieldAll();
+      await ctx.scheduler.yieldAll();
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
     });
@@ -75,7 +79,7 @@ describe('binding-resources', function () {
         public receiver: Receiver;
       }
 
-      const { au, host, scheduler } = createFixture();
+      const { au, host, ctx } = createFixture();
 
       const component = new App();
       au.app({ component, host });
@@ -100,7 +104,7 @@ describe('binding-resources', function () {
 
       assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
 
-      await scheduler.yieldAll();
+      await ctx.scheduler.yieldAll();
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
     });
@@ -125,7 +129,7 @@ describe('binding-resources', function () {
         public receiver: Receiver;
       }
 
-      const { au, host, scheduler } = createFixture();
+      const { au, host, ctx } = createFixture();
 
       const component = new App();
       au.app({ component, host });
@@ -153,7 +157,7 @@ describe('binding-resources', function () {
       assert.strictEqual(component.value, '3', `component keeps change 3`);
       assert.strictEqual(receiver.value, '2', `change 3 not yet propagated to receiver`);
 
-      await scheduler.yieldAll();
+      await ctx.scheduler.yieldAll();
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
     });
@@ -167,44 +171,44 @@ describe('binding-resources', function () {
         class App {
           public receiver: HTMLDivElement;
 
-          public events: MouseEvent[] = [];
-          public handleClick($event: MouseEvent): void {
+          public events: CustomEvent[] = [];
+          public handleClick($event: CustomEvent): void {
             this.events.push($event);
           }
         }
 
-        const { au, host, scheduler, doc } = createFixture();
+        const { au, host, ctx } = createFixture();
 
         const component = new App();
 
-        doc.body.appendChild(host);
+        ctx.doc.body.appendChild(host);
         au.app({ component, host });
         await au.start().wait();
 
         const eventInit = { bubbles: true, cancelable: true };
         const receiver = component.receiver;
-        const event1 = new MouseEvent('click', eventInit);
+        const event1 = new ctx.CustomEvent('click', eventInit);
         receiver.dispatchEvent(event1);
 
         await wait(20);
 
         assert.strictEqual(component.events.length, 0, `event 1 not yet propagated`);
 
-        const event2 = new MouseEvent('click', eventInit);
+        const event2 = new ctx.CustomEvent('click', eventInit);
         receiver.dispatchEvent(event2);
 
         await wait(20);
 
         assert.strictEqual(component.events.length, 0, `event 2 not yet propagated`);
 
-        const event3 = new MouseEvent('click', eventInit);
+        const event3 = new ctx.CustomEvent('click', eventInit);
         receiver.dispatchEvent(event3);
 
         await wait(20);
 
         assert.strictEqual(component.events.length, 0, `event 3 not yet propagated`);
 
-        await scheduler.yieldAll();
+        await ctx.scheduler.yieldAll();
 
         assert.strictEqual(component.events.length, 1, `event 3 propagated`);
         assert.strictEqual(component.events[0], event3, `event 3 is the specific event that propagated`);

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -79,7 +79,7 @@ export class Listener implements IBinding {
       this.dom,
       this.target,
       this.targetEvent,
-      this.interceptor,
+      this,
       this.delegationStrategy
     );
 


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes a slip-up in the Listener binding (responsible for `trigger`, `delegate` and `capture` commands) so that it works properly in combination with binding behaviors.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

Reported on discord
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Fix is only 1 line
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Added a few tests specifically for debounce (for regular bindings and event bindings)
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

More tests are still necessary, also for Throttle, but at least the common cases are now verified
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
