### PR TITLE
fix(di): should have a return type

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -147,9 +147,9 @@ export interface IContainerConfiguration {
 }
 
 export const DefaultResolver = {
-  none(key: Key) {throw Error(`${key.toString()} not registered, did you forget to add @singleton()?`);},
-  singleton(key: Key) {return new Resolver(key, ResolverStrategy.singleton, key);},
-  transient(key: Key) {return new Resolver(key, ResolverStrategy.transient, key);},
+  none(key: Key): IResolver {throw Error(`${key.toString()} not registered, did you forget to add @singleton()?`);},
+  singleton(key: Key): IResolver {return new Resolver(key, ResolverStrategy.singleton, key);},
+  transient(key: Key): IResolver {return new Resolver(key, ResolverStrategy.transient, key);},
 };
 
 export const DefaultContainerConfiguration: IContainerConfiguration = {


### PR DESCRIPTION
fix

```
node_modules/@aurelia/kernel/dist/di.d.ts:74:26 - error TS2304: Cannot find name 'Resolver'.

74     singleton(key: Key): Resolver;
                            ~~~~~~~~

node_modules/@aurelia/kernel/dist/di.d.ts:75:26 - error TS2304: Cannot find name 'Resolver'.

75     transient(key: Key): Resolver;
                            ~~~~~~~~
```