### PR TITLE
Logging improvement

### DIFF
--- a/packages/__tests__/aot/smoke-tests.spec.ts
+++ b/packages/__tests__/aot/smoke-tests.spec.ts
@@ -10,7 +10,7 @@ describe.skip('AOT (smoke tests)', function () {
   async function execute(content: string) {
     const container = DI.createContainer();
     container.register(
-      LoggerConfiguration.create(console, LogLevel.debug, ColorOptions.colors),
+      LoggerConfiguration.create({ $console: console, level: LogLevel.debug, colorOptions: ColorOptions.colors }),
       Registration.singleton(IFileSystem, VirtualFileSystem),
     );
 

--- a/packages/__tests__/validation/rule-provider.spec.ts
+++ b/packages/__tests__/validation/rule-provider.spec.ts
@@ -547,7 +547,7 @@ describe('ValidationRules', function () {
 describe('ValidationMessageProvider', function () {
   class EventLog implements ISink {
     public log: ILogEvent[] = [];
-    public emit(event: ILogEvent): void {
+    public handleEvent(event: ILogEvent): void {
       this.log.push(event);
     }
   }

--- a/packages/aot/src/test.ts
+++ b/packages/aot/src/test.ts
@@ -33,7 +33,7 @@ import {
 
   const container = DI.createContainer();
   container.register(
-    LoggerConfiguration.create(console, LogLevel.debug, ColorOptions.colors),
+    LoggerConfiguration.create({ $console: console, level: LogLevel.debug, colorOptions: ColorOptions.colors }),
     Registration.singleton(IFileSystem, NodeFileSystem),
   );
 

--- a/packages/http-server/src/configuration.ts
+++ b/packages/http-server/src/configuration.ts
@@ -16,7 +16,7 @@ export const HttpServerConfiguration = {
           Registration.instance(IHttpServerOptions, opts),
           Registration.singleton(IRequestHandler, FileServer),
           Registration.singleton(IHttp2FileServer, Http2FileServer),
-          LoggerConfiguration.create(console, opts.level, ColorOptions.colors)
+          LoggerConfiguration.create({ $console: console, level: opts.level, colorOptions: ColorOptions.colors })
         );
 
         if (opts.useHttp2) {

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -27,7 +27,7 @@ export {
   newInstanceOf,
   DefaultContainerConfiguration,
   DefaultResolver,
-  IContainerConfiguration
+  IContainerConfiguration,
 } from './di';
 export {
   Class,
@@ -88,6 +88,7 @@ export {
   ConsoleSink,
   LoggerConfiguration,
   format,
+  sink,
 } from './logger';
 export {
   relativeToFile,

--- a/packages/kernel/src/logger.ts
+++ b/packages/kernel/src/logger.ts
@@ -1,6 +1,9 @@
 import { all, DI, IContainer, ignore, IRegistry, optional, Registration } from './di';
 import { toLookup } from './functions';
 import { LogLevel } from './reporter';
+import { Class, Constructable } from './interfaces';
+import { Protocol } from './resource';
+import { Metadata } from '@aurelia/metadata';
 
 /**
  * Flags to enable/disable color usage in the logging output.
@@ -30,6 +33,11 @@ export interface ILogConfig {
    * The global log level. Only log calls with the same level or higher are emitted.
    */
   level: LogLevel;
+}
+
+interface ILoggingConfigurationOptions extends ILogConfig {
+  $console: IConsoleLike;
+  sinks: Class<ISink>[];
 }
 
 /**
@@ -103,11 +111,11 @@ export interface ILogEventFactory {
  */
 export interface ISink {
   /**
-   * Emit the provided `ILogEvent` to the output interface wrapped by this sink.
+   * Handle the provided `ILogEvent` to the output interface wrapped by this sink.
    *
    * @param event - The event object to emit. Built-in sinks will call `.toString()` on the event object but custom sinks can do anything they like with the event.
    */
-  emit(event: ILogEvent): void;
+  handleEvent(event: ILogEvent): void;
 }
 
 /**
@@ -298,6 +306,26 @@ export const ILogEventFactory = DI.createInterface<ILogEventFactory>('ILogEventF
 export const ILogger = DI.createInterface<ILogger>('ILogger').withDefault(x => x.singleton(DefaultLogger));
 export const ILogScopes = DI.createInterface<string[]>('ILogScope').noDefault();
 
+interface SinkDefinition {
+  handles: Exclude<LogLevel, LogLevel.none>[];
+}
+
+export const LoggerSink = Object.freeze({
+  key: Protocol.annotation.keyFor('logger-sink-handles'),
+  define<TSink extends ISink>(target: Constructable<TSink>, definition: SinkDefinition) {
+    Metadata.define(this.key, definition.handles, target.prototype);
+    return target;
+  },
+  getHandles<TSink extends ISink>(target: Constructable<TSink> | TSink) {
+    return Metadata.get(this.key, target) as LogLevel[] | undefined;
+  },
+});
+export function sink(definition: SinkDefinition) {
+  return function <TSink extends ISink>(target: Constructable<TSink>): Constructable<TSink> {
+    return LoggerSink.define(target, definition);
+  };
+}
+
 export interface IConsoleLike {
   debug(message: string, ...optionalParams: unknown[]): void;
   info(message: string, ...optionalParams: unknown[]): void;
@@ -437,10 +465,10 @@ export class DefaultLogEventFactory implements ILogEventFactory {
 }
 
 export class ConsoleSink implements ISink {
-  public readonly emit: (event: ILogEvent) => void;
+  public readonly handleEvent: (event: ILogEvent) => void;
 
   public constructor($console: IConsoleLike) {
-    this.emit = function emit(event: ILogEvent): void {
+    this.handleEvent = function emit(event: ILogEvent): void {
       const optionalParams = event.optionalParams;
       if (optionalParams === void 0 || optionalParams.length === 0) {
         switch (event.severity) {
@@ -474,8 +502,20 @@ export class ConsoleSink implements ISink {
 }
 
 export class DefaultLogger implements ILogger {
-  public readonly root: ILogger;
-  public readonly parent: ILogger;
+  public readonly root: DefaultLogger;
+  public readonly parent: DefaultLogger;
+  /** @internal */
+  public readonly traceSinks: ISink[];
+  /** @internal */
+  public readonly debugSinks: ISink[];
+  /** @internal */
+  public readonly infoSinks: ISink[];
+  /** @internal */
+  public readonly warnSinks: ISink[];
+  /** @internal */
+  public readonly errorSinks: ISink[];
+  /** @internal */
+  public readonly fatalSinks: ISink[];
 
   public readonly trace: (...args: unknown[]) => void;
   public readonly debug: (...args: unknown[]) => void;
@@ -489,62 +529,100 @@ export class DefaultLogger implements ILogger {
   public constructor(
     @ILogConfig public readonly config: ILogConfig,
     @ILogEventFactory private readonly factory: ILogEventFactory,
-    @all(ISink) private readonly sinks: ISink[],
+    @all(ISink) sinks: readonly ISink[],
     @optional(ILogScopes) public readonly scope: string[] = [],
-    @ignore parent: ILogger | null = null,
+    @ignore parent: DefaultLogger | null = null,
   ) {
+    let traceSinks: ISink[];
+    let debugSinks: ISink[];
+    let infoSinks: ISink[];
+    let warnSinks: ISink[];
+    let errorSinks: ISink[];
+    let fatalSinks: ISink[];
     if (parent === null) {
       this.root = this;
       this.parent = this;
+
+      traceSinks = this.traceSinks = [];
+      debugSinks = this.debugSinks = [];
+      infoSinks = this.infoSinks = [];
+      warnSinks = this.warnSinks = [];
+      errorSinks = this.errorSinks = [];
+      fatalSinks = this.fatalSinks = [];
+      for (const $sink of sinks) {
+        const handles = LoggerSink.getHandles($sink);
+        if (handles?.includes(LogLevel.trace) ?? true) {
+          traceSinks.push($sink);
+        }
+        if (handles?.includes(LogLevel.debug) ?? true) {
+          debugSinks.push($sink);
+        }
+        if (handles?.includes(LogLevel.info) ?? true) {
+          infoSinks.push($sink);
+        }
+        if (handles?.includes(LogLevel.warn) ?? true) {
+          warnSinks.push($sink);
+        }
+        if (handles?.includes(LogLevel.error) ?? true) {
+          errorSinks.push($sink);
+        }
+        if (handles?.includes(LogLevel.fatal) ?? true) {
+          fatalSinks.push($sink);
+        }
+      }
     } else {
       this.root = parent.root;
       this.parent = parent;
+
+      traceSinks = this.traceSinks = parent.traceSinks;
+      debugSinks = this.debugSinks = parent.debugSinks;
+      infoSinks = this.infoSinks = parent.infoSinks;
+      warnSinks = this.warnSinks = parent.warnSinks;
+      errorSinks = this.errorSinks = parent.errorSinks;
+      fatalSinks = this.fatalSinks = parent.fatalSinks;
     }
 
-    const sinksLen = sinks.length;
-    let i = 0;
-
-    const emit = (level: LogLevel, msgOrGetMsg: unknown, optionalParams: unknown[]): void => {
+    const emit = ($sinks: ISink[], level: LogLevel, msgOrGetMsg: unknown, optionalParams: unknown[]): void => {
       const message = typeof msgOrGetMsg === 'function' ? msgOrGetMsg() : msgOrGetMsg;
       const event = factory.createLogEvent(this, level, message, optionalParams);
-      for (i = 0; i < sinksLen; ++i) {
-        sinks[i].emit(event);
+      for (let i = 0, ii = $sinks.length; i < ii; ++i) {
+        $sinks[i].handleEvent(event);
       }
     };
 
     this.trace = function trace(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.trace) {
-        emit(LogLevel.trace, messageOrGetMessage, optionalParams);
+        emit(traceSinks, LogLevel.trace, messageOrGetMessage, optionalParams);
       }
     };
 
     this.debug = function debug(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.debug) {
-        emit(LogLevel.debug, messageOrGetMessage, optionalParams);
+        emit(debugSinks, LogLevel.debug, messageOrGetMessage, optionalParams);
       }
     };
 
     this.info = function info(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.info) {
-        emit(LogLevel.info, messageOrGetMessage, optionalParams);
+        emit(infoSinks, LogLevel.info, messageOrGetMessage, optionalParams);
       }
     };
 
     this.warn = function warn(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.warn) {
-        emit(LogLevel.warn, messageOrGetMessage, optionalParams);
+        emit(warnSinks, LogLevel.warn, messageOrGetMessage, optionalParams);
       }
     };
 
     this.error = function error(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.error) {
-        emit(LogLevel.error, messageOrGetMessage, optionalParams);
+        emit(errorSinks, LogLevel.error, messageOrGetMessage, optionalParams);
       }
     };
 
     this.fatal = function fatal(messageOrGetMessage: unknown, ...optionalParams: unknown[]): void {
       if (config.level <= LogLevel.fatal) {
-        emit(LogLevel.fatal, messageOrGetMessage, optionalParams);
+        emit(fatalSinks, LogLevel.fatal, messageOrGetMessage, optionalParams);
       }
     };
   }
@@ -553,7 +631,7 @@ export class DefaultLogger implements ILogger {
     const scopedLoggers = this.scopedLoggers;
     let scopedLogger = scopedLoggers[name];
     if (scopedLogger === void 0) {
-      scopedLogger = scopedLoggers[name] = new DefaultLogger(this.config, this.factory, this.sinks, this.scope.concat(name), this);
+      scopedLogger = scopedLoggers[name] = new DefaultLogger(this.config, this.factory, (void 0)!, this.scope.concat(name), this);
     }
     return scopedLogger;
   }
@@ -564,23 +642,26 @@ export class DefaultLogger implements ILogger {
  *
  * NOTE: You *must* register the return value of `.create` with the container / au instance, not this `LoggerConfiguration` object itself.
  *
+ * @example
  * ```ts
- * // GOOD
- * container.register(LoggerConfiguration.create(console))
- * // GOOD
- * container.register(LoggerConfiguration.create(console, LogLevel.debug))
- * // GOOD
- * container.register(LoggerConfiguration.create({
- *   debug: PLATFORM.noop,
- *   info: PLATFORM.noop,
- *   warn: PLATFORM.noop,
- *   error: msg => {
- *     throw new Error(msg);
- *   }
- * }, LogLevel.debug))
+ * container.register(LoggerConfiguration.create());
  *
- * // BAD
- * container.register(LoggerConfiguration)
+ * container.register(LoggerConfiguration.create({$console: console}))
+ *
+ * container.register(LoggerConfiguration.create({$console: console, level: LogLevel.debug}))
+ *
+ * container.register(LoggerConfiguration.create({
+ *  $console: {
+ *     debug: PLATFORM.noop,
+ *     info: PLATFORM.noop,
+ *     warn: PLATFORM.noop,
+ *     error: msg => {
+ *       throw new Error(msg);
+ *     }
+ *  },
+ *  level: LogLevel.debug
+ * }))
+ *
  * ```
  */
 export const LoggerConfiguration = toLookup({
@@ -590,16 +671,29 @@ export const LoggerConfiguration = toLookup({
    * @param colorOptions - Whether to use colors or not. Defaults to `noColors`. Colors are especially nice in nodejs environments but don't necessarily work (well) in all environments, such as browsers.
    */
   create(
-    $console: IConsoleLike,
-    level: LogLevel = LogLevel.warn,
-    colorOptions = ColorOptions.noColors,
+    {
+      $console,
+      level = LogLevel.warn,
+      colorOptions = ColorOptions.noColors,
+      sinks = [],
+    }: Partial<ILoggingConfigurationOptions> = {}
   ): IRegistry {
     return toLookup({
       register(container: IContainer): IContainer {
-        return container.register(
+        container.register(
           Registration.instance(ILogConfig, new LogConfig(colorOptions, level)),
-          Registration.instance(ISink, new ConsoleSink($console)),
         );
+        if ($console !== void 0 && $console !== null) {
+          container.register(
+            Registration.instance(ISink, new ConsoleSink($console))
+          );
+        }
+        for (const $sink of sinks) {
+          container.register(
+            Registration.singleton(ISink, $sink)
+          );
+        }
+        return container;
       },
     });
   },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR introduces the following improvements for logging. 
1. The `console` logging can be deactivated by simply providing `null` or `undefined` for the console implementation.
```typescript
container.register(LoggerConfiguration.create())
// OR
container.register(LoggerConfiguration.create({$console: null}));
```
2. Developers can now register Sinks explicitly while registering `LoggerConfiguration`.
```typescript
container.register(LoggerConfiguration.create({sinks: [SinkClass1, SinkClass2]}));
```
3. Sinks can declare their handling capabilities using the `sink` decorator. For the following example, the sink instance won't be notified of events other than `error`.
```typescript
@sink({ handles: [LogLevel.error] })
class EventLog implements ISink {
  public readonly log: ILogEvent[] = [];
  public handleEvent(event: ILogEvent): void {
    this.log.push(event);
  }
}
```
The use of `@sink` decorator is completely optional. By default, the sinks will be notified on every kind of events.
4. Lastly the `ISink#emit` is renamed to `ISink#handleEvent`.
### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
