### PR TITLE
docs(validating-data): missing import for decorator

### DIFF
--- a/docs/user-docs/app-basics/validating-data.md
+++ b/docs/user-docs/app-basics/validating-data.md
@@ -44,6 +44,7 @@ The plugin gives you enough flexibility to write your own rules rather than bein
   {% tab title="awesome-component.ts" %}
 
   ```typescript
+  import { newInstanceForScope } from '@aurelia/kernel';
   import { IValidationRules } from '@aurelia/validation';
   import { IValidationController } from '@aurelia/validation-html';
 


### PR DESCRIPTION
There was a missing import for the `newInstanceForScope` decorator used in the example. The "aurelia" package doesn't appear to export it and I had to import it from the kernel package.