### PR TITLE
Metadata fixes

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1022,7 +1022,7 @@ function $applyMetadataPolyfill(
   writable: boolean,
   configurable: boolean,
 ): void {
-  def(Metadata, '$Internal', metadataInternalSlot, writable, configurable);
+  def(reflect, internalSlotName, metadataInternalSlot, writable, configurable);
 
   def(reflect, 'metadata', metadata, writable, configurable);
   def(reflect, 'decorate', decorate, writable, configurable);

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -995,13 +995,21 @@ export const Metadata = {
   delete: $delete,
 };
 
-function def(obj: object, key: string, value: unknown): void {
-  Reflect.defineProperty(obj, key, {
-    writable: true,
+function def(
+  obj: object,
+  key: string,
+  value: unknown,
+  writable: boolean,
+  configurable: boolean,
+): void {
+  if (!Reflect.defineProperty(obj, key, {
+    writable,
     enumerable: false,
-    configurable: true,
+    configurable,
     value,
-  });
+  })) {
+    throw new Error(`Unable to apply metadata polyfill: could not add property '${key}' to the global Reflect object`);
+  }
 }
 
 const internalSlotName = '[[$au]]';
@@ -1009,7 +1017,32 @@ function hasInternalSlot(reflect: typeof Reflect): reflect is typeof Reflect & {
   return internalSlotName in reflect;
 }
 
-export function applyMetadataPolyfill(reflect: typeof Reflect): void {
+function $applyMetadataPolyfill(
+  reflect: typeof Reflect,
+  writable: boolean,
+  configurable: boolean,
+): void {
+  def(Metadata, '$Internal', metadataInternalSlot, writable, configurable);
+
+  def(reflect, 'metadata', metadata, writable, configurable);
+  def(reflect, 'decorate', decorate, writable, configurable);
+  def(reflect, 'defineMetadata', $define, writable, configurable);
+  def(reflect, 'hasMetadata', $has, writable, configurable);
+  def(reflect, 'hasOwnMetadata', $hasOwn, writable, configurable);
+  def(reflect, 'getMetadata', $get, writable, configurable);
+  def(reflect, 'getOwnMetadata', $getOwn, writable, configurable);
+  def(reflect, 'getMetadataKeys', $getKeys, writable, configurable);
+  def(reflect, 'getOwnMetadataKeys', $getOwnKeys, writable, configurable);
+  def(reflect, 'deleteMetadata', $delete, writable, configurable);
+}
+
+export function applyMetadataPolyfill(
+  reflect: typeof Reflect,
+  throwIfConflict: boolean = true,
+  forceOverwrite: boolean = false,
+  writable: boolean = true,
+  configurable: boolean = true,
+): void {
   if (hasInternalSlot(reflect)) {
     if (reflect[internalSlotName] === metadataInternalSlot) {
       return;
@@ -1017,31 +1050,32 @@ export function applyMetadataPolyfill(reflect: typeof Reflect): void {
     throw new Error(`Conflicting @aurelia/metadata module import detected. Please make sure you have the same version of all Aurelia packages in your dependency tree.`);
   }
 
-  if (
-    'metadata' in reflect ||
-    'decorate' in reflect ||
-    'defineMetadata' in reflect ||
-    'hasMetadata' in reflect ||
-    'hasOwnMetadata' in reflect ||
-    'getMetadata' in reflect ||
-    'getOwnMetadata' in reflect ||
-    'getMetadataKeys' in reflect ||
-    'getOwnMetadataKeys' in reflect ||
-    'deleteMetadata' in reflect
-  ) {
-    throw new Error(`Conflicting reflect.metadata polyfill found. If you have 'reflect-metadata' or any other reflect polyfill imported, please remove it, if not (or if you must use a specific polyfill) please file an issue at https://github.com/aurelia/aurelia/issues so that we can look into compatibility options for this scenario.`);
+  const presentProps = [
+    'metadata',
+    'decorate',
+    'defineMetadata',
+    'hasMetadata',
+    'hasOwnMetadata',
+    'getMetadata',
+    'getOwnMetadata',
+    'getMetadataKeys',
+    'getOwnMetadataKeys',
+    'deleteMetadata',
+  ].filter(function (p) {
+    return p in Reflect;
+  });
+
+  if (presentProps.length > 0) {
+    if (throwIfConflict) {
+      const implementationSummary = presentProps.map(function (p) {
+        const impl = `${(Reflect as { [k: string]: Function })[p].toString().slice(0, 100)}...`;
+        return `${p}:\n${impl}`;
+      }).join('\n\n');
+      throw new Error(`Conflicting reflect.metadata polyfill found. If you have 'reflect-metadata' or any other reflect polyfill imported, please remove it, if not (or if you must use a specific polyfill) please file an issue at https://github.com/aurelia/aurelia/issues so that we can look into compatibility options for this scenario. Implementation summary:\n\n${implementationSummary}`);
+    } else if (forceOverwrite) {
+      $applyMetadataPolyfill(reflect, writable, configurable);
+    }
+  } else {
+    $applyMetadataPolyfill(reflect, writable, configurable);
   }
-
-  def(Metadata, '$Internal', metadataInternalSlot);
-
-  def(reflect, 'metadata', metadata);
-  def(reflect, 'decorate', decorate);
-  def(reflect, 'defineMetadata', $define);
-  def(reflect, 'hasMetadata', $has);
-  def(reflect, 'hasOwnMetadata', $hasOwn);
-  def(reflect, 'getMetadata', $get);
-  def(reflect, 'getOwnMetadata', $getOwn);
-  def(reflect, 'getMetadataKeys', $getKeys);
-  def(reflect, 'getOwnMetadataKeys', $getOwnKeys);
-  def(reflect, 'deleteMetadata', $delete);
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
This PR exports the `applyMetadataPolyfill` as a function with options to override the defaults on how the polyfill is applied, namely:
- `reflect` - the `Reflect` object to apply the polyfill to
- `throwIfConflict` - whether to throw if any of the polyfilled properties already exist (default: `true`)
- `forceOverwrite` - whether to apply the polyfill if any of the polyfilled properties already exist (default: `false`)
- `writable` - the `writable` value to pass into `Reflect.defineProperty` when applying the polyfill (default: `true`)
- `configurable` - the `configurable` value to pass into `Reflect.defineProperty` when applying the polyfill (default: `true`)

There is a specific check for whether the polyfill has already been applied by `@aurelia/metadata` before, and if so, `applyMetadataPolyfill` becomes a no-op *unless* it was applied by a different *version* of `@aurelia/metadata`, in which case it will always throw.
The error is more specific in that case: `"Conflicting @aurelia/metadata module import detected. Please make sure you have the same version of all Aurelia packages in your dependency tree."`

The function is still called in module scope by `di` with the above defaults, but you can get "ahead" of it by importing and calling it first thing in your entry file, like so:
```ts
import { applyMetadataPolyfill } from '@aurelia/metadata';
applyMetadataPolyfill(Reflect, false, true, false, false);
```

This will apply the polyfill and make the properties non-configurable, effectively "blocking" `reflect-metadata` and ensuring everything will work in harmony.



### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Something I specifically ran into: when debugging Aurelia in node with vs code, `reflect-metadata` is loaded (not sure why), causing code to break exclusively in debugger mode while working perfectly fine in normal cli mode (you can imagine that was a lengthy troubleshooting session)
The fix: apply the above function at the top of `packages/__tests__/setup-node.ts`.

Another example: https://github.com/aurelia/aurelia/issues/902
Also related: https://github.com/aurelia/aurelia/issues/833

## 👩‍💻 Reviewer Notes

Changes are simple enough to speak for themselves I think
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Other than existing tests passing, we'll need some specific project setups to verify this stuff. I've already verified it locally, we just need e2e tests running on CI to prevent future regressions. Logged it in this issue: https://github.com/aurelia/aurelia/issues/906
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Add e2e tests to prevent regression as per https://github.com/aurelia/aurelia/issues/906
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
