### PR TITLE
Karma tests filter

### DIFF
--- a/packages/__tests__/karma.conf.js
+++ b/packages/__tests__/karma.conf.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { DefinePlugin } = require('webpack');
 
 const basePath = path.resolve(__dirname);
 
@@ -28,6 +29,7 @@ module.exports = function (config) {
     browsers = ['Chrome'];
   }
 
+  const pkgArg = process.argv.find((arg) => new RegExp(/--pkg=(.*)/).exec(arg));
   const setup = 'setup-browser' + (config.package ? '-' + config.package : '');
   const options = {
     basePath,
@@ -53,6 +55,9 @@ module.exports = function (config) {
     },
     webpack: {
       mode: 'none',
+      plugins: [
+        new DefinePlugin({ PKG_TO_TEST: JSON.stringify("./" + new RegExp(/--pkg=(.*)/).exec(pkgArg)[1]  + "/") || "" })
+      ],
       resolve: {
         extensions: [
           '.js',

--- a/packages/__tests__/setup-browser.ts
+++ b/packages/__tests__/setup-browser.ts
@@ -43,18 +43,24 @@ function importAll(r) {
   r.keys().forEach(r);
 }
 
-// Explicitly add to browser test
-importAll(require.context('./1-kernel/', true, /\.spec\.js$/));
-importAll(require.context('./2-runtime/', true, /\.spec\.js$/));
-importAll(require.context('./3-runtime-html/', true, /\.spec\.js$/));
-importAll(require.context('./4-jit/', true, /\.spec\.js$/));
-importAll(require.context('./5-jit-html/', true, /\.spec\.js$/));
+declare let PKG_TO_TEST: string;
 
-importAll(require.context('./web-components/', true, /\.spec\.js$/));
-importAll(require.context('./fetch-client/', true, /\.spec\.js$/));
-importAll(require.context('./i18n/', true, /\.spec\.js$/));
-importAll(require.context('./integration/', true, /\.spec\.js$/));
-importAll(require.context('./router/', true, /\.spec\.js$/));
-importAll(require.context('./validation/', true, /\.spec\.js$/));
-importAll(require.context('./validation-html/', true, /\.spec\.js$/));
-importAll(require.context('./validation-i18n/', true, /\.spec\.js$/));
+if (PKG_TO_TEST !== "") {
+  importAll(require.context(PKG_TO_TEST, true, /\.spec\.js$/));
+} else {
+  // Explicitly add to browser test
+  importAll(require.context('./1-kernel/', true, /\.spec\.js$/));
+  importAll(require.context('./2-runtime/', true, /\.spec\.js$/));
+  importAll(require.context('./3-runtime-html/', true, /\.spec\.js$/));
+  importAll(require.context('./4-jit/', true, /\.spec\.js$/));
+  importAll(require.context('./5-jit-html/', true, /\.spec\.js$/));
+
+  importAll(require.context('./web-components/', true, /\.spec\.js$/));
+  importAll(require.context('./fetch-client/', true, /\.spec\.js$/));
+  importAll(require.context('./i18n/', true, /\.spec\.js$/));
+  importAll(require.context('./integration/', true, /\.spec\.js$/));
+  importAll(require.context('./router/', true, /\.spec\.js$/));
+  importAll(require.context('./validation/', true, /\.spec\.js$/));
+  importAll(require.context('./validation-html/', true, /\.spec\.js$/));
+  importAll(require.context('./validation-i18n/', true, /\.spec\.js$/));
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This allows to startup inidividual package tests only compared to running all of them with `npm run test-chrome`.
The reason is that the currently preferred way is to have to do manual modifications with the `setup-browser.ts` file which has a few drawbacks:

* Pollutes the change tracking of Git
* Might be unintentionally commited
* Lots of keystrokes

This proposed change does not remove the previous manual approach but merely adds an alternative approach for people preferring not touching files ;)

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Running `npm run test-browser` should still execute all tests, whereas e.g
running `npm run test-browser -- --pkg=store` will only execute the tests for the store package.
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
