### PR TITLE
docs(routing) fix #924: Add "/" to routing with params examples

### DIFF
--- a/docs/user-docs/routing/direct-routing.md
+++ b/docs/user-docs/routing/direct-routing.md
@@ -38,7 +38,7 @@ As you will see, the direct routing approach requires no configuration. We impor
 <import from="./test-component.html"></import>
 
 <ul>
-    <li><a goto="test-component">Test Component</a></li>
+    <li><a goto="/test-component">Test Component</a></li>
 </ul>
 
 <au-viewport></au-viewport>
@@ -66,7 +66,7 @@ To access parameters from the route, we can get those from the router lifecycle 
 <import from="./test-component"></import>
 
 <ul>
-    <li><a goto="test-component(hello)">Test Component</a></li>
+    <li><a goto="/test-component(hello)">Test Component</a></li>
 </ul>
 
 <au-viewport></au-viewport>
@@ -104,7 +104,7 @@ You can name your route parameters inline by specifying the name inside of the `
 <import from="./test-component"></import>
 
 <ul>
-    <li><a goto="test-component(named=hello)">Test Component</a></li>
+    <li><a goto="/test-component(named=hello)">Test Component</a></li>
 </ul>
 
 <au-viewport></au-viewport>
@@ -142,7 +142,7 @@ While you can name them inline, specifying them inside of your component makes i
 <import from="./test-component"></import>
 
 <ul>
-    <li><a goto="test-component(hello)">Test Component</a></li>
+    <li><a goto="/test-component(hello)">Test Component</a></li>
 </ul>
 
 <au-viewport></au-viewport>


### PR DESCRIPTION
Add "/" to `goto` links, with parameters. Effectively fixing bug #924 .

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Adds "/" links to `goto` examples, with parameters.

### 🎫 Issues

See bug report #924.

## 👩‍💻 Reviewer Notes

Please note that I'm not sure it the "/" is required, or if its a bonafide bug. Feel free to reject this PR if it's not required.
-cc @Vheissu because in his Aurelia 2 book the slash is also mentioned.

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
