### PR TITLE
feat(scheduler): awaitable async task support

### DIFF
--- a/packages/__tests__/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/2-runtime/scheduler.spec.ts
@@ -1,8 +1,33 @@
+/* eslint-disable @typescript-eslint/promise-function-async */
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/require-await */
 import { TestContext, assert } from '@aurelia/testing';
 import { TaskQueuePriority, QueueTaskTargetOptions, ITask } from '@aurelia/runtime';
 
+function createExposedPromise() {
+  let resolve: () => void;
+  let reject: (err: any) => void;
+
+  const promise = new Promise(function ($resolve, $reject) {
+    resolve = $resolve;
+    reject = $reject;
+  });
+
+  return {
+    resolve,
+    reject,
+    promise,
+  };
+}
+
 function round(num: number) {
   return ((num * 10 + .5) | 0) / 10;
+}
+
+async function wait(ms: number): Promise<void> {
+  return new Promise(function (resolve) {
+    setTimeout(resolve, ms);
+  });
 }
 
 function reportTask(task: any) {
@@ -33,7 +58,25 @@ describe('Scheduler', function () {
     sut.queueTask($queue, opts);
   }
 
+  function queueRecursiveAsync(opts: QueueTaskTargetOptions, count: number, cb: () => Promise<void>) {
+    async function $queue() {
+      await cb();
+
+      if (--count > 0) {
+        sut.queueTask($queue, opts);
+      }
+    }
+
+    sut.queueTask($queue, opts);
+  }
+
   function queueSequential(opts: QueueTaskTargetOptions, count: number, cb: () => void) {
+    while (count-- > 0) {
+      sut.queueTask(cb, opts);
+    }
+  }
+
+  function queueSequentialAsync(opts: QueueTaskTargetOptions, count: number, cb: () => Promise<void>) {
     while (count-- > 0) {
       sut.queueTask(cb, opts);
     }
@@ -697,4 +740,878 @@ describe('Scheduler', function () {
       }
     }
   }
+
+  describe('async', function () {
+    for (const reusable of [true, false]) {
+      const $reusable = reusable ? 'reusable' : 'non-reusable';
+
+      for (const { priority, name } of prioritySpecs) {
+        describe(`can queue ${$reusable} ${name}`, function () {
+          it('x1, {preempt: false, delay: 0}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            sut.queueTask(
+              async function () {
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          it('x1, {preempt: true, delay: 0}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            sut.queueTask(
+              async function () {
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          it('x1, {delay: 5}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            sut.queueTask(
+              async function () {
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            const calls: number[] = [];
+
+            sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            const calls: number[] = [];
+
+            sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
+            const { promise, resolve } = createExposedPromise();
+
+            const calls: number[] = [];
+
+            sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+
+                resolve();
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(3);
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                async: true,
+              },
+            );
+
+            await promise;
+          });
+
+          for (const delay of [1, 5]) {
+            for (const expected of [2, 4]) {
+              it(`${name} x${expected} sequential, {delay: ${delay}}`, async function () {
+                const { promise, resolve } = createExposedPromise();
+
+                let actual = 0;
+                async function increment() {
+                  if (++actual === expected) {
+                    assert.isSchedulerEmpty();
+
+                    resolve();
+                  }
+                }
+                queueSequentialAsync(
+                  {
+                    reusable,
+                    priority,
+                    delay,
+                    async: true,
+                  },
+                  expected,
+                  increment,
+                );
+
+                await promise;
+              });
+
+              it(`${name} x${expected} recursive, {delay: ${delay}}`, async function () {
+                const { promise, resolve } = createExposedPromise();
+
+                let actual = 0;
+                async function increment() {
+                  if (++actual === expected) {
+                    assert.isSchedulerEmpty();
+
+                    resolve();
+                  }
+                }
+                queueRecursiveAsync(
+                  {
+                    reusable,
+                    priority,
+                    delay,
+                    async: true,
+                  },
+                  expected,
+                  increment,
+                );
+
+                await promise;
+              });
+            }
+          }
+        });
+
+        describe(`can await ${$reusable} ${name}`, function () {
+          it(`manual 2x recursive`, async function () {
+            const opts = {
+              reusable,
+              priority,
+              preempt: false,
+              delay: 0,
+              async: true,
+            };
+
+            let count = 0;
+
+            sut.queueTask(
+              async function () {
+                await Promise.resolve();
+                ++count;
+
+                sut.queueTask(
+                  async function () {
+                    ++count;
+                  },
+                  opts,
+                );
+              },
+              opts,
+            );
+
+            await sut.yield(priority);
+
+            assert.strictEqual(count, 2);
+
+            assert.isSchedulerEmpty();
+          });
+
+          it('x1, {preempt: false, delay: 0}', async function () {
+            const task = sut.queueTask(
+              async function () {
+                /* */
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          it('x1, {preempt: true, delay: 0}', async function () {
+            const task = sut.queueTask(
+              async function () {
+                /* */
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          it('x1, {delay: 5}', async function () {
+            const task = sut.queueTask(
+              async function () {
+                /* */
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
+            const calls: number[] = [];
+
+            const task = sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                delay: 0,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
+            const calls: number[] = [];
+
+            const task = sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
+            const calls: number[] = [];
+
+            const task = sut.queueTask(
+              async function () {
+                calls.push(1);
+
+                assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
+
+                assert.isSchedulerEmpty();
+              },
+              {
+                reusable,
+                priority,
+                delay: 5,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(2);
+              },
+              {
+                reusable,
+                priority,
+                preempt: false,
+                async: true,
+              },
+            );
+
+            sut.queueTask(
+              async function () {
+                calls.push(3);
+              },
+              {
+                reusable,
+                priority,
+                preempt: true,
+                async: true,
+              },
+            );
+
+            await task.result;
+          });
+
+          for (const delay of [1, 5]) {
+            for (const expected of [2, 4]) {
+              it(`x${expected} sequential, {delay: ${delay}}`, async function () {
+                let actual = 0;
+                queueSequentialAsync(
+                  {
+                    reusable,
+                    priority,
+                    delay,
+                    async: true,
+                  },
+                  expected,
+                  async function () {
+                    ++actual;
+                  },
+                );
+
+                await sut.getTaskQueue(priority).yield();
+
+                assert.strictEqual(actual, expected, 'callCount');
+
+                assert.isSchedulerEmpty();
+              });
+
+              it(`x${expected} recursive, {delay: ${delay}}`, async function () {
+                let actual = 0;
+                queueRecursiveAsync(
+                  {
+                    reusable,
+                    priority,
+                    delay,
+                    async: true,
+                  },
+                  expected,
+                  async function () {
+                    ++actual;
+                  },
+                );
+
+                await sut.getTaskQueue(priority).yield();
+
+                assert.strictEqual(actual, expected, 'callCount');
+
+                assert.isSchedulerEmpty();
+              });
+            }
+          }
+        });
+
+        if (priority !== TaskQueuePriority.microTask) {
+          describe(`can persist ${$reusable} ${name}`, function () {
+            for (const iterations of [1, 2, 3]) {
+              describe(`runs until canceled after ${iterations} iterations`, function () {
+                it(`from within the running task`, async function () {
+                  const { promise, resolve } = createExposedPromise();
+
+                  let count = 0;
+
+                  const task = sut.queueTask(
+                    async function () {
+                      if (++count === iterations) {
+                        assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+
+                        task.cancel();
+
+                        assert.isSchedulerEmpty();
+                      }
+                    },
+                    {
+                      persistent: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  let thenCount = 0;
+                  async function callback() {
+                    if (++thenCount === iterations) {
+                      assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                      assert.isSchedulerEmpty();
+
+                      resolve();
+                    } else {
+                      assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                      await task.result;
+                      await callback();
+                    }
+                  }
+
+                  await task.result;
+                  await callback();
+                  await promise;
+                });
+
+                it(`from within a followup task`, async function () {
+                  const { promise, resolve } = createExposedPromise();
+
+                  let count = 0;
+
+                  const task = sut.queueTask(
+                    async function () {
+                      assert.strictEqual(nextTask.status, 'pending', `nextTask.status in task at count=${count} ${reportTask(nextTask)}`);
+                      assert.strictEqual(task.status, 'running', `task.status in task at count=${count} ${reportTask(task)}`);
+
+                      ++count;
+                    },
+                    {
+                      persistent: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  let nextTask: ITask;
+                  function createNextTask() {
+                    return sut.queueTask(
+                      async function () {
+                        assert.strictEqual(nextTask.status, 'running', `nextTask.status in nextTask at count=${count} ${reportTask(nextTask)}`);
+                        assert.strictEqual(task.status, 'pending', `task.status in nextTask at count=${count} ${reportTask(task)}`);
+
+                        if (count === iterations) {
+                          task.cancel();
+
+                          assert.isSchedulerEmpty();
+                        } else {
+                          nextTask = createNextTask();
+                        }
+                      },
+                      {
+                        reusable,
+                        priority,
+                        async: true,
+                      },
+                    );
+                  }
+
+                  nextTask = createNextTask();
+
+                  let thenCount = 0;
+                  async function callback() {
+                    if (++thenCount === iterations) {
+                      assert.strictEqual(nextTask.status, 'completed', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
+                      assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                      assert.isSchedulerEmpty();
+
+                      resolve();
+                    } else {
+                      assert.strictEqual(nextTask.status, 'pending', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
+                      assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                      await nextTask.result;
+
+                      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                      callback();
+                    }
+                  }
+
+                  await task.result;
+                  assert.strictEqual(nextTask.status, 'pending', `nextTask.status after awaiting task.result at thenCount=${thenCount} ${reportTask(nextTask)}`);
+                  assert.strictEqual(task.status, 'pending', `task.status after awaiting task.result at thenCount=${thenCount} ${reportTask(task)}`);
+
+                  await nextTask.result;
+
+                  await callback();
+
+                  await promise;
+                });
+
+                it(`yields after the first iteration with no other tasks`, async function () {
+                  const { promise, resolve } = createExposedPromise();
+
+                  let count = 0;
+                  let yieldCount = 0;
+
+                  const task = sut.queueTask(
+                    async function () {
+                      assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+                      assert.strictEqual(++count, yieldCount + 1, '++count === yieldCount + 1');
+                    },
+                    {
+                      persistent: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  async function yieldAndVerify() {
+                    await sut.yield(priority);
+
+                    if (priority !== TaskQueuePriority.microTask) {
+                      assert.strictEqual(count, ++yieldCount, 'count === ++yieldCount');
+
+                      if (yieldCount < iterations) {
+                        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                        yieldAndVerify();
+                      } else {
+                        task.cancel();
+
+                        assert.isSchedulerEmpty();
+
+                        resolve();
+                      }
+                    }
+                  }
+
+                  await yieldAndVerify();
+                  await promise;
+                });
+
+                it(`yields after the first iteration with several other tasks`, async function () {
+                  let count = 0;
+
+                  const task = sut.queueTask(
+                    async function () {
+                      assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+
+                      ++count;
+                    },
+                    {
+                      persistent: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  let otherCount = 0;
+                  sut.queueTask(
+                    async function () {
+                      ++otherCount;
+                    },
+                    {
+                      preempt: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  sut.queueTask(
+                    async function () {
+                      ++otherCount;
+                    },
+                    {
+                      preempt: false,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  sut.queueTask(
+                    async function () {
+                      ++otherCount;
+                    },
+                    {
+                      preempt: true,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  sut.queueTask(
+                    async function () {
+                      ++otherCount;
+                    },
+                    {
+                      preempt: false,
+                      reusable,
+                      priority,
+                      async: true,
+                    },
+                  );
+
+                  await sut.yield(priority);
+
+                  assert.strictEqual(count, 1, 'count');
+                  assert.strictEqual(otherCount, 4, 'otherCount');
+
+                  task.cancel();
+
+                  assert.isSchedulerEmpty();
+                });
+              });
+            }
+
+            it(`yields after the first iteration with no other tasks, after finishing a persistent task that was canceled from within a followup task`, async function () {
+              const primerTask = sut.queueTask(
+                async function () {
+                  assert.strictEqual(primerTask.status, 'running', `primerTask.status in primerTask ${reportTask(primerTask)}`);
+                  assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status in primerTask ${reportTask(primerCancelTask)}`);
+                },
+                {
+                  persistent: true,
+                  reusable,
+                  priority,
+                  async: true,
+                },
+              );
+
+              const primerCancelTask = sut.queueTask(
+                async function () {
+                  assert.strictEqual(primerTask.status, 'pending', `primerTask.status in primerCancelTask ${reportTask(primerTask)}`);
+                  assert.strictEqual(primerCancelTask.status, 'running', `primerCancelTask.status in primerCancelTask ${reportTask(primerCancelTask)}`);
+
+                  primerTask.cancel();
+
+                  assert.isSchedulerEmpty();
+                },
+                {
+                  reusable,
+                  priority,
+                  async: true,
+                },
+              );
+
+              await primerTask.result;
+              assert.strictEqual(primerTask.status, 'pending', `primerTask.status after awaiting primerTask.result ${reportTask(primerTask)}`);
+              assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status after awaiting primerTask.result ${reportTask(primerCancelTask)}`);
+
+              await primerCancelTask.result;
+              assert.strictEqual(primerTask.status, 'canceled', `primerTask.status after awaiting primerCancelTask.result ${reportTask(primerTask)}`);
+              assert.strictEqual(primerCancelTask.status, 'completed', `primerCancelTask.status after awaiting primerCancelTask.result ${reportTask(primerCancelTask)}`);
+
+              assert.isSchedulerEmpty();
+
+              let count = 0;
+              let yieldCount = 0;
+
+              const persistentTask = sut.queueTask(
+                async function () {
+                  assert.strictEqual(persistentTask.status, 'running', `persistentTask.status in persistentTask ${reportTask(persistentTask)}`);
+                  assert.strictEqual(++count, yieldCount + 1, `++count (${count}) === yieldCount + 1 (${yieldCount + 1}) in persistentTask`);
+                },
+                {
+                  persistent: true,
+                  reusable,
+                  priority,
+                  async: true,
+                },
+              );
+
+              await sut.yield(priority);
+
+              assert.strictEqual(count, ++yieldCount, `count (${count}) === ++yieldCount (${yieldCount}) after awaiting sut.yield()`);
+
+              persistentTask.cancel();
+
+              assert.isSchedulerEmpty();
+            });
+          });
+        }
+      }
+    }
+
+    const enum TaskState {
+      NotStarted = 0,
+      Started = 1,
+      Finished = 2,
+    }
+    it(`awaits the first task before starting the second`, async function () {
+      const states = [
+        TaskState.NotStarted,
+        TaskState.NotStarted,
+        TaskState.NotStarted,
+      ];
+
+      async function callback0() {
+        states[0] = TaskState.Started;
+        assert.deepStrictEqual(states, [TaskState.Started, 0, 0], `state at the start of callback0`);
+        await new Promise(resolve => setTimeout(resolve, 50));
+        states[0] = TaskState.Finished;
+        assert.deepStrictEqual(states, [TaskState.Finished, 0, 0], `state at the end of callback0`);
+      }
+
+      async function callback1() {
+        states[1] = TaskState.Started;
+        assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Started, 0], `state at the start of callback1`);
+        await new Promise(resolve => setTimeout(resolve, 50));
+        states[1] = TaskState.Finished;
+        assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Finished, 0], `state at the end of callback1`);
+      }
+
+      async function callback2() {
+        states[2] = TaskState.Started;
+        assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Finished, TaskState.Started], `state at the start of callback2`);
+        await new Promise(resolve => setTimeout(resolve, 50));
+        states[2] = TaskState.Finished;
+        assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Finished, TaskState.Finished], `state at the end of callback2`);
+      }
+
+      const opts: QueueTaskTargetOptions = {
+        priority: TaskQueuePriority.macroTask,
+        async: true,
+      };
+
+      const task0 = sut.queueTask(callback0, opts);
+      const task1 = sut.queueTask(callback1, opts);
+      const task2 = sut.queueTask(callback2, opts);
+
+      assert.deepStrictEqual(states, [TaskState.NotStarted, TaskState.NotStarted, TaskState.NotStarted], `state after queueing 3 tasks`);
+
+      await task0.result;
+
+      // Note: the assertion pattern here is to verify that the next task is started on the next 'cycle' rather than immediately after the previous task finished.
+      // If we were to verify the opposite, the expected state would be [Finished, Started, NotStarted] instead of [Finished, NotStarted, NotStarted].
+      assert.deepStrictEqual(states, [TaskState.Finished, TaskState.NotStarted, TaskState.NotStarted], `state after awaiting task0`);
+
+      await task1.result;
+
+      assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Finished, TaskState.NotStarted], `state after awaiting task1`);
+
+      await task2.result;
+
+      assert.deepStrictEqual(states, [TaskState.Finished, TaskState.Finished, TaskState.Finished], `state after awaiting task2`);
+
+      assert.isSchedulerEmpty();
+    });
+  });
 });

--- a/packages/__tests__/5-jit-html/binding-resources.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-resources.spec.ts
@@ -104,7 +104,7 @@ describe('binding-resources', function () {
 
       assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
 
-      await ctx.scheduler.yieldAll();
+      await wait(50);
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
     });

--- a/packages/__tests__/5-jit-html/binding-resources.spec.ts
+++ b/packages/__tests__/5-jit-html/binding-resources.spec.ts
@@ -54,9 +54,12 @@ describe('binding-resources', function () {
 
       assert.strictEqual(receiver.value, '0', `change 3 not yet propagated`);
 
-      await ctx.scheduler.yieldAll();
+      await wait(50);
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+
+      await au.stop().wait();
+      assert.isSchedulerEmpty();
     });
 
     it('works with toView bindings to other components', async function () {
@@ -107,6 +110,9 @@ describe('binding-resources', function () {
       await wait(50);
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+
+      await au.stop().wait();
+      assert.isSchedulerEmpty();
     });
 
     it('works with twoWay bindings to other components', async function () {
@@ -160,6 +166,9 @@ describe('binding-resources', function () {
       await ctx.scheduler.yieldAll();
 
       assert.strictEqual(receiver.value, '3', `change 3 propagated`);
+
+      await au.stop().wait();
+      assert.isSchedulerEmpty();
     });
 
     for (const command of ['trigger', 'capture', 'delegate']) {
@@ -214,6 +223,9 @@ describe('binding-resources', function () {
         assert.strictEqual(component.events[0], event3, `event 3 is the specific event that propagated`);
 
         host.remove();
+
+        await au.stop().wait();
+        assert.isSchedulerEmpty();
       });
     }
   });

--- a/packages/__tests__/5-jit-html/injectable.spec.ts
+++ b/packages/__tests__/5-jit-html/injectable.spec.ts
@@ -1,4 +1,3 @@
-import { RouterConfiguration } from '@aurelia/router';
 import { CustomElement, Aurelia, customElement } from '@aurelia/runtime';
 import { TestContext, assert } from '@aurelia/testing';
 
@@ -88,7 +87,7 @@ describe('CustomElement.createInjectable', function () {
     const ctx = TestContext.createHTMLTestContext();
     const host = ctx.createElement('div');
     const component = new Root();
-    const au = new Aurelia(ctx.container).register(RouterConfiguration, Parent, Child).app({ host, component });
+    const au = new Aurelia(ctx.container).register(Parent, Child).app({ host, component });
 
     await au.start().wait();
 

--- a/packages/scheduler/src/log.ts
+++ b/packages/scheduler/src/log.ts
@@ -1,0 +1,70 @@
+import { TaskQueue } from './task-queue';
+import { Task } from './task';
+
+// TODO(fkleuver): get rid of this whole file and do logging/tracing via a framework api
+declare const console: {
+  log(msg: string): void;
+};
+
+export const {
+  enter,
+  leave,
+  trace,
+} = (function () {
+  const enabled = false;
+  let depth = 0;
+
+  function round(num: number) {
+    return ((num * 10 + .5) | 0) / 10;
+  }
+
+  function log(prefix: string, obj: TaskQueue | Task, method: string) {
+    if (obj instanceof TaskQueue) {
+      const processing = obj['processingSize'];
+      const pending = obj['pendingSize'];
+      const delayed = obj['delayedSize'];
+      const flushReq = obj['flushRequested'];
+      const prio = obj['priority'];
+      const procAsync = !!obj['processingAsync'];
+
+      const info = `processing=${processing} pending=${pending} delayed=${delayed} flushReq=${flushReq} prio=${prio} procAsync=${procAsync}`;
+      console.log(`${prefix}[Q.${method}] ${info}`);
+    } else {
+      const id = obj['id'];
+      const created = round(obj['createdTime']);
+      const queue = round(obj['queueTime']);
+      const preempt = obj['preempt'];
+      const reusable = obj['reusable'];
+      const persistent = obj['persistent'];
+      const async = obj['async'];
+      const status = obj['_status'];
+
+      const info = `id=${id} created=${created} queue=${queue} preempt=${preempt} persistent=${persistent} reusable=${reusable} status=${status} async=${async}`;
+      console.log(`${prefix}[T.${method}] ${info}`);
+    }
+  }
+
+  function $enter(obj: TaskQueue | Task, method: string) {
+    if (enabled) {
+      log(`${'  '.repeat(depth++)}> `, obj, method);
+    }
+  }
+
+  function $leave(obj: TaskQueue | Task, method: string) {
+    if (enabled) {
+      log(`${'  '.repeat(--depth)}< `, obj, method);
+    }
+  }
+
+  function $trace(obj: TaskQueue | Task, method: string) {
+    if (enabled) {
+      log(`${'  '.repeat(depth)}- `, obj, method);
+    }
+  }
+
+  return {
+    enter: $enter,
+    leave: $leave,
+    trace: $trace,
+  };
+})();

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -113,8 +113,8 @@ export class Scheduler implements IScheduler {
   }
 
   public queueTask<T = any>(callback: TaskCallback<T>, opts?: QueueTaskTargetOptions): Task<T> {
-    const { delay, preempt, priority, persistent, reusable } = { ...defaultQueueTaskOptions, ...opts };
-    return this.taskQueues[priority].queueTask(callback, { delay, preempt, persistent, reusable });
+    const { delay, preempt, priority, persistent, reusable, async } = { ...defaultQueueTaskOptions, ...opts };
+    return this.taskQueues[priority].queueTask(callback, { delay, preempt, persistent, reusable, async });
   }
 
   public getMicroTaskQueue(): ITaskQueue {

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -150,11 +150,13 @@ export class Scheduler implements IScheduler {
   }
   public async yieldAll(repeat: number = 1): Promise<void> {
     while (repeat-- > 0) {
-      await this.yieldIdleTask();
-      await this.yieldPostRenderTask();
-      await this.yieldMacroTask();
-      await this.yieldRenderTask();
-      await this.yieldMicroTask();
+      await Promise.all([
+        this.yieldIdleTask(),
+        this.yieldPostRenderTask(),
+        this.yieldMacroTask(),
+        this.yieldRenderTask(),
+        this.yieldMicroTask(),
+      ]);
     }
   }
 

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -150,13 +150,11 @@ export class Scheduler implements IScheduler {
   }
   public async yieldAll(repeat: number = 1): Promise<void> {
     while (repeat-- > 0) {
-      await Promise.all([
-        this.yieldIdleTask(),
-        this.yieldPostRenderTask(),
-        this.yieldMacroTask(),
-        this.yieldRenderTask(),
-        this.yieldMicroTask(),
-      ]);
+      await this.yieldMicroTask();
+      await this.yieldRenderTask();
+      await this.yieldMacroTask();
+      await this.yieldPostRenderTask();
+      await this.yieldIdleTask();
     }
   }
 

--- a/packages/scheduler/src/task-queue.ts
+++ b/packages/scheduler/src/task-queue.ts
@@ -15,6 +15,11 @@ import {
 import {
   IScheduler,
 } from './scheduler';
+import {
+  enter,
+  trace,
+  leave,
+} from './log';
 
 export interface IFlushRequestorFactory {
   create(taskQueue: ITaskQueue): IFlushRequestor;
@@ -42,6 +47,8 @@ export class TaskQueue {
   private processingHead: Task | undefined = void 0;
   private processingTail: Task | undefined = void 0;
 
+  private processingAsync: Task | undefined = void 0;
+
   private pendingSize: number = 0;
   private pendingHead: Task | undefined = void 0;
   private pendingTail: Task | undefined = void 0;
@@ -63,6 +70,34 @@ export class TaskQueue {
     return this.processingSize === 0 && this.pendingSize === 0 && this.delayedSize === 0;
   }
 
+  private get hasNoMoreFiniteWork(): boolean {
+    let cur = this.processingHead;
+    while (cur !== void 0) {
+      if (!cur.persistent) {
+        return false;
+      }
+      cur = cur.next;
+    }
+
+    cur = this.pendingHead;
+    while (cur !== void 0) {
+      if (!cur.persistent) {
+        return false;
+      }
+      cur = cur.next;
+    }
+
+    cur = this.delayedHead;
+    while (cur !== void 0) {
+      if (!cur.persistent) {
+        return false;
+      }
+      cur = cur.next;
+    }
+
+    return true;
+  }
+
   public constructor(
     public readonly now: Now,
     public readonly priority: TaskQueuePriority,
@@ -74,6 +109,8 @@ export class TaskQueue {
   }
 
   public flush(): void {
+    enter(this, 'flush');
+
     if (this.microTaskRequestFlushTask !== null) {
       this.microTaskRequestFlushTask.cancel();
       this.microTaskRequestFlushTask = null;
@@ -81,96 +118,93 @@ export class TaskQueue {
 
     this.flushRequested = false;
 
-    if (this.pendingSize > 0) {
-      this.movePendingToProcessing();
-    }
-    if (this.delayedSize > 0) {
-      this.moveDelayedToProcessing();
-    }
+    if (this.processingAsync === void 0) {
+      if (this.pendingSize > 0) {
+        this.movePendingToProcessing();
+      }
+      if (this.delayedSize > 0) {
+        this.moveDelayedToProcessing();
+      }
 
-    while (this.processingSize > 0) {
-      this.processingHead!.run();
-    }
+      let cur: Task;
+      while (this.processingSize > 0) {
+        cur = this.processingHead!;
+        cur.run();
+        // If it's still running, it can only be an async task
+        if (cur.status === 'running') {
+          this.processingAsync = cur;
+          this.requestFlushClamped();
 
-    if (this.pendingSize > 0) {
-      this.movePendingToProcessing();
-    }
-    if (this.delayedSize > 0) {
-      this.moveDelayedToProcessing();
-    }
-    if (this.processingSize > 0) {
-      this.requestFlush();
-    } else if (this.delayedSize > 0) {
-      if (this.priority <= TaskQueuePriority.microTask) {
-        // MicroTasks are not clamped so we have to clamp them with setTimeout or they'll block forever
-        this.microTaskRequestFlushTask = this.scheduler.getTaskQueue(TaskQueuePriority.macroTask).queueTask(this.requestFlush);
-      } else {
-        // Otherwise just let this queue handle itself
+          leave(this, 'flush early async');
+
+          return;
+        }
+      }
+
+      if (this.pendingSize > 0) {
+        this.movePendingToProcessing();
+      }
+      if (this.delayedSize > 0) {
+        this.moveDelayedToProcessing();
+      }
+
+      if (this.processingSize > 0) {
         this.requestFlush();
-      }
-    }
-
-    if (this.yieldPromise !== void 0) {
-      let noMoreFiniteWork = true;
-      let cur = this.processingHead;
-      while (cur !== void 0) {
-        if (!cur.persistent) {
-          noMoreFiniteWork = false;
-          break;
-        }
-        cur = cur.next;
-      }
-      if (noMoreFiniteWork) {
-        cur = this.pendingHead;
-        while (cur !== void 0) {
-          if (!cur.persistent) {
-            noMoreFiniteWork = false;
-            break;
-          }
-          cur = cur.next;
-        }
-      }
-      if (noMoreFiniteWork) {
-        cur = this.delayedHead;
-        while (cur !== void 0) {
-          if (!cur.persistent) {
-            noMoreFiniteWork = false;
-            break;
-          }
-          cur = cur.next;
-        }
+      } else if (this.delayedSize > 0) {
+        this.requestFlushClamped();
       }
 
-      if (noMoreFiniteWork) {
+      if (
+        this.yieldPromise !== void 0 &&
+        this.hasNoMoreFiniteWork
+      ) {
         const p = this.yieldPromise;
         this.yieldPromise = void 0;
         p.resolve();
       }
+    } else {
+      this.requestFlushClamped();
     }
+
+    leave(this, 'flush full');
   }
 
   public cancel(): void {
+    enter(this, 'cancel');
+
     if (this.microTaskRequestFlushTask !== null) {
       this.microTaskRequestFlushTask.cancel();
       this.microTaskRequestFlushTask = null;
     }
 
-    this.flushRequestor.cancel();
-    this.flushRequested = false;
+    if (this.flushRequested) {
+      this.flushRequestor.cancel();
+      this.flushRequested = false;
+    }
+
+    leave(this, 'cancel');
   }
 
   public async yield(): Promise<void> {
-    if (this.processingSize > 0 || this.pendingSize > 0 || this.delayedSize > 0) {
+    enter(this, 'yield');
+
+    if (this.isEmpty) {
+      leave(this, 'yield empty');
+    } else {
       if (this.yieldPromise === void 0) {
         this.yieldPromise = createExposedPromise();
       }
 
       await this.yieldPromise;
+
+      leave(this, 'yield task');
     }
   }
 
   public queueTask<T = any>(callback: TaskCallback<T>, opts?: QueueTaskOptions): Task<T> {
-    const { delay, preempt, persistent, reusable } = { ...defaultQueueTaskOptions, ...opts };
+    enter(this, 'queueTask');
+
+    const { delay, preempt, persistent, reusable, async } = { ...defaultQueueTaskOptions, ...opts };
 
     if (preempt) {
       if (delay > 0) {
@@ -199,12 +233,12 @@ export class TaskQueue {
         taskPool[index] = (void 0)!;
         this.taskPoolSize = index;
 
-        task.reuse(time, delay, preempt, persistent, callback);
+        task.reuse(time, delay, preempt, persistent, async, callback);
       } else {
-        task = new Task(this, time, time + delay, preempt, persistent, reusable, callback);
+        task = new Task(this, time, time + delay, preempt, persistent, async, reusable, callback);
       }
     } else {
-      task = new Task(this, time, time + delay, preempt, persistent, reusable, callback);
+      task = new Task(this, time, time + delay, preempt, persistent, async, reusable, callback);
     }
 
     if (preempt) {
@@ -227,11 +261,17 @@ export class TaskQueue {
       }
     }
 
+    leave(this, 'queueTask');
+
     return task;
   }
 
   public take(task: Task): void {
+    enter(this, 'take');
+
     if (task.status !== 'pending') {
+      leave(this, 'take error');
+
       throw new Error('Can only take pending tasks.');
     }
 
@@ -248,12 +288,18 @@ export class TaskQueue {
     } else {
       this.addToDelayed(task);
     }
+
+    leave(this, 'take');
   }
 
   public remove<T = any>(task: Task<T>): void {
+    enter(this, 'remove');
+
     if (task.preempt) {
       // Fast path - preempt task can only ever end up in the processing queue
       this.removeFromProcessing(task);
+
+      leave(this, 'remove processing fast');
 
       return;
     }
@@ -261,6 +307,8 @@ export class TaskQueue {
     if (task.queueTime > this.now()) {
       // Fast path - task with queueTime in the future can only ever be in the delayed queue
       this.removeFromDelayed(task);
+
+      leave(this, 'remove delayed fast');
 
       return;
     }
@@ -270,6 +318,8 @@ export class TaskQueue {
     while (cur !== void 0) {
       if (cur === task) {
         this.removeFromProcessing(task);
+
+        leave(this, 'remove processing slow');
 
         return;
       }
@@ -281,6 +331,8 @@ export class TaskQueue {
       if (cur === task) {
         this.removeFromPending(task);
 
+        leave(this, 'remove pending slow');
+
         return;
       }
       cur = cur.next;
@@ -291,19 +343,27 @@ export class TaskQueue {
       if (cur === task) {
         this.removeFromDelayed(task);
 
+        leave(this, 'remove delayed slow');
+
         return;
       }
       cur = cur.next;
     }
 
+    leave(this, 'remove error');
+
     throw new Error(`Task #${task.id} could not be found`);
   }
 
   public returnToPool(task: Task): void {
+    trace(this, 'returnToPool');
+
     this.taskPool[this.taskPoolSize++] = task;
   }
 
   public resetPersistentTask(task: Task): void {
+    enter(this, 'resetPersistentTask');
+
     task.reset(this.now());
 
     if (task.createdTime === task.queueTime) {
@@ -323,18 +383,52 @@ export class TaskQueue {
         task.next = void 0;
       }
     }
+
+    leave(this, 'resetPersistentTask');
+  }
+
+  public completeAsyncTask(task: Task): void {
+    enter(this, 'completeAsyncTask');
+
+    if (this.processingAsync !== task) {
+      leave(this, 'completeAsyncTask error');
+
+      throw new Error(`Async task completion mismatch: processingAsync=${this.processingAsync?.id}, task=${task.id}`);
+    }
+
+    this.processingAsync = void 0;
+    if (
+      this.yieldPromise !== void 0 &&
+      this.hasNoMoreFiniteWork
+    ) {
+      const p = this.yieldPromise;
+      this.yieldPromise = void 0;
+      p.resolve();
+    }
+
+    if (this.isEmpty) {
+      this.cancel();
+    }
+
+    leave(this, 'completeAsyncTask');
   }
 
   private finish(task: Task): void {
+    enter(this, 'finish');
+
     if (task.next !== void 0) {
       task.next.prev = task.prev;
     }
     if (task.prev !== void 0) {
       task.prev.next = task.next;
     }
+
+    leave(this, 'finish');
   }
 
   private removeFromProcessing(task: Task): void {
+    enter(this, 'removeFromProcessing');
+
     if (this.processingHead === task) {
       this.processingHead = task.next;
     }
@@ -345,9 +439,13 @@ export class TaskQueue {
     --this.processingSize;
 
     this.finish(task);
+
+    leave(this, 'removeFromProcessing');
   }
 
   private removeFromPending(task: Task): void {
+    enter(this, 'removeFromPending');
+
     if (this.pendingHead === task) {
       this.pendingHead = task.next;
     }
@@ -358,9 +456,13 @@ export class TaskQueue {
     --this.pendingSize;
 
     this.finish(task);
+
+    leave(this, 'removeFromPending');
   }
 
   private removeFromDelayed(task: Task): void {
+    enter(this, 'removeFromDelayed');
+
     if (this.delayedHead === task) {
       this.delayedHead = task.next;
     }
@@ -371,33 +473,49 @@ export class TaskQueue {
     --this.delayedSize;
 
     this.finish(task);
+
+    leave(this, 'removeFromDelayed');
   }
 
   private addToProcessing(task: Task): void {
+    enter(this, 'addToProcessing');
+
     if (this.processingSize++ === 0) {
       this.processingHead = this.processingTail = task;
     } else {
       this.processingTail = (task.prev = this.processingTail!).next = task;
     }
+
+    leave(this, 'addToProcessing');
   }
 
   private addToPending(task: Task): void {
+    enter(this, 'addToPending');
+
     if (this.pendingSize++ === 0) {
       this.pendingHead = this.pendingTail = task;
     } else {
       this.pendingTail = (task.prev = this.pendingTail!).next = task;
     }
+
+    leave(this, 'addToPending');
   }
 
   private addToDelayed(task: Task): void {
+    enter(this, 'addToDelayed');
+
     if (this.delayedSize++ === 0) {
       this.delayedHead = this.delayedTail = task;
     } else {
       this.delayedTail = (task.prev = this.delayedTail!).next = task;
     }
+
+    leave(this, 'addToDelayed');
   }
 
   private movePendingToProcessing(): void {
+    enter(this, 'movePendingToProcessing');
+
     // Add the previously pending tasks to the currently processing tasks
     if (this.processingSize === 0) {
       this.processingHead = this.pendingHead;
@@ -412,9 +530,13 @@ export class TaskQueue {
     this.pendingHead = void 0;
     this.pendingTail = void 0;
     this.pendingSize = 0;
+
+    leave(this, 'movePendingToProcessing');
   }
 
   private moveDelayedToProcessing(): void {
+    enter(this, 'moveDelayedToProcessing');
+
     const time = this.now();
 
     // Add any delayed tasks whose delay have expired to the currently processing tasks
@@ -445,9 +567,13 @@ export class TaskQueue {
         this.delayedTail = void 0;
       }
     }
+
+    leave(this, 'moveDelayedToProcessing');
   }
 
   private requestFlush(): void {
+    enter(this, 'requestFlush');
+
     if (this.microTaskRequestFlushTask !== null) {
       this.microTaskRequestFlushTask.cancel();
       this.microTaskRequestFlushTask = null;
@@ -458,5 +584,29 @@ export class TaskQueue {
       this.lastRequest = this.now();
       this.flushRequestor.request();
     }
+
+    leave(this, 'requestFlush');
+  }
+
+  private requestFlushClamped(): void {
+    enter(this, 'requestFlushClamped');
+
+    if (this.priority <= TaskQueuePriority.microTask) {
+      // MicroTasks are not clamped so we have to clamp them with setTimeout or they'll block forever
+      this.microTaskRequestFlushTask = this.scheduler.queueMacroTask(this.requestFlush, microTaskRequestFlushTaskOptions);
+    } else {
+      // Otherwise just let this queue handle itself
+      this.requestFlush();
+    }
+
+    leave(this, 'requestFlushClamped');
   }
 }
+
+const microTaskRequestFlushTaskOptions: QueueTaskOptions = {
+  delay: 0,
+  preempt: true,
+  persistent: false,
+  reusable: true,
+  async: false,
+};

--- a/packages/scheduler/src/task-queue.ts
+++ b/packages/scheduler/src/task-queue.ts
@@ -220,6 +220,7 @@ export class TaskQueue {
       leave(this, 'yield empty');
     } else {
       if (this.yieldPromise === void 0) {
+        trace(this, 'yield - creating promise');
         this.yieldPromise = createExposedPromise();
       }
 

--- a/packages/scheduler/src/task.ts
+++ b/packages/scheduler/src/task.ts
@@ -8,6 +8,7 @@ import {
   TaskQueue,
   TaskCallback,
 } from './task-queue';
+import { enter, trace, leave } from './log';
 
 export class TaskAbortError<T = any> extends Error {
   public constructor(public task: Task<T>) {
@@ -70,6 +71,7 @@ export class Task<T = any> implements ITask {
     public queueTime: number,
     public preempt: boolean,
     public persistent: boolean,
+    public async: boolean | 'auto',
     public readonly reusable: boolean,
     public callback: TaskCallback<T>
   ) {
@@ -77,39 +79,85 @@ export class Task<T = any> implements ITask {
   }
 
   public run(): void {
+    enter(this, 'run');
+
     if (this._status !== 'pending') {
+      leave(this, 'run error');
+
       throw new Error(`Cannot run task in ${this._status} state`);
     }
 
     // this.persistent could be changed while the task is running (this can only be done by the task itself if canceled, and is a valid way of stopping a loop)
     // so we deliberately reference this.persistent instead of the local variable, but we keep it around to know whether the task *was* persistent before running it,
     // so we can set the correct cancelation state.
-    const persistent = this.persistent;
-    const reusable = this.reusable;
-    const taskQueue = this.taskQueue;
-    const callback = this.callback;
-    const resolve = this.resolve;
-    const reject = this.reject;
-    const createdTime = this.createdTime;
+    const {
+      persistent,
+      reusable,
+      taskQueue,
+      callback,
+      resolve,
+      reject,
+      createdTime,
+      async,
+    } = this;
 
     taskQueue.remove(this);
 
     this._status = 'running';
+    let isAsync = false;
 
     try {
       const ret = callback(taskQueue.now() - createdTime);
+      if (async === true || (async === 'auto' && ret instanceof Promise)) {
+        isAsync = true;
+        (ret as unknown as Promise<T>)
+          .then(() => {
+            if (this.persistent) {
+              taskQueue.resetPersistentTask(this);
+            } else if (persistent) {
+              // Persistent tasks never reach completed status. They're either pending, running, or canceled.
+              this._status = 'canceled';
+            } else {
+              this._status = 'completed';
+            }
 
-      if (this.persistent) {
-        taskQueue.resetPersistentTask(this);
-      } else if (persistent) {
-        // Persistent tasks never reach completed status. They're either pending, running, or canceled.
-        this._status = 'canceled';
+            if (resolve !== void 0) {
+              resolve(ret);
+            }
+          })
+          .catch(err => {
+            if (reject !== void 0) {
+              reject(err);
+            } else {
+              throw err;
+            }
+          })
+          .finally(() => {
+            if (!this.persistent) {
+              this.dispose();
+
+              if (reusable) {
+                taskQueue.returnToPool(this);
+              }
+            }
+
+            taskQueue.completeAsyncTask(this);
+
+            leave(this, 'run async finally');
+          });
       } else {
-        this._status = 'completed';
-      }
+        if (this.persistent) {
+          taskQueue.resetPersistentTask(this);
+        } else if (persistent) {
+          // Persistent tasks never reach completed status. They're either pending, running, or canceled.
+          this._status = 'canceled';
+        } else {
+          this._status = 'completed';
+        }
 
-      if (resolve !== void 0) {
-        resolve(ret);
+        if (resolve !== void 0) {
+          resolve(ret);
+        }
       }
     } catch (err) {
       if (reject !== void 0) {
@@ -118,17 +166,23 @@ export class Task<T = any> implements ITask {
         throw err;
       }
     } finally {
-      if (!this.persistent) {
-        this.dispose();
+      if (!isAsync) {
+        if (!this.persistent) {
+          this.dispose();
 
-        if (reusable) {
-          taskQueue.returnToPool(this);
+          if (reusable) {
+            taskQueue.returnToPool(this);
+          }
         }
+
+        leave(this, 'run sync finally');
       }
     }
   }
 
   public cancel(): boolean {
+    enter(this, 'cancel');
+
     if (this._status === 'pending') {
 
       const taskQueue = this.taskQueue;
@@ -153,17 +207,25 @@ export class Task<T = any> implements ITask {
         taskQueue.returnToPool(this);
       }
 
+      leave(this, 'cancel true =pending');
+
       return true;
     } else if (this._status === 'running' && this.persistent) {
       this.persistent = false;
 
+      leave(this, 'cancel true =running+persistent');
+
       return true;
     }
+
+    leave(this, 'cancel false');
 
     return false;
   }
 
   public reset(time: number): void {
+    enter(this, 'reset');
+
     const delay = this.queueTime - this.createdTime;
     this.createdTime = time;
     this.queueTime = time + delay;
@@ -172,6 +234,8 @@ export class Task<T = any> implements ITask {
     this.resolve = void 0;
     this.reject = void 0;
     this._result = void 0;
+
+    leave(this, 'reset');
   }
 
   public reuse(
@@ -179,17 +243,25 @@ export class Task<T = any> implements ITask {
     delay: number,
     preempt: boolean,
     persistent: boolean,
+    async: boolean | 'auto',
     callback: TaskCallback<T>,
   ): void {
+    enter(this, 'reuse');
+
     this.createdTime = time;
     this.queueTime = time + delay;
     this.preempt = preempt;
     this.persistent = persistent;
+    this.async = async;
     this.callback = callback;
     this._status = 'pending';
+
+    leave(this, 'reuse');
   }
 
   public dispose(): void {
+    trace(this, 'dispose');
+
     this.prev = void 0;
     this.next = void 0;
 

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -72,6 +72,9 @@ export type ExposedPromise<T = void> = Promise<T> & {
   reject: PReject;
 };
 
+/**
+ * Efficiently create a promise where the `resolve` and `reject` functions are stored as properties on the prommise itself.
+ */
 export function createExposedPromise<T>(): ExposedPromise<T> {
   const p = new Promise<T>(executor) as ExposedPromise<T>;
   p.resolve = $resolve;

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -35,6 +35,14 @@ export type QueueTaskOptions = {
    * Defaults to `true`
    */
   reusable?: boolean;
+  /**
+   * If `true`, the return value of the callback will be treated as a promise. Consecutive tasks will be run only after the promise resolved.
+   *
+   * If `'auto'`, the return value of the callback will be treated as a promise only if is an instance of a promise. Use this only for callbacks that can either return `void` or `Promise` and it can't be determined upfront which of the two it is. For dealing with promises, this is less efficient than passing in `true`.
+   *
+   * Defaults to `false`
+   */
+  async?: boolean | 'auto';
 };
 
 export type QueueTaskTargetOptions = QueueTaskOptions & {
@@ -47,6 +55,7 @@ export const defaultQueueTaskOptions: Required<QueueTaskTargetOptions> = {
   priority: TaskQueuePriority.render,
   persistent: false,
   reusable: true,
+  async: false,
 };
 
 export type PResolve<T> = (value?: T | PromiseLike<T>) => void;

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -13,6 +13,7 @@ import {
   PropertyBinding,
   IBinding,
   BindingBehaviorExpression,
+  ITask,
 } from '@aurelia/runtime';
 import { PropertyRule } from '@aurelia/validation';
 import { BindingWithBehavior, IValidationController, ValidationController, BindingInfo, ValidationResultsSubscriber, ValidationEvent } from './validation-controller';
@@ -129,6 +130,9 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
   }
 
   public $unbind(flags: LifecycleFlags) {
+    this.task?.cancel();
+    this.task = null;
+
     const event = this.triggerEvent;
     if (event !== null) {
       this.target?.removeEventListener(event, this);
@@ -199,8 +203,10 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
     return new ValidateArgumentsDelta(this.ensureController(controller), this.ensureTrigger(trigger), rules);
   }
 
+  private task: ITask | null = null;
   private validateBinding() {
-    this.scheduler.getPostRenderTaskQueue().queueTask(async () => {
+    this.task?.cancel();
+    this.task = this.scheduler.getPostRenderTaskQueue().queueTask(async () => {
       await this.controller.validateBinding(this.propertyBinding);
     });
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

In this PR I cherry-picked the scheduler-related commits from https://github.com/aurelia/aurelia/pull/845 that pertain only to adding async support.

Adds a new `TaskQueueOption.async: boolean | 'auto'

- If `true`, the return value of the callback will be treated as a promise. Consecutive tasks will be run only after the promise resolved.

- If `'auto'`, the return value of the callback will be treated as a promise only if is an instance of a promise. Appropriate when it's not certain upfront whether the task callback will return a promise or not.

- If `false` (default), the scheduler will treat the task as a synchronous one and will not await it before starting the next task.


<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

I left in some trace logging helper code that I needed from time to time in pinpointing what happens to scheduled tasks in certain edge cases. These calls are no-ops unless `enabled = false` is changed to `true` in the code. I've deliberately left it as a non-configurable private api as the overhead may be too big for keeping tracing around in this much detail. So, it will probably be removed or significantly reduced before RC.

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

Added additional combinatory tests on top of the existing ones, testing various input combinations and more complex scenarios
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

Immediate follow-up to this would be other standalone pieces of aforementioned PR.

As for the scheduler specifically, it seems like the current priorities (`microTask`, `macroTask`, `renderTask` etc) don't make sense as being interchangeable for any given task. There should be some notion of prioritization, but not in the form of fundamentally different types of timings. So there will be a rework upcoming for this. Impact on API should be minimal (not a huge breaking change), but it should add a lot more capabilities in particular for things like timeslicing.

Also need the ability to group async tasks for parallelism while still keeping them awaitable. Maybe hierarchical task queues? Needs more thought and experimentation


<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
