### PR TITLE
report InterfaceSymbol friendly name when converted to string

### DIFF
--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -436,6 +436,24 @@ describe(`The DI object`, function () {
   });
 
   describe(`createInterface()`, function () {
+    it(`returns a function that stringifies its default friendly name`, function () {
+      const sut = DI.createInterface();
+      const expected = 'InterfaceSymbol<(anonymous)>';
+      assert.strictEqual(sut.toString(), expected, `sut.toString() === '${expected}'`);
+      assert.strictEqual(String(sut), expected, `String(sut) === '${expected}'`);
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      assert.strictEqual(`${sut}`, expected, `\`\${sut}\` === '${expected}'`);
+    });
+
+    it(`returns a function that stringifies its configured friendly name`, function () {
+      const sut = DI.createInterface('IFoo');
+      const expected = 'InterfaceSymbol<IFoo>';
+      assert.strictEqual(sut.toString(), expected, `sut.toString() === '${expected}'`);
+      assert.strictEqual(String(sut), expected, `String(sut) === '${expected}'`);
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      assert.strictEqual(`${sut}`, expected, `\`\${sut}\` === '${expected}'`);
+    });
+
     it(`returns a function that has withDefault and noDefault functions`, function () {
       const sut = DI.createInterface();
       assert.strictEqual(typeof sut, 'function', `typeof sut`);

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -301,7 +301,7 @@ export const DI = {
       return target;
     };
     Interface.$isInterface = true;
-    Interface.friendlyName = friendlyName == null ? 'Interface' : friendlyName;
+    Interface.friendlyName = friendlyName == null ? '(anonymous)' : friendlyName;
 
     Interface.noDefault = function (): InterfaceSymbol<K> {
       return Interface;
@@ -317,6 +317,10 @@ export const DI = {
       };
 
       return Interface;
+    };
+
+    Interface.toString = function toString(): string {
+      return `InterfaceSymbol<${Interface.friendlyName}>`;
     };
 
     return Interface;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

In some situations you still see the whole function implementation of `InterfaceSymbol` when it's added to a log or error stack trace, which isn't helpful. With this change it'll be easier to inspect declared dependencies.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
