### PR TITLE
global stop tasks

### DIFF
--- a/packages/__tests__/2-runtime/au-slot.spec.ts
+++ b/packages/__tests__/2-runtime/au-slot.spec.ts
@@ -982,8 +982,6 @@ describe('au-slot', function () {
         if (additionalAssertion != null) {
           await additionalAssertion(ctx);
         }
-
-        assert.isSchedulerEmpty();
       },
       { template, registrations });
   }

--- a/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
@@ -42,15 +42,11 @@ describe('2-runtime/binding-mode-behavior.spec.ts', function () {
 
         it(`bind()   should apply  bindingMode ${mode}`, function () {
           assert.strictEqual(binding.mode, mode, `binding.mode`);
-
-          assert.isSchedulerEmpty();
         });
 
         it(`unbind() should revert bindingMode ${initMode}`, function () {
           sut.unbind(undefined, undefined, binding);
           assert.strictEqual(binding.mode, initMode, `binding.mode`);
-
-          assert.isSchedulerEmpty();
         });
       });
     }

--- a/packages/__tests__/2-runtime/binding.spec.ts
+++ b/packages/__tests__/2-runtime/binding.spec.ts
@@ -128,8 +128,6 @@ describe('PropertyBinding', function () {
     sut.$bind(LF.fromBind, scope2, null);
 
     assert.strictEqual(target.val, count * 3, `target.val`);
-
-    assert.isSchedulerEmpty();
   }).timeout(20000);
 
   describe('$bind() [one-time] assigns the target value', function () {
@@ -197,8 +195,6 @@ describe('PropertyBinding', function () {
         // expect(targetObserver.setValue, `targetObserver.setValue`).to.have.been.calledOnce;
         // expect(targetObserver.setValue, `targetObserver.setValue`).to.have.been.calledWithExactly(srcVal, flags);
         // assert.strictEqual(lifecycle.flushCount, 0, `lifecycle.flushCount`);
-
-        assert.isSchedulerEmpty();
       });
     }
     );
@@ -425,8 +421,6 @@ describe('PropertyBinding', function () {
             // assert.strictEqual(lifecycle.flushCount, 0, `lifecycle.flushCount #61`);
           }
         }
-
-        assert.isSchedulerEmpty();
       });
     }
     );
@@ -540,8 +534,6 @@ describe('PropertyBinding', function () {
           // expect(expr.evaluate).not.to.have.been.called;
           // expect(expr.assign).not.to.have.been.called;
         }
-
-        assert.isSchedulerEmpty();
       });
     }
     );
@@ -855,8 +847,6 @@ describe('PropertyBinding', function () {
 
         verifyEqual(target[prop], srcVal);
         verifyEqual(targetObserver.currentValue, srcVal);
-
-        assert.isSchedulerEmpty();
       });
     }
     );

--- a/packages/__tests__/2-runtime/dirty-checker.spec.ts
+++ b/packages/__tests__/2-runtime/dirty-checker.spec.ts
@@ -239,7 +239,6 @@ describe('DirtyChecker', function () {
                             observer2.unsubscribe(subscriber3);
                             observer2.unsubscribe(subscriber4);
 
-                            assert.isSchedulerEmpty();
                             done();
                           });
                         });
@@ -289,7 +288,6 @@ describe('DirtyChecker', function () {
               assert.strictEqual(callCount, 0, `callCount`);
               observer.unsubscribe(subscriber);
 
-              assert.isSchedulerEmpty();
               done();
             });
           });

--- a/packages/__tests__/2-runtime/enhance.spec.ts
+++ b/packages/__tests__/2-runtime/enhance.spec.ts
@@ -55,7 +55,6 @@ describe('2-runtime/enhance.spec.ts', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(testEnhance);
@@ -146,7 +145,6 @@ describe('2-runtime/enhance.spec.ts', function () {
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
       au.dispose();
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -219,7 +217,6 @@ describe('2-runtime/enhance.spec.ts', function () {
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
         au.dispose();
-        assert.isSchedulerEmpty();
       });
     }
   );
@@ -261,7 +258,6 @@ describe('2-runtime/enhance.spec.ts', function () {
       'afterAttachChildren',
     ]);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it(`enhance is idempotent`, async function () {
@@ -293,6 +289,5 @@ describe('2-runtime/enhance.spec.ts', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/2-runtime/if.integration.spec.ts
+++ b/packages/__tests__/2-runtime/if.integration.spec.ts
@@ -230,8 +230,6 @@ describe(`If/Else`, function () {
         }
 
         assert.strictEqual(host.textContent, '', 'host.textContent #6');
-
-        assert.isSchedulerEmpty();
       });
     });
 });

--- a/packages/__tests__/2-runtime/repeater.spec.ts
+++ b/packages/__tests__/2-runtime/repeater.spec.ts
@@ -657,8 +657,6 @@ describe(`Repeat`, function () {
         }
 
         assert.strictEqual(host.textContent, '', 'host.textContent #12');
-
-        assert.isSchedulerEmpty();
       });
     });
 });

--- a/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/array-index-observer.spec.ts
@@ -184,8 +184,6 @@ describe('simple Computed Observer test case', function () {
         // test cases could be sharing the same context document
         // so wait a bit before running the next test
         await tearDown();
-
-        assert.isSchedulerEmpty();
       });
     }
   );

--- a/packages/__tests__/3-runtime-html/async-hook-cancellation.spec.ts
+++ b/packages/__tests__/3-runtime-html/async-hook-cancellation.spec.ts
@@ -336,7 +336,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterBind', async function () {
@@ -387,7 +386,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttach', async function () {
@@ -446,7 +444,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttachChildren', async function () {
@@ -513,7 +510,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
               });
 
@@ -579,7 +575,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttachChildren', async function () {
@@ -655,7 +650,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
               });
 
@@ -713,7 +707,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterBind', async function () {
@@ -777,7 +770,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttach', async function () {
@@ -849,7 +841,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttachChildren', async function () {
@@ -966,7 +957,6 @@ describe('controller short-circuit', function () {
                   }
 
                   controller.dispose();
-                  assert.isSchedulerEmpty();
                 });
               });
             });
@@ -1019,7 +1009,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   au.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterBind', async function () {
@@ -1070,7 +1059,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   au.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttach', async function () {
@@ -1129,7 +1117,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   au.dispose();
-                  assert.isSchedulerEmpty();
                 });
 
                 it('afterAttachChildren', async function () {
@@ -1196,7 +1183,6 @@ describe('controller short-circuit', function () {
                   ], `2.1`);
 
                   au.dispose();
-                  assert.isSchedulerEmpty();
                 });
               });
             }

--- a/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
@@ -202,7 +202,6 @@ describe('template-compiler.binding-commands.class', function () {
           await au.stop().wait();
 
           au.dispose();
-          assert.isSchedulerEmpty();
         }
       });
     }

--- a/packages/__tests__/3-runtime-html/binding-command.style.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-command.style.spec.ts
@@ -249,7 +249,6 @@ describe('template-compiler.binding-commands.style', function () {
           await au.stop().wait();
 
           au.dispose();
-          assert.isSchedulerEmpty();
         }
       });
     }

--- a/packages/__tests__/3-runtime-html/binding-resources.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-resources.spec.ts
@@ -61,7 +61,6 @@ describe('binding-resources', function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('works with toView bindings to other components', async function () {
@@ -116,7 +115,6 @@ describe('binding-resources', function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('works with twoWay bindings to other components', async function () {
@@ -174,7 +172,6 @@ describe('binding-resources', function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     for (const command of ['trigger', 'capture', 'delegate']) {
@@ -233,7 +230,6 @@ describe('binding-resources', function () {
         await au.stop().wait();
 
         au.dispose();
-        assert.isSchedulerEmpty();
       });
     }
   });

--- a/packages/__tests__/3-runtime-html/blur.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/blur.integration.spec.ts
@@ -361,7 +361,6 @@ describe('blur.integration.spec.ts', function () {
         testHost.remove();
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
     };
   }

--- a/packages/__tests__/3-runtime-html/checked-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/checked-observer.spec.ts
@@ -275,8 +275,6 @@ describe('checked-observer.spec.ts', function () {
           // test cases could be sharing the same context document
           // so wait a bit before running the next test
           await tearDown();
-
-          assert.isSchedulerEmpty();
         });
       }
     }

--- a/packages/__tests__/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/children-observer.spec.ts
@@ -13,7 +13,6 @@ describe('ChildrenObserver', function () {
       au.stop();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('children array with by custom query', function () {
@@ -25,9 +24,7 @@ describe('ChildrenObserver', function () {
       assert.instanceOf(viewModel.children[0], ChildOne);
 
       au.stop();
-
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('children array with by custom query, filter, and map', function () {
@@ -41,9 +38,7 @@ describe('ChildrenObserver', function () {
       assert.equal(viewModel.children[0].tagName, CustomElement.getDefinition(ChildOne).name.toUpperCase());
 
       au.stop();
-
       au.dispose();
-      assert.isSchedulerEmpty();
     });
   });
 
@@ -71,7 +66,6 @@ describe('ChildrenObserver', function () {
         au.stop();
 
         au.dispose();
-        assert.isSchedulerEmpty();
         done();
       });
     });
@@ -96,7 +90,6 @@ describe('ChildrenObserver', function () {
         au.stop();
 
         au.dispose();
-        assert.isSchedulerEmpty();
         done();
       });
     });
@@ -125,7 +118,6 @@ describe('ChildrenObserver', function () {
         au.stop();
 
         au.dispose();
-        assert.isSchedulerEmpty();
         done();
       });
     });

--- a/packages/__tests__/3-runtime-html/compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/compose.spec.ts
@@ -171,7 +171,6 @@ describe(spec, function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/computed-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/computed-observer.spec.ts
@@ -431,7 +431,6 @@ describe('simple Computed Observer test case', function () {
         testHost.remove();
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
     };
   }

--- a/packages/__tests__/3-runtime-html/focus.spec.ts
+++ b/packages/__tests__/3-runtime-html/focus.spec.ts
@@ -372,7 +372,6 @@ describe('focus.spec.ts', function () {
         testHost.remove();
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
     };
   }

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.double.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.double.spec.ts
@@ -35,7 +35,6 @@ describe("generated.template-compiler.static.if-else.double", function () {
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();
-        assert.isSchedulerEmpty();
     }
     it("tag$01 text$01 if$01 if$01 double$01 _", function () {
         const { au, host } = createFixture();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
@@ -35,7 +35,6 @@ describe("generated.template-compiler.static.if-else.repeat.double", function ()
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();
-        assert.isSchedulerEmpty();
     }
     it("tag$01 text$01 if$01 repeat$11 variant$01$double _", function () {
         const { au, host } = createFixture();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.spec.ts
@@ -35,7 +35,6 @@ describe("generated.template-compiler.static.if-else.repeat", function () {
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();
-        assert.isSchedulerEmpty();
     }
     it("tag$01 text$01 if$01 repeat$11 variant$01 _", function () {
         const { au, host } = createFixture();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.spec.ts
@@ -35,7 +35,6 @@ describe("generated.template-compiler.static.if-else", function () {
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();
-        assert.isSchedulerEmpty();
     }
     it("tag$01 text$01 if$01 if$01 _", function () {
         const { au, host } = createFixture();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.spec.ts
@@ -35,7 +35,6 @@ describe("generated.template-compiler.static", function () {
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();
-        assert.isSchedulerEmpty();
     }
     it("tag$01 text$01 _", function () {
         const { au, host } = createFixture();

--- a/packages/__tests__/3-runtime-html/injectable.spec.ts
+++ b/packages/__tests__/3-runtime-html/injectable.spec.ts
@@ -96,6 +96,5 @@ describe('CustomElement.createInjectable', function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/3-runtime-html/local-dependency-inheritance.spec.ts
+++ b/packages/__tests__/3-runtime-html/local-dependency-inheritance.spec.ts
@@ -190,6 +190,5 @@ describe('local dependency inheritance', function () {
     await verifyHostText(au, host, `147258369`);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/3-runtime-html/portal.spec.tsx
+++ b/packages/__tests__/3-runtime-html/portal.spec.tsx
@@ -443,7 +443,6 @@ describe('portal.spec.tsx 🚪-🔁-🚪', function () {
         host.remove();
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
     };
   }

--- a/packages/__tests__/3-runtime-html/repeat.contextual-props.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeat.contextual-props.spec.ts
@@ -435,7 +435,6 @@ describe(`[repeat.contextual-prop.spec.ts]`, function () {
           if (body) {
             body.focus();
           }
-          assert.isSchedulerEmpty();
         }
       });
     }

--- a/packages/__tests__/3-runtime-html/repeat.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeat.integration.spec.ts
@@ -29,7 +29,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("01 _", async function () {
     const { au, host } = createFixture();
@@ -51,7 +50,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it("012 _", async function () {
@@ -74,7 +72,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("021 _", async function () {
     const { au, host } = createFixture();
@@ -96,7 +93,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("102 _", async function () {
     const { au, host } = createFixture();
@@ -118,7 +114,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("120 _", async function () {
     const { au, host } = createFixture();
@@ -140,7 +135,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("201 _", async function () {
     const { au, host } = createFixture();
@@ -162,7 +156,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("210 _", async function () {
     const { au, host } = createFixture();
@@ -184,7 +177,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it("0123 _", async function () {
@@ -207,7 +199,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("0132 _", async function () {
     const { au, host } = createFixture();
@@ -229,7 +220,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("0213 _", async function () {
     const { au, host } = createFixture();
@@ -251,7 +241,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("0231 _", async function () {
     const { au, host } = createFixture();
@@ -273,7 +262,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("0312 _", async function () {
     const { au, host } = createFixture();
@@ -295,7 +283,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("0321 _", async function () {
     const { au, host } = createFixture();
@@ -317,7 +304,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1023 _", async function () {
     const { au, host } = createFixture();
@@ -339,7 +325,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1032 _", async function () {
     const { au, host } = createFixture();
@@ -361,7 +346,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1203 _", async function () {
     const { au, host } = createFixture();
@@ -383,7 +367,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1230 _", async function () {
     const { au, host } = createFixture();
@@ -405,7 +388,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1302 _", async function () {
     const { au, host } = createFixture();
@@ -427,7 +409,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("1320 _", async function () {
     const { au, host } = createFixture();
@@ -449,7 +430,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2013 _", async function () {
     const { au, host } = createFixture();
@@ -471,7 +451,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2031 _", async function () {
     const { au, host } = createFixture();
@@ -493,7 +472,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2103 _", async function () {
     const { au, host } = createFixture();
@@ -515,7 +493,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2130 _", async function () {
     const { au, host } = createFixture();
@@ -537,7 +514,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2301 _", async function () {
     const { au, host } = createFixture();
@@ -559,7 +535,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("2310 _", async function () {
     const { au, host } = createFixture();
@@ -581,7 +556,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3012 _", async function () {
     const { au, host } = createFixture();
@@ -603,7 +577,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3021 _", async function () {
     const { au, host } = createFixture();
@@ -625,7 +598,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3102 _", async function () {
     const { au, host } = createFixture();
@@ -647,7 +619,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3120 _", async function () {
     const { au, host } = createFixture();
@@ -669,7 +640,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3201 _", async function () {
     const { au, host } = createFixture();
@@ -691,7 +661,6 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
   it("3210 _", async function () {
     const { au, host } = createFixture();
@@ -713,6 +682,5 @@ describe("generated.template-compiler.repeat", function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/3-runtime-html/repeat_weird.spec.tsx
+++ b/packages/__tests__/3-runtime-html/repeat_weird.spec.tsx
@@ -122,7 +122,6 @@ describe('[repeat] -- funny cases', function () {
     (au.root.host as Element).remove();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   function createItems(count: number, baseName: string = 'item') {

--- a/packages/__tests__/3-runtime-html/repeater-if-else.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater-if-else.spec.ts
@@ -592,8 +592,7 @@ describe(spec, function () {
         assert.strictEqual(trimFull(host.textContent), '', `trimFull(host.textContent) === ''`);
 
         au.dispose();
-        assert.isSchedulerEmpty();
-      });
+          });
     });
 
 });

--- a/packages/__tests__/3-runtime-html/repeater.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.spec.ts
@@ -240,7 +240,6 @@ describe(spec, function () {
       assert.strictEqual(host.textContent, '', 'host.textContent');
 
       au.dispose();
-      assert.isSchedulerEmpty();
-    });
+      });
   });
 });

--- a/packages/__tests__/3-runtime-html/resources.spec.ts
+++ b/packages/__tests__/3-runtime-html/resources.spec.ts
@@ -14,7 +14,6 @@ function startAndStop(component: CustomElementType) {
   au.stop();
 
   au.dispose();
-  assert.isSchedulerEmpty();
 }
 
 function getMetadataAsObject(target: any): Record<string, any> {

--- a/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
@@ -39,8 +39,6 @@ describe('SelectValueObserver', function () {
             assert.strictEqual(el.value, next, `el.value`);
 
             sut.unbind(LF.none);
-
-            assert.isSchedulerEmpty();
           });
         }
       }
@@ -66,8 +64,6 @@ describe('SelectValueObserver', function () {
           assert.strictEqual(callbackSpy.calls.length, 1, 'callbackSpy.calls.length');
 
           sut.unbind(LF.none);
-
-          assert.isSchedulerEmpty();
         }
       });
     }
@@ -88,8 +84,6 @@ describe('SelectValueObserver', function () {
 
         assert.strictEqual(count, 1, `count`);
         assert.strictEqual(sut['nodeObserver'], null, `sut['nodeObserver']`);
-
-        assert.isSchedulerEmpty();
       }
     });
     it('unsubscribes array observer', function () {
@@ -112,8 +106,6 @@ describe('SelectValueObserver', function () {
 
         assert.strictEqual(count, 1, `count`);
         assert.strictEqual(sut['arrayObserver'], null, `sut['arrayObserver']`);
-
-        assert.isSchedulerEmpty();
       }
     });
   });
@@ -151,8 +143,6 @@ describe('SelectValueObserver', function () {
         assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       it('synchronizes with null', function () {
@@ -172,8 +162,6 @@ describe('SelectValueObserver', function () {
         assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       it('synchronizes with undefined', function () {
@@ -193,8 +181,6 @@ describe('SelectValueObserver', function () {
         assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       it('synchronizes with array (2)', function () {
@@ -222,8 +208,6 @@ describe('SelectValueObserver', function () {
         );
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       it('synchronizes with array (3): disregard "value" when there is model', function () {
@@ -251,8 +235,6 @@ describe('SelectValueObserver', function () {
         );
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       it('synchronize regardless disabled state of <option/>', function () {
@@ -280,8 +262,6 @@ describe('SelectValueObserver', function () {
         );
 
         sut.unbind(LF.none);
-
-        assert.isSchedulerEmpty();
       });
 
       describe('with <optgroup>', function () {
@@ -313,8 +293,6 @@ describe('SelectValueObserver', function () {
           );
 
           sut.unbind(LF.none);
-
-          assert.isSchedulerEmpty();
         });
 
       });

--- a/packages/__tests__/3-runtime-html/self-binding-behavior.spec.ts
+++ b/packages/__tests__/3-runtime-html/self-binding-behavior.spec.ts
@@ -25,15 +25,11 @@ describe('SelfBindingBehavior', function () {
     assert.strictEqual(binding['selfEventCallSource'] === originalCallSource, true, `binding['selfEventCallSource'] === originalCallSource`);
     assert.strictEqual(binding['callSource'] === originalCallSource, false, `binding['callSource'] === originalCallSource`);
     assert.strictEqual(typeof binding['callSource'], 'function', `typeof binding['callSource']`);
-
-    assert.isSchedulerEmpty();
   });
 
   it('unbind() should revert the original behavior', function () {
     sut.unbind(undefined, undefined, null, binding as any);
     assert.strictEqual(binding['selfEventCallSource'], null, `binding['selfEventCallSource']`);
     assert.strictEqual(binding['callSource'] === originalCallSource, true, `binding['callSource'] === originalCallSource`);
-
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/3-runtime-html/styles.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.integration.spec.ts
@@ -57,6 +57,5 @@ describe('styles', function () {
     await au.stop().wait();
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.spec.ts
@@ -115,7 +115,6 @@ describe('Styles', function () {
 
       await au.stop().wait();
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('config passes root styles to container', async function () {
@@ -139,7 +138,6 @@ describe('Styles', function () {
 
       await au.stop().wait();
       au.dispose();
-      assert.isSchedulerEmpty();
     });
 
     it('element styles apply parent styles', function () {

--- a/packages/__tests__/3-runtime-html/target-observers.spec.ts
+++ b/packages/__tests__/3-runtime-html/target-observers.spec.ts
@@ -56,8 +56,6 @@ describe('AttributeNSAccessor', function () {
         sut.bind(LifecycleFlags.none);
         actual = sut.getValue();
         assert.strictEqual(actual, value, `actual`);
-
-        assert.isSchedulerEmpty();
       });
     }
   });
@@ -74,8 +72,6 @@ describe('AttributeNSAccessor', function () {
       sut.setValue('foo', LifecycleFlags.none);
 
       assert.strictEqual(el.getAttributeNS(sut.namespace, sut.propertyKey), 'foo', `el.getAttributeNS(sut.namespace, sut.propertyKey) after flush`);
-
-      assert.isSchedulerEmpty();
     });
   }
 });
@@ -102,8 +98,6 @@ describe('DataAttributeAccessor', function () {
           sut.bind(LifecycleFlags.none);
           actual = sut.getValue();
           assert.strictEqual(actual, value, `actual`);
-
-          assert.isSchedulerEmpty();
         });
       }
     }
@@ -123,8 +117,6 @@ describe('DataAttributeAccessor', function () {
         sut.setValue(value, LifecycleFlags.none);
 
         assert.strictEqual(el.outerHTML, expected, `el.outerHTML after flush`);
-
-        assert.isSchedulerEmpty();
       });
     }
   }
@@ -172,8 +164,6 @@ describe('StyleAccessor', function () {
         ],
         `setPropertySpy.calls`,
       );
-
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -197,8 +187,6 @@ describe('StyleAccessor', function () {
         ],
         `setPropertySpy.calls`,
       );
-
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -330,8 +318,6 @@ describe('StyleAccessor', function () {
 
       const actual = sut.getValue();
       assert.strictEqual(actual, expected);
-
-      assert.isSchedulerEmpty();
     });
   }
 });
@@ -397,8 +383,6 @@ describe('ClassAccessor', function () {
 
         function tearDown() {
           scheduler.getRenderTaskQueue().flush();
-
-          assert.isSchedulerEmpty();
         }
 
         return { sut, el, initialClassList, scheduler, tearDown };

--- a/packages/__tests__/3-runtime-html/template-binder.au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-binder.au-slot.spec.ts
@@ -66,24 +66,18 @@ describe('template-binder.au-slot', function () {
       '<au-slot></au-slot>',
       (mfr) => {
         verifyAuSlot(mfr.childNodes[0] as CustomElementSymbol, "default");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
       '<au-slot name="s1"></au-slot>',
       (mfr) => {
         verifyAuSlot(mfr.childNodes[0] as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
       '<au-slot name="s2" name="s1"></au-slot>',
       (mfr) => {
         verifyAuSlot(mfr.childNodes[0] as CustomElementSymbol, "s2");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -92,8 +86,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot(tc.template as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -102,8 +94,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot((tc.template as PlainElementSymbol).childNodes[0] as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -112,8 +102,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[1] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot(tc.template as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -126,8 +114,6 @@ describe('template-binder.au-slot', function () {
         const tc2 = mfr.childNodes[1] as TemplateControllerSymbol;
         assert.instanceOf(tc2, TemplateControllerSymbol);
         verifyAuSlot(tc2.template as CustomElementSymbol, "s2");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -136,8 +122,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot(tc.template as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -146,8 +130,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot((tc.template as PlainElementSymbol).childNodes[0] as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -156,8 +138,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot(tc.template as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -166,8 +146,6 @@ describe('template-binder.au-slot', function () {
         const tc = mfr.childNodes[0] as TemplateControllerSymbol;
         assert.instanceOf(tc, TemplateControllerSymbol);
         verifyAuSlot((tc.template as PlainElementSymbol).childNodes[0] as CustomElementSymbol, "s1");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -175,8 +153,6 @@ describe('template-binder.au-slot', function () {
       (mfr) => {
         verifyAuSlot(mfr.childNodes[0] as CustomElementSymbol, "s1");
         verifyAuSlot(mfr.childNodes[1] as CustomElementSymbol, "s2");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -185,8 +161,6 @@ describe('template-binder.au-slot', function () {
         const node1 = (mfr.childNodes[0] as CustomElementSymbol);
         verifyAuSlot(node1, "s1");
         verifyAuSlot(node1.childNodes[0] as CustomElementSymbol, "s2");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -197,8 +171,6 @@ describe('template-binder.au-slot', function () {
         const node2 = (node1.childNodes[0] as CustomElementSymbol);
         verifyAuSlot(node2, "s2");
         verifyAuSlot(node2.childNodes[0] as CustomElementSymbol, "s3");
-
-        assert.isSchedulerEmpty();
       }
     );
     yield new TestData(
@@ -210,8 +182,6 @@ describe('template-binder.au-slot', function () {
         assert.deepStrictEqual(
           node.projections.map((p) => [p.name, (p.template.physicalNode as HTMLElement).outerHTML]),
           [["default", '<div></div>']]);
-
-        assert.isSchedulerEmpty();
       }
     );
     // #endregion
@@ -226,8 +196,6 @@ describe('template-binder.au-slot', function () {
         assert.deepStrictEqual(
           ce.projections.map((p) => [p.name, (p.template.physicalNode as HTMLElement).outerHTML]),
           [["default", '<div></div>']]);
-
-        assert.isSchedulerEmpty();
       },
       [createElement('')]
     );
@@ -240,8 +208,6 @@ describe('template-binder.au-slot', function () {
         assert.deepStrictEqual(
           ce.projections.map((p) => [p.name, (p.template.physicalNode as HTMLElement).outerHTML]),
           [["s1", '<div></div>'], ["s2", '<div></div>']]);
-
-        assert.isSchedulerEmpty();
       },
       [createElement('')]
     );
@@ -263,8 +229,6 @@ describe('template-binder.au-slot', function () {
           ),
         ];
         assert.deepStrictEqual(JSON.parse(JSON.stringify(ce.projections)), JSON.parse(JSON.stringify(expected)));
-
-        assert.isSchedulerEmpty();
       },
       [
         createElement('', 'my-element1'),
@@ -286,8 +250,6 @@ describe('template-binder.au-slot', function () {
         assert.deepStrictEqual(
           ce2.projections.map((p) => [p.name, (p.template.physicalNode as HTMLElement).outerHTML]),
           [["s1", '<div></div>']]);
-
-        assert.isSchedulerEmpty();
       },
       [
         createElement('', 'my-element1'),
@@ -303,8 +265,6 @@ describe('template-binder.au-slot', function () {
       const template = factory.createTemplate(markup) as HTMLTemplateElement;
 
       verify(ctx.binder.bind(template), ctx.dom, factory, ctx.resources);
-
-      assert.isSchedulerEmpty();
     });
   }
 

--- a/packages/__tests__/3-runtime-html/template-compiler.ce_and_surrogate.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.ce_and_surrogate.spec.ts
@@ -188,8 +188,6 @@ describe('template-compiler.ce_and_surrogate.spec.ts', function () {
         host.remove();
       } finally {
         host?.remove();
-
-        assert.isSchedulerEmpty();
       }
     });
   }

--- a/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
@@ -343,14 +343,10 @@ describe('template-compiler.harmony.spec.ts \n\tharmoninous combination', functi
 
         au.dispose();
       } finally {
-        assert.isSchedulerEmpty();
-
         host?.remove();
         await new Promise(r => ctx.dom.window.requestAnimationFrame(r));
         await new Promise(r => ctx.dom.window.requestAnimationFrame(r));
         body?.focus();
-
-        assert.isSchedulerEmpty();
       }
     });
   });

--- a/packages/__tests__/3-runtime-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.primary-bindable.spec.ts
@@ -526,8 +526,6 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
         if (body) {
           body.focus();
         }
-
-        assert.isSchedulerEmpty();
       }
     });
   }
@@ -612,7 +610,6 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
       await au.stop().wait();
       au.dispose();
       host.remove();
-      assert.isSchedulerEmpty();
     });
 
     it('works correctly when using with value converter and a colon', async function () {
@@ -640,7 +637,6 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
       await au.stop().wait();
       au.dispose();
       host.remove();
-      assert.isSchedulerEmpty();
     });
 
     // todo: fix:
@@ -686,7 +682,6 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
       await au.stop().wait();
       au.dispose();
       host.remove();
-      assert.isSchedulerEmpty();
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/template-compiler.ref.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.ref.spec.ts
@@ -503,8 +503,6 @@ describe('templating-compiler.ref.spec.ts', function () {
       } finally {
         host?.remove();
         body?.focus();
-
-        assert.isSchedulerEmpty();
       }
     });
   }

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -1395,7 +1395,6 @@ describe('TemplateCompiler - local templates', function () {
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
       au.dispose();
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -1421,7 +1420,6 @@ describe('TemplateCompiler - local templates', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it('works with for', async function () {
@@ -1445,7 +1443,6 @@ describe('TemplateCompiler - local templates', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it('works with nested templates - 1', async function () {
@@ -1483,7 +1480,6 @@ describe('TemplateCompiler - local templates', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it('works with nested templates - 2', async function () {
@@ -1520,7 +1516,6 @@ describe('TemplateCompiler - local templates', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 
   it('throws error if a root template is a local template', function () {

--- a/packages/__tests__/router/__smoke-tests.spec.ts.txt
+++ b/packages/__tests__/router/__smoke-tests.spec.ts.txt
@@ -101,7 +101,6 @@ async function createFixture<T extends Constructable>(
       // scheduler.getRenderTaskQueue().flush();
       // assert.isSchedulerEmpty();
 
-      router.stop();
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
 

--- a/packages/__tests__/router/_shared/configuration.ts
+++ b/packages/__tests__/router/_shared/configuration.ts
@@ -20,7 +20,7 @@ export const TestRouterConfiguration = {
         container.register(
           Registration.instance(IHistory, mockBrowserHistoryLocation),
           Registration.instance(ILocation, mockBrowserHistoryLocation),
-          StartTask.with(IRouter).beforeRender().call(router => {
+          StartTask.with(IRouter).beforeCompile().call(router => {
             mockBrowserHistoryLocation.changeCallback = router['handlePopstate'];
           }),
         );

--- a/packages/__tests__/router/_shared/configuration.ts
+++ b/packages/__tests__/router/_shared/configuration.ts
@@ -2,7 +2,7 @@ import { IContainer, Registration, IRegistry, LoggerConfiguration, LogLevel, Col
 import { MockBrowserHistoryLocation, HTMLTestContext } from '@aurelia/testing';
 import { IRouter } from '@aurelia/router';
 import { IHistory, ILocation } from '@aurelia/runtime-html';
-import { StartTask } from '@aurelia/runtime';
+import { AppTask } from '@aurelia/runtime';
 
 export const TestRouterConfiguration = {
   for(ctx: HTMLTestContext, logLevel: LogLevel = LogLevel.debug): IRegistry {
@@ -20,7 +20,7 @@ export const TestRouterConfiguration = {
         container.register(
           Registration.instance(IHistory, mockBrowserHistoryLocation),
           Registration.instance(ILocation, mockBrowserHistoryLocation),
-          StartTask.with(IRouter).beforeCompile().call(router => {
+          AppTask.with(IRouter).beforeCompile().call(router => {
             mockBrowserHistoryLocation.changeCallback = router['handlePopstate'];
           }),
         );

--- a/packages/__tests__/router/_shared/create-fixture.ts
+++ b/packages/__tests__/router/_shared/create-fixture.ts
@@ -106,14 +106,11 @@ export async function createFixture<T extends Constructable>(
       logConfig.level = level;
     },
     async tearDown() {
-      assert.isSchedulerEmpty();
-
       hia.setPhase('stop');
 
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     },
   };
 }

--- a/packages/__tests__/router/_shared/create-fixture.ts
+++ b/packages/__tests__/router/_shared/create-fixture.ts
@@ -106,9 +106,6 @@ export async function createFixture<T extends Constructable>(
       logConfig.level = level;
     },
     async tearDown() {
-
-      router.stop();
-
       assert.isSchedulerEmpty();
 
       hia.setPhase('stop');

--- a/packages/__tests__/router/configuration.spec.ts
+++ b/packages/__tests__/router/configuration.spec.ts
@@ -33,7 +33,6 @@ describe('Configuration', function () {
     await au.start().wait();
 
     async function tearDown() {
-      router.stop();
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
 
@@ -112,7 +111,6 @@ describe('Configuration', function () {
 
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
-    router.stop();
 
     au.dispose();
     assert.isSchedulerEmpty();

--- a/packages/__tests__/router/configuration.spec.ts
+++ b/packages/__tests__/router/configuration.spec.ts
@@ -37,7 +37,6 @@ describe('Configuration', function () {
       ctx.doc.body.removeChild(host);
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     return { au, container, lifecycle, host, router, ctx, tearDown };
@@ -113,6 +112,5 @@ describe('Configuration', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/router/configuration.ts
+++ b/packages/__tests__/router/configuration.ts
@@ -2,7 +2,7 @@ import { IContainer, Registration, IRegistry, LoggerConfiguration, LogLevel } fr
 import { MockBrowserHistoryLocation, HTMLTestContext } from '@aurelia/testing';
 import { IRouter } from '@aurelia/router';
 import { IHistory, ILocation } from '@aurelia/runtime-html';
-import { StartTask } from '@aurelia/runtime';
+import { AppTask } from '@aurelia/runtime';
 
 export const TestRouterConfiguration = {
   for(ctx: HTMLTestContext, logLevel: LogLevel = LogLevel.debug): IRegistry {
@@ -14,7 +14,7 @@ export const TestRouterConfiguration = {
         container.register(
           Registration.instance(IHistory, mockBrowserHistoryLocation),
           Registration.instance(ILocation, mockBrowserHistoryLocation),
-          StartTask.with(IRouter).beforeCompile().call(router => {
+          AppTask.with(IRouter).beforeCompile().call(router => {
             // mockBrowserHistoryLocation.changeCallback = router['handlePopstate'];
             mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
           }),

--- a/packages/__tests__/router/configuration.ts
+++ b/packages/__tests__/router/configuration.ts
@@ -14,7 +14,7 @@ export const TestRouterConfiguration = {
         container.register(
           Registration.instance(IHistory, mockBrowserHistoryLocation),
           Registration.instance(ILocation, mockBrowserHistoryLocation),
-          StartTask.with(IRouter).beforeRender().call(router => {
+          StartTask.with(IRouter).beforeCompile().call(router => {
             // mockBrowserHistoryLocation.changeCallback = router['handlePopstate'];
             mockBrowserHistoryLocation.changeCallback = router.navigation.handlePopstate;
           }),

--- a/packages/__tests__/router/hook-manager.spec.ts
+++ b/packages/__tests__/router/hook-manager.spec.ts
@@ -44,7 +44,6 @@ describe('HookManager', function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     const navigationInstruction = new Navigation({ instruction: 'test', fullStateInstruction: 'full-test' });

--- a/packages/__tests__/router/hook-manager.spec.ts
+++ b/packages/__tests__/router/hook-manager.spec.ts
@@ -40,7 +40,6 @@ describe('HookManager', function () {
 
     async function tearDown() {
       unspyNavigationStates(router, _pushState, _replaceState);
-      router.stop();
       RouterConfiguration.customize();
       await au.stop().wait();
 

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -31,7 +31,6 @@ describe('InstructionResolver', function () {
       ctx.doc.body.removeChild(host);
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     return { au, container, host, router, tearDown, ctx, instructionResolver };

--- a/packages/__tests__/router/instruction-resolver.spec.ts
+++ b/packages/__tests__/router/instruction-resolver.spec.ts
@@ -27,7 +27,6 @@ describe('InstructionResolver', function () {
     await au.start().wait();
 
     async function tearDown() {
-      router.stop();
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
 

--- a/packages/__tests__/router/link-handler.spec.ts
+++ b/packages/__tests__/router/link-handler.spec.ts
@@ -33,7 +33,6 @@ describe('LinkHandler', function () {
       doc.body.removeChild(host);
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     return { sut, au, container, host, ctx, tearDown };

--- a/packages/__tests__/router/nav.spec.ts
+++ b/packages/__tests__/router/nav.spec.ts
@@ -50,7 +50,6 @@ describe('Nav', function () {
       ctx.doc.body.removeChild(host);
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     const scheduler = ctx.scheduler;

--- a/packages/__tests__/router/nav.spec.ts
+++ b/packages/__tests__/router/nav.spec.ts
@@ -46,7 +46,6 @@ describe('Nav', function () {
     await au.start().wait();
 
     async function tearDown() {
-      router.stop();
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
 

--- a/packages/__tests__/router/queue.spec.ts
+++ b/packages/__tests__/router/queue.spec.ts
@@ -28,8 +28,6 @@ describe('Queue', function () {
     assert.strictEqual(q.pending.length, 1, `q.pending.length`);
     await wait(110);
     assert.strictEqual(q.pending.length, 0, `q.pending.length`);
-
-    assert.isSchedulerEmpty();
   });
 
   it('adds to queue with right costs', function () {
@@ -64,8 +62,6 @@ describe('Queue', function () {
     assert.strictEqual(q.pending.length, 6, `q.pending.length`);
     assert.strictEqual(q.pending[4].cost, 6, `q.pending[4].cost`);
     assert.strictEqual(q.pending[5].cost, 7, `q.pending[5].cost`);
-
-    assert.isSchedulerEmpty();
   });
 
   it('can tick the queue', async function () {
@@ -90,8 +86,6 @@ describe('Queue', function () {
     await wait(120);
     assert.strictEqual(q.pending.length, 0, `q.pending.length`);
     q.stop();
-
-    assert.isSchedulerEmpty();
   });
 });
 

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -961,7 +961,6 @@ describe('Router', function () {
         ctx.doc.body.removeChild(host);
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
 
       return { ctx, container, scheduler, host, component, au, router, $teardown };
@@ -1212,7 +1211,6 @@ describe('Router', function () {
         ctx.doc.body.removeChild(host);
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
 
       return { ctx, container, scheduler, host, au, router, $teardown };
@@ -1343,7 +1341,6 @@ describe('Router', function () {
         ctx.doc.body.removeChild(host);
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
 
       return { ctx, container, scheduler, host, au, router, $teardown, App };
@@ -1612,7 +1609,6 @@ describe('Router', function () {
         ctx.doc.body.removeChild(host);
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
 
       return { ctx, container, scheduler, host, au, router, $teardown, App };
@@ -1834,7 +1830,6 @@ describe('Router', function () {
         ctx.doc.body.removeChild(host);
 
         au.dispose();
-        assert.isSchedulerEmpty();
       }
 
       return { ctx, container, scheduler, host, au, router, $teardown, App };

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -151,7 +151,6 @@ describe('Router', function () {
 
     async function tearDown() {
       unspyNavigationStates(router, _pushState, _replaceState);
-      router.stop();
       await au.stop().wait();
       ctx.doc.body.removeChild(host);
     }
@@ -960,7 +959,6 @@ describe('Router', function () {
       async function $teardown() {
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
-        router.stop();
 
         au.dispose();
         assert.isSchedulerEmpty();
@@ -1210,7 +1208,6 @@ describe('Router', function () {
 
       async function $teardown() {
         unspyNavigationStates(router, _pushState, _replaceState);
-        router.stop();
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
 
@@ -1342,7 +1339,6 @@ describe('Router', function () {
 
       async function $teardown() {
         unspyNavigationStates(router, _pushState, _replaceState);
-        router.stop();
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
 
@@ -1612,7 +1608,6 @@ describe('Router', function () {
 
       async function $teardown() {
         unspyNavigationStates(router, _pushState, _replaceState);
-        router.stop();
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
 
@@ -1835,7 +1830,6 @@ describe('Router', function () {
 
       async function $teardown() {
         unspyNavigationStates(router, _pushState, _replaceState);
-        router.stop();
         await au.stop().wait();
         ctx.doc.body.removeChild(host);
 

--- a/packages/__tests__/router/viewport.spec.ts
+++ b/packages/__tests__/router/viewport.spec.ts
@@ -31,7 +31,6 @@ describe('Viewport', function () {
     await au.start().wait();
 
     async function tearDown() {
-      router.stop();
       RouterConfiguration.customize();
       await au.stop().wait();
 

--- a/packages/__tests__/router/viewport.spec.ts
+++ b/packages/__tests__/router/viewport.spec.ts
@@ -35,7 +35,6 @@ describe('Viewport', function () {
       await au.stop().wait();
 
       au.dispose();
-      assert.isSchedulerEmpty();
     }
 
     return { au, container, scheduler, host, router, tearDown };

--- a/packages/__tests__/validation-html/subscribers/validation-container-custom-element.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-container-custom-element.spec.ts
@@ -90,7 +90,6 @@ describe('validation-container-custom-element', function () {
     assert.equal(app.controllerRemoveSubscriberSpy.calls.length, template.match(/validation-container/g).length / 2 + template.match(/validate/g).length);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(runTest);
@@ -326,6 +325,5 @@ describe('validation-container-custom-element', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/validation-html/subscribers/validation-errors-custom-attribute.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-errors-custom-attribute.spec.ts
@@ -95,7 +95,6 @@ describe('validation-errors-custom-attribute', function () {
       assert.equal(app.controllerRemoveSubscriberSpy.calls.length, template.match(/validation-errors|validate/g).length);
     }
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(runTest);
@@ -434,6 +433,5 @@ describe('validation-errors-custom-attribute', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
@@ -93,7 +93,6 @@ describe('validation-result-presenter-service', function () {
     await au.stop().wait();
     ctx.doc.body.removeChild(host);
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(runTest);

--- a/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
@@ -319,7 +319,6 @@ describe('validate-binding-behavior', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(runTest);
@@ -711,7 +710,6 @@ describe('validate-binding-behavior', function () {
 
       // TODO: there's a binding somewhere without a dispose() method, causing this to fail
       // au.dispose();
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -1376,7 +1374,6 @@ describe('validate-binding-behavior', function () {
       ctx.doc.body.removeChild(host);
 
       au.dispose();
-      assert.isSchedulerEmpty();
     });
   }
 
@@ -1448,6 +1445,5 @@ describe('validate-binding-behavior', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   });
 });

--- a/packages/__tests__/validation-html/validation-controller.spec.ts
+++ b/packages/__tests__/validation-html/validation-controller.spec.ts
@@ -98,7 +98,6 @@ describe('validation controller factory', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
   const $it = createSpecFunction(runTest);
 
@@ -225,7 +224,6 @@ describe('validation-controller', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
   const $it = createSpecFunction(runTest);
 

--- a/packages/__tests__/validation-i18n/localization.spec.ts
+++ b/packages/__tests__/validation-i18n/localization.spec.ts
@@ -171,7 +171,6 @@ describe('validation-i18n', function () {
     ctx.doc.body.removeChild(host);
 
     au.dispose();
-    assert.isSchedulerEmpty();
   }
 
   const $it = createSpecFunction(runTest);

--- a/packages/i18n/src/configuration.ts
+++ b/packages/i18n/src/configuration.ts
@@ -70,7 +70,7 @@ function coreComponents(options: I18nConfigurationOptions) {
     register(container: IContainer) {
       return container.register(
         Registration.callback(I18nInitOptions, () => options.initOptions),
-        StartTask.with(I18N).beforeBind().call(i18n => i18n.task),
+        StartTask.with(I18N).beforeActivate().call(i18n => i18n.task),
         Registration.singleton(I18nWrapper, I18nextWrapper),
         Registration.singleton(I18N, I18nService),
 

--- a/packages/i18n/src/configuration.ts
+++ b/packages/i18n/src/configuration.ts
@@ -1,5 +1,5 @@
 import { IContainer, Registration } from '@aurelia/kernel';
-import { StartTask, AttributePatternDefinition, BindingCommand, AttributePattern } from '@aurelia/runtime';
+import { AppTask, AttributePatternDefinition, BindingCommand, AttributePattern } from '@aurelia/runtime';
 import { DateFormatBindingBehavior } from './df/date-format-binding-behavior';
 import { DateFormatValueConverter } from './df/date-format-value-converter';
 import { I18N, I18nService } from './i18n';
@@ -70,7 +70,7 @@ function coreComponents(options: I18nConfigurationOptions) {
     register(container: IContainer) {
       return container.register(
         Registration.callback(I18nInitOptions, () => options.initOptions),
-        StartTask.with(I18N).beforeActivate().call(i18n => i18n.task),
+        AppTask.with(I18N).beforeActivate().call(i18n => i18n.task),
         Registration.singleton(I18nWrapper, I18nextWrapper),
         Registration.singleton(I18N, I18nService),
 

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -66,7 +66,7 @@ const routerConfiguration = {
       ...DefaultComponents,
       ...DefaultResources,
       StartTask.with(IRouter).beforeActivate().call(configurationCall),
-      StartTask.with(IRouter).afterAttach().call(router => router.loadUrl()),
+      StartTask.with(IRouter).afterActivate().call(router => router.loadUrl()),
     );
   },
   /**

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -67,6 +67,7 @@ const routerConfiguration = {
       ...DefaultResources,
       StartTask.with(IRouter).beforeActivate().call(configurationCall),
       StartTask.with(IRouter).afterActivate().call(router => router.loadUrl()),
+      StartTask.with(IRouter).afterDeactivate().call(router => router.stop()),
     );
   },
   /**

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, IRegistry } from '@aurelia/kernel';
-import { StartTask } from '@aurelia/runtime';
+import { AppTask } from '@aurelia/runtime';
 import { NavCustomElement } from './resources/nav';
 import { ViewportCustomElement } from './resources/viewport';
 import { ViewportScopeCustomElement } from './resources/viewport-scope';
@@ -65,9 +65,9 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeActivate().call(configurationCall),
-      StartTask.with(IRouter).afterActivate().call(router => router.loadUrl()),
-      StartTask.with(IRouter).afterDeactivate().call(router => router.stop()),
+      AppTask.with(IRouter).beforeActivate().call(configurationCall),
+      AppTask.with(IRouter).afterActivate().call(router => router.loadUrl()),
+      AppTask.with(IRouter).afterDeactivate().call(router => router.stop()),
     );
   },
   /**

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -65,7 +65,7 @@ const routerConfiguration = {
     return container.register(
       ...DefaultComponents,
       ...DefaultResources,
-      StartTask.with(IRouter).beforeBind().call(configurationCall),
+      StartTask.with(IRouter).beforeActivate().call(configurationCall),
       StartTask.with(IRouter).afterAttach().call(router => router.loadUrl()),
     );
   },

--- a/packages/runtime-html/src/styles/style-configuration.ts
+++ b/packages/runtime-html/src/styles/style-configuration.ts
@@ -1,5 +1,5 @@
 import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
-import { StartTask } from '@aurelia/runtime';
+import { AppTask } from '@aurelia/runtime';
 import { IShadowDOMGlobalStyles } from './shadow-dom-styles';
 import { IShadowDOMStyleFactory } from './shadow-dom-registry';
 
@@ -9,7 +9,7 @@ export interface IShadowDOMConfiguration {
 
 export const StyleConfiguration = {
   shadowDOM(config: IShadowDOMConfiguration): IRegistry {
-    return StartTask.with(IContainer).beforeCreate().call(container => {
+    return AppTask.with(IContainer).beforeCreate().call(container => {
       if (config.sharedStyles) {
         const factory = container.get(IShadowDOMStyleFactory);
         container.register(

--- a/packages/runtime/src/activator.ts
+++ b/packages/runtime/src/activator.ts
@@ -69,9 +69,9 @@ export class Activator implements IActivator {
     }
 
     if (task.done) {
-      task = mgr.runAfterAttach();
+      task = mgr.runAfterActivate();
     } else {
-      task = new ContinuationTask(task, mgr.runAfterAttach, mgr);
+      task = new ContinuationTask(task, mgr.runAfterActivate, mgr);
     }
 
     return task;

--- a/packages/runtime/src/activator.ts
+++ b/packages/runtime/src/activator.ts
@@ -57,9 +57,9 @@ export class Activator implements IActivator {
     }
 
     if (task.done) {
-      task = mgr.runBeforeBind();
+      task = mgr.runBeforeActivate();
     } else {
-      task = new ContinuationTask(task, mgr.runBeforeBind, mgr);
+      task = new ContinuationTask(task, mgr.runBeforeActivate, mgr);
     }
 
     if (task.done) {

--- a/packages/runtime/src/activator.ts
+++ b/packages/runtime/src/activator.ts
@@ -48,7 +48,7 @@ export class Activator implements IActivator {
     flags = flags === void 0 ? LifecycleFlags.none : flags;
     const mgr = this.taskManager;
 
-    let task = mgr.runBeforeRender();
+    let task = mgr.runBeforeCompile();
 
     if (task.done) {
       this.render(host, component, container, flags);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -488,7 +488,7 @@ export {
   LifecycleTask,
   PromiseTask,
   TaskSlot,
-  StartTask,
+  AppTask,
   IStartTask,
   IStartTaskManager,
   ProviderTask,

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -68,40 +68,40 @@ const enum TaskType {
   from,
 }
 
-export const StartTask = class $StartTask implements IStartTask {
+export const AppTask = class $AppTask implements IStartTask {
   public get slot(): TaskSlot {
     if (this._slot === void 0) {
-      throw new Error('StartTask.slot is not set');
+      throw new Error('AppTask.slot is not set');
     }
     return this._slot;
   }
   public get promiseOrTask(): PromiseOrTask {
     if (this._promiseOrTask === void 0) {
-      throw new Error('StartTask.promiseOrTask is not set');
+      throw new Error('AppTask.promiseOrTask is not set');
     }
     return this._promiseOrTask;
   }
   public get container(): IContainer {
     if (this._container === void 0) {
-      throw new Error('StartTask.container is not set');
+      throw new Error('AppTask.container is not set');
     }
     return this._container;
   }
   public get key(): Key {
     if (this._key === void 0) {
-      throw new Error('StartTask.key is not set');
+      throw new Error('AppTask.key is not set');
     }
     return this._key;
   }
   public get callback(): (instance: unknown) => PromiseOrTask {
     if (this._callback === void 0) {
-      throw new Error('StartTask.callback is not set');
+      throw new Error('AppTask.callback is not set');
     }
     return this._callback;
   }
   public get task(): ILifecycleTask {
     if (this._task === void 0) {
-      throw new Error('StartTask.task is not set');
+      throw new Error('AppTask.task is not set');
     }
     return this._task;
   }
@@ -118,7 +118,7 @@ export const StartTask = class $StartTask implements IStartTask {
   ) {}
 
   public static with<K extends Key>(key: K): ICallbackSlotChooser<K> {
-    const task = new $StartTask(TaskType.with);
+    const task = new $AppTask(TaskType.with);
     task._key = key;
     return task as ICallbackSlotChooser<K>;
   }
@@ -127,45 +127,45 @@ export const StartTask = class $StartTask implements IStartTask {
   public static from(promise: Promise<unknown>): ISlotChooser;
   public static from(promiseOrTask: PromiseOrTask): ISlotChooser;
   public static from(promiseOrTask: PromiseOrTask): ISlotChooser {
-    const task = new $StartTask(TaskType.from);
+    const task = new $AppTask(TaskType.from);
     task._promiseOrTask = promiseOrTask;
     return task;
   }
 
-  public beforeCreate(): $StartTask {
+  public beforeCreate(): $AppTask {
     return this.at(TaskSlot.beforeCreate);
   }
 
-  public beforeCompile(): $StartTask {
+  public beforeCompile(): $AppTask {
     return this.at(TaskSlot.beforeCompile);
   }
 
-  public beforeCompileChildren(): $StartTask {
+  public beforeCompileChildren(): $AppTask {
     return this.at(TaskSlot.beforeCompileChildren);
   }
 
-  public beforeActivate(): $StartTask {
+  public beforeActivate(): $AppTask {
     return this.at(TaskSlot.beforeActivate);
   }
 
-  public afterActivate(): $StartTask {
+  public afterActivate(): $AppTask {
     return this.at(TaskSlot.afterActivate);
   }
 
-  public beforeDeactivate(): $StartTask {
+  public beforeDeactivate(): $AppTask {
     return this.at(TaskSlot.beforeDeactivate);
   }
 
-  public afterDeactivate(): $StartTask {
+  public afterDeactivate(): $AppTask {
     return this.at(TaskSlot.afterDeactivate);
   }
 
-  public at(slot: TaskSlot): $StartTask {
+  public at(slot: TaskSlot): $AppTask {
     this._slot = slot;
     return this;
   }
 
-  public call(fn: (instance: unknown) => PromiseOrTask): $StartTask {
+  public call(fn: (instance: unknown) => PromiseOrTask): $AppTask {
     this._callback = fn;
     return this;
   }

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -21,7 +21,7 @@ export const LifecycleTask = {
 
 export const enum TaskSlot {
   beforeCreate          = 0,
-  beforeRender          = 1,
+  beforeCompile          = 1,
   beforeCompileChildren = 2,
   beforeBind            = 3,
   afterAttach           = 4,
@@ -37,7 +37,7 @@ export interface IStartTask {
 
 export interface ISlotChooser {
   beforeCreate(): IStartTask;
-  beforeRender(): IStartTask;
+  beforeCompile(): IStartTask;
   beforeCompileChildren(): IStartTask;
   beforeBind(): IStartTask;
   afterAttach(): IStartTask;
@@ -46,7 +46,7 @@ export interface ISlotChooser {
 
 export interface ICallbackSlotChooser<K extends Key> {
   beforeCreate(): ICallbackChooser<K>;
-  beforeRender(): ICallbackChooser<K>;
+  beforeCompile(): ICallbackChooser<K>;
   beforeCompileChildren(): ICallbackChooser<K>;
   beforeBind(): ICallbackChooser<K>;
   afterAttach(): ICallbackChooser<K>;
@@ -130,8 +130,8 @@ export const StartTask = class $StartTask implements IStartTask {
     return this.at(TaskSlot.beforeCreate);
   }
 
-  public beforeRender(): $StartTask {
-    return this.at(TaskSlot.beforeRender);
+  public beforeCompile(): $StartTask {
+    return this.at(TaskSlot.beforeCompile);
   }
 
   public beforeCompileChildren(): $StartTask {
@@ -188,7 +188,7 @@ export interface IStartTaskManager {
    */
   enqueueBeforeCompileChildren(): void;
   runBeforeCreate(container?: IContainer): ILifecycleTask;
-  runBeforeRender(container?: IContainer): ILifecycleTask;
+  runBeforeCompile(container?: IContainer): ILifecycleTask;
   runBeforeCompileChildren(container?: IContainer): ILifecycleTask;
   runBeforeBind(container?: IContainer): ILifecycleTask;
   runAfterAttach(container?: IContainer): ILifecycleTask;
@@ -217,8 +217,8 @@ export class StartTaskManager implements IStartTaskManager {
     return this.run(TaskSlot.beforeCreate, locator);
   }
 
-  public runBeforeRender(locator: IServiceLocator = this.locator): ILifecycleTask {
-    return this.run(TaskSlot.beforeRender, locator);
+  public runBeforeCompile(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeCompile, locator);
   }
 
   public runBeforeCompileChildren(locator: IServiceLocator = this.locator): ILifecycleTask {

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -25,6 +25,8 @@ export const enum TaskSlot {
   beforeCompileChildren = 2,
   beforeActivate        = 3,
   afterActivate         = 4,
+  beforeDeactivate      = 5,
+  afterDeactivate       = 6,
 }
 
 export const IStartTask = DI.createInterface<IStartTask>('IStartTask').noDefault();
@@ -41,6 +43,8 @@ export interface ISlotChooser {
   beforeCompileChildren(): IStartTask;
   beforeActivate(): IStartTask;
   afterActivate(): IStartTask;
+  beforeDeactivate(): IStartTask;
+  afterDeactivate(): IStartTask;
   at(slot: TaskSlot): IStartTask;
 }
 
@@ -50,6 +54,8 @@ export interface ICallbackSlotChooser<K extends Key> {
   beforeCompileChildren(): ICallbackChooser<K>;
   beforeActivate(): ICallbackChooser<K>;
   afterActivate(): ICallbackChooser<K>;
+  beforeDeactivate(): ICallbackChooser<K>;
+  afterDeactivate(): ICallbackChooser<K>;
   at(slot: TaskSlot): ICallbackChooser<K>;
 }
 
@@ -146,6 +152,14 @@ export const StartTask = class $StartTask implements IStartTask {
     return this.at(TaskSlot.afterActivate);
   }
 
+  public beforeDeactivate(): $StartTask {
+    return this.at(TaskSlot.beforeDeactivate);
+  }
+
+  public afterDeactivate(): $StartTask {
+    return this.at(TaskSlot.afterDeactivate);
+  }
+
   public at(slot: TaskSlot): $StartTask {
     this._slot = slot;
     return this;
@@ -192,6 +206,8 @@ export interface IStartTaskManager {
   runBeforeCompileChildren(container?: IContainer): ILifecycleTask;
   runBeforeActivate(container?: IContainer): ILifecycleTask;
   runAfterActivate(container?: IContainer): ILifecycleTask;
+  runBeforeDeactivate(container?: IContainer): ILifecycleTask;
+  runAfterDeactivate(container?: IContainer): ILifecycleTask;
   run(slot: TaskSlot, container?: IContainer): ILifecycleTask;
 }
 
@@ -235,6 +251,14 @@ export class StartTaskManager implements IStartTaskManager {
 
   public runAfterActivate(locator: IServiceLocator = this.locator): ILifecycleTask {
     return this.run(TaskSlot.afterActivate, locator);
+  }
+
+  public runBeforeDeactivate(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeDeactivate, locator);
+  }
+
+  public runAfterDeactivate(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.afterDeactivate, locator);
   }
 
   public run(slot: TaskSlot, locator: IServiceLocator = this.locator): ILifecycleTask {

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -24,7 +24,7 @@ export const enum TaskSlot {
   beforeCompile         = 1,
   beforeCompileChildren = 2,
   beforeActivate        = 3,
-  afterAttach           = 4,
+  afterActivate         = 4,
 }
 
 export const IStartTask = DI.createInterface<IStartTask>('IStartTask').noDefault();
@@ -40,7 +40,7 @@ export interface ISlotChooser {
   beforeCompile(): IStartTask;
   beforeCompileChildren(): IStartTask;
   beforeActivate(): IStartTask;
-  afterAttach(): IStartTask;
+  afterActivate(): IStartTask;
   at(slot: TaskSlot): IStartTask;
 }
 
@@ -49,7 +49,7 @@ export interface ICallbackSlotChooser<K extends Key> {
   beforeCompile(): ICallbackChooser<K>;
   beforeCompileChildren(): ICallbackChooser<K>;
   beforeActivate(): ICallbackChooser<K>;
-  afterAttach(): ICallbackChooser<K>;
+  afterActivate(): ICallbackChooser<K>;
   at(slot: TaskSlot): ICallbackChooser<K>;
 }
 
@@ -142,8 +142,8 @@ export const StartTask = class $StartTask implements IStartTask {
     return this.at(TaskSlot.beforeActivate);
   }
 
-  public afterAttach(): $StartTask {
-    return this.at(TaskSlot.afterAttach);
+  public afterActivate(): $StartTask {
+    return this.at(TaskSlot.afterActivate);
   }
 
   public at(slot: TaskSlot): $StartTask {
@@ -191,7 +191,7 @@ export interface IStartTaskManager {
   runBeforeCompile(container?: IContainer): ILifecycleTask;
   runBeforeCompileChildren(container?: IContainer): ILifecycleTask;
   runBeforeActivate(container?: IContainer): ILifecycleTask;
-  runAfterAttach(container?: IContainer): ILifecycleTask;
+  runAfterActivate(container?: IContainer): ILifecycleTask;
   run(slot: TaskSlot, container?: IContainer): ILifecycleTask;
 }
 
@@ -233,8 +233,8 @@ export class StartTaskManager implements IStartTaskManager {
     return this.run(TaskSlot.beforeActivate, locator);
   }
 
-  public runAfterAttach(locator: IServiceLocator = this.locator): ILifecycleTask {
-    return this.run(TaskSlot.afterAttach, locator);
+  public runAfterActivate(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.afterActivate, locator);
   }
 
   public run(slot: TaskSlot, locator: IServiceLocator = this.locator): ILifecycleTask {

--- a/packages/runtime/src/lifecycle-task.ts
+++ b/packages/runtime/src/lifecycle-task.ts
@@ -21,9 +21,9 @@ export const LifecycleTask = {
 
 export const enum TaskSlot {
   beforeCreate          = 0,
-  beforeCompile          = 1,
+  beforeCompile         = 1,
   beforeCompileChildren = 2,
-  beforeBind            = 3,
+  beforeActivate        = 3,
   afterAttach           = 4,
 }
 
@@ -39,7 +39,7 @@ export interface ISlotChooser {
   beforeCreate(): IStartTask;
   beforeCompile(): IStartTask;
   beforeCompileChildren(): IStartTask;
-  beforeBind(): IStartTask;
+  beforeActivate(): IStartTask;
   afterAttach(): IStartTask;
   at(slot: TaskSlot): IStartTask;
 }
@@ -48,7 +48,7 @@ export interface ICallbackSlotChooser<K extends Key> {
   beforeCreate(): ICallbackChooser<K>;
   beforeCompile(): ICallbackChooser<K>;
   beforeCompileChildren(): ICallbackChooser<K>;
-  beforeBind(): ICallbackChooser<K>;
+  beforeActivate(): ICallbackChooser<K>;
   afterAttach(): ICallbackChooser<K>;
   at(slot: TaskSlot): ICallbackChooser<K>;
 }
@@ -138,8 +138,8 @@ export const StartTask = class $StartTask implements IStartTask {
     return this.at(TaskSlot.beforeCompileChildren);
   }
 
-  public beforeBind(): $StartTask {
-    return this.at(TaskSlot.beforeBind);
+  public beforeActivate(): $StartTask {
+    return this.at(TaskSlot.beforeActivate);
   }
 
   public afterAttach(): $StartTask {
@@ -190,7 +190,7 @@ export interface IStartTaskManager {
   runBeforeCreate(container?: IContainer): ILifecycleTask;
   runBeforeCompile(container?: IContainer): ILifecycleTask;
   runBeforeCompileChildren(container?: IContainer): ILifecycleTask;
-  runBeforeBind(container?: IContainer): ILifecycleTask;
+  runBeforeActivate(container?: IContainer): ILifecycleTask;
   runAfterAttach(container?: IContainer): ILifecycleTask;
   run(slot: TaskSlot, container?: IContainer): ILifecycleTask;
 }
@@ -229,8 +229,8 @@ export class StartTaskManager implements IStartTaskManager {
     return LifecycleTask.done;
   }
 
-  public runBeforeBind(locator: IServiceLocator = this.locator): ILifecycleTask {
-    return this.run(TaskSlot.beforeBind, locator);
+  public runBeforeActivate(locator: IServiceLocator = this.locator): ILifecycleTask {
+    return this.run(TaskSlot.beforeActivate, locator);
   }
 
   public runAfterAttach(locator: IServiceLocator = this.locator): ILifecycleTask {

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -42,7 +42,6 @@ export function createFixture<T>(template: string | Node,
       await au.stop().wait();
       root.remove();
       au.dispose();
-      assert.isSchedulerEmpty();
     }
   };
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Adds `beforeDeactivate` and `afterDeactivate` global stop tasks, for hooking up "teardown" logic to pair with setup logic that is run during startup tasks.


<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
