### PR TITLE
Feat/el observation extension

### DIFF
--- a/docs/user-docs/examples/custom-attributes/binding-to-element-size.md
+++ b/docs/user-docs/examples/custom-attributes/binding-to-element-size.md
@@ -3,7 +3,7 @@
 ## Basic implementation
 
 ```typescript
-import { bindable, BindingMode, customAttribute, HTMLDOM, IDOM, INode } from 'aurelia';
+import { bindable, BindingMode, customAttribute } from 'aurelia';
 
 @customAttribute({
   name: 'rectsize',

--- a/docs/user-docs/getting-started/observation.md
+++ b/docs/user-docs/getting-started/observation.md
@@ -1,0 +1,75 @@
+---
+description: Using different strategy to observe changes in your applications.
+---
+
+# Observation Basic 
+
+Aurelia observation system is built using observers and subscribers. By default, an observer locator is used to create observers and subscribe to them for change notification. A basic observer has the following interface:
+
+```ts
+interface IObserver {
+  obj;
+  propertyKey;
+  subscribe(subscriber);
+  unsubscribe(subscriber);
+}
+```
+
+The method `.subscribe()` of an observer can be used subscribe to the changes it observes. This method takes a subscriber as its argument. A basic subscriber has the following interface:
+
+```ts
+interface ISubscriber {
+  handleChange(newValue, oldValue);
+}
+```
+
+# HTML Element Observation
+
+HTML elements are special objects that often require different observation strategies, and most of the time, listening to some specific event is the preferred way. For this reason, Aurelia encourages using events to observe HTML elements.
+
+As an example, the `value` property of an `<input />` element should be observed by listening to the `<input />` change events such as `input` or `change` on the element. Another example is the `value` property of a `<select />` element should be observed by listening to the `change` event on it.
+
+By default, the observation of HTML elements are done using a node observer locator. This default locator has a basic set of API that allows users to teach Aurelia how to observe html element observation effectively. Following is the trimmed interface of the node observer locator, highlighting its capability to learn how to observe HTML elements:
+
+```ts
+export interface INodeObserverLocator {
+  allowDirtyCheck: boolean;
+  handles(obj, key, requestor): boolean;
+
+  useConfig(config): void;
+  useConfig(nodeName, key, eventsConfig): void;
+
+  useGlobalConfig(config): void;
+  useGlobalConfig(key, eventsConfig): void;
+}
+```
+
+`useConfig` and `useGlobalConfig` are two methods that can be used to teach the default node observer locator what events can be used to observe a property of a specific element, or any element.
+
+- An example of how to teach Aurelia observe property `value` of a `<textarea />` element:
+  ```ts
+  nodeObserverLocator.useConfig('textarea', 'value', { events: ['input', 'change'] });
+  ```
+  In this example, `eventsConfig` argument has the value `{ events: ['input', 'change']}`.
+
+- Another example of how to teach Aurelia observe property `length` of an `<input />` element:
+  ```ts
+  nodeObserverLocator.useConfig('input', 'length', { events: ['input'] });
+  ```
+  In this example, `eventsConfig` argument has the value `{ events: ['input']}`.
+
+- Another example of how to teach Aurelia observe property `scrollTop` of all elements:
+  ```ts
+  nodeObserverLocator.useGlobalConfig('scrollTop', { events: ['scroll'] });
+  ```
+  In this example, `eventsConfig` argument has the value `{ events: ['scroll']}`.
+
+# Webcomponent - Custom element observation
+
+It should be the same observing custom (HTML) elements and normal HTML elements. It is common for webcomponents to have well defined events associated with their custom properties, so observing them often means adding a few lines of configuration.
+
+- An example of how to teach Aurelia observe property `value` of a `<my-input />` element, and `<my-input />` dispatches `valueChanged` event when its value has been changed:
+
+  ```ts
+  nodeObserverLocator.useConfig('my-input', 'value', { events: ['valueChanged'] });
+  ```

--- a/docs/user-docs/getting-started/observation.md
+++ b/docs/user-docs/getting-started/observation.md
@@ -1,5 +1,5 @@
 ---
-description: Using different strategy to observe changes in your applications.
+description: Observe changes in your applications.
 ---
 
 # Observation Basic 
@@ -8,10 +8,8 @@ Aurelia observation system is built using observers and subscribers. By default,
 
 ```ts
 interface IObserver {
-  obj;
-  propertyKey;
-  subscribe(subscriber);
-  unsubscribe(subscriber);
+  subscribe(subscriber)
+  unsubscribe(subscriber)
 }
 ```
 
@@ -19,11 +17,32 @@ The method `.subscribe()` of an observer can be used subscribe to the changes it
 
 ```ts
 interface ISubscriber {
-  handleChange(newValue, oldValue);
+  handleChange(newValue, oldValue)
 }
 ```
 
-# HTML Element Observation
+An observer of an object property can be retrieved using an observer locator. An example is:
+
+```ts
+// getting the observer for property 'value'
+const observer = observerLocator.getObserver(obj, 'value')
+```
+
+And to subscribe to changes emitted by this observer:
+```ts
+const subscriber = {
+  handleChange(newValue) {
+    console.log('new value of object is:', newValue)
+  }
+}
+
+observer.subscribe(subscriber)
+
+// and to stop subscribing
+observer.unsubscribe(subscriber)
+```
+
+# HTML Observation
 
 HTML elements are special objects that often require different observation strategies, and most of the time, listening to some specific event is the preferred way. For this reason, Aurelia encourages using events to observe HTML elements.
 
@@ -64,7 +83,7 @@ export interface INodeObserverLocator {
   ```
   In this example, `eventsConfig` argument has the value `{ events: ['scroll']}`.
 
-# Webcomponent - Custom element observation
+# Webcomponent - Custom Element Observation
 
 It should be the same observing custom (HTML) elements and normal HTML elements. It is common for webcomponents to have well defined events associated with their custom properties, so observing them often means adding a few lines of configuration.
 

--- a/packages/__tests__/2-runtime/computed-observer.spec.ts
+++ b/packages/__tests__/2-runtime/computed-observer.spec.ts
@@ -4,8 +4,7 @@ import {
   IDirtyChecker,
   ILifecycle,
   IObserverLocator,
-  ITargetAccessorLocator,
-  ITargetObserverLocator,
+  INodeObserverLocator,
   LifecycleFlags as LF,
   ComputedOverrides,
   createComputedObserver,
@@ -24,8 +23,7 @@ describe.skip('ComputedObserver', function () {
     const innerLocator = {
       handles() { return false; }
     };
-    Registration.instance(ITargetAccessorLocator, innerLocator).register(container);
-    Registration.instance(ITargetObserverLocator, innerLocator).register(container);
+    Registration.instance(INodeObserverLocator, innerLocator).register(container);
     const locator = container.get(IObserverLocator);
     const dirtyChecker = container.get(IDirtyChecker);
     const lifecycle = container.get(ILifecycle);

--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -67,9 +67,9 @@ describe('PrimitiveObserver', function () {
 class Foo {}
 
 describe('SetterObserver', function () {
-  function createFixture(flags: LF, obj: IIndexable, key: string) {
+  function createFixture(obj: IIndexable, key: string) {
     const ctx = TestContext.create();
-    const sut = new SetterObserver(flags, obj, key);
+    const sut = new SetterObserver(obj, key);
 
     return { ctx, sut };
   }
@@ -80,7 +80,7 @@ describe('SetterObserver', function () {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(LF.none, object, propertyName as any);
+          const { sut } = createFixture(object, propertyName as any);
           sut.subscribe(new SpySubscriber());
           const actual = sut.getValue();
           assert.strictEqual(actual, object[propertyName], `actual`);
@@ -98,7 +98,7 @@ describe('SetterObserver', function () {
       for (const propertyName of propertyNameArr) {
         for (const value of valueArr) {
           it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
-            const { sut } = createFixture(LF.none, object, propertyName as any);
+            const { sut } = createFixture(object, propertyName as any);
             sut.subscribe(new SpySubscriber());
             sut.setValue(value, flags);
             assert.strictEqual(object[propertyName], value, `object[propertyName]`);
@@ -115,7 +115,7 @@ describe('SetterObserver', function () {
     for (const object of objectArr) {
       for (const propertyName of propertyNameArr) {
         it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(LF.none, object, propertyName as any);
+          const { sut } = createFixture(object, propertyName as any);
           sut.subscribe(new SpySubscriber());
         });
       }
@@ -134,7 +134,7 @@ describe('SetterObserver', function () {
           for (const subscribers of subscribersArr) {
             const object = {};
             it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
-              const { sut } = createFixture(LF.none, object, propertyName as any);
+              const { sut } = createFixture(object, propertyName as any);
               for (const subscriber of subscribers) {
                 sut.subscribe(subscriber);
               }

--- a/packages/__tests__/3-runtime-html/decorator-observable.spec.ts
+++ b/packages/__tests__/3-runtime-html/decorator-observable.spec.ts
@@ -112,7 +112,6 @@ describe('3-runtime-html/decorator-observable.spec.ts', function () {
       }
       const { component, platform, testHost, tearDown, startPromise } = createFixture(`<div ref="div"></div>\${div.tagName}`, App);
       await startPromise;
-
       assert.strictEqual(testHost.textContent, 'DIV');
       component.div = { tagName: 'hello' };
 

--- a/packages/__tests__/3-runtime-html/decorator-observable.spec.ts
+++ b/packages/__tests__/3-runtime-html/decorator-observable.spec.ts
@@ -112,6 +112,7 @@ describe('3-runtime-html/decorator-observable.spec.ts', function () {
       }
       const { component, platform, testHost, tearDown, startPromise } = createFixture(`<div ref="div"></div>\${div.tagName}`, App);
       await startPromise;
+
       assert.strictEqual(testHost.textContent, 'DIV');
       component.div = { tagName: 'hello' };
 

--- a/packages/__tests__/3-runtime-html/event-manager.spec.ts
+++ b/packages/__tests__/3-runtime-html/event-manager.spec.ts
@@ -194,7 +194,7 @@ describe('EventSubscriber', function () {
       });
     });
 
-    const sut = new EventSubscriber(eventNames);
+    const sut = new EventSubscriber({ events: eventNames });
 
     return { ctx, sut, handler, listener, events, el };
   }

--- a/packages/__tests__/3-runtime-html/event-manager.spec.ts
+++ b/packages/__tests__/3-runtime-html/event-manager.spec.ts
@@ -2,6 +2,7 @@ import { IDisposable } from '@aurelia/kernel';
 import {
   EventDelegator,
   EventSubscriber,
+  NodeObserverConfig,
 } from '@aurelia/runtime-html';
 import { _, TestContext, assert, createSpy } from '@aurelia/testing';
 
@@ -194,7 +195,7 @@ describe('EventSubscriber', function () {
       });
     });
 
-    const sut = new EventSubscriber({ events: eventNames });
+    const sut = new EventSubscriber(new NodeObserverConfig({ events: eventNames }));
 
     return { ctx, sut, handler, listener, events, el };
   }

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -15,7 +15,7 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
-  INodeObserverLocatorRegistration,
+  DefaultNodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -94,7 +94,7 @@ describe(`If/Else`, function () {
   ];
 
   const container = createContainer().register(
-    INodeObserverLocatorRegistration,
+    DefaultNodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -12,11 +12,10 @@ import {
   IHydratableController,
   IRenderLocation,
   PropertyBindingRendererRegistration,
-  ITargetAccessorLocatorRegistration,
-  ITargetObserverLocatorRegistration,
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
+  INodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -95,8 +94,7 @@ describe(`If/Else`, function () {
   ];
 
   const container = createContainer().register(
-    ITargetAccessorLocatorRegistration,
-    ITargetObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -15,7 +15,7 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
-  DefaultNodeObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -94,7 +94,7 @@ describe(`If/Else`, function () {
   ];
 
   const container = createContainer().register(
-    DefaultNodeObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/observer-locator.spec.ts
+++ b/packages/__tests__/3-runtime-html/observer-locator.spec.ts
@@ -304,21 +304,28 @@ describe('ObserverLocator', function () {
                 }});
               }
             }
-            const actual = sut.getObserver(LF.none, obj, property);
             if (property === 'textContent' || property === 'innerHTML' || property === 'scrollTop' || property === 'scrollLeft') {
+              const actual = sut.getObserver(LF.none, obj, property);
               assert.strictEqual(actual.constructor.name, ValueAttributeObserver.name, `actual.constructor.name`);
             } else if (property === 'style' || property === 'css') {
+              const actual = sut.getObserver(LF.none, obj, property);
               assert.strictEqual(actual.constructor.name, StyleAttributeAccessor.name, `actual.constructor.name`);
             } else if (descriptors[property].get === undefined) {
-              assert.strictEqual(actual.constructor.name, SetterObserver.name, `actual.constructor.name`);
+              assert.throws(() => {
+                const actual = sut.getObserver(LF.none, obj, property);
+                assert.strictEqual(actual.constructor.name, SetterObserver.name, `actual.constructor.name`);
+              });
             } else {
-              if (!(hasAdapterObserver && adapterIsDefined)) {
-                assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
-              } else if ((!hasGetObserver && hasAdapterObserver && adapterIsDefined) || hasGetObserver) {
-                assert.strictEqual(actual, dummyObserver, `actual`);
-              } else {
-                assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
-              }
+              assert.throws(() => {
+                const actual = sut.getObserver(LF.none, obj, property);
+                if (!(hasAdapterObserver && adapterIsDefined)) {
+                  assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
+                } else if ((!hasGetObserver && hasAdapterObserver && adapterIsDefined) || hasGetObserver) {
+                  assert.strictEqual(actual, dummyObserver, `actual`);
+                } else {
+                  assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
+                }
+              });
             }
           });
         }

--- a/packages/__tests__/3-runtime-html/observer-locator.spec.ts
+++ b/packages/__tests__/3-runtime-html/observer-locator.spec.ts
@@ -304,28 +304,13 @@ describe('ObserverLocator', function () {
                 }});
               }
             }
+            const actual = sut.getObserver(LF.none, obj, property);
             if (property === 'textContent' || property === 'innerHTML' || property === 'scrollTop' || property === 'scrollLeft') {
-              const actual = sut.getObserver(LF.none, obj, property);
               assert.strictEqual(actual.constructor.name, ValueAttributeObserver.name, `actual.constructor.name`);
             } else if (property === 'style' || property === 'css') {
-              const actual = sut.getObserver(LF.none, obj, property);
               assert.strictEqual(actual.constructor.name, StyleAttributeAccessor.name, `actual.constructor.name`);
-            } else if (descriptors[property].get === undefined) {
-              assert.throws(() => {
-                const actual = sut.getObserver(LF.none, obj, property);
-                assert.strictEqual(actual.constructor.name, SetterObserver.name, `actual.constructor.name`);
-              });
             } else {
-              assert.throws(() => {
-                const actual = sut.getObserver(LF.none, obj, property);
-                if (!(hasAdapterObserver && adapterIsDefined)) {
-                  assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
-                } else if ((!hasGetObserver && hasAdapterObserver && adapterIsDefined) || hasGetObserver) {
-                  assert.strictEqual(actual, dummyObserver, `actual`);
-                } else {
-                  assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
-                }
-              });
+              assert.strictEqual(actual.constructor.name, DirtyCheckProperty.name, `actual.constructor.name`);
             }
           });
         }

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -17,7 +17,7 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
-  DefaultNodeObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -520,7 +520,7 @@ describe(`Repeat`, function () {
   ];
 
   const container = createContainer().register(
-    DefaultNodeObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -13,12 +13,11 @@ import {
   getRenderContext,
   IHydratableController,
   IRenderLocation,
-  ITargetAccessorLocatorRegistration,
-  ITargetObserverLocatorRegistration,
   PropertyBindingRendererRegistration,
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
+  INodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -521,8 +520,7 @@ describe(`Repeat`, function () {
   ];
 
   const container = createContainer().register(
-    ITargetAccessorLocatorRegistration,
-    ITargetObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -17,7 +17,7 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
-  INodeObserverLocatorRegistration,
+  DefaultNodeObserverLocatorRegistration,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -520,7 +520,7 @@ describe(`Repeat`, function () {
   ];
 
   const container = createContainer().register(
-    INodeObserverLocatorRegistration,
+    DefaultNodeObserverLocatorRegistration,
     PropertyBindingRendererRegistration,
     TextBindingRendererRegistration,
   );

--- a/packages/__tests__/3-runtime-html/target-observers.spec.ts
+++ b/packages/__tests__/3-runtime-html/target-observers.spec.ts
@@ -127,7 +127,7 @@ describe('StyleAccessor', function () {
     it(`setValue - style="${rule}" flags.none`, function () {
       const ctx = TestContext.create();
       el = ctx.createElementFromMarkup('<div></div>');
-      sut = new StyleAttributeAccessor(LifecycleFlags.none, el);
+      sut = new StyleAttributeAccessor(el);
       const setPropertySpy = createSpy(sut, 'setProperty', true);
 
       sut.bind(LifecycleFlags.none);
@@ -155,7 +155,7 @@ describe('StyleAccessor', function () {
     it(`setValue - style="${rule}" flags.none`, function () {
       const ctx = TestContext.create();
       el = ctx.createElementFromMarkup('<div></div>');
-      sut = new StyleAttributeAccessor(LifecycleFlags.none, el);
+      sut = new StyleAttributeAccessor(el);
       const setPropertySpy = createSpy(sut, 'setProperty', true);
 
       sut.setValue(rule, LifecycleFlags.none);
@@ -292,7 +292,7 @@ describe('StyleAccessor', function () {
     it(title, function () {
       const ctx = TestContext.create();
       const el = ctx.createElementFromMarkup(`<div style="${staticStyle}"></div>`);
-      const sut = new StyleAttributeAccessor(LifecycleFlags.none, el);
+      const sut = new StyleAttributeAccessor(el);
       sut.setValue(input, LifecycleFlags.none);
 
       const actual = sut.getValue();
@@ -358,7 +358,7 @@ describe('ClassAccessor', function () {
         const el = ctx.createElementFromMarkup(markup);
         const initialClassList = el.classList.toString();
         const { platform } = ctx;
-        const sut = new ClassAttributeAccessor(LifecycleFlags.none, el);
+        const sut = new ClassAttributeAccessor(el);
 
         function tearDown() {
           platform.domWriteQueue.flush();

--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -119,6 +119,6 @@ describe('TranslationParametersBindingRenderer', function () {
       callBindingInstruction,
     );
 
-    assert.equal(binding.parametersExpr, paramExpr);
+    assert.equal(binding['parameter'].expr, paramExpr);
   });
 });

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -98,7 +98,7 @@ export interface I18N {
 export const I18N = DI.createInterface<I18N>('I18N').noDefault();
 
 export interface ILocalChangeSubscriber {
-  handleLocaleChange(locales: { oldLocale: string, newLocale: string }): void;
+  handleLocaleChange(locales: { oldLocale: string; newLocale: string }): void;
 }
 /**
  * Translation service class.
@@ -112,7 +112,7 @@ export class I18nService implements I18N {
    */
   public readonly initPromise: Promise<void>;
   private options!: I18nInitOptions;
-  private localeSubscribers: Set<ILocalChangeSubscriber> = new Set();
+  private readonly localeSubscribers: Set<ILocalChangeSubscriber> = new Set();
 
   public constructor(
     @I18nWrapper i18nextWrapper: I18nextWrapper,

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -297,7 +297,7 @@ class ParameterBinding {
 
   private scope!: Scope;
   private hostScope: Scope | null = null;
-  
+
   public constructor(
     public readonly owner: TranslationBinding,
     public readonly expr: IsExpression,

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -54,7 +54,6 @@ export class TranslationBinding implements IPartialConnectableBinding {
   public id!: number;
   public isBound: boolean = false;
   public expr!: IsExpression;
-  public parametersExpr?: IsExpression;
   private readonly i18n: I18N;
   private readonly contentAttributes: readonly string[] = contentAttributes;
   private keyExpression: string | undefined | null;

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -1,28 +1,28 @@
-import { IEventAggregator, IServiceLocator, IContainer, toArray } from '@aurelia/kernel';
+import { toArray } from '@aurelia/kernel';
 import {
   BindingType,
   connectable,
   CustomElement,
   CustomExpression,
-  IBindingTargetAccessor,
-  IConnectableBinding,
-  IExpressionParser,
   Interpolation,
-  IObserverLocator,
-  IPartialConnectableBinding,
-  IsExpression,
   LifecycleFlags,
-  INode,
-  IHydratableController,
-  IsBindingBehavior,
   IPlatform,
 } from '@aurelia/runtime-html';
 import i18next from 'i18next';
 import { I18N } from '../i18n';
-import { Signals } from '../utils';
 
-import type { Scope } from '@aurelia/runtime';
-import type { CallBindingInstruction } from '@aurelia/runtime-html';
+import type { IContainer, IServiceLocator } from '@aurelia/kernel';
+import type {
+  Scope,
+  IsBindingBehavior,
+  IsExpression,
+  IBindingTargetAccessor,
+  IConnectableBinding,
+  IExpressionParser,
+  IObserverLocator,
+  IPartialConnectableBinding,
+} from '@aurelia/runtime';
+import type { CallBindingInstruction, IHydratableController, INode } from '@aurelia/runtime-html';
 
 interface TranslationBindingCreationContext {
   parser: IExpressionParser;
@@ -58,14 +58,14 @@ export class TranslationBinding implements IPartialConnectableBinding {
   private readonly i18n: I18N;
   private readonly contentAttributes: readonly string[] = contentAttributes;
   private keyExpression: string | undefined | null;
-  private translationParameters!: i18next.TOptions;
   private scope!: Scope;
   private hostScope: Scope | null = null;
-  private isInterpolatedSourceExpr!: boolean;
+  private isInterpolation!: boolean;
   private readonly targetObservers: Set<IBindingTargetAccessor>;
 
   public target: HTMLElement;
   private readonly platform: IPlatform;
+  private parameter: ParameterBinding | null = null;
 
   public constructor(
     target: INode,
@@ -75,9 +75,9 @@ export class TranslationBinding implements IPartialConnectableBinding {
     this.target = target as HTMLElement;
     this.i18n = this.locator.get(I18N);
     this.platform = this.locator.get(IPlatform);
-    const ea: IEventAggregator = this.locator.get(IEventAggregator);
-    ea.subscribe(Signals.I18N_EA_CHANNEL, this.handleLocaleChange.bind(this));
     this.targetObservers = new Set<IBindingTargetAccessor>();
+    this.i18n.subscribeLocaleChange(this);
+    connectable.assignIdTo(this);
   }
 
   public static create({
@@ -93,11 +93,11 @@ export class TranslationBinding implements IPartialConnectableBinding {
     const expr = typeof instruction.from === 'string'
       ? parser.parse(instruction.from, BindingType.BindCommand)
       : instruction.from as IsBindingBehavior;
-    if (!isParameterContext) {
+    if (isParameterContext) {
+      binding.useParameter(expr);
+    } else {
       const interpolation = expr instanceof CustomExpression ? parser.parse(expr.value, BindingType.Interpolation) : undefined;
       binding.expr = interpolation || expr;
-    } else {
-      binding.parametersExpr = expr;
     }
   }
   private static getBinding({
@@ -115,24 +115,14 @@ export class TranslationBinding implements IPartialConnectableBinding {
   }
 
   public $bind(flags: LifecycleFlags, scope: Scope, hostScope: Scope | null): void {
-    if (!this.expr) { throw new Error('key expression is missing'); } // TODO replace with error code
+    if (!this.expr) { throw new Error('key expression is missing'); }
     this.scope = scope;
     this.hostScope = hostScope;
-    this.isInterpolatedSourceExpr = this.expr instanceof Interpolation;
+    this.isInterpolation = this.expr instanceof Interpolation;
 
-    this.keyExpression = this.expr.evaluate(flags, scope, hostScope, this.locator, null) as string;
+    this.keyExpression = this.expr.evaluate(flags, scope, hostScope, this.locator, this) as string;
     this.ensureKeyExpression();
-    if (this.parametersExpr) {
-      const parametersFlags = flags | LifecycleFlags.secondaryExpression;
-      this.translationParameters = this.parametersExpr.evaluate(parametersFlags, scope, hostScope, this.locator, null) as i18next.TOptions;
-      this.parametersExpr.connect(parametersFlags, scope, hostScope, this as any);
-    }
-
-    const expressions = !(this.expr instanceof CustomExpression) ? this.isInterpolatedSourceExpr ? (this.expr as Interpolation).expressions : [this.expr] : [];
-
-    for (const expr of expressions) {
-      expr.connect(flags, scope, hostScope, this as any);
-    }
+    this.parameter?.$bind(flags, scope, hostScope);
 
     this.updateTranslations(flags);
     this.isBound = true;
@@ -147,33 +137,36 @@ export class TranslationBinding implements IPartialConnectableBinding {
       this.expr.unbind(flags, this.scope, this.hostScope, this as any);
     }
 
-    if (this.parametersExpr?.hasUnbind) {
-      this.parametersExpr.unbind(flags | LifecycleFlags.secondaryExpression, this.scope, this.hostScope, this as any);
-    }
+    this.parameter?.$unbind(flags);
     this.unobserveTargets(flags);
 
     this.scope = (void 0)!;
-    (this as unknown as IConnectableBinding).unobserve(true);
+    this.unobserve(true);
   }
 
   public handleChange(newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions, flags: LifecycleFlags): void {
-    if (flags & LifecycleFlags.secondaryExpression) {
-      this.translationParameters = this.parametersExpr!.evaluate(flags,  this.scope,  this.hostScope,  this.locator, null) as i18next.TOptions;
-    } else {
-      this.keyExpression = this.isInterpolatedSourceExpr
-        ? this.expr.evaluate(flags,  this.scope,  this.hostScope,  this.locator, null) as string
+    this.version++;
+    this.keyExpression = this.isInterpolation
+        ? this.expr.evaluate(flags, this.scope, this.hostScope, this.locator, this) as string
         : newValue as string;
-      this.ensureKeyExpression();
-    }
+    this.unobserve(false);
+    this.ensureKeyExpression();
     this.updateTranslations(flags);
   }
 
-  private handleLocaleChange() {
+  public handleLocaleChange() {
     this.updateTranslations(LifecycleFlags.none);
   }
 
+  public useParameter(expr: IsExpression) {
+    if (this.parameter != null) {
+      throw new Error('This translation parameter has already been specified.');
+    }
+    this.parameter = new ParameterBinding(this, expr, (flags: LifecycleFlags) => this.updateTranslations(flags));
+  }
+
   private updateTranslations(flags: LifecycleFlags) {
-    const results = this.i18n.evaluate(this.keyExpression!, this.translationParameters);
+    const results = this.i18n.evaluate(this.keyExpression!, this.parameter?.value);
     const content: ContentValue = Object.create(null);
     this.unobserveTargets(flags);
 
@@ -284,10 +277,72 @@ export class TranslationBinding implements IPartialConnectableBinding {
   }
 
   private ensureKeyExpression() {
-    const expr = this.keyExpression = this.keyExpression ?? '';
+    const expr = this.keyExpression ??= '';
     const exprType = typeof expr;
     if (exprType !== 'string') {
       throw new Error(`Expected the i18n key to be a string, but got ${expr} of type ${exprType}`); // TODO use reporter/logger
     }
+  }
+}
+
+interface ParameterBinding extends IConnectableBinding {}
+
+@connectable()
+class ParameterBinding {
+
+  public value!: i18next.TOptions;
+  public readonly observerLocator: IObserverLocator;
+  public readonly locator: IServiceLocator;
+  public isBound: boolean = false;
+
+  private scope!: Scope;
+  private hostScope: Scope | null = null;
+  
+  public constructor(
+    public readonly owner: TranslationBinding,
+    public readonly expr: IsExpression,
+    public readonly updater: (flags: LifecycleFlags) => void,
+  ) {
+    this.observerLocator = owner.observerLocator;
+    this.locator = owner.locator;
+    connectable.assignIdTo(this);
+  }
+
+  public handleChange(newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions, flags: LifecycleFlags): void {
+    if ((flags & LifecycleFlags.updateTarget) === 0) {
+      throw new Error('Unexpected context in a ParameterBinding.');
+    }
+    this.version++;
+    this.value = this.expr.evaluate(flags, this.scope, this.hostScope, this.locator, this) as i18next.TOptions;
+    this.unobserve(false);
+    this.updater(flags);
+  }
+
+  public $bind(flags: LifecycleFlags, scope: Scope, hostScope: Scope | null): void {
+    if (this.isBound) {
+      return;
+    }
+    this.scope = scope;
+    this.hostScope = hostScope;
+
+    if (this.expr.hasBind) {
+      this.expr.bind(flags, scope, hostScope, this);
+    }
+
+    this.value = this.expr.evaluate(flags, scope, hostScope, this.locator, this) as i18next.TOptions;
+    this.isBound = true;
+  }
+
+  public $unbind(flags: LifecycleFlags) {
+    if (!this.isBound) {
+      return;
+    }
+
+    if (this.expr.hasUnbind) {
+      this.expr.unbind(flags, this.scope, this.hostScope, this);
+    }
+
+    this.scope = (void 0)!;
+    this.unobserve(true);
   }
 }

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -184,7 +184,6 @@ export class AttributeBinding implements IPartialConnectableBinding {
     if (!targetObserver) {
       targetObserver = this.targetObserver = new AttributeObserver(
         this.$platform,
-        flags,
         this.observerLocator,
         this.target as IHtmlElement,
         this.targetProperty,

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -50,7 +50,7 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
 } from './renderer';
-import { TargetAccessorLocator, TargetObserverLocator } from './observation/observer-locator';
+import { NodeObserverLocator } from './observation/observer-locator';
 import { SVGAnalyzer } from './observation/svg-analyzer';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
@@ -69,8 +69,7 @@ import { SanitizeValueConverter } from './resources/value-converters/sanitize';
 import { ViewValueConverter } from './resources/value-converters/view';
 
 export const ITemplateCompilerRegistration = TemplateCompiler as IRegistry;
-export const ITargetAccessorLocatorRegistration = TargetAccessorLocator as IRegistry;
-export const ITargetObserverLocatorRegistration = TargetObserverLocator as IRegistry;
+export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) implementations for the following interfaces:
@@ -80,8 +79,7 @@ export const ITargetObserverLocatorRegistration = TargetObserverLocator as IRegi
  */
 export const DefaultComponents = [
   ITemplateCompilerRegistration,
-  ITargetAccessorLocatorRegistration,
-  ITargetObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 ];
 
 export const SVGAnalyzerRegistration = SVGAnalyzer as IRegistry;

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -50,7 +50,6 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
 } from './renderer';
-import { DefaultNodeObserverLocatorRegistration } from './observation/observer-locator';
 import { SVGAnalyzer } from './observation/svg-analyzer';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
@@ -67,9 +66,10 @@ import { Compose } from './resources/custom-elements/compose';
 import { AuSlot } from './resources/custom-elements/au-slot';
 import { SanitizeValueConverter } from './resources/value-converters/sanitize';
 import { ViewValueConverter } from './resources/value-converters/view';
+import { NodeObserverLocator } from './observation/observer-locator';
 
 export const ITemplateCompilerRegistration = TemplateCompiler as IRegistry;
-export { DefaultNodeObserverLocatorRegistration };
+export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) implementations for the following interfaces:
@@ -79,7 +79,7 @@ export { DefaultNodeObserverLocatorRegistration };
  */
 export const DefaultComponents = [
   ITemplateCompilerRegistration,
-  DefaultNodeObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 ];
 
 export const SVGAnalyzerRegistration = SVGAnalyzer as IRegistry;

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -50,7 +50,7 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
 } from './renderer';
-import { NodeObserverLocator } from './observation/observer-locator';
+import { DefaultNodeObserverLocatorRegistration } from './observation/observer-locator';
 import { SVGAnalyzer } from './observation/svg-analyzer';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
@@ -69,7 +69,7 @@ import { SanitizeValueConverter } from './resources/value-converters/sanitize';
 import { ViewValueConverter } from './resources/value-converters/view';
 
 export const ITemplateCompilerRegistration = TemplateCompiler as IRegistry;
-export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry;
+export { DefaultNodeObserverLocatorRegistration };
 
 /**
  * Default HTML-specific (but environment-agnostic) implementations for the following interfaces:
@@ -79,7 +79,7 @@ export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry
  */
 export const DefaultComponents = [
   ITemplateCompilerRegistration,
-  INodeObserverLocatorRegistration,
+  DefaultNodeObserverLocatorRegistration,
 ];
 
 export const SVGAnalyzerRegistration = SVGAnalyzer as IRegistry;

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -347,6 +347,7 @@ export {
   EventDelegator
 } from './observation/event-delegator';
 export {
+  NodeEventConfig,
   NodeObserverLocator,
 } from './observation/observer-locator';
 export {
@@ -460,7 +461,7 @@ export {
 
 export {
   ITemplateCompilerRegistration,
-  INodeObserverLocatorRegistration,
+  DefaultNodeObserverLocatorRegistration,
 
   DefaultComponents,
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -125,8 +125,7 @@ export {
 
   IObjectObservationAdapter,
   IObserverLocator,
-  ITargetObserverLocator,
-  ITargetAccessorLocator,
+  INodeObserverLocator,
   getCollectionObserver,
   ObserverLocator,
 
@@ -348,8 +347,7 @@ export {
   EventDelegator
 } from './observation/event-delegator';
 export {
-  TargetAccessorLocator,
-  TargetObserverLocator
+  NodeObserverLocator,
 } from './observation/observer-locator';
 export {
   ISelectElement,
@@ -462,8 +460,7 @@ export {
 
 export {
   ITemplateCompilerRegistration,
-  ITargetAccessorLocatorRegistration,
-  ITargetObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 
   DefaultComponents,
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -326,29 +326,31 @@ export {
 } from './renderer';
 
 export {
-  AttributeNSAccessor
+  AttributeNSAccessor,
 } from './observation/attribute-ns-accessor';
 export {
   IInputElement,
-  CheckedObserver
+  CheckedObserver,
 } from './observation/checked-observer';
 export {
-  ClassAttributeAccessor
+  ClassAttributeAccessor,
 } from './observation/class-attribute-accessor';
 export {
-  DataAttributeAccessor
+  DataAttributeAccessor,
 } from './observation/data-attribute-accessor';
 export {
-  ElementPropertyAccessor
+  ElementPropertyAccessor,
 } from './observation/element-property-accessor';
 export {
   IEventDelegator,
   EventSubscriber,
-  EventDelegator
+  EventDelegator,
 } from './observation/event-delegator';
 export {
-  NodeEventConfig,
+  NodeObserverConfig,
   NodeObserverLocator,
+  INodeObserverConfig,
+  IHtmlObserverConstructor,
 } from './observation/observer-locator';
 export {
   ISelectElement,
@@ -364,20 +366,20 @@ export {
   NoopSVGAnalyzer,
 } from './observation/svg-analyzer';
 export {
-  ValueAttributeObserver
+  ValueAttributeObserver,
 } from './observation/value-attribute-observer';
 
 export {
-  AttrBindingBehavior
+  AttrBindingBehavior,
 } from './resources/binding-behaviors/attr';
 export {
   SelfableBinding,
-  SelfBindingBehavior
+  SelfBindingBehavior,
 } from './resources/binding-behaviors/self';
 export {
   UpdateTriggerBindingBehavior,
   UpdateTriggerableBinding,
-  UpdateTriggerableObserver
+  UpdateTriggerableObserver,
 } from './resources/binding-behaviors/update-trigger';
 
 export {
@@ -396,7 +398,7 @@ export {
 } from './resources/template-controllers/flags';
 export {
   If,
-  Else
+  Else,
 } from './resources/template-controllers/if';
 export {
   Repeat
@@ -412,17 +414,17 @@ export {
 
 export {
   Blur,
-  BlurManager
+  BlurManager,
 } from './resources/custom-attributes/blur';
 
 export {
-  Focus
+  Focus,
 } from './resources/custom-attributes/focus';
 
 export {
   Portal,
   PortalTarget,
-  PortalLifecycleCallback
+  PortalLifecycleCallback,
 } from './resources/template-controllers/portal';
 
 export {
@@ -444,12 +446,12 @@ export {
   CustomElementType,
   CustomElementDefinition,
   PartialCustomElementDefinition,
-  useShadowDOM
+  useShadowDOM,
 } from './resources/custom-element';
 
 export {
   Subject,
-  Compose
+  Compose,
 } from './resources/custom-elements/compose';
 export {
   ISanitizer,
@@ -461,7 +463,7 @@ export {
 
 export {
   ITemplateCompilerRegistration,
-  DefaultNodeObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 
   DefaultComponents,
 

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -256,14 +256,16 @@ export class CheckedObserver implements IObserver {
     this.callSubscribers(this.currentValue, this.oldValue, LifecycleFlags.none);
   }
 
-  public bind(): void {
+  // deepscan-disable-next-line
+  public bind(_flags: LifecycleFlags): void {
     // this is incorrect, needs to find a different way to initialize observer value,
     // relative to binding value
     // for now keeping this to do everything at once later
     this.currentValue = this.obj.checked;
   }
 
-  public unbind(): void {
+  // deepscan-disable-next-line
+  public unbind(_flags: LifecycleFlags): void {
     this.currentValue = void 0;
   }
 

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -71,14 +71,15 @@ export class CheckedObserver implements IAccessor {
     if (this.hasChanges) {
       this.hasChanges = false;
 
+      const obj = this.obj;
       const currentValue = this.oldValue = this.currentValue;
 
       if (this.valueObserver === void 0) {
-        if (this.obj.$observers !== void 0) {
-          if (this.obj.$observers.model !== void 0) {
-            this.valueObserver = this.obj.$observers.model;
-          } else if (this.obj.$observers.value !== void 0) {
-            this.valueObserver = this.obj.$observers.value;
+        if (obj.$observers !== void 0) {
+          if (obj.$observers.model !== void 0) {
+            this.valueObserver = obj.$observers.model;
+          } else if (obj.$observers.value !== void 0) {
+            this.valueObserver = obj.$observers.value;
           }
         }
         this.valueObserver?.subscribe(this);
@@ -87,7 +88,7 @@ export class CheckedObserver implements IAccessor {
       this.collectionObserver?.unsubscribeFromCollection(this);
       this.collectionObserver = void 0;
 
-      if (this.obj.type === 'checkbox') {
+      if (obj.type === 'checkbox') {
         (this.collectionObserver = getCollectionObserver(currentValue, this.observerLocator))
           ?.subscribeToCollection(this);
       }

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -86,17 +86,11 @@ export class ClassAttributeAccessor implements IAccessor {
 }
 
 export function getClassesToAdd(object: Record<string, unknown> | [] | string): string[] {
-
-  function splitClassString(classString: string): string[] {
-    const matches = classString.match(/\S+/g);
-    if (matches === null) {
-      return emptyArray;
-    }
-    return matches;
-  }
-
   if (typeof object === 'string') {
     return splitClassString(object);
+  }
+  if (typeof object !== 'object') {
+    return emptyArray;
   }
 
   if (object instanceof Array) {
@@ -110,21 +104,28 @@ export function getClassesToAdd(object: Record<string, unknown> | [] | string): 
     } else {
       return emptyArray;
     }
-  } else if (object instanceof Object) {
-    const classes: string[] = [];
-    for (const property in object) {
-      // Let non typical values also evaluate true so disable bool check
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, no-extra-boolean-cast
-      if (Boolean(object[property])) {
-        // We must do this in case object property has a space in the name which results in two classes
-        if (property.includes(' ')) {
-          classes.push(...splitClassString(property));
-        } else {
-          classes.push(property);
-        }
+  }
+
+  const classes: string[] = [];
+  for (const property in object) {
+    // Let non typical values also evaluate true so disable bool check
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, no-extra-boolean-cast
+    if (Boolean(object[property])) {
+      // We must do this in case object property has a space in the name which results in two classes
+      if (property.includes(' ')) {
+        classes.push(...splitClassString(property));
+      } else {
+        classes.push(property);
       }
     }
-    return classes;
   }
-  return emptyArray;
+  return classes;
+}
+
+function splitClassString(classString: string): string[] {
+  const matches = classString.match(/\S+/g);
+  if (matches === null) {
+    return emptyArray;
+  }
+  return matches;
 }

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -1,13 +1,11 @@
 import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray } from '@aurelia/kernel';
-import { INode } from '../dom';
 
 export class ClassAttributeAccessor implements IAccessor {
-  public readonly obj: HTMLElement;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
 
-  public readonly persistentFlags: LifecycleFlags;
+  public readonly persistentFlags: LifecycleFlags = LifecycleFlags.none;
 
   public readonly doNotCache: true = true;
   public nameIndex: Record<string, number> = {};
@@ -18,11 +16,8 @@ export class ClassAttributeAccessor implements IAccessor {
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;
 
   public constructor(
-    flags: LifecycleFlags,
-    obj: INode,
+    public readonly obj: HTMLElement
   ) {
-    this.obj = obj as HTMLElement;
-    this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 
   public getValue(): unknown {

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -64,17 +64,19 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
       this.oldValue = currentValue;
       switch (this.targetAttribute) {
         case 'class': {
-          // Why is class attribute observer setValue look different with class attribute accessor?
+          // Why does class attribute observer setValue look different with class attribute accessor?
           // ==============
           // For class list
           // newValue is simply checked if truthy or falsy
           // and toggle the class accordingly
           // -- the rule of this is quite different to normal attribute
           //
-          // for class attribute, observer is different in a way that it only observe a particular class at a time
+          // for class attribute, observer is different in a way that it only observes one class at a time
           // this also comes from syntax, where it would typically be my-class.class="someProperty"
           //
           // so there is no need for separating class by space and add all of them like class accessor
+          //
+          // note: not using .toggle API so that environment with broken impl (IE11) won't need to polfyfill by default
           if (!!currentValue) {
             this.obj.classList.add(this.propertyKey);
           } else {

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -25,7 +25,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   public currentValue: unknown = null;
   public oldValue: unknown = null;
 
-  public readonly persistentFlags: LifecycleFlags;
+  public readonly persistentFlags: LifecycleFlags = LifecycleFlags.none;
 
   public hasChanges: boolean = false;
   // layout is not certain, depends on the attribute being flushed to owner element
@@ -34,13 +34,11 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
 
   public constructor(
     private readonly platform: IPlatform,
-    flags: LifecycleFlags,
     public readonly observerLocator: IObserverLocator,
     public readonly obj: IHtmlElement,
     public readonly propertyKey: string,
     public readonly targetAttribute: string,
   ) {
-    this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 
   public getValue(): unknown {

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -1,5 +1,5 @@
 import { DI, IDisposable } from '@aurelia/kernel';
-import { INodeEventConfig } from '@aurelia/runtime';
+import type { NodeEventConfig } from './observer-locator';
 
 const defaultOptions: AddEventListenerOptions = {
   capture: false,
@@ -100,7 +100,7 @@ export class EventSubscriber {
   private handler: EventListenerOrEventListenerObject | null = null;
 
   public constructor(
-    public readonly config: INodeEventConfig,
+    public readonly config: NodeEventConfig,
   ) {}
 
   public subscribe(node: EventTarget, callbackOrListener: EventListenerOrEventListenerObject): void {

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -1,5 +1,6 @@
-import { DI, IDisposable } from '@aurelia/kernel';
-import type { NodeEventConfig } from './observer-locator';
+import { DI } from '@aurelia/kernel';
+import type { NodeObserverConfig } from './observer-locator';
+import type { IDisposable } from '@aurelia/kernel';
 
 const defaultOptions: AddEventListenerOptions = {
   capture: false,
@@ -100,7 +101,7 @@ export class EventSubscriber {
   private handler: EventListenerOrEventListenerObject | null = null;
 
   public constructor(
-    public readonly config: NodeEventConfig,
+    public readonly config: NodeObserverConfig,
   ) {}
 
   public subscribe(node: EventTarget, callbackOrListener: EventListenerOrEventListenerObject): void {

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -1,4 +1,5 @@
 import { DI, IDisposable } from '@aurelia/kernel';
+import { INodeEventConfig } from '@aurelia/runtime';
 
 const defaultOptions: AddEventListenerOptions = {
   capture: false,
@@ -99,13 +100,13 @@ export class EventSubscriber {
   private handler: EventListenerOrEventListenerObject | null = null;
 
   public constructor(
-    private readonly events: string[],
+    public readonly config: INodeEventConfig,
   ) {}
 
   public subscribe(node: EventTarget, callbackOrListener: EventListenerOrEventListenerObject): void {
     this.target = node;
     this.handler = callbackOrListener;
-    for (const event of this.events) {
+    for (const event of this.config.events) {
       node.addEventListener(event, callbackOrListener);
     }
   }
@@ -113,7 +114,7 @@ export class EventSubscriber {
   public dispose(): void {
     const { target, handler } = this;
     if (target !== null && handler !== null) {
-      for (const event of this.events) {
+      for (const event of this.config.events) {
         target.removeEventListener(event, handler);
       }
     }

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -17,8 +17,9 @@ import { ISelectElement, SelectValueObserver } from './select-value-observer';
 import { StyleAttributeAccessor } from './style-attribute-accessor';
 import { ISVGAnalyzer } from './svg-analyzer';
 import { ValueAttributeObserver } from './value-attribute-observer';
+import { AppTask } from '../app-task';
 
-import type { IContainer, IIndexable } from '@aurelia/kernel';
+import type { IIndexable } from '@aurelia/kernel';
 import type { IAccessor, IBindingTargetAccessor, IObserver, ICollectionObserver, CollectionKind } from '@aurelia/runtime';
 
 // https://infra.spec.whatwg.org/#namespaces
@@ -62,7 +63,9 @@ export class NodeEventConfig {
    */
   public readonly default?: unknown;
   public constructor(config: NodeEventConfig) {
-    Object.assign(this, config);
+    this.events = config.events;
+    this.readonly = config.readonly;
+    this.default = config.default;
   }
 }
 
@@ -75,21 +78,22 @@ export const DefaultNodeObserverLocatorRegistration: IRegistry = {
   register(container) {
     Registration.singleton(INodeObserverLocator, NodeObserverLocator).register(container);
     Registration.aliasTo(INodeObserverLocator, NodeObserverLocator).register(container);
-    const locator = container.get(NodeObserverLocator);
-    locator.useConfig({
-      INPUT: {
-        value: inputEventsConfig,
-        files: { events: inputEventsConfig.events, readonly: true },
-      },
-      TEXTAREA: {
-        value: inputEventsConfig,
-      },
-    });
-    locator.useGlobalConfig({
-      scrollTop: scrollEventsConfig,
-      scrollLeft: scrollEventsConfig,
-      textContent: contentEventsConfig,
-      innerHTML: contentEventsConfig,
+    AppTask.with(NodeObserverLocator).beforeCreate().call(locator => {
+      locator.useConfig({
+        INPUT: {
+          value: inputEventsConfig,
+          files: { events: inputEventsConfig.events, readonly: true },
+        },
+        TEXTAREA: {
+          value: inputEventsConfig,
+        },
+      });
+      locator.useGlobalConfig({
+        scrollTop: scrollEventsConfig,
+        scrollLeft: scrollEventsConfig,
+        textContent: contentEventsConfig,
+        innerHTML: contentEventsConfig,
+      });
     });
   }
 }

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -74,6 +74,7 @@ const scrollEventsConfig: NodeEventConfig = new NodeEventConfig({ events: ['scro
 export const DefaultNodeObserverLocatorRegistration: IRegistry = {
   register(container) {
     Registration.singleton(INodeObserverLocator, NodeObserverLocator).register(container);
+    Registration.aliasTo(INodeObserverLocator, NodeObserverLocator).register(container);
     const locator = container.get(NodeObserverLocator);
     locator.useConfig({
       INPUT: {
@@ -107,10 +108,6 @@ export class NodeObserverLocator implements INodeObserverLocator {
     @IDirtyChecker private readonly dirtyChecker: IDirtyChecker,
     @ISVGAnalyzer private readonly svgAnalyzer: ISVGAnalyzer,
   ) {}
-
-  public static register(container: IContainer) {
-    Registration.singleton(INodeObserverLocator, this).register(container);
-  }
 
   // deepscan-disable-next-line
   public handles(obj: unknown, _key: PropertyKey): boolean {

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -47,24 +47,6 @@ const nsAttributes = Object.assign(
   },
 );
 
-
-const getDefaultOverrideProps = () => [
-  'class',
-  'style',
-  'css',
-  'checked',
-  'value',
-  'model',
-  'xml:lang',
-  'xml:space',
-  'xmlns',
-  'xmlns:xlink',
-].reduce((overrides, attr) => {
-  overrides[attr] = true;
-  return overrides;
-},createLookup<true>());
-
-
 export class NodeEventConfig {
   /**
    * Indicates the list of events can be used to observe a particular property
@@ -252,6 +234,24 @@ export class NodeObserverLocator implements INodeObserverLocator {
     }
     return new ValueAttributeObserver(el, key, new EventSubscriber(eventsConfig));
   }
+}
+
+function getDefaultOverrideProps() {
+  return [
+    'class',
+    'style',
+    'css',
+    'checked',
+    'value',
+    'model',
+    'xml:lang',
+    'xml:space',
+    'xmlns',
+    'xmlns:xlink',
+  ].reduce((overrides, attr) => {
+    overrides[attr] = true;
+    return overrides;
+  },createLookup<true>());
 }
 
 export function getCollectionObserver(collection: unknown, observerLocator: IObserverLocator): ICollectionObserver<CollectionKind> | undefined {

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -166,13 +166,15 @@ export class NodeObserverLocator implements INodeObserverLocator {
     }
     let eventsConfig: INodeEventConfig | null;
     switch (key) {
+      case 'role':
+        return attrAccessor;
       case 'class':
         return new ClassAttributeAccessor(el);
       case 'css':
       case 'style':
         return new StyleAttributeAccessor(el);
-      case 'scrolltop':
-      case 'scrollleft':
+      case 'scrollTop':
+      case 'scrollLeft':
         eventsConfig = scrollEventsConfig;
         break;
       case 'textContent':
@@ -184,6 +186,14 @@ export class NodeObserverLocator implements INodeObserverLocator {
         break;
     }
     if (eventsConfig == null) {
+      const nsProps = nsAttributes[key as string];
+      if (nsProps !== undefined) {
+        return AttributeNSAccessor.forNs(nsProps[1]) as IBindingTargetAccessor;
+      }
+      if (isDataAttribute(el, key, this.svgAnalyzer)) {
+        // todo: should observe
+        return attrAccessor;
+      }
       if (key in el.constructor.prototype) {
         // todo: either:
         // - if DirtyChecker is register, then use it

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -48,15 +48,14 @@ const nsAttributes = Object.assign(
   },
 );
 
-export interface IHtmlObserverConstructor {
+export type IHtmlObserverConstructor =
   new (
     el: INode,
     key: PropertyKey,
     handler: EventSubscriber,
     observerLocator: IObserverLocator,
     locator: IServiceLocator,
-  ): IObserver;
-}
+  ) => IObserver;
 
 export interface INodeObserverConfig extends Partial<NodeObserverConfig> {
   events: string[];
@@ -66,7 +65,7 @@ export class NodeObserverConfig {
   /**
    * The observer constructor to use
    */
-  type: IHtmlObserverConstructor;
+  public type: IHtmlObserverConstructor;
   /**
    * Indicates the list of events can be used to observe a particular property
    */
@@ -88,8 +87,6 @@ export class NodeObserverConfig {
     this.default = config.default;
   }
 }
-
-const selectEventsConfig: NodeObserverConfig = new NodeObserverConfig({ events: ['change'], default: '' });
 
 export class NodeObserverLocator implements INodeObserverLocator {
   public allowDirtyCheck: boolean = true;

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -178,7 +178,7 @@ export class NodeObserverLocator implements INodeObserverLocator {
       // https://html.spec.whatwg.org/multipage/dom.html#wai-aria
       case 'role':
         return attrAccessor;
-      default:
+      default: {
         const nsProps = nsAttributes[key as string];
         if (nsProps !== undefined) {
           return AttributeNSAccessor.forNs(nsProps[1]) as IBindingTargetAccessor;
@@ -187,6 +187,7 @@ export class NodeObserverLocator implements INodeObserverLocator {
           return attrAccessor;
         }
         return elementPropertyAccessor;
+      }
     }
   }
 
@@ -243,7 +244,6 @@ export function getCollectionObserver(collection: unknown, observerLocator: IObs
   if (collection instanceof Set) {
     return observerLocator.getSetObserver(LifecycleFlags.none, collection);
   }
-  return;
 }
 
 function throwMappingExisted(nodeName: string, key: PropertyKey): never {

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -1,17 +1,23 @@
 import {
   CollectionKind,
-  IAccessor,
-  ICollectionObserver,
-  IndexMap,
-  IObserverLocator,
-  ISubscriber,
-  ISubscriberCollection,
   LifecycleFlags as LF,
   subscriberCollection,
   AccessorType,
 } from '@aurelia/runtime';
-import { EventSubscriber } from './event-delegator';
+
 import { IPlatform } from '../platform';
+
+import type { INode } from '../dom';
+import type { EventSubscriber } from './event-delegator';
+import type { IServiceLocator } from '@aurelia/kernel';
+import type {
+  ICollectionObserver,
+  IndexMap,
+  IObserver,
+  IObserverLocator,
+  ISubscriber,
+  ISubscriberCollection,
+} from '@aurelia/runtime';
 
 const hasOwn = Object.prototype.hasOwnProperty;
 const childObserverOptions = {
@@ -36,11 +42,13 @@ export interface SelectValueObserver extends
   ISubscriberCollection {}
 
 @subscriberCollection()
-export class SelectValueObserver implements IAccessor {
+export class SelectValueObserver implements IObserver {
   public currentValue: unknown = void 0;
   public oldValue: unknown = void 0;
 
+  public readonly obj: ISelectElement;
   public readonly persistentFlags: LF = LF.none;
+  public readonly platform: IPlatform;
 
   public hasChanges: boolean = false;
   // ObserverType.Layout is not always true
@@ -53,11 +61,15 @@ export class SelectValueObserver implements IAccessor {
   private observing: boolean = false;
 
   public constructor(
-    public readonly obj: ISelectElement,
+    obj: INode,
+    // deepscan-disable-next-line
+    _key: PropertyKey,
     public readonly handler: EventSubscriber,
     public readonly observerLocator: IObserverLocator,
-    public readonly platform: IPlatform,
+    locator: IServiceLocator,
   ) {
+    this.obj = obj as ISelectElement;
+    this.platform = locator.get(IPlatform);
   }
 
   public getValue(): unknown {

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -53,10 +53,10 @@ export class SelectValueObserver implements IAccessor {
   private observing: boolean = false;
 
   public constructor(
+    public readonly obj: ISelectElement,
+    public readonly handler: EventSubscriber,
     public readonly observerLocator: IObserverLocator,
     public readonly platform: IPlatform,
-    public readonly handler: EventSubscriber,
-    public readonly obj: ISelectElement,
   ) {
   }
 

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -3,11 +3,10 @@ import { emptyArray, kebabCase } from '@aurelia/kernel';
 import { INode } from '../dom';
 
 export class StyleAttributeAccessor implements IAccessor {
-  public readonly obj: HTMLElement;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
 
-  public readonly persistentFlags: LifecycleFlags;
+  public readonly persistentFlags: LifecycleFlags = LifecycleFlags.none;
 
   public styles: Record<string, number> = {};
   public version: number = 0;
@@ -16,11 +15,8 @@ export class StyleAttributeAccessor implements IAccessor {
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;
 
   public constructor(
-    flags: LifecycleFlags,
-    obj: INode,
+    public readonly obj: HTMLElement,
   ) {
-    this.obj = obj as HTMLElement;
-    this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
 
   public getValue(): string {

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -1,6 +1,5 @@
 import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray, kebabCase } from '@aurelia/kernel';
-import { INode } from '../dom';
 
 export class StyleAttributeAccessor implements IAccessor {
   public currentValue: unknown = '';

--- a/packages/runtime-html/src/observation/value-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/value-attribute-observer.ts
@@ -26,7 +26,7 @@ export class ValueAttributeObserver implements IAccessor {
     flags: LifecycleFlags,
     public readonly handler: EventSubscriber,
     public readonly obj: Node & IIndexable,
-    public readonly propertyKey: string,
+    public readonly propertyKey: PropertyKey,
   ) {
     this.persistentFlags = flags & LifecycleFlags.targetObserverFlags;
   }
@@ -52,9 +52,9 @@ export class ValueAttributeObserver implements IAccessor {
       const oldValue = this.oldValue;
       this.oldValue = currentValue;
       if (currentValue == void 0) {
-        this.obj[this.propertyKey] = '';
+        this.obj[this.propertyKey as string] = '';
       } else {
-        this.obj[this.propertyKey] = currentValue;
+        this.obj[this.propertyKey as string] = currentValue;
       }
 
       if ((flags & LifecycleFlags.fromBind) === 0) {
@@ -65,7 +65,7 @@ export class ValueAttributeObserver implements IAccessor {
 
   public handleEvent(): void {
     const oldValue = this.oldValue = this.currentValue;
-    const currentValue = this.currentValue = this.obj[this.propertyKey];
+    const currentValue = this.currentValue = this.obj[this.propertyKey as string];
     if (oldValue !== currentValue) {
       this.oldValue = currentValue;
       this.callSubscribers(currentValue, oldValue, LifecycleFlags.none);
@@ -75,7 +75,7 @@ export class ValueAttributeObserver implements IAccessor {
   public subscribe(subscriber: ISubscriber): void {
     if (!this.hasSubscribers()) {
       this.handler.subscribe(this.obj, this);
-      this.currentValue = this.oldValue = this.obj[this.propertyKey];
+      this.currentValue = this.oldValue = this.obj[this.propertyKey as string];
     }
     this.addSubscriber(subscriber);
   }

--- a/packages/runtime-html/src/observation/value-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/value-attribute-observer.ts
@@ -1,18 +1,16 @@
-import { IIndexable } from '@aurelia/kernel';
-import { IAccessor, ISubscriber, ISubscriberCollection, LifecycleFlags, subscriberCollection, AccessorType } from '@aurelia/runtime';
-import { EventSubscriber } from './event-delegator';
-import { INode } from '../dom';
+import { LifecycleFlags, subscriberCollection, AccessorType } from '@aurelia/runtime';
 
-export interface ValueAttributeObserver
-  extends ISubscriberCollection {}
+import type { EventSubscriber } from './event-delegator';
+import type { INode } from '../dom';
+import type { IIndexable } from '@aurelia/kernel';
+import type { ISubscriberCollection, ISubscriber, IObserver } from '@aurelia/runtime';
 
-// TODO: handle file attribute properly again, etc
-
+export interface ValueAttributeObserver extends ISubscriberCollection {}
 /**
  * Observer for non-radio, non-checkbox input.
  */
 @subscriberCollection()
-export class ValueAttributeObserver implements IAccessor {
+export class ValueAttributeObserver implements IObserver {
   public readonly obj: INode & IIndexable;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
@@ -78,8 +76,7 @@ export class ValueAttributeObserver implements IAccessor {
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    this.removeSubscriber(subscriber);
-    if (!this.hasSubscribers()) {
+    if (this.removeSubscriber(subscriber) && !this.hasSubscribers()) {
       this.handler.dispose();
     }
   }

--- a/packages/runtime-html/src/observation/value-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/value-attribute-observer.ts
@@ -1,6 +1,7 @@
 import { IIndexable } from '@aurelia/kernel';
 import { IAccessor, ISubscriber, ISubscriberCollection, LifecycleFlags, subscriberCollection, AccessorType } from '@aurelia/runtime';
 import { EventSubscriber } from './event-delegator';
+import { INode } from '../dom';
 
 export interface ValueAttributeObserver
   extends ISubscriberCollection {}
@@ -12,7 +13,7 @@ export interface ValueAttributeObserver
  */
 @subscriberCollection()
 export class ValueAttributeObserver implements IAccessor {
-  public readonly obj: Node & IIndexable;
+  public readonly obj: INode & IIndexable;
   public currentValue: unknown = '';
   public oldValue: unknown = '';
 
@@ -26,11 +27,11 @@ export class ValueAttributeObserver implements IAccessor {
   private readonly readonly: boolean;
 
   public constructor(
-    obj: Node,
+    obj: INode,
     public readonly propertyKey: PropertyKey,
     public readonly handler: EventSubscriber,
   ) {
-    this.obj = obj as Node & IIndexable;
+    this.obj = obj as INode & IIndexable;
     this.readonly = handler.config.readonly === true;
   }
 

--- a/packages/runtime-html/src/observation/value-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/value-attribute-observer.ts
@@ -24,15 +24,12 @@ export class ValueAttributeObserver implements IAccessor {
   // but for simplicity, always treat as such
   public type: AccessorType = AccessorType.Node | AccessorType.Observer | AccessorType.Layout;
 
-  private readonly readonly: boolean;
-
   public constructor(
     obj: INode,
     public readonly propertyKey: PropertyKey,
     public readonly handler: EventSubscriber,
   ) {
     this.obj = obj as INode & IIndexable;
-    this.readonly = handler.config.readonly === true;
   }
 
   public getValue(): unknown {
@@ -44,7 +41,7 @@ export class ValueAttributeObserver implements IAccessor {
   public setValue(newValue: string | null, flags: LifecycleFlags): void {
     this.currentValue = newValue;
     this.hasChanges = newValue !== this.oldValue;
-    if (!this.readonly && (flags & LifecycleFlags.noFlush) === 0) {
+    if (!this.handler.config.readonly && (flags & LifecycleFlags.noFlush) === 0) {
       this.flushChanges(flags);
     }
   }

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -6,6 +6,7 @@ import { SelectValueObserver } from '../../observation/select-value-observer';
 import { ValueAttributeObserver } from '../../observation/value-attribute-observer';
 
 import type { Scope } from '@aurelia/runtime';
+import { NodeObserverConfig } from '../../observation/observer-locator';
 
 export type UpdateTriggerableObserver = (
   (ValueAttributeObserver & Required<ValueAttributeObserver>) |
@@ -51,7 +52,11 @@ export class UpdateTriggerBindingBehavior {
     targetObserver.originalHandler = originalHandler;
 
     // replace the element subscribe function with one that uses the correct events.
-    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber({ default: originalHandler.config.default, events, readonly: originalHandler.config.readonly });
+    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber(new NodeObserverConfig({
+      default: originalHandler.config.default,
+      events,
+      readonly: originalHandler.config.readonly
+    }));
   }
 
   public unbind(flags: LifecycleFlags, _scope: Scope, _hostScope: Scope | null, binding: UpdateTriggerableBinding): void {

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -47,10 +47,11 @@ export class UpdateTriggerBindingBehavior {
     binding.targetObserver = targetObserver;
 
     // stash the original element subscribe function.
-    targetObserver.originalHandler = binding.targetObserver.handler;
+    const originalHandler = targetObserver.handler;
+    targetObserver.originalHandler = originalHandler;
 
     // replace the element subscribe function with one that uses the correct events.
-    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber({ events });
+    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber({ default: originalHandler.config.default, events, readonly: originalHandler.config.readonly });
   }
 
   public unbind(flags: LifecycleFlags, _scope: Scope, _hostScope: Scope | null, binding: UpdateTriggerableBinding): void {

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -50,7 +50,7 @@ export class UpdateTriggerBindingBehavior {
     targetObserver.originalHandler = binding.targetObserver.handler;
 
     // replace the element subscribe function with one that uses the correct events.
-    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber(events);
+    (targetObserver as Writable<typeof targetObserver>).handler = new EventSubscriber({ events });
   }
 
   public unbind(flags: LifecycleFlags, _scope: Scope, _hostScope: Scope | null, binding: UpdateTriggerableBinding): void {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -164,7 +164,6 @@ export {
 export {
   IObjectObservationAdapter,
   IObserverLocator,
-  INodeEventConfig,
   INodeObserverLocator,
   getCollectionObserver,
   ObserverLocator,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -17,7 +17,7 @@ import {
   FromViewBindingBehavior,
   OneTimeBindingBehavior,
   ToViewBindingBehavior,
-  TwoWayBindingBehavior
+  TwoWayBindingBehavior,
 } from './binding-behaviors/binding-mode';
 import { DebounceBindingBehavior } from './binding-behaviors/debounce';
 import { SignalBindingBehavior } from './binding-behaviors/signals';
@@ -109,10 +109,10 @@ export {
   InterpolationBinding,
 } from './binding/interpolation-binding';
 export {
-  LetBinding
+  LetBinding,
 } from './binding/let-binding';
 export {
-  RefBinding
+  RefBinding,
 } from './binding/ref-binding';
 
 export {
@@ -126,7 +126,7 @@ export {
 export {
   MapObserver,
   enableMapObservation,
-  disableMapObservation
+  disableMapObservation,
 } from './observation/map-observer';
 export {
   SetObserver,
@@ -136,7 +136,7 @@ export {
 export {
   BindingContext,
   Scope,
-  OverrideContext
+  OverrideContext,
 } from './observation/binding-context';
 export {
   CollectionLengthObserver,
@@ -150,12 +150,12 @@ export {
   computed,
   createComputedObserver,
   CustomSetterObserver,
-  GetterObserver
+  GetterObserver,
 } from './observation/computed-observer';
 export {
   IDirtyChecker,
   DirtyCheckProperty,
-  DirtyCheckSettings
+  DirtyCheckSettings,
 } from './observation/dirty-checker';
 export {
   IObservableDefinition,
@@ -164,25 +164,24 @@ export {
 export {
   IObjectObservationAdapter,
   IObserverLocator,
-  ITargetObserverLocator,
-  ITargetAccessorLocator,
+  INodeObserverLocator,
   getCollectionObserver,
-  ObserverLocator
+  ObserverLocator,
 } from './observation/observer-locator';
 export {
-  PrimitiveObserver
+  PrimitiveObserver,
 } from './observation/primitive-observer';
 export {
-  PropertyAccessor
+  PropertyAccessor,
 } from './observation/property-accessor';
 export {
-  BindableObserver
+  BindableObserver,
 } from './observation/bindable-observer';
 export {
-  SetterObserver
+  SetterObserver,
 } from './observation/setter-observer';
 export {
-  ISignaler
+  ISignaler,
 } from './observation/signaler';
 export {
   subscriberCollection,
@@ -208,16 +207,16 @@ export {
   OneTimeBindingBehavior,
   ToViewBindingBehavior,
   FromViewBindingBehavior,
-  TwoWayBindingBehavior
+  TwoWayBindingBehavior,
 } from './binding-behaviors/binding-mode';
 export {
-  DebounceBindingBehavior
+  DebounceBindingBehavior,
 } from './binding-behaviors/debounce';
 export {
-  SignalBindingBehavior
+  SignalBindingBehavior,
 } from './binding-behaviors/signals';
 export {
-  ThrottleBindingBehavior
+  ThrottleBindingBehavior,
 } from './binding-behaviors/throttle';
 
 export {
@@ -258,6 +257,7 @@ export {
   ICollectionSubscriber,
   IndexMap,
   IBatchable,
+  IObserver,
   IObservable,
   IObservedArray,
   IObservedMap,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -164,6 +164,7 @@ export {
 export {
   IObjectObservationAdapter,
   IObserverLocator,
+  INodeEventConfig,
   INodeObserverLocator,
   getCollectionObserver,
   ObserverLocator,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -316,6 +316,11 @@ export interface IAccessor<TValue = unknown> {
   setValue(newValue: TValue, flags: LifecycleFlags, obj?: object, key?: PropertyKey): void;
 }
 
+export interface IObserver extends IAccessor {
+  subscribe(subscriber: ISubscriber): boolean;
+  unsubscribe(subscriber: ISubscriber): boolean;
+}
+
 /**
  * Describes a target observer for to-view bindings (in other words, an observer without the observation).
  */

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -100,29 +100,28 @@ export enum BindingMode {
 }
 
 export const enum LifecycleFlags {
-  none                          = 0b00000_00_00_00_000,
+  none                          = 0b0000_000_00_00_000,
   // Bitmask for flags that need to be stored on a binding during $bind for mutation
   // callbacks outside of $bind
-  persistentBindingFlags        = 0b11111_000_00_00_111,
-  allowParentScopeTraversal     = 0b00001_000_00_00_000,
-  observeLeafPropertiesOnly     = 0b00010_000_00_00_000,
-  targetObserverFlags           = 0b01100_000_00_00_111,
-  noFlush                       = 0b00100_000_00_00_000,
-  persistentTargetObserverQueue = 0b01000_000_00_00_000,
-  secondaryExpression           = 0b10000_000_00_00_000,
-  bindingStrategy               = 0b00000_000_00_00_111,
-  getterSetterStrategy          = 0b00000_000_00_00_001,
-  proxyStrategy                 = 0b00000_000_00_00_010,
-  isStrictBindingStrategy       = 0b00000_000_00_00_100,
-  update                        = 0b00000_000_00_11_000,
-  updateTarget                  = 0b00000_000_00_01_000,
-  updateSource                  = 0b00000_000_00_10_000,
-  from                          = 0b00000_000_11_00_000,
-  fromBind                      = 0b00000_000_01_00_000,
-  fromUnbind                    = 0b00000_000_10_00_000,
-  mustEvaluate                  = 0b00000_001_00_00_000,
-  isTraversingParentScope       = 0b00000_010_00_00_000,
-  dispose                       = 0b00000_100_00_00_000,
+  persistentBindingFlags        = 0b1111_000_00_00_111,
+  allowParentScopeTraversal     = 0b0001_000_00_00_000,
+  observeLeafPropertiesOnly     = 0b0010_000_00_00_000,
+  targetObserverFlags           = 0b1100_000_00_00_111,
+  noFlush                       = 0b0100_000_00_00_000,
+  persistentTargetObserverQueue = 0b1000_000_00_00_000,
+  bindingStrategy               = 0b0000_000_00_00_111,
+  getterSetterStrategy          = 0b0000_000_00_00_001,
+  proxyStrategy                 = 0b0000_000_00_00_010,
+  isStrictBindingStrategy       = 0b0000_000_00_00_100,
+  update                        = 0b0000_000_00_11_000,
+  updateTarget                  = 0b0000_000_00_01_000,
+  updateSource                  = 0b0000_000_00_10_000,
+  from                          = 0b0000_000_11_00_000,
+  fromBind                      = 0b0000_000_01_00_000,
+  fromUnbind                    = 0b0000_000_10_00_000,
+  mustEvaluate                  = 0b0000_001_00_00_000,
+  isTraversingParentScope       = 0b0000_010_00_00_000,
+  dispose                       = 0b0000_100_00_00_000,
 }
 
 export interface IConnectable {
@@ -316,10 +315,7 @@ export interface IAccessor<TValue = unknown> {
   setValue(newValue: TValue, flags: LifecycleFlags, obj?: object, key?: PropertyKey): void;
 }
 
-export interface IObserver extends IAccessor {
-  subscribe(subscriber: ISubscriber): boolean;
-  unsubscribe(subscriber: ISubscriber): boolean;
-}
+export interface IObserver extends IAccessor, ISubscribable {}
 
 /**
  * Describes a target observer for to-view bindings (in other words, an observer without the observation).

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -81,7 +81,7 @@ export class ObserverLocator {
   public constructor(
     @ILifecycle private readonly lifecycle: ILifecycle,
     @IDirtyChecker private readonly dirtyChecker: IDirtyChecker,
-    @INodeObserverLocator private readonly nodeObserverLocator: INodeObserverLocator,
+    @INodeObserverLocator public readonly nodeObserverLocator: INodeObserverLocator,
   ) {}
 
   public addAdapter(adapter: IObjectObservationAdapter): void {

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -31,7 +31,6 @@ export interface IObjectObservationAdapter {
 export interface IObserverLocator extends ObserverLocator {}
 export const IObserverLocator = DI.createInterface<IObserverLocator>('IObserverLocator').withDefault(x => x.singleton(ObserverLocator));
 
-
 export interface INodeObserverLocator {
   handles(obj: unknown, key: PropertyKey, requestor: IObserverLocator): boolean;
   getObserver(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
@@ -47,13 +46,13 @@ export const INodeObserverLocator = DI
   }));
 
 class DefaultNodeObserverLocator implements INodeObserverLocator {
-  handles(): boolean {
+  public handles(): boolean {
     return false;
   }
-  getObserver(): IAccessor<unknown> | IObserver {
+  public getObserver(): IAccessor | IObserver {
     return propertyAccessor;
   }
-  getAccessor(): IAccessor<unknown> | IObserver {
+  public getAccessor(): IAccessor | IObserver {
     return propertyAccessor;
   }
 }

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -1,4 +1,4 @@
-import { DI, Primitive, isArrayIndex, ILogger, noop } from '@aurelia/kernel';
+import { DI, Primitive, isArrayIndex, ILogger } from '@aurelia/kernel';
 import {
   AccessorOrObserver,
   CollectionKind,
@@ -47,13 +47,13 @@ export const INodeObserverLocator = DI
   }));
 
 class DefaultNodeObserverLocator implements INodeObserverLocator {
-  handles(obj: unknown, key: string | number | symbol, requestor: IObserverLocator): boolean {
+  handles(): boolean {
     return false;
   }
-  getObserver(obj: object, key: string | number | symbol, requestor: IObserverLocator): IAccessor<unknown> | IObserver {
+  getObserver(): IAccessor<unknown> | IObserver {
     return propertyAccessor;
   }
-  getAccessor(obj: object, key: string | number | symbol, requestor: IObserverLocator): IAccessor<unknown> | IObserver {
+  getAccessor(): IAccessor<unknown> | IObserver {
     return propertyAccessor;
   }
 }

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -42,7 +42,7 @@ export interface INodeEventConfig {
    */
   readonly?: boolean;
   /**
-   * A default value to assign to the corresponding property if the incomming value is null/undefined
+   * A default value to assign to the corresponding property if the incoming value is null/undefined
    */
   default?: unknown;
 }

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -48,6 +48,7 @@ export interface INodeEventConfig {
 }
 
 export interface INodeObserverLocator {
+  allowDirtyCheck: boolean;
   handles(obj: unknown, key: PropertyKey, requestor: IObserverLocator): boolean;
   // instruct the node observer locator to use some events to observe a property of a node
   useConfig(config: Record<string, Record<string, INodeEventConfig>>): void;
@@ -64,6 +65,7 @@ export const INodeObserverLocator = DI
       logger.error('Using default INodeObserverLocator implementation. Will not be able to observe nodes (HTML etc...).');
     });
     return {
+      allowDirtyCheck: false,
       handles: () => false,
       useGlobalConfig: noop,
       useConfig: noop,

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -1,4 +1,4 @@
-import { DI, Primitive, isArrayIndex, ILogger } from '@aurelia/kernel';
+import { DI, Primitive, isArrayIndex, ILogger, noop } from '@aurelia/kernel';
 import {
   AccessorOrObserver,
   CollectionKind,
@@ -52,6 +52,8 @@ export interface INodeObserverLocator {
   // instruct the node observer locator to use some events to observe a property of a node
   useConfig(config: Record<string, Record<string, INodeEventConfig>>): void;
   useConfig(nodeName: string, key: PropertyKey, eventsConfig: INodeEventConfig): void;
+  useGlobalConfig(config: Record<string, INodeEventConfig>): void;
+  useGlobalConfig(key: PropertyKey, eventsConfig: INodeEventConfig): void;
   getObserver(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
   getAccessor(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
 }
@@ -63,7 +65,8 @@ export const INodeObserverLocator = DI
     });
     return {
       handles: () => false,
-      useConfig: () => {/* empty */},
+      useGlobalConfig: noop,
+      useConfig: noop,
       getAccessor: () => propertyAccessor,
       getObserver: () => propertyAccessor,
     };
@@ -81,7 +84,7 @@ export class ObserverLocator {
   public constructor(
     @ILifecycle private readonly lifecycle: ILifecycle,
     @IDirtyChecker private readonly dirtyChecker: IDirtyChecker,
-    @INodeObserverLocator public readonly nodeObserverLocator: INodeObserverLocator,
+    @INodeObserverLocator private readonly nodeObserverLocator: INodeObserverLocator,
   ) {}
 
   public addAdapter(adapter: IObjectObservationAdapter): void {

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -16,18 +16,16 @@ export class SetterObserver {
   public currentValue: unknown = void 0;
   public oldValue: unknown = void 0;
 
-  public readonly persistentFlags: LifecycleFlags;
+  public readonly persistentFlags: LifecycleFlags = LifecycleFlags.none;
   public inBatch: boolean = false;
   public observing: boolean = false;
   // todo(bigopon): tweak the flag based on typeof obj (array/set/map/iterator/proxy etc...)
   public type: AccessorType = AccessorType.Obj;
 
   public constructor(
-    flags: LifecycleFlags,
     public readonly obj: IIndexable,
     public readonly propertyKey: string,
   ) {
-    this.persistentFlags = flags & LifecycleFlags.persistentBindingFlags;
   }
 
   public getValue(): unknown {
@@ -38,7 +36,7 @@ export class SetterObserver {
     if (this.observing) {
       const currentValue = this.currentValue;
       this.currentValue = newValue;
-      this.callSubscribers(newValue, currentValue, this.persistentFlags | flags);
+      this.callSubscribers(newValue, currentValue, flags);
     } else {
       // If subscribe() has been called, the target property descriptor is replaced by these getter/setter methods,
       // so calling obj[propertyKey] will actually return this.currentValue.
@@ -55,7 +53,7 @@ export class SetterObserver {
     const currentValue = this.currentValue;
     const oldValue = this.oldValue;
     this.oldValue = currentValue;
-    this.callSubscribers(currentValue, oldValue, this.persistentFlags | flags);
+    this.callSubscribers(currentValue, oldValue, flags);
   }
 
   public subscribe(subscriber: ISubscriber): void {

--- a/packages/testing/src/test-builder.ts
+++ b/packages/testing/src/test-builder.ts
@@ -9,10 +9,9 @@ import {
   ILifecycle,
   IObserverLocator,
   Scope,
-  ITargetAccessorLocator,
-  ITargetObserverLocator,
   LifecycleFlags as LF,
   OverrideContext,
+  INodeObserverLocator,
 } from '@aurelia/runtime-html';
 import { createContainer } from './test-context';
 // import {
@@ -466,8 +465,7 @@ export function createObserverLocator(containerOrLifecycle?: IContainer | ILifec
     }
   };
   Registration.instance(IDirtyChecker, null).register(container);
-  Registration.instance(ITargetObserverLocator, dummyLocator).register(container);
-  Registration.instance(ITargetAccessorLocator, dummyLocator).register(container);
+  Registration.instance(INodeObserverLocator, dummyLocator).register(container);
   return container.get(IObserverLocator);
 }
 

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -3,14 +3,12 @@ import {
   bindingBehavior,
   BindingInterceptor,
   BindingMediator,
-  IsAssign,
   LifecycleFlags,
   PropertyBinding,
   IBinding,
   BindingBehaviorExpression,
   ITask,
   IPlatform,
-  CustomElement,
   ICustomElementViewModel,
 } from '@aurelia/runtime-html';
 import { PropertyRule } from '@aurelia/validation';

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -68,7 +68,6 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
   private controller!: IValidationController;
   private isChangeTrigger: boolean = false;
   private readonly defaultTrigger: ValidationTrigger;
-  private readonly connectedExpressions: IsAssign[] = [];
   private scope!: Scope;
   private hostScope: Scope | null = null;
   private readonly triggerMediator: BindingMediator<'handleTriggerChange'> = new BindingMediator('handleTriggerChange', this, this.observerLocator, this.locator);
@@ -181,24 +180,19 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
     const args = expression.args;
     for (let i = 0, ii = args.length; i < ii; i++) {
       const arg = args[i];
-      const temp = arg.evaluate(evaluationFlags, scope, hostScope, locator, null);
       switch (i) {
         case 0:
-          trigger = this.ensureTrigger(temp);
-          arg.connect(flags, scope, hostScope, this.triggerMediator);
+          trigger = this.ensureTrigger(arg.evaluate(evaluationFlags, scope, hostScope, locator, this.triggerMediator));
           break;
         case 1:
-          controller = this.ensureController(temp);
-          arg.connect(flags, scope, hostScope, this.controllerMediator);
+          controller = this.ensureController(arg.evaluate(evaluationFlags, scope, hostScope, locator, this.controllerMediator));
           break;
         case 2:
-          rules = this.ensureRules(temp);
-          arg.connect(flags, scope, hostScope, this.rulesMediator);
+          rules = this.ensureRules(arg.evaluate(evaluationFlags, scope, hostScope, locator, this.rulesMediator));
           break;
         default:
-          throw new Error(`Unconsumed argument#${i + 1} for validate binding behavior: ${temp}`); // TODO: use reporter
+          throw new Error(`Unconsumed argument#${i + 1} for validate binding behavior: ${arg.evaluate(evaluationFlags, scope, hostScope, locator, null)}`);
       }
-      this.connectedExpressions.push(arg);
     }
 
     return new ValidateArgumentsDelta(this.ensureController(controller), this.ensureTrigger(trigger), rules);

--- a/test/1kcomponents/app-double.js
+++ b/test/1kcomponents/app-double.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { SVGAnalyzerRegistration, StandardConfiguration, Aurelia, CustomElement, ValueConverter, ILifecycle } from '@aurelia/runtime-html';
+import { SVGAnalyzerRegistration, StandardConfiguration, Aurelia, CustomElement, ValueConverter } from '@aurelia/runtime-html';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
 import { interpolateViridis } from 'd3-scale-chromatic';
 

--- a/test/1kcomponents/app-double.js
+++ b/test/1kcomponents/app-double.js
@@ -1,4 +1,5 @@
-import { SVGAnalyzerRegistration, StandardConfiguration, Aurelia, CustomElementResource, ValueConverterResource, ILifecycle, Priority, LifecycleFlags } from '@aurelia/runtime-html';
+// @ts-check
+import { SVGAnalyzerRegistration, StandardConfiguration, Aurelia, CustomElement, ValueConverter, ILifecycle } from '@aurelia/runtime-html';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
 import { interpolateViridis } from 'd3-scale-chromatic';
 
@@ -137,12 +138,9 @@ class Point {
   }
 
   flushRAF() {
-    if (this.transform === void 0) {
-      this.transform = this.$controller.getTargetAccessor('transform');
-    }
     this.x = this[Point.pxProp] + (this[Point.nxProp] - this[Point.pxProp]) * Point.pct;
     this.y = this[Point.pyProp] + (this[Point.nyProp] - this[Point.pyProp]) * Point.pct;
-    this.transform.setValue(`translate(${~~this.x}, ${~~this.y})`, LifecycleFlags.fromBind);
+    this.transform = `translate(${~~this.x}, ${~~this.y})`;
   }
 }
 
@@ -157,7 +155,7 @@ Point.pyProp = '';
 Point.nyProp = '';
 
 function defineApp(fps, count) {
-  return CustomElementResource.define(
+  return CustomElement.define(
     {
       name: 'app',
       template: `
@@ -194,14 +192,12 @@ function defineApp(fps, count) {
       `,
       bindables: ['count', 'fps'],
       dependencies: [
-        ValueConverterResource.define('num', class { fromView(str) { return parseInt(str, 10); } })
+        ValueConverter.define('num', class { fromView(str) { return parseInt(str, 10); } })
       ]
     },
     class {
-      static get inject() { return [ILifecycle]; }
 
-      constructor(lifecycle) {
-        this.lifecycle = lifecycle;
+      constructor() {
         this.points = [];
         this.count = 0;
         this.fps = fps;
@@ -209,11 +205,6 @@ function defineApp(fps, count) {
 
       attached() {
         this.count = count;
-        this.lifecycle.enqueueRAF(Point.update, Point, Priority.preempt);
-      }
-
-      fpsChanged(fps) {
-        this.$controller.lifecycle.minFPS = fps;
       }
 
       countChanged(count) {
@@ -237,19 +228,12 @@ function defineApp(fps, count) {
           for (let i = 0; i < count; ++i) {
             points[i].update(i, count);
           }
-          let point;
-          for (let i = count; i < length; ++i) {
-            point = points[i];
-            this.lifecycle.dequeueRAF(point.flushRAF, point);
-          }
           points.splice(count, length - count);
         }
       }
 
       createPoint(count, i) {
-        const point = new Point(i, count);
-        this.lifecycle.enqueueRAF(point.flushRAF, point, Priority.low);
-        return point;
+        return new Point(i, count);
       }
     }
   );

--- a/test/1kcomponents/app.js
+++ b/test/1kcomponents/app.js
@@ -1,4 +1,5 @@
-import { Aurelia, SVGAnalyzerRegistration, StandardConfiguration } from '@aurelia/runtime-html';
+// @ts-check
+import { Aurelia, CustomElement, IPlatform, ValueConverter, SVGAnalyzerRegistration, StandardConfiguration } from '@aurelia/runtime-html';
 import { startFPSMonitor, startMemMonitor } from 'perf-monitor';
 import { interpolateViridis } from 'd3-scale-chromatic';
 
@@ -165,7 +166,6 @@ const App = CustomElement.define(
               class="point"
               transform.bind="point.transform"
               fill.bind="point.color"
-              view.one-time="point.$controller = $view"
             />
           </g>
         </svg>
@@ -194,13 +194,13 @@ const App = CustomElement.define(
     ]
   },
   class {
-    static get inject() { return [IScheduler]; }
+    static get inject() { return [IPlatform]; }
 
     /**
-     * @param {IScheduler} scheduler
+     * @param {IPlatform} platform
      */
-    constructor(scheduler) {
-      this.scheduler = scheduler;
+    constructor(platform) {
+      this.platform = platform;
       this.points = [];
       this.count = 0;
       this.fps = 30;
@@ -209,7 +209,7 @@ const App = CustomElement.define(
     attaching() {
       this.count = 1000;
       // this.scheduler.enqueueRAF(Point.update, Point, Priority.preempt);
-      this.scheduler.queueRenderTask(
+      this.platform.domWriteQueue.queueTask(
         () => {
           Point.update();
           this.points.forEach(point => point.flushRAF());
@@ -218,10 +218,6 @@ const App = CustomElement.define(
         persistent: true,
       });
     }
-
-    // fpsChanged(fps) {
-    //   this.$controller.lifecycle.minFPS = fps;
-    // }
 
     countChanged(count) {
       Phyllotaxis.count = count;

--- a/test/1kcomponents/webpack.config.js
+++ b/test/1kcomponents/webpack.config.js
@@ -2,7 +2,7 @@ const { resolve } = require('path');
 
 module.exports = function () {
   return {
-    mode: 'none',
+    mode: 'development',
     devtool: false,
     performance: {
       hints: false

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
@@ -1,7 +1,6 @@
 import {
   ITemplateCompilerRegistration,
-  ITargetAccessorLocatorRegistration,
-  ITargetObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 
   RepeatRegistration,
   OneTimeBindingBehaviorRegistration,
@@ -28,8 +27,7 @@ import { App } from './app';
 global['Aurelia'] = new Aurelia()
   .register(
     ITemplateCompilerRegistration,
-    ITargetAccessorLocatorRegistration,
-    ITargetObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
 
     DotSeparatedAttributePatternRegistration,
 

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
@@ -1,6 +1,6 @@
 import {
   ITemplateCompilerRegistration,
-  DefaultNodeObserverLocatorRegistration,
+  INodeObserverLocatorRegistration,
 
   RepeatRegistration,
   OneTimeBindingBehaviorRegistration,
@@ -27,7 +27,7 @@ import { App } from './app';
 global['Aurelia'] = new Aurelia()
   .register(
     ITemplateCompilerRegistration,
-    DefaultNodeObserverLocatorRegistration,
+    INodeObserverLocatorRegistration,
 
     DotSeparatedAttributePatternRegistration,
 

--- a/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
+++ b/test/js-framework-benchmark/frameworks/keyed/aurelia2-local/src/main.ts
@@ -1,6 +1,6 @@
 import {
   ITemplateCompilerRegistration,
-  INodeObserverLocatorRegistration,
+  DefaultNodeObserverLocatorRegistration,
 
   RepeatRegistration,
   OneTimeBindingBehaviorRegistration,
@@ -27,7 +27,7 @@ import { App } from './app';
 global['Aurelia'] = new Aurelia()
   .register(
     ITemplateCompilerRegistration,
-    INodeObserverLocatorRegistration,
+    DefaultNodeObserverLocatorRegistration,
 
     DotSeparatedAttributePatternRegistration,
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Continue the element observation refactoring
- Add ability to extend element observation back
- Merge target get accessor/observer
- Simplify setter observer

## 👩‍💻 Reviewer Notes

- There' some extra touches in i18n related to how translation binding handle its parameter: `secondaryExpression` is gone, and a real binding is used to handle parameter observation instead. This removes the need to have special cases for AST
- Merge some evaluate and connect code together in validation, resulted into simpler code for evaluating + observing validation params
- Basic doc for observation is in, mostly focus on the new API `.useConfig` & `.useGlobalConfig` to map events to props

## 📑 Test Plan

All existing tests work 

## ⏭ Next Steps

- remove redundant flags & flags properties (etc persistentFlags, ...)
- ~~remove `.connect()` (no longer has any places that use `.connect` of ASTs~~ (removed by the merged of #1004 into this branch)