### PR TITLE
refactor: remove all ast.connect()

### DIFF
--- a/packages/__tests__/2-runtime/ast.integration.spec.ts
+++ b/packages/__tests__/2-runtime/ast.integration.spec.ts
@@ -22,8 +22,6 @@ describe('2-runtime/ast.integration.spec.ts', function () {
         const container = createContainer();
         const observerLocator = createObserverLocator(container);
         const accessScopeExpr = new AccessScopeExpression('name', 0);
-        // disable connect to verifies evaluate works
-        accessScopeExpr.connect = () => {/* empty */};
 
         const source = { name: 'hello' };
         const target = { name: '' };
@@ -47,9 +45,6 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           new AccessScopeExpression('yesMessage'),
           new AccessScopeExpression('noMessage'),
         );
-
-        // disable connect to verifies evaluate works
-        conditionalExpr.connect = () => {/* empty */};
 
         const source = { checked: false, yesMessage: 'yes', noMessage: 'no' };
         const target = { value: '' };
@@ -105,9 +100,6 @@ describe('2-runtime/ast.integration.spec.ts', function () {
         const observerLocator = createObserverLocator(container);
         const accessScopeExpr = new AccessScopeExpression('name', 0);
 
-        // disable connect to verifies evaluate works
-        accessScopeExpr.connect = () => {/* empty */};
-
         const source = { value: '' };
         const oc = { name: 'hello' };
         const scope = createScopeForTest(source, oc);
@@ -131,9 +123,6 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           new AccessScopeExpression('yesMessage'),
           new AccessScopeExpression('noMessage'),
         );
-
-        // disable connect to verifies evaluate works
-        conditionalExpr.connect = () => {/* empty */};
 
         const source = { value: '' };
         const oc = { checked: false, yesMessage: 'yes', noMessage: 'no' };

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -249,12 +249,6 @@ describe('interpolation', function () {
       );
       const source = { checked: false, yesMsg: 'yes', noMsg: 'no' };
 
-      // disable connect to verify evaluate works
-      interpolation.connect = () => {/* empty */};
-      interpolation.expressions.forEach(expr => {
-        expr.connect = () => {/* empty */};
-      });
-
       let handleChangeCallCount = 0;
       let updateTargetCallCount = 0;
 
@@ -344,12 +338,6 @@ describe('interpolation', function () {
         yes2: 'yes2',
         no2: 'no2'
       };
-
-      // disable connect to verify evaluate works
-      interpolation.connect = () => {/* empty */};
-      interpolation.expressions.forEach(expr => {
-        expr.connect = () => {/* empty */};
-      });
 
       let handleChange1CallCount = 0;
       let handleChange2CallCount = 0;


### PR DESCRIPTION
# Pull Request

## 📖 Description

The AST `.connect()` methods are no longer in use in any part, simply remove this, and tweak the tests so that they verify connecting while evaluating instead.