### PR TITLE
Controller / ShadowDOM fixes

### DIFF
--- a/packages/__tests__/3-runtime-html/binding-behaviors.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-behaviors.spec.ts
@@ -50,10 +50,7 @@ describe('binding-behaviors', function () {
     class FooAttr5 {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);
@@ -65,10 +62,7 @@ describe('binding-behaviors', function () {
     class FooAttr4 {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);

--- a/packages/__tests__/3-runtime-html/compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/compose.spec.ts
@@ -166,7 +166,7 @@ describe(spec, function () {
       au.app({ host, component: App });
       await au.start();
 
-      assert.visibleTextEqual(au.root, 'Hello world!');
+      assert.visibleTextEqual(host, 'Hello world!');
 
       await au.stop();
 

--- a/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/restrict-template-expressions */
+import {
+  Aurelia,
+  customElement,
+  ICustomElementController,
+  IPlatform,
+  CustomElementDefinition,
+  ICustomElementViewModel,
+  Controller,
+  CustomElement,
+  LifecycleFlags,
+  IHydratedController,
+} from '@aurelia/runtime-html';
+
+import { assert, TestContext } from '@aurelia/testing';
+
+function createFixture() {
+  const ctx = TestContext.create();
+  const { container } = ctx;
+  const p = container.get(IPlatform);
+  const host = ctx.createElement('div');
+  const au = new Aurelia(container);
+
+  return { p, au, host };
+}
+
+const specs: (Partial<CustomElementDefinition> & { toString(): string })[] = [
+  {
+    // nothing (control test)
+    toString(): string { return `nothing`; },
+  },
+  {
+    shadowOptions: { mode: 'open' },
+    toString(): string { return `shadowOptions: { mode: 'open' }`; },
+  },
+  {
+    shadowOptions: { mode: 'closed' },
+    toString(): string { return `shadowOptions: { mode: 'closed' }`; },
+  },
+  {
+    containerless: true,
+    toString(): string { return `containerless: true`; },
+  },
+];
+
+for (const parentSpec of specs) {
+  describe(`parentSpec: ${parentSpec}`, function () {
+    for (const childSpec of specs) {
+      describe(`childSpec: ${childSpec}`, function () {
+        it(`can activate/deactivate twice with the same outcomes`, async function () {
+          const { au, host } = createFixture();
+
+          @customElement({ ...childSpec, name: 'the-child', template: `child` })
+          class TheChild implements ICustomElementViewModel {}
+
+          @customElement({ ...parentSpec, name: 'the-parent', template: `parent`, dependencies: [TheChild] })
+          class TheParent implements ICustomElementViewModel {
+            public $controller!: ICustomElementController<this>;
+
+            private childController!: ICustomElementController;
+
+            public created(controller: ICustomElementController<this>): void {
+              const context = controller.context;
+              this.childController = Controller.forCustomElement(null, context, context.get(CustomElement.keyFrom('the-child')), controller.host, null);
+            }
+            public attaching(initiator: IHydratedController): void {
+              // No async hooks so all of these are synchronous.
+              void this.childController.activate(initiator, this.$controller, LifecycleFlags.none);
+            }
+            public detaching(initiator: IHydratedController): void {
+              void this.childController.deactivate(initiator, this.$controller, LifecycleFlags.none);
+            }
+            public activateChild(): void {
+              void this.childController.activate(this.childController, this.$controller, LifecycleFlags.none);
+            }
+            public deactivateChild(): void {
+              void this.childController.deactivate(this.childController, this.$controller, LifecycleFlags.none);
+            }
+          }
+
+          @customElement({ name: 'the-app', template: `<the-parent></the-parent>`, dependencies: [TheParent] })
+          class TheApp implements ICustomElementViewModel {}
+
+          au.app({ host, component: TheApp });
+          const theApp = au.root.controller.children[0].viewModel as TheParent;
+
+          await au.start();
+
+          assert.visibleTextEqual(host, `parentchild`, `visible text after start() #1`);
+          theApp.deactivateChild();
+          assert.visibleTextEqual(host, `parent`, `visible text after deactivateChild() #1`);
+          theApp.activateChild();
+          assert.visibleTextEqual(host, `parentchild`, `visible text after activateChild() #1`);
+          theApp.deactivateChild();
+          assert.visibleTextEqual(host, `parent`, `visible text after deactivateChild() #2`);
+          theApp.activateChild();
+          assert.visibleTextEqual(host, `parentchild`, `visible text after activateChild() #2`);
+
+          await au.stop();
+
+          assert.visibleTextEqual(host, ``, `visible text after stop() #1`);
+
+          await au.start();
+
+          assert.visibleTextEqual(host, `parentchild`, `visible text after start() #2`);
+
+          assert.visibleTextEqual(host, `parentchild`, `visible text after start() #1`);
+          theApp.deactivateChild();
+          assert.visibleTextEqual(host, `parent`, `visible text after deactivateChild() #1`);
+          theApp.activateChild();
+          assert.visibleTextEqual(host, `parentchild`, `visible text after activateChild() #1`);
+          theApp.deactivateChild();
+          assert.visibleTextEqual(host, `parent`, `visible text after deactivateChild() #2`);
+          theApp.activateChild();
+          assert.visibleTextEqual(host, `parentchild`, `visible text after activateChild() #2`);
+
+          await au.stop(true);
+        });
+      });
+    }
+  });
+}

--- a/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
@@ -16,10 +16,7 @@ describe('custom-attributes', function () {
     class Fooatt5 {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);
@@ -31,10 +28,7 @@ describe('custom-attributes', function () {
     class Fooatt4 {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);
@@ -47,10 +41,7 @@ describe('custom-attributes', function () {
     class FooMultipleAlias {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);
@@ -142,9 +133,7 @@ describe('custom-attributes', function () {
       @bindable public b: string;
       public aResult: boolean;
       public bResult: string;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
+      public constructor(@INode private readonly element: INode<Element>) {
         this.element.innerHTML = 'Created';
       }
       public bound() {
@@ -169,9 +158,7 @@ describe('custom-attributes', function () {
       @bindable({ primary: true }) public b: string;
       public aResult: boolean;
       public bResult: string;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
+      public constructor(@INode private readonly element: INode<Element>) {
         this.element.innerHTML = 'Created';
       }
       public bound() {

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.double.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.double.spec.ts
@@ -9,19 +9,18 @@ describe("generated.template-compiler.static.if-else.double", function () {
         return { au, host };
     }
     function verify(au, host, expected) {
-        const root = au.root;
         au.start();
         const outerHtmlAfterStart1 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #1");
+        assert.visibleTextEqual(host, expected, "after start #1");
         au.stop();
         const outerHtmlAfterStop1 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #1");
+        assert.visibleTextEqual(host, "", "after stop #1");
         au.start();
         const outerHtmlAfterStart2 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #2");
+        assert.visibleTextEqual(host, expected, "after start #2");
         au.stop();
         const outerHtmlAfterStop2 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #2");
+        assert.visibleTextEqual(host, "", "after stop #2");
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.double.spec.ts
@@ -9,19 +9,18 @@ describe("generated.template-compiler.static.if-else.repeat.double", function ()
         return { au, host };
     }
     function verify(au, host, expected) {
-        const root = au.root;
         au.start();
         const outerHtmlAfterStart1 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #1");
+        assert.visibleTextEqual(host, expected, "after start #1");
         au.stop();
         const outerHtmlAfterStop1 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #1");
+        assert.visibleTextEqual(host, "", "after stop #1");
         au.start();
         const outerHtmlAfterStart2 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #2");
+        assert.visibleTextEqual(host, expected, "after start #2");
         au.stop();
         const outerHtmlAfterStop2 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #2");
+        assert.visibleTextEqual(host, "", "after stop #2");
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.repeat.spec.ts
@@ -9,19 +9,18 @@ describe("generated.template-compiler.static.if-else.repeat", function () {
         return { au, host };
     }
     function verify(au, host, expected) {
-        const root = au.root;
         au.start();
         const outerHtmlAfterStart1 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #1");
+        assert.visibleTextEqual(host, expected, "after start #1");
         au.stop();
         const outerHtmlAfterStop1 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #1");
+        assert.visibleTextEqual(host, "", "after stop #1");
         au.start();
         const outerHtmlAfterStart2 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #2");
+        assert.visibleTextEqual(host, expected, "after start #2");
         au.stop();
         const outerHtmlAfterStop2 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #2");
+        assert.visibleTextEqual(host, "", "after stop #2");
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.if-else.spec.ts
@@ -9,19 +9,18 @@ describe("generated.template-compiler.static.if-else", function () {
         return { au, host };
     }
     function verify(au, host, expected) {
-        const root = au.root;
         au.start();
         const outerHtmlAfterStart1 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #1");
+        assert.visibleTextEqual(host, expected, "after start #1");
         au.stop();
         const outerHtmlAfterStop1 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #1");
+        assert.visibleTextEqual(host, "", "after stop #1");
         au.start();
         const outerHtmlAfterStart2 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #2");
+        assert.visibleTextEqual(host, expected, "after start #2");
         au.stop();
         const outerHtmlAfterStop2 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #2");
+        assert.visibleTextEqual(host, "", "after stop #2");
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();

--- a/packages/__tests__/3-runtime-html/generated/template-compiler.static.spec.ts
+++ b/packages/__tests__/3-runtime-html/generated/template-compiler.static.spec.ts
@@ -9,19 +9,18 @@ describe("generated.template-compiler.static", function () {
         return { au, host };
     }
     function verify(au, host, expected) {
-        const root = au.root;
         au.start();
         const outerHtmlAfterStart1 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #1");
+        assert.visibleTextEqual(host, expected, "after start #1");
         au.stop();
         const outerHtmlAfterStop1 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #1");
+        assert.visibleTextEqual(host, "", "after stop #1");
         au.start();
         const outerHtmlAfterStart2 = host.outerHTML;
-        assert.visibleTextEqual(root, expected, "after start #2");
+        assert.visibleTextEqual(host, expected, "after start #2");
         au.stop();
         const outerHtmlAfterStop2 = host.outerHTML;
-        assert.visibleTextEqual(root, "", "after stop #2");
+        assert.visibleTextEqual(host, "", "after stop #2");
         assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, "outerHTML after start #1 / #2");
         assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, "outerHTML after stop #1 / #2");
         au.dispose();

--- a/packages/__tests__/3-runtime-html/injectable.spec.ts
+++ b/packages/__tests__/3-runtime-html/injectable.spec.ts
@@ -91,7 +91,7 @@ describe('CustomElement.createInjectable', function () {
 
     await au.start();
 
-    assert.visibleTextEqual(au.root, ' P(1 C(1) C(5) C(2) C(6)) P(3 C(7) C(9) C(8) C(10)) P(2 C(3) C(11) C(4) C(12)) P(4 C(13) C(15) C(14) C(16))');
+    assert.visibleTextEqual(host, ' P(1 C(1) C(5) C(2) C(6)) P(3 C(7) C(9) C(8) C(10)) P(2 C(3) C(11) C(4) C(12)) P(4 C(13) C(15) C(14) C(16))');
 
     await au.stop();
 

--- a/packages/__tests__/3-runtime-html/local-dependency-inheritance.spec.ts
+++ b/packages/__tests__/3-runtime-html/local-dependency-inheritance.spec.ts
@@ -10,19 +10,18 @@ describe('local dependency inheritance', function () {
     return { ctx, au, host };
   }
   async function verifyHostText(au: Aurelia, host: Element, expected: string) {
-    const root = au.root;
     await au.start();
     const outerHtmlAfterStart1 = host.outerHTML;
-    assert.visibleTextEqual(root, expected, 'after start #1');
+    assert.visibleTextEqual(host, expected, 'after start #1');
     await au.stop();
     const outerHtmlAfterStop1 = host.outerHTML;
-    assert.visibleTextEqual(root, '', 'after stop #1');
+    assert.visibleTextEqual(host, '', 'after stop #1');
     await au.start();
     const outerHtmlAfterStart2 = host.outerHTML;
-    assert.visibleTextEqual(root, expected, 'after start #2');
+    assert.visibleTextEqual(host, expected, 'after start #2');
     await au.stop();
     const outerHtmlAfterStop2 = host.outerHTML;
-    assert.visibleTextEqual(root, '', 'after stop #2');
+    assert.visibleTextEqual(host, '', 'after stop #2');
     assert.strictEqual(outerHtmlAfterStart1, outerHtmlAfterStart2, 'outerHTML after start #1 / #2');
     assert.strictEqual(outerHtmlAfterStop1, outerHtmlAfterStop2, 'outerHTML after stop #1 / #2');
   }

--- a/packages/__tests__/3-runtime-html/signaler.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/signaler.integration.spec.ts
@@ -43,33 +43,33 @@ describe('signaler.integration', function () {
 
     await au.start();
 
-    assert.visibleTextEqual(au.root, '1', 'assert #1');
+    assert.visibleTextEqual(host, '1', 'assert #1');
     assert.areTaskQueuesEmpty();
 
     component.increment();
-    assert.visibleTextEqual(au.root, '1', 'assert #2');
+    assert.visibleTextEqual(host, '1', 'assert #2');
     tq.flush();
-    assert.visibleTextEqual(au.root, '2', 'assert #3');
+    assert.visibleTextEqual(host, '2', 'assert #3');
 
     component.factor = 2;
-    assert.visibleTextEqual(au.root, '2', 'assert #4');
+    assert.visibleTextEqual(host, '2', 'assert #4');
     tq.flush();
-    assert.visibleTextEqual(au.root, '6', 'assert #5');
+    assert.visibleTextEqual(host, '6', 'assert #5');
 
     component.increment();
-    assert.visibleTextEqual(au.root, '6', 'assert #6');
+    assert.visibleTextEqual(host, '6', 'assert #6');
     tq.flush();
-    assert.visibleTextEqual(au.root, '8', 'assert #7');
+    assert.visibleTextEqual(host, '8', 'assert #7');
 
     component.input = 10;
-    assert.visibleTextEqual(au.root, '8', 'assert #8');
+    assert.visibleTextEqual(host, '8', 'assert #8');
     tq.flush();
-    assert.visibleTextEqual(au.root, '20', 'assert #9');
+    assert.visibleTextEqual(host, '20', 'assert #9');
 
     component.increment();
-    assert.visibleTextEqual(au.root, '20', 'assert #10');
+    assert.visibleTextEqual(host, '20', 'assert #10');
     tq.flush();
-    assert.visibleTextEqual(au.root, '22', 'assert #11');
+    assert.visibleTextEqual(host, '22', 'assert #11');
 
     await au.stop();
   });
@@ -111,45 +111,45 @@ describe('signaler.integration', function () {
 
         await au.start();
 
-        assert.visibleTextEqual(au.root, '012', 'assert #1');
+        assert.visibleTextEqual(host, '012', 'assert #1');
         assert.areTaskQueuesEmpty();
 
         items[0] = 2;
         assert.areTaskQueuesEmpty();
         component.updateItem();
-        assert.visibleTextEqual(au.root, '012', 'assert #2');
+        assert.visibleTextEqual(host, '012', 'assert #2');
         tq.flush();
-        assert.visibleTextEqual(au.root, '212', 'assert #3');
+        assert.visibleTextEqual(host, '212', 'assert #3');
 
         items[0] = 3;
         items[1] = 4;
         items[2] = 5;
         assert.areTaskQueuesEmpty();
         component.updateItem();
-        assert.visibleTextEqual(au.root, '212', 'assert #3');
+        assert.visibleTextEqual(host, '212', 'assert #3');
         tq.flush();
-        assert.visibleTextEqual(au.root, '345', 'assert #4');
+        assert.visibleTextEqual(host, '345', 'assert #4');
 
         items.reverse();
-        assert.visibleTextEqual(au.root, '345', 'assert #5');
+        assert.visibleTextEqual(host, '345', 'assert #5');
         if (expr.includes('oneTime')) {
           tq.flush();
-          assert.visibleTextEqual(au.root, '345', 'assert #6');
+          assert.visibleTextEqual(host, '345', 'assert #6');
           component.updateItem();
-          assert.visibleTextEqual(au.root, '345', 'assert #7');
+          assert.visibleTextEqual(host, '345', 'assert #7');
           tq.flush();
-          assert.visibleTextEqual(au.root, '543', 'assert #8');
+          assert.visibleTextEqual(host, '543', 'assert #8');
         } else {
           tq.flush();
-          assert.visibleTextEqual(au.root, '543', 'assert #9');
+          assert.visibleTextEqual(host, '543', 'assert #9');
         }
 
         items[1] = 6;
         assert.areTaskQueuesEmpty();
         component.updateItem();
-        assert.visibleTextEqual(au.root, '543', 'assert #10');
+        assert.visibleTextEqual(host, '543', 'assert #10');
         tq.flush();
-        assert.visibleTextEqual(au.root, '563', 'assert #11');
+        assert.visibleTextEqual(host, '563', 'assert #11');
 
         await au.stop();
       });

--- a/packages/__tests__/3-runtime-html/template-compiler.primary-bindable.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.primary-bindable.spec.ts
@@ -42,10 +42,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -70,10 +67,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public diameter: number;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -99,10 +93,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable({ primary: true })
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -127,10 +118,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -157,10 +145,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public diameter: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -188,10 +173,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable({ primary: true })
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -218,10 +200,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.color;
@@ -243,10 +222,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
         @customAttribute({ name: 'square' })
         class Square {
           public value: string;
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding() {
             this.el.style.background = this.value;
@@ -270,10 +246,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @customAttribute({ name: 'square' })
           class Square {
             public value: string;
-            private readonly el: HTMLElement;
-            public constructor(@INode el: INode) {
-              this.el = el as HTMLElement;
-            }
+            public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
             public binding() {
               const value = this.value === 'literal:literal' ? 'red' : this.value;
@@ -320,10 +293,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
         }
         return [Square];
       },
@@ -346,10 +316,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable({ primary: true })
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
         }
         return [Square];
       },
@@ -375,10 +342,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;
@@ -405,10 +369,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;
@@ -438,10 +399,7 @@ describe('template-compiler.primary-bindable.spec.ts', function () {
           @bindable()
           public color: string;
 
-          private readonly el: HTMLElement;
-          public constructor(@INode el: INode) {
-            this.el = el as HTMLElement;
-          }
+          public constructor(@INode private readonly el: INode<HTMLElement>) {}
 
           public binding(): void {
             this.el.style.borderRadius = `${this.borderRadius || 0}px`;

--- a/packages/__tests__/3-runtime-html/value-converters.spec.ts
+++ b/packages/__tests__/3-runtime-html/value-converters.spec.ts
@@ -33,10 +33,7 @@ describe('value-converters', function () {
     class FooAttribute {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);
@@ -48,10 +45,7 @@ describe('value-converters', function () {
     class FooAttribute2 {
       @bindable({ primary: true })
       public value: any;
-      private readonly element: Element;
-      public constructor(@INode element: INode) {
-        this.element = element as Element;
-      }
+      public constructor(@INode private readonly element: INode<Element>) {}
 
       public bound() {
         this.element.setAttribute('test', this.value);

--- a/packages/__tests__/integration/integration.spec.ts
+++ b/packages/__tests__/integration/integration.spec.ts
@@ -607,13 +607,13 @@ describe('app', function () {
       products.sort((pa, pb) => (pa.name < pb.name ? -1 : 1));
       ctx.platform.domWriteQueue.flush();
       inputs = getInputs();
-      assert.deepEqual(inputs.map(i => getVisibleText(undefined, i.parentElement as any, true)), products.map(p => `${p.id}-${p.name}`));
+      assert.deepEqual(inputs.map(i => getVisibleText(i.parentElement as any, true)), products.map(p => `${p.id}-${p.name}`));
 
       // reverse
       products.reverse();
       ctx.platform.domWriteQueue.flush();
       inputs = getInputs();
-      assert.deepEqual(inputs.map(i => getVisibleText(undefined, i.parentElement as any, true)), products.map(p => `${p.id}-${p.name}`));
+      assert.deepEqual(inputs.map(i => getVisibleText(i.parentElement as any, true)), products.map(p => `${p.id}-${p.name}`));
 
       // clear
       products.splice(0);

--- a/packages/__tests__/validation-html/subscribers/validation-container-custom-element.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-container-custom-element.spec.ts
@@ -135,8 +135,8 @@ describe('validation-container-custom-element', function () {
       await assertEventHandler(input1, platform, controllerSpy, spy1, ctx);
       await assertEventHandler(input2, platform, controllerSpy, spy2, ctx);
 
-      const errors1 = toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true));
-      const errors2 = toArray(ceEl2.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true));
+      const errors1 = toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(el, true));
+      const errors2 = toArray(ceEl2.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(el, true));
 
       assert.deepStrictEqual(errors1, ['Name is required.']);
       assert.deepStrictEqual(errors2, ['Age is required.']);
@@ -168,7 +168,7 @@ describe('validation-container-custom-element', function () {
       await assertEventHandler(target1, platform, controllerSpy, spy, ctx);
       await assertEventHandler(target2, platform, controllerSpy, spy, ctx);
 
-      const errors = toArray(ceEl.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true));
+      const errors = toArray(ceEl.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(el, true));
       assert.deepStrictEqual(errors, ['Age is required.', 'Name is required.']);
     },
     {
@@ -195,8 +195,8 @@ describe('validation-container-custom-element', function () {
       const spy1 = createSpy(ceVm1, 'handleValidationEvent', true);
       await assertEventHandler(input1, platform, controllerSpy, spy1, ctx);
 
-      assert.deepStrictEqual(toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), ['Name is required.']);
-      assert.deepStrictEqual(toArray(ceEl1.querySelectorAll('small')).map((el) => getVisibleText(void 0, el, true)), ['Name is required.']);
+      assert.deepStrictEqual(toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(el, true)), ['Name is required.']);
+      assert.deepStrictEqual(toArray(ceEl1.querySelectorAll('small')).map((el) => getVisibleText(el, true)), ['Name is required.']);
     },
     {
       template: `
@@ -315,7 +315,7 @@ describe('validation-container-custom-element', function () {
     const spy1 = createSpy(ceVm1, 'handleValidationEvent', true);
     await assertEventHandler(input1, platform, controllerSpy, spy1, ctx);
 
-    const errors1 = toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true));
+    const errors1 = toArray(ceEl1.shadowRoot.querySelectorAll('span')).map((el) => getVisibleText(el, true));
 
     assert.deepStrictEqual(errors1, ['Name is required.']);
 

--- a/packages/__tests__/validation-html/subscribers/validation-errors-custom-attribute.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-errors-custom-attribute.spec.ts
@@ -157,7 +157,7 @@ describe('validation-errors-custom-attribute', function () {
       assert.html.textContent(div1.querySelector('span.error'), 'Name is required.');
       assert.deepEqual(
         toArray(div2.querySelectorAll('span.error'))
-          .map((span) => getVisibleText((void 0)!, span, true)),
+          .map((span) => getVisibleText(span, true)),
         ['Age is required.', 'Age is not fizbaz']
       );
 
@@ -223,7 +223,7 @@ describe('validation-errors-custom-attribute', function () {
 
       assert.deepEqual(
         toArray(div.querySelectorAll('span.error'))
-          .map((span) => getVisibleText((void 0)!, span, true)),
+          .map((span) => getVisibleText(span, true)),
         ['Name is required.', 'Age is required.', 'Age is not fizbaz']
       );
     },
@@ -277,7 +277,7 @@ describe('validation-errors-custom-attribute', function () {
       assert.html.textContent(div1.querySelector('span.error'), 'Name is required.');
       assert.deepEqual(
         toArray(div2.querySelectorAll('span.error'))
-          .map((span) => getVisibleText((void 0)!, span, true)),
+          .map((span) => getVisibleText(span, true)),
         ['Age is required.', 'Age is not fizbaz']
       );
 

--- a/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
@@ -193,8 +193,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['DIV', false, nameError]);
       assert.deepStrictEqual([(showResultsArgs[1][0] as HTMLElement).tagName, ...getResult(showResultsArgs[1][1])], ['DIV', false, ageRequiredError, false, ageFizbazError]);
 
-      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), [nameError]);
-      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), [ageRequiredError, ageFizbazError]);
+      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(el, true)), [nameError]);
+      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(el, true)), [ageRequiredError, ageFizbazError]);
 
       addSpy.reset();
       removeSpy.reset();
@@ -219,8 +219,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(removeResultsArgs[0][0] as HTMLElement).tagName, ...getResult(removeResultsArgs[0][1])], ['DIV', false, ageRequiredError, false, ageFizbazError]);
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['DIV', true, undefined, false, ageFizbazError]);
 
-      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), [nameError]);
-      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), [ageFizbazError]);
+      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(el, true)), [nameError]);
+      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(el, true)), [ageFizbazError]);
 
       addSpy.reset();
       removeSpy.reset();
@@ -245,8 +245,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(removeResultsArgs[0][0] as HTMLElement).tagName, ...getResult(removeResultsArgs[0][1])], ['DIV', true, undefined, false, ageFizbazError]);
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['DIV', true, undefined, true, undefined]);
 
-      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), [nameError]);
-      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(void 0, el, true)), []);
+      assert.deepStrictEqual(toArray(div1.querySelectorAll('span')).map((el) => getVisibleText(el, true)), [nameError]);
+      assert.deepStrictEqual(toArray(div2.querySelectorAll('span')).map((el) => getVisibleText(el, true)), []);
     },
     {
       template: `
@@ -300,8 +300,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['SMALL', false, nameError]);
       assert.deepStrictEqual([(showResultsArgs[1][0] as HTMLElement).tagName, ...getResult(showResultsArgs[1][1])], ['SMALL', false, ageRequiredError, false, ageFizbazError]);
 
-      assert.equal(getVisibleText(void 0, validationContainer1.shadowRoot.querySelector('small'), true), nameError);
-      assert.equal(getVisibleText(void 0, validationContainer2.shadowRoot.querySelector('small'), true), `${ageRequiredError}${ageFizbazError}`);
+      assert.equal(getVisibleText(validationContainer1.shadowRoot.querySelector('small'), true), nameError);
+      assert.equal(getVisibleText(validationContainer2.shadowRoot.querySelector('small'), true), `${ageRequiredError}${ageFizbazError}`);
 
       addSpy.reset();
       removeSpy.reset();
@@ -326,8 +326,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(removeResultsArgs[0][0] as HTMLElement).tagName, ...getResult(removeResultsArgs[0][1])], ['SMALL', false, ageRequiredError, false, ageFizbazError]);
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['SMALL', true, undefined, false, ageFizbazError]);
 
-      assert.equal(getVisibleText(void 0, validationContainer1.shadowRoot.querySelector('small'), true), nameError);
-      assert.equal(getVisibleText(void 0, validationContainer2.shadowRoot.querySelector('small'), true), ageFizbazError);
+      assert.equal(getVisibleText(validationContainer1.shadowRoot.querySelector('small'), true), nameError);
+      assert.equal(getVisibleText(validationContainer2.shadowRoot.querySelector('small'), true), ageFizbazError);
 
       addSpy.reset();
       removeSpy.reset();
@@ -352,8 +352,8 @@ describe('validation-result-presenter-service', function () {
       assert.deepStrictEqual([(removeResultsArgs[0][0] as HTMLElement).tagName, ...getResult(removeResultsArgs[0][1])], ['SMALL', true, undefined, false, ageFizbazError]);
       assert.deepStrictEqual([(showResultsArgs[0][0] as HTMLElement).tagName, ...getResult(showResultsArgs[0][1])], ['SMALL', true, undefined, true, undefined]);
 
-      assert.equal(getVisibleText(void 0, validationContainer1.shadowRoot.querySelector('small'), true), nameError);
-      assert.equal(getVisibleText(void 0, validationContainer2.shadowRoot.querySelector('small'), true), '');
+      assert.equal(getVisibleText(validationContainer1.shadowRoot.querySelector('small'), true), nameError);
+      assert.equal(getVisibleText(validationContainer2.shadowRoot.querySelector('small'), true), '');
     },
     {
       presenterService: new CustomPresenterService(PLATFORM),

--- a/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
@@ -206,11 +206,8 @@ describe('validate-binding-behavior', function () {
     public static staticText: string = 'from foo-bar ca';
     @bindable public value: unknown;
     @bindable public triggeringEvents: string[];
-    private readonly node: HTMLElement;
 
-    public constructor(@INode node: INode) {
-      this.node = node as HTMLElement;
-    }
+    public constructor(@INode private readonly node: INode<Element>) {}
 
     public binding() {
       for (const event of this.triggeringEvents) {

--- a/packages/router/src/resources/goto.ts
+++ b/packages/router/src/resources/goto.ts
@@ -10,18 +10,16 @@ export class GotoCustomAttribute implements ICustomAttributeViewModel {
 
   private hasHref: boolean | null = null;
 
-  private readonly element: Element;
   private observer: any;
 
   public readonly $controller!: ICustomAttributeController<this>;
 
   private readonly activeClass: string = 'goto-active';
   public constructor(
-    @INode element: INode,
+    @INode private readonly element: INode<Element>,
     @IRouter private readonly router: IRouter,
   ) {
     deprecationWarning('"goto" custom attribute', '"load" custom attribute');
-    this.element = element as Element;
   }
 
   public binding(): void {

--- a/packages/router/src/resources/href.ts
+++ b/packages/router/src/resources/href.ts
@@ -10,15 +10,12 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
   @bindable({ mode: BindingMode.toView })
   public value: string | undefined;
 
-  private readonly element: Element;
   public readonly $controller!: ICustomAttributeController<this>;
 
   public constructor(
-    @INode element: INode,
+    @INode private readonly element: INode<Element>,
     @IRouter private readonly router: IRouter,
-  ) {
-    this.element = element as Element;
-  }
+  ) {}
 
   public binding(): void {
     if (this.router.options.useHref && !this.hasGoto()) {

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -9,18 +9,15 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
 
   private hasHref: boolean | null = null;
 
-  private readonly element: Element;
   private observer: any;
 
   public readonly $controller!: ICustomAttributeController<this>;
 
   private readonly activeClass: string = 'load-active';
   public constructor(
-    @INode element: INode,
+    @INode private readonly element: INode<Element>,
     @IRouter private readonly router: IRouter,
-  ) {
-    this.element = element as Element;
-  }
+  ) {}
 
   public binding(): void {
     this.element.addEventListener('click', this.router.linkHandler.handler);

--- a/packages/router/src/resources/viewport-scope.ts
+++ b/packages/router/src/resources/viewport-scope.ts
@@ -36,19 +36,16 @@ export class ViewportScopeCustomElement implements ICustomElementViewModel {
   public readonly $controller!: ICustomElementController<this>;
 
   public controller!: IRoutingController;
-  public readonly element: HTMLElement;
 
   private isBound: boolean = false;
 
   public constructor(
     @IRouter private readonly router: IRouter,
-    @INode element: INode,
+    @INode public readonly element: INode<HTMLElement>,
     @IContainer public container: IContainer,
     @ParentViewportScope private readonly parent: ViewportScopeCustomElement,
     @IController private readonly parentController: IHydratedController,
-  ) {
-    this.element = element as HTMLElement;
-  }
+  ) {}
 
   // Maybe this really should be here. Check with Fred
   // public create(

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -48,18 +48,15 @@ export class ViewportCustomElement implements ICustomElementViewModel {
   public readonly $controller!: ICustomElementController<this>;
 
   public controller!: IRoutingController;
-  public readonly element: HTMLElement;
 
   private isBound: boolean = false;
 
   public constructor(
     @IRouter private readonly router: IRouter,
-    @INode element: INode,
+    @INode public readonly element: INode<HTMLElement>,
     @IContainer public container: IContainer,
     @ParentViewport public readonly parentViewport: ViewportCustomElement,
-  ) {
-    this.element = element as HTMLElement;
-  }
+  ) {}
 
   public hydrated(controller: ICompiledCustomElementController) {
     // console.log('hydrated', this.name, this.router.isActive);

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -4,10 +4,10 @@ import { IPlatform } from './platform.js';
 import { CustomElement } from './resources/custom-element.js';
 import { MountTarget } from './templating/controller.js';
 
-export interface INode extends Node {}
+export type INode<T extends Node = Node> = T;
 export const INode = DI.createInterface<INode>('INode').noDefault();
 
-export interface IEventTarget extends EventTarget {}
+export type IEventTarget<T extends EventTarget = EventTarget> = T;
 export const IEventTarget = DI.createInterface<IEventTarget>('IEventTarget').withDefault(x => x.cachedCallback(handler => {
   if (handler.has(IAppRoot, true)) {
     return handler.get(IAppRoot).host;
@@ -16,10 +16,9 @@ export const IEventTarget = DI.createInterface<IEventTarget>('IEventTarget').wit
 }));
 
 export const IRenderLocation = DI.createInterface<IRenderLocation>('IRenderLocation').noDefault();
-export interface IRenderLocation<T extends Node = Node> extends Node {
+export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
-  $nodes?: INodeSequence<T> | Readonly<{}>;
-}
+};
 
 /**
  * Represents a DocumentFragment
@@ -48,7 +47,7 @@ export interface INodeSequence<T extends INode = INode> {
   /**
    * Insert this sequence as a sibling before refNode
    */
-  insertBefore(refNode: T | IRenderLocation<T>): void;
+  insertBefore(refNode: T | IRenderLocation): void;
 
   /**
    * Append this sequence as a child to parent
@@ -64,7 +63,7 @@ export interface INodeSequence<T extends INode = INode> {
 
   unlink(): void;
 
-  link(next: INodeSequence<T> | IRenderLocation<T> | undefined): void;
+  link(next: INodeSequence<T> | IRenderLocation | undefined): void;
 }
 
 export const enum NodeType {
@@ -188,7 +187,6 @@ export function convertToRenderLocation(node: Node): IRenderLocation {
   locationEnd.parentNode!.insertBefore(locationStart, locationEnd);
 
   (locationEnd as IRenderLocation).$start = locationStart as IRenderLocation;
-  (locationStart as IRenderLocation).$nodes = null!;
 
   return locationEnd as IRenderLocation;
 }

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -175,16 +175,13 @@ export function convertToRenderLocation(node: Node): IRenderLocation {
     return node; // it's already a IRenderLocation (converted by FragmentNodeSequence)
   }
 
-  if (node.parentNode == null) {
-    throw new Error('Cannot convert an element without a parent to a RenderLocation');
-  }
-
   const locationEnd = node.ownerDocument!.createComment('au-end');
   const locationStart = node.ownerDocument!.createComment('au-start');
 
-  node.parentNode.replaceChild(locationEnd, node);
-
-  locationEnd.parentNode!.insertBefore(locationStart, locationEnd);
+  if (node.parentNode !== null) {
+    node.parentNode.replaceChild(locationEnd, node);
+    locationEnd.parentNode!.insertBefore(locationStart, locationEnd);
+  }
 
   (locationEnd as IRenderLocation).$start = locationStart as IRenderLocation;
 

--- a/packages/runtime-html/src/resources/custom-attributes/blur.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/blur.ts
@@ -134,10 +134,10 @@ export class Blur implements ICustomAttributeViewModel {
    */
   private readonly manager: BlurManager;
 
-  private readonly element: HTMLElement;
-
-  public constructor(@INode element: INode, @IPlatform private readonly p: IPlatform) {
-    this.element = element as HTMLElement;
+  public constructor(
+    @INode private readonly element: INode<HTMLElement>,
+    @IPlatform private readonly p: IPlatform,
+  ) {
     /**
      * By default, the behavior should be least surprise possible, that:
      *

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -20,11 +20,10 @@ export class Focus implements ICustomAttributeViewModel {
    */
   private needsApply: boolean = false;
 
-  private readonly element: HTMLElement;
-
-  public constructor(@INode element: INode, @IPlatform private readonly p: IPlatform) {
-    this.element = element as HTMLElement;
-  }
+  public constructor(
+    @INode private readonly element: INode<HTMLElement>,
+    @IPlatform private readonly p: IPlatform,
+  ) {}
 
   public binding(): void {
     this.valueChanged();

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -22,11 +22,9 @@ export class CSSModulesProcessorRegistry implements IRegistry {
     class ClassCustomAttribute {
       @bindable public value!: string;
 
-      private element: HTMLElement;
-
-      public constructor(@INode element: INode) {
-        this.element = element as HTMLElement;
-      }
+      public constructor(
+        @INode private readonly element: INode<HTMLElement>,
+      ) {}
 
       public binding() {
         this.valueChanged();

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -382,8 +382,8 @@ export function fail(message: string | Error = 'Failed'): never {
   throw err;
 }
 
-export function visibleTextEqual(root: IAppRoot, expectedText: string, message?: string): void {
-  const actualText = getVisibleText(root.controller!, root.host as Node);
+export function visibleTextEqual(host: Node, expectedText: string, message?: string): void {
+  const actualText = getVisibleText(host);
   if (actualText !== expectedText) {
     innerFail({
       actual: actualText,
@@ -682,7 +682,7 @@ function getNode(elementOrSelector: string | Node, root: Node = PLATFORM.documen
 }
 function isTextContentEqual(elementOrSelector: string | Node, expectedText: string, message?: string, root?: Node) {
   const host = getNode(elementOrSelector, root);
-  const actualText = host && getVisibleText((void 0)!, host, true);
+  const actualText = host && getVisibleText(host, true);
   if (actualText !== expectedText) {
     innerFail({
       actual: actualText,

--- a/packages/testing/src/specialized-assertions.ts
+++ b/packages/testing/src/specialized-assertions.ts
@@ -73,7 +73,7 @@ function nextNode(host: Node, node: Node): Node | null {
 
 export function getVisibleText(host: Node, removeWhiteSpace?: boolean): string | null {
   let text = '';
-  let cur = CustomElement.for(host, { optional: true })?.shadowRoot?.firstChild ?? host.firstChild as Node | null;;
+  let cur = CustomElement.for(host, { optional: true })?.shadowRoot?.firstChild ?? host.firstChild as Node | null;
   while (cur !== null) {
     if (cur.nodeType === NodeType.Text) {
       text += (cur as Text).data;

--- a/packages/validation-html/src/subscribers/validation-container-custom-element.ts
+++ b/packages/validation-html/src/subscribers/validation-container-custom-element.ts
@@ -19,14 +19,11 @@ export const defaultContainerDefinition: PartialCustomElementDefinition = {
 export class ValidationContainerCustomElement implements ValidationResultsSubscriber {
   @bindable public controller!: IValidationController;
   @bindable public errors: ValidationResultTarget[] = [];
-  private readonly host: HTMLElement;
 
   public constructor(
-    @INode host: INode,
+    @INode private readonly host: INode<HTMLElement>,
     @optional(IValidationController) private readonly scopedController: IValidationController
-  ) {
-    this.host = host as HTMLElement;
-  }
+  ) {}
 
   public handleValidationEvent(event: ValidationEvent): void {
     for (const { result } of event.removedResults) {

--- a/packages/validation-html/src/subscribers/validation-errors-custom-attribute.ts
+++ b/packages/validation-html/src/subscribers/validation-errors-custom-attribute.ts
@@ -30,13 +30,10 @@ export class ValidationErrorsCustomAttribute implements ValidationResultsSubscri
   public errors: ValidationResultTarget[] = [];
 
   private readonly errorsInternal: ValidationResultTarget[] = [];
-  private readonly host: HTMLElement;
   public constructor(
-    @INode host: INode,
+    @INode private readonly host: INode<HTMLElement>,
     @optional(IValidationController) private readonly scopedController: IValidationController
-  ) {
-    this.host = host as HTMLElement;
-  }
+  ) {}
 
   public handleValidationEvent(event: ValidationEvent) {
     for (const { result } of event.removedResults) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

- Let the controller automatically detect when its host comes from another controller. If that is the case, it will create its host element as a wrapper to put in-between the passed-in host and its fragment contents.

This enables shadowDOM to work seamlessly in components like `au-viewport` and `au-compose`, and also provides more consistency in non-shadowDOM situations. If this is not desired, just make the element `containerless`. However, the preferred way should be to always have a named host element as it's closer to web components.

Also:
- Make `INode`, `IEventTarget` and `IRenderLocation` easier to use with specific element types
- Improve `getVisibleText` test helper to traverse the (Shadow)DOM without relying on specific `instanceof` checks

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
