### PR TITLE
refactor: separate type import for runtime

### DIFF
--- a/packages/__tests__/tsconfig.json
+++ b/packages/__tests__/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["esnext", "dom"],
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": false,
+    "emitDecoratorMetadata": true,
     "strict": false,
     "alwaysStrict": true,
 

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -21,9 +21,9 @@ import type {
   IsBindingBehavior,
   ITask,
   QueueTaskOptions,
+  Scope,
 } from '@aurelia/runtime';
 import type { IHtmlElement } from '../observation/element-attribute-observer.js';
-import type { Scope } from '@aurelia/runtime';
 import type { INode } from '../dom.js';
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -1,26 +1,30 @@
 import { IServiceLocator } from '@aurelia/kernel';
 import {
-  AccessorOrObserver,
   BindingMode,
   connectable,
   ExpressionKind,
+  LifecycleFlags,
+  AccessorType,
+} from '@aurelia/runtime';
+
+import { AttributeObserver } from '../observation/element-attribute-observer.js';
+import { IPlatform } from '../platform.js';
+import { CustomElementDefinition } from '../resources/custom-element.js';
+
+import type {
+  AccessorOrObserver,
   IBindingTargetObserver,
   IConnectableBinding,
   ForOfStatement,
   IObserverLocator,
   IPartialConnectableBinding,
   IsBindingBehavior,
-  LifecycleFlags,
   ITask,
-  AccessorType,
   QueueTaskOptions,
 } from '@aurelia/runtime';
-import { AttributeObserver, IHtmlElement } from '../observation/element-attribute-observer.js';
-
+import type { IHtmlElement } from '../observation/element-attribute-observer.js';
 import type { Scope } from '@aurelia/runtime';
-import { IPlatform } from '../platform.js';
-import { CustomElementDefinition } from '../resources/custom-element.js';
-import { INode } from '../dom.js';
+import type { INode } from '../dom.js';
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak
 const { oneTime, toView, fromView } = BindingMode;

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -6,9 +6,8 @@ import {
 import { IEventTarget } from '../dom.js';
 
 import type { IDisposable, IIndexable, IServiceLocator } from '@aurelia/kernel';
-import type { IBinding, IConnectableBinding, IsBindingBehavior } from '@aurelia/runtime';
+import type { IBinding, IConnectableBinding, IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IEventDelegator } from '../observation/event-delegator.js';
-import type { Scope } from '@aurelia/runtime';
 import type { IPlatform } from '../platform.js';
 
 const options = {

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -1,16 +1,15 @@
-import { IDisposable, IIndexable, IServiceLocator } from '@aurelia/kernel';
 import {
   DelegationStrategy,
-  IBinding,
-  IConnectableBinding,
-  IsBindingBehavior,
   LifecycleFlags,
 } from '@aurelia/runtime';
-import { IEventDelegator } from '../observation/event-delegator.js';
 
-import type { Scope } from '@aurelia/runtime';
-import { IPlatform } from '../platform.js';
 import { IEventTarget } from '../dom.js';
+
+import type { IDisposable, IIndexable, IServiceLocator } from '@aurelia/kernel';
+import type { IBinding, IConnectableBinding, IsBindingBehavior } from '@aurelia/runtime';
+import type { IEventDelegator } from '../observation/event-delegator.js';
+import type { Scope } from '@aurelia/runtime';
+import type { IPlatform } from '../platform.js';
 
 const options = {
   [DelegationStrategy.capturing]: { capture: true } as const,

--- a/packages/runtime-html/src/observation/attribute-ns-accessor.ts
+++ b/packages/runtime-html/src/observation/attribute-ns-accessor.ts
@@ -1,4 +1,6 @@
-import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
+import { AccessorType } from '@aurelia/runtime';
+
+import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 
 const nsMap: Record<string, AttributeNSAccessor> = Object.create(null);
 

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -1,5 +1,7 @@
-import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray } from '@aurelia/kernel';
+import { AccessorType, LifecycleFlags } from '@aurelia/runtime';
+
+import type { IAccessor } from '@aurelia/runtime';
 
 export class ClassAttributeAccessor implements IAccessor {
   public currentValue: unknown = '';

--- a/packages/runtime-html/src/observation/data-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/data-attribute-accessor.ts
@@ -1,4 +1,6 @@
-import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
+import { AccessorType } from '@aurelia/runtime';
+
+import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 
 /**
  * Attribute accessor for HTML elements.

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,5 +1,7 @@
-import { IBindingTargetObserver, IObserverLocator, ISubscriber, ISubscriberCollection, LifecycleFlags, subscriberCollection, AccessorType } from '@aurelia/runtime';
+import { LifecycleFlags, subscriberCollection, AccessorType } from '@aurelia/runtime';
 import { IPlatform } from '../platform.js';
+
+import type { IBindingTargetObserver, IObserverLocator, ISubscriber, ISubscriberCollection } from '@aurelia/runtime';
 
 export interface IHtmlElement extends HTMLElement {
   $mObserver: MutationObserver;

--- a/packages/runtime-html/src/observation/element-property-accessor.ts
+++ b/packages/runtime-html/src/observation/element-property-accessor.ts
@@ -1,5 +1,7 @@
-import { IIndexable } from '@aurelia/kernel';
-import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
+import { AccessorType } from '@aurelia/runtime';
+
+import type { IIndexable } from '@aurelia/kernel';
+import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 
 /**
  * Property accessor for HTML Elements.

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -1,5 +1,7 @@
-import { IAccessor, LifecycleFlags, AccessorType } from '@aurelia/runtime';
+import { LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray, kebabCase } from '@aurelia/kernel';
+
+import type { IAccessor } from '@aurelia/runtime';
 
 export class StyleAttributeAccessor implements IAccessor {
   public currentValue: unknown = '';

--- a/packages/runtime/src/binding/property-binding.ts
+++ b/packages/runtime/src/binding/property-binding.ts
@@ -1,29 +1,13 @@
-import {
-  IServiceLocator,
-  ITask,
-  QueueTaskOptions,
-  TaskQueue,
-} from '@aurelia/kernel';
-import {
-  AccessorOrObserver,
-  IBindingTargetObserver,
-  AccessorType,
-  BindingMode,
-  ILifecycle,
-  LifecycleFlags,
-} from '../observation.js';
-import { IObserverLocator } from '../observation/observer-locator.js';
-import {
-  ExpressionKind,
-  ForOfStatement,
-  IsBindingBehavior,
-} from './ast.js';
-import {
-  connectable,
-  IConnectableBinding,
-  IPartialConnectableBinding,
-} from './connectable.js';
+import { TaskQueue } from '@aurelia/kernel';
+import { BindingMode, LifecycleFlags, ILifecycle, AccessorType } from '../observation.js';
+import { ExpressionKind } from './ast.js';
+import { connectable } from './connectable.js';
 
+import type { IServiceLocator, ITask, QueueTaskOptions } from '@aurelia/kernel';
+import type { AccessorOrObserver, IBindingTargetObserver } from '../observation.js';
+import type { IObserverLocator } from '../observation/observer-locator.js';
+import type { ForOfStatement, IsBindingBehavior, } from './ast.js';
+import type { IConnectableBinding, IPartialConnectableBinding } from './connectable.js';
 import type { Scope } from '../observation/binding-context.js';
 
 // BindingMode is not a const enum (and therefore not inlined), so assigning them to a variable to save a member accessor is a minor perf tweak

--- a/packages/runtime/src/binding/ref-binding.ts
+++ b/packages/runtime/src/binding/ref-binding.ts
@@ -2,13 +2,12 @@ import {
   IIndexable,
   IServiceLocator,
 } from '@aurelia/kernel';
-import {
-  IsBindingBehavior,
-} from './ast.js';
-import { IConnectableBinding } from './connectable.js';
+import { LifecycleFlags } from '../observation.js';
 
+import type { IsBindingBehavior } from './ast.js';
+import type { IConnectableBinding } from './connectable.js';
 import type { Scope } from '../observation/binding-context.js';
-import { IBinding, LifecycleFlags } from '../observation.js';
+import type { IBinding } from '../observation.js';
 
 export interface RefBinding extends IConnectableBinding {}
 export class RefBinding implements IBinding {

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -1,22 +1,25 @@
 import {
   CollectionKind,
   createIndexMap,
-  ICollectionObserver,
   IndexMap,
-  IObservedArray,
-  ICollectionIndexObserver,
-  ISubscriber,
+  LifecycleFlags,
   AccessorType,
-  ILifecycle,
-  LifecycleFlags
 } from '../observation.js';
 import {
-  CollectionLengthObserver
+  CollectionLengthObserver,
 } from './collection-length-observer.js';
 import {
   collectionSubscriberCollection,
-  subscriberCollection
+  subscriberCollection,
 } from './subscriber-collection.js';
+
+import type {
+  ICollectionObserver,
+  ICollectionIndexObserver,
+  ILifecycle,
+  IObservedArray,
+  ISubscriber,
+} from '../observation.js';
 
 const observerLookup = new WeakMap<unknown[], ArrayObserver>();
 

--- a/packages/runtime/src/observation/bindable-observer.ts
+++ b/packages/runtime/src/observation/bindable-observer.ts
@@ -1,7 +1,10 @@
-import { IIndexable, noop } from '@aurelia/kernel';
-import { InterceptorFunc } from '../bindable.js';
-import { IPropertyObserver, ISubscriber, AccessorType, ILifecycle, LifecycleFlags } from '../observation.js';
+import { noop } from '@aurelia/kernel';
+import { AccessorType, LifecycleFlags } from '../observation.js';
 import { subscriberCollection } from './subscriber-collection.js';
+
+import type { IIndexable } from '@aurelia/kernel';
+import type { InterceptorFunc } from '../bindable.js';
+import type { IPropertyObserver, ISubscriber, ILifecycle } from '../observation.js';
 
 export interface BindableObserver extends IPropertyObserver<IIndexable, string> {}
 

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { IIndexable } from '@aurelia/kernel';
-import { IBinding, IBindingContext, IOverrideContext, LifecycleFlags } from '../observation.js';
+import { LifecycleFlags } from '../observation.js';
+
+import type { IBinding, IBindingContext, IOverrideContext } from '../observation.js';
 
 const marker = Object.freeze({});
 

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -1,5 +1,7 @@
-import { ISubscriberCollection, AccessorType, LifecycleFlags } from '../observation.js';
+import { AccessorType, LifecycleFlags } from '../observation.js';
 import { subscriberCollection } from './subscriber-collection.js';
+
+import type { ISubscriberCollection } from '../observation.js';
 
 export interface CollectionLengthObserver extends ISubscriberCollection {}
 

--- a/packages/runtime/src/observation/collection-size-observer.ts
+++ b/packages/runtime/src/observation/collection-size-observer.ts
@@ -1,5 +1,7 @@
-import { ISubscriberCollection, AccessorType, LifecycleFlags } from '../observation.js';
+import { AccessorType, LifecycleFlags } from '../observation.js';
 import { subscriberCollection } from './subscriber-collection.js';
+
+import type { ISubscriberCollection } from '../observation.js';
 
 export interface CollectionSizeObserver extends ISubscriberCollection {}
 

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -1,6 +1,9 @@
-import { DI, IIndexable, ITask, IPlatform, QueueTaskOptions } from '@aurelia/kernel';
-import { IBindingTargetObserver, IObservable, ISubscriber, AccessorType, LifecycleFlags } from '../observation.js';
+import { DI, IPlatform } from '@aurelia/kernel';
+import { AccessorType, LifecycleFlags } from '../observation.js';
 import { subscriberCollection } from './subscriber-collection.js';
+
+import type { IIndexable, ITask, QueueTaskOptions } from '@aurelia/kernel';
+import type { IBindingTargetObserver, IObservable, ISubscriber } from '../observation';
 
 export interface IDirtyChecker extends DirtyChecker {}
 export const IDirtyChecker = DI.createInterface<IDirtyChecker>('IDirtyChecker').withDefault(x => x.singleton(DirtyChecker));

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -187,10 +187,7 @@ export class MapObserver {
   }
 
   public getLengthObserver(): CollectionSizeObserver {
-    if (this.lengthObserver === void 0) {
-      this.lengthObserver = new CollectionSizeObserver(this.collection);
-    }
-    return this.lengthObserver as CollectionSizeObserver;
+    return this.lengthObserver ??= new CollectionSizeObserver(this.collection);
   }
 
   public getIndexObserver(index: number): ICollectionIndexObserver {
@@ -204,9 +201,7 @@ export class MapObserver {
     this.inBatch = false;
     this.indexMap = createIndexMap(size);
     this.callCollectionSubscribers(indexMap, LifecycleFlags.updateTarget);
-    if (this.lengthObserver !== void 0) {
-      this.lengthObserver.notify();
-    }
+    this.lengthObserver?.notify();
   }
 }
 

--- a/packages/runtime/src/observation/primitive-observer.ts
+++ b/packages/runtime/src/observation/primitive-observer.ts
@@ -1,5 +1,7 @@
 import { Primitive } from '@aurelia/kernel';
-import { IAccessor, ISubscribable, AccessorType } from '../observation.js';
+import { AccessorType } from '../observation.js';
+
+import type { IAccessor, ISubscribable } from '../observation.js';
 
 export class PrimitiveObserver implements IAccessor, ISubscribable {
   public get doNotCache(): true { return true; }

--- a/packages/runtime/src/observation/property-accessor.ts
+++ b/packages/runtime/src/observation/property-accessor.ts
@@ -1,4 +1,5 @@
-import { AccessorType, IAccessor, IObservable, LifecycleFlags } from '../observation.js';
+import { AccessorType, LifecycleFlags } from '../observation.js';
+import type { IAccessor, IObservable } from '../observation.js';
 
 export class PropertyAccessor implements IAccessor {
   // the only thing can be guaranteed is it's an object

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -165,10 +165,7 @@ export class SetObserver {
   }
 
   public getLengthObserver(): CollectionSizeObserver {
-    if (this.lengthObserver === void 0) {
-      this.lengthObserver = new CollectionSizeObserver(this.collection);
-    }
-    return this.lengthObserver as CollectionSizeObserver;
+    return this.lengthObserver ??= new CollectionSizeObserver(this.collection);
   }
 
   public getIndexObserver(index: number): ICollectionIndexObserver {
@@ -182,9 +179,7 @@ export class SetObserver {
     this.inBatch = false;
     this.indexMap = createIndexMap(size);
     this.callCollectionSubscribers(indexMap, LifecycleFlags.updateTarget);
-    if (this.lengthObserver !== void 0) {
-      this.lengthObserver.notify();
-    }
+    this.lengthObserver?.notify();
   }
 }
 

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -3,8 +3,6 @@ import { IPropertyObserver, ISubscriber, AccessorType, ISubscribable, IAccessor,
 import { subscriberCollection } from './subscriber-collection.js';
 import { InterceptorFunc } from '../bindable.js';
 
-const $is = Object.is;
-
 export interface SetterObserver extends IPropertyObserver<IIndexable, string> {}
 
 /**
@@ -79,7 +77,7 @@ export class SetterObserver {
           set: value => {
             this.setValue(value, LifecycleFlags.none);
           },
-        }
+        },
       );
     }
     return this;
@@ -126,7 +124,7 @@ export class SetterNotifier implements IAccessor, ISubscribable {
       value = this.s(value);
     }
     const oldValue = this.v;
-    if (!$is(value, oldValue)) {
+    if (!Object.is(value, oldValue)) {
       this.v = value;
       this.callSubscribers(value, oldValue, flags);
     }

--- a/packages/runtime/src/observation/signaler.ts
+++ b/packages/runtime/src/observation/signaler.ts
@@ -1,5 +1,6 @@
 import { DI } from '@aurelia/kernel';
-import { ISubscriber, LifecycleFlags } from '../observation.js';
+import { LifecycleFlags } from '../observation.js';
+import type { ISubscriber } from '../observation.js';
 
 type Signal = string;
 

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "importHelpers": false,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": false,
     "rootDir": ".",
 
     "declaration": true,


### PR DESCRIPTION
Some more separation to make runtime code simpler for real values vs typings