### PR TITLE
Feat/templating extension

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -29,6 +29,7 @@
 * [Dependency Injection](app-basics/dependency-injection.md)
 * [Components Revisited](app-basics/components-revisited.md)
 * [Styling Components](app-basics/styling-components.md)
+* [Extending Templating Syntax](app-basics/extending-templating-syntax.md)
 * [Routing](app-basics/routing.md)
 * [Tooling](app-basics/tooling.md)
 * [Building a Dashboard App](app-basics/building-a-dashboard-app.md)
@@ -90,6 +91,9 @@
   * [Binding to Element Size](examples/custom-attributes/binding-to-element-size.md)
 * [Routing](examples/routing/README.md)
   * [Configuring Auth-Protected Routes](examples/routing/configuring-auth-protected-routes.md)
+* [Integration](examples/integration/README.md)
+  * [Microsoft FAST](examples/integration/ms-fast.md)
+  * [Ionic](examples/integration/ionic.md)
 
 ## Community Contribution
 

--- a/docs/user-docs/app-basics/extending-templating-syntax.md
+++ b/docs/user-docs/app-basics/extending-templating-syntax.md
@@ -4,20 +4,20 @@ Sometimes you will see the following template in an Aurelia application:
 ```html
 <input value.bind="message">
 ```
-Aurelia undertstands that `value.bind="message"` means `value.two-way="message"`, and later creates a two way binding between view model `message` property, and input `value` property. How does Aurelia know this?
+Aurelia understands that `value.bind="message"` means `value.two-way="message"`, and later creates a two way binding between view model `message` property, and input `value` property. How does Aurelia know this?
 
 By default, Aurelia is taught how to interpret a `bind` binding command on a property of an element via a Attribute Syntax Transformer. Application can also tap into this class to teach Aurelia some extra knowledge so that it understands more than just `value.bind` on an `<input/>` element.
 
 # Examples
 
-You may sometimes come accross some custom input element in a component library, some examples are:
+You may sometimes come across some custom input element in a component library, some examples are:
 
 - Microsoft FAST `text-field` element: https://explore.fast.design/components/fast-text-field
 - Ionic `ion-input` element: https://ionicframework.com/docs/api/input
 - Polymer `paper-input` element: https://www.webcomponents.org/element/@polymer/paper-input
 - and many more...
 
-Regardless of lib choice an application takes, what is needed in common is the ability to have a concise syntax to describe two way binding with those custom elements. Some examples for the above:
+Regardless of the lib choice an application takes, what is needed in common is the ability to have a concise syntax to describe the two way binding intention with those custom elements. Some examples for the above custom input elements:
 
 ```html
 <fast-text-field value.bind="message">

--- a/docs/user-docs/app-basics/extending-templating-syntax.md
+++ b/docs/user-docs/app-basics/extending-templating-syntax.md
@@ -1,0 +1,155 @@
+# Context
+
+Sometimes you will see the following template in an Aurelia application:
+```html
+<input value.bind="message">
+```
+Aurelia undertstands that `value.bind="message"` means `value.two-way="message"`, and later creates a two way binding between view model `message` property, and input `value` property. How does Aurelia know this?
+
+By default, Aurelia is taught how to interpret a `bind` binding command on a property of an element via a Attribute Syntax Transformer. Application can also tap into this class to teach Aurelia some extra knowledge so that it understands more than just `value.bind` on an `<input/>` element.
+
+# Examples
+
+You may sometimes come accross some custom input element in a component library, some examples are:
+
+- Microsoft FAST `text-field` element: https://explore.fast.design/components/fast-text-field
+- Ionic `ion-input` element: https://ionicframework.com/docs/api/input
+- Polymer `paper-input` element: https://www.webcomponents.org/element/@polymer/paper-input
+- and many more...
+
+Regardless of lib choice an application takes, what is needed in common is the ability to have a concise syntax to describe two way binding with those custom elements. Some examples for the above:
+
+```html
+<fast-text-field value.bind="message">
+<ion-input value.bind="message">
+<paper-input value.bind="message">
+```
+should be treated as:
+```html
+<fast-text-field value.two-way="message">
+<ion-input value.two-way="message">
+<paper-input value.two-way="message">
+```
+
+In the next section, we will look into how to teach Aurelia such knowledge.
+
+# Using the Attribute Syntax Transformer
+
+As mentioned earlier, the Attribute Syntax Transformer will be used to transform `value.bind` into `value.two-way`. Every Aurelia application uses a single instance of this class. The instance can be retrieved via the injection of interface `IAttrSyntaxTransformer`, like the following example:
+
+```ts
+import { inject, IAttrSyntaxTransformer } from '@aurelia/runtime-html';
+
+@inject(IAttrSyntaxTransformer)
+export class MyCustomElement {
+  constructor(attrTransformer) {
+    // do something with the attrTransformer
+  }
+}
+```
+
+After grabbing the `IAttrSyntaxTransformer` instance, we can use the method `useTwoWay(fn)` of it to extend its knowledge. Following is an example of teaching it that the `bind` command on `value` property of the custom input elements above should be transformed to `two-way`:
+
+```ts
+attrTransformer.useTwoWay(function(element, property) {
+  switch (element.tagName) {
+    // <fast-text-field value.bind="message">
+    case 'FAST-TEXT-FIELD': return property === 'value';
+    // <ion-input value.bind="message">
+    case 'ION-INPUT': return property === 'value';
+    // <paper-input value.bind="message">
+    case 'PAPER-INPUT': return property === 'value';
+    // let other two way transformer check the validity
+    default:
+      return false;
+  }
+})
+```
+
+# Combining the Attribute Syntax Transformer with the Node Observer Locator
+
+Teaching Aurelia to transform `value.bind` to `value.two-way` is the first half of the story. The second half is about how we can teach Aurelia to observe the `value` property for changes on those custom input elements. We can do this via the Node Observer Locator. Every Aurelia application uses a single instance of this class, and this instance can be retrieved via the injection of interface `INodeObserverLocator` like the following example:
+
+```ts
+import { inject, INodeObserverLocator } from '@aurelia/runtime-html';
+
+@inject(INodeObserverLocator)
+export class MyCustomElement {
+  constructor(nodeObserverLocator) {
+    // do something with the locator
+  }
+}
+```
+
+After grabbing the `INodeObserverLocator` instance, we can use the method `useConfig` of it to extend its knowledge. Following is an example of teaching it that the `value` property, on a `<fast-text-field>` element could be observed using `change` event:
+```ts
+nodeObserverLocator.useConfig('FAST-TEXT-FIELD', 'value', { events: ['change' ] });
+```
+
+Similarly, examples for `<ion-input>` and `<paper-input>`:
+```ts
+nodeObserverLocator.useConfig('ION-INPUT', 'value', { events: ['change' ] });
+nodeObserverLocator.useConfig('PAPER-INPUT', 'value', { events: ['change' ] });
+```
+
+{% hint style="success" %}
+If an object is passed to the `.useConfig` API of the Node Observer Locator, it will be used as a multi-registration call, as per following example, where we register `<fast-text-field>`, `<ion-input>`, `<paper-input>` all in a single call:
+```ts
+nodeObserverLocator.useConfig({
+  'FAST-TEXT-FIELD': {
+    value: { events: ['change'] }
+  },
+  'ION-INPUT': {
+    value: { events: ['change'] }
+  },
+  'PAPER-INPUT': {
+    value: { events: ['changer'] }
+  }
+})
+```
+{% endhint %}
+
+---
+
+Combining the examples in the two sections above into some more complete code block example, for [Microsoft FAST components](https://explore.fast.design/components/fast-text-field):
+
+```ts
+import { inject, IContainer, IAttrSyntaxTransformer, INodeObserverLocator, AppTask, Aurelia } from 'aurelia';
+
+Aurelia
+  .register(
+    AppTask.with(IContainer).beforeCreate().call(container => {
+      const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
+      const nodeObserverLocator = container.get(INodeObserverLocator);
+      attrSyntaxTransformer.useTwoWay((el, property) => {
+        switch (el.tagName) {
+          case 'FAST-TEXT-FIELD': return property === 'value';
+          case 'FAST-TEXT-AREA': return property === 'value';
+          case 'FAST-SLIDER': return property === 'value';
+          // etc...
+        }
+      });
+      nodeObserverLocator.useConfig({
+        'FAST-TEXT-FIELD': {
+          value: { events: ['change'] }
+        },
+        'FAST-TEXT-AREA': {
+          value: { events: ['change'] }
+        },
+        'FAST-SLIDER': {
+          value: { events: ['change'] }
+        }
+      });
+    })
+  )
+  .app(class MyApp {})
+  .start();
+
+```
+
+And with the above, your Aurelia application will get two way binding flow seamlessly:
+```html
+<fast-text-field value.bind="message"></fast-text-field>
+<fast-text-area value.bind="description"></fast-text-area>
+<fast-slider value.bind="fontSize"></fast-slider>
+```

--- a/docs/user-docs/examples/integration/README.md
+++ b/docs/user-docs/examples/integration/README.md
@@ -1,0 +1,19 @@
+---
+description: The basics of integrating web component libraries with Aurelia.
+---
+
+{% hint style="success" %}
+**Here's what you'll learn...**
+
+* How to integrate with [Microsoft FAST web components](https://www.fast.design/).
+* How to integrate with [Ionic web components](https://ionicframework.com/docs/components).
+* And more to be updated...
+{% endhint %}
+
+# Integrating with [Microsoft FAST web components](https://www.fast.design/)
+
+[The guide for the integration here](./ms-fast.md)
+
+# Integrating with [Ionic web components](https://ionicframework.com/docs/components)
+
+[The guide for the integration here](./ionic.md)

--- a/docs/user-docs/examples/integration/README.md
+++ b/docs/user-docs/examples/integration/README.md
@@ -17,3 +17,10 @@ description: The basics of integrating web component libraries with Aurelia.
 # Integrating with [Ionic web components](https://ionicframework.com/docs/components)
 
 [The guide for the integration here](./ionic.md)
+
+
+{% hint style="info" %}
+**For our community**
+
+It is difficult for the core team members to try and test and document all possible integrations with web component frameworks/libraries. It is helpful that everyone in our community could lend a hand building the examples together, starting with the library choice of yours.
+{% endhint %}

--- a/docs/user-docs/examples/integration/ionic.md
+++ b/docs/user-docs/examples/integration/ionic.md
@@ -1,0 +1,4 @@
+# Integrating with Ionic Web Components
+
+Placeholder...
+

--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -29,8 +29,8 @@ Aurelia.register(AppTask.with(IContainer).beforeCreate().call(container => {
     }
   });
 
-  // teaching Aurelia what events to use to observe properties of elements
-  // because fast component simply use a single change even to notify
+  // Teach Aurelia what events to use to observe properties of elements.
+  // Because FAST components all use a single change event to notify,
   // we can use a single common object
   const valuePropertyConfig = { events: ['change'] };
   nodeObserverLocator.useConfig({

--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -1,0 +1,63 @@
+# Integrating with Microsoft FAST Web Components
+
+If the example doesn't seem obvious, the following prerequisite reads are recommended:
+- [extending templating syntax](/app-basics/extening-templating-syntax.md)
+
+The following is a code example of how to teach Aurelia to work seamlessly with [Microsoft FAST](https://www.fast.design/):
+
+```ts
+import { AppTask, IContainer, IAttrSyntaxTransformer, INodeObserverLocator } from 'aurelia';
+
+Aurelia.register(AppTask.with(IContainer).beforeCreate().call(container => {
+  const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
+  const nodeObserverLocator = container.get(INodeObserverLocator);
+  attrSyntaxTransformer.useTwoWay((el, property) => {
+    switch (el.tagName) {
+      case 'FAST-SLIDER':
+      case 'FAST-TEXT-FIELD':
+      case 'FAST-TEXT-AREA':
+        return property === 'value';
+      case 'FAST-CHECKBOX':
+      case 'FAST-RADIO':
+      case 'FAST-RADIO-GROUP':
+      case 'FAST-SWITCH':
+        return property === 'checked';
+      case 'FAST-TABS':
+        return property === 'activeid';
+      default:
+        return false;
+    }
+  });
+
+  // teaching Aurelia what events to use to observe properties of elements
+  // because fast component simply use a single change even to notify
+  // we can use a single common object
+  const valuePropertyConfig = { events: ['change'] };
+  nodeObserverLocator.useConfig({
+    'FAST-CHECKBOX': {
+      value: valuePropertyConfig
+    },
+    'FAST-RADIO': {
+      value: valuePropertyConfig
+    },
+    'FAST-RADIO-GROUP': {
+      value: valuePropertyConfig
+    },
+    'FAST-SLIDER': {
+      value: valuePropertyConfig
+    },
+    'FAST-SWITCH': {
+      value: valuePropertyConfig
+    },
+    'FAST-TABS': {
+      value: valuePropertyConfig
+    },
+    'FAST-TEXT-FIELD': {
+      value: valuePropertyConfig
+    },
+    'FAST-TEXT-AREA': {
+      value: valuePropertyConfig
+    }
+  });
+}))
+```

--- a/docs/user-docs/getting-started/displaying-basic-data.md
+++ b/docs/user-docs/getting-started/displaying-basic-data.md
@@ -18,7 +18,7 @@ One of Aurelia's strengths is its powerful, performant, and extensible templatin
 
 ## The Basics
 
-As you learned in [Building Components](components.md), a component typically involves two pieces: a _view-model_ and a _view_. The view-model is a vanilla JS class or object that provides basic state and actions through properties and methods. View-models don't require inheriting from a special base class, construction with a special factory function, or any other intrusive framework behavior. The view is a standards-based HTML template that renders the current state of the view-model. Aurelia joins these two pieces together through binding, allowing your view to efficiently update in response to view-model changes. Let's start by reviewing a class that's very similar to our `say-hello` view-model from earlier.
+As you learned in [Building Components](components/README.md), a component typically involves two pieces: a _view-model_ and a _view_. The view-model is a vanilla JS class or object that provides basic state and actions through properties and methods. View-models don't require inheriting from a special base class, construction with a special factory function, or any other intrusive framework behavior. The view is a standards-based HTML template that renders the current state of the view-model. Aurelia joins these two pieces together through binding, allowing your view to efficiently update in response to view-model changes. Let's start by reviewing a class that's very similar to our `say-hello` view-model from earlier.
 
 {% code title="say-hello.js" %}
 ```javascript

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -1,5 +1,5 @@
 import { IContainer, IPlatform } from '@aurelia/kernel';
-import { AppTask, BrowserPlatform, IAttrSyntaxTransformer, NodeObserverLocator } from '@aurelia/runtime-html';
+import { AppTask, BrowserPlatform, CustomElement, IAttrSyntaxTransformer, NodeObserverLocator } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -1,0 +1,69 @@
+import { IContainer, IPlatform } from '@aurelia/kernel';
+import { AppTask, IAttrSyntaxTransformer, NodeObserverLocator } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
+  let elementNameSeed = 0;
+  it('understands how to transform .bind on web component custom elements', async function () {
+    class MyElement extends HTMLElement {
+
+      public select: HTMLSelectElement;
+
+      public constructor() {
+        super();
+        this.innerHTML = '<select><option>1</option><option>2</option><option>3</option></select>';
+        this.select = this.firstElementChild as any;
+        this.select.addEventListener('change', () => {
+          this.dispatchEvent(new CustomEvent('my-el-change'));
+        });
+      }
+
+      public get value() {
+        return this.select.value;
+      }
+
+      public set value(v) {
+        this.select.value = v;
+      }
+    }
+
+    const elName = `my-el-${elementNameSeed++}`;
+
+    const { ctx, component, appHost, startPromise } = createFixture(
+      `<${elName} value.bind="option"></${elName}>`,
+      class App {
+        public option = '1';
+      },
+      [
+        AppTask.with(IContainer).beforeCreate().call(container => {
+          const platform = container.get(IPlatform);
+          platform.globalThis.customElements.define(elName, MyElement);
+
+          const transformer = container.get(IAttrSyntaxTransformer);
+          transformer.useTwoWay((el, property) => {
+            return el.tagName === elName.toUpperCase() && property === 'value';
+          });
+
+          const nodeObserverLocator = container.get(NodeObserverLocator);
+          nodeObserverLocator.useConfig(elName.toUpperCase(), 'value', { events: ['my-el-change'] });
+        })
+      ]
+    );
+
+    await startPromise;
+
+    const selectEl = appHost.querySelector('select');
+    assert.strictEqual(selectEl.value, '1');
+    assert.strictEqual(selectEl.options[0].selected, true);
+
+    selectEl.options[1].selected = true;
+    selectEl.dispatchEvent(new Event('change'));
+
+    assert.strictEqual(component.option, '2');
+
+    component.option = '3';
+    assert.strictEqual(selectEl.value, '2');
+    ctx.platform.domWriteQueue.flush();
+    assert.strictEqual(selectEl.value, '3');
+  });
+});

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -3,10 +3,14 @@ import { AppTask, BrowserPlatform, IAttrSyntaxTransformer, NodeObserverLocator }
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
+  // cant deal with custom elements on nodejs
+  if (typeof process !== 'undefined') {
+    return;
+  }
   let elementNameSeed = 0;
   it('understands how to transform .bind on web component custom elements', async function () {
     const elName = `my-el-${elementNameSeed++}`;
-    const { ctx, component, appHost, startPromise } = createFixture(
+    const { ctx, component, appHost, startPromise, tearDown } = createFixture(
       `<${elName} value.bind="option"></${elName}>`,
       class App {
         public option = '1';
@@ -14,7 +18,7 @@ describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
       [
         AppTask.with(IContainer).beforeCreate().call(container => {
           const platform = container.get(IPlatform) as BrowserPlatform;
-          platform.customElements.define(elName, class MyElement extends platform.HTMLElement {
+          platform.window.customElements.define(elName, class MyElement extends platform.window.HTMLElement {
 
             public select: HTMLSelectElement;
 
@@ -62,5 +66,7 @@ describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
     assert.strictEqual(selectEl.value, '2');
     ctx.platform.domWriteQueue.flush();
     assert.strictEqual(selectEl.value, '3');
+
+    await tearDown();
   });
 });

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -7,9 +7,8 @@ describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
   if (typeof process !== 'undefined') {
     return;
   }
-  let elementNameSeed = 0;
   it('understands how to transform .bind on web component custom elements', async function () {
-    const elName = `my-el-${elementNameSeed++}`;
+    const elName = CustomElement.generateName();
     const { ctx, component, appHost, startPromise, tearDown } = createFixture(
       `<${elName} value.bind="option"></${elName}>`,
       class App {

--- a/packages/runtime-html/src/attribute-syntax-transformer.ts
+++ b/packages/runtime-html/src/attribute-syntax-transformer.ts
@@ -69,6 +69,7 @@ export class AttrSyntaxTransformer {
 
   /**
    * todo: this should be in the form of a lookup. the following is not extensible
+   *
    * @internal
    */
   public map(tagName: string, attr: string): string {

--- a/packages/runtime-html/src/attribute-syntax-transformer.ts
+++ b/packages/runtime-html/src/attribute-syntax-transformer.ts
@@ -14,26 +14,26 @@ export class AttrSyntaxTransformer {
    */
   private readonly fns: ITwoWayTransformerFn[] = [];
   public constructor() {
-    this.useTwoWay((element, attr) => {
+    this.useTwoWay((element, property) => {
       switch (element.tagName) {
         case 'INPUT':
           switch ((element as HTMLInputElement).type) {
             case 'checkbox':
             case 'radio':
-              return attr === 'checked';
+              return property === 'checked';
             default:
-              return attr === 'value' || attr === 'files';
+              return property === 'value' || property === 'files';
           }
         case 'TEXTAREA':
         case 'SELECT':
-          return attr === 'value';
+          return property === 'value';
         default:
-          switch (attr) {
-            case 'textcontent':
-            case 'innerhtml':
+          switch (property) {
+            case 'textContent':
+            case 'innerHTML':
               return element.hasAttribute('contenteditable');
-            case 'scrolltop':
-            case 'scrollleft':
+            case 'scrollTop':
+            case 'scrollLeft':
               return true;
             default:
               return false;
@@ -48,6 +48,10 @@ export class AttrSyntaxTransformer {
    *
    * If one of those functions in this lists returns true, the `'bind'` command
    * will be transformed into `'two-way'` command.
+   *
+   * The function will be called with 2 parameters:
+   * - element: the element that the template compiler is currently working with
+   * - property: the target property name
    */
   public useTwoWay(fn: ITwoWayTransformerFn): void {
     this.fns.push(fn);

--- a/packages/runtime-html/src/attribute-syntax-transformer.ts
+++ b/packages/runtime-html/src/attribute-syntax-transformer.ts
@@ -6,7 +6,7 @@ export const IAttrSyntaxTransformer = DI
   .createInterface<IAttrSyntaxTransformer>('IAttrSyntaxTransformer')
   .withDefault(x => x.singleton(AttrSyntaxTransformer));
 
-type ITwoWayTransformerFn = (element: HTMLElement, property: PropertyKey) => boolean;
+type IsTwoWayPredicate = (element: HTMLElement, property: string) => boolean;
 
 export class AttrSyntaxTransformer {
   /**
@@ -62,7 +62,13 @@ export class AttrSyntaxTransformer {
    */
   public transform(node: HTMLElement, attrSyntax: AttrSyntax): void {
     attrSyntax.target = this.map(node.tagName, attrSyntax.target);
-    if (attrSyntax.command === 'bind' && this.fns.some(fn => fn(node, attrSyntax.target))) {
+    if (
+      attrSyntax.command === 'bind' &&
+      (
+        shouldDefaultToTwoWay(node, attrSyntax) ||
+        this.fns.length > 0 && this.fns.some(fn => fn(node, attrSyntax.target))
+      )
+    ) {
       attrSyntax.command = 'two-way';
     }
   }

--- a/packages/runtime-html/src/attribute-syntax-transformer.ts
+++ b/packages/runtime-html/src/attribute-syntax-transformer.ts
@@ -1,5 +1,5 @@
 import { DI } from '@aurelia/kernel';
-import { AttrSyntax } from './resources/attribute-pattern.js';
+import type { AttrSyntax } from './resources/attribute-pattern.js';
 
 export interface IAttrSyntaxTransformer extends AttrSyntaxTransformer {}
 export const IAttrSyntaxTransformer = DI
@@ -12,7 +12,7 @@ export class AttrSyntaxTransformer {
   /**
    * @internal
    */
-  private fns: ITwoWayTransformerFn[] = [];
+  private readonly fns: ITwoWayTransformerFn[] = [];
   public constructor() {
     this.useTwoWay((element, attr) => {
       switch (element.tagName) {
@@ -57,13 +57,14 @@ export class AttrSyntaxTransformer {
    * @internal
    */
   public transform(node: HTMLElement, attrSyntax: AttrSyntax): void {
+    attrSyntax.target = this.map(node.tagName, attrSyntax.target);
     if (attrSyntax.command === 'bind' && this.fns.some(fn => fn(node, attrSyntax.target))) {
       attrSyntax.command = 'two-way';
     }
-    attrSyntax.target = this.map(node.tagName, attrSyntax.target);
   }
 
   /**
+   * todo: this should be in the form of a lookup. the following is not extensible
    * @internal
    */
   public map(tagName: string, attr: string): string {

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -112,6 +112,12 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
     public propertyKey: string,
   ) {}
 
+  public setValue(v: unknown, f: LifecycleFlags) {
+    // todo: this should be allowed, probably
+    // but the construction of dirty checker should throw instead
+    throw new Error(`Trying to set value for property ${this.propertyKey} in dirty checker`);
+  }
+
   public isDirty(): boolean {
     return this.oldValue !== this.obj[this.propertyKey];
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add back the ability to extend Aurelia to transform `.bind` to `.two-way` on different combinations of elements and properties

Additionally:
- Add an explicit throw on `DirtyCheckProperty.prototype.setValue` so the error message makes more sense
- In attr syntax transformer, check two way binding from mapped target, instead of raw target

### 🎫 Issues

Closes #975
Resolves https://github.com/microsoft/fast/issues/3612

## 📑 Test Plan

Add tests for some custom element two way binding + observation

## ⏭ Next Steps

More doc on as many as possible web component library integration