### PR TITLE
docs(integration-fast): fix typing issue

### DIFF
--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -6,11 +6,11 @@ If the example doesn't seem obvious, the following prerequisite reads are recomm
 The following is a code example of how to teach Aurelia to work seamlessly with [Microsoft FAST](https://www.fast.design/):
 
 ```ts
-import { AppTask, IContainer, IAttrSyntaxTransformer, INodeObserverLocator } from 'aurelia';
+import { AppTask, IContainer, IAttrSyntaxTransformer, NodeObserverLocator } from 'aurelia';
 
 Aurelia.register(AppTask.with(IContainer).beforeCreate().call(container => {
   const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
-  const nodeObserverLocator = container.get(INodeObserverLocator);
+  const nodeObserverLocator = container.get(NodeObserverLocator);
   attrSyntaxTransformer.useTwoWay((el, property) => {
     switch (el.tagName) {
       case 'FAST-SLIDER':

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -738,6 +738,8 @@ export {
   // EventSubscription,
   // EventDelegator,
 
+  NodeObserverLocator,
+
   // TargetAccessorLocator,
   // TargetObserverLocator,
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -520,6 +520,7 @@ export {
   // TaskAbortError,
   // TaskCallback,
   // TaskQueue,
+  AppTask,
   TaskQueuePriority,
   // TaskStatus,
   // QueueTaskTargetOptions,
@@ -802,6 +803,7 @@ export {
   // IAttributePatternHandler,
   // Interpretation,
   // ISyntaxInterpreter,
+  IAttrSyntaxTransformer,
 
   // AtPrefixedTriggerAttributePattern,
   // ColonPrefixedBindAttributePattern,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Improvement for the Fast integration documentation.

* Re-export NodeObserverLocator from Aurelia package
* Import the NodeObserverLocator class instead of interface in the fast integration exemple

### 🎫 Issues

* Fixes: #1028 

## 👩‍💻 Reviewer Notes

As a follow up question: in the [Fast integration doc page](https://docs.aurelia.io/examples/integration/ms-fast) the imports look like this:

```ts
import { AppTask, IContainer, IAttrSyntaxTransformer, NodeObserverLocator } from 'aurelia';
```

However, in my current application the `aurelia` package doesn't export `AppTask` and `IAttrSyntaxTransformer`. Should them be re-exported from the Aurelia package as well ?

Currently I've changed the imports to look as such: 

```ts
import { AppTask, IContainer, IAttrSyntaxTransformer, NodeObserverLocator } from 'aurelia';
import { IAttrSyntaxTransformer, AppTask } from '@aurelia/runtime-html';
```

Or is the plan to have all the public API re-exported by `aurelia` ?

## 📑 Test Plan

No unique tests. I've ran the[ tests explained in the doc](https://docs.aurelia.io/community-contribution/building-and-testing-aurelia).

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
