### PR TITLE
docs(fast-integration): fix fast-tabs two-way obs

### DIFF
--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -50,7 +50,7 @@ Aurelia.register(AppTask.with(IContainer).beforeCreate().call(container => {
       value: valuePropertyConfig
     },
     'FAST-TABS': {
-      value: valuePropertyConfig
+      activeid: valuePropertyConfig
     },
     'FAST-TEXT-FIELD': {
       value: valuePropertyConfig


### PR DESCRIPTION
The property that need to be observed with FAST-TABS is `activeid` and not `value`. Fixed the typo

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
