### PR TITLE
Refactor/subscribers record

### DIFF
--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -2326,13 +2326,13 @@ describe('BindingBehaviorExpression', function () {
 
   const connectVariations: (($1: $1, $2: $2, $3: $3) => /* connect */() => void)[] = [
     ([t1, flags], [t2, $kind], [t3, scope, hs, sut, mock, locator, binding, value, argValues]) => () => {
-      assert.strictEqual(binding.record.count, 0, `binding.record.count`);
+      assert.strictEqual(binding.obs.count, 0, `binding.obs.count`);
 
       // act
       sut.evaluate(flags, scope, hs, locator, binding);
 
       // assert
-      assert.strictEqual(binding.record.count, 1, `binding.record.count`);
+      assert.strictEqual(binding.obs.count, 1, `binding.obs.count`);
 
       assert.strictEqual(mock.calls.length, 1, `mock.calls.length`);
 
@@ -2668,13 +2668,13 @@ describe('ValueConverterExpression', function () {
 
   const evaluateWithConnectVariations: (($1: $1, $2: $2, $3: $3) => /* connect */() => void)[] = [
     ([t1, flags], [t2, signals, signaler], [t3, scope, hs, sut, mock, locator, binding, value, argValues, methods]) => () => {
-      assert.strictEqual(binding.record.count, 0, `binding.observerSlots`);
+      assert.strictEqual(binding.obs.count, 0, `binding.obs.count`);
 
       // act
       sut.evaluate(flags, scope, hs, locator, binding);
 
       // assert
-      assert.strictEqual(binding.record.count, 1 + argValues.length, `binding.observerSlots`);
+      assert.strictEqual(binding.obs.count, 1 + argValues.length, `binding.obs.count`);
 
       const hasToView = methods.includes('toView');
       assert.strictEqual(mock.calls.length, hasToView ? 2 : 0, `mock.calls.length`);

--- a/packages/__tests__/2-runtime/subscriber-collection.spec.ts
+++ b/packages/__tests__/2-runtime/subscriber-collection.spec.ts
@@ -126,7 +126,7 @@ describe('subscriberCollection', function () {
         removalCount++;
       }
     }
-    assert.strictEqual(observer['_sRest'].length, subscribers.length - 3 - removalCount, `observer['_sRest'].length`);
+    assert.strictEqual(observer['subs']['_sRest'].length, subscribers.length - 3 - removalCount, `observer['subs']['_sRest'].length`);
 
     assert.strictEqual(observer['removeSubscriber']({} as any), false, `observer['removeSubscriber']({} as any)`);
   });

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -140,15 +140,15 @@ export class TranslationBinding implements IPartialConnectableBinding {
     this.targetObservers.clear();
 
     this.scope = (void 0)!;
-    this.record.clear(true);
+    this.obs.clear(true);
   }
 
   public handleChange(newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions, flags: LifecycleFlags): void {
-    this.record.version++;
+    this.obs.version++;
     this.keyExpression = this.isInterpolation
         ? this.expr.evaluate(flags, this.scope, this.hostScope, this.locator, this) as string
         : newValue as string;
-    this.record.clear(false);
+    this.obs.clear(false);
     this.ensureKeyExpression();
     this.updateTranslations(flags);
   }
@@ -304,9 +304,9 @@ class ParameterBinding {
     if ((flags & LifecycleFlags.updateTarget) === 0) {
       throw new Error('Unexpected context in a ParameterBinding.');
     }
-    this.record.version++;
+    this.obs.version++;
     this.value = this.expr.evaluate(flags, this.scope, this.hostScope, this.locator, this) as i18next.TOptions;
-    this.record.clear(false);
+    this.obs.clear(false);
     this.updater(flags);
   }
 
@@ -335,6 +335,6 @@ class ParameterBinding {
     }
 
     this.scope = (void 0)!;
-    this.record.clear(true);
+    this.obs.clear(true);
   }
 }

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -118,14 +118,14 @@ export class AttributeBinding implements IPartialConnectableBinding {
       //  (2). if not, then fix tests to reflect the changes/platform to properly yield all with aurelia.start()
       const shouldQueueFlush = (flags & LifecycleFlags.fromBind) === 0 && (targetObserver.type & AccessorType.Layout) > 0;
 
-      if (sourceExpression.$kind !== ExpressionKind.AccessScope || this.record.count > 1) {
+      if (sourceExpression.$kind !== ExpressionKind.AccessScope || this.obs.count > 1) {
         const shouldConnect = (mode & oneTime) === 0;
         if (shouldConnect) {
-          this.record.version++;
+          this.obs.version++;
         }
         newValue = sourceExpression.evaluate(flags, $scope, this.$hostScope, locator, interceptor);
         if (shouldConnect) {
-          this.record.clear(false);
+          this.obs.clear(false);
         }
       }
 
@@ -231,7 +231,7 @@ export class AttributeBinding implements IPartialConnectableBinding {
 
     this.task?.cancel();
     this.task = null;
-    this.record.clear(true);
+    this.obs.clear(true);
 
     // remove isBound and isUnbinding flags
     this.isBound = false;

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -163,7 +163,7 @@ export class ContentBinding implements ContentBinding, ICollectionSubscriber {
       return;
     }
     const sourceExpression = this.sourceExpression;
-    const obsRecord = this.record;
+    const obsRecord = this.obs;
     const canOptimize = sourceExpression.$kind === ExpressionKind.AccessScope && obsRecord.count === 1;
     if (!canOptimize) {
       const shouldConnect = (this.mode & toView) > 0;
@@ -177,7 +177,7 @@ export class ContentBinding implements ContentBinding, ICollectionSubscriber {
     }
     if (newValue != this.value) {
       this.value = newValue;
-      this.cRecord.clear();
+      this.cObs.clear();
       if (newValue instanceof Array) {
         this.observeCollection(newValue);
       }
@@ -229,8 +229,8 @@ export class ContentBinding implements ContentBinding, ICollectionSubscriber {
 
     this.$scope = void 0;
     this.$hostScope = null;
-    this.record.clear(true);
-    this.cRecord.clear(true);
+    this.obs.clear(true);
+    this.cObs.clear(true);
   }
 }
 

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -44,9 +44,9 @@ export class LetBinding implements IPartialConnectableBinding {
       const target = this.target as IIndexable;
       const targetProperty = this.targetProperty as string;
       const previousValue: unknown = target[targetProperty];
-      this.record.version++;
+      this.obs.version++;
       const newValue: unknown = this.sourceExpression.evaluate(flags, this.$scope!, this.$hostScope, this.locator, this.interceptor);
-      this.record.clear(false);
+      this.obs.clear(false);
       if (newValue !== previousValue) {
         target[targetProperty] = newValue;
       }
@@ -91,7 +91,7 @@ export class LetBinding implements IPartialConnectableBinding {
     }
     this.$scope = void 0;
     this.$hostScope = null;
-    this.record.clear(true);
+    this.obs.clear(true);
 
     // remove isBound and isUnbinding flags
     this.isBound = false;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -80,7 +80,7 @@ export class PropertyBinding implements IPartialConnectableBinding {
       //  (1). determine whether this should be the behavior
       //  (2). if not, then fix tests to reflect the changes/platform to properly yield all with aurelia.start()
       const shouldQueueFlush = (flags & LifecycleFlags.fromBind) === 0 && (targetObserver.type & AccessorType.Layout) > 0;
-      const obsRecord = this.record;
+      const obsRecord = this.obs;
 
       // if the only observable is an AccessScope then we can assume the passed-in newValue is the correct and latest value
       if (sourceExpression.$kind !== ExpressionKind.AccessScope || obsRecord.count > 1) {
@@ -199,7 +199,7 @@ export class PropertyBinding implements IPartialConnectableBinding {
       task.cancel();
       this.task = null;
     }
-    this.record.clear(true);
+    this.obs.clear(true);
 
     this.isBound = false;
   }

--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -79,7 +79,7 @@ export class BindableObserver {
       }
       this.currentValue = newValue;
       if (this.lifecycle.batch.depth === 0) {
-        this.callSubscribers(newValue, currentValue, flags);
+        this.subs.notify(newValue, currentValue, flags);
         if ((flags & LifecycleFlags.fromBind) === 0 || (flags & LifecycleFlags.updateSource) > 0) {
           this.callback?.call(this.obj, newValue, currentValue, flags);
 
@@ -109,7 +109,7 @@ export class BindableObserver {
       this.createGetterSetter();
     }
 
-    this.addSubscriber(subscriber);
+    this.subs.add(subscriber);
   }
 
   private createGetterSetter(): void {

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -44,7 +44,6 @@ export class CheckedObserver implements IObserver {
 
   public collectionObserver?: ICollectionObserver<CollectionKind> = void 0;
   public valueObserver?: ValueAttributeObserver | SetterObserver = void 0;
-  public subscriberCount: number = 0;
 
   public constructor(
     obj: INode,

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -69,7 +69,7 @@ export class CheckedObserver implements IObserver {
     this.oldValue = currentValue;
     this.observe();
     this.synchronizeElement();
-    this.callSubscribers(newValue, currentValue, flags);
+    this.subs.notify(newValue, currentValue, flags);
   }
 
   public handleCollectionChange(indexMap: IndexMap, flags: LifecycleFlags): void {
@@ -222,7 +222,7 @@ export class CheckedObserver implements IObserver {
       return;
     }
     this.value = currentValue;
-    this.callSubscribers(this.value, this.oldValue, LifecycleFlags.none);
+    this.subs.notify(this.value, this.oldValue, LifecycleFlags.none);
   }
 
   public start() {
@@ -240,13 +240,13 @@ export class CheckedObserver implements IObserver {
   }
 
   public subscribe(subscriber: ISubscriber): void {
-    if (this.addSubscriber(subscriber) && ++this.subscriberCount === 1) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.start();
     }
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    if (this.removeSubscriber(subscriber) && --this.subscriberCount === 0) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.stop();
     }
   }

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -121,7 +121,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
         const { currentValue } = this;
         this.currentValue = this.oldValue = newValue;
         this.hasChanges = false;
-        this.callSubscribers(newValue, currentValue, LifecycleFlags.none);
+        this.subs.notify(newValue, currentValue, LifecycleFlags.none);
       }
     }
   }

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -129,7 +129,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   public subscribe(subscriber: ISubscriber): void {
     if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.currentValue = this.oldValue = this.obj.getAttribute(this.propertyKey);
-      startObservation(this.obj.ownerDocument.defaultView?.MutationObserver!, this.obj, this);
+      startObservation(this.obj.ownerDocument.defaultView!.MutationObserver, this.obj, this);
     }
   }
 

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -127,16 +127,14 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   }
 
   public subscribe(subscriber: ISubscriber): void {
-    if (!this.hasSubscribers()) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.currentValue = this.oldValue = this.obj.getAttribute(this.propertyKey);
-      startObservation(this.platform.MutationObserver, this.obj, this);
+      startObservation(this.obj.ownerDocument.defaultView?.MutationObserver!, this.obj, this);
     }
-    this.addSubscriber(subscriber);
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    this.removeSubscriber(subscriber);
-    if (!this.hasSubscribers()) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       stopObservation(this.obj, this);
     }
   }

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -105,13 +105,13 @@ export class SelectValueObserver implements IObserver {
     if (newValue === oldValue) {
       return;
     }
-    this.callSubscribers(newValue, oldValue, flags);
+    this.subs.notify(newValue, oldValue, flags);
   }
 
   public handleEvent(): void {
     const shouldNotify = this.synchronizeValue();
     if (shouldNotify) {
-      this.callSubscribers(this.currentValue, this.oldValue, LF.none);
+      this.subs.notify(this.currentValue, this.oldValue, LF.none);
     }
   }
 
@@ -263,16 +263,14 @@ export class SelectValueObserver implements IObserver {
   }
 
   public subscribe(subscriber: ISubscriber): void {
-    if (!this.hasSubscribers()) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.handler.subscribe(this.obj, this);
       this.start();
     }
-    this.addSubscriber(subscriber);
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    this.removeSubscriber(subscriber);
-    if (!this.hasSubscribers()) {
+    if (this.removeSubscriber(subscriber) && this.subs.count === 0) {
       this.handler.dispose();
       this.stop();
     }

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -270,7 +270,7 @@ export class SelectValueObserver implements IObserver {
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    if (this.removeSubscriber(subscriber) && this.subs.count === 0) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.handler.dispose();
       this.stop();
     }

--- a/packages/runtime-html/src/observation/value-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/value-attribute-observer.ts
@@ -50,7 +50,7 @@ export class ValueAttributeObserver implements IObserver {
       this.obj[this.propertyKey as string] = currentValue ?? this.handler.config.default;
 
       if ((flags & LifecycleFlags.fromBind) === 0) {
-        this.callSubscribers(currentValue, oldValue, flags);
+        this.subs.notify(currentValue, oldValue, flags);
       }
     }
   }
@@ -60,20 +60,19 @@ export class ValueAttributeObserver implements IObserver {
     const currentValue = this.currentValue = this.obj[this.propertyKey as string];
     if (oldValue !== currentValue) {
       this.oldValue = currentValue;
-      this.callSubscribers(currentValue, oldValue, LifecycleFlags.none);
+      this.subs.notify(currentValue, oldValue, LifecycleFlags.none);
     }
   }
 
   public subscribe(subscriber: ISubscriber): void {
-    if (!this.hasSubscribers()) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.handler.subscribe(this.obj, this);
       this.currentValue = this.oldValue = this.obj[this.propertyKey as string];
     }
-    this.addSubscriber(subscriber);
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    if (this.removeSubscriber(subscriber) && !this.hasSubscribers()) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.handler.dispose();
     }
   }

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -203,7 +203,7 @@ export class ChildrenObserver {
 
   public subscribe(subscriber: ISubscriber): void {
     this.tryStartObserving();
-    this.addSubscriber(subscriber);
+    this.subs.add(subscriber);
   }
 
   private tryStartObserving() {
@@ -222,7 +222,7 @@ export class ChildrenObserver {
       this.callback.call(this.obj);
     }
 
-    this.callSubscribers(this.children, undefined, LifecycleFlags.updateTarget);
+    this.subs.notify(this.children, undefined, LifecycleFlags.updateTarget);
   }
 }
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -16,18 +16,13 @@ import {
 } from '@aurelia/kernel';
 import {
   AccessScopeExpression,
-  IBinding,
+  BindingType,
   Scope,
   LifecycleFlags,
   ILifecycle,
-  BindingType,
   IObserverLocator,
-  IObservable,
   IExpressionParser,
-  AccessorOrObserver,
 } from '@aurelia/runtime';
-import { PropertyBinding } from '../binding/property-binding.js';
-import { BindableDefinition } from '../bindable';
 import { BindableObserver } from '../observation/bindable-observer';
 import { convertToRenderLocation, INode, INodeSequence, IRenderLocation } from '../dom.js';
 import { CustomElementDefinition, CustomElement, PartialCustomElementDefinition } from '../resources/custom-element.js';
@@ -38,6 +33,13 @@ import { IAppRoot } from '../app-root.js';
 import { IPlatform } from '../platform.js';
 import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles.js';
 import { ComputedWatcher, ExpressionWatcher } from './watchers.js';
+import type {
+  IBinding,
+  IObservable,
+  AccessorOrObserver,
+} from '@aurelia/runtime';
+import type { BindableDefinition } from '../bindable.js';
+import type { PropertyBinding } from '../binding/property-binding.js';
 import type { RegisteredProjections } from '../resources/custom-elements/au-slot.js';
 import type { IViewFactory } from './view.js';
 import type { Instruction } from '../renderer.js';

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -68,8 +68,8 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
       return;
     }
     this.isBound = false;
-    this.record.clear(true);
-    this.cRecord.clear(true);
+    this.obs.clear(true);
+    this.cObs.clear(true);
   }
 
   private run(): void {
@@ -88,13 +88,13 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
 
   private compute(): unknown {
     this.running = true;
-    this.record.version++;
+    this.obs.version++;
     try {
       enter(this);
       return this.value = unwrap(this.get.call(void 0, this.useProxy ? wrap(this.obj) : this.obj, this));
     } finally {
-      this.record.clear(false);
-      this.cRecord.clear(false);
+      this.obs.clear(false);
+      this.cObs.clear(false);
       this.running = false;
       exit(this);
     }
@@ -131,11 +131,11 @@ export class ExpressionWatcher implements IConnectableBinding {
     const expr = this.expression;
     const obj = this.obj;
     const oldValue = this.value;
-    const canOptimize = expr.$kind === ExpressionKind.AccessScope && this.record.count === 1;
+    const canOptimize = expr.$kind === ExpressionKind.AccessScope && this.obs.count === 1;
     if (!canOptimize) {
-      this.record.version++;
+      this.obs.version++;
       value = expr.evaluate(0, this.scope, null, this.locator, this);
-      this.record.clear(false);
+      this.obs.clear(false);
     }
     if (!Object.is(value, oldValue)) {
       this.value = value;
@@ -149,9 +149,9 @@ export class ExpressionWatcher implements IConnectableBinding {
       return;
     }
     this.isBound = true;
-    this.record.version++;
+    this.obs.version++;
     this.value = this.expression.evaluate(LifecycleFlags.none, this.scope, null, this.locator, this);
-    this.record.clear(false);
+    this.obs.clear(false);
   }
 
   public $unbind(): void {
@@ -159,7 +159,7 @@ export class ExpressionWatcher implements IConnectableBinding {
       return;
     }
     this.isBound = false;
-    this.record.clear(true);
+    this.obs.clear(true);
     this.value = void 0;
   }
 }

--- a/packages/runtime/src/binding-behavior.ts
+++ b/packages/runtime/src/binding-behavior.ts
@@ -174,11 +174,11 @@ export class BindingInterceptor implements IInterceptableBinding {
   public get isBound(): boolean {
     return this.binding.isBound;
   }
-  public get record(): BindingObserverRecord {
-    return this.binding.record;
+  public get obs(): BindingObserverRecord {
+    return this.binding.obs;
   }
-  public get cRecord(): BindingCollectionObserverRecord {
-    return this.binding.cRecord;
+  public get cObs(): BindingCollectionObserverRecord {
+    return this.binding.cObs;
   }
 
   public constructor(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -149,6 +149,7 @@ export {
 export {
   subscriberCollection,
   collectionSubscriberCollection,
+  SubscriberRecord,
 } from './observation/subscriber-collection.js';
 export {
   ConnectableSwitcher,
@@ -209,6 +210,7 @@ export {
   ICollectionSubscriberCollection,
   ICollectionSubscribable,
   ISubscriber,
+  ISubscriberRecord,
   isIndexMap,
   copyIndexMap,
   cloneIndexMap,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -171,14 +171,22 @@ export interface ICollectionSubscribable {
   unsubscribeFromCollection(subscriber: ICollectionSubscriber): void;
 }
 
+export interface ISubscriberRecord<T extends ISubscriber | ICollectionSubscriber = ISubscriber | ICollectionSubscriber> {
+  readonly count: number;
+  add(subscriber: T): boolean;
+  has(subscriber: T): boolean;
+  remove(subscriber: T): boolean;
+  any(): boolean;
+  notify(value: unknown, oldValue: unknown, flags: LifecycleFlags): void;
+  notifyCollection(indexMap: IndexMap, flags: LifecycleFlags): void;
+}
+
 export interface ISubscriberCollection extends ISubscribable {
   [key: number]: LifecycleFlags;
-
-  /** @internal */_sFlags: SubscriberFlags;
-  /** @internal */_s0?: ISubscriber;
-  /** @internal */_s1?: ISubscriber;
-  /** @internal */_s2?: ISubscriber;
-  /** @internal */_sRest?: ISubscriber[];
+  /**
+   * The backing subscriber record for all subscriber methods of this collection
+   */
+  readonly subs: ISubscriberRecord;
 
   callSubscribers(newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void;
   hasSubscribers(): boolean;
@@ -190,11 +198,10 @@ export interface ISubscriberCollection extends ISubscribable {
 export interface ICollectionSubscriberCollection extends ICollectionSubscribable, ISubscribable {
   [key: number]: LifecycleFlags;
 
-  /** @internal */_csFlags: SubscriberFlags;
-  /** @internal */_cs0?: ICollectionSubscriber;
-  /** @internal */_cs1?: ICollectionSubscriber;
-  /** @internal */_cs2?: ICollectionSubscriber;
-  /** @internal */_csRest?: ICollectionSubscriber[];
+  /**
+   * The backing subscriber record for all subscriber methods of this collection
+   */
+  readonly subs: ISubscriberRecord;
 
   callCollectionSubscribers(indexMap: IndexMap, flags: LifecycleFlags): void;
   hasCollectionSubscribers(): boolean;

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -19,10 +19,6 @@ export class CollectionLengthObserver {
   public value: number;
   public readonly type: AccessorType = AccessorType.Array;
   public readonly obj: unknown[];
-  /**
-   * @internal
-   */
-  public subCount: number = 0;
 
   public constructor(
     public readonly owner: ICollectionObserver<CollectionKind.array>,
@@ -63,10 +59,6 @@ export class CollectionSizeObserver {
   public value: number;
   public readonly type: AccessorType;
   public readonly obj: Set<unknown> | Map<unknown, unknown>;
-  /**
-   * @internal
-   */
-  public subCount: number = 0;
 
   public constructor(
     public readonly owner: ICollectionObserver<CollectionKind.map | CollectionKind.set>,
@@ -94,7 +86,6 @@ export class CollectionSizeObserver {
 }
 
 interface CollectionLengthObserverImpl extends IObserver, ISubscriberCollection, ICollectionSubscriber {
-  subCount: number;
   owner: ICollectionObserver<CollectionKind>;
 }
 

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -44,7 +44,7 @@ export class CollectionLengthObserver {
         this.obj.length = newValue;
       }
       this.value = newValue;
-      this.callSubscribers(newValue, currentValue, flags | LifecycleFlags.updateTarget);
+      this.subs.notify(newValue, currentValue, flags | LifecycleFlags.updateTarget);
     }
   }
 
@@ -52,7 +52,7 @@ export class CollectionLengthObserver {
     const oldValue = this.value;
     const value = this.obj.length;
     if ((this.value = value) !== oldValue) {
-      this.callSubscribers(value, oldValue, flags);
+      this.subs.notify(value, oldValue, flags);
     }
   }
 }
@@ -88,7 +88,7 @@ export class CollectionSizeObserver {
     const value = this.obj.size;
     this.value = value;
     if (value !== oldValue) {
-      this.callSubscribers(value, oldValue, flags);
+      this.subs.notify(value, oldValue, flags);
     }
   }
 }
@@ -106,14 +106,14 @@ function implementLengthObserver(klass: Constructable<CollectionLengthObserverIm
 }
 
 function subscribe(this: CollectionLengthObserverImpl, subscriber: ISubscriber): void {
-  if (this.addSubscriber(subscriber) && ++this.subCount === 1) {
-    this.owner.addCollectionSubscriber(this);
+  if (this.subs.add(subscriber) && this.subs.count === 1) {
+    this.owner.subs.add(this);
   }
 }
 
 function unsubscribe(this: CollectionLengthObserverImpl, subscriber: ISubscriber): void {
-  if (this.removeSubscriber(subscriber) && --this.subCount) {
-    this.owner.removeCollectionSubscriber(this);
+  if (this.subs.remove(subscriber) && this.subs.count === 0) {
+    this.owner.subs.remove(this);
   }
 }
 

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -49,10 +49,6 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
   public type: AccessorType = AccessorType.Obj;
   public value: unknown = void 0;
 
-  /**
-   * @internal
-   */
-  private subCount: number = 0;
   // todo: maybe use a counter allow recursive call to a certain level
   /**
    * @internal
@@ -72,7 +68,7 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
   }
 
   public getValue() {
-    if (this.subCount === 0) {
+    if (this.subs.count === 0) {
       return this.get.call(this.obj, this);
     }
     if (this.isDirty) {
@@ -100,14 +96,14 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
 
   public handleChange(): void {
     this.isDirty = true;
-    if (this.subCount > 0) {
+    if (this.subs.count > 0) {
       this.run();
     }
   }
 
   public handleCollectionChange(): void {
     this.isDirty = true;
-    if (this.subCount > 0) {
+    if (this.subs.count > 0) {
       this.run();
     }
   }

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -116,14 +116,14 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
     // in theory, a collection subscriber could be added before a property subscriber
     // and it should be handled similarly in subscribeToCollection
     // though not handling for now, and wait until the merge of normal + collection subscription
-    if (this.addSubscriber(subscriber) && ++this.subCount === 1) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.compute();
       this.isDirty = false;
     }
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    if (this.removeSubscriber(subscriber) && --this.subCount === 0) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.isDirty = true;
       this.obs.clear(true);
       this.cObs.clear(true);

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -125,8 +125,8 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
   public unsubscribe(subscriber: ISubscriber): void {
     if (this.removeSubscriber(subscriber) && --this.subCount === 0) {
       this.isDirty = true;
-      this.record.clear(true);
-      this.cRecord.clear(true);
+      this.obs.clear(true);
+      this.cObs.clear(true);
     }
   }
 
@@ -141,19 +141,19 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
 
     if (!Object.is(newValue, oldValue)) {
       // should optionally queue
-      this.callSubscribers(newValue, oldValue, LifecycleFlags.none);
+      this.subs.notify(newValue, oldValue, LifecycleFlags.none);
     }
   }
 
   private compute(): unknown {
     this.running = true;
-    this.record.version++;
+    this.obs.version++;
     try {
       enterConnectable(this);
       return this.value = unwrap(this.get.call(this.useProxy ? wrap(this.obj) : this.obj, this));
     } finally {
-      this.record.clear(false);
-      this.cRecord.clear(false);
+      this.obs.clear(false);
+      this.cObs.clear(false);
       this.running = false;
       exitConnectable(this);
     }

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -109,8 +109,6 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
   public oldValue: unknown;
   public type: AccessorType = AccessorType.Obj;
 
-  private subCount: number = 0;
-
   public constructor(
     private readonly dirtyChecker: IDirtyChecker,
     public obj: IObservable & IIndexable,
@@ -135,20 +133,20 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
     const oldValue = this.oldValue;
     const newValue = this.getValue();
 
-    this.callSubscribers(newValue, oldValue, flags | LifecycleFlags.updateTarget);
+    this.subs.notify(newValue, oldValue, flags | LifecycleFlags.updateTarget);
 
     this.oldValue = newValue;
   }
 
   public subscribe(subscriber: ISubscriber): void {
-    if (this.addSubscriber(subscriber) && ++this.subCount === 1) {
+    if (this.subs.add(subscriber) && this.subs.count === 1) {
       this.oldValue = this.obj[this.propertyKey];
       this.dirtyChecker.addProperty(this);
     }
   }
 
   public unsubscribe(subscriber: ISubscriber): void {
-    if (this.removeSubscriber(subscriber) && --this.subCount === 0) {
+    if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.dirtyChecker.removeProperty(this);
     }
   }

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -1,6 +1,7 @@
 import { CollectionKind, createIndexMap, AccessorType, LifecycleFlags } from '../observation.js';
 import { CollectionSizeObserver } from './collection-length-observer.js';
 import { collectionSubscriberCollection } from './subscriber-collection.js';
+import { def } from '../utilities-objects.js';
 
 import type { ICollectionObserver, ILifecycle } from '../observation.js';
 
@@ -108,8 +109,6 @@ const descriptorProps = {
   configurable: true
 };
 
-const def = Reflect.defineProperty;
-
 for (const method of methods) {
   def(observe[method], 'observing', { value: true, writable: false, configurable: false, enumerable: false });
 }
@@ -175,7 +174,7 @@ export class MapObserver {
 
     this.inBatch = false;
     this.indexMap = createIndexMap(size);
-    this.callCollectionSubscribers(indexMap, LifecycleFlags.updateTarget);
+    this.subs.notifyCollection(indexMap, LifecycleFlags.updateTarget);
   }
 }
 

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -162,7 +162,7 @@ export class SetObserver {
 
     this.inBatch = false;
     this.indexMap = createIndexMap(size);
-    this.callCollectionSubscribers(indexMap, LifecycleFlags.updateTarget);
+    this.subs.notifyCollection(indexMap, LifecycleFlags.updateTarget);
   }
 }
 

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -33,7 +33,7 @@ export class SetterObserver {
     if (this.observing) {
       const currentValue = this.currentValue;
       this.currentValue = newValue;
-      this.callSubscribers(newValue, currentValue, flags);
+      this.subs.notify(newValue, currentValue, flags);
     } else {
       // If subscribe() has been called, the target property descriptor is replaced by these getter/setter methods,
       // so calling obj[propertyKey] will actually return this.currentValue.
@@ -50,7 +50,7 @@ export class SetterObserver {
     const currentValue = this.currentValue;
     const oldValue = this.oldValue;
     this.oldValue = currentValue;
-    this.callSubscribers(currentValue, oldValue, flags);
+    this.subs.notify(currentValue, oldValue, flags);
   }
 
   public subscribe(subscriber: ISubscriber): void {
@@ -58,7 +58,7 @@ export class SetterObserver {
       this.start();
     }
 
-    this.addSubscriber(subscriber);
+    this.subs.add(subscriber);
   }
 
   public start(): this {
@@ -124,7 +124,7 @@ export class SetterNotifier implements IAccessor, ISubscribable {
     const oldValue = this.v;
     if (!Object.is(value, oldValue)) {
       this.v = value;
-      this.callSubscribers(value, oldValue, flags);
+      this.subs.notify(value, oldValue, flags);
     }
   }
 }

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -60,9 +60,9 @@ export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRe
   private _sRest?: T[];
 
   public count: number = 0;
-  public readonly owner: ISubscriberCollection;
+  public readonly owner: ISubscriberCollection | ICollectionSubscriberCollection;
 
-  public constructor(owner: ISubscriberCollection) {
+  public constructor(owner: ISubscriberCollection | ICollectionSubscriberCollection) {
     this.owner = owner;
   }
 

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -124,17 +124,17 @@ export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> imp
     if ((subscriberFlags & SF.Subscriber0) > 0 && this._s0 === subscriber) {
       this._s0 = void 0;
       this._sFlags = (this._sFlags | SF.Subscriber0) ^ SF.Subscriber0;
-      this.count--;
+      --this.count;
       return true;
     } else if ((subscriberFlags & SF.Subscriber1) > 0 && this._s1 === subscriber) {
       this._s1 = void 0;
       this._sFlags = (this._sFlags | SF.Subscriber1) ^ SF.Subscriber1;
-      this.count--;
+      --this.count;
       return true;
     } else if ((subscriberFlags & SF.Subscriber2) > 0 && this._s2 === subscriber) {
       this._s2 = void 0;
       this._sFlags = (this._sFlags | SF.Subscriber2) ^ SF.Subscriber2;
-      this.count--;
+      --this.count;
       return true;
     } else if ((subscriberFlags & SF.SubscribersRest) > 0) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -147,8 +147,8 @@ export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> imp
           if (ii === 1) {
             this._sFlags = (this._sFlags | SF.SubscribersRest) ^ SF.SubscribersRest;
           }
-          --i;
-          --ii;
+          // deepscan-disable-next-line
+          --i; --ii;
           --this.count;
           return true;
         }

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -170,17 +170,19 @@ export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> imp
     const sub1 = this._s1 as ISubscriber;
     const sub2 = this._s2 as ISubscriber;
     let subRest = this._sRest as ISubscriber[];
+    flags = (flags | LF.update) ^ LF.update;
+
     if (subRest !== void 0) {
       subRest = subRest.slice();
     }
     if (sub0 !== void 0) {
-      sub0.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub0.id === void 0 ? 0 : owner[sub0.id]));
+      sub0.handleChange(val, oldVal, flags | /* sub own flags */(sub0.id === void 0 ? 0 : owner[sub0.id]));
     }
     if (sub1 !== void 0) {
-      sub1.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub1.id === void 0 ? 0 : owner[sub1.id]));
+      sub1.handleChange(val, oldVal, flags | /* sub own flags */(sub1.id === void 0 ? 0 : owner[sub1.id]));
     }
     if (sub2 !== void 0) {
-      sub2.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub2.id === void 0 ? 0 : owner[sub2.id]));
+      sub2.handleChange(val, oldVal, flags | /* sub own flags */(sub2.id === void 0 ? 0 : owner[sub2.id]));
     }
     if (subRest !== void 0) {
       const length = subRest.length;
@@ -189,7 +191,7 @@ export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> imp
       for (; i < length; ++i) {
         sub = subRest[i];
         if (sub !== void 0) {
-          sub.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub.id === void 0 ? 0 : owner[sub.id]));
+          sub.handleChange(val, oldVal, flags | /* sub own flags */(sub.id === void 0 ? 0 : owner[sub.id]));
         }
       }
     }

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -13,6 +13,8 @@ import type {
   ISubscriberCollection,
 } from '../observation.js';
 
+type IAnySubscriber = ISubscriber | ICollectionSubscriber;
+
 export function subscriberCollection(): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return function (target: Function): void { // ClassDecorator expects it to be derived from Function
@@ -50,7 +52,7 @@ export function collectionSubscriberCollection(): ClassDecorator {
   };
 }
 
-export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> implements ISubscriberRecord<T> {
+export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
   private _sFlags: SF = SF.None;
   private _s0?: T;
   private _s1?: T;
@@ -234,15 +236,15 @@ function getSubscriberRecord(this: ISubscriberCollection) {
   return record;
 }
 
-function addSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
+function addSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber): boolean {
   return this.subs.add(subscriber);
 }
 
-function removeSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
+function removeSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber): boolean {
   return this.subs.remove(subscriber);
 }
 
-function hasSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
+function hasSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber): boolean {
   return this.subs.has(subscriber);
 }
 

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -1,8 +1,9 @@
 import {
+  ISubscriberRecord,
   LifecycleFlags as LF,
   SubscriberFlags as SF,
 } from '../observation.js';
-import { ensureProto } from '../utilities-objects.js';
+import { def, defineHiddenProp, ensureProto } from '../utilities-objects.js';
 
 import type {
   ICollectionSubscriber,
@@ -17,12 +18,14 @@ export function subscriberCollection(): ClassDecorator {
   return function (target: Function): void { // ClassDecorator expects it to be derived from Function
     const proto = target.prototype as ISubscriberCollection;
 
-    ensureProto(proto, '_sFlags', SF.None, true);
     ensureProto(proto, 'addSubscriber', addSubscriber, true);
     ensureProto(proto, 'removeSubscriber', removeSubscriber, true);
     ensureProto(proto, 'hasSubscriber', hasSubscriber, true);
     ensureProto(proto, 'hasSubscribers', hasSubscribers, true);
     ensureProto(proto, 'callSubscribers', callSubscribers, true);
+    // not configurable, as in devtool, the getter could be invoked on the prototype,
+    // and become permanently broken
+    def(proto, 'subs', { get: getSubscriberRecord });
 
     ensureProto(proto, 'subscribe', addSubscriber);
     ensureProto(proto, 'unsubscribe', removeSubscriber);
@@ -34,254 +37,221 @@ export function collectionSubscriberCollection(): ClassDecorator {
   return function (target: Function): void { // ClassDecorator expects it to be derived from Function
     const proto = target.prototype as ICollectionSubscriberCollection;
 
-    ensureProto(proto, '_csFlags', SF.None, true);
-    ensureProto(proto, 'addCollectionSubscriber', addCollectionSubscriber, true);
-    ensureProto(proto, 'removeCollectionSubscriber', removeCollectionSubscriber, true);
-    ensureProto(proto, 'hasCollectionSubscriber', hasCollectionSubscriber, true);
-    ensureProto(proto, 'hasCollectionSubscribers', hasCollectionSubscribers, true);
+    ensureProto(proto, 'addCollectionSubscriber', addSubscriber, true);
+    ensureProto(proto, 'removeCollectionSubscriber', removeSubscriber, true);
+    ensureProto(proto, 'hasCollectionSubscriber', hasSubscriber, true);
+    ensureProto(proto, 'hasCollectionSubscribers', hasSubscribers, true);
     ensureProto(proto, 'callCollectionSubscribers', callCollectionSubscribers, true);
-
-    ensureProto(proto, 'subscribeToCollection', addCollectionSubscriber);
-    ensureProto(proto, 'unsubscribeFromCollection', removeCollectionSubscriber);
+    // not configurable, as in devtool, the getter could be invoked on the prototype,
+    // and become permanently broken
+    def(proto, 'subs', { get: getSubscriberRecord });
+    ensureProto(proto, 'subscribeToCollection', addSubscriber);
+    ensureProto(proto, 'unsubscribeFromCollection', removeSubscriber);
   };
 }
 
-function addSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
-  if (this.hasSubscriber(subscriber)) {
+export class SubscriberRecord<T extends ISubscriber | ICollectionSubscriber> implements ISubscriberRecord<T> {
+  private _sFlags: SF = SF.None;
+  private _s0?: T;
+  private _s1?: T;
+  private _s2?: T;
+  private _sRest?: T[];
+
+  public count: number = 0;
+  public readonly owner: ISubscriberCollection;
+
+  public constructor(owner: ISubscriberCollection) {
+    this.owner = owner;
+  }
+
+  public add(subscriber: T): boolean {
+    if (this.has(subscriber)) {
+      return false;
+    }
+    const subscriberFlags = this._sFlags;
+    if ((subscriberFlags & SF.Subscriber0) === 0) {
+      this._s0 = subscriber;
+      this._sFlags |= SF.Subscriber0;
+    } else if ((subscriberFlags & SF.Subscriber1) === 0) {
+      this._s1 = subscriber;
+      this._sFlags |= SF.Subscriber1;
+    } else if ((subscriberFlags & SF.Subscriber2) === 0) {
+      this._s2 = subscriber;
+      this._sFlags |= SF.Subscriber2;
+    } else if ((subscriberFlags & SF.SubscribersRest) === 0) {
+      this._sRest = [subscriber];
+      this._sFlags |= SF.SubscribersRest;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      this._sRest!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
+    }
+    ++this.count;
+    return true;
+  }
+
+  public has(subscriber: T): boolean {
+    // Flags here is just a perf tweak
+    // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
+    // and minor slow-down when it does, and the former is more common than the latter.
+    const subscriberFlags = this._sFlags;
+    if ((subscriberFlags & SF.Subscriber0) > 0 && this._s0 === subscriber) {
+      return true;
+    }
+    if ((subscriberFlags & SF.Subscriber1) > 0 && this._s1 === subscriber) {
+      return true;
+    }
+    if ((subscriberFlags & SF.Subscriber2) > 0 && this._s2 === subscriber) {
+      return true;
+    }
+    if ((subscriberFlags & SF.SubscribersRest) > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const subscribers = this._sRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
+      for (let i = 0, ii = subscribers.length; i < ii; ++i) {
+        if (subscribers[i] === subscriber) {
+          return true;
+        }
+      }
+    }
     return false;
   }
-  const subscriberFlags = this._sFlags;
-  if ((subscriberFlags & SF.Subscriber0) === 0) {
-    this._s0 = subscriber;
-    this._sFlags |= SF.Subscriber0;
-  } else if ((subscriberFlags & SF.Subscriber1) === 0) {
-    this._s1 = subscriber;
-    this._sFlags |= SF.Subscriber1;
-  } else if ((subscriberFlags & SF.Subscriber2) === 0) {
-    this._s2 = subscriber;
-    this._sFlags |= SF.Subscriber2;
-  } else if ((subscriberFlags & SF.SubscribersRest) === 0) {
-    this._sRest = [subscriber];
-    this._sFlags |= SF.SubscribersRest;
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this._sRest!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
+
+  public any(): boolean {
+    return this._sFlags !== SF.None;
   }
-  return true;
+
+  public remove(subscriber: T): boolean {
+    const subscriberFlags = this._sFlags;
+    if ((subscriberFlags & SF.Subscriber0) > 0 && this._s0 === subscriber) {
+      this._s0 = void 0;
+      this._sFlags = (this._sFlags | SF.Subscriber0) ^ SF.Subscriber0;
+      this.count--;
+      return true;
+    } else if ((subscriberFlags & SF.Subscriber1) > 0 && this._s1 === subscriber) {
+      this._s1 = void 0;
+      this._sFlags = (this._sFlags | SF.Subscriber1) ^ SF.Subscriber1;
+      this.count--;
+      return true;
+    } else if ((subscriberFlags & SF.Subscriber2) > 0 && this._s2 === subscriber) {
+      this._s2 = void 0;
+      this._sFlags = (this._sFlags | SF.Subscriber2) ^ SF.Subscriber2;
+      this.count--;
+      return true;
+    } else if ((subscriberFlags & SF.SubscribersRest) > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const subscribers = this._sRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
+      let i = 0;
+      let ii = subscribers.length;
+      for (; i < ii; ++i) {
+        if (subscribers[i] === subscriber) {
+          subscribers.splice(i, 1);
+          if (ii === 1) {
+            this._sFlags = (this._sFlags | SF.SubscribersRest) ^ SF.SubscribersRest;
+          }
+          --i;
+          --ii;
+          --this.count;
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public notify(val: unknown, oldVal: unknown, flags: LF): void {
+    /**
+     * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
+     * callSubscribers invocation, so we're caching them all before invoking any.
+     * Subscribers added during this invocation are not invoked (and they shouldn't be).
+     * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
+     * however this is accounted for via $isBound and similar flags on the subscriber objects)
+     */
+    const owner = this.owner;
+    const sub0 = this._s0 as ISubscriber;
+    const sub1 = this._s1 as ISubscriber;
+    const sub2 = this._s2 as ISubscriber;
+    let subRest = this._sRest as ISubscriber[];
+    if (subRest !== void 0) {
+      subRest = subRest.slice();
+    }
+    if (sub0 !== void 0) {
+      sub0.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub0.id === void 0 ? 0 : owner[sub0.id]));
+    }
+    if (sub1 !== void 0) {
+      sub1.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub1.id === void 0 ? 0 : owner[sub1.id]));
+    }
+    if (sub2 !== void 0) {
+      sub2.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub2.id === void 0 ? 0 : owner[sub2.id]));
+    }
+    if (subRest !== void 0) {
+      const length = subRest.length;
+      let sub: ISubscriber | undefined;
+      let i = 0;
+      for (; i < length; ++i) {
+        sub = subRest[i];
+        if (sub !== void 0) {
+          sub.handleChange(val, oldVal, ((flags | LF.update) ^ LF.update) | (sub.id === void 0 ? 0 : owner[sub.id]));
+        }
+      }
+    }
+  }
+
+  public notifyCollection(indexMap: IndexMap, flags: LF): void {
+    const subscriber0 = this._s0 as ICollectionSubscriber;
+    const subscriber1 = this._s1 as ICollectionSubscriber;
+    const subscriber2 = this._s2 as ICollectionSubscriber;
+    let subscribers = this._sRest as ICollectionSubscriber[];
+    if (subscribers !== void 0) {
+      subscribers = subscribers.slice();
+    }
+    if (subscriber0 !== void 0) {
+      subscriber0.handleCollectionChange(indexMap, flags);
+    }
+    if (subscriber1 !== void 0) {
+      subscriber1.handleCollectionChange(indexMap, flags);
+    }
+    if (subscriber2 !== void 0) {
+      subscriber2.handleCollectionChange(indexMap, flags);
+    }
+    if (subscribers !== void 0) {
+      const length = subscribers.length;
+      let subscriber: ICollectionSubscriber | undefined;
+      let i = 0;
+      for (; i < length; ++i) {
+        subscriber = subscribers[i];
+        if (subscriber !== void 0) {
+          subscriber.handleCollectionChange(indexMap, flags);
+        }
+      }
+    }
+  }
 }
 
-function addCollectionSubscriber(this: ICollectionSubscriberCollection, subscriber: ICollectionSubscriber): boolean {
-  if (this.hasCollectionSubscriber(subscriber)) {
-    return false;
-  }
-  const subscriberFlags = this._csFlags;
-  if ((subscriberFlags & SF.Subscriber0) === 0) {
-    this._cs0 = subscriber;
-    this._csFlags |= SF.Subscriber0;
-  } else if ((subscriberFlags & SF.Subscriber1) === 0) {
-    this._cs1 = subscriber;
-    this._csFlags |= SF.Subscriber1;
-  } else if ((subscriberFlags & SF.Subscriber2) === 0) {
-    this._cs2 = subscriber;
-    this._csFlags |= SF.Subscriber2;
-  } else if ((subscriberFlags & SF.SubscribersRest) === 0) {
-    this._csRest = [subscriber];
-    this._csFlags |= SF.SubscribersRest;
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this._csRest!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
-  }
-  return true;
+function getSubscriberRecord(this: ISubscriberCollection) {
+  const record = new SubscriberRecord(this);
+  defineHiddenProp(this, 'subs', record);
+  return record;
+}
+
+function addSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
+  return this.subs.add(subscriber);
 }
 
 function removeSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
-  const subscriberFlags = this._sFlags;
-  if ((subscriberFlags & SF.Subscriber0) > 0 && this._s0 === subscriber) {
-    this._s0 = void 0;
-    this._sFlags = (this._sFlags | SF.Subscriber0) ^ SF.Subscriber0;
-    return true;
-  } else if ((subscriberFlags & SF.Subscriber1) > 0 && this._s1 === subscriber) {
-    this._s1 = void 0;
-    this._sFlags = (this._sFlags | SF.Subscriber1) ^ SF.Subscriber1;
-    return true;
-  } else if ((subscriberFlags & SF.Subscriber2) > 0 && this._s2 === subscriber) {
-    this._s2 = void 0;
-    this._sFlags = (this._sFlags | SF.Subscriber2) ^ SF.Subscriber2;
-    return true;
-  } else if ((subscriberFlags & SF.SubscribersRest) > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const subscribers = this._sRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-      if (subscribers[i] === subscriber) {
-        subscribers.splice(i, 1);
-        if (ii === 1) {
-          this._sFlags = (this._sFlags | SF.SubscribersRest) ^ SF.SubscribersRest;
-        }
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function removeCollectionSubscriber(this: ICollectionSubscriberCollection, subscriber: ICollectionSubscriber): boolean {
-  const subscriberFlags = this._csFlags;
-  if ((subscriberFlags & SF.Subscriber0) > 0 && this._cs0 === subscriber) {
-    this._cs0 = void 0;
-    this._csFlags = (this._csFlags | SF.Subscriber0) ^ SF.Subscriber0;
-    return true;
-  } else if ((subscriberFlags & SF.Subscriber1) > 0 && this._cs1 === subscriber) {
-    this._cs1 = void 0;
-    this._csFlags = (this._csFlags | SF.Subscriber1) ^ SF.Subscriber1;
-    return true;
-  } else if ((subscriberFlags & SF.Subscriber2) > 0 && this._cs2 === subscriber) {
-    this._cs2 = void 0;
-    this._csFlags = (this._csFlags | SF.Subscriber2) ^ SF.Subscriber2;
-    return true;
-  } else if ((subscriberFlags & SF.SubscribersRest) > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const subscribers = this._csRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-      if (subscribers[i] === subscriber) {
-        subscribers.splice(i, 1);
-        if (ii === 1) {
-          this._csFlags = (this._csFlags | SF.SubscribersRest) ^ SF.SubscribersRest;
-        }
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function hasSubscribers(this: ISubscriberCollection): boolean {
-  return this._sFlags !== SF.None;
-}
-
-function hasCollectionSubscribers(this: ICollectionSubscriberCollection): boolean {
-  return this._csFlags !== SF.None;
+  return this.subs.remove(subscriber);
 }
 
 function hasSubscriber(this: ISubscriberCollection, subscriber: ISubscriber): boolean {
-  // Flags here is just a perf tweak
-  // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
-  // and minor slow-down when it does, and the former is more common than the latter.
-  const subscriberFlags = this._sFlags;
-  if ((subscriberFlags & SF.Subscriber0) > 0 && this._s0 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.Subscriber1) > 0 && this._s1 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.Subscriber2) > 0 && this._s2 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.SubscribersRest) > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const subscribers = this._sRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-      if (subscribers[i] === subscriber) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return this.subs.has(subscriber);
 }
 
-function hasCollectionSubscriber(this: ICollectionSubscriberCollection, subscriber: ICollectionSubscriber): boolean {
-  const subscriberFlags = this._csFlags;
-  if ((subscriberFlags & SF.Subscriber0) > 0 && this._cs0 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.Subscriber1) > 0 && this._cs1 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.Subscriber2) > 0 && this._cs2 === subscriber) {
-    return true;
-  }
-  if ((subscriberFlags & SF.SubscribersRest) > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const subscribers = this._csRest!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-    for (let i = 0, ii = subscribers.length; i < ii; ++i) {
-      if (subscribers[i] === subscriber) {
-        return true;
-      }
-    }
-  }
-  return false;
+function hasSubscribers(this: ISubscriberCollection): boolean {
+  return this.subs.any();
 }
 
 function callSubscribers(this: ISubscriberCollection, newValue: unknown, previousValue: unknown, flags: LF): void {
-  /**
-   * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
-   * callSubscribers invocation, so we're caching them all before invoking any.
-   * Subscribers added during this invocation are not invoked (and they shouldn't be).
-   * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
-   * however this is accounted for via $isBound and similar flags on the subscriber objects)
-   */
-  const subscriber0 = this._s0;
-  const subscriber1 = this._s1;
-  const subscriber2 = this._s2;
-  let subscribers = this._sRest;
-  if (subscribers !== void 0) {
-    subscribers = subscribers.slice();
-  }
-  if (subscriber0 !== void 0) {
-    callSubscriber(subscriber0, newValue, previousValue, flags, subscriber0.id === void 0 ? 0 : this[subscriber0.id]);
-  }
-  if (subscriber1 !== void 0) {
-    callSubscriber(subscriber1, newValue, previousValue, flags, subscriber1.id === void 0 ? 0 : this[subscriber1.id]);
-  }
-  if (subscriber2 !== void 0) {
-    callSubscriber(subscriber2, newValue, previousValue, flags, subscriber2.id === void 0 ? 0 : this[subscriber2.id]);
-  }
-  if (subscribers !== void 0) {
-    const length = subscribers.length;
-    let subscriber: ISubscriber | undefined;
-    for (let i = 0; i < length; ++i) {
-      subscriber = subscribers[i];
-      if (subscriber !== void 0) {
-        callSubscriber(subscriber, newValue, previousValue, flags, subscriber.id === void 0 ? 0 : this[subscriber.id]);
-      }
-    }
-  }
-}
-
-function callSubscriber(
-  subscriber: ISubscriber,
-  newValue: unknown,
-  previousValue: unknown,
-  flags: LF,
-  ownFlags: LF,
-): void {
-  subscriber.handleChange(newValue, previousValue, ((flags | LF.update) ^ LF.update) | ownFlags);
+  this.subs.notify(newValue, previousValue, flags);
 }
 
 function callCollectionSubscribers(this: ICollectionSubscriberCollection, indexMap: IndexMap, flags: LF): void {
-  const subscriber0 = this._cs0;
-  const subscriber1 = this._cs1;
-  const subscriber2 = this._cs2;
-  let subscribers = this._csRest;
-  if (subscribers !== void 0) {
-    subscribers = subscribers.slice();
-  }
-  if (subscriber0 !== void 0) {
-    subscriber0.handleCollectionChange(indexMap, flags);
-  }
-  if (subscriber1 !== void 0) {
-    subscriber1.handleCollectionChange(indexMap, flags);
-  }
-  if (subscriber2 !== void 0) {
-    subscriber2.handleCollectionChange(indexMap, flags);
-  }
-  if (subscribers !== void 0) {
-    const length = subscribers.length;
-    let subscriber: ICollectionSubscriber | undefined;
-    for (let i = 0; i < length; ++i) {
-      subscriber = subscribers[i];
-      if (subscriber !== void 0) {
-        subscriber.handleCollectionChange(indexMap, flags);
-      }
-    }
-  }
+  this.subs.notifyCollection(indexMap, flags);
 }

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -1,3 +1,5 @@
+
+export const def = Reflect.defineProperty;
 export function defineHiddenProp(obj: object, key: PropertyKey, value: unknown): void {
   Reflect.defineProperty(obj, key, {
     enumerable: false,

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -35,8 +35,8 @@ export class MockBinding implements IConnectableBinding {
   public $hostScope!: Scope | null;
   public isBound!: boolean;
   public value: unknown;
-  public record!: BindingObserverRecord;
-  public cRecord!: BindingCollectionObserverRecord;
+  public obs!: BindingObserverRecord;
+  public cObs!: BindingCollectionObserverRecord;
 
   public calls: [keyof MockBinding, ...any[]][] = [];
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Following the connectable changes, use a record to keep track of subscribers instead of the mixed in class instances. Also merge the collection subscribers & normal subscribers record.