### PR TITLE
refactor(connectable): merge observer record & collection observer re…

### DIFF
--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -177,7 +177,6 @@ export class ContentBinding implements ContentBinding, ICollectionSubscriber {
     }
     if (newValue != this.value) {
       this.value = newValue;
-      this.cObs.clear();
       if (newValue instanceof Array) {
         this.observeCollection(newValue);
       }
@@ -230,7 +229,6 @@ export class ContentBinding implements ContentBinding, ICollectionSubscriber {
     this.$scope = void 0;
     this.$hostScope = null;
     this.obs.clear(true);
-    this.cObs.clear(true);
   }
 }
 

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -69,7 +69,6 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
     }
     this.isBound = false;
     this.obs.clear(true);
-    this.cObs.clear(true);
   }
 
   private run(): void {
@@ -94,7 +93,6 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
       return this.value = unwrap(this.get.call(void 0, this.useProxy ? wrap(this.obj) : this.obj, this));
     } finally {
       this.obs.clear(false);
-      this.cObs.clear(false);
       this.running = false;
       exit(this);
     }

--- a/packages/runtime/src/binding-behavior.ts
+++ b/packages/runtime/src/binding-behavior.ts
@@ -177,9 +177,6 @@ export class BindingInterceptor implements IInterceptableBinding {
   public get obs(): BindingObserverRecord {
     return this.binding.obs;
   }
-  public get cObs(): BindingCollectionObserverRecord {
-    return this.binding.cObs;
-  }
 
   public constructor(
     public readonly binding: IInterceptableBinding,

--- a/packages/runtime/src/binding-behavior.ts
+++ b/packages/runtime/src/binding-behavior.ts
@@ -20,7 +20,7 @@ import type {
   IServiceLocator,
   Key,
 } from '@aurelia/kernel';
-import type { BindingCollectionObserverRecord, BindingObserverRecord, IConnectableBinding } from './binding/connectable.js';
+import type { BindingObserverRecord, IConnectableBinding } from './binding/connectable.js';
 import type { BindingBehaviorExpression, IBindingBehaviorExpression } from './binding/ast.js';
 import type { IObserverLocator } from './observation/observer-locator.js';
 import type { IBinding } from './observation.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -70,7 +70,6 @@ export {
   BindingMediator,
   MediatedBinding,
   BindingObserverRecord,
-  BindingCollectionObserverRecord,
 } from './binding/connectable.js';
 export {
   IExpressionParser,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -299,6 +299,7 @@ export interface ICollectionChangeTracker<T extends Collection> {
 export interface ICollectionObserver<T extends CollectionKind> extends
   ICollectionChangeTracker<CollectionKindToType<T>>,
   ICollectionSubscribable {
+  [id: number]: number;
   type: AccessorType;
   collection: ObservedCollectionKindToType<T>;
   getLengthObserver(): T extends CollectionKind.array ? CollectionLengthObserver : CollectionSizeObserver;

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -123,7 +123,6 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
     if (this.subs.remove(subscriber) && this.subs.count === 0) {
       this.isDirty = true;
       this.obs.clear(true);
-      this.cObs.clear(true);
     }
   }
 
@@ -150,7 +149,6 @@ export class ComputedObserver implements IConnectableBinding, ISubscriber, IColl
       return this.value = unwrap(this.get.call(this.useProxy ? wrap(this.obj) : this.obj, this));
     } finally {
       this.obs.clear(false);
-      this.cObs.clear(false);
       this.running = false;
       exitConnectable(this);
     }

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -20,7 +20,6 @@ import type {
   IObserverLocator,
   ISignaler,
   BindingObserverRecord,
-  BindingCollectionObserverRecord,
   Collection,
 } from '@aurelia/runtime';
 

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -36,7 +36,6 @@ export class MockBinding implements IConnectableBinding {
   public isBound!: boolean;
   public value: unknown;
   public obs!: BindingObserverRecord;
-  public cObs!: BindingCollectionObserverRecord;
 
   public calls: [keyof MockBinding, ...any[]][] = [];
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

With the rename of collection observation subscribe/unsubscribe methods, now it's simpler to keep track of both observers & collection observers. Merge them and remove some more fat.