### PR TITLE
Build/roll up

### DIFF
--- a/packages-cjs/aot/package.json
+++ b/packages-cjs/aot/package.json
@@ -33,7 +33,8 @@
     "dev": "tsc -b -w --preserveWatchOutput",
     "test": "node dist/cjs/test.js",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -47,6 +48,8 @@
     "typescript": "^4.0.3"
   },
   "devDependencies": {
-    "@types/node": "^14.11.5"
+    "@rollup/plugin-typescript": "^8.1.0",
+    "@types/node": "^14.11.5",
+    "rollup": "^2.35.1"
   }
 }

--- a/packages-cjs/aot/rollup.config.js
+++ b/packages-cjs/aot/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/aot/tsconfig.build.json
+++ b/packages-cjs/aot/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "types": [
+      "node"
+    ],
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/babel-jest/package.json
+++ b/packages-cjs/babel-jest/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -48,7 +49,9 @@
   "devDependencies": {
     "@jest/transform": "^26.3.0",
     "@jest/types": "^26.3.0",
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/node": "^14.11.5",
+    "rollup": "^2.35.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages-cjs/babel-jest/rollup.config.js
+++ b/packages-cjs/babel-jest/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/babel-jest/tsconfig.build.json
+++ b/packages-cjs/babel-jest/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/plugin-conventions/package.json
+++ b/packages-cjs/plugin-conventions/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -48,7 +49,9 @@
     "typescript": "^4.0.3"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/node": "^14.11.5",
-    "@types/parse5": "^5.0.2"
+    "@types/parse5": "^5.0.2",
+    "rollup": "^2.35.1"
   }
 }

--- a/packages-cjs/plugin-conventions/rollup.config.js
+++ b/packages-cjs/plugin-conventions/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/plugin-conventions/tsconfig.build.json
+++ b/packages-cjs/plugin-conventions/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/plugin-gulp/package.json
+++ b/packages-cjs/plugin-gulp/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -46,8 +47,10 @@
     "vinyl": "^2.2.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/node": "^14.11.5",
     "@types/vinyl": "^2.0.4",
+    "rollup": "^2.35.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages-cjs/plugin-gulp/rollup.config.js
+++ b/packages-cjs/plugin-gulp/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/plugin-gulp/tsconfig.build.json
+++ b/packages-cjs/plugin-gulp/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"],
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/plugin-parcel/package.json
+++ b/packages-cjs/plugin-parcel/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -44,7 +45,9 @@
     "@aurelia/runtime": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/node": "^14.11.5",
+    "rollup": "^2.35.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages-cjs/plugin-parcel/rollup.config.js
+++ b/packages-cjs/plugin-parcel/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/plugin-parcel/tsconfig.build.json
+++ b/packages-cjs/plugin-parcel/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/ts-jest/package.json
+++ b/packages-cjs/ts-jest/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -48,7 +49,9 @@
   "devDependencies": {
     "@jest/transform": "^26.3.0",
     "@jest/types": "^26.3.0",
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/node": "^14.11.5",
+    "rollup": "^2.35.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages-cjs/ts-jest/rollup.config.js
+++ b/packages-cjs/ts-jest/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/ts-jest/tsconfig.build.json
+++ b/packages-cjs/ts-jest/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages-cjs/webpack-loader/package.json
+++ b/packages-cjs/webpack-loader/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -46,9 +47,11 @@
     "loader-utils": "^2.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.11.5",
+    "@rollup/plugin-typescript": "^8.1.0",
     "@types/loader-utils": "^2.0.1",
+    "@types/node": "^14.11.5",
     "@types/webpack": "^4.41.25",
+    "rollup": "^2.35.1",
     "typescript": "^4.0.3"
   }
 }

--- a/packages-cjs/webpack-loader/rollup.config.js
+++ b/packages-cjs/webpack-loader/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages-cjs/webpack-loader/tsconfig.build.json
+++ b/packages-cjs/webpack-loader/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/au/package.json
+++ b/packages/au/package.json
@@ -38,19 +38,22 @@
     "bundle": "ts-node -P ../../tsconfig.json ../../scripts/bundle.ts umd,esm,system aurelia",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@aurelia/metadata": "0.8.0",
-    "@aurelia/platform": "0.8.0",
+    "@aurelia/http-server": "0.8.0",
     "@aurelia/kernel": "0.8.0",
-    "@aurelia/http-server": "0.8.0"
+    "@aurelia/metadata": "0.8.0",
+    "@aurelia/platform": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
     "@types/node": "^14.11.5",
+    "rollup": "^2.33.2",
     "tslib": "^1.10.0",
     "typescript": "^4.0.3"
   }

--- a/packages/au/rollup.config.js
+++ b/packages/au/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/au/tsconfig.build.json
+++ b/packages/au/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -31,7 +31,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -44,10 +45,12 @@
     "@aurelia/platform-browser": "0.8.0",
     "@aurelia/route-recognizer": "0.8.0",
     "@aurelia/router": "0.8.0",
-    "@aurelia/runtime-html": "0.8.0",
-    "@aurelia/runtime": "0.8.0"
+    "@aurelia/runtime": "0.8.0",
+    "@aurelia/runtime-html": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/aurelia/rollup.config.js
+++ b/packages/aurelia/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/aurelia/tsconfig.build.json
+++ b/packages/aurelia/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/aurelia/tsconfig.json
+++ b/packages/aurelia/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../tsconfig-build.json",
   "compilerOptions": {
     "types": ["node"],
-    "lib": ["dom"],
+    "lib": [
+      "dom",
+      "esnext"
+    ],
     "rootDir": "src",
     "declarationDir": "dist",
     "outDir": "dist/esm"

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -42,6 +43,8 @@
     "@aurelia/metadata": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/fetch-client/rollup.config.js
+++ b/packages/fetch-client/rollup.config.js
@@ -1,0 +1,16 @@
+import typescript from '@rollup/plugin-typescript';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  external: ['url'],
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/fetch-client/src/http-client.ts
+++ b/packages/fetch-client/src/http-client.ts
@@ -306,7 +306,8 @@ export class HttpClient {
           // TODO: Fix this, as it violates `strictBindCallApply`.
           return chain.then(
             successHandler ? (value => successHandler.call(interceptor, value, ...interceptorArgs)) : identity,
-            errorHandler ? (reason => errorHandler.call(interceptor, reason, ...interceptorArgs)) : thrower);
+            errorHandler ? (reason => errorHandler.call(interceptor, reason, ...interceptorArgs)) : thrower
+          ) as Promise<Request | Response>;
         },
         Promise.resolve(input)
       );

--- a/packages/fetch-client/tsconfig.build.json
+++ b/packages/fetch-client/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "strictBindCallApply": false
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -35,19 +35,22 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
+    "@aurelia/kernel": "0.8.0",
     "@aurelia/metadata": "0.8.0",
     "@aurelia/platform": "0.8.0",
-    "@aurelia/kernel": "0.8.0",
     "@aurelia/runtime": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
     "@types/node": "^14.11.5",
+    "rollup": "^2.33.2",
     "tslib": "^1.10.0",
     "typescript": "^4.0.3"
   }

--- a/packages/http-server/rollup.config.js
+++ b/packages/http-server/rollup.config.js
@@ -1,0 +1,16 @@
+import typescript from '@rollup/plugin-typescript';
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  external: ['url'],
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/http-server/tsconfig.build.json
+++ b/packages/http-server/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "types": ["node"],
+    "lib": ["esnext"],
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -41,11 +42,13 @@
     "@aurelia/kernel": "0.8.0",
     "@aurelia/metadata": "0.8.0",
     "@aurelia/platform": "0.8.0",
-    "@aurelia/runtime-html": "0.8.0",
     "@aurelia/runtime": "0.8.0",
+    "@aurelia/runtime-html": "0.8.0",
     "i18next": "^17.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/i18n/rollup.config.js
+++ b/packages/i18n/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/i18n/tsconfig.build.json
+++ b/packages/i18n/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "allowSyntheticDefaultImports": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -42,6 +43,8 @@
     "@aurelia/platform": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/kernel/rollup.config.js
+++ b/packages/kernel/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/kernel/tsconfig.build.json
+++ b/packages/kernel/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -32,13 +32,15 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/metadata/rollup.config.js
+++ b/packages/metadata/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/metadata/tsconfig.build.json
+++ b/packages/metadata/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -41,6 +42,8 @@
     "@aurelia/platform": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/platform-browser/tsconfig.build.json
+++ b/packages/platform-browser/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -32,13 +32,15 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/platform/rollup.config.js
+++ b/packages/platform/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/platform/tsconfig.build.json
+++ b/packages/platform/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -32,13 +32,15 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/route-recognizer/rollup.config.js
+++ b/packages/route-recognizer/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/route-recognizer/tsconfig.build.json
+++ b/packages/route-recognizer/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "strict": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -43,10 +44,12 @@
     "@aurelia/platform": "0.8.0",
     "@aurelia/platform-browser": "0.8.0",
     "@aurelia/route-recognizer": "0.8.0",
-    "@aurelia/runtime-html": "0.8.0",
-    "@aurelia/runtime": "0.8.0"
+    "@aurelia/runtime": "0.8.0",
+    "@aurelia/runtime-html": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "strict": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -45,6 +46,8 @@
     "@aurelia/runtime": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/runtime-html/rollup.config.js
+++ b/packages/runtime-html/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/runtime-html/tsconfig.build.json
+++ b/packages/runtime-html/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -43,6 +44,8 @@
     "@aurelia/platform": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/runtime/rollup.config.js
+++ b/packages/runtime/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store/rollup.config.js
+++ b/packages/store/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/store/tsconfig.build.json
+++ b/packages/store/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/testing/tsconfig.build.json
+++ b/packages/testing/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "types": [
+      "node",
+      "mocha"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -33,7 +33,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -48,6 +49,8 @@
     "@aurelia/validation": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/validation-html/rollup.config.js
+++ b/packages/validation-html/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation-html/tsconfig.build.json
+++ b/packages/validation-html/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -33,7 +33,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -44,13 +45,15 @@
     "@aurelia/metadata": "0.8.0",
     "@aurelia/platform": "0.8.0",
     "@aurelia/platform-browser": "0.8.0",
-    "@aurelia/runtime-html": "0.8.0",
     "@aurelia/runtime": "0.8.0",
-    "@aurelia/validation-html": "0.8.0",
+    "@aurelia/runtime-html": "0.8.0",
     "@aurelia/validation": "0.8.0",
+    "@aurelia/validation-html": "0.8.0",
     "i18next": "^17.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/validation-i18n/rollup.config.js
+++ b/packages/validation-i18n/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation-i18n/tsconfig.build.json
+++ b/packages/validation-i18n/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"
@@ -44,6 +45,8 @@
     "@aurelia/runtime": "0.8.0"
   },
   "devDependencies": {
+    "@rollup/plugin-typescript": "^6.1.0",
+    "rollup": "^2.33.2",
     "typescript": "^4.0.3"
   }
 }

--- a/packages/validation/rollup.config.js
+++ b/packages/validation/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'esm',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation/tsconfig.build.json
+++ b/packages/validation/tsconfig.build.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Use rollup for all of our builds, so that it will produce a single dist file. Also simplify the circular dependencies story, if we manage to keep it under control