### PR TITLE
fix(missing): resource.d.ts exposing incorrect

### DIFF
--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -528,7 +528,7 @@ export {
   // QueueTaskTargetOptions,
 
   bindable,
-  // PartialBindableDefinition,
+  PartialBindableDefinition,
   // BindableDefinition,
   Bindable,
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Exposes partial bindable for use in the resource.d.ts file from template so it is now correct.
```ts
declare module '*.html' {
  import { IContainer, PartialBindableDefinition } from 'aurelia';
  export const name: string;
  export const template: string;
  export default template;
  export const dependencies: string[];
  export const containerless: boolean | undefined;
  export const bindables: Record<string, PartialBindableDefinition>;
  export const shadowOptions: { mode: 'open' | 'closed' } | undefined;
  export function register(container: IContainer);
}

declare module '*.css';
declare module '*.scss';
```
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

Update the template for aurelia to utilize

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
