### PR TITLE
refactor(bindable): use controller for determining bound state & change handler 

### DIFF
--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -31,7 +31,10 @@ export class BindableObserver {
     public readonly propertyKey: string,
     cbName: string,
     private readonly set: InterceptorFunc,
-    public readonly $controller: IController,
+    // todo: a future feature where the observer is not instantiated via a controller
+    // this observer can become more static, as in immediately available when used
+    // in the form of a decorator
+    public readonly $controller: IController | null,
   ) {
     const cb = obj[cbName] as typeof BindableObserver.prototype.cb;
     const cbAll = (obj as IMayHavePropertyChangedCallback).propertyChanged!;
@@ -72,7 +75,9 @@ export class BindableObserver {
       }
       this.currentValue = newValue;
       // todo: controller (if any) state should determine the invocation instead
-      if ((flags & LifecycleFlags.fromBind) === 0 || (flags & LifecycleFlags.updateSource) > 0) {
+      if (/* either not instantiated via a controller */this.$controller == null
+        /* or the controller instantiating this is bound */|| this.$controller.isBound
+      ) {
         if (this.hasCb) {
           this.cb.call(this.obj, newValue, currentValue, flags);
         }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -76,6 +76,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
   public scope: Scope | null = null;
   public hostScope: Scope | null = null;
+  public isBound: boolean = false;
 
   // If a host from another custom element was passed in, then this will be the controller for that custom element (could be `au-viewport` for example).
   // In that case, this controller will create a new host node (with the definition's name) and use that as the target host for the nodes instead.
@@ -520,6 +521,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       if (ret instanceof Promise) {
         this.ensurePromise();
         ret.then(() => {
+          this.isBound = true;
           this.attach();
         }).catch(err => {
           this.reject(err);
@@ -528,6 +530,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       }
     }
 
+    this.isBound = true;
     this.attach();
   }
 
@@ -874,6 +877,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       let next: Controller | null = null;
       while (cur !== null) {
         if (cur !== this) {
+          cur.isBound = false;
           cur.unbind();
         }
         next = cur.next as Controller;
@@ -882,6 +886,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       }
 
       this.head = this.tail = null;
+      this.isBound = false;
       this.unbind();
     }
   }
@@ -1269,6 +1274,7 @@ export interface IController<C extends IViewModel = IViewModel> extends IDisposa
   readonly state: State;
   readonly isActive: boolean;
   readonly parent: IHydratedController | null;
+  readonly isBound: boolean;
 
   /** @internal */head: IHydratedController | null;
   /** @internal */tail: IHydratedController | null;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Continue the work at https://github.com/aurelia/aurelia/pull/1077 . This PR removes the reliance of `BindableObserver` on the `LifecycleFlags`.

### 🎫 Issues

In the related PR, we are removing the necessity of using `id` from connectable to determine what flags to pass around, in case of a `binding.handleChange`. The removal of that `id` removed the need of having `LifecycleFlags.updateTarget` & `LifecycleFlags.updateSource` flags. Though we couldn't remove it at that time, since `BindableObserver` still relies on `.updateSource` flag. This PR removes this so that in a next couple of PR, we revamp the flags and their usages a bit more.