### PR TITLE
feat(inline-html): Allow inline views with convention

### DIFF
--- a/packages-cjs/plugin-conventions/src/options.ts
+++ b/packages-cjs/plugin-conventions/src/options.ts
@@ -15,6 +15,7 @@ export interface IFileUnit {
   // For foo.js or foo.ts, this is foo.html or foo.md or foo.haml or foo.pug
   // For foo.html (or other templates), this is foo.css or foo.scss or foo.sass or foo.less or foo.styl
   filePair?: string;
+  inline?: boolean;
 }
 
 export interface IOptionalPreprocessOptions {

--- a/packages-cjs/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-cjs/plugin-conventions/src/preprocess-resource.ts
@@ -22,6 +22,7 @@ interface IFoundResource {
   implicitStatement?: IPos;
   runtimeImportName?: string;
   customName?: IPos;
+  customElementName?: string;
 }
 
 interface IFoundDecorator {
@@ -35,7 +36,8 @@ interface IModifyResourceOptions {
   implicitElement?: IPos;
   localDeps: string[];
   conventionalDecorators: [number, string][];
-  customElementName?: IPos;
+  customElementNamePosition?: IPos;
+  customElementName?: string;
 }
 
 export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions): ModifyCodeResult {
@@ -47,7 +49,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
   let runtimeImport: ICapturedImport = { names: [], start: 0, end: 0 };
 
   let implicitElement: IPos | undefined;
-  let customElementName: IPos | undefined; // for @customName('custom-name')
+  let customElementNamePosition: IPos | undefined; // for @customName('custom-name')
 
   // When there are multiple exported classes (e.g. local value converters),
   // they might be deps for composing the main implicit custom element.
@@ -75,7 +77,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     // Note this convention simply doesn't work for
     //   class Foo {}
     //   export {Foo};
-    const resource = findResource(s, expectedResourceName, unit.filePair, unit.contents);
+    const resource = findResource(s, expectedResourceName, unit);
     if (!resource) return;
     const {
       localDep,
@@ -91,7 +93,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     if (runtimeImportName && !auImport.names.includes(runtimeImportName)) {
       ensureTypeIsExported(runtimeImport.names, runtimeImportName);
     }
-    if (customName) customElementName = customName;
+    if (customName) customElementNamePosition = customName;
   });
 
   return modifyResource(unit, {
@@ -100,7 +102,7 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     implicitElement,
     localDeps,
     conventionalDecorators,
-    customElementName
+    customElementNamePosition
   });
 }
 
@@ -111,17 +113,20 @@ function modifyResource(unit: IFileUnit, options: IModifyResourceOptions) {
     implicitElement,
     localDeps,
     conventionalDecorators,
+    customElementNamePosition,
     customElementName
   } = options;
 
   const m = modifyCode(unit.contents, unit.path);
-  if (implicitElement && unit.filePair) {
+  if (implicitElement && (unit.filePair || unit.inline)) {
     // @view() for foo.js and foo-view.html
     // @customElement() for foo.js and foo.html
-    const dec = kebabCase(unit.filePair).startsWith(`${expectedResourceName}-view`) ? 'view' : 'customElement';
+    const dec = unit.filePair !== undefined && kebabCase(unit.filePair).startsWith(`${expectedResourceName}-view`) ? 'view' : 'customElement';
 
-    const viewDef = '__au2ViewDef';
-    m.prepend(`import * as ${viewDef} from './${unit.filePair}';\n`);
+    const viewDef = unit.inline ? `{ name: ${customElementName}}` : '__au2ViewDef';
+    if (!unit.inline) {
+      m.prepend(`import * as ${viewDef} from './${unit.filePair}';\n`);
+    }
 
     if (localDeps.length) {
       // When in-file deps are used, move the body of custom element to end of the file,
@@ -129,18 +134,18 @@ function modifyResource(unit: IFileUnit, options: IModifyResourceOptions) {
       const elementStatement = unit.contents.slice(implicitElement.pos, implicitElement.end);
       m.replace(implicitElement.pos, implicitElement.end, '');
 
-      if (customElementName) {
-        const name = unit.contents.slice(customElementName.pos, customElementName.end);
+      if (customElementNamePosition) {
+        const name = unit.contents.slice(customElementNamePosition.pos, customElementNamePosition.end);
         // Overwrite element name
-        m.append(`\n${elementStatement.substring(0, customElementName.pos - implicitElement.pos)}{ ...${viewDef}, name: ${name}, dependencies: [ ...${viewDef}.dependencies, ${localDeps.join(', ')} ] }${elementStatement.substring(customElementName.end - implicitElement.pos)}\n`);
+        m.append(`\n${elementStatement.substring(0, customElementNamePosition.pos - implicitElement.pos)}{ ...${viewDef}, name: ${name}, dependencies: [ ...${viewDef}.dependencies, ${localDeps.join(', ')} ] }${elementStatement.substring(customElementNamePosition.end - implicitElement.pos)}\n`);
       } else {
         m.append(`\n@${dec}({ ...${viewDef}, dependencies: [ ...${viewDef}.dependencies, ${localDeps.join(', ')} ] })\n${elementStatement}\n`);
       }
     } else {
-      if (customElementName) {
+      if (customElementNamePosition) {
         // Overwrite element name
-        const name = unit.contents.slice(customElementName.pos, customElementName.end);
-        m.replace(customElementName.pos, customElementName.end,`{ ...${viewDef}, name: ${name} }`);
+        const name = unit.contents.slice(customElementNamePosition.pos, customElementNamePosition.end);
+        m.replace(customElementNamePosition.pos, customElementNamePosition.end, `{ ...${viewDef}, name: ${name} }`);
       } else {
         conventionalDecorators.push([implicitElement.pos, `@${dec}(${viewDef})\n`]);
       }
@@ -162,11 +167,11 @@ function modifyResource(unit: IFileUnit, options: IModifyResourceOptions) {
 
 function captureImport(s: ts.Statement, lib: string, code: string): ICapturedImport | void {
   if (ts.isImportDeclaration(s) &&
-      ts.isStringLiteral(s.moduleSpecifier) &&
-      s.moduleSpecifier.text === lib &&
-      s.importClause &&
-      s.importClause.namedBindings &&
-      ts.isNamedImports(s.importClause.namedBindings)) {
+    ts.isStringLiteral(s.moduleSpecifier) &&
+    s.moduleSpecifier.text === lib &&
+    s.importClause &&
+    s.importClause.namedBindings &&
+    ts.isNamedImports(s.importClause.namedBindings)) {
     return {
       names: s.importClause.namedBindings.elements.map(e => e.name.text),
       start: ensureTokenStart(s.pos, code),
@@ -220,14 +225,15 @@ function isKindOfSame(name1: string, name2: string): boolean {
   return name1.replace(/-/g, '') === name2.replace(/-/g, '');
 }
 
-function findResource(node: ts.Node, expectedResourceName: string, filePair: string | undefined, code: string): IFoundResource | void {
+function findResource(node: ts.Node, expectedResourceName: string, unit: IFileUnit): IFoundResource | void {
+  const { contents: code, filePair, inline } = unit;
   if (!ts.isClassDeclaration(node)) return;
   if (!node.name) return;
   if (!isExported(node)) return;
   const pos = ensureTokenStart(node.pos, code);
 
   const className = node.name.text;
-  const {name, type} = nameConvention(className);
+  const { name, type } = nameConvention(className);
   const isImplicitResource = isKindOfSame(name, expectedResourceName);
   const foundType = findDecoratedResourceType(node);
 
@@ -251,16 +257,18 @@ function findResource(node: ts.Node, expectedResourceName: string, filePair: str
       const customName = foundType.expression.arguments[0] as ts.StringLiteral;
       return {
         implicitStatement: { pos: pos, end: node.end },
-        customName: { pos: ensureTokenStart(customName.pos, code), end: customName.end }
+        customName: { pos: ensureTokenStart(customName.pos, code), end: customName.end },
+        customElementName: name
       };
     }
   } else {
     if (type === 'customElement') {
       // Custom element can only be implicit resource
-      if (isImplicitResource && filePair) {
+      if (isImplicitResource && (inline || filePair)) {
         return {
           implicitStatement: { pos: pos, end: node.end },
-          runtimeImportName: kebabCase(filePair).startsWith(`${expectedResourceName}-view`) ? 'view' : 'customElement'
+          runtimeImportName: filePair && kebabCase(filePair).startsWith(`${expectedResourceName}-view`) ? 'view' : 'customElement',
+          customElementName: name
         };
       }
     } else {

--- a/packages-cjs/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-cjs/plugin-conventions/src/preprocess-resource.ts
@@ -121,7 +121,7 @@ function modifyResource(unit: IFileUnit, options: IModifyResourceOptions) {
   if (implicitElement && (unit.filePair || unit.inline)) {
     // @view() for foo.js and foo-view.html
     // @customElement() for foo.js and foo.html
-    const dec = unit.filePair !== undefined && kebabCase(unit.filePair).startsWith(`${expectedResourceName}-view`) ? 'view' : 'customElement';
+    const dec = (unit.filePair !== undefined && kebabCase(unit.filePair).startsWith(`${expectedResourceName}-view`)) ? 'view' : 'customElement';
 
     const viewDef = unit.inline ? `{ name: ${customElementName}}` : '__au2ViewDef';
     if (!unit.inline) {

--- a/packages-cjs/plugin-conventions/src/preprocess.ts
+++ b/packages-cjs/plugin-conventions/src/preprocess.ts
@@ -33,7 +33,11 @@ export function preprocess(
       path.join(base, unit.path.slice(0, - ext.length) + e)
     );
     const filePair = possibleFilePair.find(_fileExists);
-    if (filePair) {
+    const containsInline = /@(template|inlineView)\((.*)\)/g.test(unit.contents);
+    if (containsInline) {
+      unit.inline = true;
+    }
+    else if (filePair) {
       if (allOptions.useProcessedFilePairFilename) {
         unit.filePair = `${basename}.html`;
       } else {
@@ -43,7 +47,7 @@ export function preprocess(
       // Try foo.js and foo-view.html convention.
       // This convention is handled by @view(), not @customElement().
       const possibleViewPair = allOptions.templateExtensions.map(e =>
-        path.join(base, `${unit.path.slice(0, - ext.length)  }-view${e}`)
+        path.join(base, `${unit.path.slice(0, - ext.length)}-view${e}`)
       );
       const viewPair = possibleViewPair.find(_fileExists);
       if (viewPair) {

--- a/packages/__tests__/3-runtime-html/template-decorator.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-decorator.spec.ts
@@ -59,10 +59,10 @@ describe('template-decorator', function () {
 
   describe('Simple inline using inlineView with dependencies', function () {
 
-    @template('<div>Inner Test</div>')
+    @inlineView('<div>Inner Test</div>')
     class InnerSimple { }
 
-    @template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
+    @inlineView('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
     class Simple {
     }
 

--- a/packages/__tests__/3-runtime-html/template-decorator.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-decorator.spec.ts
@@ -1,0 +1,77 @@
+import {
+  bindable,
+  alias,
+  customAttribute,
+  INode,
+  valueConverter,
+  template,
+  customElement,
+  CustomElement,
+  inlineView
+} from '@aurelia/runtime-html';
+import { assert, createFixture, } from '@aurelia/testing';
+
+describe('template-decorator', function () {
+  describe('Simple inline template', function () {
+
+    @template('<div>TEST</div>')
+    class Simple {
+    }
+
+    it('Simple test with @template renders correct template string', async function () {
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.firstElementChild.innerHTML, '<div>TEST</div>');
+      await options.tearDown();
+    });
+
+  });
+
+  describe('Simple inline template with dependencies', function () {
+
+    @template('<div>Inner Test</div>')
+    class InnerSimple { }
+
+    @template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
+    class Simple {
+    }
+
+    it('Simple test with @template renders correct template string', async function () {
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
+      await options.tearDown();
+    });
+
+  });
+
+  describe('Simple inline using inlineView', function () {
+
+    @inlineView('<div>TEST</div>')
+    class Simple {
+    }
+
+    it('Simple test with @inlineView renders correct template string', async function () {
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.firstElementChild.innerHTML, '<div>TEST</div>');
+      await options.tearDown();
+    });
+
+  });
+
+  describe('Simple inline using inlineView with dependencies', function () {
+
+    @template('<div>Inner Test</div>')
+    class InnerSimple { }
+
+    @template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
+    class Simple {
+    }
+
+    it('Simple test with @template renders correct template string', async function () {
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
+      await options.tearDown();
+    });
+
+  });
+
+});

--- a/packages/__tests__/3-runtime-html/template-decorator.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-decorator.spec.ts
@@ -1,18 +1,12 @@
 import {
-  bindable,
-  alias,
-  customAttribute,
-  INode,
-  valueConverter,
   template,
-  customElement,
   CustomElement,
   inlineView
 } from '@aurelia/runtime-html';
 import { assert, createFixture, } from '@aurelia/testing';
 
-describe('template-decorator', function () {
-  describe('Simple inline template', function () {
+describe('@template', function () {
+  describe('without dependencies', function () {
 
     @template('<div>TEST</div>')
     class Simple {
@@ -25,17 +19,26 @@ describe('template-decorator', function () {
     });
 
   });
+  describe('with dependencies', function () {
 
-  describe('Simple inline template with dependencies', function () {
+    it('renders correct template string with array', async function () {
+      @template('<div>Inner Test</div>')
+      class InnerSimple { }
 
-    @template('<div>Inner Test</div>')
-    class InnerSimple { }
+      @template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
+      class Simple {
+      }
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
+      await options.tearDown();
+    });
+    it('renders correct template string with params', async function () {
+      @template('<div>Inner Test</div>')
+      class InnerSimple { }
 
-    @template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
-    class Simple {
-    }
-
-    it('Simple test with @template renders correct template string', async function () {
+      @template('<div><inner></inner></div>', CustomElement.define('inner', InnerSimple))
+      class Simple {
+      }
       const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
       assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
       await options.tearDown();
@@ -43,7 +46,10 @@ describe('template-decorator', function () {
 
   });
 
-  describe('Simple inline using inlineView', function () {
+
+});
+describe('@inlineView', function () {
+  describe('without dependencies', function () {
 
     @inlineView('<div>TEST</div>')
     class Simple {
@@ -56,22 +62,33 @@ describe('template-decorator', function () {
     });
 
   });
+  describe('with dependencies', function () {
 
-  describe('Simple inline using inlineView with dependencies', function () {
 
-    @inlineView('<div>Inner Test</div>')
-    class InnerSimple { }
 
-    @inlineView('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
-    class Simple {
-    }
+    it('renders correct template string using array', async function () {
+      @inlineView('<div>Inner Test</div>')
+      class InnerSimple { }
 
-    it('Simple test with @template renders correct template string', async function () {
+      @inlineView('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
+      class Simple {
+      }
+      const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
+      assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
+      await options.tearDown();
+    });
+
+    it('renders correct template string using non array', async function () {
+      @inlineView('<div>Inner Test</div>')
+      class InnerSimple { }
+
+      @inlineView('<div><inner></inner></div>', CustomElement.define('inner', InnerSimple))
+      class Simple {
+      }
       const options = createFixture('<simple></simple>', class { }, [CustomElement.define('simple', Simple)]);
       assert.strictEqual(options.appHost.querySelector('inner').innerHTML, '<div>Inner Test</div>');
       await options.tearDown();
     });
 
   });
-
 });

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -77,21 +77,21 @@ module.exports = function (config) {
   //   Because they're not watched, they're also not cached, so that the browser will always serve the latest version from disk.
   //
   const files = [
-    { type: 'script', watched: false, included: true, nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
-    { type: 'module', watched: true, included: true, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-browser.js` }, // 1.1
-    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-shared.js` }, // 1.2
-    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/util.js` }, // 1.3
-    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/Spy.js` }, // 1.4
+    { type: 'script', watched: false, included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
+    { type: 'module', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-browser.js` }, // 1.1
+    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-shared.js` }, // 1.2
+    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/util.js` }, // 1.3
+    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/Spy.js` }, // 1.4
     ...testDirs.flatMap(name => [
-      { type: 'module', watched: true, included: true, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.spec.js` }, // 2.1
-      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.js.map` }, // 2.2
-      { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/!(*.$au)*.js` }, // 2.3
-      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
+      { type: 'module', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.spec.js` }, // 2.1
+      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.js.map` }, // 2.2
+      { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/!(*.$au)*.js` }, // 2.3
+      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
     ]),
     ...packageNames.flatMap(name => [
-      { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/${name}/dist/esm/**/!(*.$au)*.js` }, // 3.1
-      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/${name}/dist/esm/**/*.js.map` }, // 3.2
-      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/${name}/src/**/*.ts` }, // 3.3
+      { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/${name}/dist/esm/**/!(*.$au)*.js` }, // 3.1
+      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/dist/esm/**/*.js.map` }, // 3.2
+      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
     ])
   ];
 
@@ -140,7 +140,6 @@ module.exports = function (config) {
     },
     client: {
       captureConsole: true,
-      terminal: true,
       mocha: {
         bail: config['bail'],
         ui: 'bdd',

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -77,21 +77,21 @@ module.exports = function (config) {
   //   Because they're not watched, they're also not cached, so that the browser will always serve the latest version from disk.
   //
   const files = [
-    { type: 'script', watched: false, included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
-    { type: 'module', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-browser.js` }, // 1.1
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-shared.js` }, // 1.2
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/util.js` }, // 1.3
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/Spy.js` }, // 1.4
+    { type: 'script', watched: false, included: true, nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
+    { type: 'module', watched: true, included: true, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-browser.js` }, // 1.1
+    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/setup-shared.js` }, // 1.2
+    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/util.js` }, // 1.3
+    { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/Spy.js` }, // 1.4
     ...testDirs.flatMap(name => [
-      { type: 'module', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.spec.js` }, // 2.1
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.js.map` }, // 2.2
-      { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/!(*.$au)*.js` }, // 2.3
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
+      { type: 'module', watched: true, included: true, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.spec.js` }, // 2.1
+      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/*.js.map` }, // 2.2
+      { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/__tests__/dist/esm/__tests__/${name}/**/!(*.$au)*.js` }, // 2.3
+      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
     ]),
     ...packageNames.flatMap(name => [
-      { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/${name}/dist/esm/**/!(*.$au)*.js` }, // 3.1
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/dist/esm/**/*.js.map` }, // 3.2
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
+      { type: 'module', watched: true, included: false, nocache: false, pattern: `packages/${name}/dist/esm/**/!(*.$au)*.js` }, // 3.1
+      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/${name}/dist/esm/**/*.js.map` }, // 3.2
+      { type: 'module', watched: false, included: false, nocache: true, pattern: `packages/${name}/src/**/*.ts` }, // 3.3
     ])
   ];
 
@@ -140,6 +140,7 @@ module.exports = function (config) {
     },
     client: {
       captureConsole: true,
+      terminal: true,
       mocha: {
         bail: config['bail'],
         ui: 'bdd',

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -417,6 +417,8 @@ export {
   // With,
 
   containerless,
+  template,
+  inlineView,
   customElement,
   CustomElement,
   // CustomElementDecorator,

--- a/packages/kernel/src/resource.ts
+++ b/packages/kernel/src/resource.ts
@@ -155,7 +155,7 @@ export function fromAnnotationOrDefinitionOrTypeOrDefault<
 /**
  * The order in which the values are checked:
  * 1. Annotations (usually set by decorators) have the highest priority; they override static properties on the type.
- * 2. Static properties on the typ. Note that this does not look up the prototype chain (bindables are an exception here, but we do that differently anyway)
+ * 2. Static properties on the type. Note that this does not look up the prototype chain (bindables are an exception here, but we do that differently anyway)
  * 3. The default property that is provided last. The function is only called if the default property is needed
  */
 export function fromAnnotationOrTypeOrDefault<T, K extends keyof T, V>(

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -437,6 +437,8 @@ export {
 
 export {
   containerless,
+  template,
+  inlineView,
   customElement,
   CustomElement,
   CustomElementDecorator,

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -243,11 +243,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly projectionsMap: Map<IInstruction, IProjections>,
     public readonly watches: IWatchDefinition[],
     public readonly processContent: ProcessContentHook | null,
-  ) {
-
-    console.log(template);
-
-  }
+  ) {}
 
   public static create<T extends Constructable = Constructable>(
     def: PartialCustomElementDefinition,

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -108,10 +108,10 @@ export type CustomElementKind = IResourceKind<CustomElementType, CustomElementDe
    */
   for<C extends ICustomElementViewModel = ICustomElementViewModel>(node: Node, opts: { optional: true }): ICustomElementController<C> | null;
   isType<C>(value: C): value is (C extends Constructable ? CustomElementType<C> : never);
-  define<C extends Constructable>(name: string, Type: C): CustomElementType<C>;
-  define<C extends Constructable>(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
-  define<C extends Constructable>(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
-  define<C extends Constructable>(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable >(name: string, Type: C): CustomElementType<C>;
+  define<C extends Constructable >(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable >(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
+  define<C extends Constructable >(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
   getDefinition<C extends Constructable>(Type: C): CustomElementDefinition<C>;
   annotate<K extends keyof PartialCustomElementDefinition>(Type: Constructable, prop: K, value: PartialCustomElementDefinition[K]): void;
   getAnnotation<K extends keyof PartialCustomElementDefinition>(Type: Constructable, prop: K): PartialCustomElementDefinition[K];
@@ -549,13 +549,13 @@ export const CustomElement: CustomElementKind = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultProto = {} as any;
 
-    return function <P extends {} = {}>(
+    return function <P extends {} = {}> (
       name: string,
       proto: P = defaultProto,
     ): CustomElementType<Constructable<P>> {
       // Anonymous class ensures that minification cannot cause unintended side-effects, and keeps the class
       // looking similarly from the outside (when inspected via debugger, etc).
-      const Type = class { } as CustomElementType<Constructable<P>>;
+      const Type = class {} as CustomElementType<Constructable<P>>;
 
       // Define the name property so that Type.name can be used by end users / plugin authors if they really need to,
       // even when minified.

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -108,10 +108,10 @@ export type CustomElementKind = IResourceKind<CustomElementType, CustomElementDe
    */
   for<C extends ICustomElementViewModel = ICustomElementViewModel>(node: Node, opts: { optional: true }): ICustomElementController<C> | null;
   isType<C>(value: C): value is (C extends Constructable ? CustomElementType<C> : never);
-  define<C extends Constructable >(name: string, Type: C): CustomElementType<C>;
-  define<C extends Constructable >(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
-  define<C extends Constructable >(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
-  define<C extends Constructable >(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(name: string, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
+  define<C extends Constructable>(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
   getDefinition<C extends Constructable>(Type: C): CustomElementDefinition<C>;
   annotate<K extends keyof PartialCustomElementDefinition>(Type: Constructable, prop: K, value: PartialCustomElementDefinition[K]): void;
   getAnnotation<K extends keyof PartialCustomElementDefinition>(Type: Constructable, prop: K): PartialCustomElementDefinition[K];
@@ -182,6 +182,25 @@ export function containerless(target?: Constructable): void | ((target: Construc
 }
 
 /**
+ * Decorator: Indicates that the custom element should be rendered with the template provided.
+ */
+export function template(html: string | Node, dependencies?: PartialCustomElementDefinition['dependencies']) {
+  return function ($target: Constructable) {
+    CustomElement.annotate($target, 'template', html);
+    if (dependencies !== undefined && dependencies.length > 0) {
+      CustomElement.annotate($target, 'dependencies', dependencies);
+    }
+  };
+}
+
+/**
+ * Decorator: Indicates that the custom element should be rendered with the template provided.
+ */
+export function inlineView(html: string | Node, dependencies?: PartialCustomElementDefinition['dependencies']) {
+  return template(html, dependencies);
+}
+
+/**
  * Decorator: Indicates that the custom element should be rendered with the strict binding option. undefined/null -> 0 or '' based on type
  */
 export function strict(target: Constructable): void;
@@ -224,7 +243,11 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly projectionsMap: Map<IInstruction, IProjections>,
     public readonly watches: IWatchDefinition[],
     public readonly processContent: ProcessContentHook | null,
-  ) {}
+  ) {
+
+    console.log(template);
+
+  }
 
   public static create<T extends Constructable = Constructable>(
     def: PartialCustomElementDefinition,
@@ -530,13 +553,13 @@ export const CustomElement: CustomElementKind = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultProto = {} as any;
 
-    return function <P extends {} = {}> (
+    return function <P extends {} = {}>(
       name: string,
       proto: P = defaultProto,
     ): CustomElementType<Constructable<P>> {
       // Anonymous class ensures that minification cannot cause unintended side-effects, and keeps the class
       // looking similarly from the outside (when inspected via debugger, etc).
-      const Type = class {} as CustomElementType<Constructable<P>>;
+      const Type = class { } as CustomElementType<Constructable<P>>;
 
       // Define the name property so that Type.name can be used by end users / plugin authors if they really need to,
       // even when minified.

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -184,7 +184,7 @@ export function containerless(target?: Constructable): void | ((target: Construc
 /**
  * Decorator: Indicates that the custom element should be rendered with the template provided.
  */
-export function template(html: string | Node, dependencies?: PartialCustomElementDefinition['dependencies']) {
+export function template(html: string | Node, ...dependencies: Exclude<PartialCustomElementDefinition['dependencies'], undefined>) {
   return function ($target: Constructable) {
     CustomElement.annotate($target, 'template', html);
     if (dependencies !== undefined && dependencies.length > 0) {
@@ -196,7 +196,7 @@ export function template(html: string | Node, dependencies?: PartialCustomElemen
 /**
  * Decorator: Indicates that the custom element should be rendered with the template provided.
  */
-export function inlineView(html: string | Node, dependencies?: PartialCustomElementDefinition['dependencies']) {
+export function inlineView(html: string | Node, ...dependencies: Exclude<PartialCustomElementDefinition['dependencies'], undefined>) {
   return template(html, dependencies);
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This enables conventions to work with decorators for inlining HTML.  This will also lay some groundwork for having a default inline-view strategy which could be useful for tools like snowpack.

```ts
@template('<div>Inner Test</div>')
class InnerSimple { }

// second arg is a spread so can be used single as well
@template('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
class Simple {
}
```
Or
```ts
@inlineView('<div>Inner Test</div>')
class InnerSimple { }
// second arg is a spread so can be used single as well
@inlineView('<div><inner></inner></div>', [CustomElement.define('inner', InnerSimple)])
class Simple {
}
```

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
