### PR TITLE
fix(template-binder): check if as-element was used

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.ts
@@ -1256,6 +1256,25 @@ describe('au-slot', function () {
         }
       );
     }
+
+    {
+      class MyElement { }
+      yield new TestData(
+        'works with as-element',
+        `<div as-element="my-element"><template au-slot>content</template></div>`,
+        [
+          CustomElement.define(
+            {
+              name: 'my-element',
+              template: `<au-slot>default content</au-slot>`
+            },
+            MyElement),
+        ],
+        {
+          'div': [`content`, undefined],
+        },
+      );
+    }
   }
   for (const { spec, template, expected, registrations, additionalAssertion } of getTestData()) {
     $it(spec,

--- a/packages/runtime-html/src/template-binder.ts
+++ b/packages/runtime-html/src/template-binder.ts
@@ -389,7 +389,7 @@ export class TemplateBinder {
        * This means by the time the template controller in the ancestor is processed, the projection is already registered.
        */
     }
-    const parentName = node.parentNode?.nodeName.toLowerCase();
+    const parentName = node.parentElement?.getAttribute('as-element') ?? node.parentNode?.nodeName.toLowerCase();
     if (hasProjection
       && (manifestRoot === null
         || parentName === void 0


### PR DESCRIPTION
# Pull Request

## 📖 Description

Slotted elements might be used with `as-element` attribute.
The correct parent name allows for the proper usage check.

### 🎫 Issues

#1103 

## 📑 Test Plan

The test makes sure that using `as-element` with slots does not throw.
