### PR TITLE
fix(observer-locator): consider as-element for events config

### DIFF
--- a/packages/__tests__/3-runtime-html/observer-locator.spec.ts
+++ b/packages/__tests__/3-runtime-html/observer-locator.spec.ts
@@ -173,6 +173,7 @@ describe('ObserverLocator', function () {
     { markup: `<div css="color:green;"></div>`, ctor: StyleAttributeAccessor },
     { markup: `<select value=""></select>`, ctor: SelectValueObserver },
     { markup: `<input value=""></input>`, ctor: ValueAttributeObserver },
+    { markup: `<div value="" as-element="input"></div>`, ctor: ValueAttributeObserver },
     { markup: `<input checked="true"></input>`, ctor: CheckedObserver },
     { markup: `<input files=""></input>`, ctor: ValueAttributeObserver },
     { markup: `<textarea value=""></textarea>`, ctor: ValueAttributeObserver },
@@ -209,11 +210,11 @@ describe('ObserverLocator', function () {
                       if (hasAdapterObserver) {
                         if (adapterIsDefined) {
                           sut.addAdapter({getObserver() {
-                            return dummyObserver;
+                              return dummyObserver;
                           }});
                         } else {
                           sut.addAdapter({getObserver() {
-                            return null;
+                              return null;
                           }});
                         }
                       }
@@ -282,11 +283,11 @@ describe('ObserverLocator', function () {
             if (hasAdapterObserver) {
               if (adapterIsDefined) {
                 sut.addAdapter({getObserver() {
-                  return dummyObserver;
+                    return dummyObserver;
                 }});
               } else {
                 sut.addAdapter({getObserver() {
-                  return null;
+                    return null;
                 }});
               }
             }

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -276,7 +276,7 @@ export class NodeObserverLocator implements INodeObserverLocator {
       case 'style':
         return new StyleAttributeAccessor(el);
     }
-    const eventsConfig: NodeObserverConfig | undefined = this.events[el.tagName]?.[key as string] ?? this.globalEvents[key as string];
+    const eventsConfig: NodeObserverConfig | undefined = this.events[el.getAttribute('as-element')?.toUpperCase() ?? el.tagName]?.[key as string] ?? this.globalEvents[key as string];
     if (eventsConfig != null) {
       return new eventsConfig.type(el, key, new EventSubscriber(eventsConfig), requestor, this.locator);
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Consider a custom element with a value observer configured to listen to `change` and `input` events.
When this element is used via `as-element` attribute the correct event value observer is not created.
This fix uses `as-element` value to get the actual node name.

## 👩‍💻 Reviewer Notes

MDC framework requires text fields to be `label` elements. Therefore the only correct usage is 
```html
<label as-element="mdc-text-field" value.bind="value"></label>
```
Without this fix value changes are not passed to bindings.

## 📑 Test Plan
The test makes sure that a legitimate use case is supported.
