### PR TITLE
refactor(all): rename currentValue -> value

### DIFF
--- a/packages/__tests__/2-runtime/binding.spec.ts
+++ b/packages/__tests__/2-runtime/binding.spec.ts
@@ -995,7 +995,7 @@ class MockObserver {
   public propertyKey?: string | number | symbol;
   public oldValue?: any;
   public previousValue?: any;
-  public currentValue: any;
+  public value: any;
   public hasChanges?: boolean;
   public flush = createSpy();
   public getValue = createSpy();

--- a/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
@@ -721,7 +721,7 @@ describe('custom-attributes', function () {
 
         rootVm.prop = 5;
         assert.strictEqual(foo5Vm.prop, 5, '#2 <-> RootVm.prop << 5 -> foo5Vm');
-        assert.strictEqual((foo5Vm as any).$observers.prop.currentValue, 5, '#2 Foo5.$observer.prop.currentValue');
+        assert.strictEqual((foo5Vm as any).$observers.prop.value, 5, '#2 Foo5.$observer.prop.value');
         assert.strictEqual(rootVm.prop, 5, '#2 <-> RootVm.prop << 5 -> rootVm');
         options.platform.domWriteQueue.flush();
         assert.strictEqual(options.appHost.textContent, '5');

--- a/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
@@ -60,13 +60,13 @@ describe('SelectValueObserver', function () {
           option({ text: 'C' })
         ]);
 
-        const currentValue = sut.currentValue as any[];
+        const currentValue = sut.value as any[];
         assert.instanceOf(currentValue, Array);
         assert.strictEqual(currentValue['length'], 0, `currentValue['length']`);
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
         assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
       });
 
@@ -77,12 +77,12 @@ describe('SelectValueObserver', function () {
           option({ text: 'C' })
         ]);
 
-        const currentValue = sut.currentValue as any;
+        const currentValue = sut.value as any;
         assert.strictEqual(currentValue, null, `currentValue`);
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
       });
 
       it('synchronizes with undefined', function () {
@@ -92,12 +92,12 @@ describe('SelectValueObserver', function () {
           option({ text: 'C' })
         ]);
 
-        const currentValue = sut.currentValue as any;
+        const currentValue = sut.value as any;
         assert.strictEqual(currentValue, undefined, `currentValue`);
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
       });
 
       it('synchronizes with array (2)', function () {
@@ -107,11 +107,11 @@ describe('SelectValueObserver', function () {
           option({ text: 'C' })
         ]);
 
-        const currentValue = sut.currentValue as any[];
+        const currentValue = sut.value as any[];
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
         assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
 
         verifyEqual(
@@ -130,11 +130,11 @@ describe('SelectValueObserver', function () {
           option({ text: 'C', value: 'CC' })
         ]);
 
-        const currentValue = sut.currentValue as any[];
+        const currentValue = sut.value as any[];
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
         assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
 
         verifyEqual(
@@ -153,11 +153,11 @@ describe('SelectValueObserver', function () {
           option({ text: 'C', value: 'CC', disabled: true, selected: true })
         ]);
 
-        const currentValue = sut.currentValue as any[];
+        const currentValue = sut.value as any[];
 
         sut.synchronizeValue();
 
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
 
         verifyEqual(
           currentValue,
@@ -177,7 +177,7 @@ describe('SelectValueObserver', function () {
         ]);
 
         let handleChangeCallCount = 0;
-        const currentValue = sut.currentValue as any[];
+        const currentValue = sut.value as any[];
         const noopSubscriber = {
           handleChange() {
             handleChangeCallCount++;
@@ -185,7 +185,7 @@ describe('SelectValueObserver', function () {
         };
 
         sut.synchronizeValue();
-        assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+        assert.strictEqual(currentValue, sut.value, `currentValue`);
         sut.subscribe(noopSubscriber);
 
         sut.obj.add(option({ text: 'DD', value: 'DD', selected: true })(ctx));
@@ -231,11 +231,11 @@ describe('SelectValueObserver', function () {
             option({ text: 'C', value: 'CC' })
           ]);
 
-          const currentValue = sut.currentValue as any[];
+          const currentValue = sut.value as any[];
 
           sut.synchronizeValue();
 
-          assert.strictEqual(currentValue, sut.currentValue, `currentValue`);
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
           assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
 
           verifyEqual(
@@ -258,7 +258,7 @@ describe('SelectValueObserver', function () {
         const el = select(...optionFactories.map(create => create(ctx)))(ctx);
         const sut = observerLocator.getObserver(el, 'value') as SelectValueObserver;
 
-        sut.oldValue = sut.currentValue = initialValue;
+        sut.oldValue = sut.value = initialValue;
         return { ctx, el, sut };
       }
 

--- a/packages/runtime-html/src/observation/attribute-ns-accessor.ts
+++ b/packages/runtime-html/src/observation/attribute-ns-accessor.ts
@@ -14,8 +14,6 @@ export class AttributeNSAccessor implements IAccessor<string | null> {
     return nsMap[ns] ??= new AttributeNSAccessor(ns);
   }
 
-  public currentValue: string | null = null;
-
   // ObserverType.Layout is not always true, it depends on the property
   // but for simplicity, always treat as such
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;

--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -24,7 +24,7 @@ type HasPropertyChangedCallback = Required<IMayHavePropertyChangedCallback>;
 export class BindableObserver implements IFlushable, IWithFlushQueue {
   public get type(): AccessorType { return AccessorType.Observer; }
   // todo: name too long. just value/oldValue, or v/oV
-  public currentValue: unknown = void 0;
+  public value: unknown = void 0;
   public oldValue: unknown = void 0;
 
   public observing: boolean;
@@ -65,13 +65,13 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
       this.observing = true;
 
       const val = obj[propertyKey];
-      this.currentValue = hasSetter && val !== void 0 ? set(val) : val;
+      this.value = hasSetter && val !== void 0 ? set(val) : val;
       this.createGetterSetter();
     }
   }
 
   public getValue(): unknown {
-    return this.currentValue;
+    return this.value;
   }
 
   public setValue(newValue: unknown, flags: LifecycleFlags): void {
@@ -80,11 +80,11 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
     }
 
     if (this.observing) {
-      const currentValue = this.currentValue;
+      const currentValue = this.value;
       if (Object.is(newValue, currentValue)) {
         return;
       }
-      this.currentValue = newValue;
+      this.value = newValue;
       this.oldValue = currentValue;
       this.f = flags;
       // todo: controller (if any) state should determine the invocation instead
@@ -110,7 +110,7 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
     if (!this.observing === false) {
       this.observing = true;
       const currentValue = this.obj[this.propertyKey];
-      this.currentValue = this.hasSetter
+      this.value = this.hasSetter
         ? this.set(currentValue)
         : currentValue;
       this.createGetterSetter();
@@ -121,8 +121,8 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
 
   public flush(): void {
     oV = this.oldValue;
-    this.oldValue = this.currentValue;
-    this.subs.notify(this.currentValue, oV, this.f);
+    this.oldValue = this.value;
+    this.subs.notify(this.value, oV, this.f);
   }
 
   private createGetterSetter(): void {
@@ -132,7 +132,7 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
       {
         enumerable: true,
         configurable: true,
-        get: (/* Bindable Observer */) => this.currentValue,
+        get: (/* Bindable Observer */) => this.value,
         set: (/* Bindable Observer */value: unknown) => {
           this.setValue(value, LifecycleFlags.none);
         }

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -4,7 +4,7 @@ import { AccessorType, LifecycleFlags } from '@aurelia/runtime';
 import type { IAccessor } from '@aurelia/runtime';
 
 export class ClassAttributeAccessor implements IAccessor {
-  public currentValue: unknown = '';
+  public value: unknown = '';
   public oldValue: unknown = '';
 
   public readonly doNotCache: true = true;
@@ -16,18 +16,18 @@ export class ClassAttributeAccessor implements IAccessor {
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;
 
   public constructor(
-    public readonly obj: HTMLElement
+    public readonly obj: HTMLElement,
   ) {
   }
 
   public getValue(): unknown {
     // is it safe to assume the observer has the latest value?
     // todo: ability to turn on/off cache based on type
-    return this.currentValue;
+    return this.value;
   }
 
   public setValue(newValue: unknown, flags: LifecycleFlags): void {
-    this.currentValue = newValue;
+    this.value = newValue;
     this.hasChanges = newValue !== this.oldValue;
     if ((flags & LifecycleFlags.noFlush) === 0) {
       this.flushChanges(flags);
@@ -37,7 +37,7 @@ export class ClassAttributeAccessor implements IAccessor {
   public flushChanges(flags: LifecycleFlags): void {
     if (this.hasChanges) {
       this.hasChanges = false;
-      const currentValue = this.currentValue;
+      const currentValue = this.value;
       const nameIndex = this.nameIndex;
       let version = this.version;
       this.oldValue = currentValue;

--- a/packages/runtime-html/src/observation/data-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/data-attribute-accessor.ts
@@ -12,7 +12,6 @@ import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 export class DataAttributeAccessor implements IAccessor<string | null> {
   public readonly obj!: HTMLElement;
   public readonly propertyKey: string = '';
-  public currentValue: string | null = null;
 
   // ObserverType.Layout is not always true, it depends on the property
   // but for simplicity, always treat as such

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -44,7 +44,7 @@ export interface SelectValueObserver extends
   ISubscriberCollection {}
 
 export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQueue {
-  public currentValue: unknown = void 0;
+  public value: unknown = void 0;
   public oldValue: unknown = void 0;
 
   public readonly obj: ISelectElement;
@@ -74,14 +74,14 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
     // is it safe to assume the observer has the latest value?
     // todo: ability to turn on/off cache based on type
     return this.observing
-      ? this.currentValue
+      ? this.value
       : this.obj.multiple
         ? Array.from(this.obj.options).map(o => o.value)
         : this.obj.value;
   }
 
   public setValue(newValue: unknown, flags: LF): void {
-    this.currentValue = newValue;
+    this.value = newValue;
     this.hasChanges = newValue !== this.oldValue;
     this.observeArray(newValue instanceof Array ? newValue : null);
     if ((flags & LF.noFlush) === 0) {
@@ -103,7 +103,7 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
   }
 
   public synchronizeOptions(indexMap?: IndexMap): void {
-    const { currentValue, obj } = this;
+    const { value: currentValue, obj } = this;
     const isArray = Array.isArray(currentValue);
     const matcher = obj.matcher !== void 0 ? obj.matcher : defaultMatcher;
     const options = obj.options;
@@ -139,7 +139,7 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
     const obj = this.obj;
     const options = obj.options;
     const len = options.length;
-    const currentValue = this.currentValue;
+    const currentValue = this.value;
     let i = 0;
 
     if (obj.multiple) {
@@ -202,9 +202,9 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
       ++i;
     }
     // B.2
-    this.oldValue = this.currentValue;
+    this.oldValue = this.value;
     // B.3
-    this.currentValue = value;
+    this.value = value;
     // B.4
     return true;
   }
@@ -212,7 +212,7 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
   private start(): void {
     (this.nodeObserver = new this.obj.ownerDocument.defaultView!.MutationObserver(this.handleNodeChange.bind(this)))
       .observe(this.obj, childObserverOptions);
-    this.observeArray(this.currentValue instanceof Array ? this.currentValue : null);
+    this.observeArray(this.value instanceof Array ? this.value : null);
     this.observing = true;
   }
 
@@ -268,7 +268,7 @@ export class SelectValueObserver implements IObserver, IFlushable, IWithFlushQue
   }
 
   public flush(): void {
-    this.subs.notify(this.currentValue, this.oldValue, LifecycleFlags.none);
+    this.subs.notify(this.value, this.oldValue, LifecycleFlags.none);
   }
 }
 

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -5,7 +5,7 @@ import type { IAccessor } from '@aurelia/runtime';
 const customPropertyPrefix: string = '--';
 
 export class StyleAttributeAccessor implements IAccessor {
-  public currentValue: unknown = '';
+  public value: unknown = '';
   public oldValue: unknown = '';
 
   public styles: Record<string, number> = {};
@@ -24,7 +24,7 @@ export class StyleAttributeAccessor implements IAccessor {
   }
 
   public setValue(newValue: unknown, flags: LifecycleFlags): void {
-    this.currentValue = newValue;
+    this.value = newValue;
     this.hasChanges = newValue !== this.oldValue;
     if ((flags & LifecycleFlags.noFlush) === 0) {
       this.flushChanges(flags);
@@ -117,7 +117,7 @@ export class StyleAttributeAccessor implements IAccessor {
   public flushChanges(flags: LifecycleFlags): void {
     if (this.hasChanges) {
       this.hasChanges = false;
-      const currentValue = this.currentValue;
+      const currentValue = this.value;
       const styles = this.styles;
       const styleTuples = this.getStyleTuples(currentValue);
 
@@ -166,6 +166,6 @@ export class StyleAttributeAccessor implements IAccessor {
   }
 
   public bind(flags: LifecycleFlags): void {
-    this.currentValue = this.oldValue = this.obj.style.cssText;
+    this.value = this.oldValue = this.obj.style.cssText;
   }
 }

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -22,7 +22,7 @@ export interface SetterObserver extends IAccessor, ISubscriberCollection {}
  * This is used for observing object properties that has no decorator.
  */
 export class SetterObserver implements IWithFlushQueue, IFlushable {
-  public currentValue: unknown = void 0;
+  public value: unknown = void 0;
   public oldValue: unknown = void 0;
 
   public observing: boolean = false;
@@ -39,22 +39,22 @@ export class SetterObserver implements IWithFlushQueue, IFlushable {
   }
 
   public getValue(): unknown {
-    return this.currentValue;
+    return this.value;
   }
 
   public setValue(newValue: unknown, flags: LifecycleFlags): void {
     if (this.observing) {
-      const currentValue = this.currentValue;
-      if (Object.is(newValue, currentValue)) {
+      const value = this.value;
+      if (Object.is(newValue, value)) {
         return;
       }
-      this.currentValue = newValue;
-      this.oldValue = currentValue;
+      this.value = newValue;
+      this.oldValue = value;
       this.f = flags;
       this.queue.add(this);
     } else {
       // If subscribe() has been called, the target property descriptor is replaced by these getter/setter methods,
-      // so calling obj[propertyKey] will actually return this.currentValue.
+      // so calling obj[propertyKey] will actually return this.value.
       // However, if subscribe() was not yet called (indicated by !this.observing), the target descriptor
       // is unmodified and we need to explicitly set the property value.
       // This will happen in one-time, to-view and two-way bindings during $bind, meaning that the $bind will not actually update the target value.
@@ -73,14 +73,14 @@ export class SetterObserver implements IWithFlushQueue, IFlushable {
 
   public flush(): void {
     oV = this.oldValue;
-    this.oldValue = this.currentValue;
-    this.subs.notify(this.currentValue, oV, this.f);
+    this.oldValue = this.value;
+    this.subs.notify(this.value, oV, this.f);
   }
 
   public start(): this {
     if (this.observing === false) {
       this.observing = true;
-      this.currentValue = this.obj[this.propertyKey];
+      this.value = this.obj[this.propertyKey];
       def(
         this.obj,
         this.propertyKey,
@@ -103,7 +103,7 @@ export class SetterObserver implements IWithFlushQueue, IFlushable {
         enumerable: true,
         configurable: true,
         writable: true,
-        value: this.currentValue,
+        value: this.value,
       });
       this.observing = false;
       // todo(bigopon/fred): add .removeAllSubscribers()


### PR DESCRIPTION
# Pull Request

## 📖 Description

Make all the value prop names of observers consistent, and to `value`