### PR TITLE
fix(lifecycle-hooks): properly maintain resources semantic

### DIFF
--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.spec.ts
@@ -1,0 +1,137 @@
+import {
+  CustomElement,
+  ICustomElementViewModel,
+  IHydratedComponentController,
+  LifecycleHooks,
+  LifecycleHooksLookup,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.spec.ts', function () {
+  it('retrieves global hooks at root', async function () {
+    class Hooks {
+      public attaching() {/* empty */}
+    }
+    const { au, startPromise, tearDown } = createFixture(`\${message}`, class App {}, [LifecycleHooks.define({}, Hooks)]);
+    await startPromise;
+
+    const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.strictEqual(hooks.attaching.length, 1);
+
+    await tearDown();
+  });
+
+  it('retrieves global hooks at child', async function () {
+    class Hooks {
+      public attaching() {/* empty */}
+    }
+    const { au, component, startPromise, tearDown } = createFixture(
+      `<el view-model.ref="el">`,
+      class App {
+        public el: ICustomElementViewModel;
+      },
+      [
+        CustomElement.define({
+          name: 'el',
+          dependencies: []
+        }),
+        LifecycleHooks.define({}, Hooks)
+      ],
+    );
+    await startPromise;
+
+    const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.strictEqual(hooks.attaching.length, 1);
+
+    const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.strictEqual(childHooks.attaching.length, 1);
+
+    await tearDown();
+  });
+
+  it('retrieves local hooks at child', async function () {
+    class Hooks {
+      public attaching() {/* empty */}
+    }
+    const { au, component, startPromise, tearDown } = createFixture(
+      `<el view-model.ref="el">`,
+      class App {
+        public el: ICustomElementViewModel;
+      },
+      [
+        CustomElement.define({
+          name: 'el',
+          dependencies: [
+            LifecycleHooks.define({}, Hooks)
+          ]
+        }),
+      ],
+    );
+    await startPromise;
+
+    const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.notStrictEqual(hooks.attaching?.length, 0);
+
+    const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.strictEqual(childHooks.attaching.length, 1);
+
+    await tearDown();
+  });
+
+  it('does not retrieve hooks in the middle layer', async function () {
+    let hooksCall = 0;
+    let differentHooksCall = 0;
+    class Hooks {
+      public attaching() {
+        hooksCall++;
+      }
+    }
+    class DifferentHooks {
+      public attaching() {
+        differentHooksCall++;
+      }
+    }
+    const { au, component, startPromise, tearDown } = createFixture(
+      `<el view-model.ref="el">`,
+      class App {
+        public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
+      },
+      [
+        CustomElement.define({
+          name: 'el',
+          template: '<el-child view-model.ref="elChild">',
+          dependencies: [
+            LifecycleHooks.define({}, Hooks),
+            CustomElement.define({
+              name: 'el-child',
+              dependencies: [
+                LifecycleHooks.define({}, DifferentHooks)
+              ]
+            })
+          ]
+        }),
+      ],
+    );
+    await startPromise;
+
+    const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.notStrictEqual(hooks.attaching?.length, 0);
+
+    const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
+    assert.strictEqual(childHooks.attaching.length, 1);
+
+    const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
+    assert.strictEqual(grandChildHooks.attaching.length, 1);
+
+    assert.strictEqual(hooksCall, 0);
+    assert.strictEqual(differentHooksCall, 0);
+
+    childHooks.attaching.forEach(x => x.instance.attaching(null!));
+    grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
+
+    assert.strictEqual(hooksCall, 1);
+    assert.strictEqual(differentHooksCall, 1);
+
+    await tearDown();
+  });
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.spec.ts
@@ -2,6 +2,7 @@ import {
   CustomElement,
   ICustomElementViewModel,
   IHydratedComponentController,
+  lifecycleHooks,
   LifecycleHooks,
   LifecycleHooksLookup,
 } from '@aurelia/runtime-html';
@@ -10,9 +11,9 @@ import { assert, createFixture } from '@aurelia/testing';
 describe('3-runtime-html/lifecycle-hooks.spec.ts', function () {
   it('retrieves global hooks at root', async function () {
     class Hooks {
-      public attaching() {/* empty */}
+      public attaching() {/* empty */ }
     }
-    const { au, startPromise, tearDown } = createFixture(`\${message}`, class App {}, [LifecycleHooks.define({}, Hooks)]);
+    const { au, startPromise, tearDown } = createFixture(`\${message}`, class App { }, [LifecycleHooks.define({}, Hooks)]);
     await startPromise;
 
     const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
@@ -23,7 +24,7 @@ describe('3-runtime-html/lifecycle-hooks.spec.ts', function () {
 
   it('retrieves global hooks at child', async function () {
     class Hooks {
-      public attaching() {/* empty */}
+      public attaching() {/* empty */ }
     }
     const { au, component, startPromise, tearDown } = createFixture(
       `<el view-model.ref="el">`,
@@ -51,7 +52,7 @@ describe('3-runtime-html/lifecycle-hooks.spec.ts', function () {
 
   it('retrieves local hooks at child', async function () {
     class Hooks {
-      public attaching() {/* empty */}
+      public attaching() {/* empty */ }
     }
     const { au, component, startPromise, tearDown } = createFixture(
       `<el view-model.ref="el">`,
@@ -78,60 +79,156 @@ describe('3-runtime-html/lifecycle-hooks.spec.ts', function () {
     await tearDown();
   });
 
-  it('does not retrieve hooks in the middle layer', async function () {
-    let hooksCall = 0;
-    let differentHooksCall = 0;
-    class Hooks {
-      public attaching() {
-        hooksCall++;
+  describe('<App/> -> <Child/> -> <Grand Child/>', function () {
+    it('does not retrieve hooks in the middle layer', async function () {
+      let hooksCall = 0;
+      let differentHooksCall = 0;
+      class Hooks {
+        public attaching() {
+          hooksCall++;
+        }
       }
-    }
-    class DifferentHooks {
-      public attaching() {
-        differentHooksCall++;
+      class Hooks2 {
+        public attaching() {
+          hooksCall++;
+        }
       }
-    }
-    const { au, component, startPromise, tearDown } = createFixture(
-      `<el view-model.ref="el">`,
-      class App {
-        public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
-      },
-      [
-        CustomElement.define({
-          name: 'el',
-          template: '<el-child view-model.ref="elChild">',
-          dependencies: [
-            LifecycleHooks.define({}, Hooks),
-            CustomElement.define({
-              name: 'el-child',
-              dependencies: [
-                LifecycleHooks.define({}, DifferentHooks)
-              ]
-            })
-          ]
-        }),
-      ],
-    );
-    await startPromise;
+      class DifferentHooks {
+        public attaching() {
+          differentHooksCall++;
+        }
+      }
+      class DifferentHooks2 {
+        public attaching() {
+          differentHooksCall++;
+        }
+      }
+      const { au, component, startPromise, tearDown } = createFixture(
+        `<el view-model.ref="el">`,
+        class App {
+          public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
+        },
+        [
+          CustomElement.define({
+            name: 'el',
+            template: '<el-child view-model.ref="elChild">',
+            dependencies: [
+              LifecycleHooks.define({}, Hooks),
+              LifecycleHooks.define({}, Hooks2),
+              CustomElement.define({
+                name: 'el-child',
+                dependencies: [
+                  LifecycleHooks.define({}, DifferentHooks),
+                  LifecycleHooks.define({}, DifferentHooks2)
+                ]
+              })
+            ]
+          }),
+        ],
+      );
+      await startPromise;
 
-    const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
-    assert.notStrictEqual(hooks.attaching?.length, 0);
+      const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+      assert.notStrictEqual(hooks.attaching?.length, 0);
 
-    const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
-    assert.strictEqual(childHooks.attaching.length, 1);
+      const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
+      assert.strictEqual(childHooks.attaching.length, 2);
 
-    const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
-    assert.strictEqual(grandChildHooks.attaching.length, 1);
+      const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
+      assert.strictEqual(grandChildHooks.attaching.length, 2);
 
-    assert.strictEqual(hooksCall, 0);
-    assert.strictEqual(differentHooksCall, 0);
+      assert.strictEqual(hooksCall, 0);
+      assert.strictEqual(differentHooksCall, 0);
 
-    childHooks.attaching.forEach(x => x.instance.attaching(null!));
-    grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
+      childHooks.attaching.forEach(x => x.instance.attaching(null!));
+      grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
 
-    assert.strictEqual(hooksCall, 1);
-    assert.strictEqual(differentHooksCall, 1);
+      assert.strictEqual(hooksCall, 2);
+      assert.strictEqual(differentHooksCall, 2);
 
-    await tearDown();
+      await tearDown();
+    });
+
+    it('retrieves the same hooks Type twice as declaration', async function () {
+      let hooksCall = 0;
+      let differentHooksCall = 0;
+
+      @lifecycleHooks()
+      class Hooks {
+        public attaching() {
+          hooksCall++;
+        }
+      }
+
+      @lifecycleHooks()
+      class Hooks2 {
+        public attaching() {
+          hooksCall++;
+        }
+      }
+
+      @lifecycleHooks()
+      class DifferentHooks {
+        public attaching() {
+          differentHooksCall++;
+        }
+      }
+
+      @lifecycleHooks()
+      class DifferentHooks2 {
+        public attaching() {
+          differentHooksCall++;
+        }
+      }
+
+      const { au, component, startPromise, tearDown } = createFixture(
+        `<el view-model.ref="el">`,
+        class App {
+          public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
+        },
+        [
+          CustomElement.define({
+            name: 'el',
+            template: '<el-child view-model.ref="elChild">',
+            dependencies: [
+              Hooks,
+              Hooks2,
+              Hooks,
+              Hooks2,
+              CustomElement.define({
+                name: 'el-child',
+                dependencies: [
+                  DifferentHooks,
+                  DifferentHooks2,
+                  DifferentHooks,
+                  DifferentHooks2,
+                ]
+              })
+            ]
+          }),
+        ],
+      );
+      await startPromise;
+
+      const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
+      assert.notStrictEqual(hooks.attaching?.length, 0);
+
+      const childHooks = component.el.$controller!.lifecycleHooks as LifecycleHooksLookup<Hooks>;
+      assert.strictEqual(childHooks.attaching.length, 4);
+
+      const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
+      assert.strictEqual(grandChildHooks.attaching.length, 4);
+
+      assert.strictEqual(hooksCall, 0);
+      assert.strictEqual(differentHooksCall, 0);
+
+      childHooks.attaching.forEach(x => x.instance.attaching(null!));
+      grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
+
+      assert.strictEqual(hooksCall, 4);
+      assert.strictEqual(differentHooksCall, 4);
+
+      await tearDown();
+    });
   });
 });

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -19,13 +19,14 @@ import {
   LifecycleFlags,
   IObserverLocator,
   IExpressionParser,
+  IsBindingBehavior,
 } from '@aurelia/runtime';
 import { BindableObserver } from '../observation/bindable-observer.js';
 import { convertToRenderLocation, INode, INodeSequence, IRenderLocation, setRef } from '../dom.js';
 import { CustomElementDefinition, CustomElement, PartialCustomElementDefinition } from '../resources/custom-element.js';
 import { CustomAttributeDefinition, CustomAttribute } from '../resources/custom-attribute.js';
 import { IRenderContext, getRenderContext, RenderContext, ICompiledRenderContext } from './render-context.js';
-import { ChildrenObserver } from './children.js';
+import { ChildrenDefinition, ChildrenObserver } from './children.js';
 import { IAppRoot } from '../app-root.js';
 import { IPlatform } from '../platform.js';
 import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles.js';
@@ -1055,9 +1056,10 @@ function createObservers(
   if (length > 0) {
     let name: string;
     let bindable: BindableDefinition;
+    let i = 0;
     const observers = getLookup(instance as IIndexable);
 
-    for (let i = 0; i < length; ++i) {
+    for (; i < length; ++i) {
       name = observableNames[i];
 
       if (observers[name] === void 0) {
@@ -1089,11 +1091,13 @@ function createChildrenObservers(
     const observers = getLookup(instance as IIndexable);
 
     let name: string;
-    for (let i = 0; i < length; ++i) {
+    let i = 0;
+    let childrenDescription: ChildrenDefinition;
+    for (; i < length; ++i) {
       name = childObserverNames[i];
 
       if (observers[name] == void 0) {
-        const childrenDescription = childrenObservers[name];
+        childrenDescription = childrenObservers[name];
         observers[name] = new ChildrenObserver(
           controller as ICustomElementController,
           instance as IIndexable,
@@ -1130,10 +1134,13 @@ function createWatchers(
   const observerLocator = context!.get(IObserverLocator);
   const expressionParser = context.get(IExpressionParser);
   const watches = definition.watches;
+  const ii = watches.length;
   let expression: IWatchDefinition['expression'];
   let callback: IWatchDefinition['callback'];
+  let ast: IsBindingBehavior;
+  let i = 0;
 
-  for (let i = 0, ii = watches.length; ii > i; ++i) {
+  for (; ii > i; ++i) {
     ({ expression, callback } = watches[i]);
     callback = typeof callback === 'function'
       ? callback
@@ -1152,7 +1159,7 @@ function createWatchers(
         true,
       ));
     } else {
-      const ast = typeof expression === 'string'
+      ast = typeof expression === 'string'
         ? expressionParser.parse(expression, BindingType.BindCommand)
         : AccessScopeAst.for(expression);
 

--- a/packages/runtime-html/src/templating/render-context.ts
+++ b/packages/runtime-html/src/templating/render-context.ts
@@ -261,12 +261,13 @@ export class RenderContext implements IComponentFactory {
     const container = this.container = parentContainer.createChild();
     // TODO(fkleuver): get contextual + root renderers
     const renderers = container.getAll(IRenderer);
-    for (let i = 0; i < renderers.length; ++i) {
-      const renderer = renderers[i];
+    let i = 0;
+    let renderer: IRenderer;
+    for (; i < renderers.length; ++i) {
+      renderer = renderers[i];
       this.renderers[renderer.instructionType as string] = renderer;
     }
     this.projectionProvider = container.get(IProjectionProvider);
-    const p = this.platform = container.get(IPlatform);
 
     container.registerResolver(
       IViewFactory,
@@ -293,6 +294,7 @@ export class RenderContext implements IComponentFactory {
       this.auSlotsInfoProvider = new InstanceProvider<IAuSlotsInfo>('IAuSlotsInfo'),
       true,
     );
+    const p = this.platform = container.get(IPlatform);
     const ep = this.elementProvider = new InstanceProvider('ElementResolver');
     container.registerResolver(INode, ep);
     container.registerResolver(p.Node, ep);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently the hooks are resolved twice if it's not from root. Fix this, also ensure that resources semantic is maintain by checking if there's a resolver first.

## Misc

Tweak some code so that it's friendlier for minification