### PR TITLE
Fix(select-observer): ensure value fresh when notify

### DIFF
--- a/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/select-value-observer.spec.ts
@@ -1,239 +1,116 @@
 import { LifecycleFlags as LF, LifecycleFlags, SelectValueObserver } from '@aurelia/runtime-html';
-import { h, TestContext, verifyEqual, assert } from '@aurelia/testing';
+import { h, TestContext, verifyEqual, assert, createFixture } from '@aurelia/testing';
 
 type Anything = any;
 
 // TODO: need many more tests here, this is just preliminary
-describe('SelectValueObserver', function () {
-  function createFixture(initialValue: Anything = '', options = [], multiple = false) {
-    const ctx = TestContext.create();
-    const { platform, observerLocator } = ctx;
+describe('3-runtime-html/select-value-observer.spec.ts', function () {
+  describe('[UNIT]', function () {
+    function createFixture(initialValue: Anything = '', options = [], multiple = false) {
+      const ctx = TestContext.create();
+      const { platform, observerLocator } = ctx;
 
-    const optionElements = options.map(o => `<option value="${o}">${o}</option>`).join('\n');
-    const markup = `<select ${multiple ? 'multiple' : ''}>\n${optionElements}\n</select>`;
-    const el = ctx.createElementFromMarkup(markup) as HTMLSelectElement;
-    const sut = observerLocator.getObserver(el, 'value') as SelectValueObserver;
-    sut.setValue(initialValue, LF.fromBind);
+      const optionElements = options.map(o => `<option value="${o}">${o}</option>`).join('\n');
+      const markup = `<select ${multiple ? 'multiple' : ''}>\n${optionElements}\n</select>`;
+      const el = ctx.createElementFromMarkup(markup) as HTMLSelectElement;
+      const sut = observerLocator.getObserver(el, 'value') as SelectValueObserver;
+      sut.setValue(initialValue, LF.fromBind);
 
-    return { ctx, el, sut, platform };
-  }
+      return { ctx, el, sut, platform };
+    }
 
-  describe('setValue()', function () {
-    const valuesArr = [['', 'foo', 'bar']];
-    const initialArr = ['', 'foo', 'bar'];
-    const nextArr = ['', 'foo', 'bar'];
-    for (const values of valuesArr) {
-      for (const initial of initialArr) {
-        for (const next of nextArr) {
-          it(`sets 'value' from "${initial}" to "${next}"`, function () {
-            const { el, sut } = createFixture(initial, values);
+    describe('setValue()', function () {
+      const valuesArr = [['', 'foo', 'bar']];
+      const initialArr = ['', 'foo', 'bar'];
+      const nextArr = ['', 'foo', 'bar'];
+      for (const values of valuesArr) {
+        for (const initial of initialArr) {
+          for (const next of nextArr) {
+            it(`sets 'value' from "${initial}" to "${next}"`, function () {
+              const { el, sut } = createFixture(initial, values);
 
-            assert.strictEqual(el.value, initial, `el.value`);
+              assert.strictEqual(el.value, initial, `el.value`);
 
-            sut.setValue(next, LifecycleFlags.none);
+              sut.setValue(next, LifecycleFlags.none);
 
-            assert.strictEqual(el.value, next, `el.value`);
-          });
+              assert.strictEqual(el.value, next, `el.value`);
+            });
+          }
         }
       }
-    }
-  });
+    });
 
-  describe('synchronizeOptions', function () {
-    return;
-  });
-
-  describe('synchronizeValue()', function () {
-    describe('<select />', function () {
+    describe('synchronizeOptions', function () {
       return;
     });
-    // There is subtle difference in behavior of synchronization for SelectObserver
-    // When synchronzing value without synchronizing Options prior
-    // the behavior is different, as such, if currentValue is an array
-    //    1. With synchronizeOptions: source => target => source. Or selected <option/> are based on value array
-    //    2. Without synchronizeOptions: target => source. Or selected values are based on selected <option/>
-    describe('<select multiple="true" />', function () {
-      it('synchronizes with array', function () {
-        const { sut } = createMutiSelectSut([], [
-          option({ text: 'A', selected: true }),
-          option({ text: 'B', selected: true }),
-          option({ text: 'C' })
-        ]);
 
-        const currentValue = sut.value as any[];
-        assert.instanceOf(currentValue, Array);
-        assert.strictEqual(currentValue['length'], 0, `currentValue['length']`);
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-        assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
+    describe('synchronizeValue()', function () {
+      describe('<select />', function () {
+        return;
       });
-
-      it('synchronizes with null', function () {
-        const { sut } = createMutiSelectSut(null, [
-          option({ text: 'A', selected: true }),
-          option({ text: 'B', selected: true }),
-          option({ text: 'C' })
-        ]);
-
-        const currentValue = sut.value as any;
-        assert.strictEqual(currentValue, null, `currentValue`);
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-      });
-
-      it('synchronizes with undefined', function () {
-        const { sut } = createMutiSelectSut(undefined, [
-          option({ text: 'A', selected: true }),
-          option({ text: 'B', selected: true }),
-          option({ text: 'C' })
-        ]);
-
-        const currentValue = sut.value as any;
-        assert.strictEqual(currentValue, undefined, `currentValue`);
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-      });
-
-      it('synchronizes with array (2)', function () {
-        const { sut } = createMutiSelectSut([], [
-          option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
-          option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
-          option({ text: 'C' })
-        ]);
-
-        const currentValue = sut.value as any[];
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-        assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
-
-        verifyEqual(
-          currentValue,
-          [
-            { id: 1, name: 'select 1' },
-            { id: 2, name: 'select 2' }
-          ]
-        );
-      });
-
-      it('synchronizes with array (3): disregard "value" when there is model', function () {
-        const { sut } = createMutiSelectSut([], [
-          option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
-          option({ text: 'B', value: 'BB', _model: { id: 2, name: 'select 2' }, selected: true }),
-          option({ text: 'C', value: 'CC' })
-        ]);
-
-        const currentValue = sut.value as any[];
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-        assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
-
-        verifyEqual(
-          currentValue,
-          [
-            { id: 1, name: 'select 1' },
-            { id: 2, name: 'select 2' }
-          ]
-        );
-      });
-
-      it('synchronize regardless disabled state of <option/>', function () {
-        const { sut } = createMutiSelectSut([], [
-          option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
-          option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
-          option({ text: 'C', value: 'CC', disabled: true, selected: true })
-        ]);
-
-        const currentValue = sut.value as any[];
-
-        sut.synchronizeValue();
-
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-
-        verifyEqual(
-          currentValue,
-          [
-            { id: 1, name: 'select 1' },
-            { id: 2, name: 'select 2' },
-            'CC'
-          ]
-        );
-      });
-
-      it('syncs array & <option/> mutation (from repeat etc...)', async function () {
-        const { sut, ctx } = createMutiSelectSut([], [
-          option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
-          option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
-          option({ text: 'C', value: 'CC', disabled: true, selected: true })
-        ]);
-
-        let handleChangeCallCount = 0;
-        const currentValue = sut.value as any[];
-        const noopSubscriber = {
-          handleChange() {
-            handleChangeCallCount++;
-          },
-        };
-
-        sut.synchronizeValue();
-        assert.strictEqual(currentValue, sut.value, `currentValue`);
-        sut.subscribe(noopSubscriber);
-
-        sut.obj.add(option({ text: 'DD', value: 'DD', selected: true })(ctx));
-        await Promise.resolve();
-
-        assert.strictEqual(handleChangeCallCount, 0);
-        assert.strictEqual(sut.obj.options[3].value, 'DD');
-        assert.strictEqual(sut.obj.options[3].selected, false);
-        assert.deepStrictEqual(
-          currentValue,
-          [
-            { id: 1, name: 'select 1' },
-            { id: 2, name: 'select 2' },
-            'CC',
-          ]
-        );
-
-        currentValue.push('DD');
-        assert.strictEqual(handleChangeCallCount, 0);
-        assert.strictEqual(sut.obj.options[3].value, 'DD');
-        assert.strictEqual(sut.obj.options[3].selected, true);
-        assert.deepStrictEqual(
-          currentValue,
-          [
-            { id: 1, name: 'select 1' },
-            { id: 2, name: 'select 2' },
-            'CC',
-            'DD'
-          ]
-        );
-
-        sut.unsubscribe(noopSubscriber);
-      });
-
-      describe('with <optgroup>', function () {
+      // There is subtle difference in behavior of synchronization for SelectObserver
+      // When synchronzing value without synchronizing Options prior
+      // the behavior is different, as such, if currentValue is an array
+      //    1. With synchronizeOptions: source => target => source. Or selected <option/> are based on value array
+      //    2. Without synchronizeOptions: target => source. Or selected values are based on selected <option/>
+      describe('<select multiple="true" />', function () {
         it('synchronizes with array', function () {
           const { sut } = createMutiSelectSut([], [
-            optgroup(
-              {},
-              option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
-              option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
-            ),
-            option({ text: 'C', value: 'CC' })
+            option({ text: 'A', selected: true }),
+            option({ text: 'B', selected: true }),
+            option({ text: 'C' })
+          ]);
+
+          const currentValue = sut.value as any[];
+          assert.instanceOf(currentValue, Array);
+          assert.strictEqual(currentValue['length'], 0, `currentValue['length']`);
+
+          sut.syncValue();
+
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+          assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
+        });
+
+        it('synchronizes with null', function () {
+          const { sut } = createMutiSelectSut(null, [
+            option({ text: 'A', selected: true }),
+            option({ text: 'B', selected: true }),
+            option({ text: 'C' })
+          ]);
+
+          const currentValue = sut.value as any;
+          assert.strictEqual(currentValue, null, `currentValue`);
+
+          sut.syncValue();
+
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+        });
+
+        it('synchronizes with undefined', function () {
+          const { sut } = createMutiSelectSut(undefined, [
+            option({ text: 'A', selected: true }),
+            option({ text: 'B', selected: true }),
+            option({ text: 'C' })
+          ]);
+
+          const currentValue = sut.value as any;
+          assert.strictEqual(currentValue, undefined, `currentValue`);
+
+          sut.syncValue();
+
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+        });
+
+        it('synchronizes with array (2)', function () {
+          const { sut } = createMutiSelectSut([], [
+            option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
+            option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
+            option({ text: 'C' })
           ]);
 
           const currentValue = sut.value as any[];
 
-          sut.synchronizeValue();
+          sut.syncValue();
 
           assert.strictEqual(currentValue, sut.value, `currentValue`);
           assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
@@ -247,42 +124,207 @@ describe('SelectValueObserver', function () {
           );
         });
 
-      });
+        it('synchronizes with array (3): disregard "value" when there is model', function () {
+          const { sut } = createMutiSelectSut([], [
+            option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
+            option({ text: 'B', value: 'BB', _model: { id: 2, name: 'select 2' }, selected: true }),
+            option({ text: 'C', value: 'CC' })
+          ]);
 
-      type SelectValidChild = HTMLOptionElement | HTMLOptGroupElement;
+          const currentValue = sut.value as any[];
 
-      function createMutiSelectSut(initialValue: Anything[], optionFactories: ((ctx: TestContext) => SelectValidChild)[]) {
-        const ctx = TestContext.create();
-        const { observerLocator } = ctx;
+          sut.syncValue();
 
-        const el = select(...optionFactories.map(create => create(ctx)))(ctx);
-        const sut = observerLocator.getObserver(el, 'value') as SelectValueObserver;
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+          assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
 
-        sut.oldValue = sut.value = initialValue;
-        return { ctx, el, sut };
-      }
-
-      function select(...options: SelectValidChild[]): (ctx: TestContext) => HTMLSelectElement {
-        return function (ctx: TestContext) {
-          return h(
-            'select',
-            { multiple: true },
-            ...options
+          verifyEqual(
+            currentValue,
+            [
+              { id: 1, name: 'select 1' },
+              { id: 2, name: 'select 2' }
+            ]
           );
-        };
-      }
+        });
+
+        it('synchronize regardless disabled state of <option/>', function () {
+          const { sut } = createMutiSelectSut([], [
+            option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
+            option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
+            option({ text: 'C', value: 'CC', disabled: true, selected: true })
+          ]);
+
+          const currentValue = sut.value as any[];
+
+          sut.syncValue();
+
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+
+          verifyEqual(
+            currentValue,
+            [
+              { id: 1, name: 'select 1' },
+              { id: 2, name: 'select 2' },
+              'CC'
+            ]
+          );
+        });
+
+        it('syncs array & <option/> mutation (from repeat etc...)', async function () {
+          const { sut, ctx } = createMutiSelectSut([], [
+            option({ text: 'A', value: 'AA', _model: { id: 1, name: 'select 1' }, selected: true }),
+            option({ text: 'B', value: 'BB', disabled: true, _model: { id: 2, name: 'select 2' }, selected: true }),
+            option({ text: 'C', value: 'CC', disabled: true, selected: true })
+          ]);
+
+          let handleChangeCallCount = 0;
+          const currentValue = sut.value as any[];
+          const noopSubscriber = {
+            handleChange() {
+              handleChangeCallCount++;
+            },
+          };
+
+          sut.syncValue();
+          assert.strictEqual(currentValue, sut.value, `currentValue`);
+          sut.subscribe(noopSubscriber);
+
+          sut.obj.add(option({ text: 'DD', value: 'DD', selected: true })(ctx));
+          await Promise.resolve();
+
+          assert.strictEqual(handleChangeCallCount, 0);
+          assert.strictEqual(sut.obj.options[3].value, 'DD');
+          assert.strictEqual(sut.obj.options[3].selected, false);
+          assert.deepStrictEqual(
+            currentValue,
+            [
+              { id: 1, name: 'select 1' },
+              { id: 2, name: 'select 2' },
+              'CC',
+            ]
+          );
+
+          currentValue.push('DD');
+          assert.strictEqual(handleChangeCallCount, 0);
+          assert.strictEqual(sut.obj.options[3].value, 'DD');
+          assert.strictEqual(sut.obj.options[3].selected, true);
+          assert.deepStrictEqual(
+            currentValue,
+            [
+              { id: 1, name: 'select 1' },
+              { id: 2, name: 'select 2' },
+              'CC',
+              'DD'
+            ]
+          );
+
+          sut.unsubscribe(noopSubscriber);
+        });
+
+        describe('with <optgroup>', function () {
+          it('synchronizes with array', function () {
+            const { sut } = createMutiSelectSut([], [
+              optgroup(
+                {},
+                option({ text: 'A', _model: { id: 1, name: 'select 1' }, selected: true }),
+                option({ text: 'B', _model: { id: 2, name: 'select 2' }, selected: true }),
+              ),
+              option({ text: 'C', value: 'CC' })
+            ]);
+
+            const currentValue = sut.value as any[];
+
+            sut.syncValue();
+
+            assert.strictEqual(currentValue, sut.value, `currentValue`);
+            assert.strictEqual(currentValue['length'], 2, `currentValue['length']`);
+
+            verifyEqual(
+              currentValue,
+              [
+                { id: 1, name: 'select 1' },
+                { id: 2, name: 'select 2' }
+              ]
+            );
+          });
+
+        });
+
+        type SelectValidChild = HTMLOptionElement | HTMLOptGroupElement;
+
+        function createMutiSelectSut(initialValue: Anything[], optionFactories: ((ctx: TestContext) => SelectValidChild)[]) {
+          const ctx = TestContext.create();
+          const { observerLocator } = ctx;
+
+          const el = select(...optionFactories.map(create => create(ctx)))(ctx);
+          const sut = observerLocator.getObserver(el, 'value') as SelectValueObserver;
+
+          sut.oldValue = sut.value = initialValue;
+          return { ctx, el, sut };
+        }
+
+        function select(...options: SelectValidChild[]): (ctx: TestContext) => HTMLSelectElement {
+          return function (ctx: TestContext) {
+            return h(
+              'select',
+              { multiple: true },
+              ...options
+            );
+          };
+        }
+      });
     });
+
+    function option(attributes: Record<string, any>) {
+      return function (ctx: TestContext) {
+        return h('option', attributes);
+      };
+    }
+
+    function optgroup(attributes: Record<string, any>, ...optionFactories: ((ctx: TestContext) => HTMLOptionElement)[]) {
+      return function (ctx: TestContext) {
+        return h('optgroup', attributes, ...optionFactories.map(create => create(ctx)));
+      };
+    }
   });
 
-  function option(attributes: Record<string, any>) {
-    return function (ctx: TestContext) {
-      return h('option', attributes);
-    };
-  }
+  it('handles source change', async function () {
+    const { ctx, startPromise, component, tearDown } = createFixture(
+      `<h3>Select Product</h3>
+      <select value.bind="selectedProductId" ref="selectEl">
+        <option model.bind="null">Choose...</option>
+        <option repeat.for="product of products" model.bind="product.id">
+            \${product.id} - \${product.name}
+        </option>
+      </select>
 
-  function optgroup(attributes: Record<string, any>, ...optionFactories: ((ctx: TestContext) => HTMLOptionElement)[]) {
-    return function (ctx: TestContext) {
-      return h('optgroup', attributes, ...optionFactories.map(create => create(ctx)));
-    };
-  }
+      <h3>Data</h3>
+      Selected product ID: \${selectedProductId}
+      <button click.trigger="clear()">clear</button>`,
+      class App {
+        public selectEl: HTMLSelectElement;
+        public products = [
+          { id: 0, name: "Motherboard" },
+          { id: 1, name: "CPU" },
+          { id: 2, name: "Memory" }
+        ];
+        public selectedProductId = null;
+        public clear() {
+          this.selectedProductId = null;
+        }
+      }
+    );
+    await startPromise;
+
+    component.selectEl.selectedIndex = 2;
+    component.selectEl.dispatchEvent(new ctx.CustomEvent('change'));
+    assert.strictEqual(component.selectedProductId, 1);
+
+    component.clear();
+    assert.strictEqual(component.selectEl.selectedIndex, 2);
+    ctx.platform.domWriteQueue.flush();
+    assert.strictEqual(component.selectEl.selectedIndex, 0);
+
+    await tearDown();
+  });
 });

--- a/test/benchmarking-apps/storage/package.json
+++ b/test/benchmarking-apps/storage/package.json
@@ -7,7 +7,7 @@
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
   "scripts": {
-    "build": "tsc -b; tsc -b ./tsconfig.cjs.json",
+    "build": "tsc -b && tsc -b ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/test/benchmarking-apps/test-result/package.json
+++ b/test/benchmarking-apps/test-result/package.json
@@ -7,7 +7,7 @@
   "module": "dist/esm/index.js",
   "typings": "dist/types/index.d.ts",
   "scripts": {
-    "build": "tsc -b; tsc -b ./tsconfig.cjs.json",
+    "build": "tsc -b && tsc -b ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, when calling `.notify()`, `oldValue` prop of the select observer is not refreshed so future notification may not work properly because changes are not detected. Fix this & also try to fix the build on local for https://discourse.aurelia.io/t/unable-to-build-au2-on-windows/4156/

### 🎫 Issues
For the following template & view model:
```html
<h3>Select Product</h3>
<select value.bind="selectedProductId">
  <option model.bind="null">Choose...</option>
  <option repeat.for="product of products" model.bind="product.id">
      \${product.id} - \${product.name}
  </option>
</select>

<h3>Data</h3>
Selected product ID: \${selectedProductId}
<button click.trigger="clear()">clear</button>
```
```ts
class App {
  products = [
    { id: 0, name: "Motherboard" },
    { id: 1, name: "CPU" },
    { id: 2, name: "Memory" }
  ];
  selectedProductId = null;
  clear() {
    this.selectedProductId = null;
  }
}
```

After selecting a product, clicking the clear button should change the select value to `Choose ...`, but it's not.