### PR TITLE
refactor: ease multiple metadata polyfill strictness

### DIFF
--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -1,6 +1,6 @@
 import { Metadata, isObject, applyMetadataPolyfill } from '@aurelia/metadata';
 
-applyMetadataPolyfill(Reflect);
+applyMetadataPolyfill(Reflect, false, false);
 
 import { isArrayIndex, isNativeFunction } from './functions.js';
 import { Class, Constructable, IDisposable } from './interfaces.js';


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, metadata polyfill application strict, but it probably can be eased. This is to support HMR, storybook and similar scenarios where the bundle will be loaded again and again.
