### PR TITLE
refactor(app-task): simplify usage, align with .createInterface

### DIFF
--- a/docs/user-docs/advanced-scenarios/write-custom-plugin.md
+++ b/docs/user-docs/advanced-scenarios/write-custom-plugin.md
@@ -182,7 +182,7 @@ import { AppTask, DI, Registration } from 'aurelia';
 
 function configure(container: IContainer, config: IBootstrapV5Options = defaultOptions) {
     return container.register(
-        AppTask.with(IContainer).hydrating().call(async cfg => {
+        AppTask.hydrating(IContainer, async container => {
             if (config.enableSpecificOption) {
                 const file = await import('file');
                 cfg.register(Registration.instance(ISpecificOption, file.do());

--- a/docs/user-docs/app-basics/extending-templating-syntax.md
+++ b/docs/user-docs/app-basics/extending-templating-syntax.md
@@ -125,7 +125,7 @@ import { inject, IContainer, IAttrSyntaxTransformer, INodeObserverLocator, AppTa
 
 Aurelia
   .register(
-    AppTask.with(IContainer).beforeCreate().call(container => {
+    AppTask.beforeCreate(IContainer, container => {
       const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
       const nodeObserverLocator = container.get(INodeObserverLocator);
       attrSyntaxTransformer.useTwoWay((el, property) => {

--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -9,7 +9,7 @@ The following is a code example of how to teach Aurelia to work seamlessly with 
 ```typescript
 import { AppTask, IContainer, IAttrSyntaxTransformer, NodeObserverLocator } from 'aurelia';
 
-Aurelia.register(AppTask.with(IContainer).beforeCreate().call(container => {
+Aurelia.register(AppTask.beforeCreate(IContainer, container => {
   const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
   const nodeObserverLocator = container.get(NodeObserverLocator);
   attrSyntaxTransformer.useTwoWay((el, property) => {

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -15,7 +15,7 @@ describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
         public option = '1';
       },
       [
-        AppTask.with(IContainer).beforeCreate().call(container => {
+        AppTask.beforeCreate(IContainer, container => {
           const platform = container.get(IPlatform) as BrowserPlatform;
           platform.window.customElements.define(elName, class MyElement extends platform.window.HTMLElement {
 

--- a/packages/__tests__/router/_shared/configuration.ts
+++ b/packages/__tests__/router/_shared/configuration.ts
@@ -19,7 +19,7 @@ export const TestRouterConfiguration = {
         container.register(
           Registration.instance(IHistory, mockBrowserHistoryLocation),
           Registration.instance(ILocation, mockBrowserHistoryLocation),
-          AppTask.with(IRouter).hydrating().call(router => {
+          AppTask.hydrating(IRouter, router => {
             mockBrowserHistoryLocation.changeCallback = router['handlePopstate'];
           }),
         );

--- a/packages/i18n/src/configuration.ts
+++ b/packages/i18n/src/configuration.ts
@@ -70,7 +70,7 @@ function coreComponents(options: I18nConfigurationOptions) {
     register(container: IContainer) {
       return container.register(
         Registration.callback(I18nInitOptions, () => options.initOptions),
-        AppTask.with(I18N).beforeActivate().call(i18n => i18n.initPromise),
+        AppTask.beforeActivate(I18N, i18n => i18n.initPromise),
         Registration.singleton(I18nWrapper, I18nextWrapper),
         Registration.singleton(I18N, I18nService),
 

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -42,8 +42,8 @@ export const DefaultResources: IRegistry[] = [
 export type RouterConfig = IRouterOptions | ((router: IRouter) => ReturnType<IRouter['start']>);
 function configure(container: IContainer, config?: RouterConfig): IContainer {
   return container.register(
-    AppTask.with(IContainer).hydrated().call(RouteContext.setRoot),
-    AppTask.with(IRouter).afterActivate().call(router => {
+    AppTask.hydrated(IContainer, RouteContext.setRoot),
+    AppTask.afterActivate(IRouter, router => {
       if (isObject(config)) {
         if (typeof config === 'function') {
           return config(router) as void | Promise<void>;
@@ -53,7 +53,7 @@ function configure(container: IContainer, config?: RouterConfig): IContainer {
       }
       return router.start({}, true) as void | Promise<void>;
     }),
-    AppTask.with(IRouter).afterDeactivate().call(router => {
+    AppTask.afterDeactivate(IRouter, router => {
       router.stop();
     }),
     ...DefaultComponents,

--- a/packages/runtime-html/src/app-task.ts
+++ b/packages/runtime-html/src/app-task.ts
@@ -1,6 +1,7 @@
 import {
   DI,
   IContainer,
+  IRegistry,
   Key,
   Registration,
   Resolved,
@@ -24,83 +25,59 @@ export interface IAppTask extends Pick<
   'register'
 > {}
 
-export interface ICallbackSlotChooser<K extends Key> extends Pick<
-  $AppTask<K>,
-  'beforeCreate' |
-  'hydrating' |
-  'hydrated' |
-  'beforeActivate' |
-  'afterActivate' |
-  'beforeDeactivate' |
-  'afterDeactivate'
-> {}
-
-export interface ICallbackChooser<K extends Key> extends Pick<
-  $AppTask<K>,
-  'call'
-> {}
-
 class $AppTask<K extends Key = Key> {
-  public slot: TaskSlot = (void 0)!;
-  public callback: (instance: unknown) => void | Promise<void> = (void 0)!;
-  public container: IContainer = (void 0)!;
+  public readonly slot: TaskSlot;
+  /** @internal */
+  private c: IContainer = (void 0)!;
+  /** @internal */
+  private readonly k: K | null;
+  /** @internal */
+  private readonly cb: AppTaskCallback<K> | AppTaskCallbackNoArg;
 
-  private constructor(
-    private readonly key: K,
-  ) {}
-
-  public static with<K1 extends Key>(key: K1): ICallbackSlotChooser<K1> {
-    return new $AppTask(key);
-  }
-
-  public beforeCreate(): ICallbackChooser<K> {
-    return this.at('beforeCreate');
-  }
-
-  public hydrating(): ICallbackChooser<K> {
-    return this.at('hydrating');
-  }
-
-  public hydrated(): ICallbackChooser<K> {
-    return this.at('hydrated');
-  }
-
-  public beforeActivate(): ICallbackChooser<K> {
-    return this.at('beforeActivate');
-  }
-
-  public afterActivate(): ICallbackChooser<K> {
-    return this.at('afterActivate');
-  }
-
-  public beforeDeactivate(): ICallbackChooser<K> {
-    return this.at('beforeDeactivate');
-  }
-
-  public afterDeactivate(): ICallbackChooser<K> {
-    return this.at('afterDeactivate');
-  }
-
-  public at(slot: TaskSlot): ICallbackChooser<K> {
+  public constructor(
+    slot: TaskSlot,
+    key: K | null,
+    cb: AppTaskCallback<K> | AppTaskCallbackNoArg,
+  ) {
     this.slot = slot;
-    return this;
-  }
-
-  public call<K1 extends Key = K>(fn: (instance: Resolved<K1>) => void | Promise<void>): IAppTask {
-    this.callback = fn as (instance: unknown) => void | Promise<void>;
-    return this;
+    this.k = key;
+    this.cb = cb;
   }
 
   public register(container: IContainer): IContainer {
-    return this.container = container.register(Registration.instance(IAppTask, this));
+    return this.c = container.register(Registration.instance(IAppTask, this));
   }
 
   public run(): void | Promise<void> {
-    const callback = this.callback;
-    const instance = this.container.get(this.key);
-    return callback(instance);
+    const key = this.k;
+    const cb = this.cb;
+    return key === null
+      ? (cb as AppTaskCallbackNoArg)()
+      : cb(this.c.get(key));
   }
 }
-export const AppTask = $AppTask as {
-  with<K extends Key>(key: K): ICallbackSlotChooser<K>;
-};
+
+export const AppTask = Object.freeze({
+  beforeCreate: createAppTaskSlotHook('beforeCreate'),
+  hydrating: createAppTaskSlotHook('hydrating'),
+  hydrated: createAppTaskSlotHook('hydrated'),
+  beforeActivate: createAppTaskSlotHook('beforeActivate'),
+  afterActivate: createAppTaskSlotHook('afterActivate'),
+  beforeDeactivate: createAppTaskSlotHook('beforeDeactivate'),
+  afterDeactivate: createAppTaskSlotHook('afterDeactivate'),
+});
+
+export type AppTaskCallbackNoArg = () => void | Promise<void>;
+export type AppTaskCallback<T> = (arg: Resolved<T>) => void | Promise<void>;
+
+function createAppTaskSlotHook(slotName: TaskSlot) {
+  function appTaskFactory<T extends Key = Key>(callback: AppTaskCallbackNoArg): IRegistry;
+  function appTaskFactory<T extends Key = Key>(key: T, callback: AppTaskCallback<T>): IRegistry;
+  function appTaskFactory<T extends Key = Key>(keyOrCallback: T | AppTaskCallback<T> | AppTaskCallbackNoArg, callback?: AppTaskCallback<T>): IRegistry {
+    if (typeof callback === 'function') {
+      return new $AppTask(slotName, keyOrCallback as T, callback);
+    }
+    return new $AppTask(slotName, null, keyOrCallback as Exclude<typeof keyOrCallback, T>);
+  }
+  return appTaskFactory;
+}

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -229,6 +229,8 @@ export {
   TaskSlot,
   AppTask,
   IAppTask,
+  AppTaskCallback,
+  AppTaskCallbackNoArg,
 } from './app-task.js';
 export {
   AttrSyntax,

--- a/packages/runtime-html/src/templating/dialog/dialog-configuration.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-configuration.ts
@@ -18,10 +18,7 @@ function createDialogConfiguration(settingsProvider: DialogConfigurationProvider
     settingsProvider: settingsProvider,
     register: (ctn: IContainer) => ctn.register(
       ...registrations,
-      AppTask
-        .with(IContainer)
-        .beforeCreate()
-        .call(c => settingsProvider(c.get(IDialogGlobalSettings)) as void)
+      AppTask.beforeCreate(() => settingsProvider(ctn.get(IDialogGlobalSettings)) as void)
     ),
     customize(cb: DialogConfigurationProvider, regs?: IRegistry[]) {
       return createDialogConfiguration(cb, regs ?? registrations);

--- a/packages/runtime-html/src/templating/dialog/dialog-service.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-service.ts
@@ -50,7 +50,7 @@ export class DialogService implements IDialogService {
   public static register(container: IContainer) {
     container.register(
       Registration.singleton(IDialogService, this),
-      AppTask.with(IDialogService).beforeDeactivate().call(dialogService => onResolve(
+      AppTask.beforeDeactivate(IDialogService, dialogService => onResolve(
         dialogService.closeAll(),
         (openDialogController) => {
           if (openDialogController.length > 0) {

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -176,7 +176,7 @@ export interface IShadowDOMConfiguration {
 
 export const StyleConfiguration = {
   shadowDOM(config: IShadowDOMConfiguration): IRegistry {
-    return AppTask.with(IContainer).beforeCreate().call(container => {
+    return AppTask.beforeCreate(IContainer, container => {
       if (config.sharedStyles != null) {
         const factory = container.get(IShadowDOMStyleFactory);
         container.register(Registration.instance(IShadowDOMGlobalStyles, factory.createStyles(config.sharedStyles, null)));


### PR DESCRIPTION
# Pull Request

## 📖 Description

feat(app-task): allow app task to be created without a key

Make app task signature similar to `DI.createInterface<T>(...)`, where it would require all parameters to the final resolution to be declared upfront

Before:
```ts
AppTask.with(IContainer).beforeCreate().call((container) => { ... })
```

After:
```ts
// with injection usage
AppTask.beforeCreate(IContainer, (container) => { ... })
// no injection usage
AppTask.beforeCreate((container) => { ... })
```

### 🎫 Issues

1. `AppTask` cannot be created without a key, the following usage would throw a compilation error (TS), and runtime error (JS):
```ts
AppTask.with().beforeCreate().call(() => { ... })
```
2. `AppTask` callback may not be specified properly:
```ts
AppTask.with(IContainer).beforeCreate() // missing callback specification
```
3. `AppTask` construction is not similar to `DI.createInterface`:
```ts
// single call to specify all the necessary parts of an interface
Di.createInterface('my interface', x => x.singleton(MyClass))
// multiple calls to specify all necessary parts of a task
AppTask.with().beforeCreate().call(() => { ... })
```

Similar refactoring: https://github.com/aurelia/aurelia/pull/1041
