### PR TITLE
chore(dist): add a bundled dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
       ],
       "devDependencies": {
         "@commitlint/cli": "^8.2.0",
+        "@rollup/plugin-typescript": "^8.2.1",
         "@typescript-eslint/eslint-plugin": "^4.10.0",
         "@typescript-eslint/parser": "^4.10.0",
         "chalk": "^4.1.0",
@@ -69,6 +70,7 @@
         "husky": "^4.3.0",
         "lage": "^0.26.2",
         "rimraf": "^3.0.0",
+        "rollup": "^2.49.0",
         "ts-node": "^9.0.0",
         "tsconfig-paths": "^3.9.0",
         "typescript": "^4.0.3"
@@ -1953,6 +1955,47 @@
       "funding": {
         "url": "https://opencollective.com/pnpm"
       }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
+      "integrity": "sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@rushstack/node-core-library": {
       "version": "3.35.2",
@@ -7152,6 +7195,12 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -15015,6 +15064,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollup": {
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.49.0.tgz",
+      "integrity": "sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
     "node_modules/rsvp": {
       "version": "4.8.5",
       "license": "MIT",
@@ -21001,6 +21065,35 @@
       "version": "6.4.0",
       "dev": true
     },
+    "@rollup/plugin-typescript": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz",
+      "integrity": "sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        }
+      }
+    },
     "@rushstack/node-core-library": {
       "version": "3.35.2",
       "dev": true,
@@ -24666,6 +24759,12 @@
     },
     "estraverse": {
       "version": "4.3.0"
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3"
@@ -29942,6 +30041,15 @@
       "version": "3.0.2",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.49.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.49.0.tgz",
+      "integrity": "sha512-UnrCjMXICx9q0jF8L7OYs7LPk95dW0U5UYp/VANnWqfuhyr66FWi/YVlI34Oy8Tp4ZGLcaUDt4APJm80b9oPWQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.3.1"
       }
     },
     "rsvp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,8 +643,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/lodash": {
-      "version": "4.17.20",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "5.7.1",
@@ -722,8 +723,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms/node_modules/lodash": {
-      "version": "4.17.20",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.12.10",
@@ -1005,8 +1007,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/lodash": {
-      "version": "4.17.20",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/@babel/types": {
       "version": "7.12.12",
@@ -1018,8 +1021,9 @@
       }
     },
     "node_modules/@babel/types/node_modules/lodash": {
-      "version": "4.17.20",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -1444,9 +1448,10 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/@examples/1kcomponents": {
       "resolved": "examples/1kcomponents",
@@ -2364,9 +2369,10 @@
       "license": "MIT"
     },
     "node_modules/@types/http-proxy": {
-      "version": "1.17.5",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.6.tgz",
+      "integrity": "sha512-+qsjqR75S/ib0ig0R9WN+CDoZeOBU6F2XLewgC4KVgdXiNHiKKHFEMRHOrs5PbYE97D5vataw5wPj4KLYfUkuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -2484,8 +2490,9 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -3288,11 +3295,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/array-filter": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "dev": true,
@@ -3444,20 +3446,6 @@
     "node_modules/aurelia": {
       "resolved": "packages/aurelia",
       "link": true
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-filter": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -4188,15 +4176,16 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.16.3",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4428,9 +4417,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001183",
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
       "dev": true,
-      "license": "CC-BY-4.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -4783,9 +4777,10 @@
       }
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.2.5",
@@ -5207,9 +5202,10 @@
       }
     },
     "node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "dev": true,
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -5904,7 +5900,8 @@
     },
     "node_modules/d3-scale-chromatic": {
       "version": "2.0.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "dependencies": {
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
@@ -6252,9 +6249,10 @@
       "license": "MIT"
     },
     "node_modules/dns-packet": {
-      "version": "1.3.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.2.tgz",
+      "integrity": "sha512-qH/MS6fDOeNBTsF3k/v/SrwaXlDeewxgddXGUUfwauEBZkz7u59oF+3ZNSzcZeCuPWOfkqmcAnXW1gliiFW+1A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -6469,9 +6467,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.650",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.3.737",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz",
+      "integrity": "sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==",
+      "dev": true
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -6527,9 +6526,10 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "3.5.0",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "component-emitter": "~1.3.0",
         "component-inherit": "0.0.3",
@@ -6540,7 +6540,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -6980,9 +6980,10 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
       "version": "7.3.4",
@@ -7056,9 +7057,10 @@
       }
     },
     "node_modules/eslint/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/semver": {
       "version": "7.3.4",
@@ -7185,17 +7187,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "original": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/exec-sh": {
@@ -8045,11 +8036,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/foreach": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "license": "Apache-2.0",
@@ -8488,9 +8474,10 @@
       }
     },
     "node_modules/git-raw-commits/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "dev": true,
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/git-raw-commits/node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -8724,8 +8711,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "license": "ISC"
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -8741,9 +8729,10 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.6",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
@@ -8899,8 +8888,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "license": "ISC"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -9046,9 +9036,10 @@
       }
     },
     "node_modules/html-webpack-plugin/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/htmlparser2": {
       "version": "4.1.0",
@@ -9118,24 +9109,32 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "1.0.6",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
+      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.4",
+        "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.20",
+        "is-plain-obj": "^3.0.0",
         "micromatch": "^4.0.2"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/lodash": {
-      "version": "4.17.20",
+    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -9711,17 +9710,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "dev": true,
@@ -9873,24 +9861,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
-        "foreach": "^2.0.5",
-        "has-symbols": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -11287,11 +11257,6 @@
       "version": "5.0.1",
       "license": "ISC"
     },
-    "node_modules/json3": {
-      "version": "3.3.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "1.0.1",
       "dev": true,
@@ -11670,9 +11635,10 @@
       }
     },
     "node_modules/karma/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/karma/node_modules/log4js": {
       "version": "6.3.0",
@@ -12158,8 +12124,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "1.2.8",
-      "license": "MIT",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
       "bin": {
         "marked": "bin/marked"
       },
@@ -13168,8 +13135,9 @@
     },
     "node_modules/node-forge": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -13186,9 +13154,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.70",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
+      "dev": true
     },
     "node_modules/nopt": {
       "version": "3.0.6",
@@ -13490,9 +13459,10 @@
       }
     },
     "node_modules/open": {
-      "version": "7.4.0",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -13526,14 +13496,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "url-parse": "^1.4.3"
       }
     },
     "node_modules/p-defer": {
@@ -13624,9 +13586,10 @@
       "license": "MIT"
     },
     "node_modules/p-retry": {
-      "version": "4.3.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
@@ -13850,7 +13813,8 @@
     },
     "node_modules/perf-monitor": {
       "version": "0.4.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/perf-monitor/-/perf-monitor-0.4.1.tgz",
+      "integrity": "sha1-sK+HB4cv5Z0hTX+Kknd1zwqNqiY="
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -14068,13 +14032,14 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.4",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "colorette": "^1.2.1",
-        "nanoid": "^3.1.20",
-        "source-map": "^0.6.1"
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -14159,9 +14124,10 @@
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.1.20",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -14187,9 +14153,10 @@
       }
     },
     "node_modules/pretty-error/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/pretty-format": {
       "version": "26.6.2",
@@ -14374,11 +14341,6 @@
       "engines": {
         "node": ">=0.4.x"
       }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "1.1.0",
@@ -14757,9 +14719,10 @@
       }
     },
     "node_modules/renderkid/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/renderkid/node_modules/readable-stream": {
       "version": "3.6.0",
@@ -14876,8 +14839,9 @@
       }
     },
     "node_modules/request-promise-core/node_modules/lodash": {
-      "version": "4.17.20",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
@@ -15397,9 +15361,10 @@
       "license": "MIT"
     },
     "node_modules/selfsigned": {
-      "version": "1.10.8",
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "node-forge": "^0.10.0"
       }
@@ -15941,27 +15906,6 @@
         "websocket-driver": "^0.7.4"
       }
     },
-    "node_modules/sockjs-client": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
-        "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.4.7"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/sockjs/node_modules/uuid": {
       "version": "3.4.0",
       "dev": true,
@@ -15978,6 +15922,15 @@
     "node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16182,9 +16135,10 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -16622,9 +16576,10 @@
       "license": "MIT"
     },
     "node_modules/table/node_modules/lodash": {
-      "version": "4.17.20",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/table/node_modules/string-width": {
       "version": "4.2.0",
@@ -17354,6 +17309,19 @@
         "node": "*"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "license": "MIT",
@@ -17522,15 +17490,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.4.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "dev": true,
@@ -17546,19 +17505,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -17900,45 +17846,44 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "4.0.0-beta.0",
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.0.0-beta.3.tgz",
+      "integrity": "sha512-Ud7ieH15No/KiSdRuzk+2k+S4gSCR/N7m4hJhesDbKQEZy3P+NPXTXfsimNOZvbVX2TRuIEFB+VdLZFn8DwGwg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "ansi-html": "0.0.7",
+        "ansi-html": "^0.0.7",
         "bonjour": "^3.5.0",
-        "chokidar": "^3.4.3",
+        "chokidar": "^3.5.1",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^1.6.0",
         "del": "^6.0.0",
         "express": "^4.17.1",
         "find-cache-dir": "^3.3.1",
-        "graceful-fs": "^4.2.4",
-        "html-entities": "^1.3.1",
-        "http-proxy-middleware": "^1.0.6",
+        "graceful-fs": "^4.2.6",
+        "html-entities": "^2.3.2",
+        "http-proxy-middleware": "^1.3.1",
         "internal-ip": "^6.2.0",
-        "ip": "^1.1.5",
+        "ipaddr.js": "^2.0.0",
         "is-absolute-url": "^3.0.3",
         "killable": "^1.0.1",
-        "open": "^7.3.0",
-        "p-retry": "^4.2.0",
+        "open": "^7.4.2",
+        "p-retry": "^4.5.0",
         "portfinder": "^1.0.28",
         "schema-utils": "^3.0.0",
-        "selfsigned": "^1.10.8",
+        "selfsigned": "^1.10.11",
         "serve-index": "^1.9.1",
-        "sockjs": "0.3.21",
-        "sockjs-client": "1.5.0",
+        "sockjs": "^0.3.21",
         "spdy": "^4.0.2",
         "strip-ansi": "^6.0.0",
         "url": "^0.11.0",
-        "util": "^0.12.3",
-        "webpack-dev-middleware": "^4.0.2",
-        "ws": "^7.4.0"
+        "webpack-dev-middleware": "^4.1.0",
+        "ws": "^7.4.5"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 12.13.0"
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
@@ -17963,6 +17908,21 @@
       },
       "funding": {
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+      "dev": true
+    },
+    "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+      "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/webpack-dev-server/node_modules/make-dir": {
@@ -18230,26 +18190,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/which-typed-array": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
-        "foreach": "^2.0.5",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.1",
-        "is-typed-array": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/wide-align": {
       "version": "1.1.3",
       "dev": true,
@@ -18383,8 +18323,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.3",
-      "license": "MIT",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -18430,7 +18371,9 @@
       "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.5.5",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -18839,6 +18782,7 @@
         "@aurelia/validation-i18n": "2.0.0-alpha.4",
         "i18next": "^17.0.0",
         "jsdom": "^15.2.1",
+        "rxjs": "^6.5.3",
         "typescript": "^4.0.3"
       },
       "devDependencies": {
@@ -19101,6 +19045,7 @@
         "@aurelia/kernel": "2.0.0-alpha.4",
         "@aurelia/metadata": "2.0.0-alpha.4",
         "@aurelia/platform": "2.0.0-alpha.4",
+        "@aurelia/runtime-html": "2.0.0-alpha.4",
         "rxjs": "^6.5.3"
       },
       "devDependencies": {
@@ -19408,6 +19353,7 @@
         "karma-mocha-reporter": "^2.2.5",
         "karma-sourcemap-loader": "^0.3.7",
         "mocha": "^8.1.3",
+        "rxjs": "^6.5.3",
         "source-map": "^0.7.3",
         "source-map-support": "^0.5.19",
         "ts-node": "^9.0.0",
@@ -19631,6 +19577,7 @@
         "@aurelia/kernel": "2.0.0-alpha.4",
         "@aurelia/metadata": "2.0.0-alpha.4",
         "@aurelia/platform": "2.0.0-alpha.4",
+        "@aurelia/runtime-html": "2.0.0-alpha.4",
         "rxjs": "^6.5.3",
         "typescript": "^4.0.3"
       }
@@ -19911,7 +19858,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "semver": {
           "version": "5.7.1"
@@ -19975,7 +19924,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -20174,7 +20125,9 @@
           "version": "11.12.0"
         },
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -20187,7 +20140,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -20553,7 +20508,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -21393,7 +21350,9 @@
       "dev": true
     },
     "@types/http-proxy": {
-      "version": "1.17.5",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.6.tgz",
+      "integrity": "sha512-+qsjqR75S/ib0ig0R9WN+CDoZeOBU6F2XLewgC4KVgdXiNHiKKHFEMRHOrs5PbYE97D5vataw5wPj4KLYfUkuQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -21494,6 +21453,8 @@
     },
     "@types/retry": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
     },
     "@types/source-list-map": {
@@ -22029,10 +21990,6 @@
     "array-equal": {
       "version": "1.0.0"
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "dev": true
@@ -22139,13 +22096,6 @@
         "@aurelia/runtime": "2.0.0-alpha.4",
         "@aurelia/runtime-html": "2.0.0-alpha.4",
         "typescript": "^4.0.3"
-      }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "array-filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -22638,14 +22588,16 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.16.3",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "bs-logger": {
@@ -22801,7 +22753,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001183",
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
       "dev": true
     },
     "capture-exit": {
@@ -23040,7 +22994,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "colors": {
@@ -23325,7 +23281,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.8",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "normalize-package-data": {
@@ -23831,6 +23789,8 @@
     },
     "d3-scale-chromatic": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz",
+      "integrity": "sha512-LLqy7dJSL8yDy7NRmf6xSlsFZ6zYvJ4BcWFE4zBrOPnQERv9zj24ohnXKRbyi9YHnYV+HN1oEO3iFK971/gkzA==",
       "requires": {
         "d3-color": "1 - 2",
         "d3-interpolate": "1 - 2"
@@ -24057,7 +24017,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.2.tgz",
+      "integrity": "sha512-qH/MS6fDOeNBTsF3k/v/SrwaXlDeewxgddXGUUfwauEBZkz7u59oF+3ZNSzcZeCuPWOfkqmcAnXW1gliiFW+1A==",
       "dev": true,
       "requires": {
         "ip": "^1.1.0",
@@ -24221,7 +24183,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.650",
+      "version": "1.3.737",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz",
+      "integrity": "sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==",
       "dev": true
     },
     "emittery": {
@@ -24266,7 +24230,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.0",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -24278,7 +24244,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -24493,7 +24459,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {
@@ -24605,7 +24573,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {
@@ -24715,13 +24685,6 @@
     "events": {
       "version": "3.2.0",
       "dev": true
-    },
-    "eventsource": {
-      "version": "1.0.7",
-      "dev": true,
-      "requires": {
-        "original": "^1.0.0"
-      }
     },
     "exec-sh": {
       "version": "0.3.4"
@@ -25316,10 +25279,6 @@
     "for-in": {
       "version": "1.0.2"
     },
-    "foreach": {
-      "version": "2.0.5",
-      "dev": true
-    },
     "forever-agent": {
       "version": "0.6.1"
     },
@@ -25595,7 +25554,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.8",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "normalize-package-data": {
@@ -25756,7 +25717,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4"
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "growl": {
       "version": "1.10.5",
@@ -25767,7 +25730,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -25867,7 +25832,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.8"
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -25971,7 +25938,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -26030,18 +25999,22 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "1.0.6",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
+      "integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
       "dev": true,
       "requires": {
-        "@types/http-proxy": "^1.17.4",
+        "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.20",
+        "is-plain-obj": "^3.0.0",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.20",
+        "is-plain-obj": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
           "dev": true
         }
       }
@@ -26380,10 +26353,6 @@
       "version": "2.1.0",
       "peer": true
     },
-    "is-generator-function": {
-      "version": "1.0.8",
-      "dev": true
-    },
     "is-glob": {
       "version": "4.0.1",
       "dev": true,
@@ -26465,17 +26434,6 @@
       "dev": true,
       "requires": {
         "text-extensions": "^1.0.0"
-      }
-    },
-    "is-typed-array": {
-      "version": "1.1.4",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
-        "foreach": "^2.0.5",
-        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -27440,10 +27398,6 @@
     "json-stringify-safe": {
       "version": "5.0.1"
     },
-    "json3": {
-      "version": "3.3.3",
-      "dev": true
-    },
     "json5": {
       "version": "1.0.1",
       "dev": true,
@@ -27534,7 +27488,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "log4js": {
@@ -28054,7 +28010,9 @@
       }
     },
     "marked": {
-      "version": "1.2.8"
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
+      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -28757,6 +28715,8 @@
     },
     "node-forge": {
       "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -28766,7 +28726,9 @@
       "version": "1.0.0"
     },
     "node-releases": {
-      "version": "1.1.70",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "nopt": {
@@ -28957,7 +28919,9 @@
       }
     },
     "open": {
-      "version": "7.4.0",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -28978,13 +28942,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "p-defer": {
@@ -29033,7 +28990,9 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.3.0",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
+      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
       "dev": true,
       "requires": {
         "@types/retry": "^0.12.0",
@@ -29199,7 +29158,9 @@
       "dev": true
     },
     "perf-monitor": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/perf-monitor/-/perf-monitor-0.4.1.tgz",
+      "integrity": "sha1-sK+HB4cv5Z0hTX+Kknd1zwqNqiY="
     },
     "performance-now": {
       "version": "2.1.0"
@@ -29342,16 +29303,20 @@
       "version": "0.1.1"
     },
     "postcss": {
-      "version": "8.2.4",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.1",
-        "nanoid": "^3.1.20",
-        "source-map": "^0.6.1"
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.1.20",
+          "version": "3.1.23",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+          "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
           "dev": true
         }
       }
@@ -29411,7 +29376,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -29538,10 +29505,6 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "dev": true
-    },
-    "querystringify": {
-      "version": "2.2.0",
       "dev": true
     },
     "quick-lru": {
@@ -29799,7 +29762,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "readable-stream": {
@@ -29895,7 +29860,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.20"
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         }
       }
     },
@@ -30205,7 +30172,9 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.8",
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
+      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
       "dev": true,
       "requires": {
         "node-forge": "^0.10.0"
@@ -30616,33 +30585,18 @@
         }
       }
     },
-    "sockjs-client": {
-      "version": "1.5.0",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
-        "faye-websocket": "^0.11.3",
-        "inherits": "^2.0.4",
-        "json3": "^3.3.3",
-        "url-parse": "^1.4.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1"
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -30798,7 +30752,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"
@@ -31087,7 +31043,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.20",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "string-width": {
@@ -31568,6 +31526,13 @@
       "version": "0.7.22",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+      "integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
+      "dev": true,
+      "optional": true
+    },
     "union-value": {
       "version": "1.0.1",
       "requires": {
@@ -31685,32 +31650,12 @@
         }
       }
     },
-    "url-parse": {
-      "version": "1.4.7",
-      "dev": true,
-      "requires": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "urlgrey": {
       "version": "0.4.4",
       "dev": true
     },
     "use": {
       "version": "3.1.1"
-    },
-    "util": {
-      "version": "0.12.3",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2"
@@ -31983,38 +31928,38 @@
       }
     },
     "webpack-dev-server": {
-      "version": "4.0.0-beta.0",
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.0.0-beta.3.tgz",
+      "integrity": "sha512-Ud7ieH15No/KiSdRuzk+2k+S4gSCR/N7m4hJhesDbKQEZy3P+NPXTXfsimNOZvbVX2TRuIEFB+VdLZFn8DwGwg==",
       "dev": true,
       "requires": {
-        "ansi-html": "0.0.7",
+        "ansi-html": "^0.0.7",
         "bonjour": "^3.5.0",
-        "chokidar": "^3.4.3",
+        "chokidar": "^3.5.1",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^1.6.0",
         "del": "^6.0.0",
         "express": "^4.17.1",
         "find-cache-dir": "^3.3.1",
-        "graceful-fs": "^4.2.4",
-        "html-entities": "^1.3.1",
-        "http-proxy-middleware": "^1.0.6",
+        "graceful-fs": "^4.2.6",
+        "html-entities": "^2.3.2",
+        "http-proxy-middleware": "^1.3.1",
         "internal-ip": "^6.2.0",
-        "ip": "^1.1.5",
+        "ipaddr.js": "^2.0.0",
         "is-absolute-url": "^3.0.3",
         "killable": "^1.0.1",
-        "open": "^7.3.0",
-        "p-retry": "^4.2.0",
+        "open": "^7.4.2",
+        "p-retry": "^4.5.0",
         "portfinder": "^1.0.28",
         "schema-utils": "^3.0.0",
-        "selfsigned": "^1.10.8",
+        "selfsigned": "^1.10.11",
         "serve-index": "^1.9.1",
-        "sockjs": "0.3.21",
-        "sockjs-client": "1.5.0",
+        "sockjs": "^0.3.21",
         "spdy": "^4.0.2",
         "strip-ansi": "^6.0.0",
         "url": "^0.11.0",
-        "util": "^0.12.3",
-        "webpack-dev-middleware": "^4.0.2",
-        "ws": "^7.4.0"
+        "webpack-dev-middleware": "^4.1.0",
+        "ws": "^7.4.5"
       },
       "dependencies": {
         "find-cache-dir": {
@@ -32025,6 +31970,18 @@
             "make-dir": "^3.0.2",
             "pkg-dir": "^4.1.0"
           }
+        },
+        "html-entities": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+          "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+          "dev": true
+        },
+        "ipaddr.js": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+          "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==",
+          "dev": true
         },
         "make-dir": {
           "version": "3.1.0",
@@ -32128,19 +32085,6 @@
       "version": "1.0.0",
       "dev": true
     },
-    "which-typed-array": {
-      "version": "1.1.4",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
-        "foreach": "^2.0.5",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.1",
-        "is-typed-array": "^1.1.3"
-      }
-    },
     "wide-align": {
       "version": "1.1.3",
       "dev": true,
@@ -32241,7 +32185,9 @@
       }
     },
     "ws": {
-      "version": "7.4.3",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
       "requires": {}
     },
     "xml-name-validator": {
@@ -32263,7 +32209,9 @@
       "version": "2.2.0"
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
+      "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
     "init": "npm ci && npm run build",
     "rebuild": "npm run clean && npm run build",
     "build": "lage build --scope @aurelia/* --scope aurelia --scope au --scope @benchmarking-apps/* --no-cache --verbose --no-deps",
+    "postbuild": "npm run rollup",
     "build:release": "lage run build --scope aurelia --scope au --scope @aurelia/a* --scope @aurelia/b* --scope @aurelia/f* --scope @aurelia/h* --scope @aurelia/i* --scope @aurelia/k* --scope @aurelia/m* --scope @aurelia/p* --scope @aurelia/r* --scope @aurelia/s* --scope @aurelia/t* --scope @aurelia/v* --scope @aurelia/w* --no-cache --verbose --no-deps",
-    "postbuild:release": "npm run clean:tsconfig-build-cache",
+    "postbuild:release": "npm run rollup && npm run clean:tsconfig-build-cache",
     "build:release:full": "npm run build:release && npm run change-tsconfigs:invert && npm run build:release && npm run change-tsconfigs:restore",
     "change-package-refs:dev": "ts-node -P tsconfig.json scripts/change-package-refs.ts dev",
     "change-package-refs:release": "ts-node -P tsconfig.json scripts/change-package-refs.ts release",
@@ -84,10 +85,12 @@
     "pregenerate-tests:template-compiler.static": "tsc --resolveJsonModule --module commonjs --moduleResolution node --outDir scripts/dist scripts/generate-tests/template-compiler.static.ts",
     "generate-tests:template-compiler.static": "node scripts/dist/scripts/generate-tests/template-compiler.static.js",
     "generate-tests:template-compiler.mutations": "ts-node -P tsconfig.json scripts/generate-tests/template-compiler.mutations.ts",
-    "mermaid": "ts-node -P tsconfig.json scripts/generate-mermaid-diagrams.ts"
+    "mermaid": "ts-node -P tsconfig.json scripts/generate-mermaid-diagrams.ts",
+    "rollup": "lage rollup"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
+    "@rollup/plugin-typescript": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.10.0",
     "@typescript-eslint/parser": "^4.10.0",
     "chalk": "^4.1.0",
@@ -101,6 +104,7 @@
     "husky": "^4.3.0",
     "lage": "^0.26.2",
     "rimraf": "^3.0.0",
+    "rollup": "^2.49.0",
     "ts-node": "^9.0.0",
     "tsconfig-paths": "^3.9.0",
     "typescript": "^4.0.3"

--- a/packages/au/package.json
+++ b/packages/au/package.json
@@ -38,7 +38,8 @@
     "bundle": "ts-node -P ../../tsconfig.json ../../scripts/bundle.ts umd,esm,system aurelia",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/au/rollup.config.js
+++ b/packages/au/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/au/tsconfig.build.json
+++ b/packages/au/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "types": ["node"],
+    "lib": ["esnext"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -31,7 +31,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/aurelia/rollup.config.js
+++ b/packages/aurelia/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/aurelia/tsconfig.build.json
+++ b/packages/aurelia/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fetch-client/rollup.config.js
+++ b/packages/fetch-client/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/fetch-client/tsconfig.build.json
+++ b/packages/fetch-client/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"],
+    "strictBindCallApply": false
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -35,7 +35,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http-server/rollup.config.js
+++ b/packages/http-server/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/http-server/tsconfig.build.json
+++ b/packages/http-server/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "types": ["node"],
+    "lib": ["esnext"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/i18n/rollup.config.js
+++ b/packages/i18n/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/i18n/tsconfig.build.json
+++ b/packages/i18n/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src",
+    "custom-type-definitions"
+  ]
+}

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kernel/rollup.config.js
+++ b/packages/kernel/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/kernel/tsconfig.build.json
+++ b/packages/kernel/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/metadata/rollup.config.js
+++ b/packages/metadata/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/metadata/tsconfig.build.json
+++ b/packages/metadata/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/platform-browser/tsconfig.build.json
+++ b/packages/platform-browser/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/platform/rollup.config.js
+++ b/packages/platform/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/platform/tsconfig.build.json
+++ b/packages/platform/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/route-recognizer/rollup.config.js
+++ b/packages/route-recognizer/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/route-recognizer/tsconfig.build.json
+++ b/packages/route-recognizer/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/router/tsconfig.build.json
+++ b/packages/router/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"],
+    "strict": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runtime-html/rollup.config.js
+++ b/packages/runtime-html/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/runtime-html/tsconfig.build.json
+++ b/packages/runtime-html/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runtime/rollup.config.js
+++ b/packages/runtime/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/store-v1/README.md
+++ b/packages/store-v1/README.md
@@ -9,11 +9,11 @@
 For the latest stable version:
 
 ```bash
-npm i @aurelia/store
+npm i @aurelia/store-v1
 ```
 
 For our nightly builds:
 
 ```bash
-npm i @aurelia/store@dev
+npm i @aurelia/store-v1@dev
 ```

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/store-v1/rollup.config.js
+++ b/packages/store-v1/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/store-v1/tsconfig.build.json
+++ b/packages/store-v1/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/testing/tsconfig.build.json
+++ b/packages/testing/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"],
+    "types": ["node", "mocha"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -33,7 +33,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/validation-html/rollup.config.js
+++ b/packages/validation-html/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation-html/tsconfig.build.json
+++ b/packages/validation-html/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -33,7 +33,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/validation-i18n/rollup.config.js
+++ b/packages/validation-i18n/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation-i18n/tsconfig.build.json
+++ b/packages/validation-i18n/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -32,7 +32,8 @@
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",
     "publish:dev": "npm publish --tag dev",
-    "publish:latest": "npm publish --tag latest"
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/validation/rollup.config.js
+++ b/packages/validation/rollup.config.js
@@ -1,0 +1,15 @@
+import typescript from '@rollup/plugin-typescript'
+
+export default {
+  input: 'src/index.ts',
+  output: {
+    file: 'dist/bundle/index.js',
+    format: 'es',
+    sourcemap: true
+  },
+  plugins: [
+    typescript({
+      tsconfig: 'tsconfig.build.json'
+    })
+  ]
+}

--- a/packages/validation/tsconfig.build.json
+++ b/packages/validation/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
At the moment, packages are distributed in multiple file form, causing slow downloading time for online repl/IDEs. Fix this by adding additional dist format that has only a single file. Existing format will still be used, and this dist is a hidden one. First step is to add custom resolution to this new format and later make a switch.

The bundle file is at `dist/bundle/index.js`. Only the main packages for applications will be rolled this way, tooling packages (cjs) will be kept as is.

cc @fkleuver @3cp 