### PR TITLE
feat(compose): add v1 ability to compose from view + view model + model

### DIFF
--- a/docs/user-docs/app-basics/dynamic-ui-composition.md
+++ b/docs/user-docs/app-basics/dynamic-ui-composition.md
@@ -1,0 +1,82 @@
+---
+name: "Templating: Dynamic UI Composition"
+description: An overview of Aurelia's dynamic template composition functionality.
+---
+
+## Introduction
+
+In this section, we are going to be learning how you can dynamically render components in your applications by utilizing Aurelia's dynamic composition functionality.
+
+When using Aurelia's `<au-compose>` element, inside of the view-model being used, you have access to all of Aurelia's standard view lifecycle events, as well as an extra `activate`.
+
+## Basic Composition
+
+The `au-compose` element can be used to render any custom element given to its `view-model` property. A basic example is:
+
+```html
+<au-compose view-model.bind="MyField"></au-compose>
+```
+
+```javascript
+import { CustomElement } from '@aurelia/runtime-html';
+
+export class App {
+  MyField = CustomElement.define({
+    name: 'my-input',
+    template: '<input value.bind="value">'
+  })
+}
+```
+
+{% hint style="info" %}
+With a custom element as view model, all standard lifecycles, and `activate` will be called during the composition.
+{% endhint %}
+
+## Composing Without a Custom Element
+
+It's not always necessary, or convenient to compose using a custom element definition. The `au-compose` can also work with a slightly simpler composition: either using view only, or view and simple view model combination.
+
+An example of view only composition:
+
+```html
+<au-compose view="<p>Hello world</p>"></au-compose>
+```
+
+Inside of our template, we are using the `<au-compose>` element and passing through a view to be rendered. The view is just a plain html string.
+
+During a composition, this html string is processed by Aurelia template compiler to produce necessary parts for UI composition and renders it inside the `<au-compose>` element.
+
+Combining simple view and literal object as view model, we can also have powerful rendering without boilerplate:
+
+```html
+<au-compose repeat.for="i of 5" view-model.bind="{ value: i }" view="<div>\\${value}</div>"></au-compose>
+```
+
+{% hint style="info" %}
+When composing without a custom element as view-model, the result component will use parent scope as its scope, unless `scope-behavior` is set to `scoped`
+{% endhint %}
+
+## Passing Through Data
+
+`activate` method on the view model, regardless a custom element or a plain object will be called during the first composition, and subsequent changes of the `model` property on the `<au-compose>` element.
+
+## Migration from v1:
+
+- `view`/`view-model` (BREAKING CHANGE): passing a string to either view/ view model no longer means module name. The composer only understands string as template for view and objects and classes for view-model now. Though if it's still possible to turn treat string as module name, with the help of value converter:
+    ```html
+    <au-compose view="https://my-server.com/views/${componentName} | loadView">
+    ```
+    ```js
+    class LoadViewValueConverter {
+      toView(v) { return fetch(v).then(r => r.text()) }
+    }
+    ```
+- `scope` (BREAKING CHANGE): context is no longer inherited by default. It will only inherit parent scope when it's not a custom element composition (can be view only, or with plain object as view model). User can also disable this via scope-behavior bindable:
+    ```html
+    <au-compose scope-behavior="scoped">
+    ```
+    Possible values are:
+    - auto: in view only composition: inherit the parent scope
+    - scoped: never inherit parent scope even in view only composition
+- **naming** (BREAKING CHANGE): `compose` (v1) is changed to `au-compose` (v2)
+    - (v2 only): the existing `au-compose` is renamed to `au-render`.

--- a/packages/__tests__/3-runtime-html/compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/compose.spec.ts
@@ -8,17 +8,17 @@ import {
   Aurelia,
   RenderPlan,
   IPlatform,
+  AuCompose,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
   TestContext,
   trimFull,
   assert,
+  createFixture,
 } from '@aurelia/testing';
 
-const spec = 'compose';
-
-describe(spec, function () {
+describe('3-runtime-html/compose.spec.ts/au-render', function () {
   function createFixture(): SpecContext {
     const ctx = TestContext.create();
     const { container, platform, observerLocator } = ctx;
@@ -86,39 +86,39 @@ describe(spec, function () {
   const templateSpecs: TemplateSpec[] = [
     {
       t: '1',
-      template: `<template><au-compose subject.bind="sub"></au-compose></template>`
+      template: `<template><au-render subject.bind="sub"></au-render></template>`
     },
     {
       t: '2',
-      template: `<template><template as-element="au-compose" subject.bind="sub"></template></template>`
+      template: `<template><template as-element="au-render" subject.bind="sub"></template></template>`
     },
     {
       t: '13',
-      template: `<template><au-compose repeat.for="i of 1" subject.bind="sub"></au-compose></template>`
+      template: `<template><au-render repeat.for="i of 1" subject.bind="sub"></au-render></template>`
     },
     {
       t: '4',
-      template: `<template><au-compose if.bind="true" subject.bind="sub"></au-compose></template>`
+      template: `<template><au-render if.bind="true" subject.bind="sub"></au-render></template>`
     },
     {
       t: '5',
-      template: `<template><div if.bind="false"></div><au-compose else subject.bind="sub"></au-compose></template>`
+      template: `<template><div if.bind="false"></div><au-render else subject.bind="sub"></au-render></template>`
     },
     {
       t: '16',
-      template: `<template><au-compose if.bind="true" repeat.for="i of 1" subject.bind="sub"></au-compose></template>`
+      template: `<template><au-render if.bind="true" repeat.for="i of 1" subject.bind="sub"></au-render></template>`
     },
     {
       t: '17',
-      template: `<template><au-compose if.bind="true" repeat.for="i of 1" subject.bind="sub"></au-compose></template>`
+      template: `<template><au-render if.bind="true" repeat.for="i of 1" subject.bind="sub"></au-render></template>`
     },
     {
       t: '18',
-      template: `<template><au-compose subject.bind="sub" if.bind="true" repeat.for="i of 1"></au-compose></template>`
+      template: `<template><au-render subject.bind="sub" if.bind="true" repeat.for="i of 1"></au-render></template>`
     },
     {
       t: '19',
-      template: `<template><au-compose if.bind="true" subject.bind="sub" repeat.for="i of 1"></au-compose></template>`
+      template: `<template><au-render if.bind="true" subject.bind="sub" repeat.for="i of 1"></au-render></template>`
     },
   ];
 
@@ -156,7 +156,7 @@ describe(spec, function () {
         public message = 'Hello world!';
       }
 
-      @customElement({ name: 'app', template: '<au-compose subject.bind="model | view"></au-compose>' })
+      @customElement({ name: 'app', template: '<au-render subject.bind="model | view"></au-compose>' })
       class App {
         public model = new MyModel();
       }
@@ -171,4 +171,455 @@ describe(spec, function () {
       au.dispose();
     });
   });
+});
+
+describe('3-runtime-html/compose.spec.ts/au-compose', function () {
+  describe('view', function () {
+    it('works with literal string', async function () {
+      const { appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view="<div>hello world</div>">'
+      );
+
+      await startPromise;
+      assert.strictEqual(appHost.textContent, 'hello world');
+
+      await tearDown();
+
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    // this test is a different with the rest, where the view is being recreated
+    // and the composition happens again.
+    // Instead of the bindings getting notified by the changes in the view model
+    it('works with dynamic view + interpolation', async function () {
+      const { ctx, component, appHost, startPromise, tearDown } = createFixture(
+        `<au-compose view="<div>\${message}</div>">`,
+        class App {
+          public message = 'hello world';
+        }
+      );
+
+      await startPromise;
+      assert.strictEqual(appHost.textContent, 'hello world');
+
+      component.message = 'hello';
+      const auComponentVm = CustomElement.for(appHost.querySelector('au-compose')).viewModel as AuCompose;
+
+      assert.strictEqual(auComponentVm.view, '<div>hello</div>');
+      assert.strictEqual(appHost.textContent, 'hello world');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, 'hello');
+
+      await tearDown();
+
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    it('works with view string from view model', async function () {
+      const { ctx, component, appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view.bind="view">',
+        class App {
+          public message = 'hello world';
+          public view = `<div>\${message}</div>`;
+        }
+      );
+
+      await startPromise;
+      assert.strictEqual(appHost.textContent, 'hello world');
+
+      component.message = 'hello';
+
+      assert.strictEqual(appHost.textContent, 'hello world');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, 'hello');
+
+      await tearDown();
+
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    it('understands non-inherit scope config', async function () {
+      const { ctx, component, appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view.bind="view" scope-behavior="scoped">',
+        class App {
+          public message = 'hello world';
+          public view = `<div>\${message}</div>`;
+        }
+      );
+
+      await startPromise;
+      assert.strictEqual(appHost.textContent, '');
+
+      component.message = 'hello';
+
+      assert.strictEqual(appHost.textContent, '');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, '');
+
+      const auComponentVm = CustomElement.for(appHost.querySelector('au-compose')).viewModel as AuCompose;
+      auComponentVm.composition.controller.scope.bindingContext['message'] = 'hello';
+      assert.strictEqual(appHost.textContent, '');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, 'hello');
+
+      await tearDown();
+
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    it('understands view promise', async function () {
+      const { ctx, component, appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view.bind="getView()" scope-behavior="scoped">',
+        class App {
+          public message = 'hello world';
+          public view = `<div>\${message}</div>`;
+
+          public getView() {
+            return Promise.resolve(this.view);
+          }
+        }
+      );
+
+      await startPromise;
+      assert.strictEqual(appHost.textContent, '');
+
+      component.message = 'hello';
+
+      assert.strictEqual(appHost.textContent, '');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, '');
+
+      const auComponentVm = CustomElement.for(appHost.querySelector('au-compose')).viewModel as AuCompose;
+      auComponentVm.composition.controller.scope.bindingContext['message'] = 'hello';
+      assert.strictEqual(appHost.textContent, '');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, 'hello');
+
+      await tearDown();
+
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    it('throws on invalid scope-behavior value', async function () {
+      const { component, startPromise, tearDown } = createFixture(
+        '<au-compose view.bind="view" scope-behavior.bind="behavior">',
+        class App {
+          public message = 'hello world';
+          public view = `<div>\${message}</div>`;
+          public behavior = "auto";
+        }
+      );
+
+      await startPromise;
+
+      assert.throws(() => component.behavior = 'scope', 'Invalid scope behavior');
+
+      await tearDown();
+    });
+  });
+
+  describe('view-model', function () {
+    it('works with literal object', async function () {
+      const { ctx, appHost, startPromise, tearDown } = createFixture(
+        `\${message}<au-compose view-model.bind="{ activate }">`,
+        class App {
+          public message = 'hello world';
+          public view = `<div>\${message}</div>`;
+          public behavior = "auto";
+
+          public activate = () => {
+            this.message = 'Aurelia!!';
+          };
+        }
+      );
+
+      await startPromise;
+
+      assert.strictEqual(appHost.textContent, 'hello world');
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.textContent, 'Aurelia!!');
+
+      await tearDown();
+      assert.strictEqual(appHost.textContent, '');
+    });
+
+    it('works with custom element', async function () {
+      let activateCallCount = 0;
+      const { appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view-model.bind="fieldVm">',
+        class App {
+          public message = 'hello world';
+          public fieldVm = CustomElement.define(
+            { name: 'input-field', template: '<input value.bind="value">' },
+            class InputField {
+              public value = 'hello';
+              public activate() {
+                activateCallCount++;
+              }
+            }
+          );
+        }
+      );
+
+      await startPromise;
+
+      assert.strictEqual(appHost.textContent, '');
+      assert.strictEqual(appHost.querySelector('input').value, 'hello');
+      assert.strictEqual(activateCallCount, 1);
+
+      await tearDown();
+      assert.strictEqual(appHost.textContent, '');
+      assert.strictEqual(appHost.querySelector('input'), null);
+    });
+
+    it('works with promise of custom element', async function () {
+      let activateCallCount = 0;
+      const { appHost, startPromise, tearDown } = createFixture(
+        '<au-compose view-model.bind="getVm()">',
+        class App {
+          public getVm() {
+            return Promise.resolve(CustomElement.define(
+              { name: 'input-field', template: '<input value.bind="value">' },
+              class InputField {
+                public value = 'hello';
+                public activate() {
+                  activateCallCount++;
+                }
+              }
+            ));
+          }
+        }
+      );
+
+      await startPromise;
+
+      assert.strictEqual(appHost.textContent, '');
+      assert.strictEqual(appHost.querySelector('input').value, 'hello');
+      assert.strictEqual(activateCallCount, 1);
+
+      await tearDown();
+      assert.strictEqual(appHost.textContent, '');
+      assert.strictEqual(appHost.querySelector('input'), null);
+    });
+
+    it('passes model to activate method', async function () {
+      const models: unknown[] = [];
+      const model = { a: 1, b: Symbol() };
+      const { startPromise, tearDown } = createFixture(
+        `<au-compose view-model.bind="{ activate }" model.bind="model">`,
+        class App {
+          public model = model;
+          public activate = (model: unknown) => {
+            models.push(model);
+          };
+        }
+      );
+
+      await startPromise;
+
+      assert.deepStrictEqual(models, [model]);
+
+      await tearDown();
+    });
+
+    it('waits for activate promise', async function () {
+      let resolve: (v?: unknown) => unknown;
+      let attachedCallCount = 0;
+      const { startPromise, tearDown } = createFixture(
+        `<au-compose view-model.bind="{ activate }" view.bind="view">`,
+        class App {
+          public activate = () => {
+            return new Promise<unknown>(r => {
+              resolve = r;
+            });
+          };
+          public attached() {
+            attachedCallCount++;
+          }
+        }
+      );
+
+      await Promise.race([
+        new Promise(r => setTimeout(r, 50)),
+        startPromise
+      ]);
+      assert.strictEqual(attachedCallCount, 0);
+      resolve();
+
+      await Promise.race([
+        new Promise(r => setTimeout(r)),
+        startPromise
+      ]);
+      assert.strictEqual(attachedCallCount, 1);
+
+      await tearDown();
+    });
+
+    it('does not re-compose when only model is updated', async function () {
+      let constructorCallCount = 0;
+      let model = { a: 1, b: Symbol() };
+      const models1: unknown[] = [model];
+      const models2: unknown[] = [];
+      class PlainViewModelClass {
+        public constructor() {
+          constructorCallCount++;
+        }
+        public activate(model: unknown) {
+          models2.push(model);
+        }
+      }
+      const { ctx, component, startPromise, tearDown } = createFixture(
+        `<au-compose view-model.bind="vm" model.bind="model">`,
+        class App {
+          public model = model;
+          public vm = PlainViewModelClass;
+        }
+      );
+
+      await startPromise;
+
+      assert.strictEqual(constructorCallCount, 1);
+      assert.deepStrictEqual(models1, models2);
+
+      model = { a: 2, b: Symbol() };
+      models1.push(model);
+      component.model = model;
+
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(constructorCallCount, 1);
+      assert.strictEqual(models2.length, 2);
+      assert.deepStrictEqual(models1, models2);
+
+      await tearDown();
+    });
+  });
+
+  describe('integration with repeat', function () {
+    it('works with repeat in view only composition', async function () {
+      const { appHost, startPromise, tearDown } = createFixture(
+        `<au-compose repeat.for="i of 5" view.bind="getView()">`,
+        class App {
+          public getMessage(i: number) {
+            return `Hello ${i}`;
+          }
+          public getView() {
+            return `<div>div \${i}: \${getMessage(i)}</div>`;
+          }
+        }
+      );
+
+      await startPromise;
+
+      const divs = Array.from(appHost.querySelectorAll('div'));
+      assert.strictEqual(divs.length, 5);
+      divs.forEach((div, i) => {
+        assert.strictEqual(div.textContent, `div ${i}: Hello ${i}`);
+      });
+
+      await tearDown();
+    });
+
+    it('works with repeat in literal object composition', async function () {
+      const models: unknown[] = [];
+      const { startPromise, tearDown } = createFixture(
+        `<au-compose repeat.for="i of 5" view-model.bind="{ activate }" model.bind="{ index: i }">`,
+        class App {
+          public activate = (model: unknown) => {
+            models.push(model);
+          };
+        }
+      );
+
+      await startPromise;
+
+      assert.deepStrictEqual(models, Array.from({ length: 5 }, (_, index) => ({ index })));
+
+      await tearDown();
+    });
+
+    it('deactivates when collection changes', async function () {
+      const { component, appHost, startPromise, tearDown } = createFixture(
+        `<au-compose repeat.for="i of items" view.bind="getView()">`,
+        class App {
+          public items = 5;
+          public getMessage(i: number) {
+            return `Hello ${i}`;
+          }
+          public getView() {
+            return `<div>div \${i}: \${getMessage(i)}</div>`;
+          }
+        }
+      );
+
+      await startPromise;
+
+      let divs = Array.from(appHost.querySelectorAll('div'));
+      assert.strictEqual(divs.length, 5);
+      divs.forEach((div, i) => {
+        assert.strictEqual(div.textContent, `div ${i}: Hello ${i}`);
+      });
+
+      component.items = 3;
+      divs = Array.from(appHost.querySelectorAll('div'));
+      assert.strictEqual(divs.length, 3);
+      divs.forEach((div, i) => {
+        assert.strictEqual(div.textContent, `div ${i}: Hello ${i}`);
+      });
+
+      await tearDown();
+    });
+  });
+
+  describe('multi au-compose', function () {
+    it('composes au-compose', async function () {
+      const { appHost, startPromise, tearDown } = createFixture(
+        `<au-compose repeat.for="i of 5" view.bind="getView()">`,
+        class App {
+          public getMessage(i: number) {
+            return `Hello ${i}`;
+          }
+          public getView() {
+            return `<au-compose view.bind="getInnerView()">`;
+          }
+          public getInnerView() {
+            return `<div>div \${i}: \${getMessage(i)}</div>`;
+          }
+        }
+      );
+
+      await startPromise;
+
+      const divs = Array.from(appHost.querySelectorAll('div'));
+      assert.strictEqual(divs.length, 5);
+      divs.forEach((div, i) => {
+        assert.strictEqual(div.textContent, `div ${i}: Hello ${i}`);
+      });
+
+      await tearDown();
+      assert.strictEqual(appHost.querySelectorAll('div').length, 0);
+    });
+  });
+
+  // TODO:
+  // fix containerless in core compilation
+  //
+  // describe('containerless', function () {
+  //   it('works with containerless on the host element', async function () {
+  //     const models: unknown[] = [];
+  //     const { startPromise, tearDown } = createFixture(
+  //       `<au-compose view-model.bind="{ activate }" model.bind="{ index: 0 }" containerless>`,
+  //       class App {
+  //         public activate = (model: unknown) => {
+  //           models.push(model);
+  //         };
+  //       }
+  //     );
+
+  //     await startPromise;
+
+  //     assert.deepStrictEqual(models, [{ index: 0 }]);
+
+  //     await tearDown();
+  //   });
+  // });
 });

--- a/packages/__tests__/integration/app/molecules/specs-viewer/specs-viewer.html
+++ b/packages/__tests__/integration/app/molecules/specs-viewer/specs-viewer.html
@@ -1,6 +1,6 @@
 <template>
   <template repeat.for="pair of pairs">
-    <au-compose subject.bind="pair.vm" model="pair.thing"></au-compose>
+    <au-render subject.bind="pair.vm" model="pair.thing"></au-compose>
     <hr> <!-- just a marker to separate the items -->
   </template>
 </template>

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -73,7 +73,8 @@ import {
   // FulfilledAttributePattern,
   // RejectedAttributePattern,
 } from './resources/template-controllers/promise.js';
-import { Compose } from './resources/custom-elements/compose.js';
+import { AuRender } from './resources/custom-elements/au-render.js';
+import { AuCompose } from './resources/custom-elements/au-compose.js';
 import { AuSlot } from './resources/custom-elements/au-slot.js';
 import { SanitizeValueConverter } from './resources/value-converters/sanitize.js';
 import { ViewValueConverter } from './resources/value-converters/view.js';
@@ -189,7 +190,8 @@ export const RejectedTemplateControllerRegistration = RejectedTemplateController
 export const AttrBindingBehaviorRegistration = AttrBindingBehavior as unknown as IRegistry;
 export const SelfBindingBehaviorRegistration = SelfBindingBehavior as unknown as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as unknown as IRegistry;
-export const ComposeRegistration = Compose as unknown as IRegistry;
+export const AuRenderRegistration = AuRender as unknown as IRegistry;
+export const AuComposeRegistration = AuCompose as unknown as IRegistry;
 export const PortalRegistration = Portal as unknown as IRegistry;
 export const FocusRegistration = Focus as unknown as IRegistry;
 export const BlurRegistration = Blur as unknown as IRegistry;
@@ -233,7 +235,8 @@ export const DefaultResources = [
   AttrBindingBehaviorRegistration,
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
-  ComposeRegistration,
+  AuRenderRegistration,
+  AuComposeRegistration,
   PortalRegistration,
   FocusRegistration,
   BlurRegistration,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -457,8 +457,12 @@ export {
 
 export {
   Subject,
-  Compose,
-} from './resources/custom-elements/compose.js';
+  AuRender,
+} from './resources/custom-elements/au-render.js';
+export {
+  AuCompose,
+  IDynamicComponentActivate,
+} from './resources/custom-elements/au-compose.js';
 export {
   ISanitizer,
   SanitizeValueConverter,
@@ -511,7 +515,7 @@ export {
   AttrBindingBehaviorRegistration,
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
-  ComposeRegistration,
+  AuRenderRegistration as ComposeRegistration,
 
   DefaultResources,
 

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,0 +1,371 @@
+import { Constructable, IContainer, InstanceProvider, ITask, onResolve, transient } from '@aurelia/kernel';
+import { LifecycleFlags, Scope } from '@aurelia/runtime';
+import { bindable } from '../../bindable.js';
+import { INode } from '../../dom.js';
+import { IPlatform } from '../../platform.js';
+import { HydrateElementInstruction, IInstruction } from '../../renderer.js';
+import { Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller.js';
+import { getRenderContext } from '../../templating/render-context.js';
+import { CustomElement, customElement, CustomElementDefinition } from '../custom-element.js';
+
+// plan:
+// 0. <au-component/> is containerless
+//    this probably won't work, since it prohibits the use of shadow dom + slot naturally
+//    this probably will still allows au-slot
+// 1. create host element corresponding to the composed component view model
+//    if there's no view model def, then creates a div
+//    if there's no view model at all, then creates a div
+//    this probably has issue related to containerless, since it's sometimes desirable
+
+/**
+ * An optional interface describing the dialog activate convention.
+ */
+export interface IDynamicComponentActivate<T> {
+  /**
+   * Implement this hook if you want to perform custom logic just before the component is is composed.
+   * The returned value is not used.
+   */
+  activate?(model?: T): unknown | Promise<unknown>;
+}
+
+type MaybePromise<T> = T | Promise<T>;
+type ChangeSource = 'view' | 'viewModel' | 'model' | 'scopeBehavior';
+
+// Desired usage:
+// <au-component view.bind="Promise<string>" view-model.bind="" model.bind="" />
+// <au-component view.bind="<string>" model.bind="" />
+//
+
+@customElement('au-compose')
+export class AuCompose {
+
+  /** @internal */
+  protected static get inject() {
+    return [IContainer, IController, INode, IPlatform, IInstruction, transient(CompositionContextFactory)];
+  }
+
+  /* determine what template used to compose the component */
+  @bindable
+  public view?: string | Promise<string>;
+
+  /* determine the view model instance used to compose the component */
+  @bindable
+  public viewModel?: Constructable | object | Promise<Constructable | object>;
+
+  /* the model used to pass to activate lifecycle of the component */
+  @bindable
+  public model?: unknown;
+
+  @bindable({ set: v => {
+    if (v === 'scoped' || v === 'auto') {
+      return v;
+    }
+    throw new Error('Invalid scope behavior config. Only "scoped" or "auto" allowed.');
+  }})
+  public scopeBehavior: 'auto' | 'scoped' = 'auto';
+
+  /** @internal */
+  public readonly $controller!: ICustomElementController<AuCompose>;
+
+  /** @internal */
+  private task: ITask | null = null;
+
+  /** @internal */
+  private c: ICompositionController | undefined = void 0;
+  public get composition(): ICompositionController | undefined {
+    return this.c;
+  }
+
+  public constructor(
+    private readonly container: IContainer,
+    private readonly parent: ISyntheticView | ICustomElementController,
+    private readonly host: HTMLElement,
+    private readonly p: IPlatform,
+    // todo: use this to retrieve au-slot instruction
+    //        for later enhancement related to <au-slot/> + compose
+    private readonly instruction: HydrateElementInstruction,
+    private readonly contextFactory: CompositionContextFactory,
+  ) {
+  }
+
+  public attaching(initiator: IHydratedController, parent: IHydratedController, flags: LifecycleFlags): void | Promise<void> {
+    return this.queue(new ChangeInfo(this.view, this.viewModel, this.model, initiator, void 0));
+  }
+
+  public detaching(initiator: IHydratedController): void | Promise<void> {
+    this.task?.cancel();
+    this.task = null;
+    const cmpstn = this.c;
+    if (cmpstn != null) {
+      this.c = void 0;
+      return cmpstn.deactivate(initiator);
+    }
+  }
+
+  /** @internal */
+  protected propertyChanged(name: ChangeSource): void {
+    const task = this.task;
+    this.task = this.p.domWriteQueue.queueTask(() => {
+      return onResolve(this.queue(new ChangeInfo(this.view!, this.viewModel, this.model, void 0, name)), () => {
+        this.task = null;
+      });
+    });
+    task?.cancel();
+  }
+
+  /** @internal */
+  private queue(change: ChangeInfo): void | Promise<void> {
+    const factory = this.contextFactory;
+    const currentComposition = this.c;
+    if (change.src === 'model' && currentComposition != null) {
+      return currentComposition.update(change.model);
+    }
+    // todo: handle consequitive changes that create multiple queues
+    return onResolve(
+      factory.create(change),
+      context => {
+        // Don't compose [stale] view/view model
+        // by always ensuring that the composition context is the latest one
+        if (factory.isCurrent(context)) {
+          return onResolve(this.compose(context), (result) => {
+            // Don't activate [stale] controller
+            // by always ensuring that the composition context is the latest one
+            if (factory.isCurrent(context)) {
+              return onResolve(result.activate(), () => {
+                // Don't conclude the [stale] composition
+                // by always ensuring that the composition context is the latest one
+                if (factory.isCurrent(context)) {
+                  // after activation, if the composition context is still the most recent one
+                  // then the job is done
+                  this.c = result;
+                  return currentComposition?.deactivate(change.initiator);
+                } else {
+                  // the stale controller should be deactivated
+                  return onResolve(
+                    result.controller.deactivate(result.controller, this.$controller, LifecycleFlags.fromUnbind),
+                    // todo: do we need to deactivate?
+                    () => result.controller.dispose()
+                  );
+                }
+              });
+            } else {
+              result.controller.dispose();
+            }
+          });
+        }
+      }
+    );
+  }
+
+  /** @internal */
+  private compose(context: CompositionContext): MaybePromise<ICompositionController> {
+    // todo: when both view model and view are empty
+    //       should it throw or try it best to proceed?
+    //       current: proceed
+    const { view, viewModel, model, initiator } = context.change;
+    const { container, host, $controller, contextFactory } = this;
+    const comp = this.getOrCreateVm(container, viewModel, host);
+    const compose: () => ICompositionController = () => {
+      const srcDef = this.getDefinition(comp);
+      // custom element based composition
+      if (srcDef !== null) {
+        const targetDef = CustomElementDefinition.create(
+          srcDef ?? { name: CustomElement.generateName(), template: view }
+        );
+        const controller = Controller.forCustomElement(
+          null,
+          container,
+          comp,
+          host,
+          null,
+          LifecycleFlags.none,
+          true,
+          targetDef,
+        );
+
+        return new CompositionController(
+          controller,
+          () => controller.activate(initiator ?? controller, $controller, LifecycleFlags.fromBind),
+          // todo: call deactivate on the component view model
+          (deactachInitiator) => controller.deactivate(deactachInitiator ?? controller, $controller, LifecycleFlags.fromUnbind),
+          // casting is technically incorrect
+          // but it's ignored in the caller anyway
+          (model) => comp.activate?.(model) as MaybePromise<void>,
+          context,
+        );
+      } else {
+        const targetDef = CustomElementDefinition.create({
+          name: CustomElement.generateName(),
+          template: view
+        });
+        const renderContext = getRenderContext(targetDef, container);
+        const viewFactory = renderContext.getViewFactory();
+        const controller = Controller.forSyntheticView(
+          contextFactory.isFirst(context) ? $controller.root : null,
+          renderContext,
+          viewFactory,
+          LifecycleFlags.fromBind,
+          $controller
+        );
+        const scope = this.scopeBehavior === 'auto'
+          ? Scope.fromParent(this.parent.scope, comp)
+          : Scope.create(comp);
+
+        controller.setHost(host);
+
+        return new CompositionController(
+          controller,
+          () => controller.activate(initiator ?? controller, $controller, LifecycleFlags.fromBind, scope, null),
+          // todo: call deactivate on the component view model
+          (detachInitiator) => controller.deactivate(detachInitiator ?? controller, $controller, LifecycleFlags.fromUnbind),
+          // casting is technically incorrect
+          // but it's ignored in the caller anyway
+          (model) => comp.activate?.(model) as MaybePromise<void>,
+          context,
+        );
+      }
+    };
+    if ('activate' in comp) {
+      // todo: try catch
+      // req:  ensure synchronosity of compositions that dont employ promise
+      return onResolve(comp.activate!(model), () => compose());
+    } else {
+      return compose();
+    }
+  }
+
+  /** @internal */
+  private getOrCreateVm(container: IContainer, comp: Constructable | object | undefined, host: HTMLElement): IDynamicComponentActivate<unknown> {
+    if (comp == null) {
+      return new EmptyComponent();
+    }
+    if (typeof comp === 'object') {
+      return comp;
+    }
+
+    const p = this.p;
+    const ep = new InstanceProvider('ElementResolver');
+
+    ep.prepare(host);
+    container.registerResolver(INode, ep);
+    container.registerResolver(p.Node, ep);
+    container.registerResolver(p.Element, ep);
+    container.registerResolver(p.HTMLElement, ep);
+
+    return container.invoke(comp);
+  }
+
+  /** @internal */
+  private getDefinition(component?: object | Constructable) {
+    const Ctor = (typeof component === 'function'
+      ? component
+      : component?.constructor) as Constructable;
+    return CustomElement.isType(Ctor)
+      ? CustomElement.getDefinition(Ctor)
+      : null;
+  }
+}
+
+class EmptyComponent { }
+
+interface ICompositionController {
+  readonly controller: IHydratedController;
+  readonly context: CompositionContext;
+  activate(): void | Promise<void>;
+  // deactivation is done differently, compared to activation
+  // when the `<au-component/>` is deactivated, initiator will be an ancestor controller
+  //
+  // while when the value of the @bindables changes, initiator should be
+  // the controller wrapped in this composition controller
+  deactivate(detachInitator?: IHydratedController): void | Promise<void>;
+  update(model: unknown): void | Promise<void>;
+}
+
+class CompositionContextFactory {
+  private id = 0;
+
+  public isFirst(context: CompositionContext): boolean {
+    return context.id === 0;
+  }
+
+  public isCurrent(context: CompositionContext): boolean {
+    return context.id === this.id - 1;
+  }
+
+  public create(changes: ChangeInfo): MaybePromise<CompositionContext> {
+    return onResolve(changes.load(), (loaded) => new CompositionContext(this.id++, loaded));
+  }
+}
+
+class ChangeInfo {
+  public constructor(
+    public readonly view: MaybePromise<string> | undefined,
+    public readonly viewModel: MaybePromise<Constructable | object> | undefined,
+    public readonly model: unknown | undefined,
+    public readonly initiator: IHydratedController | undefined,
+    public readonly src: ChangeSource | undefined,
+  ) { }
+
+  public load(): MaybePromise<LoadedChangeInfo> {
+    if (this.view instanceof Promise || this.viewModel instanceof Promise) {
+      return Promise
+        .all([this.view, this.viewModel])
+        .then(([view, viewModel]) => {
+          return new LoadedChangeInfo(view, viewModel, this.model, this.initiator, this.src);
+        });
+    } else {
+      return new LoadedChangeInfo(this.view, this.viewModel, this.model, this.initiator, this.src);
+    }
+  }
+}
+
+class LoadedChangeInfo {
+  public constructor(
+    public readonly view: string | undefined,
+    public readonly viewModel: Constructable | object | undefined,
+    public readonly model: unknown | undefined,
+    public readonly initiator: IHydratedController | undefined,
+    public readonly src: ChangeSource | undefined,
+  ) { }
+}
+
+class CompositionContext {
+  public constructor(
+    public readonly id: number,
+    public readonly change: LoadedChangeInfo,
+  ) { }
+}
+
+class CompositionController implements ICompositionController {
+  private state: /* stopped */-1 | /* initial */0 | /* started */1 = 0;
+
+  public constructor(
+    public readonly controller: ISyntheticView | ICustomElementController,
+    private readonly start: () => void | Promise<void>,
+    private readonly stop: (detachInitator?: IHydratedController) => void | Promise<void>,
+    public readonly update: (model: unknown) => void | Promise<void>,
+    public readonly context: CompositionContext,
+  ) {
+
+  }
+
+  public activate() {
+    if (this.state !== 0) {
+      throw new Error(`Composition has already been activated/deactivated. Id: ${this.controller.id}`);
+    }
+    this.state = 1;
+    return this.start();
+  }
+
+  public deactivate(detachInitator?: IHydratedController) {
+    switch (this.state) {
+      case 1:
+        this.state = -1;
+        return this.stop(detachInitator);
+      case -1:
+        throw new Error('Composition has already been deactivated.');
+      default:
+        this.state = -1;
+    }
+  }
+}

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -24,8 +24,8 @@ function toLookup(
   return acc;
 }
 
-@customElement({ name: 'au-compose', template: null, containerless: true })
-export class Compose implements ICustomElementViewModel {
+@customElement({ name: 'au-render', template: null, containerless: true })
+export class AuRender implements ICustomElementViewModel {
   public readonly id: number = nextId('au$component');
 
   @bindable public subject?: MaybeSubjectPromise = void 0;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Compared to v1 `<compose/>`, the current `au-compose` is having a different API set aiming to take advantages of the new templating primitives in v2, though since the time it was envisioned, things have changed quite a bit and its capabilities don't address the core needs of a more familiar API set in V1. This PR adds back the v1 composition functionalities, with a few breaking changes as noted below:

- main: passing a string to either view/ view model no longer means module name. The composer only understands string as template for `view` and objects and classes for `view-model` now. Though if it's still possible to turn treat string as module name, with the help of value converter:
    ```html
    <au-compose view="https://my-server.com/views/${componentName} | loadView">
    ```
    ```ts
    class LoadViewValueConverter {
      toView(v) { return fetch(v).then(r => r.text()) }
    }
    ```
- inherit binding context is no longer the default in all cases: it will only inherit parent binding context (or scope) when it's a view only composition. User can also disable this via `scope-behavior ` bindable:
    ```html
    <au-compose scope-behavior="scoped">
    ```
  Possible values are:
      - `auto`: in view only composition: inherit the parent scope
      - `scoped`: never inherit parent scope even in view only composition
- naming change: `compose` (v1) is  changed to `au-compose` (v2), and the existing `au-compose` will be renamed to a different name. Possibly either `au-element` or `au-render`.

closes #953
closes #498

## 📑 Test Plan

Prepare tests for:
- view only
- view model only
- view + view model
- literal objects
- activate + deactivate
- shadow dom + native slot

## ⏭ Next Steps

Refactor templating to support binding instruction transferring, and au-slot. native slot should works fine with shadow dom enabled on the view model of the composition.