### PR TITLE
fix(resources): prevent duplication, don't carry root resources to leaf

### DIFF
--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -1371,7 +1371,11 @@ describe(`The Container class`, function () {
         assert.strictEqual(childHasKey, false, `childHasKey`);
       });
 
-      it(`stores resource resolvers in resourceResolvers in parent and inherits them from root but does not from parent`, function () {
+      // container used to copy resource keys all the way down
+      // it's not only wasteful, but also inappropriate
+      // a change in the way resources information is carried forward resulted in this test being skipped
+      // but kept as a reminder how it used to be, in case someone relying on this behavior ran into the odd behavior
+      it.skip(`stores resource resolvers in resourceResolvers in parent and inherits them from root but does not from parent`, function () {
         const type = class {};
         const keyFromRoot = 'foo:bar' as any;
         const keyFromParent = 'foo:baz' as any;
@@ -1392,10 +1396,10 @@ describe(`The Container class`, function () {
         const childHasKeyFromRoot = child['resourceResolvers'][keyFromRoot] !== void 0;
         const childHasKeyFromParent = child['resourceResolvers'][keyFromParent] !== void 0;
 
-        assert.strictEqual(parentHasKeyFromRoot, true, `parentHasKeyFromRoot`);
+        assert.strictEqual(parentHasKeyFromRoot, false, `parentHasKeyFromRoot`);
         assert.strictEqual(parentHasKeyFromParent, true, `parentHasKeyFromParent`);
 
-        assert.strictEqual(childHasKeyFromRoot, true, `childHasKeyFromRoot`);
+        assert.strictEqual(childHasKeyFromRoot, false, `childHasKeyFromRoot`);
         assert.strictEqual(childHasKeyFromParent, false, `childHasKeyFromParent`);
       });
     });

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -859,10 +859,7 @@ export class Container implements IContainer {
           this.root.resourceResolvers,
         );
       } else {
-        this.resourceResolvers = Object.assign(
-          Object.create(null),
-          this.root.resourceResolvers,
-        );
+        this.resourceResolvers = Object.create(null);
       }
     }
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -930,6 +930,9 @@ export class Container implements IContainer {
     if (result == null) {
       resolvers.set(key, resolver);
       if (isResourceKey(key)) {
+        if (this.resourceResolvers[key] !== void 0) {
+          throw new Error(`Resource key "${key}" already registered`);
+        }
         this.resourceResolvers[key] = resolver;
       }
     } else if (result instanceof Resolver && result.strategy === ResolverStrategy.array) {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -268,7 +268,7 @@ export class AuCompose {
 
 class EmptyComponent { }
 
-interface ICompositionController {
+export interface ICompositionController {
   readonly controller: IHydratedController;
   readonly context: CompositionContext;
   activate(): void | Promise<void>;

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -114,7 +114,7 @@ function chooseContext(
 
   // traverse the context and it's ancestors, searching for a context that has the name.
   while (
-    (!currentScope?.isComponentBoundary
+    (!currentScope?.isBoundary
       || projectionScope !== null && projectionScope !== currentScope
     )
     && overrideContext
@@ -140,7 +140,7 @@ export class Scope {
     public parentScope: Scope | null,
     public bindingContext: IBindingContext,
     public overrideContext: IOverrideContext,
-    public readonly isComponentBoundary: boolean,
+    public readonly isBoundary: boolean,
   ) {}
 
   /**
@@ -161,7 +161,7 @@ export class Scope {
    * during binding, it will traverse up via the `parentScope` of the scope until
    * it finds the property.
    */
-  public static create(bc: object, oc: IOverrideContext, isComponentBoundary?: boolean): Scope;
+  public static create(bc: object, oc: IOverrideContext, isBoundary?: boolean): Scope;
   /**
    * Create a new `Scope` backed by the provided `BindingContext` and `OverrideContext`.
    *
@@ -171,9 +171,9 @@ export class Scope {
    * @param bc - The `BindingContext` to back the `Scope` with.
    * @param oc - null. This overload is functionally equivalent to not passing this argument at all.
    */
-  public static create(bc: object, oc: null, isComponentBoundary?: boolean): Scope;
-  public static create(bc: object, oc?: IOverrideContext | null, isComponentBoundary?: boolean): Scope {
-    return new Scope(null, bc as IBindingContext, oc == null ? OverrideContext.create(bc) : oc, isComponentBoundary ?? false);
+  public static create(bc: object, oc: null, isBoundary?: boolean): Scope;
+  public static create(bc: object, oc?: IOverrideContext | null, isBoundary?: boolean): Scope {
+    return new Scope(null, bc as IBindingContext, oc == null ? OverrideContext.create(bc) : oc, isBoundary ?? false);
   }
 
   public static fromOverride(oc: IOverrideContext): Scope {

--- a/packages/testing/src/test-builder.ts
+++ b/packages/testing/src/test-builder.ts
@@ -465,10 +465,10 @@ export function createObserverLocator(containerOrLifecycle?: IContainer): IObser
   return container.get(IObserverLocator);
 }
 
-export function createScopeForTest(bindingContext: any = {}, parentBindingContext?: any, isComponentBoundary?: boolean): Scope {
+export function createScopeForTest(bindingContext: any = {}, parentBindingContext?: any, isBoundary?: boolean): Scope {
   return parentBindingContext
     ? Scope.fromParent(Scope.create(parentBindingContext), bindingContext)
-    : Scope.create(bindingContext, OverrideContext.create(bindingContext), isComponentBoundary);
+    : Scope.create(bindingContext, OverrideContext.create(bindingContext), isBoundary);
 }
 
 // export type CustomAttribute = Writable<IViewModel> & IComponentLifecycleMock;


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, root resources is carried over to every leaf, this seems excessive.
Rename prop `isComponentBoundary` -> `isBoundary` on scope, as scope wouldn't care how it's used.