### PR TITLE
Fix dialog-default-impl: display flex on overlay

### DIFF
--- a/packages/runtime-html/src/templating/dialog/dialog-default-impl.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-default-impl.ts
@@ -30,8 +30,8 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer {
     Registration.singleton(IDialogDomRenderer, this).register(container);
   }
 
-  private readonly wrapperCss: string = baseWrapperCss;
-  private readonly overlayCss: string = `${baseWrapperCss} display:flex;`;
+  private readonly wrapperCss: string = `${baseWrapperCss} display:flex;`;
+  private readonly overlayCss: string = baseWrapperCss;
   private readonly hostCss: string = 'position:relative;margin:auto;';
 
   public render(dialogHost: HTMLElement): IDialogDom {
@@ -43,7 +43,7 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer {
     };
     const wrapper = dialogHost.appendChild(h('au-dialog-container', this.wrapperCss));
     const overlay = wrapper.appendChild(h('au-dialog-overlay', this.overlayCss));
-    const host = overlay.appendChild(h('div', this.hostCss));
+    const host = wrapper.appendChild(h('div', this.hostCss));
     return new DefaultDialogDom(wrapper, overlay, host);
   }
 }

--- a/packages/runtime-html/src/templating/dialog/dialog-default-impl.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-default-impl.ts
@@ -30,8 +30,8 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer {
     Registration.singleton(IDialogDomRenderer, this).register(container);
   }
 
-  private readonly wrapperCss: string = `${baseWrapperCss} display:flex;`;
-  private readonly overlayCss: string = baseWrapperCss;
+  private readonly wrapperCss: string = baseWrapperCss;
+  private readonly overlayCss: string = `${baseWrapperCss} display:flex;`;
   private readonly hostCss: string = 'position:relative;margin:auto;';
 
   public render(dialogHost: HTMLElement): IDialogDom {


### PR DESCRIPTION
In order for the dialog itself to be centered with the `margin: auto`, its direct parent must be `display: flex` which is the overlay and not the container.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
