### PR TITLE
chore: clean up

### DIFF
--- a/docs/user-docs/examples/integration/ionic.md
+++ b/docs/user-docs/examples/integration/ionic.md
@@ -9,9 +9,9 @@ The following is a code example of how to teach Aurelia to work seamlessly with 
 ```typescript
 export class IonicFramework implements IRegistry {
     register(container: IContainer) {
-        const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
+        const attrMapper = container.get(IAttrMapper);
         const nodeObserverLocator = container.get(NodeObserverLocator);
-        attrSyntaxTransformer.useTwoWay((el, property) => {
+        attrMapper.useTwoWay((el, property) => {
             if (el.tagName === 'ION-CHECKBOX' ||
                 el.tagName === 'ION-TOGGLE'
             ) {

--- a/docs/user-docs/examples/integration/ms-fast.md
+++ b/docs/user-docs/examples/integration/ms-fast.md
@@ -7,12 +7,12 @@ If the example doesn't seem obvious, the following prerequisite reads are recomm
 The following is a code example of how to teach Aurelia to work seamlessly with [Microsoft FAST](https://www.fast.design/):
 
 ```typescript
-import { AppTask, IContainer, IAttrSyntaxTransformer, NodeObserverLocator } from 'aurelia';
+import { AppTask, IContainer, IAttrMapper, NodeObserverLocator } from 'aurelia';
 
 Aurelia.register(AppTask.beforeCreate(IContainer, container => {
-  const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
+  const attrMapper = container.get(IAttrMapper);
   const nodeObserverLocator = container.get(NodeObserverLocator);
-  attrSyntaxTransformer.useTwoWay((el, property) => {
+  attrMapper.useTwoWay((el, property) => {
     switch (el.tagName) {
       case 'FAST-SLIDER':
       case 'FAST-TEXT-FIELD':

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=14.15.0",
-    "npm": ">=6.14.8"
+    "node": ">=16.0.0",
+    "npm": ">=7.0.0"
   },
   "scripts": {
     "commit": "git-cz",

--- a/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-syntax-extension.spec.ts
@@ -1,5 +1,5 @@
 import { IContainer, IPlatform } from '@aurelia/kernel';
-import { AppTask, BrowserPlatform, CustomElement, IAttrSyntaxTransformer, NodeObserverLocator } from '@aurelia/runtime-html';
+import { AppTask, BrowserPlatform, CustomElement, IAttrMapper, NodeObserverLocator } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
@@ -39,8 +39,8 @@ describe('3-runtime-html/attr-syntax-extension.spec.ts', function () {
             }
           });
 
-          const transformer = container.get(IAttrSyntaxTransformer);
-          transformer.useTwoWay((el, property) => {
+          const attrMapper = container.get(IAttrMapper);
+          attrMapper.useTwoWay((el, property) => {
             return el.tagName === elName.toUpperCase() && property === 'value';
           });
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -733,7 +733,7 @@ export {
   // IAttributePatternHandler,
   // Interpretation,
   // ISyntaxInterpreter,
-  IAttrSyntaxTransformer,
+  IAttrMapper,
 
   // AtPrefixedTriggerAttributePattern,
   // ColonPrefixedBindAttributePattern,

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -14,7 +14,7 @@ import {
   AttrSyntax,
   bindingCommand,
   IPlatform,
-  IAttrSyntaxTransformer,
+  IAttrMapper,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -48,13 +48,13 @@ export class TranslationParametersBindingInstruction {
 export class TranslationParametersBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): TranslationParametersBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
+      target = this.m.map(info.node, info.attr.target)
         // if the transformer doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -12,7 +12,7 @@ import {
   IHydratableController,
   AttrSyntax,
   IPlatform,
-  IAttrSyntaxTransformer,
+  IAttrMapper,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -46,14 +46,14 @@ export class TranslationBindingInstruction {
 export class TranslationBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.CustomCommand = BindingType.CustomCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): TranslationBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
@@ -116,14 +116,14 @@ export class TranslationBindBindingInstruction {
 export class TranslationBindBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): TranslationBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -1,21 +1,14 @@
-import {
-  Constructable,
-  DI,
-  IContainer,
-  Registration,
-  InstanceProvider,
-  IDisposable,
-  onResolve,
-  resolveAll,
-  ILogger
-} from '@aurelia/kernel';
+import { DI, Registration, InstanceProvider, onResolve, resolveAll, ILogger } from '@aurelia/kernel';
 import { LifecycleFlags } from '@aurelia/runtime';
 import { INode } from './dom.js';
-import { IAppTask, TaskSlot } from './app-task.js';
+import { IAppTask } from './app-task.js';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
 import { Controller } from './templating/controller.js';
-import { IPlatform } from './platform.js';
+
+import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
+import type { TaskSlot } from './app-task.js';
 import type { ICustomElementViewModel, ICustomElementController } from './templating/controller.js';
+import type { IPlatform } from './platform.js';
 
 export interface ISinglePageApp {
   host: HTMLElement;

--- a/packages/runtime-html/src/app-task.ts
+++ b/packages/runtime-html/src/app-task.ts
@@ -1,11 +1,5 @@
-import {
-  DI,
-  IContainer,
-  IRegistry,
-  Key,
-  Registration,
-  Resolved,
-} from '@aurelia/kernel';
+import { DI, Registration } from '@aurelia/kernel';
+import type { IContainer, IRegistry, Key, Resolved } from '@aurelia/kernel';
 
 export type TaskSlot = (
   'beforeCreate' |

--- a/packages/runtime-html/src/attribute-mapper.ts
+++ b/packages/runtime-html/src/attribute-mapper.ts
@@ -2,13 +2,13 @@ import { DI } from '@aurelia/kernel';
 import { createLookup, isDataAttribute } from './utilities-html.js';
 import { ISVGAnalyzer } from './observation/svg-analyzer.js';
 
-export interface IAttrSyntaxTransformer extends AttrSyntaxTransformer {}
-export const IAttrSyntaxTransformer = DI
-  .createInterface<IAttrSyntaxTransformer>('IAttrSyntaxTransformer', x => x.singleton(AttrSyntaxTransformer));
+export interface IAttrMapper extends AttrMapper {}
+export const IAttrMapper = DI
+  .createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
 
 type IsTwoWayPredicate = (element: Element, attribute: string) => boolean;
 
-export class AttrSyntaxTransformer {
+export class AttrMapper {
   public static get inject() { return [ISVGAnalyzer]; }
   /**
    * @internal
@@ -92,24 +92,23 @@ export class AttrSyntaxTransformer {
 
   /**
    * Add a given function to a list of fns that will be used
-   * to check if `'bind'` command can be transformed to `'two-way'` command.
-   *
-   * If one of those functions in this lists returns true, the `'bind'` command
-   * will be transformed into `'two-way'` command.
-   *
-   * The function will be called with 2 parameters:
-   * - element: the element that the template compiler is currently working with
-   * - property: the target property name
+   * to check if `'bind'` command can be understood as `'two-way'` command.
    */
   public useTwoWay(fn: IsTwoWayPredicate): void {
     this.fns.push(fn);
   }
 
+  /**
+   * Returns true if an attribute should be two way bound based on an element
+   */
   public isTwoWay(node: Element, attrName: string): boolean {
     return shouldDefaultToTwoWay(node, attrName)
       || this.fns.length > 0 && this.fns.some(fn => fn(node, attrName));
   }
 
+  /**
+   * Retrieves the mapping information this mapper have for an attribute on an element
+   */
   public map(node: Element, attr: string): string | null {
     return this.tagAttrMap[node.nodeName]?.[attr] as string
       ?? this.globalAttrMap[attr]

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -1,17 +1,8 @@
-import {
-  Constructable,
-  kebabCase,
-  Metadata,
-  Protocol,
-  firstDefined,
-  getPrototypeChain,
-  Writable,
-  noop,
-} from '@aurelia/kernel';
-import {
-  BindingMode,
-  InterceptorFunc,
-} from '@aurelia/runtime';
+import { kebabCase, Metadata, Protocol, firstDefined, getPrototypeChain, noop } from '@aurelia/kernel';
+import { BindingMode } from '@aurelia/runtime';
+
+import type { Constructable, Writable } from '@aurelia/kernel';
+import type { InterceptorFunc } from '@aurelia/runtime';
 
 export type PartialBindableDefinition = {
   mode?: BindingMode;

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -21,7 +21,7 @@ import {
   StyleBindingCommand,
   TriggerBindingCommand,
 } from './resources/binding-command.js';
-import { ViewCompiler } from './template-compiler.js';
+import { TemplateCompiler } from './template-compiler.js';
 import {
   CallBindingRenderer,
   CustomAttributeRenderer,
@@ -88,7 +88,7 @@ export const SignalBindingBehaviorRegistration = SignalBindingBehavior as unknow
 export const ThrottleBindingBehaviorRegistration = ThrottleBindingBehavior as unknown as IRegistry;
 export const TwoWayBindingBehaviorRegistration = TwoWayBindingBehavior as unknown as IRegistry;
 
-export const ITemplateCompilerRegistration = ViewCompiler as IRegistry;
+export const ITemplateCompilerRegistration = TemplateCompiler as IRegistry;
 export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry;
 
 /**

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -269,8 +269,8 @@ export {
   StyleBindingCommand,
 } from './resources/binding-command.js';
 export {
-  IAttrSyntaxTransformer,
-} from './attribute-syntax-transformer.js';
+  IAttrMapper,
+} from './attribute-mapper.js';
 export {
   Listener,
 } from './binding/listener.js';

--- a/packages/runtime-html/src/observation/attribute-ns-accessor.ts
+++ b/packages/runtime-html/src/observation/attribute-ns-accessor.ts
@@ -1,8 +1,9 @@
 import { AccessorType } from '@aurelia/runtime';
+import { createLookup } from '../utilities-html.js';
 
 import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 
-const nsMap: Record<string, AttributeNSAccessor> = Object.create(null);
+const nsMap: Record<string, AttributeNSAccessor> = createLookup();
 
 /**
  * Attribute accessor in a XML document/element that can be accessed via a namespace.

--- a/packages/runtime-html/src/observation/svg-analyzer.ts
+++ b/packages/runtime-html/src/observation/svg-analyzer.ts
@@ -1,6 +1,9 @@
-import { DI, IContainer, IResolver, Registration } from '@aurelia/kernel';
-import { INode } from '../dom.js';
+import { DI, Registration } from '@aurelia/kernel';
 import { IPlatform } from '../platform.js';
+import { createLookup } from '../utilities-html.js';
+
+import type { IContainer, IResolver } from '@aurelia/kernel';
+import type { INode } from '../dom.js';
 
 export interface ISVGAnalyzer extends NoopSVGAnalyzer {}
 export const ISVGAnalyzer = DI.createInterface<ISVGAnalyzer>('ISVGAnalyzer', x => x.singleton(NoopSVGAnalyzer));
@@ -12,8 +15,9 @@ export class NoopSVGAnalyzer {
 }
 
 function o(keys: string[]): Record<string, true | undefined> {
-  const lookup = Object.create(null);
-  for (const key of keys) {
+  const lookup = createLookup<true | undefined>();
+  let key: string;
+  for (key of keys) {
     lookup[key] = true;
   }
   return lookup;
@@ -28,14 +32,14 @@ export class SVGAnalyzer {
     return Registration.singleton(ISVGAnalyzer, this).register(container);
   }
 
-  private readonly svgElements: Record<string, Record<string, true | undefined> | undefined> = Object.assign(Object.create(null) as {}, {
+  private readonly svgElements: Record<string, Record<string, true | undefined> | undefined> = Object.assign(createLookup<Record<string, true | undefined> | undefined>(), {
     'a': o(['class', 'externalResourcesRequired', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'style', 'systemLanguage', 'target', 'transform', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space']),
     'altGlyph': o(['class', 'dx', 'dy', 'externalResourcesRequired', 'format', 'glyphRef', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'rotate', 'style', 'systemLanguage', 'x', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space', 'y']),
-    'altglyph': Object.create(null) as Record<string, true | undefined>,
+    'altglyph': createLookup<true | undefined>(),
     'altGlyphDef': o(['id', 'xml:base', 'xml:lang', 'xml:space']),
-    'altglyphdef': Object.create(null) as Record<string, true | undefined>,
+    'altglyphdef': createLookup<true | undefined>(),
     'altGlyphItem': o(['id', 'xml:base', 'xml:lang', 'xml:space']),
-    'altglyphitem': Object.create(null) as Record<string, true | undefined>,
+    'altglyphitem': createLookup<true | undefined>(),
     'animate': o(['accumulate', 'additive', 'attributeName', 'attributeType', 'begin', 'by', 'calcMode', 'dur', 'end', 'externalResourcesRequired', 'fill', 'from', 'id', 'keySplines', 'keyTimes', 'max', 'min', 'onbegin', 'onend', 'onload', 'onrepeat', 'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures', 'restart', 'systemLanguage', 'to', 'values', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space']),
     'animateColor': o(['accumulate', 'additive', 'attributeName', 'attributeType', 'begin', 'by', 'calcMode', 'dur', 'end', 'externalResourcesRequired', 'fill', 'from', 'id', 'keySplines', 'keyTimes', 'max', 'min', 'onbegin', 'onend', 'onload', 'onrepeat', 'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures', 'restart', 'systemLanguage', 'to', 'values', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space']),
     'animateMotion': o(['accumulate', 'additive', 'begin', 'by', 'calcMode', 'dur', 'end', 'externalResourcesRequired', 'fill', 'from', 'id', 'keyPoints', 'keySplines', 'keyTimes', 'max', 'min', 'onbegin', 'onend', 'onload', 'onrepeat', 'origin', 'path', 'repeatCount', 'repeatDur', 'requiredExtensions', 'requiredFeatures', 'restart', 'rotate', 'systemLanguage', 'to', 'values', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space']),
@@ -82,7 +86,7 @@ export class SVGAnalyzer {
     'g': o(['class', 'externalResourcesRequired', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'style', 'systemLanguage', 'transform', 'xml:base', 'xml:lang', 'xml:space']),
     'glyph': o(['arabic-form', 'class', 'd', 'glyph-name', 'horiz-adv-x', 'id', 'lang', 'orientation', 'style', 'unicode', 'vert-adv-y', 'vert-origin-x', 'vert-origin-y', 'xml:base', 'xml:lang', 'xml:space']),
     'glyphRef': o(['class', 'dx', 'dy', 'format', 'glyphRef', 'id', 'style', 'x', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space', 'y']),
-    'glyphref': Object.create(null) as Record<string, true | undefined>,
+    'glyphref': createLookup<true | undefined>(),
     'hkern': o(['g1', 'g2', 'id', 'k', 'u1', 'u2', 'xml:base', 'xml:lang', 'xml:space']),
     'image': o(['class', 'externalResourcesRequired', 'height', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'preserveAspectRatio', 'requiredExtensions', 'requiredFeatures', 'style', 'systemLanguage', 'transform', 'width', 'x', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space', 'y']),
     'line': o(['class', 'externalResourcesRequired', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'style', 'systemLanguage', 'transform', 'x1', 'x2', 'xml:base', 'xml:lang', 'xml:space', 'y1', 'y2']),

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -151,11 +151,20 @@ export class HydrateElementInstruction {
   public get type(): InstructionType.hydrateElement { return InstructionType.hydrateElement; }
 
   public constructor(
+    /**
+     * The name of the custom element this instruction is associated with
+     */
     public res: string,
     public alias: string | undefined,
+    /**
+     * Bindable instructions for the custom element instance
+     */
     public instructions: IInstruction[],
-    // only not null if this is an au-slot instruction
+    /**
+     * Indicates what projections are associated with the element usage
+     */
     public projections: Record<string, CustomElementDefinition> | null,
+    // only not null if this is an au-slot instruction
     public slotInfo: SlotInfo | null,
   ) {
   }
@@ -167,6 +176,9 @@ export class HydrateAttributeInstruction {
   public constructor(
     public res: string,
     public alias: string | undefined,
+    /**
+     * Bindable instructions for the custom attribute instance
+     */
     public instructions: IInstruction[],
   ) {}
 }
@@ -178,6 +190,9 @@ export class HydrateTemplateController {
     public def: PartialCustomElementDefinition,
     public res: string,
     public alias: string | undefined,
+    /**
+     * Bindable instructions for the template controller instance
+     */
     public instructions: IInstruction[],
   ) {}
 }

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -1,4 +1,5 @@
-import { Class, Constructable, DI, IContainer, Metadata, emptyArray, Protocol, Registration, ResourceDefinition, ResourceType, all } from '@aurelia/kernel';
+import { DI, Metadata, emptyArray, Protocol, Registration, all } from '@aurelia/kernel';
+import type { Class, Constructable, IContainer, ResourceDefinition, ResourceType } from '@aurelia/kernel';
 
 export interface AttributePatternDefinition {
   pattern: string;

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -1,13 +1,6 @@
-import {
-  camelCase,
-  Registration,
-  mergeArrays,
-  Protocol,
-  firstDefined,
-  Metadata
-} from '@aurelia/kernel';
+import { camelCase, Registration, mergeArrays, Protocol, firstDefined, Metadata } from '@aurelia/kernel';
 import { BindingMode, BindingType, DelegationStrategy, registerAliases } from '@aurelia/runtime';
-import { IAttrSyntaxTransformer } from '../attribute-syntax-transformer.js';
+import { IAttrMapper } from '../attribute-mapper.js';
 import {
   AttributeBindingInstruction,
   PropertyBindingInstruction,
@@ -147,14 +140,14 @@ export const BindingCommand: BindingCommandKind = {
 export class OneTimeBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.OneTimeCommand = BindingType.OneTimeCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
@@ -168,14 +161,14 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
 export class ToViewBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.ToViewCommand = BindingType.ToViewCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
@@ -189,14 +182,14 @@ export class ToViewBindingCommand implements BindingCommandInstance {
 export class FromViewBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.FromViewCommand = BindingType.FromViewCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
@@ -210,14 +203,14 @@ export class FromViewBindingCommand implements BindingCommandInstance {
 export class TwoWayBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.TwoWayCommand = BindingType.TwoWayCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     let target: string;
     if (info.bindable == null) {
-      target = this.t.map(info.node, info.attr.target)
-        // if the transformer doesn't know how to map it
+      target = this.m.map(info.node, info.attr.target)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
@@ -231,8 +224,8 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
 export class DefaultBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrSyntaxTransformer]; }
-  public constructor(private readonly t: IAttrSyntaxTransformer) {}
+  public static get inject() { return [IAttrMapper]; }
+  public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     type CA = CustomAttributeDefinition;
@@ -242,9 +235,9 @@ export class DefaultBindingCommand implements BindingCommandInstance {
     let mode: BindingMode;
     let target: string;
     if (bindable == null) {
-      mode = this.t.isTwoWay(info.node, attrName) ? BindingMode.twoWay : BindingMode.toView;
-      target = this.t.map(info.node, attrName)
-        // if the transformer doesn't know how to map it
+      mode = this.m.isTwoWay(info.node, attrName) ? BindingMode.twoWay : BindingMode.toView;
+      target = this.m.map(info.node, attrName)
+        // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(attrName);
     } else {

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -1,29 +1,20 @@
-import {
+import { Registration, Protocol, Metadata, mergeArrays, firstDefined } from '@aurelia/kernel';
+import { BindingMode, registerAliases } from '@aurelia/runtime';
+import { Bindable } from '../bindable.js';
+import { Watch } from '../watch.js';
+import { getRef } from '../dom.js';
+
+import type {
   Constructable,
   IContainer,
   IResourceKind,
-  Registration,
-  Protocol,
-  Metadata,
   ResourceDefinition,
   PartialResourceDefinition,
   ResourceType,
-  mergeArrays,
-  firstDefined,
 } from '@aurelia/kernel';
-import {
-  BindingMode,
-  registerAliases,
-} from '@aurelia/runtime';
-import {
-  Bindable,
-  BindableDefinition,
-  PartialBindableDefinition,
-} from '../bindable.js';
-import { Watch } from '../watch.js';
+import type { BindableDefinition, PartialBindableDefinition } from '../bindable.js';
 import type { ICustomAttributeViewModel, ICustomAttributeController } from '../templating/controller.js';
 import type { IWatchDefinition } from '../watch.js';
-import { getRef } from '../dom.js';
 
 export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
   readonly defaultBindingMode?: BindingMode;

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -1,4 +1,5 @@
-import { Constructable, Protocol, Metadata, emptyArray } from '@aurelia/kernel';
+import { Protocol, Metadata, emptyArray } from '@aurelia/kernel';
+import type { Constructable } from '@aurelia/kernel';
 import type { IConnectable } from '@aurelia/runtime';
 
 export type IDepCollectionFn<TType extends object, TReturn = unknown> = (vm: TType, watcher: IConnectable) => TReturn;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some small changes to cleanup the project before going for the next bigger ones.

- With previous compiler refactoring, attr syntax transformer now is no longer a transformer, just a mapper. Rename this to properly reflect this. Updated doc.
- Continue separate type/value imports
- Add some comments to a few sections of the code. Ideally should be a rename, though keeping the scope small each PR.
- fix #1169 