### PR TITLE
fix(let): camel-case let target when using with interpolation/literal

### DIFF
--- a/packages/__tests__/3-runtime-html/let.spec.ts
+++ b/packages/__tests__/3-runtime-html/let.spec.ts
@@ -1,0 +1,66 @@
+import { ILogger } from '@aurelia/kernel';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/let.spec.ts', function () {
+  for (const command of [
+    'from-view',
+    'two-way',
+    'trigger',
+    'delegate',
+    'one-time',
+    'capture',
+    'attr'
+  ]) {
+    it(`throws on non .bind/.to-view: "${command}"`, async function () {
+      const { tearDown, start } = createFixture(`<let a.${command}="bc">`, class { }, [], /* no start */false);
+
+      let ex: Error;
+      try {
+        await start();
+      } catch (e) {
+        ex = e;
+        assert.includes(e.toString(), `Invalid command ${command} for <let>. Only to-view/bind supported.`);
+      }
+      assert.instanceOf(ex, Error);
+      await tearDown();
+    });
+  }
+
+  for (const command of ['bind', 'to-view']) {
+    it(`camel-cases the target with binding command [${command}]`, async function () {
+      const { tearDown, appHost, startPromise } = createFixture(`<let my-prop.${command}="1"></let>\${myProp}`);
+
+      await startPromise;
+      assert.visibleTextEqual(appHost, '1');
+      await tearDown();
+    });
+  }
+
+  it('camel-cases the target with interpolation', async function () {
+    const { tearDown, appHost, startPromise } = createFixture(`<let my-prop="\${1}"></let>\${myProp}`);
+
+    await startPromise;
+    assert.visibleTextEqual(appHost, '1');
+    await tearDown();
+  });
+
+  it('works with, and warns when encountering literal', async function () {
+    const { ctx, tearDown, appHost, start } = createFixture(`<let my-prop="1"></let>\${myProp}`, class { }, [], false);
+
+    const logger = ctx.container.get(ILogger);
+    const callArgs = [];
+    logger.warn = (fn => (...args: unknown[]) => {
+      callArgs.push(args);
+      return fn.apply(logger, args);
+    })(logger.warn);
+
+    await start();
+    assert.visibleTextEqual(appHost, '1');
+    assert.strictEqual(callArgs.length, 1);
+    assert.deepStrictEqual(callArgs[0], [
+      `Property my-prop is declared with literal string 1. ` +
+      `Did you mean my-prop.bind="1"?`
+    ]);
+    await tearDown();
+  });
+});

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -331,7 +331,7 @@ export class TemplateCompiler implements ITemplateCompiler {
           ));
           continue;
         }
-        throw new Error('Invalid binding command for <let>. Only to-view/bind supported.');
+        throw new Error(`Invalid command ${attrSyntax.command} for <let>. Only to-view/bind supported.`);
       }
 
       expr = exprParser.parse(realAttrValue, BindingType.Interpolation);
@@ -341,9 +341,10 @@ export class TemplateCompiler implements ITemplateCompiler {
           `Did you mean ${realAttrTarget}.bind="${realAttrValue}"?`
         );
       }
+
       letInstructions.push(new LetBindingInstruction(
         expr === null ? new PrimitiveLiteralExpression(realAttrValue) : expr,
-        realAttrTarget
+        camelCase(realAttrTarget)
       ));
     }
     context.rows.push([new HydrateLetElementInstruction(letInstructions, toBindingContext)]);


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, `<let/>` does not camelising the target property if it's an interpolation or literal:
```html
<let my-prop="1" my-p="${myProp}-2" >
```
will results in instructions against `my-prop` and `my-p` respectively, which is wrong. They should be `myProp` and `myP`. This PR fixes it.