### PR TITLE
refactor(templating): change custom element own container timing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **template-compiler:** use class base impl for compilation context ([6cf1435](https://github.com/aurelia/aurelia/commit/6cf1435))
 * **template-compiler:** merge binder & compiler ([240692d](https://github.com/aurelia/aurelia/commit/240692d))
 
+  A breaking change is that custom attribute bindables are always checked against attribute form of bindables. This means it should be changed
+  from:
+  ```html
+  <form form-expander="isActive: true">
+  ```
+  to:
+  ```html
+  <form form-expander="is-active: true">
+  ```
+  this is to align with the style attribute, and CE bindable.
+
+  It's still possible to have any case for bindable properties inside multi-binding custom attribute usage, via `attribute` configuration of bindables:
+  ```ts
+  class MyAttr {
+    @bindable({ attribute: 'isActive' })
+    isActive: boolean;
+  }
+  ```
+
 <a name="2.0.0-alpha.7"></a>
 # 2.0.0-alpha.7 (2021-06-20)
 
@@ -37,7 +56,8 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **router:** ensure href recognize external ([387c084](https://github.com/aurelia/aurelia/commit/387c084))
 * **new-instance:** correctly invoke a registered interface ([8753b4e](https://github.com/aurelia/aurelia/commit/8753b4e))
-* **s #1166: this commit prepares a test where the most intuitive behavior is show:** ability to invoke an interface without having to declare it, if it has a default registration. Though this is inconsistent with the core, so will have to reconsider ([8753b4e](https://github.com/aurelia/aurelia/commit/8753b4e))
+
+  Add a few failling tests (skipped) for the most intuitive behaviors:** ability to invoke an interface without having to declare it, if it has a default registration. ([8753b4e](https://github.com/aurelia/aurelia/commit/8753b4e))
 * **di:** disallow resource key override ([f92ac3b](https://github.com/aurelia/aurelia/commit/f92ac3b))
 
 

--- a/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
@@ -61,7 +61,7 @@ for (const parentSpec of specs) {
 
             public created(controller: ICustomElementController<this>): void {
               const context = controller.context;
-              this.childController = Controller.forCustomElement(null, context, context.get(CustomElement.keyFrom('the-child')), controller.host, null);
+              this.childController = Controller.forCustomElement(null, context, context, context.get(CustomElement.keyFrom('the-child')), controller.host, null);
             }
             public attaching(initiator: IHydratedController): void {
               // No async hooks so all of these are synchronous.

--- a/packages/__tests__/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.spec.ts
@@ -207,7 +207,7 @@ describe('Styles', function () {
       });
 
       const component = new FooBar();
-      const controller = Controller.forCustomElement(null, ctx.container, component, host, null, null);
+      const controller = Controller.forCustomElement(null, ctx.container, ctx.container.createChild(), component, host, null, null);
 
       void controller.activate(controller, null, LifecycleFlags.none);
 

--- a/packages/router/src/component-agent.ts
+++ b/packages/router/src/component-agent.ts
@@ -60,7 +60,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
     let componentAgent = componentAgentLookup.get(componentInstance);
     if (componentAgent === void 0) {
       const definition = RouteDefinition.resolve(componentInstance.constructor as Constructable);
-      const controller = Controller.forCustomElement(ctx.get(IAppRoot), ctx, componentInstance, hostController.host, null);
+      const controller = Controller.forCustomElement(ctx.get(IAppRoot), ctx, ctx, componentInstance, hostController.host, null);
 
       componentAgentLookup.set(
         componentInstance,

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -78,9 +78,9 @@ export class AppRoot implements IDisposable {
     this.host = config.host;
     this.work = container.get(IWorkTracker);
     rootProvider.prepare(this);
-    if (container.has(INode, false) && container.get(INode) !== config.host) {
-      this.container = container.createChild();
-    }
+    // if (container.has(INode, false) && container.get(INode) !== config.host) {
+    //   this.container = container.createChild();
+    // }
     this.container.register(Registration.instance(INode, config.host));
 
     if (enhance) {
@@ -93,13 +93,19 @@ export class AppRoot implements IDisposable {
     }
 
     this.hydratePromise = onResolve(this.runAppTasks('beforeCreate'), () => {
-      const instance = CustomElement.isType(config.component as Constructable)
-        ? this.container.get(config.component as Constructable | {}) as ICustomElementViewModel
-        : config.component as ICustomElementViewModel;
+      const component = config.component as Constructable | ICustomElementViewModel;
+      const ownContainer = container.createChild();
+      let instance: object;
+      if (CustomElement.isType(component)) {
+        instance = this.container.get(component);
+      } else {
+        instance = config.component as ICustomElementViewModel;
+      }
 
       const controller = (this.controller = Controller.forCustomElement(
         this,
         container,
+        ownContainer,
         instance,
         this.host,
         null,

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -33,6 +33,7 @@ export function createElement<C extends Constructable = Constructable>(
  */
 export class RenderPlan {
   private lazyDefinition?: CustomElementDefinition = void 0;
+  private readonly childFor: WeakMap<IContainer, IContainer> = new WeakMap();
 
   public constructor(
     private readonly node: Node,
@@ -53,8 +54,13 @@ export class RenderPlan {
     return this.lazyDefinition;
   }
 
-  public getContext(parentContainer: IContainer): IRenderContext {
-    return getRenderContext(this.definition, parentContainer);
+  public getContext(container: IContainer): IRenderContext {
+    const childFor = this.childFor;
+    let childContainer: IContainer | undefined = childFor.get(container);
+    if (childContainer == null) {
+      childFor.set(container, (childContainer = container.createChild()).register(...this.dependencies));
+    }
+    return getRenderContext(this.definition, childContainer);
   }
 
   public createView(parentContainer: IContainer): ISyntheticView {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -175,6 +175,7 @@ export class AuCompose {
         const controller = Controller.forCustomElement(
           null,
           container,
+          container.createChild(),
           comp,
           host,
           null,
@@ -198,7 +199,7 @@ export class AuCompose {
           name: CustomElement.generateName(),
           template: view
         });
-        const renderContext = getRenderContext(targetDef, container);
+        const renderContext = getRenderContext(targetDef, container.createChild());
         const viewFactory = renderContext.getViewFactory();
         const controller = Controller.forSyntheticView(
           contextFactory.isFirst(context) ? $controller.root : null,

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -159,7 +159,7 @@ export class AuRender implements ICustomElementViewModel {
     }
 
     if ('createView' in subject) { // RenderPlan
-      return subject.createView(this.$controller.context!);
+      return subject.createView(this.$controller.context!.container);
     }
 
     if ('create' in subject) { // IViewFactory
@@ -168,7 +168,7 @@ export class AuRender implements ICustomElementViewModel {
 
     if ('template' in subject) { // Raw Template Definition
       const definition = CustomElementDefinition.getOrCreate(subject);
-      return getRenderContext(definition, this.$controller.context!).getViewFactory().create(flags);
+      return getRenderContext(definition, this.$controller.context!.container).getViewFactory().create(flags);
     }
 
     // Constructable (Custom Element Constructor)
@@ -177,7 +177,7 @@ export class AuRender implements ICustomElementViewModel {
       subject,
       this.properties,
       this.$controller.host.childNodes,
-    ).createView(this.$controller.context!);
+    ).createView(this.$controller.context!.container);
   }
 
   public dispose(): void {

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -76,7 +76,7 @@ export class DialogController implements IDialogController {
 
   /** @internal */
   public activate(settings: IDialogLoadedSettings): Promise<DialogOpenResult> {
-    const { ctn: container } = this;
+    const container = this.ctn.createChild();
     const { model, template, rejectOnCancel } = settings;
     const hostRenderer: IDialogDomRenderer = container.get(IDialogDomRenderer);
     const dialogTargetHost = settings.host ?? this.p.document.body;
@@ -120,6 +120,7 @@ export class DialogController implements IDialogController {
         return onResolve(cmp.activate?.(model), () => {
           const ctrlr = this.controller = Controller.forCustomElement(
             null,
+            container,
             container,
             cmp,
             contentHost,


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, the container of a custom element is created after the corresponding view model has been instantiated. This creates unexpected behavior in the scope of the dependencies. Example is `@newInstanceForScope` would register the dependencies onto the parent container instead of the CE own one:
```html
app.html
<list ref="list1"></list>
<list ref="list2"></list>
```
```ts
class Model {}

class List {
  constructor(@newInstanceForScope(Model) model) {}
}
```
Would result in 2 instances of `Model` scoped to with the app component container, instead of the 2 containers of `List` components.

Other changes:

- Custom element own container now registers the constructor with the instance, allowing its children to inject based on the constructor, beside the injectable token API. This is to align the behavior of container with v1. Custom attribute container behavior is kept as is: no container is instantiated for custom attributes or template controllers. This is a nice optimization in v2.
- `getRenderContext` now uses container given as is, instead of treating it like parent container. This should allow renderer and `createElement` API to have much better control over the timing of the hydration process, and less prone to cache invalidation issues.
- tweak `au-render` & `RenderPlan` to adopt `getRenderContext` changes.

### 🎫 Issues

A related issue is at #1166 where `@newInstanceOf` and `@newInstanceForScope` of an interface is not working. It's probably should be kept this way, since we don't JIT register an interface, those 2 resolvers shouldn't do it either.

## ⏭ Next Steps

- Prepare a new injectable `IHydrationContext` so that `<au-slot/>` can inject & retrieve the scope of its bindings, instead of having to walk the controller tree. https://github.com/aurelia/aurelia/blob/6d4685a5039f9d397ddd7e268b22fd7985373e56/packages/runtime-html/src/resources/custom-elements/au-slot.ts#L54-L66
- Consider removing injectable token API of custom element definition, since this is now achievable in user land without any boilerplate.
- Tweak the compiler and hydrate CE/CA/TC instruction so that they accept the constructor instead of resource name, to avoid having to resolve the resources again during hydration. This should give a some perf improvement.