### PR TITLE
feat(templating): add a injectable hydration token

### DIFF
--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -566,6 +566,7 @@ export {
   IContextualCustomElementController,
   IControllerElementHydrationInstruction,
   IHydratableController,
+  IHydrationContext,
   IDryCustomElementController,
   ICustomAttributeController,
   IHydratedController,
@@ -593,7 +594,6 @@ export {
   isRenderContext,
   IRenderContext,
   ICompiledRenderContext,
-  IComponentFactory,
 } from './templating/render-context.js';
 export {
   ViewFactory,

--- a/packages/runtime-html/src/templating/render-context.ts
+++ b/packages/runtime-html/src/templating/render-context.ts
@@ -11,7 +11,6 @@ import { IController } from './controller.js';
 import type {
   Constructable,
   IContainer,
-  IDisposable,
   IFactory,
   IResolver,
   IResourceKind,
@@ -146,40 +145,6 @@ export interface ICompiledRenderContext extends IRenderContext {
   ): void;
 }
 
-/**
- * A compiled `IRenderContext` that is ready to be used for creating component instances, and composing them.
- */
-export interface IComponentFactory extends ICompiledRenderContext, IDisposable {
-  /**
-   * Creates a new component instance based on the provided `resourceKey`.
-   *
-   * It is only safe to override the generic type argument if you know / own the component type associated with the name.
-   *
-   * @param resourceKey - The (full) resource key as returned from the `keyFrom` helper.
-   *
-   * @returns A new instance of the requested component. Will throw an error if the registration does not exist.
-   *
-   * @example
-   *
-   * ```ts
-   * // Create a new instance of the 'au-compose' custom element
-   * const elementInstance = factory.createComponent<Compose>(CustomElement.keyFrom('au-compose'));
-   *
-   * // Create a new instance of the 'if' template controller
-   * const attributeInstance = factory.createComponent<If>(CustomAttribute.keyFrom('if'));
-   *
-   * // Dynamically create a new instance of a custom element
-   * const attributeInstance = factory.createComponent(CustomElement.keyFrom(name));
-   * ```
-   */
-  createComponent<TViewModel = ICustomAttributeViewModel | ICustomElementViewModel>(resourceKey: string): TViewModel;
-
-  /**
-   * Release any resources that were stored by `getComponentFactory()`.
-   */
-  dispose(): void;
-}
-
 let renderContextCount = 0;
 export function getRenderContext(
   partialDefinition: PartialCustomElementDefinition,
@@ -247,7 +212,7 @@ Reflect.defineProperty(getRenderContext, 'count', {
 
 const emptyNodeCache = new WeakMap<IPlatform, FragmentNodeSequence>();
 
-export class RenderContext implements IComponentFactory {
+export class RenderContext implements ICompiledRenderContext {
   public get id(): number {
     return this.container.id;
   }
@@ -561,10 +526,6 @@ export class RenderContext implements IComponentFactory {
 
   // #region IComponentFactory api
 
-  public createComponent<TViewModel = ICustomElementViewModel>(resourceKey: string): TViewModel {
-    return this.container.get(resourceKey) as unknown as TViewModel;
-  }
-
   public render(
     flags: LifecycleFlags,
     controller: IHydratableController,
@@ -608,7 +569,7 @@ export class RenderContext implements IComponentFactory {
   }
 
   public dispose(): void {
-    this.elementProvider.dispose();
+    throw new Error('Cannot dispose a render context');
   }
   // #endregion
 }

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -1,9 +1,11 @@
-import { IContainer, IRegistry, Registration, DI, noop } from '@aurelia/kernel';
+import { IContainer, Registration, DI, noop } from '@aurelia/kernel';
 import { AppTask } from '../app-task.js';
 import { INode } from '../dom.js';
 import { getClassesToAdd } from '../observation/class-attribute-accessor.js';
 import { IPlatform } from '../platform.js';
 import { CustomAttribute } from '../resources/custom-attribute.js';
+
+import type { IRegistry } from '@aurelia/kernel';
 
 export function cssModules(...modules: (Record<string, string>)[]): CSSModulesProcessorRegistry {
   return new CSSModulesProcessorRegistry(modules);

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -1,9 +1,23 @@
-import { Constructable, ConstructableClass, DI, IContainer, Metadata, Protocol } from '@aurelia/kernel';
-import { LifecycleFlags, Scope } from '@aurelia/runtime';
-import { CustomElement, PartialCustomElementDefinition, CustomElementDefinition } from '../resources/custom-element.js';
+import { DI, Metadata, Protocol } from '@aurelia/kernel';
+import { Scope } from '@aurelia/runtime';
+import { CustomElement, CustomElementDefinition } from '../resources/custom-element.js';
 import { Controller } from './controller.js';
-import { IRenderContext } from './render-context.js';
-import type { ICustomElementViewModel, ISyntheticView, IDryCustomElementController, IContextualCustomElementController, ICompiledCustomElementController, ICustomElementController, ICustomAttributeController, IHydratedController, IHydratedParentController } from './controller.js';
+
+import type { Constructable, ConstructableClass, IContainer } from '@aurelia/kernel';
+import type { LifecycleFlags } from '@aurelia/runtime';
+import type {
+  ICustomElementViewModel,
+  ISyntheticView,
+  IDryCustomElementController,
+  IContextualCustomElementController,
+  ICompiledCustomElementController,
+  ICustomElementController,
+  ICustomAttributeController,
+  IHydratedController,
+  IHydratedParentController,
+} from './controller.js';
+import type { IRenderContext } from './render-context.js';
+import type { PartialCustomElementDefinition } from '../resources/custom-element.js';
 
 export interface IViewFactory extends ViewFactory {}
 export const IViewFactory = DI.createInterface<IViewFactory>('IViewFactory');


### PR DESCRIPTION
refactor(au-slot): use new hydration context token

# Pull Request

## 📖 Description

With the hydration context timing now more controllable, add a new injectable token: `IHydrationContext` that is only available inside a custom element hydration.

`<au-slot/>` can also retrieve its context information with ease. Also employ DI instead of manual tree walk.