### PR TITLE
refactor(au-slot): lazily determine view factory at instantiation time

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.ts
@@ -1726,6 +1726,58 @@ describe('au-slot', function () {
         },
       );
     }
+
+    {
+      yield new TestData(
+        'works with 3 layers of slot[default] pass through + template controller',
+        `<mdc></mdc><mdc></mdc>`,
+        [
+          CustomElement.define({ name: 'mdc', template:
+          `<mdc-tab-bar
+            ><mdc-tab au-slot repeat.for="i of 3" id="mdc-\${id}-\${i}" click.trigger="increase()">\${count + i}</mdc-tab>`
+          }, class Mdc {
+            public static id = 0;
+            public id = Mdc.id++;
+            public count = 0;
+            public increase() {
+              this.count++;
+            }
+          }),
+            CustomElement.define({ name: 'mdc-tab-scroller', template: '<au-slot>' }),
+            CustomElement.define({ name: 'mdc-tab-bar', template: '<mdc-tab-scroller><au-slot au-slot></au-slot></mdc-tab-scroller>' }),
+            CustomElement.define({ name: 'mdc-tab', template: '<button>Tab</button>' }),
+        ],
+        {
+          '#mdc-0-0': ['0<button>Tab</button>', undefined],
+          '#mdc-0-1': ['1<button>Tab</button>', undefined],
+          '#mdc-0-2': ['2<button>Tab</button>', undefined],
+          '#mdc-1-0': ['0<button>Tab</button>', undefined],
+          '#mdc-1-1': ['1<button>Tab</button>', undefined],
+          '#mdc-1-2': ['2<button>Tab</button>', undefined],
+        },
+        function ({ host, platform }) {
+          const [tab00, tab01, tab02, tab10, tab11, tab12] = Array.from(host.querySelectorAll<HTMLElement>('mdc-tab'));
+
+          tab00.click();
+          platform.domWriteQueue.flush();
+          assert.html.innerEqual(tab00, '1<button>Tab</button>');
+          assert.html.innerEqual(tab01, '2<button>Tab</button>');
+          assert.html.innerEqual(tab02, '3<button>Tab</button>');
+          assert.html.innerEqual(tab10, '0<button>Tab</button>');
+          assert.html.innerEqual(tab11, '1<button>Tab</button>');
+          assert.html.innerEqual(tab12, '2<button>Tab</button>');
+
+          tab10.click();
+          platform.domWriteQueue.flush();
+          assert.html.innerEqual(tab00, '1<button>Tab</button>');
+          assert.html.innerEqual(tab01, '2<button>Tab</button>');
+          assert.html.innerEqual(tab02, '3<button>Tab</button>');
+          assert.html.innerEqual(tab10, '1<button>Tab</button>');
+          assert.html.innerEqual(tab11, '2<button>Tab</button>');
+          assert.html.innerEqual(tab12, '3<button>Tab</button>');
+        },
+      );
+    }
   }
 
   for (const { spec, template, expected, registrations, additionalAssertion, only } of getTestData()) {

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -27,18 +27,14 @@ import {
   PrimitiveLiteralExpression,
   PartialCustomAttributeDefinition,
   CustomElementDefinition,
-  IProjections,
   IInstruction,
   CustomElementType,
   AuSlot,
-  AuSlotContentType,
-  Scope,
   parseExpression,
   Aurelia,
   HydrateElementInstruction,
   HydrateTemplateController,
   InstructionType as HTT,
-  ITemplateElementFactory,
   InstructionType as TT,
   HydrateLetElementInstruction,
   InstructionType,
@@ -51,7 +47,6 @@ import {
   TestContext,
   verifyBindingInstructionsEqual,
   generateCartesianProduct,
-  createScopeForTest,
 } from '@aurelia/testing';
 
 export function createAttribute(name: string, value: string): Attr {
@@ -793,7 +788,7 @@ function createCustomElement(
     type: TT.hydrateElement,
     res: tagName,
     instructions: childInstructions as IInstruction[],
-    slotInfo: null,
+    auSlot: void 0,
     projections: null,
   };
   const exprParser = ctx.container.get(IExpressionParser);
@@ -1858,103 +1853,99 @@ describe('TemplateCompiler - au-slot', function () {
     const sut = ctx.templateCompiler;
     return { ctx, container, sut };
   }
-  function $createCustomElement(template: string, name: string = 'my-element') {
+  function $createCustomElement(template: string, name: string) {
     return CustomElement.define({ name, isStrictBinding: true, template, bindables: { people: { mode: BindingMode.default } }, }, class MyElement { });
   }
 
-  class ExpectedSlotInfo {
+  class ExpectedSlotFallbackInfo {
     public constructor(
       public readonly slotName: string,
-      public readonly contentType: AuSlotContentType,
       public readonly content: string,
-      public readonly scope: Scope | null = null,
     ) { }
   }
   class TestData {
     public constructor(
       public readonly template: string,
       public readonly customElements: CustomElementType[],
-      public readonly partialTargetedProjections: [Scope, Record<string, string>] | null,
-      public readonly expectedSlotInfos: ExpectedSlotInfo[],
+      public readonly allExpectedProjections: [string, Record<string, string>][] | null,
+      public readonly expectedSlotInfos: ExpectedSlotFallbackInfo[],
     ) {
-      this.getTargetedProjections = this.getTargetedProjections.bind(this);
-    }
-
-    public getTargetedProjections(factory: ITemplateElementFactory): IProjections {
-      if (this.partialTargetedProjections === null) { return null; }
-      const [, projections] = this.partialTargetedProjections;
-      return Object.entries(projections)
-          .reduce((acc: Record<string, CustomElementDefinition>, [key, template]) => {
-            acc[key] = CustomElementDefinition.create({
-              name: CustomElement.generateName(),
-              template: template ? factory.createTemplate(template) : factory.createTemplate(''),
-              needsCompile: false
-            });
-            return acc;
-          }, Object.create(null));
     }
   }
 
   function *getTestData() {
+    // projections verification
     yield new TestData(
       `<my-element><div au-slot></div></my-element>`,
-      [$createCustomElement('')],
-      null,
+      [$createCustomElement('', 'my-element')],
+      [['my-element', { 'default': '<div></div>' }]],
       [],
     );
     yield new TestData(
       `<my-element><div au-slot="s1">p1</div><div au-slot="s2">p2</div></my-element>`,
-      [$createCustomElement('')],
-      null,
+      [$createCustomElement('', 'my-element')],
+      [['my-element', { s1: '<div>p1</div>', s2: '<div>p2</div>' }]],
       [],
     );
+    yield new TestData(
+      `<my-element><div au-slot="s1">p1</div><div au-slot="s1">p2</div></my-element>`,
+      [$createCustomElement('', 'my-element')],
+      [['my-element', { s1: '<div>p1</div><div>p2</div>' }]],
+      [],
+    );
+    yield new TestData(
+      `<my-element><au-slot au-slot><div au-slot="s1">p1</div><div au-slot="s1">p2</div></au-slot></my-element>`,
+      [$createCustomElement('', 'my-element')],
+      [['my-element', { 'default': '<au-m class="au"></au-m>' }]],
+      [],
+    );
+
+    // fallback verification
     yield new TestData(
       `<au-slot name="s1">s1fb</au-slot><au-slot name="s2"><div>s2fb</div></au-slot>`,
       [],
       null,
       [
-        new ExpectedSlotInfo('s1', AuSlotContentType.Fallback, 's1fb'),
-        new ExpectedSlotInfo('s2', AuSlotContentType.Fallback, '<div>s2fb</div>'),
-      ],
-    );
-    const scope1 = createScopeForTest();
-    yield new TestData(
-      `<au-slot name="s1">s1fb</au-slot><au-slot name="s2"><div>s2fb</div></au-slot>`,
-      [],
-      [scope1, { s1: '<span>s1p</span>' }],
-      [
-        new ExpectedSlotInfo('s1', AuSlotContentType.Projection, '<span>s1p</span>', scope1),
-        new ExpectedSlotInfo('s2', AuSlotContentType.Fallback, '<div>s2fb</div>'),
+        new ExpectedSlotFallbackInfo('s1', 's1fb'),
+        new ExpectedSlotFallbackInfo('s2', '<div>s2fb</div>'),
       ],
     );
     yield new TestData(
       `<au-slot name="s1">s1fb</au-slot><au-slot name="s2"><div>s2fb</div></au-slot>`,
       [],
-      [scope1, { s1: '<span>s1p</span>', s2: '<div><span>s2p</span></div>' }],
+      null,
       [
-        new ExpectedSlotInfo('s1', AuSlotContentType.Projection, '<span>s1p</span>', scope1),
-        new ExpectedSlotInfo('s2', AuSlotContentType.Projection, '<div><span>s2p</span></div>', scope1),
+        new ExpectedSlotFallbackInfo('s1', 's1fb'),
+        new ExpectedSlotFallbackInfo('s2', '<div>s2fb</div>'),
+      ],
+    );
+    yield new TestData(
+      `<au-slot name="s1">s1fb</au-slot><au-slot name="s2"><div>s2fb</div></au-slot>`,
+      [],
+      null,
+      [
+        new ExpectedSlotFallbackInfo('s1', 's1fb'),
+        new ExpectedSlotFallbackInfo('s2', '<div>s2fb</div>'),
       ],
     );
     yield new TestData(
       `<au-slot name="s1">s1fb</au-slot><my-element><div au-slot>p</div></my-element>`,
-      [$createCustomElement('')],
-      [scope1, { s1: '<span>s1p</span>' }],
+      [$createCustomElement('', 'my-element')],
+      null,
       [
-        new ExpectedSlotInfo('s1', AuSlotContentType.Projection, '<span>s1p</span>', scope1),
+        new ExpectedSlotFallbackInfo('s1', 's1fb'),
       ],
     );
   }
-  for (const { customElements, template, getTargetedProjections, expectedSlotInfos } of getTestData()) {
+  for (const { customElements, template, expectedSlotInfos, allExpectedProjections } of getTestData()) {
     it(`compiles - ${template}`, function () {
       const { sut, container } = createFixture();
       container.register(AuSlot, ...customElements);
-      const factory = container.get(ITemplateElementFactory);
 
       const compiledDefinition = sut.compile(
         CustomElementDefinition.create({ name: 'my-ce', template }, class MyCe { }),
         container,
-        { projections: getTargetedProjections(factory) }
+        { projections: null }
       );
 
       const allInstructions = compiledDefinition.instructions.flat();
@@ -1962,13 +1953,33 @@ describe('TemplateCompiler - au-slot', function () {
         const actualInstruction = allInstructions.find((i) =>
           i.type === InstructionType.hydrateElement
           && (i as HydrateElementInstruction).res.includes('au-slot')
-          && (i as HydrateElementInstruction).slotInfo.name === expectedSlotInfo.slotName
+          && (i as HydrateElementInstruction).auSlot.name === expectedSlotInfo.slotName
         ) as HydrateElementInstruction;
         assert.notEqual(actualInstruction, void 0, 'instruction');
-        const actualSlotInfo = actualInstruction.slotInfo;
-        assert.strictEqual(actualSlotInfo.type, expectedSlotInfo.contentType, 'content type');
-        assert.deepStrictEqual((actualSlotInfo.content.template as HTMLElement).outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
-        assert.deepStrictEqual(actualSlotInfo.content.needsCompile, false, 'needsCompile');
+        const actualSlotInfo = actualInstruction.auSlot!;
+        assert.deepStrictEqual((actualSlotInfo.fallback.template as HTMLElement).outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
+        assert.deepStrictEqual(actualSlotInfo.fallback.needsCompile, false, 'needsCompile');
+      }
+
+      // for each element instruction found
+      // verify projections for it compiles properly
+      if (allExpectedProjections == null) {
+        return;
+      }
+
+      for (const [elName, projections] of allExpectedProjections) {
+        const elementInstruction = allInstructions.find(i =>
+          i.type === InstructionType.hydrateElement
+          && (i as HydrateElementInstruction).res === elName
+        ) as HydrateElementInstruction;
+        assert.notEqual(elementInstruction, void 0, `Instruction for element "${elName}" missing`);
+        const actualProjections = elementInstruction.projections;
+        for (const slotName in projections) {
+          const def = actualProjections[slotName];
+          assert.instanceOf(def, CustomElementDefinition);
+          assert.deepStrictEqual((def.template as HTMLElement).outerHTML, `<template>${projections[slotName]}</template>`, 'content');
+          assert.deepStrictEqual(def.needsCompile, false, 'needsCompile');
+        }
       }
     });
   }

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -622,8 +622,7 @@ ignore.$isResolver = true;
 ignore.resolve = () => undefined;
 export const newInstanceForScope = createResolver((key: any, handler: IContainer, requestor: IContainer) => {
   const instance = createNewInstance(key, handler, requestor);
-  const instanceProvider: InstanceProvider<any> = new InstanceProvider<any>(String(key));
-  instanceProvider.prepare(instance);
+  const instanceProvider: InstanceProvider<any> = new InstanceProvider<any>(String(key), instance);
   requestor.registerResolver(key, instanceProvider);
 
   return instance;
@@ -1425,7 +1424,16 @@ export class InstanceProvider<K extends Key> implements IDisposableResolver<K | 
 
   public constructor(
     public readonly friendlyName?: string,
-  ) {}
+    /**
+     * if not undefined, then this is the value this provider will resolve to
+     * until overridden by explicit prepare call
+     */
+    instance?: Resolved<K> | null,
+  ) {
+    if (instance !== void 0) {
+      this.instance = instance;
+    }
+  }
 
   public prepare(instance: Resolved<K>): void {
     this.instance = instance;

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -132,7 +132,7 @@ function createElementForType(
     dependencies.push(Type);
   }
 
-  instructions.push(new HydrateElementInstruction(tagName, void 0, childInstructions, null, null));
+  instructions.push(new HydrateElementInstruction(tagName, void 0, childInstructions, null));
 
   if (props) {
     Object.keys(props)

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -435,8 +435,6 @@ export {
 export {
   AuSlot,
   IProjections,
-  SlotInfo,
-  AuSlotContentType,
   AuSlotsInfo,
   IAuSlotsInfo,
 } from './resources/custom-elements/au-slot.js';

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -18,7 +18,7 @@ import { Listener } from './binding/listener.js';
 import { IEventDelegator } from './observation/event-delegator.js';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
 import { getRenderContext } from './templating/render-context.js';
-import { AuSlotsInfo, IProjections, SlotInfo } from './resources/custom-elements/au-slot.js';
+import { AuSlotsInfo, IProjections } from './resources/custom-elements/au-slot.js';
 import { CustomAttribute } from './resources/custom-attribute.js';
 import { convertToRenderLocation, setRef } from './dom.js';
 import { Controller } from './templating/controller.js';
@@ -36,7 +36,6 @@ import type {
   DelegationStrategy,
 } from '@aurelia/runtime';
 import type { IHydratableController, IController } from './templating/controller.js';
-import type { IViewFactory } from './templating/view.js';
 import type { PartialCustomElementDefinition } from './resources/custom-element.js';
 import type { ICompiledRenderContext } from './templating/render-context.js';
 import type { INode } from './dom.js';
@@ -156,10 +155,10 @@ export class SetPropertyInstruction {
 
 export class HydrateElementInstruction {
   public get type(): InstructionType.hydrateElement { return InstructionType.hydrateElement; }
-  public auSlot: {
+  public auSlot?: {
     name: string;
     fallback: CustomElementDefinition;
-  } | null = null;
+  };
 
   public constructor(
     /**
@@ -175,8 +174,6 @@ export class HydrateElementInstruction {
      * Indicates what projections are associated with the element usage
      */
     public projections: Record<string, CustomElementDefinition> | null,
-    // only not null if this is an au-slot instruction
-    public slotInfo: SlotInfo | null,
   ) {
   }
 }
@@ -444,19 +441,12 @@ export class CustomElementRenderer implements IRenderer {
     target: HTMLElement,
     instruction: HydrateElementInstruction,
   ): void {
-    let viewFactory: IViewFactory | undefined;
-
-    const slotInfo = instruction.slotInfo;
-    // if (instruction.res === 'au-slot' && slotInfo !== null) {
-    //   viewFactory = getRenderContext(slotInfo.content, context.container).getViewFactory(void 0);
-    // }
-
     const projections = instruction.projections;
     const container = context.createElementContainer(
       /* parentController */controller,
       /* host             */target,
       /* instruction      */instruction,
-      /* viewFactory      */viewFactory,
+      /* viewFactory      */void 0,
       /* location         */target,
       /* auSlotsInfo      */new AuSlotsInfo(projections == null ? emptyArray : Object.keys(projections)),
     );

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -459,10 +459,8 @@ export class CustomElementRenderer implements IRenderer {
     const definition = context.find(CustomElement, instruction.res) as CustomElementDefinition;
     const Ctor = definition.Type;
     const component = container.invoke(Ctor);
-    const provider = new InstanceProvider<typeof Ctor>();
     const key = CustomElement.keyFrom(instruction.res);
-    provider.prepare(component);
-    container.registerResolver(Ctor, provider);
+    container.registerResolver(Ctor, new InstanceProvider<typeof Ctor>(key, component));
 
     const childController = Controller.forCustomElement(
       /* root                */controller.root,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -156,6 +156,10 @@ export class SetPropertyInstruction {
 
 export class HydrateElementInstruction {
   public get type(): InstructionType.hydrateElement { return InstructionType.hydrateElement; }
+  public auSlot: {
+    name: string;
+    fallback: CustomElementDefinition;
+  } | null = null;
 
   public constructor(
     /**
@@ -443,9 +447,9 @@ export class CustomElementRenderer implements IRenderer {
     let viewFactory: IViewFactory | undefined;
 
     const slotInfo = instruction.slotInfo;
-    if (instruction.res === 'au-slot' && slotInfo !== null) {
-      viewFactory = getRenderContext(slotInfo.content, context).getViewFactory(void 0);
-    }
+    // if (instruction.res === 'au-slot' && slotInfo !== null) {
+    //   viewFactory = getRenderContext(slotInfo.content, context.container).getViewFactory(void 0);
+    // }
 
     const projections = instruction.projections;
     const container = context.createElementContainer(

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -245,9 +245,8 @@ export class AuCompose {
     }
 
     const p = this.p;
-    const ep = new InstanceProvider('ElementResolver');
+    const ep = new InstanceProvider('ElementResolver', host);
 
-    ep.prepare(host);
     container.registerResolver(INode, ep);
     container.registerResolver(p.Node, ep);
     container.registerResolver(p.Element, ep);

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -1,9 +1,10 @@
 import { DI } from '@aurelia/kernel';
 import { IRenderLocation } from '../../dom.js';
+import { customElement } from '../custom-element.js';
 import { IInstruction } from '../../renderer.js';
 import { IHydrationContext } from '../../templating/controller.js';
+import { getRenderContext } from '../../templating/render-context.js';
 import { IViewFactory } from '../../templating/view.js';
-import { customElement } from '../custom-element.js';
 
 import type { Writable } from '@aurelia/kernel';
 import type { LifecycleFlags, Scope } from '@aurelia/runtime';
@@ -29,21 +30,32 @@ export class SlotInfo {
 
 export class AuSlot implements ICustomElementViewModel {
   /** @internal */
-  public static get inject() { return [IViewFactory, IRenderLocation, IInstruction, IHydrationContext]; }
+  public static get inject() { return [/* IViewFactory, */ IRenderLocation, IInstruction, IHydrationContext]; }
 
-  public readonly view: ISyntheticView;
+  public readonly view!: ISyntheticView;
   public readonly $controller!: ICustomElementController<this>; // This is set by the controller after this instance is constructed
 
   private hostScope: Scope | null = null;
   private outerScope: Scope | null = null;
+  private hasProjection: boolean = false;
 
   public constructor(
-    factory: IViewFactory,
+    // factory: IViewFactory,
     location: IRenderLocation,
     private readonly instruction: HydrateElementInstruction,
     private readonly hdrContext: IHydrationContext,
   ) {
+    let factory: IViewFactory;
+    const slotInfo = instruction.auSlot!;
+    const projection = hdrContext.instruction?.projections?.[slotInfo.name];
+    if (projection == null) {
+      factory = getRenderContext(slotInfo.fallback, hdrContext.controller.context.container).getViewFactory()
+    } else {
+      factory = getRenderContext(projection, hdrContext.parent!.controller.context.container).getViewFactory();
+      this.hasProjection = true;
+    }
     this.view = factory.create().setLocation(location);
+    // this.view = factory.create().setLocation(location);
   }
 
   public binding(
@@ -52,9 +64,10 @@ export class AuSlot implements ICustomElementViewModel {
     _flags: LifecycleFlags,
   ): void | Promise<void> {
     this.hostScope = this.$controller.scope.parentScope!;
-    this.outerScope = this.instruction.slotInfo!.type === AuSlotContentType.Projection
-      ? this.hdrContext.controller.scope.parentScope! ?? null
-      : this.hostScope;
+    this.outerScope = /* this.instruction.slotInfo!.type === AuSlotContentType.Projection */
+      this.hasProjection
+        ? this.hdrContext.controller.scope.parentScope! ?? null
+        : this.hostScope;
   }
 
   public attaching(

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -213,7 +213,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     );
 
     ownCt.register(...definition.dependencies);
-    ownCt.registerResolver(IHydrationContext, new InstanceProvider<IHydrationContext>(
+    ownCt.registerResolver(IHydrationContext, new InstanceProvider(
       'IHydrationContext',
       new HydrationContext(controller, hydrationInst)
     ));
@@ -333,10 +333,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     if (definition.injectable !== null) {
       container.registerResolver(
         definition.injectable,
-        new InstanceProvider<ICustomElementViewModel>(
-          'definition.injectable',
-          instance as ICustomElementViewModel
-        ),
+        new InstanceProvider('definition.injectable', instance as ICustomElementViewModel),
       );
     }
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -211,11 +211,12 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       /* viewModel      */viewModel as BindingContext<C>,
       /* host           */host,
     );
-    const hydrationContextProvider = new InstanceProvider<IHydrationContext>();
-    hydrationContextProvider.prepare(new HydrationContext(controller, hydrationInst));
 
     ownCt.register(...definition.dependencies);
-    ownCt.registerResolver(IHydrationContext, hydrationContextProvider);
+    ownCt.registerResolver(IHydrationContext, new InstanceProvider<IHydrationContext>(
+      'IHydrationContext',
+      new HydrationContext(controller, hydrationInst)
+    ));
     controllerLookup.set(viewModel, controller as Controller);
 
     if (hydrate) {
@@ -299,7 +300,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     const flags = this.flags;
     const instance = this.viewModel as BindingContext<C>;
     let definition = this.definition as CustomElementDefinition;
-    let vmProvider: InstanceProvider<ICustomElementViewModel>;
 
     this.scope = Scope.create(instance, null, true);
 
@@ -333,9 +333,11 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     if (definition.injectable !== null) {
       container.registerResolver(
         definition.injectable,
-        vmProvider = new InstanceProvider<ICustomElementViewModel>('definition.injectable'),
+        new InstanceProvider<ICustomElementViewModel>(
+          'definition.injectable',
+          instance as ICustomElementViewModel
+        ),
       );
-      vmProvider.prepare(instance as ICustomElementViewModel);
     }
 
     // If this is the root controller, then the AppRoot will invoke things in the following order:
@@ -354,7 +356,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   /** @internal */
   public hydrate(hydrationInst: IControllerElementHydrationInstruction | null): void {
     if (this.hooks.hasHydrating) {
-      if (this.debug) { this.logger!.trace(`invoking hasHydrating() hook`); }
+      if (this.debug) { this.logger!.trace(`invoking hydrating() hook`); }
       (this.viewModel as BindingContext<C>).hydrating(this as ICustomElementController);
     }
 
@@ -386,7 +388,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this.nodes = compiledContext.createNodes();
 
     if (this.hooks.hasHydrated) {
-      if (this.debug) { this.logger!.trace(`invoking hasHydrated() hook`); }
+      if (this.debug) { this.logger!.trace(`invoking hydrated() hook`); }
       (this.viewModel as BindingContext<C>).hydrated(this as ICustomElementController);
     }
   }

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -250,9 +250,8 @@ export class DialogController implements IDialogController {
     }
 
     const p = this.p;
-    const ep = new InstanceProvider('ElementResolver');
+    const ep = new InstanceProvider('ElementResolver', host);
 
-    ep.prepare(host);
     container.registerResolver(INode, ep);
     container.registerResolver(p.Node, ep);
     container.registerResolver(p.Element, ep);


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, `<au-slot/>` view factory is determined at compilation time, which is prone to cached compilation issue, also prohibits the ability to toggle between projected content and fallback content (if there's projection, do not render fallback and vice versa) to align `<au-slot/>` behavior with native `<slot/>`. Refactor this, and move factory creation to the instantiation time of `AuSlot` so that there can be more flexibility in terms on scope choosing, factory constructing, and ensure correctness in tricky situation like 3 layers of pass through slot seen in this issue #1205.
In order to support this, `IHydrationContext` has been enhanced with a `parent` property so that it can build the proper hydration context hierarchy, allowing `<au-slot/>` to pick the right scope.

### 🎫 Issues

Closes #1203

## 👩‍💻 Reviewer Notes

- In `HydrateElementRenderer`, there's no longer a need for special treatment related to au-slot factory. With this, we can probably remove quite a number of parameters across templating calls.
- Render context shouldn't be bothered by projections anymore, and we can turn `getRenderContext` back to its previous, purer form: only take a definition and a container.
- `Controller.hydrateCustomElement` now builds the `IHydrationContext` hierarchy, instead of isolated pieces.
- `InstanceProvider` now accepts a 2nd param to remove boilerplate and intermediate variables
- Remove `AuSlotInfo` and `SlotContentType`, as they are no longer needed. Fallback and projections are always compiled and included in the instructions.

## 📑 Test Plan

All existing tests works and add tests covering the scenarios at the linked issues. Also added a test for tricky combination like this
```html
<mdc-tab-bar>
    <mdc-tab au-slot repeat.for="i of 3" id="mdc-\${id}-\${i}" click.trigger="increase()">\${count + i}</mdc-tab>
```
with els:
```ts
CustomElement.define({ name: 'mdc-tab-scroller', template: '<au-slot>' }),
CustomElement.define({ name: 'mdc-tab-bar', template: '<mdc-tab-scroller><au-slot au-slot></au-slot></mdc-tab-scroller>' }),
CustomElement.define({ name: 'mdc-tab', template: '<button>Tab</button>' }),
```

## ⏭ Next Steps

- start removing unused bits related to projects caching in render context
- start removing unused bits related to projections marking in compilation
- employ root level caching for compilation, as an optimization, as now there's no need to recompile CE definition anymore.