### PR TITLE
feat(template-compiler): add beforeCompile hooks

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -85,6 +85,7 @@
   * [DOM Style Injection](developer-guides/scenarios/dom-style-injection.md)
   * [Markdown Integration](developer-guides/scenarios/markdown-integration.md)
 * [Extending templating syntax](developer-guides/extending-templating-syntax.md)
+* [Template Compiler Hooks](developer-guides/template-compiler-hooks.md)
 * [Components revisited](developer-guides/components-revisited.md)
 
 ## Tutorials

--- a/docs/user-docs/developer-guides/extending-templating-syntax.md
+++ b/docs/user-docs/developer-guides/extending-templating-syntax.md
@@ -10,7 +10,7 @@ Sometimes you will see the following template in an Aurelia application:
 
 Aurelia understands that `value.bind="message"` means `value.two-way="message"`, and later creates a two way binding between view model `message` property, and input `value` property. How does Aurelia know this?
 
-By default, Aurelia is taught how to interpret a `bind` binding command on a property of an element via a Attribute Syntax Transformer. Application can also tap into this class to teach Aurelia some extra knowledge so that it understands more than just `value.bind` on an `<input/>` element.
+By default, Aurelia is taught how to interpret a `bind` binding command on a property of an element via a Attribute Syntax Mapper. Application can also tap into this class to teach Aurelia some extra knowledge so that it understands more than just `value.bind` on an `<input/>` element.
 
 ## Examples
 
@@ -39,25 +39,25 @@ should be treated as:
 
 In the next section, we will look into how to teach Aurelia such knowledge.
 
-## Using the Attribute Syntax Transformer
+## Using the Attribute Syntax Mapper
 
-As mentioned earlier, the Attribute Syntax Transformer will be used to transform `value.bind` into `value.two-way`. Every Aurelia application uses a single instance of this class. The instance can be retrieved via the injection of interface `IAttrSyntaxTransformer`, like the following example:
+As mentioned earlier, the Attribute Syntax Mapper will be used to map `value.bind` into `value.two-way`. Every Aurelia application uses a single instance of this class. The instance can be retrieved via the injection of interface `IAttrMapper`, like the following example:
 
 ```typescript
-import { inject, IAttrSyntaxTransformer } from '@aurelia/runtime-html';
+import { inject, IAttrMapper } from '@aurelia/runtime-html';
 
-@inject(IAttrSyntaxTransformer)
+@inject(IAttrMapper)
 export class MyCustomElement {
-  constructor(attrTransformer) {
-    // do something with the attrTransformer
+  constructor(attrMapper) {
+    // do something with the attr mapper
   }
 }
 ```
 
-After grabbing the `IAttrSyntaxTransformer` instance, we can use the method `useTwoWay(fn)` of it to extend its knowledge. Following is an example of teaching it that the `bind` command on `value` property of the custom input elements above should be transformed to `two-way`:
+After grabbing the `IAttrMapper` instance, we can use the method `useTwoWay(fn)` of it to extend its knowledge. Following is an example of teaching it that the `bind` command on `value` property of the custom input elements above should be mapped to `two-way`:
 
 ```typescript
-attrTransformer.useTwoWay(function(element, property) {
+attrMapper.useTwoWay(function(element, property) {
   switch (element.tagName) {
     // <fast-text-field value.bind="message">
     case 'FAST-TEXT-FIELD': return property === 'value';
@@ -65,16 +65,16 @@ attrTransformer.useTwoWay(function(element, property) {
     case 'ION-INPUT': return property === 'value';
     // <paper-input value.bind="message">
     case 'PAPER-INPUT': return property === 'value';
-    // let other two way transformer check the validity
+    // let other two way mapper check the validity
     default:
       return false;
   }
 })
 ```
 
-## Combining the attribute syntax transformer with the node observer locator
+## Combining the attribute syntax mapper with the node observer locator
 
-Teaching Aurelia to transform `value.bind` to `value.two-way` is the first half of the story. The second half is about how we can teach Aurelia to observe the `value` property for changes on those custom input elements. We can do this via the Node Observer Locator. Every Aurelia application uses a single instance of this class, and this instance can be retrieved via the injection of interface `INodeObserverLocator` like the following example:
+Teaching Aurelia to map `value.bind` to `value.two-way` is the first half of the story. The second half is about how we can teach Aurelia to observe the `value` property for changes on those custom input elements. We can do this via the Node Observer Locator. Every Aurelia application uses a single instance of this class, and this instance can be retrieved via the injection of interface `INodeObserverLocator` like the following example:
 
 ```typescript
 import { inject, INodeObserverLocator } from '@aurelia/runtime-html';
@@ -121,14 +121,14 @@ nodeObserverLocator.useConfig({
 Combining the examples in the two sections above into some more complete code block example, for [Microsoft FAST components](https://explore.fast.design/components/fast-text-field):
 
 ```typescript
-import { inject, IContainer, IAttrSyntaxTransformer, INodeObserverLocator, AppTask, Aurelia } from 'aurelia';
+import { inject, IContainer, IAttrMapper, INodeObserverLocator, AppTask, Aurelia } from 'aurelia';
 
 Aurelia
   .register(
     AppTask.beforeCreate(IContainer, container => {
-      const attrSyntaxTransformer = container.get(IAttrSyntaxTransformer);
+      const attrMapper = container.get(IAttrMapper);
       const nodeObserverLocator = container.get(INodeObserverLocator);
-      attrSyntaxTransformer.useTwoWay((el, property) => {
+      attrMapper.useTwoWay((el, property) => {
         switch (el.tagName) {
           case 'FAST-TEXT-FIELD': return property === 'value';
           case 'FAST-TEXT-AREA': return property === 'value';
@@ -160,4 +160,3 @@ And with the above, your Aurelia application will get two way binding flow seaml
 <fast-text-area value.bind="description"></fast-text-area>
 <fast-slider value.bind="fontSize"></fast-slider>
 ```
-

--- a/docs/user-docs/developer-guides/template-compiler-hooks.md
+++ b/docs/user-docs/developer-guides/template-compiler-hooks.md
@@ -1,0 +1,44 @@
+# Template Compiler Hooks
+
+## Introduction
+
+There are scenarios where an application wants to control how to preprocess a template before it is compiled. There could be various reasons such as accessibility validation, adding debugging attributes etc...
+
+Aurelia supports this via template compiler hooks, that is enabled with the default template compiler. To use this features, declare and then register the desired hooks with either global (at startup) or local container (at dependencies (runtime) or `<import>` with convention).
+
+An example of declaring global hooks, that will be called for every template:
+
+1. With vanillajs
+```ts
+import Aurelia, { TemplateCompilerHooks } from 'aurelia';
+
+Aurelia.register(TemplateCompilerHooks.define(class {
+  beforeCompile(template: HTMLElement) {
+    element.querySelector('table').setAttribute(someAttribute, someValue);
+  }
+}))
+```
+2. With decorator
+```ts
+import Aurelia, { templateCompilerHooks } from 'aurelia';
+
+@templateCompilerHooks
+class MyTableHook1 {
+  beforeCompile(template) {...}
+}
+// paren ok too
+@templateCompilerHooks()
+class MyTableHook1 {
+  beforeCompile(template) {...}
+}
+
+Aurelia.register(MyTableHook1);
+```
+
+## Supported hooks
+
+- **beforeCompile**: this hook will be invoked right before the template compiler starts the compilation. Use this hooks if there needs to be some changes to a template before any compilation.
+
+## Hooks invocation order
+
+All hooks from local and global registrations will be invoked in order: local first then global.

--- a/packages/__tests__/3-runtime-html/template-compiler.hooks.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.hooks.spec.ts
@@ -1,0 +1,303 @@
+import {
+  CustomElement, templateCompilerHooks, TemplateCompilerHooks
+} from '@aurelia/runtime-html';
+import {
+  assert,
+  createFixture
+} from '@aurelia/testing';
+
+describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
+  it('compiles with child hooks', async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [TemplateCompilerHooks.define(class {
+            public beforeCompile(template: HTMLTemplateElement) {
+              template.content.querySelector('input').setAttribute('value.bind', 'value');
+            }
+          })]
+        }, class MyEll {
+          public value = 'hello';
+        })
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+
+    await tearDown();
+  });
+
+  it('compiles with root hooks', async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: []
+        }, class MyEll {
+          public value = 'hello';
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            template.content.querySelector('input')?.setAttribute('value.bind', 'value');
+          }
+        })
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+
+    await tearDown();
+  });
+
+  it('does not compiles with hooks from parent', async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<parent>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'parent',
+          template: '<child>',
+          dependencies: [
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input')?.setAttribute('value.bind', 'value');
+              }
+            }),
+            CustomElement.define({
+              name: 'child',
+              template: '<input>',
+              dependencies: [
+                TemplateCompilerHooks.define(class {
+                  public beforeCompile(template: HTMLTemplateElement) {
+                    assert.strictEqual(template.content.querySelector('input').getAttribute('value.bind'), null);
+                    template.content.querySelector('input')?.setAttribute('value.bind', 'value2');
+                  }
+                }),
+              ]
+            }, class Child {
+              public value = 'hello';
+              public value2 = 'hello 2';
+            })
+          ]
+        }, class Parent {
+        }),
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello 2');
+
+    await tearDown();
+  });
+
+  it('gets all hooks registered in child', async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input').setAttribute('value.bind', 'value');
+              }
+            }),
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input').setAttribute('id.bind', 'value');
+              }
+            }),
+          ]
+        }, class MyEll {
+          public value = 'hello';
+        })
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+    assert.strictEqual(appHost.querySelector('input').id, 'hello');
+
+    await tearDown();
+  });
+
+  it('gets all hooks registered in root', async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [
+          ]
+        }, class MyEll {
+          public value = 'hello';
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            template.content.querySelector('input')?.setAttribute('value.bind', 'value');
+          }
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            template.content.querySelector('input')?.setAttribute('id.bind', 'value');
+          }
+        }),
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+    assert.strictEqual(appHost.querySelector('input').id, 'hello');
+
+    await tearDown();
+  });
+
+  it('gets all hooks registered in root and child',  async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input')?.setAttribute('data-id-1.bind', 'value');
+              }
+            }),
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input')?.setAttribute('data-id-2.bind', 'value');
+              }
+            }),
+          ]
+        }, class MyEll {
+          public value = 'hello';
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            template.content.querySelector('input')?.setAttribute('data-id-3.bind', 'value');
+          }
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            template.content.querySelector('input')?.setAttribute('data-id-4.bind', 'value');
+          }
+        }),
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-1'), 'hello');
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-2'), 'hello');
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-3'), 'hello');
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-4'), 'hello');
+
+    await tearDown();
+  });
+
+  it('calls hooks in child before root',  async function () {
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [
+            TemplateCompilerHooks.define(class {
+              public beforeCompile(template: HTMLTemplateElement) {
+                template.content.querySelector('input')?.setAttribute('data-id-2.bind', 'value');
+              }
+            }),
+          ]
+        }, class MyEll {
+          public value = 'hello';
+        }),
+        TemplateCompilerHooks.define(class {
+          public beforeCompile(template: HTMLTemplateElement) {
+            const input = template.content.querySelector('input');
+            input?.setAttribute('data-id-1.bind', 'value');
+            if (input) {
+              assert.strictEqual(input.getAttribute('data-id-2.bind'), 'value');
+            }
+          }
+        }),
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-1'), 'hello');
+    assert.strictEqual(appHost.querySelector('input').getAttribute('data-id-2'), 'hello');
+
+    await tearDown();
+  });
+
+  it('works with decorator @templateCompilerHooks (no paren)', async function () {
+    @templateCompilerHooks
+    class Hooks {
+      public beforeCompile(template: HTMLTemplateElement) {
+        template.content.querySelector('input').setAttribute('value.bind', 'value');
+      }
+    }
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [Hooks]
+        }, class MyEll {
+          public value = 'hello';
+        })
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+
+    await tearDown();
+  });
+
+  it('works with decorator @templateCompilerHooks() (with paren)', async function () {
+    @templateCompilerHooks()
+    class Hooks {
+      public beforeCompile(template: HTMLTemplateElement) {
+        template.content.querySelector('input').setAttribute('value.bind', 'value');
+      }
+    }
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<my-el>`,
+      class App {},
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<input >',
+          dependencies: [Hooks]
+        }, class MyEll {
+          public value = 'hello';
+        })
+      ]
+    );
+    await startPromise;
+
+    assert.strictEqual(appHost.querySelector('input').value, 'hello');
+
+    await tearDown();
+  });
+});

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -8,6 +8,7 @@ import {
   DefaultLogger,
   LogLevel,
   camelCase,
+  Registration,
 } from '@aurelia/kernel';
 import {
   AccessScopeExpression,
@@ -40,6 +41,7 @@ import {
   InstructionType,
   IExpressionParser,
   CustomAttributeDefinition,
+  ITemplateCompilerHooks,
 } from '@aurelia/runtime-html';
 import {
   assert,
@@ -1984,6 +1986,107 @@ describe('TemplateCompiler - au-slot', function () {
       }
     });
   }
+});
+
+describe('TemplateCompiler - hooks', function () {
+  function createFixture() {
+    const ctx = TestContext.create();
+    const container = ctx.container;
+    const sut = ctx.templateCompiler;
+    return { ctx, container, sut };
+  }
+
+  it('invokes before compile hooks', function () {
+    const template = `<template></template>`;
+    const { container, sut } = createFixture();
+    let hookCallCount = 0;
+
+    container.register(Registration.instance(ITemplateCompilerHooks, {
+      beforeCompile(template: HTMLElement) {
+        hookCallCount++;
+        template.setAttribute('data-hello', 'world');
+      }
+    }));
+
+    const definition = sut.compile({ name: 'lorem-ipsum', template }, container, null);
+    assert.strictEqual(hookCallCount, 1);
+    assert.strictEqual((definition.template as Element).getAttribute('data-hello'), 'world');
+  });
+
+  it('invokes all hooks', function () {
+    const template = `<template></template>`;
+    const { container, sut } = createFixture();
+    let hookCallCount = 0;
+
+    container.register(Registration.instance(ITemplateCompilerHooks, {
+      beforeCompile(template: HTMLElement) {
+        hookCallCount++;
+        template.setAttribute('data-hello', 'world');
+      }
+    }));
+    container.register(Registration.instance(ITemplateCompilerHooks, {
+      beforeCompile(template: HTMLElement) {
+        hookCallCount++;
+        template.setAttribute('data-world', 'hello');
+      }
+    }));
+
+    const definition = sut.compile({ name: 'lorem-ipsum', template }, container, null);
+    assert.strictEqual(hookCallCount, 2);
+    assert.strictEqual((definition.template as Element).getAttribute('data-hello'), 'world');
+    assert.strictEqual((definition.template as Element).getAttribute('data-world'), 'hello');
+  });
+
+  it('does not throw if the compile hooks does not have any hooks', function () {
+    const template = `<template></template>`;
+    const { container, sut } = createFixture();
+
+    container.register(Registration.instance(ITemplateCompilerHooks, {}));
+    assert.doesNotThrow(() => sut.compile({ name: 'lorem-ipsum', template }, container, null));
+  });
+
+  it('invokes hooks with resources semantic - only leaf', function () {
+    const template = `<template></template>`;
+    const { container, sut } = createFixture();
+    let hookCallCount = 0;
+    const createResolver = () => Registration.instance(ITemplateCompilerHooks, {
+      beforeCompile(template: HTMLElement) {
+        hookCallCount++;
+        template.setAttribute('data-hello', 'world');
+      }
+    });
+    const middleContainer = container.createChild();
+    const leafContainer = middleContainer.createChild();
+    middleContainer.register(createResolver());
+    leafContainer.register(createResolver());
+
+    const definition = sut.compile({ name: 'lorem-ipsum', template }, leafContainer, null);
+    assert.strictEqual(hookCallCount, 1);
+    assert.strictEqual((definition.template as Element).getAttribute('data-hello'), 'world');
+  });
+
+  it('invokes hooks with resources semantic - leaf + root', function () {
+    const template = `<template></template>`;
+    const { container, sut } = createFixture();
+    let hookCallCount = 0;
+    const createResolver = (value: string) => Registration.instance(ITemplateCompilerHooks, {
+      beforeCompile(template: HTMLElement) {
+        hookCallCount++;
+        template.setAttribute(`data-${value}`, value);
+      }
+    });
+    const middleContainer = container.createChild();
+    const leafContainer = middleContainer.createChild();
+    container.register(createResolver('root'));
+    middleContainer.register(createResolver('middle'));
+    leafContainer.register(createResolver('leaf'));
+
+    const definition = sut.compile({ name: 'lorem-ipsum', template }, leafContainer, null);
+    assert.strictEqual(hookCallCount, 2);
+    assert.strictEqual((definition.template as Element).getAttribute('data-root'), 'root');
+    assert.strictEqual((definition.template as Element).getAttribute('data-middle'), null);
+    assert.strictEqual((definition.template as Element).getAttribute('data-leaf'), 'leaf');
+  });
 });
 
 class BindablesInfo<T extends 0 | 1 = 0> {

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -717,6 +717,9 @@ export {
   // ITemplate,
   // ITemplateCompiler,
   // ITemplateFactory,
+  ITemplateCompilerHooks,
+  TemplateCompilerHooks,
+  templateCompilerHooks,
 
   // RenderContext
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -43,6 +43,7 @@ export interface IServiceLocator {
   get<K extends Key>(key: INewInstanceResolver<K>): Resolved<K>;
   get<K extends Key>(key: ILazyResolver<K>): IResolvedLazy<K>;
   get<K extends Key>(key: IFactoryResolver<K>): IResolvedFactory<K>;
+  get<K extends Key>(key: IResolver<K>): Resolved<K>;
   get<K extends Key>(key: K): Resolved<K>;
   get<K extends Key>(key: Key): Resolved<K>;
   get<K extends Key>(key: K | Key): Resolved<K>;

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -633,6 +633,35 @@ export function ignore(target: Injectable, property?: string | number, descripto
 ignore.$isResolver = true;
 ignore.resolve = () => undefined;
 
+/**
+ * Inject a function that will return a resolved instance of the [[key]] given.
+ * Also supports passing extra parameters to the invocation of the resolved constructor of [[key]]
+ *
+ * For typings, it's a function that take 0 or more arguments and return an instance. Example:
+ * ```ts
+ * class Foo {
+ *   constructor( @factory(MyService) public createService: (...args: unknown[]) => MyService)
+ * }
+ * const foo = container.get(Foo); // instanceof Foo
+ * const myService_1 = foo.createService('user service')
+ * const myService_2 = foo.createService('content service')
+ * ```
+ *
+ * ```ts
+ * class Foo {
+ *   constructor( @factory('random') public createRandomizer: () => Randomizer)
+ * }
+ * container.get(Foo).createRandomizer(); // create a randomizer
+ * ```
+ * would throw an exception because you haven't registered `'random'` before calling the method. This, would give you a
+ * new instance of Randomizer each time.
+ *
+ * `@factory` does not manage the lifecycle of the underlying key. If you want a singleton, you have to register as a
+ * `singleton`, `transient` would also behave as you would expect, providing you a new instance each time.
+ *
+ * - @param key [[`Key`]]
+ * see { @link DI.createInterface } on interactions with interfaces
+ */
 export const factory = createResolver((key: any, handler: IContainer, requestor: IContainer) => {
   return (...args: unknown[]) => handler.getFactory(key).construct(requestor, args);
 }) as <K>(key: K) => IFactoryResolver<K>;
@@ -910,7 +939,10 @@ export class Container implements IContainer {
     let value: IRegistry;
     let j: number;
     let jj: number;
-    for (let i = 0, ii = params.length; i < ii; ++i) {
+    let i = 0;
+    // eslint-disable-next-line
+    let ii = params.length;
+    for (; i < ii; ++i) {
       current = params[i];
       if (!isObject(current)) {
         continue;
@@ -923,9 +955,11 @@ export class Container implements IContainer {
           // Fast path for the very common case
           defs[0].register(this);
         } else {
-          const len = defs.length;
-          for (let d = 0; d < len; ++d) {
-            defs[d].register(this);
+          j = 0;
+          jj = defs.length;
+          while (jj > j) {
+            defs[j].register(this);
+            ++j;
           }
         }
       } else if (isClass(current)) {

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -537,6 +537,15 @@ export {
 export {
   ITemplateElementFactory
 } from './template-element-factory.js';
+export {
+  BindablesInfo,
+  TemplateCompiler,
+  ITemplateCompilerHooks,
+} from './template-compiler.js';
+
+export {
+  allResources,
+} from './utilities-di.js';
 
 export {
   PartialChildrenDefinition,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -541,6 +541,8 @@ export {
   BindablesInfo,
   TemplateCompiler,
   ITemplateCompilerHooks,
+  TemplateCompilerHooks,
+  templateCompilerHooks,
 } from './template-compiler.js';
 
 export {

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -297,6 +297,7 @@ export class AttributeBindingInstruction {
   ) {}
 }
 
+export const ITemplateCompiler = DI.createInterface<ITemplateCompiler>('ITemplateCompiler');
 export interface ITemplateCompiler {
   compile(
     partialDefinition: PartialCustomElementDefinition,
@@ -313,8 +314,6 @@ export interface ICompliationInstruction {
    */
   projections: IProjections | null;
 }
-
-export const ITemplateCompiler = DI.createInterface<ITemplateCompiler>('ITemplateCompiler');
 
 export interface IInstructionTypeClassifier<TType extends string = string> {
   instructionType: TType;

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -1514,8 +1514,8 @@ function getBindingMode(bindable: Element): BindingMode {
 export const ITemplateCompilerHooks = DI.createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
 export interface ITemplateCompilerHooks {
   /**
-  * Should be invoked immediately before a template gets compiled
-  */
+   * Should be invoked immediately before a template gets compiled
+   */
   beforeCompile?(template: HTMLElement): void;
 }
 

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -1,0 +1,48 @@
+import { DI, Resolved } from '@aurelia/kernel';
+
+import type {
+  Constructable,
+  IContainer,
+  IResolver,
+  Key,
+} from '@aurelia/kernel';
+
+// todo: replace existing resource code with this resolver
+// ===================
+// export const resource = function <T extends Key>(key: T) {
+//   function Resolver(target: Injectable, property?: string | number, descriptor?: PropertyDescriptor | number) {
+//     DI.inject(Resolver)(target, property, descriptor);
+//   }
+//   Resolver.$isResolver = true;
+//   Resolver.resolve = function (handler: IContainer, requestor: IContainer) {
+//     if (/* is root? */requestor.root === requestor) {
+//       return requestor.get(key);
+//     }
+
+//     return requestor.has(key, false)
+//       ? requestor.get(key)
+//       : requestor.root.get(key);
+//   };
+//   return Resolver as IResolver<T> & ((...args: unknown[]) => any);
+// };
+
+/**
+ * A resolver builder for resolving all registrations of a key
+ * with resource semantic (leaf + root + ignore middle layer container)
+ */
+export const allResources = function <T extends Key>(key: T) {
+  function Resolver(target: Constructable, property?: string | number, descriptor?: PropertyDescriptor | number) {
+    DI.inject(Resolver)(target, property, descriptor);
+  }
+  Resolver.$isResolver = true;
+  Resolver.resolve = function (handler: IContainer, requestor: IContainer) {
+    if (/* is root? */requestor.root === requestor) {
+      return requestor.getAll(key, false);
+    }
+
+    return requestor.has(key, false)
+      ? requestor.root.getAll(key, false).concat(requestor.getAll(key, false))
+      : requestor.root.getAll(key, false);
+  };
+  return Resolver as IResolver<Resolved<T>[]> & ((...args: unknown[]) => any);
+};

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -41,7 +41,7 @@ export const allResources = function <T extends Key>(key: T) {
     }
 
     return requestor.has(key, false)
-      ? requestor.root.getAll(key, false).concat(requestor.getAll(key, false))
+      ? requestor.getAll(key, false).concat(requestor.root.getAll(key, false))
       : requestor.root.getAll(key, false);
   };
   return Resolver as IResolver<Resolved<T>[]> & ((...args: unknown[]) => any);


### PR DESCRIPTION
# Pull Request

## 📖 Description

A missing capabilities of v1 is the compilation hooks. This is a very focused hooks of the compilation that should be much more ergonomic than the existing define hooks, which is also quite intimidating. Probably the `define` hooks can be partially replaced by a `before` + `after` compilation hooks instead.

The interface of a hook is:
```ts
interface ITemplateCompilerHooks {
  beforeCompile(template: HTMLElement): void;
}
```
Note that `Hooks` in the name indicates that there may be more hooks in the future, beside `beforeCompile`.

## 👩‍💻 Reviewer Notes

- **added**: `allResources` resolver builder. This is to be used for many resources like injectable: `IAttrPattern`, `IBindingCommand` etc...

## 📑 Test Plan

- Existing tests work
- Verify the resources are retrieved with resources semantic

## ⏭ Next Steps

- Refactor the compilation process & start caching for perf improvement.