### PR TITLE
fix(scope): disable host scope on CE controller

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.ts
@@ -1778,6 +1778,34 @@ describe('au-slot', function () {
         },
       );
     }
+
+    {
+      yield new TestData(
+        'picks the right scope of component [ref] bindings',
+        `<my-component>
+          <template au-slot>
+            <my-component>
+            </my-component>
+          </template>
+        </my-component>`,
+        [
+          CustomElement.define({
+            name: 'my-component',
+            template: `<div ref="container" id="div-\${id}"> ref.id=\${container.id} <au-slot></au-slot></div>`
+          }, class MyComponent {
+            public static count = 0;
+            public id: number = MyComponent.count++;
+          })
+        ],
+        {},
+        function ({ host }) {
+          assert.notStrictEqual(host.querySelector('#div-0'), null);
+          assert.notStrictEqual(host.querySelector('#div-1'), null);
+          assert.strictEqual(host.querySelector('#div-0').textContent.replace(/\s/g, ''), 'ref.id=div-0ref.id=div-1');
+          assert.strictEqual(host.querySelector('#div-1').textContent.replace(/\s/g, ''), 'ref.id=div-1');
+        },
+      );
+    }
   }
 
   for (const { spec, template, expected, registrations, additionalAssertion, only } of getTestData()) {

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -50,7 +50,7 @@ export class AuSlot implements ICustomElementViewModel {
   ): void | Promise<void> {
     this.hostScope = this.$controller.scope.parentScope!;
     this.outerScope = this.hasProjection
-      ? this.hdrContext.controller.scope.parentScope! ?? null
+      ? this.hdrContext.controller.scope.parentScope
       : this.hostScope;
   }
 
@@ -59,8 +59,7 @@ export class AuSlot implements ICustomElementViewModel {
     parent: IHydratedParentController,
     flags: LifecycleFlags,
   ): void | Promise<void> {
-    const { $controller } = this;
-    return this.view.activate(initiator, $controller, flags, this.outerScope ?? this.hostScope!, this.hostScope);
+    return this.view.activate(initiator, this.$controller, flags, this.outerScope ?? this.hostScope!, this.hostScope);
   }
 
   public detaching(

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -486,7 +486,9 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       this.logger = this.context!.get(ILogger).root.scopeTo(this.name);
       this.logger!.trace(`activate()`);
     }
-    this.hostScope = hostScope ?? null;
+    if (this.vmKind === ViewModelKind.synthetic) {
+      this.hostScope = hostScope ?? null;
+    }
     flags |= LifecycleFlags.fromBind;
 
     switch (this.vmKind) {

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -76,7 +76,6 @@ export interface IBatchable {
 }
 
 export interface ISubscriber<TValue = unknown> {
-  id?: number;
   handleChange(newValue: TValue, previousValue: TValue, flags: LifecycleFlags): void;
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently the all controllers are accepting host scope, which is a bit wasteful and incorrect. Issues can come up like #1210 where normal binding from CE accidentally picks up some scope from parent because it's activated by an `<au-slot/>`. Disable this, which fixes the issue, and should help avoid doing unnecessary work.

### 🎫 Issues

fixes #1210

Thanks @MaximBalaganskiy 