### PR TITLE
feat(template-compiler): ability to toggle expressions removal

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.ts
@@ -805,9 +805,9 @@ describe('au-slot', function () {
             ListBox, Assignee, ItemRow
           ],
           {
-            'item-row': ['<div><assignee class="au"><list-box value.two-way="value" class="au"> <div> 0 </div></list-box></assignee></div>',null],
-            'item-row+item-row': ['<div><assignee class="au"><list-box value.two-way="value" class="au"> <div> 1 </div></list-box></assignee></div>',null],
-            'item-row+item-row+item-row': ['<div><assignee class="au"><list-box value.two-way="value" class="au"> <div> 2 </div></list-box></assignee></div>',null],
+            'item-row': ['<div><assignee class="au"><list-box class="au"> <div> 0 </div></list-box></assignee></div>',null],
+            'item-row+item-row': ['<div><assignee class="au"><list-box class="au"> <div> 1 </div></list-box></assignee></div>',null],
+            'item-row+item-row+item-row': ['<div><assignee class="au"><list-box class="au"> <div> 2 </div></list-box></assignee></div>',null],
           },
         );
       }
@@ -951,7 +951,7 @@ describe('au-slot', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr collection.bind="person.pets" class="au"><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr collection.bind="person.pets" class="au"><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo([])] },
+        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr class="au"><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr class="au"><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo([])] },
       );
 
       yield new TestData(
@@ -969,7 +969,7 @@ describe('au-slot', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr collection.bind="$host.person.pets" class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr collection.bind="$host.person.pets" class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
+        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
       );
 
       yield new TestData(
@@ -988,7 +988,7 @@ describe('au-slot', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr collection.bind="person.pets" class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr collection.bind="person.pets" class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
+        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
       );
 
       yield new TestData(
@@ -1007,7 +1007,7 @@ describe('au-slot', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr collection.bind="h.person.pets" class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr collection.bind="h.person.pets" class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
+        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr class="au"> <ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr class="au"> <ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
       );
 
       // tag: nonsense-example
@@ -1020,7 +1020,7 @@ describe('au-slot', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr collection.bind="person.pets" class="au"><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr collection.bind="person.pets" class="au"><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo(['colleslawt'])] },
+        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr class="au"><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr class="au"><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo(['colleslawt'])] },
       );
 
       yield new TestData(
@@ -1067,7 +1067,7 @@ describe('au-slot', function () {
           CustomElement.define({ name: 'my-element', isStrictBinding: true, template: `<au-slot name="s1"><foo-bar foo.bind="message"></foo-bar></au-slot>` }, class MyElement { public readonly message = 'inner'; }),
           CustomElement.define({ name: 'foo-bar', isStrictBinding: true, template: `\${foo}`, bindables: ['foo'] }, class MyElement { }),
         ],
-        { 'my-element': ['<foo-bar foo.bind="message" class="au">inner</foo-bar>', null] },
+        { 'my-element': ['<foo-bar class="au">inner</foo-bar>', null] },
       );
 
       yield new TestData(
@@ -1079,7 +1079,7 @@ describe('au-slot', function () {
           createMyElement(`<au-slot name="s1">s1fb</au-slot>`),
           CustomElement.define({ name: 'foo-bar', isStrictBinding: true, template: `\${foo}`, bindables: ['foo'] }, class MyElement { }),
         ],
-        { 'my-element': ['<foo-bar foo.bind="message" class="au">root</foo-bar>', new AuSlotsInfo(['s1'])] },
+        { 'my-element': ['<foo-bar class="au">root</foo-bar>', new AuSlotsInfo(['s1'])] },
       );
 
       {
@@ -1102,7 +1102,7 @@ describe('au-slot', function () {
             ),
             CustomElement.define({ name: 'foo-bar', isStrictBinding: true, template: `\${foo}`, bindables: ['foo'] }, class MyElement { }),
           ],
-          { 'my-element': ['<foo-bar foo.bind="$host.message" class="au">inner</foo-bar>', new AuSlotsInfo(['s1'])] },
+          { 'my-element': ['<foo-bar class="au">inner</foo-bar>', new AuSlotsInfo(['s1'])] },
         );
       }
 
@@ -1385,8 +1385,8 @@ describe('au-slot', function () {
           `<elem text="1"></elem><elem text="2"></elem>`,
           [Elem, Notch, Child],
           {
-            'elem': ['Parent 1 <notch class="au"> Notch <child text.bind="text" view-model.ref="child" class="au">Id: 0. Child 1</child></notch> 0', null],
-            'elem+elem': ['Parent 2 <notch class="au"> Notch <child text.bind="text" view-model.ref="child" class="au">Id: 1. Child 2</child></notch> 1', null],
+            'elem': ['Parent 1 <notch class="au"> Notch <child class="au">Id: 0. Child 1</child></notch> 0', null],
+            'elem+elem': ['Parent 2 <notch class="au"> Notch <child class="au">Id: 1. Child 2</child></notch> 1', null],
           }
         );
       }
@@ -1458,7 +1458,7 @@ describe('au-slot', function () {
         <input au-slot type="text" value.two-way="$host.foo">
       </my-element>`,
         [CustomElement.define({ name: 'my-element', isStrictBinding: true, template: `<au-slot></au-slot>` }, MyElement)],
-        { 'my-element': ['<input type="text" value.two-way="$host.foo" class="au">', new AuSlotsInfo(['default'])] },
+        { 'my-element': ['<input type="text" class="au">', new AuSlotsInfo(['default'])] },
         async function ({ host, platform }) {
           const el = host.querySelector('my-element');
           const vm = CustomElement.for(el).viewModel as any;
@@ -1477,7 +1477,7 @@ describe('au-slot', function () {
         <input au-slot type="text" value.two-way="people[0].firstName">
       </my-element>`,
       [createMyElement(`<au-slot></au-slot>`)],
-      { 'my-element': ['<input type="text" value.two-way="people[0].firstName" class="au">', new AuSlotsInfo(['default'])] },
+      { 'my-element': ['<input type="text" class="au">', new AuSlotsInfo(['default'])] },
       async function ({ app, host, platform }) {
         const el = host.querySelector('my-element');
         const input = el.querySelector('input');

--- a/packages/__tests__/3-runtime-html/compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/compose.spec.ts
@@ -703,7 +703,7 @@ describe('3-runtime-html/compose.spec.ts/au-compose', function () {
       assert.visibleTextEqual(appHost, 'Hello');
       assert.html.innerEqual(
         appHost,
-        '<au-compose view-model.bind="El" view="<div>Hello</div>" model.bind="{ index: 0 }" class="au"><div>Hello</div></au-compose>'
+        '<au-compose class="au"><div>Hello</div></au-compose>'
       );
 
       assert.strictEqual(node, appHost.querySelector('au-compose'));

--- a/packages/__tests__/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/3-runtime-html/enhance.spec.ts
@@ -319,7 +319,7 @@ describe('3-runtime/enhance.spec.ts', function () {
           .enhance({ host: _host, component: CustomElement.define({ name: 'enhance' }, class EnhanceRoot { }) })
           .start();
 
-        assert.html.innerEqual(_host, '<my-element value.bind="42.toString()" class="au"><span>42</span></my-element>', 'enhanced.innerHtml');
+        assert.html.innerEqual(_host, '<my-element class="au"><span>42</span></my-element>', 'enhanced.innerHtml');
         assert.html.innerEqual(this.container, '', 'container.innerHtml - before attach');
       }
 
@@ -330,8 +330,8 @@ describe('3-runtime/enhance.spec.ts', function () {
       // The inverse order of the stop and detaching is intentional
       public async detaching() {
         await this.enhanceAu.stop();
-        assert.html.innerEqual(this.enhancedHost, '<my-element value.bind="42.toString()" class="au"></my-element>', 'enhanced.innerHtml');
-        assert.html.innerEqual(this.container, '<div><my-element value.bind="42.toString()" class="au"></my-element></div>', 'enhanced.innerHtml');
+        assert.html.innerEqual(this.enhancedHost, '<my-element class="au"></my-element>', 'enhanced.innerHtml');
+        assert.html.innerEqual(this.container, '<div><my-element class="au"></my-element></div>', 'enhanced.innerHtml');
       }
 
       public unbinding() {
@@ -349,7 +349,7 @@ describe('3-runtime/enhance.spec.ts', function () {
       .app({ host, component: App })
       .start();
 
-    assert.html.innerEqual(host.querySelector('#container'), '<div><my-element value.bind="42.toString()" class="au"><span>42</span></my-element></div>', 'container.innerHTML - after attach');
+    assert.html.innerEqual(host.querySelector('#container'), '<div><my-element class="au"><span>42</span></my-element></div>', 'container.innerHTML - after attach');
 
     await au.stop();
 

--- a/packages/__tests__/3-runtime-html/process-content.spec.ts
+++ b/packages/__tests__/3-runtime-html/process-content.spec.ts
@@ -351,7 +351,7 @@ describe('processContent', function () {
           class MyElement { }
         )
       ],
-      { 'my-element': '<div><span-ce value="foo" class="au"><span>foo</span></span-ce><strong-ce value="bar" class="au"><strong>bar</strong></strong-ce></div>' },
+      { 'my-element': '<div><span-ce class="au"><span>foo</span></span-ce><strong-ce class="au"><strong>bar</strong></strong-ce></div>' },
     );
 
     function processContentWithNewBinding(compile: boolean) {
@@ -462,7 +462,7 @@ describe('processContent', function () {
           class MyElement { }
         )
       ],
-      { 'my-element': `<div><span-ce value="foo" class="au"><span>foo</span></span-ce><strong-ce value="bar" class="au"><strong>bar</strong></strong-ce></div>` },
+      { 'my-element': `<div><span-ce class="au"><span>foo</span></span-ce><strong-ce class="au"><strong>bar</strong></strong-ce></div>` },
       noop,
       true,
     );

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -431,15 +431,15 @@ describe('promise template-controller', function () {
     return wait;
   }
 
-  function* getTestData() {
-    function wrap(content: string, type: 'p' | 'f' | 'r') {
+  function *getTestData() {
+    function wrap(content: string, type: 'p' | 'f' | 'r', debugMode = false) {
       switch (type) {
         case 'p':
-          return `<${phost} p.bind="promise" class="au">${content}</${phost}>`;
+          return `<${phost} ${debugMode ? `p.bind="promise" ` : ''}class="au">${content}</${phost}>`;
         case 'f':
-          return `<${fhost} data.bind="data" class="au">${content}</${fhost}>`;
+          return `<${fhost} ${debugMode ? `data.bind="data" ` : ''}class="au">${content}</${fhost}>`;
         case 'r':
-          return `<${rhost} err.bind="err" class="au">${content}</${rhost}>`;
+          return `<${rhost} ${debugMode ? `err.bind="err" ` : ''}class="au">${content}</${rhost}>`;
       }
     }
 
@@ -1285,7 +1285,7 @@ describe('promise template-controller', function () {
             </template>`
             },
             config(),
-            '<rejected-host err.bind="updateError(err)" class="au">rejected with foo-bar1</rejected-host>',
+            '<rejected-host class="au">rejected with foo-bar1</rejected-host>',
             getActivationSequenceFor(`${rhost}-1`),
             getDeactivationSequenceFor(`${rhost}-1`),
           );
@@ -1449,7 +1449,7 @@ describe('promise template-controller', function () {
             );
 
             {
-              const staticPart = '<my-el prop.bind="fooBar" class="au">Fizz Bazz</my-el>';
+              const staticPart = '<my-el class="au">Fizz Bazz</my-el>';
               let resolve: (value: unknown) => void;
               let reject: (value: unknown) => void;
               yield new TestData(
@@ -1623,7 +1623,7 @@ describe('promise template-controller', function () {
                 registrations,
               },
               config(),
-              '<rej-host err.bind="err" class="au">rejected with 42</rej-host><rej-host err.bind="err" class="au">rejected with forty-two</rej-host>',
+              '<rej-host class="au">rejected with 42</rej-host><rej-host class="au">rejected with forty-two</rej-host>',
               getActivationSequenceFor(['rej-host-1', 'rej-host-2']),
               getDeactivationSequenceFor(['rej-host-1', 'rej-host-2']),
             );
@@ -1643,7 +1643,7 @@ describe('promise template-controller', function () {
                 registrations,
               },
               config(),
-              '<rej-host err.bind="err" class="au">rejected with 42</rej-host><rej-host err.bind="err" class="au">rejected with forty-two</rej-host>',
+              '<rej-host class="au">rejected with 42</rej-host><rej-host class="au">rejected with forty-two</rej-host>',
               getActivationSequenceFor(['rej-host-1', 'rej-host-2']),
               getDeactivationSequenceFor(['rej-host-1', 'rej-host-2']),
             );
@@ -1924,7 +1924,7 @@ describe('promise template-controller', function () {
           </template>`,
             },
             config(),
-            '<fulfilled-host data="unknown" class="au">resolved with unknown</fulfilled-host>',
+            '<fulfilled-host class="au">resolved with unknown</fulfilled-host>',
             getActivationSequenceFor(`${fhost}-2`),
             getDeactivationSequenceFor(`${fhost}-1`),
             async (ctx) => {
@@ -1939,7 +1939,7 @@ describe('promise template-controller', function () {
               await q.yield();
               await waitSwitch($switch);
 
-              assert.html.innerEqual(ctx.host, '<fulfilled-host data="processing" class="au">resolved with processing</fulfilled-host>');
+              assert.html.innerEqual(ctx.host, '<fulfilled-host class="au">resolved with processing</fulfilled-host>');
               ctx.assertCallSet([...getDeactivationSequenceFor(`${fhost}-2`), ...getActivationSequenceFor(`${fhost}-1`)]);
             },
           );
@@ -1960,7 +1960,7 @@ describe('promise template-controller', function () {
           </template>`,
             },
             config(),
-            '<fulfilled-host data="processing" class="au">resolved with processing</fulfilled-host>',
+            '<fulfilled-host class="au">resolved with processing</fulfilled-host>',
             getActivationSequenceFor(`${fhost}-1`),
             getDeactivationSequenceFor(`${fhost}-2`),
             async (ctx) => {
@@ -1971,7 +1971,7 @@ describe('promise template-controller', function () {
               const $switch = tc['fulfilled'].view.children.find((c) => c.viewModel instanceof Switch).viewModel as Switch;
               controller.scope.overrideContext.status = 'foo';
               await waitSwitch($switch);
-              assert.html.innerEqual(ctx.host, '<fulfilled-host data="unknown" class="au">resolved with unknown</fulfilled-host>');
+              assert.html.innerEqual(ctx.host, '<fulfilled-host class="au">resolved with unknown</fulfilled-host>');
               ctx.assertCallSet([...getDeactivationSequenceFor(`${fhost}-1`), ...getActivationSequenceFor(`${fhost}-2`)]);
             }
           );
@@ -1993,7 +1993,7 @@ describe('promise template-controller', function () {
           </template>`,
             },
             config(),
-            '<rejected-host err.bind="{message: \'unknown\'}" class="au">rejected with unknown</rejected-host>',
+            '<rejected-host class="au">rejected with unknown</rejected-host>',
             getActivationSequenceFor(`${rhost}-2`),
             getDeactivationSequenceFor(`${rhost}-1`),
             async (ctx) => {
@@ -2012,7 +2012,10 @@ describe('promise template-controller', function () {
               await q.yield();
               await waitSwitch($switch);
 
-              assert.html.innerEqual(ctx.host, '<rejected-host err.bind="{message: \'processing\'}" class="au">rejected with processing</rejected-host>');
+              assert.html.innerEqual(
+                ctx.host,
+                '<rejected-host class="au">rejected with processing</rejected-host>'
+              );
               ctx.assertCallSet([...getDeactivationSequenceFor(`${rhost}-2`), ...getActivationSequenceFor(`${rhost}-1`)]);
             },
           );
@@ -2033,7 +2036,7 @@ describe('promise template-controller', function () {
           </template>`,
             },
             config(),
-            '<rejected-host err.bind="{message: \'processing\'}" class="au">rejected with processing</rejected-host>',
+            '<rejected-host class="au">rejected with processing</rejected-host>',
             getActivationSequenceFor(`${rhost}-1`),
             getDeactivationSequenceFor(`${rhost}-2`),
             async (ctx) => {
@@ -2044,7 +2047,7 @@ describe('promise template-controller', function () {
               const $switch = tc['rejected'].view.children.find((c) => c.viewModel instanceof Switch).viewModel as Switch;
               controller.scope.overrideContext.status = 'foo';
               await waitSwitch($switch);
-              assert.html.innerEqual(ctx.host, '<rejected-host err.bind="{message: \'unknown\'}" class="au">rejected with unknown</rejected-host>');
+              assert.html.innerEqual(ctx.host, '<rejected-host class="au">rejected with unknown</rejected-host>');
               ctx.assertCallSet([...getDeactivationSequenceFor(`${rhost}-1`), ...getActivationSequenceFor(`${rhost}-2`)]);
             }
           );
@@ -2072,7 +2075,7 @@ describe('promise template-controller', function () {
           </template>`,
             },
             config(),
-            '<foo-bar p.bind="42|promisify:true" class="au"> <div>f1</div> </foo-bar> <foo-bar p.bind="\'forty-two\'|promisify:false" class="au"> <div>r2</div> </foo-bar>',
+            '<foo-bar class="au"> <div>f1</div> </foo-bar> <foo-bar class="au"> <div>r2</div> </foo-bar>',
             [],
             [],
           );
@@ -2868,7 +2871,7 @@ describe('promise template-controller', function () {
     ) { }
   }
 
-  function* getNegativeTestData() {
+  function *getNegativeTestData() {
     yield new NegativeTestData(
       `pending cannot be used in isolation`,
       `<template><template pending>pending</template></template>`

--- a/packages/__tests__/3-runtime-html/repeater-custom-element.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater-custom-element.spec.ts
@@ -104,7 +104,7 @@ describe(spec, function () {
       const q = platform.domWriteQueue;
       await q.yield();
 
-      assert.html.innerEqual(host, '<foo prop.bind="i" class="au">0</foo> <foo prop.bind="i" class="au">1</foo> <foo prop.bind="i" class="au">2</foo>', `host.textContent`);
+      assert.html.innerEqual(host, '<foo class="au">0</foo> <foo class="au">1</foo> <foo class="au">2</foo>', `host.textContent`);
     }, setup);
   }
   {
@@ -126,7 +126,7 @@ describe(spec, function () {
       const q = platform.domWriteQueue;
       await q.yield();
 
-      assert.html.innerEqual(host, '<foo prop.bind="item.p" class="au">1</foo> <foo prop.bind="item.p" class="au">2</foo> <foo prop.bind="item.p" class="au">3</foo>', `host.textContent`);
+      assert.html.innerEqual(host, '<foo class="au">1</foo> <foo class="au">2</foo> <foo class="au">3</foo>', `host.textContent`);
     }, setup);
   }
   {
@@ -156,7 +156,7 @@ describe(spec, function () {
       const q = platform.domWriteQueue;
       await q.yield();
 
-      assert.html.innerEqual(host, '<bar id.from-view="id" class="au">bar</bar> <foo prop.bind="id" class="au">1</foo> <bar id.from-view="id" class="au">bar</bar> <foo prop.bind="id" class="au">2</foo>', `host.textContent`);
+      assert.html.innerEqual(host, '<bar class="au">bar</bar> <foo class="au">1</foo> <bar class="au">bar</bar> <foo class="au">2</foo>', `host.textContent`);
     }, setup);
   }
 

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -905,7 +905,7 @@ describe('switch', function () {
           registrations: [MyEcho],
         },
         config(),
-        `${wrap('Delivered.')} <span>foobar</span> <span>foo</span> <span>bar</span> <span>0</span><span>1</span><span>2</span> <my-echo message="awesome possum" class="au">Echoed 'awesome possum'</my-echo>`,
+        `${wrap('Delivered.')} <span>foobar</span> <span>foo</span> <span>bar</span> <span>0</span><span>1</span><span>2</span> <my-echo class="au">Echoed 'awesome possum'</my-echo>`,
         [...getActivationSequenceFor('my-echo-1'), 1, 2, 3, 4, ...getActivationSequenceFor('case-host-4')],
         getDeactivationSequenceFor(['case-host-4', 'my-echo-1']),
       );
@@ -1263,7 +1263,7 @@ describe('switch', function () {
       `,
         },
         config(),
-        `<foo-bar status.bind="status" class="au"> <div> ${wrap('Delivered.')} </div> </foo-bar>`,
+        `<foo-bar class="au"> <div> ${wrap('Delivered.')} </div> </foo-bar>`,
         null,
         getDeactivationSequenceFor('case-host-4'),
         (ctx) => {
@@ -1297,7 +1297,7 @@ describe('switch', function () {
       `,
         },
         config(),
-        '<foo-bar status.bind="status" class="au"> <div> <span>Projection</span> </div> </foo-bar>',
+        '<foo-bar class="au"> <div> <span>Projection</span> </div> </foo-bar>',
         null,
         [],
         async (ctx) => {
@@ -1308,7 +1308,7 @@ describe('switch', function () {
           await ctx.assertChange(
             $switch,
             () => { ctx.app.status = Status.delivered; },
-            '<foo-bar status.bind="status" class="au"> <div> Delivered. </div> </foo-bar>',
+            '<foo-bar class="au"> <div> Delivered. </div> </foo-bar>',
             new Array(4).fill(0).map((_, i) => `Case-#${$switch['cases'][i].id}.isMatch()`),
           );
         }
@@ -1338,7 +1338,7 @@ describe('switch', function () {
           await ctx.assertChange(
             $switch,
             () => { ctx.app.status = Status.delivered; },
-            '<my-echo message="Delivered." class="au">Echoed \'Delivered.\'</my-echo>',
+            '<my-echo class="au">Echoed \'Delivered.\'</my-echo>',
             [1, 2, 3, 4, ...getDeactivationSequenceFor('case-host-1'), ...getActivationSequenceFor('my-echo-1')]
           );
         }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -156,6 +156,9 @@ export class SetPropertyInstruction {
 export class HydrateElementInstruction {
   public get type(): InstructionType.hydrateElement { return InstructionType.hydrateElement; }
 
+  /**
+   * A special property that can be used to store <au-slot/> usage information
+   */
   public auSlot: { name: string; fallback: CustomElementDefinition } | null = null;
 
   public constructor(
@@ -299,6 +302,12 @@ export class AttributeBindingInstruction {
 
 export const ITemplateCompiler = DI.createInterface<ITemplateCompiler>('ITemplateCompiler');
 export interface ITemplateCompiler {
+  /**
+   * Indicates whether this compiler should compile template in debug mode
+   *
+   * For the default compiler, this means all expressions are kept as is on the template
+   */
+  debug: boolean;
   compile(
     partialDefinition: PartialCustomElementDefinition,
     context: IContainer,

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -16,6 +16,12 @@ import type { BindableDefinition, PartialBindableDefinition } from '../bindable.
 import type { ICustomAttributeViewModel, ICustomAttributeController } from '../templating/controller.js';
 import type { IWatchDefinition } from '../watch.js';
 
+declare module '@aurelia/kernel' {
+  interface IContainer {
+    find<T>(kind: CustomAttributeKind, name: string): CustomAttributeDefinition<Constructable<T>> | null;
+  }
+}
+
 export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
   readonly defaultBindingMode?: BindingMode;
   readonly isTemplateController?: boolean;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -36,6 +36,12 @@ import type { IPlatform } from '../platform.js';
 import type { IInstruction } from '../renderer.js';
 import type { IWatchDefinition } from '../watch.js';
 
+declare module '@aurelia/kernel' {
+  interface IContainer {
+    find<T>(kind: CustomElementKind, name: string): CustomElementDefinition<Constructable<T>> | null;
+  }
+}
+
 export type PartialCustomElementDefinition = PartialResourceDefinition<{
   readonly cache?: '*' | number;
   readonly template?: null | string | Node;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add ability to remove binding expressions, including:
- containerless
- as-element
- ref
- attr with binding expression (`attr.command="..."`)
- attr with interpolation (`attr="${someExpression}"`)
- custom attribute
- custom element bindables

The default of the default template compiler is removing all expressions. To toggle off this behavior, set `debug` to `true` (for the default compiler):
```ts
Aurelia.register(
  AppTask.beforeCreate(ITemplateCompiler, compiler => compiler.debug = true)
).app(MyApp)
```

### 🎫 Issues

Closes #420

Example:

Before:
```html
<input type="text" value.bind="firstName">
```
After:
```html
<input type="text" class="au">
```