### PR TITLE
refactor(render-context): remove IContainer APIs from rendering context

### DIFF
--- a/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
@@ -60,8 +60,16 @@ for (const parentSpec of specs) {
             private childController!: ICustomElementController;
 
             public created(controller: ICustomElementController<this>): void {
-              const context = controller.context;
-              this.childController = Controller.forCustomElement(null, context.container, context.container, context.container.get(CustomElement.keyFrom('the-child')), controller.host, null);
+              const container = controller.container;
+              this.childController = Controller.forCustomElement(
+                null,
+                container,
+                // todo: should this not be allowed to work?
+                container,
+                container.get(CustomElement.keyFrom('the-child')),
+                controller.host,
+                null
+              );
             }
             public attaching(initiator: IHydratedController): void {
               // No async hooks so all of these are synchronous.

--- a/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
@@ -61,7 +61,7 @@ for (const parentSpec of specs) {
 
             public created(controller: ICustomElementController<this>): void {
               const context = controller.context;
-              this.childController = Controller.forCustomElement(null, context, context, context.get(CustomElement.keyFrom('the-child')), controller.host, null);
+              this.childController = Controller.forCustomElement(null, context.container, context.container, context.container.get(CustomElement.keyFrom('the-child')), controller.host, null);
             }
             public attaching(initiator: IHydratedController): void {
               // No async hooks so all of these are synchronous.

--- a/packages/__tests__/3-runtime-html/di-resolutions.spec.ts
+++ b/packages/__tests__/3-runtime-html/di-resolutions.spec.ts
@@ -38,56 +38,6 @@ describe('3-runtime-html/di-resolutions.spec.ts', function () {
 
       await tearDown();
     });
-
-    it.skip('resolves dependency with: interface + @newInstanceForScope + registration at requestor', async function () {
-      // arrange
-      let contextCallCount = 0;
-      const IListboxContext = DI.createInterface<IListboxContext>(
-        'IListboxContext',
-        x => x.singleton(class ListboxContext {
-          public open = false;
-          public constructor() {
-            contextCallCount++;
-          }
-        })
-      );
-      interface IListboxContext {
-        open: boolean;
-      }
-
-      @customElement({
-        name: 'list-box',
-        template: '<listbox-item repeat.for="i of 5" value.bind="i">',
-        dependencies: []
-      })
-      class Listbox {
-        public constructor(
-          @newInstanceForScope(IListboxContext) public readonly context: IListboxContext
-        ) { }
-      }
-
-      // act
-      const { component, startPromise, tearDown } = createFixture(
-        `<list-box view-model.ref="listbox">`,
-        class App {
-          public readonly listbox: IHydratedCustomElementViewModel & Listbox;
-        },
-        [Listbox]
-      );
-
-      await startPromise;
-
-      // assert
-      const container = component.$controller!.context.container;
-      assert.strictEqual(container.getResolver(IListboxContext, false), null);
-      assert.strictEqual(container.has(IListboxContext, false), true);
-      assert.strictEqual(container.get(IListboxContext), component.listbox.context);
-      assert.strictEqual(component.listbox.context.open, false);
-      assert.strictEqual(contextCallCount, 1);
-
-      await tearDown();
-    });
-
     // TODO
     // A skipped test for the most intuitive behavior: @newInstanceForScope(Interface_With_Default)
     //

--- a/packages/__tests__/3-runtime-html/di-resolutions.spec.ts
+++ b/packages/__tests__/3-runtime-html/di-resolutions.spec.ts
@@ -78,9 +78,10 @@ describe('3-runtime-html/di-resolutions.spec.ts', function () {
       await startPromise;
 
       // assert
-      assert.strictEqual(component.$controller!.context.getResolver(IListboxContext, false), null);
-      assert.strictEqual(component.listbox.$controller.context.has(IListboxContext, false), true);
-      assert.strictEqual(component.listbox.$controller.context.get(IListboxContext), component.listbox.context);
+      const container = component.$controller!.context.container;
+      assert.strictEqual(container.getResolver(IListboxContext, false), null);
+      assert.strictEqual(container.has(IListboxContext, false), true);
+      assert.strictEqual(container.get(IListboxContext), component.listbox.context);
       assert.strictEqual(component.listbox.context.open, false);
       assert.strictEqual(contextCallCount, 1);
 

--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -85,7 +85,7 @@ describe('TranslationParametersBindingRenderer', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationParametersBindingRenderer(container.get(IExpressionParser), container.get(IObserverLocator), container.get(IPlatform));
     const expressionParser = container.get(IExpressionParser);
-    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
     const callBindingInstruction: CallBindingInstruction = { from: expressionParser.parse('{foo: "bar"}', BindingType.BindCommand) } as unknown as CallBindingInstruction;
 
     sut.render(
@@ -105,7 +105,7 @@ describe('TranslationParametersBindingRenderer', function () {
     const expressionParser = container.get(IExpressionParser);
     const targetElement = PLATFORM.document.createElement('span');
     const binding = new TranslationBinding(targetElement, container.get(IObserverLocator), container, container.get(IPlatform));
-    const hydratable = ({ bindings: [binding] } as unknown as IHydratableController);
+    const hydratable = ({ container, bindings: [binding] } as unknown as IHydratableController);
     const paramExpr = expressionParser.parse('{foo: "bar"}', BindingType.BindCommand);
     const callBindingInstruction: CallBindingInstruction = { from: paramExpr } as unknown as CallBindingInstruction;
 

--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -85,12 +85,12 @@ describe('TranslationParametersBindingRenderer', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationParametersBindingRenderer(container.get(IExpressionParser), container.get(IObserverLocator), container.get(IPlatform));
     const expressionParser = container.get(IExpressionParser);
-    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); }} as unknown as IHydratableController);
+    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
     const callBindingInstruction: CallBindingInstruction = { from: expressionParser.parse('{foo: "bar"}', BindingType.BindCommand) } as unknown as CallBindingInstruction;
 
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       PLATFORM.document.createElement('span'),
       callBindingInstruction,
@@ -111,7 +111,7 @@ describe('TranslationParametersBindingRenderer', function () {
 
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       hydratable,
       targetElement,
       callBindingInstruction,

--- a/packages/__tests__/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-renderer.spec.ts
@@ -77,7 +77,7 @@ describe('TranslationBindingCommand', function () {
   function createFixture(aliases?: string[]) {
     aliases = aliases || [];
     const container = createContainer().register(
-      BindingCommand.define({name: 't', aliases}, TranslationBindingCommand)
+      BindingCommand.define({ name: 't', aliases }, TranslationBindingCommand)
     );
     if (!aliases.includes('t')) {
       aliases.push('t');
@@ -139,7 +139,7 @@ describe('TranslationBindingRenderer', function () {
     const callBindingInstruction: CallBindingInstruction = { from } as unknown as CallBindingInstruction;
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       PLATFORM.document.createElement('span'),
       callBindingInstruction,
@@ -160,7 +160,7 @@ describe('TranslationBindingRenderer', function () {
     const callBindingInstruction: CallBindingInstruction = { from } as unknown as CallBindingInstruction;
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       targetElement,
       callBindingInstruction,
@@ -220,7 +220,7 @@ describe('TranslationBindBindingCommand', function () {
     aliases = aliases || [];
     aliases = aliases.map(alias => `${alias}.bind`);
     const container = createContainer().register(
-      BindingCommand.define({name: 't.bind', aliases}, TranslationBindBindingCommand)
+      BindingCommand.define({ name: 't.bind', aliases }, TranslationBindBindingCommand)
     );
     if (!aliases.includes('t.bind')) {
       aliases.push('t.bind');
@@ -284,7 +284,7 @@ describe('TranslationBindBindingRenderer', function () {
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       PLATFORM.document.createElement('span'),
       callBindingInstruction,
@@ -303,7 +303,7 @@ describe('TranslationBindBindingRenderer', function () {
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       PLATFORM.document.createElement('span'),
       callBindingInstruction,
@@ -324,7 +324,7 @@ describe('TranslationBindBindingRenderer', function () {
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;
     sut.render(
       LifecycleFlags.none,
-      container as unknown as ICompiledRenderContext,
+      { container } as unknown as ICompiledRenderContext,
       controller,
       targetElement,
       callBindingInstruction,

--- a/packages/__tests__/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-renderer.spec.ts
@@ -133,7 +133,7 @@ describe('TranslationBindingRenderer', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationBindingRenderer(container.get(IExpressionParser), {} as unknown as IObserverLocator, container.get(IPlatform));
     const expressionParser = container.get(IExpressionParser);
-    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
 
     const from = expressionParser.parse('simple.key', BindingType.CustomCommand);
     const callBindingInstruction: CallBindingInstruction = { from } as unknown as CallBindingInstruction;
@@ -154,7 +154,7 @@ describe('TranslationBindingRenderer', function () {
     const expressionParser = container.get(IExpressionParser);
     const targetElement = PLATFORM.document.createElement('span');
     const binding = new TranslationBinding(targetElement, {} as unknown as IObserverLocator, container, container.get(IPlatform));
-    const controller = ({ bindings: [binding], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [binding], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
 
     const from = expressionParser.parse('simple.key', BindingType.CustomCommand);
     const callBindingInstruction: CallBindingInstruction = { from } as unknown as CallBindingInstruction;
@@ -278,7 +278,7 @@ describe('TranslationBindBindingRenderer', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationBindBindingRenderer(container.get(IExpressionParser), {} as unknown as IObserverLocator, container.get(IPlatform));
     const expressionParser = container.get(IExpressionParser);
-    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
 
     const from = expressionParser.parse('simple.key', BindingType.BindCommand);
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;
@@ -297,7 +297,7 @@ describe('TranslationBindBindingRenderer', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationBindBindingRenderer(container.get(IExpressionParser), {} as unknown as IObserverLocator, container.get(IPlatform));
     const expressionParser = container.get(IExpressionParser);
-    const controller = ({ bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
 
     const from = expressionParser.parse('simple.key', BindingType.BindCommand);
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;
@@ -318,7 +318,7 @@ describe('TranslationBindBindingRenderer', function () {
     const expressionParser = container.get(IExpressionParser);
     const targetElement = PLATFORM.document.createElement('span');
     const binding = new TranslationBinding(targetElement, {} as unknown as IObserverLocator, container, container.get(IPlatform));
-    const controller = ({ bindings: [binding], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
+    const controller = ({ container, bindings: [binding], addBinding(binding) { (controller.bindings as unknown as IBinding[]).push(binding); } } as unknown as IHydratableController);
 
     const from = expressionParser.parse('simple.key', BindingType.BindCommand);
     const callBindingInstruction: CallBindingInstruction = { from, to: '.bind' } as unknown as CallBindingInstruction;

--- a/packages/__tests__/router/_shared/create-fixture.ts
+++ b/packages/__tests__/router/_shared/create-fixture.ts
@@ -24,7 +24,7 @@ export async function createFixture<T extends Constructable>(
   deps: Constructable[],
   createHIAConfig: () => IHIAConfig,
   createRouterOptions: () => IRouterOptions,
-  level: LogLevel = LogLevel.warn,
+  level: LogLevel = LogLevel.fatal,
 ) {
   const hiaConfig = createHIAConfig();
   const routerOptions = createRouterOptions();
@@ -34,7 +34,7 @@ export async function createFixture<T extends Constructable>(
   container.register(Registration.instance(IHIAConfig, hiaConfig));
   container.register(TestRouterConfiguration.for(ctx, level));
   container.register(RouterConfiguration.customize(routerOptions));
-  container.register(LoggerConfiguration.create({ sinks: [ConsoleSink], level: LogLevel.warn }));
+  container.register(LoggerConfiguration.create({ sinks: [ConsoleSink], level: LogLevel.fatal }));
   container.register(...deps);
 
   const activityTracker = container.get(IActivityTracker);

--- a/packages/__tests__/router/hook-tests.spec.ts
+++ b/packages/__tests__/router/hook-tests.spec.ts
@@ -484,7 +484,7 @@ async function createFixture<T extends Constructable>(
   Component: T,
   deps: Constructable[],
   routerOptions: IRouterOptions,
-  level: LogLevel = LogLevel.warn,
+  level: LogLevel = LogLevel.fatal,
 ) {
   const ctx = TestContext.create();
   const cfg = new NotifierConfig([], 100);

--- a/packages/__tests__/router/smoke-tests.spec.ts
+++ b/packages/__tests__/router/smoke-tests.spec.ts
@@ -1,4 +1,4 @@
-import { LogLevel, Constructable, kebabCase, ILogConfig, ILogger } from '@aurelia/kernel';
+import { LogLevel, Constructable, kebabCase, ILogConfig } from '@aurelia/kernel';
 import { assert, TestContext } from '@aurelia/testing';
 import { RouterConfiguration, IRouter, NavigationInstruction, IRouteContext, RouteNode, Params } from '@aurelia/router';
 import { Aurelia, customElement, CustomElement } from '@aurelia/runtime-html';

--- a/packages/__tests__/router/smoke-tests.spec.ts
+++ b/packages/__tests__/router/smoke-tests.spec.ts
@@ -36,7 +36,7 @@ function assertIsActive(
 async function createFixture<T extends Constructable>(
   Component: T,
   deps: Constructable[],
-  level: LogLevel = LogLevel.warn,
+  level: LogLevel = LogLevel.fatal,
 ) {
   const ctx = TestContext.create();
   const { container, platform } = ctx;

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -1,4 +1,4 @@
-import { camelCase, IContainer } from '@aurelia/kernel';
+import { camelCase } from '@aurelia/kernel';
 import { TranslationBinding } from './translation-binding.js';
 import {
   BindingMode,
@@ -15,6 +15,7 @@ import {
   bindingCommand,
   IPlatform,
   IAttrMapper,
+  ICompiledRenderContext,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -75,11 +76,11 @@ export class TranslationParametersBindingRenderer implements IRenderer {
 
   public render(
     flags: LifecycleFlags,
-    context: IContainer,
+    context: ICompiledRenderContext,
     controller: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
   ): void {
-    TranslationBinding.create({ parser: this.parser, observerLocator: this.observerLocator, context, controller: controller, target, instruction, isParameterContext: true, platform: this.platform });
+    TranslationBinding.create({ parser: this.parser, observerLocator: this.observerLocator, context: context.container, controller: controller, target, instruction, isParameterContext: true, platform: this.platform });
   }
 }

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -77,10 +77,19 @@ export class TranslationParametersBindingRenderer implements IRenderer {
   public render(
     flags: LifecycleFlags,
     context: ICompiledRenderContext,
-    controller: IHydratableController,
+    renderingController: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
   ): void {
-    TranslationBinding.create({ parser: this.parser, observerLocator: this.observerLocator, context: context.container, controller: controller, target, instruction, isParameterContext: true, platform: this.platform });
+    TranslationBinding.create({
+      parser: this.parser,
+      observerLocator: this.observerLocator,
+      context: renderingController.container,
+      controller: renderingController,
+      target,
+      instruction,
+      isParameterContext: true,
+      platform: this.platform
+    });
   }
 }

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -1,4 +1,4 @@
-import { camelCase, IContainer } from '@aurelia/kernel';
+import { camelCase } from '@aurelia/kernel';
 import { TranslationBinding } from './translation-binding.js';
 import {
   BindingMode,
@@ -13,6 +13,7 @@ import {
   AttrSyntax,
   IPlatform,
   IAttrMapper,
+  ICompiledRenderContext,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -73,7 +74,7 @@ export class TranslationBindingRenderer implements IRenderer {
 
   public render(
     flags: LifecycleFlags,
-    context: IContainer,
+    context: ICompiledRenderContext,
     controller: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
@@ -81,7 +82,7 @@ export class TranslationBindingRenderer implements IRenderer {
     TranslationBinding.create({
       parser: this.parser,
       observerLocator: this.observerLocator,
-      context,
+      context: context.container,
       controller,
       target,
       instruction,
@@ -143,7 +144,7 @@ export class TranslationBindBindingRenderer implements IRenderer {
 
   public render(
     flags: LifecycleFlags,
-    context: IContainer,
+    context: ICompiledRenderContext,
     controller: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
@@ -151,7 +152,7 @@ export class TranslationBindBindingRenderer implements IRenderer {
     TranslationBinding.create({
       parser: this.parser,
       observerLocator: this.observerLocator,
-      context,
+      context: context.container,
       controller,
       target,
       instruction,

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -75,15 +75,15 @@ export class TranslationBindingRenderer implements IRenderer {
   public render(
     flags: LifecycleFlags,
     context: ICompiledRenderContext,
-    controller: IHydratableController,
+    renderingController: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
   ): void {
     TranslationBinding.create({
       parser: this.parser,
       observerLocator: this.observerLocator,
-      context: context.container,
-      controller,
+      context: renderingController.container,
+      controller: renderingController,
       target,
       instruction,
       platform: this.platform,
@@ -145,15 +145,15 @@ export class TranslationBindBindingRenderer implements IRenderer {
   public render(
     flags: LifecycleFlags,
     context: ICompiledRenderContext,
-    controller: IHydratableController,
+    renderingController: IHydratableController,
     target: HTMLElement,
     instruction: CallBindingInstruction,
   ): void {
     TranslationBinding.create({
       parser: this.parser,
       observerLocator: this.observerLocator,
-      context: context.container,
-      controller,
+      context: renderingController.container,
+      controller: renderingController,
       target,
       instruction,
       platform: this.platform

--- a/packages/router/src/component-agent.ts
+++ b/packages/router/src/component-agent.ts
@@ -36,7 +36,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
     public readonly routeNode: RouteNode,
     public readonly ctx: IRouteContext,
   ) {
-    this.logger = ctx.get(ILogger).scopeTo(`ComponentAgent<${ctx.friendlyPath}>`);
+    this.logger = ctx.container.get(ILogger).scopeTo(`ComponentAgent<${ctx.friendlyPath}>`);
 
     this.logger.trace(`constructor()`);
 
@@ -59,8 +59,9 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
   ): ComponentAgent<T> {
     let componentAgent = componentAgentLookup.get(componentInstance);
     if (componentAgent === void 0) {
+      const container = ctx.container;
       const definition = RouteDefinition.resolve(componentInstance.constructor as Constructable);
-      const controller = Controller.forCustomElement(ctx.get(IAppRoot), ctx, ctx, componentInstance, hostController.host, null);
+      const controller = Controller.forCustomElement(container.get(IAppRoot), container, container, componentInstance, hostController.host, null);
 
       componentAgentLookup.set(
         componentInstance,

--- a/packages/router/src/route-context.ts
+++ b/packages/router/src/route-context.ts
@@ -27,7 +27,7 @@ const RESIDUE = 'au$residue' as const;
  * - The `RouteDefinition` for a type is overridden manually via `Route.define`
  * - Different components (with different `RenderContext`s) reference the same component via a child route config
  */
-export class RouteContext implements IContainer {
+export class RouteContext {
   public get id(): number {
     return this.container.id;
   }
@@ -137,7 +137,7 @@ export class RouteContext implements IContainer {
 
     this.moduleLoader = parentContainer.get(IModuleLoader);
 
-    const container = this.container = parentContainer.createChild({ inheritParentResources: true });
+    const container = this.container = parentContainer.createChild();
 
     container.registerResolver(
       IController,

--- a/packages/router/src/route-context.ts
+++ b/packages/router/src/route-context.ts
@@ -254,7 +254,7 @@ export class RouteContext implements IContainer {
         // This also gives us a set point in the future to potentially handle supported scenarios where this could occur.
         const controller = CustomElement.for(context, { searchParents: true });
         logger.trace(`resolve(context:Node(nodeName:'${context.nodeName}'),controller:'${controller.context.definition.name}') - resolving RouteContext from controller's RenderContext`);
-        return controller.context.get(IRouteContext);
+        return controller.context.container.get(IRouteContext);
       } catch (err) {
         logger.error(`Failed to resolve RouteContext from Node(nodeName:'${context.nodeName}')`, err);
         throw err;
@@ -264,13 +264,13 @@ export class RouteContext implements IContainer {
     if (isCustomElementViewModel(context)) {
       const controller = context.$controller!;
       logger.trace(`resolve(context:CustomElementViewModel(name:'${controller.context.definition.name}')) - resolving RouteContext from controller's RenderContext`);
-      return controller.context.get(IRouteContext);
+      return controller.context.container.get(IRouteContext);
     }
 
     if (isCustomElementController(context)) {
       const controller = context;
       logger.trace(`resolve(context:CustomElementController(name:'${controller.context.definition.name}')) - resolving RouteContext from controller's RenderContext`);
-      return controller.context.get(IRouteContext);
+      return controller.context.container.get(IRouteContext);
     }
 
     logAndThrow(new Error(`Invalid context type: ${Object.prototype.toString.call(context)}`), logger);

--- a/packages/router/src/route-context.ts
+++ b/packages/router/src/route-context.ts
@@ -255,7 +255,7 @@ export class RouteContext {
         // This also gives us a set point in the future to potentially handle supported scenarios where this could occur.
         const controller = CustomElement.for(context, { searchParents: true });
         logger.trace(`resolve(context:Node(nodeName:'${context.nodeName}'),controller:'${controller.context.definition.name}') - resolving RouteContext from controller's RenderContext`);
-        return controller.context.container.get(IRouteContext);
+        return controller.container.get(IRouteContext);
       } catch (err) {
         logger.error(`Failed to resolve RouteContext from Node(nodeName:'${context.nodeName}')`, err);
         throw err;
@@ -265,13 +265,13 @@ export class RouteContext {
     if (isCustomElementViewModel(context)) {
       const controller = context.$controller!;
       logger.trace(`resolve(context:CustomElementViewModel(name:'${controller.context.definition.name}')) - resolving RouteContext from controller's RenderContext`);
-      return controller.context.container.get(IRouteContext);
+      return controller.container.get(IRouteContext);
     }
 
     if (isCustomElementController(context)) {
       const controller = context;
       logger.trace(`resolve(context:CustomElementController(name:'${controller.context.definition.name}')) - resolving RouteContext from controller's RenderContext`);
-      return controller.context.container.get(IRouteContext);
+      return controller.container.get(IRouteContext);
     }
 
     logAndThrow(new Error(`Invalid context type: ${Object.prototype.toString.call(context)}`), logger);

--- a/packages/router/src/route-definition.ts
+++ b/packages/router/src/route-definition.ts
@@ -79,7 +79,7 @@ export class RouteDefinition {
         if (context === void 0) {
           throw new Error(`When retrieving the RouteDefinition for a component name, a RouteContext (that can resolve it) must be provided`);
         }
-        const component = context.find(CustomElement, typedInstruction.value);
+        const component = context.container.find(CustomElement, typedInstruction.value);
         if (component === null) {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
           throw new Error(`Could not find a CustomElement named '${typedInstruction.value}' in the current container scope of ${context}. This means the component is neither registered at Aurelia startup nor via the 'dependencies' decorator or static property.`);

--- a/packages/router/src/route-tree.ts
+++ b/packages/router/src/route-tree.ts
@@ -314,7 +314,7 @@ export function updateRouteTree(
   vit: ViewportInstructionTree,
   ctx: IRouteContext,
 ): Promise<void> | void {
-  const log = ctx.get(ILogger).scopeTo('RouteTree');
+  const log = ctx.container.get(ILogger).scopeTo('RouteTree');
 
   // The root of the routing tree is always the CompositionRoot of the Aurelia app.
   // From a routing perspective it's simply a "marker": it does not need to be loaded,
@@ -386,7 +386,7 @@ function updateNode(
 
 export function processResidue(node: RouteNode): Promise<void> | void {
   const ctx = node.context;
-  const log = ctx.get(ILogger).scopeTo('RouteTree');
+  const log = ctx.container.get(ILogger).scopeTo('RouteTree');
 
   const suffix = ctx.resolved instanceof Promise ? ' - awaiting promise' : '';
   log.trace(`processResidue(node:%s)${suffix}`, node);
@@ -408,7 +408,7 @@ export function processResidue(node: RouteNode): Promise<void> | void {
 
 export function getDynamicChildren(node: RouteNode): Promise<readonly RouteNode[]> | readonly RouteNode[] {
   const ctx = node.context;
-  const log = ctx.get(ILogger).scopeTo('RouteTree');
+  const log = ctx.container.get(ILogger).scopeTo('RouteTree');
 
   const suffix = ctx.resolved instanceof Promise ? ' - awaiting promise' : '';
   log.trace(`getDynamicChildren(node:%s)${suffix}`, node);
@@ -495,7 +495,7 @@ function createNode(
   const rr = ctx.recognize(path);
   if (rr === null) {
     const name = vi.component.value;
-    let ced: CustomElementDefinition | null = ctx.find(CustomElement, name);
+    let ced: CustomElementDefinition | null = ctx.container.find(CustomElement, name);
     switch (node.tree.options.routingMode) {
       case 'configured-only':
         if (ced === null) {
@@ -517,7 +517,7 @@ function createNode(
             throw new Error(`'${name}' did not match any configured route or registered component name at '${ctx.friendlyPath}' and no fallback was provided for viewport '${vpName}' - did you forget to add the component '${name}' to the dependencies of '${ctx.component.name}' or to register it as a global dependency?`);
           }
           const fallback = fallbackVPA.viewport.fallback;
-          ced = ctx.find(CustomElement, fallback);
+          ced = ctx.container.find(CustomElement, fallback);
           if (ced === null) {
             throw new Error(`the requested component '${name}' and the fallback '${fallback}' at viewport '${vpName}' did not match any configured route or registered component name at '${ctx.friendlyPath}' - did you forget to add the component '${name}' to the dependencies of '${ctx.component.name}' or to register it as a global dependency?`);
           }
@@ -559,7 +559,7 @@ function createConfiguredNode(
         resolution: rt.options.resolutionMode,
       }));
 
-      const router = ctx.get(IRouter);
+      const router = ctx.container.get(IRouter);
       const childCtx = router.getRouteContext(vpa, ced, vpa.hostController.context);
 
       childCtx.node = RouteNode.create({
@@ -666,7 +666,7 @@ function createConfiguredNode(
     const redirRR = ctx.recognize(newPath);
     if (redirRR === null) {
       const name = newPath;
-      const ced: CustomElementDefinition | null = ctx.find(CustomElement, newPath);
+      const ced: CustomElementDefinition | null = ctx.container.find(CustomElement, newPath);
       switch (rt.options.routingMode) {
         case 'configured-only':
           if (ced === null) {
@@ -703,7 +703,7 @@ function createDirectNode(
     resolution: rt.options.resolutionMode,
   }));
 
-  const router = ctx.get(IRouter);
+  const router = ctx.container.get(IRouter);
   const childCtx = router.getRouteContext(vpa, ced, vpa.hostController.context);
 
   // TODO(fkleuver): process redirects in direct routing (?)

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -617,7 +617,8 @@ export class Router {
     component: CustomElementDefinition,
     renderContext: ICompiledRenderContext,
   ): IRouteContext {
-    const logger = renderContext.get(ILogger).scopeTo('RouteContext');
+    const container = renderContext.container;
+    const logger = container.get(ILogger).scopeTo('RouteContext');
 
     const routeDefinition = RouteDefinition.resolve(component.Type);
     let routeDefinitionLookup = this.vpaLookup.get(viewportAgent);
@@ -629,7 +630,7 @@ export class Router {
     if (routeContext === void 0) {
       logger.trace(`creating new RouteContext for %s`, routeDefinition);
 
-      const parent = renderContext.has(IRouteContext, true) ? renderContext.get(IRouteContext) : null;
+      const parent = container.has(IRouteContext, true) ? container.get(IRouteContext) : null;
 
       routeDefinitionLookup.set(
         routeDefinition,
@@ -638,7 +639,7 @@ export class Router {
           parent,
           component,
           routeDefinition,
-          renderContext,
+          container,
         ),
       );
     } else {

--- a/packages/router/src/viewport-agent.ts
+++ b/packages/router/src/viewport-agent.ts
@@ -64,7 +64,7 @@ export class ViewportAgent {
     public readonly hostController: ICustomElementController,
     public readonly ctx: IRouteContext,
   ) {
-    this.logger = ctx.get(ILogger).scopeTo(`ViewportAgent<${ctx.friendlyPath}>`);
+    this.logger = ctx.container.get(ILogger).scopeTo(`ViewportAgent<${ctx.friendlyPath}>`);
 
     this.logger.trace(`constructor()`);
   }

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -114,7 +114,7 @@ export class AppRoot implements IDisposable {
         this.enhanceDefinition,
       )) as Controller;
 
-      controller.hydrateCustomElement(container, null);
+      controller.hydrateCustomElement(null);
       return onResolve(this.runAppTasks('hydrating'), () => {
         controller.hydrate(null);
         return onResolve(this.runAppTasks('hydrated'), () => {

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -4,8 +4,8 @@ import {
   isInstruction,
   SetAttributeInstruction,
   IInstruction,
-  InstructionType,
   Instruction,
+  SetPropertyInstruction,
 } from './renderer.js';
 import { IPlatform } from './platform.js';
 import { CustomElement, CustomElementDefinition, CustomElementType } from './resources/custom-element.js';
@@ -142,16 +142,10 @@ function createElementForType(
         if (isInstruction(value)) {
           childInstructions.push(value);
         } else {
-          const bindable = bindables[to];
-
-          if (bindable !== void 0) {
-            childInstructions.push({
-              type: InstructionType.setProperty,
-              to,
-              value
-            });
-          } else {
+          if (bindables[to] === void 0) {
             childInstructions.push(new SetAttributeInstruction(value, to));
+          } else {
+            childInstructions.push(new SetPropertyInstruction(value, to));
           }
         }
       });

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -456,7 +456,7 @@ export class CustomElementRenderer implements IRenderer {
       /* location         */target,
       /* auSlotsInfo      */new AuSlotsInfo(projections == null ? emptyArray : Object.keys(projections)),
     );
-    const definition = context.container.find(CustomElement, instruction.res) as CustomElementDefinition;
+    const definition = renderingController.container.find(CustomElement, instruction.res) as CustomElementDefinition;
     const Ctor = definition.Type;
     const component = container.invoke(Ctor);
     const key = CustomElement.keyFrom(instruction.res);
@@ -482,7 +482,7 @@ export class CustomElementRenderer implements IRenderer {
       /* target       */childController,
     );
 
-    renderingController.addController(childController);
+    renderingController.addChild(childController);
   }
 }
 
@@ -508,7 +508,7 @@ export class CustomAttributeRenderer implements IRenderer {
     );
     const childController = Controller.forCustomAttribute(
       /* root       */renderingController.root,
-      /* context ct */context.container,
+      /* context ct */renderingController.container,
       /* viewModel  */component,
       /* host       */target,
       /* flags      */flags,
@@ -524,7 +524,7 @@ export class CustomAttributeRenderer implements IRenderer {
       /* target       */childController,
     );
 
-    renderingController.addController(childController);
+    renderingController.addChild(childController);
   }
 }
 
@@ -538,7 +538,7 @@ export class TemplateControllerRenderer implements IRenderer {
     target: HTMLElement,
     instruction: HydrateTemplateController,
   ): void {
-    const viewFactory = getRenderContext(instruction.def, context.container).getViewFactory();
+    const viewFactory = getRenderContext(instruction.def, renderingController.container).getViewFactory();
     const renderLocation = convertToRenderLocation(target);
     const component = context.invokeAttribute(
       /* parentController */renderingController,
@@ -549,7 +549,7 @@ export class TemplateControllerRenderer implements IRenderer {
     );
     const childController = Controller.forCustomAttribute(
       /* root         */renderingController.root,
-      /* container ct */context.container,
+      /* container ct */renderingController.container,
       /* viewModel    */component,
       /* host         */target,
       /* flags        */flags,
@@ -567,7 +567,7 @@ export class TemplateControllerRenderer implements IRenderer {
       /* target       */childController,
     );
 
-    renderingController.addController(childController);
+    renderingController.addChild(childController);
   }
 }
 
@@ -715,9 +715,9 @@ export class PropertyBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const binding = applyBindingBehavior(
-      new PropertyBinding(expr, getTarget(target), instruction.to, instruction.mode, this.observerLocator, context.container, this.platform.domWriteQueue),
+      new PropertyBinding(expr, getTarget(target), instruction.to, instruction.mode, this.observerLocator, renderingController.container, this.platform.domWriteQueue),
       expr,
-      context.container,
+      renderingController.container,
     );
     renderingController.addBinding(binding);
   }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -453,7 +453,7 @@ export class CustomElementRenderer implements IRenderer {
       /* location         */target,
       /* auSlotsInfo      */new AuSlotsInfo(projections == null ? emptyArray : Object.keys(projections)),
     );
-    const definition = context.find(CustomElement, instruction.res) as CustomElementDefinition;
+    const definition = context.container.find(CustomElement, instruction.res) as CustomElementDefinition;
     const Ctor = definition.Type;
     const component = container.invoke(Ctor);
     const key = CustomElement.keyFrom(instruction.res);
@@ -461,7 +461,7 @@ export class CustomElementRenderer implements IRenderer {
 
     const childController = Controller.forCustomElement(
       /* root                */controller.root,
-      /* context ct          */context,
+      /* context ct          */context.container,
       /* own container       */container,
       /* viewModel           */component,
       /* host                */target,
@@ -502,7 +502,7 @@ export class CustomAttributeRenderer implements IRenderer {
     );
     const childController = Controller.forCustomAttribute(
       /* root       */controller.root,
-      /* context ct */context,
+      /* context ct */context.container,
       /* viewModel  */component,
       /* host       */target,
       /* flags      */flags,
@@ -543,7 +543,7 @@ export class TemplateControllerRenderer implements IRenderer {
     );
     const childController = Controller.forCustomAttribute(
       /* root         */controller.root,
-      /* container ct */context,
+      /* container ct */context.container,
       /* viewModel    */component,
       /* host         */target,
       /* flags        */flags,
@@ -591,9 +591,9 @@ export class LetElementRenderer implements IRenderer {
       childInstruction = childInstructions[i];
       expr = ensureExpression(this.parser, childInstruction.from, BindingType.IsPropertyCommand);
       binding = applyBindingBehavior(
-        new LetBinding(expr, childInstruction.to, this.observerLocator, context, toBindingContext),
+        new LetBinding(expr, childInstruction.to, this.observerLocator, context.container, toBindingContext),
         expr as unknown as IsBindingBehavior,
-        context,
+        context.container,
       ) as LetBinding;
       controller.addBinding(binding);
     }
@@ -617,9 +617,9 @@ export class CallBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.CallCommand);
     const binding = applyBindingBehavior(
-      new CallBinding(expr, getTarget(target), instruction.to, this.observerLocator, context),
+      new CallBinding(expr, getTarget(target), instruction.to, this.observerLocator, context.container),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -641,9 +641,9 @@ export class RefBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsRef);
     const binding = applyBindingBehavior(
-      new RefBinding(expr, getRefTarget(target, instruction.to), context),
+      new RefBinding(expr, getRefTarget(target, instruction.to), context.container),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -672,7 +672,7 @@ export class InterpolationBindingRenderer implements IRenderer {
       getTarget(target),
       instruction.to,
       BindingMode.toView,
-      context,
+      context.container,
       this.platform.domWriteQueue,
     );
     const partBindings = binding.partBindings;
@@ -684,7 +684,7 @@ export class InterpolationBindingRenderer implements IRenderer {
       partBindings[i] = applyBindingBehavior(
         partBinding,
         partBinding.sourceExpression as unknown as IsBindingBehavior,
-        context
+        context.container
       ) as InterpolationPartBinding;
     }
     controller.addBinding(binding);
@@ -709,9 +709,9 @@ export class PropertyBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | instruction.mode);
     const binding = applyBindingBehavior(
-      new PropertyBinding(expr, getTarget(target), instruction.to, instruction.mode, this.observerLocator, context, this.platform.domWriteQueue),
+      new PropertyBinding(expr, getTarget(target), instruction.to, instruction.mode, this.observerLocator, context.container, this.platform.domWriteQueue),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -735,9 +735,9 @@ export class IteratorBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.ForCommand);
     const binding = applyBindingBehavior(
-      new PropertyBinding(expr, getTarget(target), instruction.to, BindingMode.toView, this.observerLocator, context, this.platform.domWriteQueue),
+      new PropertyBinding(expr, getTarget(target), instruction.to, BindingMode.toView, this.observerLocator, context.container, this.platform.domWriteQueue),
       expr as unknown as IsBindingBehavior,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -805,13 +805,13 @@ export class TextBindingRenderer implements IRenderer {
           // support seamless transition between a html node, or a text
           // reduce the noise in the template, caused by html comment
           parent.insertBefore(doc.createTextNode(''), next),
-          context,
+          context.container,
           this.observerLocator,
           this.platform,
           instruction.strict
         ),
         dynamicParts[i] as unknown as IsBindingBehavior,
-        context
+        context.container
       ) as ContentBinding);
       // while each of the static part of an interpolation
       // will just be a text node
@@ -843,9 +843,9 @@ export class ListenerBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsEventCommand | (instruction.strategy + BindingType.DelegationStrategyDelta));
     const binding = applyBindingBehavior(
-      new Listener(context.platform, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventDelegator, context),
+      new Listener(context.platform, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this.eventDelegator, context.container),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -909,9 +909,9 @@ export class StylePropertyBindingRenderer implements IRenderer {
   ): void {
     const expr = ensureExpression(this.parser, instruction.from, BindingType.IsPropertyCommand | BindingMode.toView);
     const binding = applyBindingBehavior(
-      new PropertyBinding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context, this.platform.domWriteQueue),
+      new PropertyBinding(expr, target.style, instruction.to, BindingMode.toView, this.observerLocator, context.container, this.platform.domWriteQueue),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }
@@ -941,10 +941,10 @@ export class AttributeBindingRenderer implements IRenderer {
         instruction.to/* targetKey */,
         BindingMode.toView,
         this.observerLocator,
-        context
+        context.container
       ),
       expr,
-      context,
+      context.container,
     );
     controller.addBinding(binding);
   }

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -35,9 +35,9 @@ export class AuSlot implements ICustomElementViewModel {
     const slotInfo = instruction.auSlot!;
     const projection = hdrContext.instruction?.projections?.[slotInfo.name];
     if (projection == null) {
-      factory = getRenderContext(slotInfo.fallback, hdrContext.controller.context.container).getViewFactory();
+      factory = getRenderContext(slotInfo.fallback, hdrContext.controller.container).getViewFactory();
     } else {
-      factory = getRenderContext(projection, hdrContext.parent!.controller.context.container).getViewFactory();
+      factory = getRenderContext(projection, hdrContext.parent!.controller.container).getViewFactory();
       this.hasProjection = true;
     }
     this.view = factory.create().setLocation(location);

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -40,12 +40,10 @@ import type {
 import type {
   IBinding,
   IObservable,
-  AccessorOrObserver,
   IsBindingBehavior,
 } from '@aurelia/runtime';
 import type { IProjections } from '../resources/custom-elements/au-slot.js';
 import type { BindableDefinition } from '../bindable.js';
-import type { PropertyBinding } from '../binding/property-binding.js';
 import type { LifecycleHooksLookup } from './lifecycle-hooks.js';
 import type { INode, INodeSequence, IRenderLocation } from '../dom.js';
 import type { IViewFactory } from './view.js';
@@ -274,7 +272,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   ): ISyntheticView {
     const controller = new Controller(
       /* root           */root,
-      // todo: context container
+      // todo: view factory should carry its own container
       /* container      */context.container,
       /* container      */context.container,
       /* vmKind         */ViewModelKind.synthetic,
@@ -951,7 +949,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
-  public addController(controller: Controller): void {
+  public addChild(controller: Controller): void {
     if (this.children === null) {
       this.children = [controller];
     } else {
@@ -1065,17 +1063,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         }
       }
     }
-  }
-
-  public getTargetAccessor(propertyName: string): AccessorOrObserver | undefined {
-    const { bindings } = this;
-    if (bindings !== null) {
-      const binding = bindings.find(b => (b as PropertyBinding).targetProperty === propertyName) as PropertyBinding;
-      if (binding !== void 0) {
-        return binding.targetObserver;
-      }
-    }
-    return void 0;
   }
 }
 
@@ -1389,10 +1376,8 @@ export interface IHydratableController<C extends IViewModel = IViewModel> extend
   readonly bindings: readonly IBinding[] | null;
   readonly children: readonly IHydratedController[] | null;
 
-  getTargetAccessor(propertyName: string): AccessorOrObserver | null;
-
   addBinding(binding: IBinding): void;
-  addController(controller: IController): void;
+  addChild(controller: IController): void;
 }
 
 export const enum State {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -162,6 +162,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     switch (vmKind) {
       case ViewModelKind.customAttribute:
       case ViewModelKind.customElement:
+        // todo: cache-able based on constructor type
         this.hooks = new HooksDefinition(viewModel!);
         break;
       case ViewModelKind.synthetic:
@@ -478,7 +479,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this.parent = parent;
     if (this.debug && !this.fullyNamed) {
       this.fullyNamed = true;
-      (this.logger = this.container.get(ILogger).root.scopeTo(this.name))
+      (this.logger ??= this.container.get(ILogger).root.scopeTo(this.name))
         .trace(`activate()`);
     }
     if (this.vmKind === ViewModelKind.synthetic) {
@@ -1330,6 +1331,12 @@ export type ControllerVisitor = (controller: IHydratedController) => void | true
  */
 export interface IController<C extends IViewModel = IViewModel> extends IDisposable {
   /** @internal */readonly id: number;
+  /**
+   * The container associated with this controller.
+   * By default, CE should have their own container while custom attribute & synthetic view
+   * will use the parent container one, since they do not need to manage one
+   */
+  readonly container: IContainer;
   readonly platform: IPlatform;
   readonly root: IAppRoot | null;
   readonly flags: LifecycleFlags;

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -478,8 +478,8 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this.parent = parent;
     if (this.debug && !this.fullyNamed) {
       this.fullyNamed = true;
-      this.logger = this.context!.get(ILogger).root.scopeTo(this.name);
-      this.logger!.trace(`activate()`);
+      (this.logger = this.container.get(ILogger).root.scopeTo(this.name))
+        .trace(`activate()`);
     }
     if (this.vmKind === ViewModelKind.synthetic) {
       this.hostScope = hostScope ?? null;
@@ -611,9 +611,10 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         this.nodes!.appendTo(this.host!, (this.definition as CustomElementDefinition | null)?.enhance);
         break;
       case MountTarget.shadowRoot: {
-        const styles = this.context!.has(IShadowDOMStyles, false)
-          ? this.context!.get(IShadowDOMStyles)
-          : this.context!.get(IShadowDOMGlobalStyles);
+        const container = this.context!.container;
+        const styles = container.has(IShadowDOMStyles, false)
+          ? container.get(IShadowDOMStyles)
+          : container.get(IShadowDOMGlobalStyles);
         styles.applyTo(this.shadowRoot!);
         this.nodes!.appendTo(this.shadowRoot!);
         break;

--- a/packages/runtime-html/src/templating/render-context.ts
+++ b/packages/runtime-html/src/templating/render-context.ts
@@ -8,18 +8,7 @@ import { AuSlotsInfo, IAuSlotsInfo } from '../resources/custom-elements/au-slot.
 import { IPlatform } from '../platform.js';
 import { IController } from './controller.js';
 
-import type {
-  Constructable,
-  IContainer,
-  IFactory,
-  IResolver,
-  IResourceKind,
-  Key,
-  Resolved,
-  ResourceDefinition,
-  ResourceType,
-  Transformer,
-} from '@aurelia/kernel';
+import type { IContainer, IResolver } from '@aurelia/kernel';
 import type { LifecycleFlags } from '@aurelia/runtime';
 import type { ICustomAttributeViewModel, IHydratableController } from './controller.js';
 import type {
@@ -218,70 +207,6 @@ export class RenderContext implements ICompiledRenderContext {
     this.auSlotsInfoProvider = new InstanceProvider<IAuSlotsInfo>('IAuSlotsInfo');
   }
 
-  // #region IServiceLocator api
-  public has<K extends Key>(key: K | Key, searchAncestors: boolean): boolean {
-    return this.container.has(key, searchAncestors);
-  }
-
-  public get<K extends Key>(key: K | Key): Resolved<K> {
-    return this.container.get(key);
-  }
-
-  public getAll<K extends Key>(key: K | Key): readonly Resolved<K>[] {
-    return this.container.getAll(key);
-  }
-  // #endregion
-
-  // #region IContainer api
-  public register(...params: unknown[]): IContainer {
-    return this.container.register(...params);
-  }
-
-  public registerResolver<K extends Key, T = K>(key: K, resolver: IResolver<T>): IResolver<T> {
-    return this.container.registerResolver(key, resolver);
-  }
-
-  // public deregisterResolverFor<K extends Key, T = K>(key: K): void {
-  //   this.container.deregisterResolverFor(key);
-  // }
-
-  public registerTransformer<K extends Key, T = K>(key: K, transformer: Transformer<T>): boolean {
-    return this.container.registerTransformer(key, transformer);
-  }
-
-  public getResolver<K extends Key, T = K>(key: K | Key, autoRegister?: boolean): IResolver<T> | null {
-    return this.container.getResolver(key, autoRegister);
-  }
-
-  public invoke<T, TDeps extends unknown[] = unknown[]>(key: Constructable<T>, dynamicDependencies?: TDeps): T {
-    return this.container.invoke(key, dynamicDependencies);
-  }
-
-  public getFactory<T extends Constructable>(key: T): IFactory<T> {
-    return this.container.getFactory(key);
-  }
-
-  public registerFactory<K extends Constructable>(key: K, factory: IFactory<K>): void {
-    this.container.registerFactory(key, factory);
-  }
-
-  public createChild(): IContainer {
-    return this.container.createChild();
-  }
-
-  public find<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): TDef | null {
-    return this.container.find(kind, name);
-  }
-
-  public create<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): InstanceType<TType> | null {
-    return this.container.create(kind, name);
-  }
-
-  public disposeResolvers() {
-    this.container.disposeResolvers();
-  }
-  // #endregion
-
   // #region IRenderContext api
   public compile(compilationInstruction: ICompliationInstruction | null): ICompiledRenderContext {
     let compiledDefinition: CustomElementDefinition;
@@ -301,7 +226,7 @@ export class RenderContext implements ICompiledRenderContext {
     }
 
     // Support Recursive Components by adding self to own context
-    compiledDefinition.register(this);
+    compiledDefinition.register(this.container);
 
     if (fragmentCache.has(compiledDefinition)) {
       this.fragment = fragmentCache.get(compiledDefinition)!;

--- a/packages/runtime-html/src/templating/render-context.ts
+++ b/packages/runtime-html/src/templating/render-context.ts
@@ -41,7 +41,7 @@ export function isRenderContext(value: unknown): value is IRenderContext {
 /**
  * A render context that wraps an `IContainer` and must be compiled before it can be used for composing.
  */
-export interface IRenderContext extends IContainer {
+export interface IRenderContext {
   readonly platform: IPlatform;
 
   /**
@@ -54,7 +54,7 @@ export interface IRenderContext extends IContainer {
   /**
    * The `IContainer` (which may be, but is not guaranteed to be, an `IRenderContext`) that this `IRenderContext` was created with.
    */
-  readonly parentContainer: IContainer;
+  // readonly parentContainer: IContainer;
 
   readonly container: IContainer;
 
@@ -143,11 +143,6 @@ export function getRenderContext(
 ): IRenderContext {
   const definition = CustomElementDefinition.getOrCreate(partialDefinition);
 
-  // injectable completely prevents caching, ensuring that each instance gets a new context context
-  if (definition.injectable !== null) {
-    return new RenderContext(definition, container);
-  }
-
   let containerLookup = definitionContainerLookup.get(definition);
   if (containerLookup === void 0) {
     definitionContainerLookup.set(
@@ -200,10 +195,10 @@ export class RenderContext implements ICompiledRenderContext {
 
   public constructor(
     public readonly definition: CustomElementDefinition,
-    public readonly parentContainer: IContainer,
+    container: IContainer,
   ) {
     ++renderContextCount;
-    const container = this.container = parentContainer;
+    this.container = container;
     // TODO(fkleuver): get contextual + root renderers
     const renderers = container.getAll(IRenderer);
     let i = 0;
@@ -213,7 +208,7 @@ export class RenderContext implements ICompiledRenderContext {
       this.renderers[renderer.instructionType as string] = renderer;
     }
 
-    this.root = parentContainer.root;
+    this.root = container.root;
     this.platform = container.get(IPlatform);
     this.elementProvider = new InstanceProvider('ElementResolver');
     this.factoryProvider = new ViewFactoryProvider();

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -24,6 +24,7 @@ export const IViewFactory = DI.createInterface<IViewFactory>('IViewFactory');
 export class ViewFactory implements IViewFactory {
   public static maxCacheSize: number = 0xFFFF;
 
+  public readonly container: IContainer;
   public isCaching: boolean = false;
 
   private cache: ISyntheticView[] = null!;
@@ -32,7 +33,9 @@ export class ViewFactory implements IViewFactory {
   public constructor(
     public name: string,
     public readonly context: IRenderContext,
-  ) {}
+  ) {
+    this.container = context.container;
+  }
 
   public setCacheSize(size: number | '*', doNotOverrideIfAlreadySet: boolean): void {
     if (size) {

--- a/packages/store-v1/src/decorator.ts
+++ b/packages/store-v1/src/decorator.ts
@@ -78,7 +78,7 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       }
 
       const store = Controller.getCached(this)
-        ? Controller.getCached(this)!.context.container.get<Store<T>>(Store)
+        ? Controller.getCached(this)!.container.get<Store<T>>(Store)
         : STORE.container.get<Store<T>>(Store); // TODO: need to get rid of this helper for classic unit tests
 
       this._stateSubscriptions = createSelectors().map(s => getSource(store, s.selector).subscribe((state: unknown) => {

--- a/packages/store-v1/src/decorator.ts
+++ b/packages/store-v1/src/decorator.ts
@@ -78,7 +78,7 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       }
 
       const store = Controller.getCached(this)
-        ? Controller.getCached(this)!.context.get<Store<T>>(Store)
+        ? Controller.getCached(this)!.context.container.get<Store<T>>(Store)
         : STORE.container.get<Store<T>>(Store); // TODO: need to get rid of this helper for classic unit tests
 
       this._stateSubscriptions = createSelectors().map(s => getSource(store, s.selector).subscribe((state: unknown) => {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Continue the removal of `IContainer` APIs out of `IRenderContext`, and eventual removal of the `IRenderContext` itself. This is to avoid wasteful creation of `IRenderContext`. Also, having a context on a controller unnecessarily complicate the meaning of a controller itself, where there' a few concepts that need to be juggled: `IViewFactory`, `IRenderContext`, `IController`

Also a part of this optimization, treat renderers as root only resources now. This is some kind of resources that we probably don't want to make overflexible.