### PR TITLE
feat(if-else): add ability to disable caching behavior

### DIFF
--- a/docs/user-docs/resources/migrating-to-aurelia-2.md
+++ b/docs/user-docs/resources/migrating-to-aurelia-2.md
@@ -4,6 +4,8 @@ Introduction Placeholder...
 
 ## BREAKING CHANGES
 
+### Call binding \(some-prop.call="..."\)
+
 - Call binding no longer assign properties of the first argument pass to the call to the calling override context. This is unreasonably dynamic and could result in hard-to-understand templates. Example:
 
 ```ts
@@ -24,4 +26,18 @@ v1:
 v2:
 ```html
 <my-element on-change.call="elValue = $event.value">
+```
+
+### If attribute \(if.bind="..."\)
+
+- Primary property of `If` has been renamed from `condition` to `value`. If you are using `if.bind`, you are not affected. If you are using the multi prop binding syntax, that the template looks like this:
+
+```html
+<div if="condition.bind: yes">
+```
+
+Change it to:
+
+```html
+<div if="value.bind: yes">
 ```

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -15,6 +15,7 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
+  IWorkTracker,
   INodeObserverLocatorRegistration,
   CustomAttribute,
 } from '@aurelia/runtime-html';
@@ -151,9 +152,10 @@ describe(`3-runtime-html/if.integration.spec.ts`, function () {
           container,
         );
 
+        const work = container.get(IWorkTracker);
         const ifFactory = new ViewFactory('if-view', ifContext);
         const elseFactory = new ViewFactory('else-view', elseContext);
-        const sut = new If(ifFactory, ifLoc);
+        const sut = new If(ifFactory, ifLoc, work);
         const elseSut = new Else(elseFactory);
         const ifController = (sut as Writable<If>).$controller = Controller.forCustomAttribute(null, container, sut, (void 0)!);
         elseSut.link(LifecycleFlags.none, void 0!, { children: [ifController] } as unknown as IHydratableController, void 0!, void 0!, void 0!);
@@ -276,18 +278,18 @@ describe(`3-runtime-html/if.integration.spec.ts`, function () {
             }
           })]
         );
-  
+
         await startPromise;
         assert.visibleTextEqual(appHost, 'hello');
         assert.strictEqual(callCount, 1);
-  
+
         component.condition = false;
         assert.visibleTextEqual(appHost, '');
-  
+
         component.condition = true;
         assert.visibleTextEqual(appHost, 'hello');
         assert.strictEqual(callCount, 2);
-  
+
         await tearDown();
 
         assert.visibleTextEqual(appHost, '');

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -15,18 +15,19 @@ import {
   TextBindingRendererRegistration,
   TextBindingInstruction,
   Interpolation,
-  IWorkTracker,
   INodeObserverLocatorRegistration,
+  CustomAttribute,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
   assert,
   PLATFORM,
   createContainer,
+  createFixture,
 } from '@aurelia/testing';
 import { Writable } from '@aurelia/kernel';
 
-describe(`If/Else`, function () {
+describe(`3-runtime-html/if.integration.spec.ts`, function () {
   function runActivateLifecycle(sut: If, flags: LifecycleFlags, scope: Scope): void {
     void sut.$controller.activate(sut.$controller, null, flags, scope);
   }
@@ -150,10 +151,9 @@ describe(`If/Else`, function () {
           container,
         );
 
-        const work = container.get(IWorkTracker);
         const ifFactory = new ViewFactory('if-view', ifContext);
         const elseFactory = new ViewFactory('else-view', elseContext);
-        const sut = new If(ifFactory, ifLoc, work);
+        const sut = new If(ifFactory, ifLoc);
         const elseSut = new Else(elseFactory);
         const ifController = (sut as Writable<If>).$controller = Controller.forCustomAttribute(null, container, sut, (void 0)!);
         elseSut.link(LifecycleFlags.none, void 0!, { children: [ifController] } as unknown as IHydratableController, void 0!, void 0!, void 0!);
@@ -230,4 +230,183 @@ describe(`If/Else`, function () {
         assert.strictEqual(host.textContent, '', 'host.textContent #6');
       });
     });
+
+  describe('with caching', function () {
+    it('disables cache with "false" string', async function () {
+      let callCount = 0;
+      const { appHost, component, startPromise, tearDown } = createFixture(
+        `<div if="value.bind: condition; cache: false" abc>hello`,
+        class App {
+          public condition: unknown = true;
+        },
+        [CustomAttribute.define('abc', class Abc {
+          public constructor() {
+            callCount++;
+          }
+        })]
+      );
+
+      await startPromise;
+      assert.visibleTextEqual(appHost, 'hello');
+      assert.strictEqual(callCount, 1);
+
+      component.condition = false;
+      assert.visibleTextEqual(appHost, '');
+
+      component.condition = true;
+      assert.visibleTextEqual(appHost, 'hello');
+      assert.strictEqual(callCount, 2);
+
+      await tearDown();
+
+      assert.visibleTextEqual(appHost, '');
+    });
+
+    for (const falsyValue of [null, undefined, 0, NaN, false]) {
+      it(`disables cache with fasly value: "${falsyValue}" string`, async function () {
+        let callCount = 0;
+        const { appHost, component, startPromise, tearDown } = createFixture(
+          `<div if="value.bind: condition; cache.bind: ${falsyValue}" abc>hello`,
+          class App {
+            public condition: unknown = true;
+          },
+          [CustomAttribute.define('abc', class Abc {
+            public constructor() {
+              callCount++;
+            }
+          })]
+        );
+  
+        await startPromise;
+        assert.visibleTextEqual(appHost, 'hello');
+        assert.strictEqual(callCount, 1);
+  
+        component.condition = false;
+        assert.visibleTextEqual(appHost, '');
+  
+        component.condition = true;
+        assert.visibleTextEqual(appHost, 'hello');
+        assert.strictEqual(callCount, 2);
+  
+        await tearDown();
+
+        assert.visibleTextEqual(appHost, '');
+      });
+    }
+
+    it('disables cache on [else]', async function () {
+      let callCount = 0;
+      const { appHost, component, startPromise, tearDown } = createFixture(
+        `<div if="value.bind: condition; cache: false" abc>hello</div><div else abc>world</div>`,
+        class App {
+          public condition: unknown = true;
+        },
+        [CustomAttribute.define('abc', class Abc {
+          public constructor() {
+            callCount++;
+          }
+        })]
+      );
+
+      await startPromise;
+      assert.visibleTextEqual(appHost, 'hello');
+      assert.strictEqual(callCount, 1);
+
+      component.condition = false;
+      assert.visibleTextEqual(appHost, 'world');
+      assert.strictEqual(callCount, 2);
+
+      component.condition = true;
+      assert.visibleTextEqual(appHost, 'hello');
+      assert.strictEqual(callCount, 3);
+
+      component.condition = false;
+      assert.visibleTextEqual(appHost, 'world');
+      assert.strictEqual(callCount, 4);
+
+      await tearDown();
+
+      assert.visibleTextEqual(appHost, '');
+    });
+
+    it('does not affected nested [if]', async function () {
+      let callCount = 0;
+      const { appHost, component, startPromise, tearDown } = createFixture(
+        `<div if="value.bind: condition; cache: false" abc>hello<span if.bind="condition2" abc> span`,
+        class App {
+          public condition: unknown = true;
+          public condition2: unknown = true;
+        },
+        [CustomAttribute.define('abc', class Abc {
+          public constructor() {
+            callCount++;
+          }
+        })]
+      );
+
+      await startPromise;
+      assert.visibleTextEqual(appHost, 'hello span');
+      assert.strictEqual(callCount, 2);
+
+      // change to false
+      component.condition2 = false;
+      assert.visibleTextEqual(appHost, 'hello');
+      // then true again
+      component.condition2 = true;
+      assert.visibleTextEqual(appHost, 'hello span');
+      // wouldn't create another view
+      assert.strictEqual(callCount, 2);
+
+      component.condition = false;
+      assert.visibleTextEqual(appHost, '');
+
+      component.condition = true;
+      assert.visibleTextEqual(appHost, 'hello span');
+      assert.strictEqual(callCount, 4);
+
+      await tearDown();
+
+      assert.visibleTextEqual(appHost, '');
+    });
+
+    it('works on subsequent activation when nested inside other [if]', async function () {
+      let callCount = 0;
+      const { appHost, component, startPromise, tearDown } = createFixture(
+        `<div if.bind="condition" abc>hello<span if="value.bind: condition2; cache: false" abc> span`,
+        class App {
+          public condition: unknown = true;
+          public condition2: unknown = true;
+        },
+        [CustomAttribute.define('abc', class Abc {
+          public constructor() {
+            callCount++;
+          }
+        })]
+      );
+
+      await startPromise;
+      assert.visibleTextEqual(appHost, 'hello span');
+      assert.strictEqual(callCount, 2);
+
+      // change to false
+      component.condition2 = false;
+      assert.visibleTextEqual(appHost, 'hello');
+      // then true again
+      component.condition2 = true;
+      assert.visibleTextEqual(appHost, 'hello span');
+      // wouldn't create another view
+      assert.strictEqual(callCount, 3);
+
+      component.condition = false;
+      assert.visibleTextEqual(appHost, '');
+
+      component.condition = true;
+      assert.visibleTextEqual(appHost, 'hello span');
+      assert.strictEqual(callCount, 4);
+
+      await tearDown();
+
+      assert.visibleTextEqual(appHost, '');
+    });
+  });
 });

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/aurelia/rollup.config.js
+++ b/packages/aurelia/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/fetch-client/rollup.config.js
+++ b/packages/fetch-client/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/i18n/rollup.config.js
+++ b/packages/i18n/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/kernel/rollup.config.js
+++ b/packages/kernel/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/metadata/rollup.config.js
+++ b/packages/metadata/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/platform-browser/rollup.config.js
+++ b/packages/platform-browser/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/platform/rollup.config.js
+++ b/packages/platform/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/route-recognizer/rollup.config.js
+++ b/packages/route-recognizer/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/router/rollup.config.js
+++ b/packages/router/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/runtime-html/rollup.config.js
+++ b/packages/runtime-html/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -4,7 +4,6 @@ import { IRenderLocation } from '../../dom.js';
 import { IViewFactory } from '../../templating/view.js';
 import { templateController } from '../custom-attribute.js';
 import { bindable } from '../../bindable.js';
-import { IWorkTracker } from '../../app-root.js';
 
 import type { ISyntheticView, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor, IHydratableController } from '../../templating/controller.js';
 import type { ICompiledRenderContext } from '../../templating/render-context.js';
@@ -23,20 +22,61 @@ export class If implements ICustomAttributeViewModel {
   public readonly $controller!: ICustomAttributeController<this>; // This is set by the controller after this instance is constructed
 
   @bindable public value: unknown = false;
+  /**
+   * `false` to always dispose the existing `view` whenever the value of if changes to false
+   */
+  @bindable({
+    set: v => v === '' || !!v && v !== 'false'
+  })
+  public cache: boolean = true;
   private pending: void | Promise<void> = void 0;
   private wantsDeactivate: boolean = false;
+  private swapId: number = 0;
+  private ctrl!: ICustomAttributeController<If>;
 
   public constructor(
     @IViewFactory private readonly ifFactory: IViewFactory,
     @IRenderLocation private readonly location: IRenderLocation,
-    @IWorkTracker private readonly work: IWorkTracker,
   ) {}
 
-  public attaching(initiator: IHydratedController, parent: IHydratedController, flags: LifecycleFlags): void | Promise<void> {
+  public created(): void {
+    this.ctrl = this.$controller;
+  }
+
+  public attaching(initiator: IHydratedController, parent: IHydratedController, f: LifecycleFlags): void | Promise<void> {
+    let view: ISyntheticView | undefined;
+    const swapId = this.swapId++;
+    /**
+     * returns true when
+     * 1. entering deactivation of the [if] itself
+     * 2. new swap has started since this change
+     */
+    const isCurrent = () => !this.wantsDeactivate && this.swapId === swapId + 1;
     return onResolve(this.pending, () => {
+      if (!isCurrent()) {
+        return;
+      }
       this.pending = void 0;
+      if (this.value) {
+        view = (this.view = this.ifView = this.cache && this.ifView != null
+          ? this.ifView
+          : this.ifFactory.create(f)
+        );
+      } else {
+        // truthy -> falsy
+        view = (this.view = this.elseView = this.cache && this.elseView != null
+          ? this.elseView
+          : this.elseFactory?.create(f)
+        );
+      }
+      if (view == null) {
+        return;
+      }
+      // todo: else view should set else location
+      view.setLocation(this.location);
       // Promise return values from user VM hooks are awaited by the initiator
-      void (this.view = this.updateView(this.value, flags))?.activate(initiator, this.$controller, flags, this.$controller.scope, this.$controller.hostScope);
+      this.pending = view.activate(initiator, this.ctrl, f, this.ctrl.scope, this.ctrl.hostScope);
+      // void (this.view = this.updateView(this.value, f))?.activate(initiator, this.ctrl, f, this.ctrl.scope, this.ctrl.hostScope);
     });
   }
 
@@ -46,74 +86,76 @@ export class If implements ICustomAttributeViewModel {
       this.wantsDeactivate = false;
       this.pending = void 0;
       // Promise return values from user VM hooks are awaited by the initiator
-      void this.view?.deactivate(initiator, this.$controller, flags);
+      void this.view?.deactivate(initiator, this.ctrl, flags);
     });
   }
 
-  public valueChanged(newValue: unknown, oldValue: unknown, flags: LifecycleFlags): void {
-    if (!this.$controller.isActive) {
+  public valueChanged(newValue: unknown, oldValue: unknown, f: LifecycleFlags): void | Promise<void> {
+    if (!this.ctrl.isActive) {
       return;
     }
-    this.pending = onResolve(this.pending, () => {
-      return this.swap(flags);
-    });
-  }
-
-  private swap(flags: LifecycleFlags): void | Promise<void> {
-    if (this.view === this.updateView(this.value, flags)) {
+    // change scenarios:
+    // truthy -> truthy (do nothing)
+    // falsy -> falsy (do nothing)
+    // truthy -> falsy (no cache = destroy)
+    // falsy -> truthy (no view = create)
+    newValue = !!newValue;
+    oldValue = !!oldValue;
+    if (newValue === oldValue) {
       return;
     }
-    this.work.start();
-    const ctrl = this.$controller;
-    return onResolve(
-      this.view?.deactivate(this.view, ctrl, flags),
-      () => {
-        // return early if detaching was called during the swap
-        if (this.wantsDeactivate) {
-          return;
+    const currView = this.view;
+    const swapId = this.swapId++;
+    /**
+     * returns true when
+     * 1. entering deactivation of the [if] itself
+     * 2. new swap has started since this change
+     */
+    const isCurrent = () => !this.wantsDeactivate && this.swapId === swapId + 1;
+    let view: ISyntheticView | undefined;
+    return onResolve( this.pending,
+      () => this.pending = onResolve(
+        currView?.deactivate(currView, this.ctrl, f),
+        () => {
+          if (!isCurrent()) {
+            return;
+          }
+          // falsy -> truthy
+          if (newValue) {
+            view = (this.view = this.ifView = this.cache && this.ifView != null
+              ? this.ifView
+              : this.ifFactory.create(f)
+            );
+          } else {
+            // truthy -> falsy
+            view = (this.view = this.elseView = this.cache && this.elseView != null
+              ? this.elseView
+              : this.elseFactory?.create(f)
+            );
+          }
+          if (view == null) {
+            return;
+          }
+          // todo: location should be based on either the [if]/[else] attribute
+          //       instead of always the if
+          view.setLocation(this.location);
+          return onResolve(
+            view.activate(view, this.ctrl, f, this.ctrl.scope, this.ctrl.hostScope),
+            () =>
+              this.pending = isCurrent() ? void 0 : this.pending
+          )
         }
-        // value may have changed during deactivate
-        const nextView = this.view = this.updateView(this.value, flags);
-        return onResolve(
-          nextView?.activate(nextView, ctrl, flags, ctrl.scope, ctrl.hostScope),
-          () => {
-            this.work.finish();
-            // only null the pending promise if nothing changed since the activation start
-            if (this.view === this.updateView(this.value, flags)) {
-              this.pending = void 0;
-            }
-          },
-        );
-      },
+      )
     );
-  }
-
-  /** @internal */
-  public updateView(value: unknown, flags: LifecycleFlags): ISyntheticView | undefined {
-    if (value) {
-      return this.ifView = this.ensureView(this.ifView, this.ifFactory, flags);
-    }
-    if (this.elseFactory !== void 0) {
-      return this.elseView = this.ensureView(this.elseView, this.elseFactory, flags);
-    }
-    return void 0;
-  }
-
-  /** @internal */
-  public ensureView(view: ISyntheticView | undefined, factory: IViewFactory, flags: LifecycleFlags): ISyntheticView {
-    if (view === void 0) {
-      view = factory.create(flags);
-      view.setLocation(this.location);
-    }
-    return view;
   }
 
   public dispose(): void {
     this.ifView?.dispose();
-    this.ifView = void 0;
     this.elseView?.dispose();
-    this.elseView = void 0;
-    this.view = void 0;
+    this.ifView
+      = this.elseView
+      = this.view
+      = void 0;
   }
 
   public accept(visitor: ControllerVisitor): void | true {

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -113,7 +113,7 @@ export class If implements ICustomAttributeViewModel {
      */
     const isCurrent = () => !this.wantsDeactivate && this.swapId === swapId + 1;
     let view: ISyntheticView | undefined;
-    return onResolve( this.pending,
+    return onResolve(this.pending,
       () => this.pending = onResolve(
         currView?.deactivate(currView, this.ctrl, f),
         () => {
@@ -143,7 +143,7 @@ export class If implements ICustomAttributeViewModel {
             view.activate(view, this.ctrl, f, this.ctrl.scope, this.ctrl.hostScope),
             () =>
               this.pending = isCurrent() ? void 0 : this.pending
-          )
+          );
         }
       )
     );

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/runtime/rollup.config.js
+++ b/packages/runtime/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/store-v1/rollup.config.js
+++ b/packages/store-v1/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -36,7 +36,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/testing/rollup.config.js
+++ b/packages/testing/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -38,7 +38,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/validation-html/rollup.config.js
+++ b/packages/validation-html/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -38,7 +38,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/validation-i18n/rollup.config.js
+++ b/packages/validation-i18n/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -37,7 +37,7 @@
     "build:dev": "rollup -c --environment MAP,BUILD:dev",
     "postbuild": "tsc --emitDeclarationOnly",
     "dev:tsc": "tsc -b -w --preserveWatchOutput",
-    "dev": "rollup -c -w --environment MAP",
+    "dev": "rollup -c -w --environment MAP,TYPES",
     "publish:dev": "npm publish --tag dev",
     "publish:latest": "npm publish --tag latest",
     "rollup": "rollup -c --environment MAP"

--- a/packages/validation/rollup.config.js
+++ b/packages/validation/rollup.config.js
@@ -3,11 +3,13 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import pkg from './package.json';
+import { exec } from 'child_process';
 
 const BUILD = process.env.BUILD ?? '';
 const isDevBuild = BUILD === 'dev';
 const isProduction = BUILD === 'prod';
 const sourceMap = process.env.MAP === 'true';
+const emitDeclaration = process.env.TYPES === 'true';
 
 export default {
   input: 'src/index.ts',
@@ -47,5 +49,13 @@ export default {
           }
         })
       : null,
+    emitDeclaration
+      ? {
+        closeBundle() {
+          console.log(`building types for ${pkg.name}...`);
+          exec('npm run build:tsc');
+        }
+      }
+      : null
   ].filter(Boolean)
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description

Sometimes, it's possible to always create a new template instance of a view controlled by the `if` template controller. In v1, this is possible via the `cache` property binding, that the template looks like this:

```html
<div if="condition.bind: myValue; cache: false">
```

Add this capability to v2.

Closes #1230

Thanks @rzasinets

- Added: breaking change doc for if primary property: from `condition` to `value`