### PR TITLE
refactor(template-compiler): beforeCompile -> compiling

### DIFF
--- a/docs/user-docs/developer-guides/the-template-compiler.md
+++ b/docs/user-docs/developer-guides/the-template-compiler.md
@@ -15,7 +15,7 @@ import Aurelia, { TemplateCompilerHooks } from 'aurelia';
 
 Aurelia
   .register(TemplateCompilerHooks.define(class {
-    beforeCompile(template: HTMLElement) {
+    compiling(template: HTMLElement) {
       element.querySelector('table').setAttribute(someAttribute, someValue);
     }
   }))
@@ -28,12 +28,12 @@ import Aurelia, { templateCompilerHooks } from 'aurelia';
 
 @templateCompilerHooks
 class MyTableHook1 {
-  beforeCompile(template) {...}
+  compiling(template) {...}
 }
 // paren ok too
 @templateCompilerHooks()
 class MyTableHook1 {
-  beforeCompile(template) {...}
+  compiling(template) {...}
 }
 
 Aurelia.register(MyTableHook1);
@@ -41,7 +41,7 @@ Aurelia.register(MyTableHook1);
 
 ### Supported hooks
 
-* **beforeCompile**: this hook will be invoked right before the template compiler starts the compilation. Use this hooks if there needs to be some changes to a template before any compilation.
+* **compiling**: this hook will be invoked right before the template compiler starts the compilation of a template. Use this hooks if there needs to be some changes to a template before any compilation.
 
 ### Hooks invocation order
 

--- a/packages/__tests__/3-runtime-html/template-compiler.hooks.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.hooks.spec.ts
@@ -16,7 +16,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           name: 'my-el',
           template: '<input >',
           dependencies: [TemplateCompilerHooks.define(class {
-            public beforeCompile(template: HTMLTemplateElement) {
+            public compiling(template: HTMLTemplateElement) {
               template.content.querySelector('input').setAttribute('value.bind', 'value');
             }
           })]
@@ -45,7 +45,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           public value = 'hello';
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             template.content.querySelector('input')?.setAttribute('value.bind', 'value');
           }
         })
@@ -68,7 +68,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           template: '<child>',
           dependencies: [
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input')?.setAttribute('value.bind', 'value');
               }
             }),
@@ -77,7 +77,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
               template: '<input>',
               dependencies: [
                 TemplateCompilerHooks.define(class {
-                  public beforeCompile(template: HTMLTemplateElement) {
+                  public compiling(template: HTMLTemplateElement) {
                     assert.strictEqual(template.content.querySelector('input').getAttribute('value.bind'), null);
                     template.content.querySelector('input')?.setAttribute('value.bind', 'value2');
                   }
@@ -109,12 +109,12 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           template: '<input >',
           dependencies: [
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input').setAttribute('value.bind', 'value');
               }
             }),
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input').setAttribute('id.bind', 'value');
               }
             }),
@@ -146,12 +146,12 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           public value = 'hello';
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             template.content.querySelector('input')?.setAttribute('value.bind', 'value');
           }
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             template.content.querySelector('input')?.setAttribute('id.bind', 'value');
           }
         }),
@@ -175,12 +175,12 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           template: '<input >',
           dependencies: [
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input')?.setAttribute('data-id-1.bind', 'value');
               }
             }),
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input')?.setAttribute('data-id-2.bind', 'value');
               }
             }),
@@ -189,12 +189,12 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           public value = 'hello';
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             template.content.querySelector('input')?.setAttribute('data-id-3.bind', 'value');
           }
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             template.content.querySelector('input')?.setAttribute('data-id-4.bind', 'value');
           }
         }),
@@ -220,7 +220,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           template: '<input >',
           dependencies: [
             TemplateCompilerHooks.define(class {
-              public beforeCompile(template: HTMLTemplateElement) {
+              public compiling(template: HTMLTemplateElement) {
                 template.content.querySelector('input')?.setAttribute('data-id-2.bind', 'value');
               }
             }),
@@ -229,7 +229,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
           public value = 'hello';
         }),
         TemplateCompilerHooks.define(class {
-          public beforeCompile(template: HTMLTemplateElement) {
+          public compiling(template: HTMLTemplateElement) {
             const input = template.content.querySelector('input');
             input?.setAttribute('data-id-1.bind', 'value');
             if (input) {
@@ -250,7 +250,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
   it('works with decorator @templateCompilerHooks (no paren)', async function () {
     @templateCompilerHooks
     class Hooks {
-      public beforeCompile(template: HTMLTemplateElement) {
+      public compiling(template: HTMLTemplateElement) {
         template.content.querySelector('input').setAttribute('value.bind', 'value');
       }
     }
@@ -277,7 +277,7 @@ describe('3-runtime-html/templating-compiler.hooks.spec.ts', function () {
   it('works with decorator @templateCompilerHooks() (with paren)', async function () {
     @templateCompilerHooks()
     class Hooks {
-      public beforeCompile(template: HTMLTemplateElement) {
+      public compiling(template: HTMLTemplateElement) {
         template.content.querySelector('input').setAttribute('value.bind', 'value');
       }
     }

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -2166,7 +2166,7 @@ describe('TemplateCompiler - hooks', function () {
     let hookCallCount = 0;
 
     container.register(Registration.instance(ITemplateCompilerHooks, {
-      beforeCompile(template: HTMLElement) {
+      compiling(template: HTMLElement) {
         hookCallCount++;
         template.setAttribute('data-hello', 'world');
       }
@@ -2183,13 +2183,13 @@ describe('TemplateCompiler - hooks', function () {
     let hookCallCount = 0;
 
     container.register(Registration.instance(ITemplateCompilerHooks, {
-      beforeCompile(template: HTMLElement) {
+      compiling(template: HTMLElement) {
         hookCallCount++;
         template.setAttribute('data-hello', 'world');
       }
     }));
     container.register(Registration.instance(ITemplateCompilerHooks, {
-      beforeCompile(template: HTMLElement) {
+      compiling(template: HTMLElement) {
         hookCallCount++;
         template.setAttribute('data-world', 'hello');
       }
@@ -2214,7 +2214,7 @@ describe('TemplateCompiler - hooks', function () {
     const { container, sut } = createFixture();
     let hookCallCount = 0;
     const createResolver = () => Registration.instance(ITemplateCompilerHooks, {
-      beforeCompile(template: HTMLElement) {
+      compiling(template: HTMLElement) {
         hookCallCount++;
         template.setAttribute('data-hello', 'world');
       }
@@ -2234,7 +2234,7 @@ describe('TemplateCompiler - hooks', function () {
     const { container, sut } = createFixture();
     let hookCallCount = 0;
     const createResolver = (value: string) => Registration.instance(ITemplateCompilerHooks, {
-      beforeCompile(template: HTMLElement) {
+      compiling(template: HTMLElement) {
         hookCallCount++;
         template.setAttribute(`data-${value}`, value);
       }

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -71,7 +71,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     let i = 0;
     if (ii > 0) {
       while (ii > i) {
-        hooks[i].beforeCompile?.(template);
+        hooks[i].compiling?.(template);
         ++i;
       }
     }
@@ -1526,7 +1526,7 @@ export interface ITemplateCompilerHooks {
   /**
    * Should be invoked immediately before a template gets compiled
    */
-  beforeCompile?(template: HTMLElement): void;
+  compiling?(template: HTMLElement): void;
 }
 
 const typeToHooksDefCache = new WeakMap<Constructable, TemplateCompilerHooksDefinition<unknown>>();


### PR DESCRIPTION
BREAKING CHANGE: the hook name has been changed to keep the consistency with the rest of templating lifecycles

Thanks @jwx for the reminder.