### PR TITLE
Small change to Redirecting routes code snippet

### DIFF
--- a/docs/user-docs/developer-guides/routing/common-routing-tasks.md
+++ b/docs/user-docs/developer-guides/routing/common-routing-tasks.md
@@ -142,7 +142,7 @@ The router allows you to redirect to other parts of your application using the `
 ```typescript
 @route({
   routes: [
-    { id: 'home', path: '', redirectTo: 'products' },
+    { path: '', redirectTo: 'products' },
     { path: 'products', component: import('./products'), title: 'Products' },
     { path: 'product/:id', component: import('./product'), title: 'Product' }
   ]


### PR DESCRIPTION
Copying the code from the snippet:

```typescript
@route({
  routes: [
    { id: 'home', path: '', redirectTo: 'products' },
    { path: 'products', component: import('./products'), title: 'Products' },
    { path: 'product/:id', component: import('./product'), title: 'Product' }
  ]
})
```

I get the following error:

```
Only 'path' and 'redirectTo' should be specified for redirects
```

Hence removing `id: 'home'` from the redirect route

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
