### PR TITLE
refactor(enhance): change working mechanism of enhance to the same with v1

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
+++ b/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
@@ -108,15 +108,13 @@ The basic syntax of `enhance` matches closely that of the normal startup.
 
 ```typescript
 const au = new Aurelia();
-au.enhance({ host, component: MyComponent });
-await au.start();
+await au.enhance({ host, component: MyComponent });
 ```
 
 There are a few important points to note here.
 
-1. For every enhance root, a new instance of `Aurelia` is needed. To this end, you can also use the static syntax `Aurelia.enhance({...})`. This is to enforce a new root DI container for every enhance root. Importantly, this also means that you can have multiple root nodes in your app \(this is true for `Aurelia.app(...)` as well\), where each one of those roots can be started/stopped independently of each other.
-2. The `host` is usually an existing non-enhanced \(neither by `.app` nor by `.enhance`\) DOM node. Note that `.enhance` does not detach or attach the `host` node to the DOM by itself. If the `host` is truly detached, then it needs to be explicitly attached to the DOM. An important consequence to note is that if there are existing event handlers attached to the `host` node or one of its successor node, then those stays as it is.
-3. Lastly, the component passed in to `Aurelia.enhance` \(`MyComponent` in our example, above\) can be a custom element class, an instance of a class, or an object literal.
+1. Every enhancement is treated as an anonymous custom element hydration, where the node being enhance is the only element inside this anonymous element template.
+2. The component passed in to `Aurelia.enhance` \(`MyComponent` in our example, above\) can be a custom element class, an instance of a class, or an object literal. If it's a class, then it will be instantiated by a container created for this enhancement. `@inject` works like normal view model instantiation.
+3. The `host` is usually an existing non-enhanced \(neither by `.app` nor by `.enhance`\) DOM node. Note that `.enhance` does not detach or attach the `host` node to the DOM by itself. If the `host` is truly detached, then it needs to be explicitly attached to the DOM. An important consequence to note is that if there are existing event handlers attached to the `host` node or one of its successor node, then those stays as it is.
 
 That's it. Those are the main differences between enhance and the normal empty-root startup. In every other aspect, those two are same, because once a node is enhanced, all the data bindings, or change handling will work like a normal Aurelia hydrated empty-root node.
-

--- a/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
+++ b/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
@@ -114,7 +114,16 @@ await au.enhance({ host, component: MyComponent });
 There are a few important points to note here.
 
 1. Every enhancement is treated as an anonymous custom element hydration, where the node being enhance is the only element inside this anonymous element template.
-2. The component passed in to `Aurelia.enhance` \(`MyComponent` in our example, above\) can be a custom element class, an instance of a class, or an object literal. If it's a class, then it will be instantiated by a container created for this enhancement. `@inject` works like normal view model instantiation.
+2. The component passed in to `Aurelia.enhance` \(`MyComponent` in our example, above\) can be a custom element class, an instance of a class, or an object literal. If it's a class, then it will be instantiated by a container.
+This container can be either specified by property `container` in the enhancement config object, or a new one will be created for this enhancement. `@inject` works like normal view model instantiation.
 3. The `host` is usually an existing non-enhanced \(neither by `.app` nor by `.enhance`\) DOM node. Note that `.enhance` does not detach or attach the `host` node to the DOM by itself. If the `host` is truly detached, then it needs to be explicitly attached to the DOM. An important consequence to note is that if there are existing event handlers attached to the `host` node or one of its successor node, then those stays as it is.
+4. The result of an `enhance` call is an activated custom element controller. This controller needs to be deactivated manually by the application, or connected to an existing controller hierarchy to be deactivated automatically by the framework.
+An example of enhancement result deactivation:
+
+```typescript
+const controller = au.enhance({ host, component });
+
+controller.deactivate(controller, null, LifecycleFlags.none);
+```
 
 That's it. Those are the main differences between enhance and the normal empty-root startup. In every other aspect, those two are same, because once a node is enhanced, all the data bindings, or change handling will work like a normal Aurelia hydrated empty-root node.

--- a/docs/user-docs/resources/migrating-to-aurelia-2.md
+++ b/docs/user-docs/resources/migrating-to-aurelia-2.md
@@ -14,6 +14,29 @@ TODO: examples + pros & cons...
 
 In v1, if you happen to use `.observeProperty` method from bindings in your application/library, then change it to `observe` instead. The parameters of the signature remain the same.
 
+### Enhance API changes:
+
+In v1, `enhance` method on an `Aurelia` instance has the signature:
+
+```typescript
+class Aurelia {
+  ...
+
+  enhance(elementOrConfig: Element | IEnhancementConfig): View;
+}
+```
+
+In v2, `enhance` method on an `Aurelia` instance has the signature:
+
+```typescript
+interface IAurelia {
+  ...
+
+  enhance(enhancementConfig: IEnhancementConfig): IEnhancedView;
+}
+```
+Parent container and resources can be specified through this config.
+
 ### Call binding \(some-prop.call="..."\)
 
 - Call binding no longer assign properties of the first argument pass to the call to the calling override context. This is unreasonably dynamic and could result in hard-to-understand templates. Example:

--- a/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/controller.host-sharing.integration.spec.ts
@@ -62,7 +62,6 @@ for (const parentSpec of specs) {
             public created(controller: ICustomElementController<this>): void {
               const container = controller.container;
               this.childController = Controller.forCustomElement(
-                null,
                 container,
                 container.get(CustomElement.keyFrom('the-child')),
                 controller.host,

--- a/packages/__tests__/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/3-runtime-html/enhance.spec.ts
@@ -1,5 +1,5 @@
 // This is to test for some intrinsic properties of enhance which is otherwise difficult to test in Data-driven tests parallel to `.app`
-import { Constructable, DI, IContainer, ILogEvent, InstanceProvider, ISink, LogLevel, Registration } from '@aurelia/kernel';
+import { Constructable, DI, IContainer, Registration } from '@aurelia/kernel';
 import {
   CustomElement,
   ICustomElementViewModel,
@@ -61,7 +61,6 @@ describe('3-runtime/enhance.spec.ts', function () {
     const container = ctx.container;
     const au = new Aurelia(container);
     const controller = await au.enhance({ host, component: getComponent() });
-    // await au.start();
 
     const app = controller.scope.bindingContext;
     await testFunction(new EnhanceTestExecutionContext(ctx, container, host, app, child));
@@ -279,7 +278,6 @@ describe('3-runtime/enhance.spec.ts', function () {
     const container = ctx.container;
     const au = new Aurelia(container);
     host.innerHTML = `<div repeat.for="i of 3">\${i}</div>`;
-    debugger
     const controller = await au.enhance({ host, component: { message: 'hello world' } });
     assert.html.textContent(host, '012');
     assert.strictEqual(host.querySelectorAll('div').length, 3);

--- a/packages/__tests__/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/3-runtime-html/enhance.spec.ts
@@ -368,7 +368,7 @@ describe('3-runtime/enhance.spec.ts', function () {
       component: { i: 1 },
       resources: [
         ValueConverter.define('plus10', class Plus10 {
-          toView(v: any) {
+          public toView(v: any) {
             return Number(v) + 10;
           }
         })

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -151,7 +151,7 @@ describe(`3-runtime-html/if.integration.spec.ts`, function () {
         const elseFactory = rendering.getViewFactory(elseDef, container);
         const sut = new If(ifFactory, ifLoc, work);
         const elseSut = new Else(elseFactory);
-        const ifController = (sut as Writable<If>).$controller = Controller.forCustomAttribute(null, container, sut, (void 0)!);
+        const ifController = (sut as Writable<If>).$controller = Controller.forCustomAttribute(container, sut, (void 0)!);
         elseSut.link(LifecycleFlags.none, { children: [ifController] } as unknown as IHydratableController, void 0!, void 0!, void 0!);
 
         const firstBindInitialNodesText: string = value1 ? ifText : elseText;

--- a/packages/__tests__/3-runtime-html/process-content.spec.ts
+++ b/packages/__tests__/3-runtime-html/process-content.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 import { IContainer, noop, toArray } from '@aurelia/kernel';
-import { Aurelia, bindable, BindingMode, CustomElement, customElement, INode, IPlatform, processContent } from '@aurelia/runtime-html';
+import { Aurelia, bindable, BindingMode, CustomElement, customElement, INode, IPlatform, LifecycleFlags, processContent } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext as $TestExecutionContext, TestFunction } from '../util.js';
 
@@ -40,9 +40,9 @@ describe('processContent', function () {
       au.register(...registrations);
       if (enhance) {
         host.innerHTML = template;
-        const { controller, deactivate: $dispose } = await au.enhance({ host, component: CustomElement.define({ name: 'app', isStrictBinding: true }, App) });
+        const controller = await au.enhance({ host, component: CustomElement.define({ name: 'app', isStrictBinding: true }, App) });
         app = controller.viewModel;
-        stop = $dispose;
+        stop = () => controller.deactivate(controller, null, LifecycleFlags.none);
       } else {
         await au.app({ host, component: CustomElement.define({ name: 'app', isStrictBinding: true, template }, App) })
           .start();

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -567,7 +567,7 @@ describe(`Repeat`, function () {
           bindings: [binding]
         } as any;
         const sut = new Repeat(loc, hydratable, itemFactory);
-        (sut as Writable<Repeat>).$controller = Controller.forCustomAttribute(null, container, sut, (void 0)!);
+        (sut as Writable<Repeat>).$controller = Controller.forCustomAttribute(container, sut, (void 0)!);
         binding.target = sut as any;
 
         // -- Round 1 --

--- a/packages/__tests__/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.spec.ts
@@ -207,7 +207,7 @@ describe('Styles', function () {
       });
 
       const component = new FooBar();
-      const controller = Controller.forCustomElement(null, ctx.container.createChild(), component, host, null, null);
+      const controller = Controller.forCustomElement(ctx.container.createChild(), component, host, null, null);
 
       void controller.activate(controller, null, LifecycleFlags.none);
 

--- a/packages/__tests__/integration/app/molecules/random-generator/random-generator.ts
+++ b/packages/__tests__/integration/app/molecules/random-generator/random-generator.ts
@@ -21,6 +21,6 @@ export class RandomGenerator {
   }
 
   public doSomething() {
-    console.log('foobar');
+    console.log('random-generator.ts__doSomething()');
   }
 }

--- a/packages/__tests__/integration/app/startup.ts
+++ b/packages/__tests__/integration/app/startup.ts
@@ -55,12 +55,18 @@ export async function startup(config: StartupConfiguration = {}) {
       break;
   }
 
+  let $deactivate: () => any;
   ctx.doc.body.appendChild(host);
-  au[method]({ host, component });
-  await au.start();
+  if (method === 'app') {
+    au.app({ host, component });
+    await au.start();
+  } else {
+    $deactivate = (await au.enhance({ host, component })).deactivate;
+  }
 
   async function tearDown() {
     await au.stop();
+    await $deactivate?.();
     ctx.doc.body.removeChild(host);
     callCollection.calls.splice(0);
   }

--- a/packages/__tests__/integration/app/startup.ts
+++ b/packages/__tests__/integration/app/startup.ts
@@ -1,5 +1,5 @@
 import { IRegistration } from '@aurelia/kernel';
-import { Aurelia, CustomElement, FrequentMutations, CustomElementType } from '@aurelia/runtime-html';
+import { Aurelia, CustomElement, FrequentMutations, CustomElementType, LifecycleFlags } from '@aurelia/runtime-html';
 import { CallCollection, TestContext } from '@aurelia/testing';
 import { App } from './app.js';
 import { appTemplate as template } from './app-template.js';
@@ -61,7 +61,8 @@ export async function startup(config: StartupConfiguration = {}) {
     au.app({ host, component });
     await au.start();
   } else {
-    $deactivate = (await au.enhance({ host, component })).deactivate;
+    const controller = (await au.enhance({ host, component }));
+    $deactivate = () => controller.deactivate(controller, null, LifecycleFlags.none);
   }
 
   async function tearDown() {

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,7 +1,7 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
 import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IEnhancedView, IHydratedParentController } from '@aurelia/runtime-html';
-import type { ISinglePageApp } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
+import type { ISinglePageApp, IEnhancementConfig } from '@aurelia/runtime-html';
 
 export const PLATFORM = BrowserPlatform.getOrCreate(globalThis);
 export { IPlatform };
@@ -27,7 +27,7 @@ export class Aurelia extends $Aurelia {
     return new Aurelia().app(config);
   }
 
-  public static enhance(config: ISinglePageApp, parentController?: IHydratedParentController): IEnhancedView | Promise<IEnhancedView> {
+  public static enhance<T extends unknown>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController): IEnhancedView<T> | Promise<IEnhancedView<T>> {
     return new Aurelia().enhance(config, parentController);
   }
 
@@ -757,6 +757,7 @@ export {
   // TwoWayBindingCommand,
 
   IEnhancedView,
+  IEnhancementConfig,
   IHydratedParentController,
 
   // IExpressionParserRegistration,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
-import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IEnhancedView, IHydratedParentController } from '@aurelia/runtime-html';
+import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IHydratedParentController, ICustomElementController } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import type { ISinglePageApp, IEnhancementConfig } from '@aurelia/runtime-html';
 
@@ -27,7 +27,7 @@ export class Aurelia extends $Aurelia {
     return new Aurelia().app(config);
   }
 
-  public static enhance<T extends unknown>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController): IEnhancedView<T> | Promise<IEnhancedView<T>> {
+  public static enhance<T extends unknown>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController): ReturnType<$Aurelia['enhance']> {
     return new Aurelia().enhance(config, parentController);
   }
 
@@ -756,7 +756,6 @@ export {
   // ToViewBindingCommand,
   // TwoWayBindingCommand,
 
-  IEnhancedView,
   IEnhancementConfig,
   IHydratedParentController,
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,6 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
-import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, ISinglePageApp, CustomElement } from '@aurelia/runtime-html';
+import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IEnhancedView, IHydratedParentController } from '@aurelia/runtime-html';
+import type { ISinglePageApp } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 
 export const PLATFORM = BrowserPlatform.getOrCreate(globalThis);
@@ -26,8 +27,8 @@ export class Aurelia extends $Aurelia {
     return new Aurelia().app(config);
   }
 
-  public static enhance(config: ISinglePageApp): Omit<Aurelia, 'register' | 'app' | 'enhance'> {
-    return new Aurelia().enhance(config) as Omit<Aurelia, 'register' | 'app' | 'enhance'>;
+  public static enhance(config: ISinglePageApp, parentController?: IHydratedParentController): IEnhancedView | Promise<IEnhancedView> {
+    return new Aurelia().enhance(config, parentController);
   }
 
   public static register(...params: readonly unknown[]): Aurelia {
@@ -754,6 +755,9 @@ export {
   // OneTimeBindingCommand,
   // ToViewBindingCommand,
   // TwoWayBindingCommand,
+
+  IEnhancedView,
+  IHydratedParentController,
 
   // IExpressionParserRegistration,
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
-import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IHydratedParentController, ICustomElementController } from '@aurelia/runtime-html';
+import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IHydratedParentController } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import type { ISinglePageApp, IEnhancementConfig } from '@aurelia/runtime-html';
 

--- a/packages/router/src/component-agent.ts
+++ b/packages/router/src/component-agent.ts
@@ -1,4 +1,4 @@
-import { ICustomElementController, Controller, IHydratedController, LifecycleFlags, ICustomElementViewModel, IAppRoot, ILifecycleHooks, LifecycleHooksLookup } from '@aurelia/runtime-html';
+import { ICustomElementController, Controller, IHydratedController, LifecycleFlags, ICustomElementViewModel, ILifecycleHooks, LifecycleHooksLookup } from '@aurelia/runtime-html';
 import { Constructable, ILogger } from '@aurelia/kernel';
 
 import { RouteDefinition } from './route-definition.js';

--- a/packages/router/src/component-agent.ts
+++ b/packages/router/src/component-agent.ts
@@ -61,7 +61,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
     if (componentAgent === void 0) {
       const container = ctx.container;
       const definition = RouteDefinition.resolve(componentInstance.constructor as Constructable);
-      const controller = Controller.forCustomElement(container.get(IAppRoot), container, componentInstance, hostController.host, null);
+      const controller = Controller.forCustomElement(container, componentInstance, hostController.host, null);
 
       componentAgentLookup.set(
         componentInstance,

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -550,7 +550,7 @@ export class Router {
    * ```ts
    * // Given an already defined custom element named Greeter
    * const greeter = new Greeter();
-   * Controller.forCustomElement(null, container, greeter, host);
+   * Controller.forCustomElement(container, greeter, host);
    * router.load(greeter);
    * ```
    */

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -2,10 +2,10 @@ import { DI, Registration, InstanceProvider, onResolve, resolveAll, ILogger } fr
 import { LifecycleFlags } from '@aurelia/runtime';
 import { INode } from './dom.js';
 import { IAppTask } from './app-task.js';
-import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
+import { CustomElement } from './resources/custom-element.js';
 import { Controller, IControllerElementHydrationInstruction } from './templating/controller.js';
 
-import type { Constructable, IContainer, IDisposable, Writable } from '@aurelia/kernel';
+import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
 import type { TaskSlot } from './app-task.js';
 import type { ICustomElementViewModel, ICustomElementController } from './templating/controller.js';
 import type { IPlatform } from './platform.js';
@@ -91,7 +91,7 @@ export class AppRoot implements IDisposable {
         instance = config.component as ICustomElementViewModel;
       }
 
-      const hydrationInst = { hydrate: false, projections: null } as Writable<IControllerElementHydrationInstruction>;
+      const hydrationInst: IControllerElementHydrationInstruction = { hydrate: false, projections: null };
       const controller = (this.controller = Controller.forCustomElement(
         childCtn,
         instance,

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -93,7 +93,6 @@ export class AppRoot implements IDisposable {
 
       const hydrationInst = { hydrate: false, projections: null } as Writable<IControllerElementHydrationInstruction>;
       const controller = (this.controller = Controller.forCustomElement(
-        this,
         childCtn,
         instance,
         this.host,

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -98,7 +98,6 @@ export class AppRoot implements IDisposable {
         this.host,
         hydrationInst,
         LifecycleFlags.none,
-        false,
       )) as Controller;
 
       controller.hydrateCustomElement(hydrationInst, /* root does not have hydration context */null);

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -72,7 +72,6 @@ export class AppRoot implements IDisposable {
     public readonly platform: IPlatform,
     public readonly container: IContainer,
     rootProvider: InstanceProvider<IAppRoot>,
-    enhance = false,
   ) {
     this.host = config.host;
     this.work = container.get(IWorkTracker);

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -100,7 +100,6 @@ export class Aurelia implements IDisposable {
     //        - there's no lifecycles
     // todo: should this be move to a method enhance on Controller?
     const view = Controller.forCustomElement(
-      null,
       childCtn,
       bc,
       host,

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -109,7 +109,6 @@ export class Aurelia implements IDisposable {
       host,
       null,
       void 0,
-      void 0,
       CustomElementDefinition.create({ name: CustomElement.generateName(), template: host, enhance: true }),
     );
     const enhancedView: IEnhancedView<K> = {

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -1,7 +1,17 @@
-import { DI, IContainer, Registration, InstanceProvider, IDisposable, onResolve } from '@aurelia/kernel';
+import { DI, Registration, InstanceProvider, onResolve } from '@aurelia/kernel';
 import { BrowserPlatform } from '@aurelia/platform-browser';
+import { LifecycleFlags } from '@aurelia/runtime';
 import { AppRoot, IAppRoot, ISinglePageApp } from './app-root.js';
+import { IEventTarget, INode } from './dom.js';
 import { IPlatform } from './platform.js';
+import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
+import { Controller, ICustomElementController, IHydratedParentController } from './templating/controller.js';
+
+import type {
+  Constructable,
+  IContainer,
+  IDisposable,
+} from '@aurelia/kernel';
 
 export interface IAurelia extends Aurelia {}
 export const IAurelia = DI.createInterface<IAurelia>('IAurelia');
@@ -14,6 +24,11 @@ export class Aurelia implements IDisposable {
   private _isStopping: boolean = false;
   public get isStopping(): boolean { return this._isStopping; }
 
+  // TODO:
+  // root should just be a controller,
+  // in all other parts of the framework, root of something is always the same type of that thing
+  // i.e: container.root => a container, RouteContext.root => a RouteContext
+  // Aurelia.root of a controller hierarchy should behave similarly
   private _root: IAppRoot | undefined = void 0;
   public get root(): IAppRoot {
     if (this._root == null) {
@@ -36,7 +51,7 @@ export class Aurelia implements IDisposable {
       throw new Error('An instance of Aurelia is already registered with the container or an ancestor of it.');
     }
 
-    container.register(Registration.instance(IAurelia, this));
+    container.registerResolver(IAurelia, new InstanceProvider<IAurelia>('IAurelia', this));
     container.registerResolver(IAppRoot, this.rootProvider = new InstanceProvider('IAppRoot'));
   }
 
@@ -46,13 +61,62 @@ export class Aurelia implements IDisposable {
   }
 
   public app(config: ISinglePageApp): Omit<this, 'register' | 'app' | 'enhance'> {
-    this.next = new AppRoot(config, this.initPlatform(config.host), this.container, this.rootProvider, false);
+    this.next = new AppRoot(config, this.initPlatform(config.host), this.container, this.rootProvider);
     return this;
   }
 
-  public enhance(config: ISinglePageApp): Omit<this, 'register' | 'app' | 'enhance'> {
-    this.next = new AppRoot(config, this.initPlatform(config.host), this.container, this.rootProvider, true);
-    return this;
+  /**
+   * @param parentController The owning controller of the view created by this enhance call
+   */
+  public enhance(config: ISinglePageApp, parentController?: IHydratedParentController | null): IEnhancedView | Promise<IEnhancedView> {
+    const ctn = this.container;
+    const childCtn = ctn.createChild();
+    const host = config.host;
+    const p = this.initPlatform(host);
+    const comp = config.component;
+    let bc: object;
+    if (typeof comp === 'function') {
+      childCtn.registerResolver(
+        p.HTMLElement,
+        childCtn.registerResolver(
+          p.Element,
+          childCtn.registerResolver(
+            p.Node,
+            childCtn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+          )
+        )
+      );
+      bc = childCtn.invoke(comp as Constructable);
+    } else {
+      bc = comp as object;
+    }
+    childCtn.registerResolver(IEventTarget, new InstanceProvider('IEventTarget', host));
+    parentController = parentController ?? null;
+
+    // todo: shouldn't this be just a synthetic view?
+    //       pros of synthetic view:
+    //        - is it feels right-er
+    //       cons of synthetic view:
+    //        - there's no lifecycles
+    // todo: should this be move to a method enhance on Controller?
+    const view = Controller.forCustomElement(
+      null,
+      childCtn,
+      bc,
+      host,
+      null,
+      void 0,
+      void 0,
+      CustomElementDefinition.create({ name: CustomElement.generateName(), template: host, enhance: true }),
+    );
+    const enhancedView: IEnhancedView = {
+      controller: view,
+      deactivate: () => view.deactivate(view, parentController!, LifecycleFlags.fromUnbind)
+    };
+    return onResolve(
+      view.activate(view, parentController, LifecycleFlags.fromBind),
+      () => enhancedView
+    );
   }
 
   public async waitForIdle(): Promise<void> {
@@ -135,4 +199,9 @@ export class Aurelia implements IDisposable {
     const ev = new root.platform.window.CustomEvent(name, { detail: this, bubbles: true, cancelable: true });
     target.dispatchEvent(ev);
   }
+}
+
+export interface IEnhancedView {
+  readonly controller: ICustomElementController;
+  readonly deactivate: () => void | Promise<void>;
 }

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -1,4 +1,4 @@
-import { DI, Registration, InstanceProvider, onResolve, emptyArray } from '@aurelia/kernel';
+import { DI, Registration, InstanceProvider, onResolve } from '@aurelia/kernel';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import { LifecycleFlags } from '@aurelia/runtime';
 import { AppRoot, IAppRoot, ISinglePageApp } from './app-root.js';
@@ -92,12 +92,6 @@ export class Aurelia implements IDisposable {
     ctn.registerResolver(IEventTarget, new InstanceProvider('IEventTarget', host));
     parentController = parentController ?? null;
 
-    // todo: shouldn't this be just a synthetic view?
-    //       pros of synthetic view:
-    //        - is it feels right-er
-    //       cons of synthetic view:
-    //        - there's no lifecycles
-    // todo: should this be move to a method enhance on Controller?
     const view = Controller.forCustomElement(
       ctn,
       bc,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -218,7 +218,6 @@ export {
 export {
   Aurelia,
   IAurelia,
-  IEnhancedView,
   IEnhancementConfig,
 } from './aurelia.js';
 export {

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -219,6 +219,7 @@ export {
   Aurelia,
   IAurelia,
   IEnhancedView,
+  IEnhancementConfig,
 } from './aurelia.js';
 export {
   ISinglePageApp,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -218,6 +218,7 @@ export {
 export {
   Aurelia,
   IAurelia,
+  IEnhancedView,
 } from './aurelia.js';
 export {
   ISinglePageApp,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -499,7 +499,6 @@ export class CustomElementRenderer implements IRenderer {
     component = container.invoke(Ctor);
     container.registerResolver(Ctor, new InstanceProvider<typeof Ctor>(def.key, component));
     childCtrl = Controller.forCustomElement(
-      /* root                */renderingCtrl.root,
       /* own container       */container,
       /* viewModel           */component,
       /* host                */target,
@@ -572,7 +571,6 @@ export class CustomAttributeRenderer implements IRenderer {
       /* location         */void 0,
     );
     const childController = Controller.forCustomAttribute(
-      /* root       */renderingCtrl.root,
       /* context ct */renderingCtrl.container,
       /* viewModel  */component,
       /* host       */target,
@@ -641,7 +639,6 @@ export class TemplateControllerRenderer implements IRenderer {
       /* location         */renderLocation,
     );
     const childController = Controller.forCustomAttribute(
-      /* root         */renderingCtrl.root,
       /* container ct */renderingCtrl.container,
       /* viewModel    */component,
       /* host         */target,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -502,9 +502,8 @@ export class CustomElementRenderer implements IRenderer {
       /* own container       */container,
       /* viewModel           */component,
       /* host                */target,
-      /* instructions        */instruction,
+      /* instruction         */instruction,
       /* flags               */f,
-      /* hydrate             */true,
       /* definition          */def,
     );
 

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -184,7 +184,7 @@ export class AuCompose {
     //       should it throw or try it best to proceed?
     //       current: proceed
     const { view, viewModel, model, initiator } = context.change;
-    const { container, host, $controller, contextFactory, loc } = this;
+    const { container, host, $controller, loc } = this;
     const srcDef = this.getDef(viewModel);
     const childCtn: IContainer = container.createChild();
     const parentNode = loc == null ? host.parentNode : loc.parentNode;

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -222,7 +222,6 @@ export class AuCompose {
           compositionHost as HTMLElement,
           null,
           LifecycleFlags.none,
-          true,
           srcDef,
         );
 

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -217,7 +217,6 @@ export class AuCompose {
       // custom element based composition
       if (srcDef !== null) {
         const controller = Controller.forCustomElement(
-          null,
           childCtn,
           comp,
           compositionHost as HTMLElement,
@@ -247,8 +246,6 @@ export class AuCompose {
         });
         const viewFactory = this.r.getViewFactory(targetDef, childCtn);
         const controller = Controller.forSyntheticView(
-          contextFactory.isFirst(context) ? $controller.root : null,
-          // null!,
           viewFactory,
           LifecycleFlags.fromBind,
           $controller

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -428,12 +428,15 @@ export class TemplateCompiler implements ITemplateCompiler {
       ii = attrs.length;
     }
 
-    if (__DEV__ && context.root.def.enhance && el.classList.contains('au')) {
-      context.logger.warn(
-        'Trying to enhance with a template that was probably compiled before. '
-        + 'This is likely going to cause issues. '
-        + 'Consider enhancing only untouched elements.'
-      );
+    if (context.root.def.enhance && el.classList.contains('au')) {
+      if (__DEV__)
+        throw new Error(
+          'Trying to enhance with a template that was probably compiled before. '
+          + 'This is likely going to cause issues. '
+          + 'Consider enhancing only untouched elements.'
+        );
+      else
+        throw new Error(`AUR0710`);
     }
 
     for (; ii > i; ++i) {

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -428,6 +428,14 @@ export class TemplateCompiler implements ITemplateCompiler {
       ii = attrs.length;
     }
 
+    if (__DEV__ && context.root.def.enhance && el.classList.contains('au')) {
+      context.logger.warn(
+        'Trying to enhance with a template that was probably compiled before. '
+        + 'This is likely going to cause issues. '
+        + 'Consider enhancing only untouched elements.'
+      );
+    }
+
     for (; ii > i; ++i) {
       attr = attrs[i];
       attrName = attr.name;

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -183,7 +183,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     host: HTMLElement,
     hydrationInst: IControllerElementHydrationInstruction | null,
     flags: LifecycleFlags = LifecycleFlags.none,
-    hydrate: boolean = true,
     // Use this when `instance.constructor` is not a custom element type
     // to pass on the CustomElement definition
     definition: CustomElementDefinition | undefined = void 0,

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -22,7 +22,6 @@ import { convertToRenderLocation, setRef } from '../dom.js';
 import { CustomElementDefinition, CustomElement } from '../resources/custom-element.js';
 import { CustomAttributeDefinition, CustomAttribute } from '../resources/custom-attribute.js';
 import { ChildrenDefinition, ChildrenObserver } from './children.js';
-import { IAppRoot } from '../app-root.js';
 import { IPlatform } from '../platform.js';
 import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles.js';
 import { ComputedWatcher, ExpressionWatcher } from './watchers.js';

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -131,8 +131,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   public readonly hooks: HooksDefinition;
 
   public constructor(
-    // todo: remove this property along with the root initialization below
-    public root: IAppRoot | null,
     public container: IContainer,
     public readonly vmKind: ViewModelKind,
     public flags: LifecycleFlags,
@@ -154,10 +152,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
      */
     public host: HTMLElement | null,
   ) {
-    // todo: remove this along with the root parameter
-    // if (root === null && container.has(IAppRoot, true)) {
-    //   this.root = container.get<IAppRoot>(IAppRoot);
-    // }
     this.r = container.root.get(IRendering);
     this.platform = container.get(IPlatform);
     switch (vmKind) {
@@ -185,7 +179,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   }
 
   public static forCustomElement<C extends ICustomElementViewModel = ICustomElementViewModel>(
-    root: IAppRoot | null,
     ctn: IContainer,
     viewModel: C,
     host: HTMLElement,
@@ -203,7 +196,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     definition = definition ?? CustomElement.getDefinition(viewModel.constructor as Constructable);
 
     const controller = new Controller<C>(
-      /* root           */root,
       /* container      */ctn,
       /* vmKind         */ViewModelKind.customElement,
       /* flags          */flags,
@@ -237,7 +229,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   }
 
   public static forCustomAttribute<C extends ICustomAttributeViewModel = ICustomAttributeViewModel>(
-    root: IAppRoot | null,
     ctn: IContainer,
     viewModel: C,
     host: HTMLElement,
@@ -256,7 +247,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     definition = definition ?? CustomAttribute.getDefinition(viewModel.constructor as Constructable);
 
     const controller = new Controller<C>(
-      /* root           */root,
       /* own ct         */ctn,
       /* vmKind         */ViewModelKind.customAttribute,
       /* flags          */flags,
@@ -274,13 +264,11 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   }
 
   public static forSyntheticView(
-    root: IAppRoot | null,
     viewFactory: IViewFactory,
     flags: LifecycleFlags = LifecycleFlags.none,
     parentController: ISyntheticView | ICustomElementController | ICustomAttributeController | undefined = void 0,
   ): ISyntheticView {
     const controller = new Controller(
-      /* root           */root,
       /* container      */viewFactory.container,
       /* vmKind         */ViewModelKind.synthetic,
       /* flags          */flags,
@@ -355,8 +343,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     // - runAppTasks('hydrated') // may return a promise
     // - Controller.compileChildren
     // This keeps hydration synchronous while still allowing the composition root compile hooks to do async work.
-    // if ((this.root?.controller as this | undefined) !== this) {
-    // }
     if (hydrationInst == null || hydrationInst.hydrate !== false) {
       this.hydrate(hydrationInst);
       this.hydrateChildren();
@@ -1055,7 +1041,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this.viewModel = null;
     this.host = null;
     this.shadowRoot = null;
-    this.root = null;
   }
 
   public accept(visitor: ControllerVisitor): void | true {
@@ -1336,7 +1321,6 @@ export interface IController<C extends IViewModel = IViewModel> extends IDisposa
   readonly name: string;
   readonly container: IContainer;
   readonly platform: IPlatform;
-  readonly root: IAppRoot | null;
   readonly flags: LifecycleFlags;
   readonly vmKind: ViewModelKind;
   readonly definition: CustomElementDefinition | CustomAttributeDefinition | null;

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -119,7 +119,6 @@ export class DialogController implements IDialogController {
 
         return onResolve(cmp.activate?.(model), () => {
           const ctrlr = this.controller = Controller.forCustomElement(
-            null,
             container,
             cmp,
             contentHost,

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -124,7 +124,6 @@ export class DialogController implements IDialogController {
             contentHost,
             null,
             LifecycleFlags.none,
-            true,
             CustomElementDefinition.create(
               this.getDefinition(cmp) ?? { name: CustomElement.generateName(), template }
             )

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -88,7 +88,7 @@ export class ViewFactory implements IViewFactory {
       return controller;
     }
 
-    controller = Controller.forSyntheticView(null, /* null!,  */this, flags, parentController);
+    controller = Controller.forSyntheticView(this, flags, parentController);
     return controller;
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, `Aurelia.enhance` works similarly to `Aurelia.app`: it would become an application root of itself. While this gives some interesting perspective to look at enhance, it makes the usage of enhance more difficult than the method name suggests. Change the way `Aurelia.enhance` work to the same with `enhance` in v1.

CHANGES:
- remove: root requirement in `Controller.forCustomElement`, `Controller.forSyntheticView`, `Controller.forCustomAttribute`: it shouldn't require irrelevant information to the construction of a controller. The existing internal way to halt/resume hydration is moved to hydration instruction.
- remove: root property in `IController`/`Controller`. This should give some more perf boost.

## ⏭ Next Steps

- doc: add examples how to create a view factory
- doc: add examples how to apply a custom attribute dynamically to an element