### PR TITLE
chore(cleanup): avoid doing wasteful work

### DIFF
--- a/examples/realworld-advanced/e2e/auth.spec.ts
+++ b/examples/realworld-advanced/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { CustomElement, INode, IPlatform, PLATFORM } from 'aurelia';
+import { INode, IPlatform } from 'aurelia';
 import { assert } from '@aurelia/testing';
 import * as playwright from 'playwright';
 
@@ -47,7 +47,7 @@ describe('register', function () {
   async function waitForFramework(): Promise<void> {
     await page.evaluate(async function () {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const p = (document.querySelector('app-root') as INode).$au!['au:resource:custom-element']!.platform;
+      const p = (document.querySelector('app-root') as INode).$au!['au:resource:custom-element']!.container.get(IPlatform);
       await p.taskQueue.yield();
       await p.domWriteQueue.yield();
     });

--- a/examples/realworld/e2e/auth.spec.ts
+++ b/examples/realworld/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { CustomElement, INode, IPlatform, PLATFORM } from 'aurelia';
+import { INode, IPlatform } from 'aurelia';
 import { assert } from '@aurelia/testing';
 import * as playwright from 'playwright';
 
@@ -47,7 +47,7 @@ describe('register', function () {
   async function waitForFramework(): Promise<void> {
     await page.evaluate(async function () {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const p = (document.querySelector('app-root') as INode).$au!['au:resource:custom-element']!.platform;
+      const p = (document.querySelector('app-root') as INode).$au!['au:resource:custom-element']!.container.get(IPlatform);
       await p.taskQueue.yield();
       await p.domWriteQueue.yield();
     });

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -1,4 +1,4 @@
-import { DI, Registration, InstanceProvider, onResolve, resolveAll, ILogger } from '@aurelia/kernel';
+import { DI, InstanceProvider, onResolve, resolveAll, ILogger } from '@aurelia/kernel';
 import { LifecycleFlags } from '@aurelia/runtime';
 import { INode } from './dom.js';
 import { IAppTask } from './app-task.js';
@@ -76,10 +76,12 @@ export class AppRoot implements IDisposable {
     this.host = config.host;
     this.work = container.get(IWorkTracker);
     rootProvider.prepare(this);
-    // if (container.has(INode, false) && container.get(INode) !== config.host) {
-    //   this.container = container.createChild();
-    // }
-    this.container.register(Registration.instance(INode, config.host));
+    container.registerResolver(INode,
+      container.registerResolver(
+        platform.Element,
+        new InstanceProvider('ElementProvider', config.host)
+      )
+    );
 
     this.hydratePromise = onResolve(this.runAppTasks('beforeCreate'), () => {
       const component = config.component as Constructable | ICustomElementViewModel;

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -76,14 +76,8 @@ export class Aurelia implements IDisposable {
     let bc: ICustomElementViewModel & K;
     if (typeof comp === 'function') {
       ctn.registerResolver(
-        p.HTMLElement,
-        ctn.registerResolver(
-          p.Element,
-          ctn.registerResolver(
-            p.Node,
-            ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
-          )
-        )
+        p.Element,
+        ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
       );
       bc = ctn.invoke(comp as unknown as Constructable<ICustomElementViewModel & K>);
     } else {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -293,11 +293,13 @@ export class AuCompose {
 
     const p = this.p;
     const isLocation = isRenderLocation(host);
-    const nodeProvider = new InstanceProvider('ElementResolver', isLocation ? null : host as HTMLElement);
-    container.registerResolver(INode, nodeProvider);
-    container.registerResolver(p.Node, nodeProvider);
-    container.registerResolver(p.Element, nodeProvider);
-    container.registerResolver(p.HTMLElement, nodeProvider);
+    container.registerResolver(
+      p.Element,
+      container.registerResolver(
+        INode,
+        new InstanceProvider('ElementResolver', isLocation ? null : host as HTMLElement)
+      )
+    );
     container.registerResolver(
       IRenderLocation,
       new InstanceProvider('IRenderLocation', isLocation ? host as IRenderLocation : null)

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -126,7 +126,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   /** @internal */
   private readonly r: IRendering;
 
-  public readonly platform: IPlatform;
   public readonly hooks: HooksDefinition;
 
   public constructor(
@@ -152,7 +151,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     public host: HTMLElement | null,
   ) {
     this.r = container.root.get(IRendering);
-    this.platform = container.get(IPlatform);
     switch (vmKind) {
       case ViewModelKind.customAttribute:
       case ViewModelKind.customElement:
@@ -360,7 +358,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this.isStrictBinding = isStrictBinding;
 
     if ((this.hostController = CustomElement.for(this.host!, optionalCeFind) as Controller | null) !== null) {
-      this.host = this.platform.document.createElement(this.definition!.name);
+      this.host = this.container.root.get(IPlatform).document.createElement(this.definition!.name);
     }
 
     setRef(this.host!, CustomElement.name, this as IHydratedController);
@@ -1318,7 +1316,6 @@ export interface IController<C extends IViewModel = IViewModel> extends IDisposa
    */
   readonly name: string;
   readonly container: IContainer;
-  readonly platform: IPlatform;
   readonly flags: LifecycleFlags;
   readonly vmKind: ViewModelKind;
   readonly definition: CustomElementDefinition | CustomAttributeDefinition | null;

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -247,12 +247,11 @@ export class DialogController implements IDialogController {
     }
 
     const p = this.p;
-    const ep = new InstanceProvider('ElementResolver', host);
 
-    container.registerResolver(INode, ep);
-    container.registerResolver(p.Node, ep);
-    container.registerResolver(p.Element, ep);
-    container.registerResolver(p.HTMLElement, ep);
+    container.registerResolver(
+      INode,
+      container.registerResolver(p.Element, new InstanceProvider('ElementResolver', host))
+    );
 
     return container.invoke(Component!);
   }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently `Controller` always try to determine the platform associated with its container, though this is not always used. Remove this and the associated properties + interfaces.
For host injection, currently we are supporting 4 injection key: `INode`, `Node`, `Element`, `HTMLElement`, This is a bit unnecessary. Remove `Node` & `HTMLElement` registration during container preparation.