### PR TITLE
chore(all): mark privates with _

### DIFF
--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -1157,11 +1157,11 @@ describe(`The Container class`, function () {
 
       parent.register(Registration.singleton(key, type));
 
-      const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+      const parentHasKey = parent['res'][key] !== void 0;
 
       const child = parent.createChild();
 
-      const childHasKey = child['resourceResolvers'][key] !== void 0;
+      const childHasKey = child['res'][key] !== void 0;
 
       assert.strictEqual(parentHasKey, false, `has@root`);
       assert.strictEqual(childHasKey, false, `has@child`);
@@ -1176,11 +1176,11 @@ describe(`The Container class`, function () {
 
     //   parent.register(Registration.singleton(key, type));
 
-    //   const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+    //   const parentHasKey = parent['res'][key] !== void 0;
 
     //   const child = parent.createChild();
 
-    //   const childHasKey = child['resourceResolvers'][key] !== void 0;
+    //   const childHasKey = child['res'][key] !== void 0;
 
     //   assert.strictEqual(parentHasKey, false, `has@root`);
     //   assert.strictEqual(childHasKey, false, `has@child`);
@@ -1195,11 +1195,11 @@ describe(`The Container class`, function () {
 
     //   parent.register(Registration.singleton(key, type));
 
-    //   const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+    //   const parentHasKey = parent['res'][key] !== void 0;
 
     //   const child = parent.createChild();
 
-    //   const childHasKey = child['resourceResolvers'][key] !== void 0;
+    //   const childHasKey = child['res'][key] !== void 0;
 
     //   assert.strictEqual(parentHasKey, true, `has@root`);
     //   assert.strictEqual(childHasKey, true, `has@child`);
@@ -1327,11 +1327,11 @@ describe(`The Container class`, function () {
 
         parent.register(Registration.singleton(key, type));
 
-        const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+        const parentHasKey = parent['res'][key] !== void 0;
 
         const child = parent.createChild();
 
-        const childHasKey = child['resourceResolvers'][key] !== void 0;
+        const childHasKey = child['res'][key] !== void 0;
 
         assert.strictEqual(parentHasKey, false, `parentHasKey`);
         assert.strictEqual(childHasKey, false, `childHasKey`);
@@ -1346,11 +1346,11 @@ describe(`The Container class`, function () {
 
         parent.register(Registration.singleton(key, type));
 
-        const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+        const parentHasKey = parent['res'][key] !== void 0;
 
         const child = parent.createChild();
 
-        const childHasKey = child['resourceResolvers'][key] !== void 0;
+        const childHasKey = child['res'][key] !== void 0;
 
         assert.strictEqual(parentHasKey, false, `parentHasKey`);
         assert.strictEqual(childHasKey, false, `childHasKey`);
@@ -1365,11 +1365,11 @@ describe(`The Container class`, function () {
 
         parent.register(Registration.singleton(key, type));
 
-        const parentHasKey = parent['resourceResolvers'][key] !== void 0;
+        const parentHasKey = parent['res'][key] !== void 0;
 
         const child = parent.createChild();
 
-        const childHasKey = child['resourceResolvers'][key] !== void 0;
+        const childHasKey = child['res'][key] !== void 0;
 
         assert.strictEqual(parentHasKey, true, `parentHasKey`);
         assert.strictEqual(childHasKey, false, `childHasKey`);
@@ -1392,13 +1392,13 @@ describe(`The Container class`, function () {
 
         parent.register(Registration.singleton(keyFromParent, type));
 
-        const parentHasKeyFromRoot = parent['resourceResolvers'][keyFromRoot] !== void 0;
-        const parentHasKeyFromParent = parent['resourceResolvers'][keyFromParent] !== void 0;
+        const parentHasKeyFromRoot = parent['res'][keyFromRoot] !== void 0;
+        const parentHasKeyFromParent = parent['res'][keyFromParent] !== void 0;
 
         const child = parent.createChild();
 
-        const childHasKeyFromRoot = child['resourceResolvers'][keyFromRoot] !== void 0;
-        const childHasKeyFromParent = child['resourceResolvers'][keyFromParent] !== void 0;
+        const childHasKeyFromRoot = child['res'][keyFromRoot] !== void 0;
+        const childHasKeyFromParent = child['res'][keyFromParent] !== void 0;
 
         assert.strictEqual(parentHasKeyFromRoot, false, `parentHasKeyFromRoot`);
         assert.strictEqual(parentHasKeyFromParent, true, `parentHasKeyFromParent`);

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -388,7 +388,8 @@ export function mergeObjects<T extends object>(...objects: readonly (T | undefin
   const objectsLen = objects.length;
   let object: T | undefined;
   let key: keyof T;
-  for (let i = 0; i < objectsLen; ++i) {
+  let i = 0;
+  for (; objectsLen > i; ++i) {
     object = objects[i];
     if (object !== void 0) {
       for (key in object) {
@@ -402,7 +403,8 @@ export function mergeObjects<T extends object>(...objects: readonly (T | undefin
 export function firstDefined<T>(...values: readonly (T | undefined)[]): T {
   const len = values.length;
   let value: T | undefined;
-  for (let i = 0; i < len; ++i) {
+  let i = 0;
+  for (; len > i; ++i) {
     value = values[i];
     if (value !== void 0) {
       return value;

--- a/packages/kernel/src/resource.ts
+++ b/packages/kernel/src/resource.ts
@@ -39,12 +39,13 @@ export interface IResourceKind<TType extends ResourceType, TDef extends Resource
   keyFrom(name: string): string;
 }
 
+const annoBaseName = 'au:annotation';
 const annotation = {
   name: 'au:annotation',
   appendTo(target: Constructable, key: string): void {
-    const keys = Metadata.getOwn(annotation.name, target) as string[];
+    const keys = Metadata.getOwn(annoBaseName, target) as string[];
     if (keys === void 0) {
-      Metadata.define(annotation.name, [key], target);
+      Metadata.define(annoBaseName, [key], target);
     } else {
       keys.push(key);
     }
@@ -56,39 +57,40 @@ const annotation = {
     return Metadata.getOwn(annotation.keyFor(prop), target);
   },
   getKeys(target: Constructable): readonly string[] {
-    let keys = Metadata.getOwn(annotation.name, target) as string[];
+    let keys = Metadata.getOwn(annoBaseName, target) as string[];
     if (keys === void 0) {
-      Metadata.define(annotation.name, keys = [], target);
+      Metadata.define(annoBaseName, keys = [], target);
     }
     return keys;
   },
   isKey(key: string): boolean {
-    return key.startsWith(annotation.name);
+    return key.startsWith(annoBaseName);
   },
   keyFor(name: string, context?: string): string {
     if (context === void 0) {
-      return `${annotation.name}:${name}`;
+      return `${annoBaseName}:${name}`;
     }
 
-    return `${annotation.name}:${name}:${context}`;
+    return `${annoBaseName}:${name}:${context}`;
   },
 };
 
-const resource = {
-  name: 'au:resource',
+const resBaseName = 'au:resource';
+const resource = Object.freeze({
+  name: resBaseName,
   appendTo(target: Constructable, key: string): void {
-    const keys = Metadata.getOwn(resource.name, target) as string[];
+    const keys = Metadata.getOwn(resBaseName, target) as string[];
     if (keys === void 0) {
-      Metadata.define(resource.name, [key], target);
+      Metadata.define(resBaseName, [key], target);
     } else {
       keys.push(key);
     }
   },
   has(target: unknown): target is Constructable {
-    return Metadata.hasOwn(resource.name, target);
+    return Metadata.hasOwn(resBaseName, target);
   },
   getAll(target: Constructable): readonly ResourceDefinition[] {
-    const keys = Metadata.getOwn(resource.name, target) as string[];
+    const keys = Metadata.getOwn(resBaseName, target) as string[];
     if (keys === void 0) {
       return emptyArray;
     } else {
@@ -96,23 +98,23 @@ const resource = {
     }
   },
   getKeys(target: Constructable): readonly string[] {
-    let keys = Metadata.getOwn(resource.name, target) as string[];
+    let keys = Metadata.getOwn(resBaseName, target) as string[];
     if (keys === void 0) {
-      Metadata.define(resource.name, keys = [], target);
+      Metadata.define(resBaseName, keys = [], target);
     }
     return keys;
   },
   isKey(key: string): boolean {
-    return key.startsWith(resource.name);
+    return key.startsWith(resBaseName);
   },
   keyFor(name: string, context?: string): string {
     if (context === void 0) {
-      return `${resource.name}:${name}`;
+      return `${resBaseName}:${name}`;
     }
 
-    return `${resource.name}:${name}:${context}`;
+    return `${resBaseName}:${name}:${context}`;
   },
-};
+});
 
 export const Protocol = {
   annotation,

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -21,41 +21,43 @@ export const IAppRoot = DI.createInterface<IAppRoot>('IAppRoot');
 export interface IWorkTracker extends WorkTracker {}
 export const IWorkTracker = DI.createInterface<IWorkTracker>('IWorkTracker', x => x.singleton(WorkTracker));
 export class WorkTracker {
-  private stack: number = 0;
-  private promise: Promise<void> | null = null;
-  private resolve: (() => void) | null = null;
+  public static inject = [ILogger];
+  private _stack: number = 0;
+  private _promise: Promise<void> | null = null;
+  private _resolve: (() => void) | null = null;
+  private readonly _logger: ILogger;
 
-  public constructor(@ILogger private readonly logger: ILogger) {
-    this.logger = logger.scopeTo('WorkTracker');
+  public constructor(logger: ILogger) {
+    this._logger = logger.scopeTo('WorkTracker');
   }
 
   public start(): void {
-    this.logger.trace(`start(stack:${this.stack})`);
-    ++this.stack;
+    this._logger.trace(`start(stack:${this._stack})`);
+    ++this._stack;
   }
 
   public finish(): void {
-    this.logger.trace(`finish(stack:${this.stack})`);
-    if (--this.stack === 0) {
-      const resolve = this.resolve;
+    this._logger.trace(`finish(stack:${this._stack})`);
+    if (--this._stack === 0) {
+      const resolve = this._resolve;
       if (resolve !== null) {
-        this.resolve  = this.promise = null;
+        this._resolve  = this._promise = null;
         resolve();
       }
     }
   }
 
   public wait(): Promise<void> {
-    this.logger.trace(`wait(stack:${this.stack})`);
-    if (this.promise === null) {
-      if (this.stack === 0) {
+    this._logger.trace(`wait(stack:${this._stack})`);
+    if (this._promise === null) {
+      if (this._stack === 0) {
         return Promise.resolve();
       }
-      this.promise = new Promise(resolve => {
-        this.resolve = resolve;
+      this._promise = new Promise(resolve => {
+        this._resolve = resolve;
       });
     }
-    return this.promise;
+    return this._promise;
   }
 }
 
@@ -65,7 +67,7 @@ export class AppRoot implements IDisposable {
   public controller: ICustomElementController = (void 0)!;
   public work: IWorkTracker;
 
-  private hydratePromise: Promise<void> | void = void 0;
+  private _hydratePromise: Promise<void> | void = void 0;
 
   public constructor(
     public readonly config: ISinglePageApp,
@@ -83,7 +85,7 @@ export class AppRoot implements IDisposable {
       )
     );
 
-    this.hydratePromise = onResolve(this.runAppTasks('beforeCreate'), () => {
+    this._hydratePromise = onResolve(this._runAppTasks('beforeCreate'), () => {
       const component = config.component as Constructable | ICustomElementViewModel;
       const childCtn = container.createChild();
       let instance: object;
@@ -103,36 +105,36 @@ export class AppRoot implements IDisposable {
       )) as Controller;
 
       controller.hydrateCustomElement(hydrationInst, /* root does not have hydration context */null);
-      return onResolve(this.runAppTasks('hydrating'), () => {
-        controller.hydrate(null);
-        return onResolve(this.runAppTasks('hydrated'), () => {
-          controller.hydrateChildren();
-          this.hydratePromise = void 0;
+      return onResolve(this._runAppTasks('hydrating'), () => {
+        controller._hydrate(null);
+        return onResolve(this._runAppTasks('hydrated'), () => {
+          controller._hydrateChildren();
+          this._hydratePromise = void 0;
         });
       });
     });
   }
 
   public activate(): void | Promise<void> {
-    return onResolve(this.hydratePromise, () => {
-      return onResolve(this.runAppTasks('beforeActivate'), () => {
+    return onResolve(this._hydratePromise, () => {
+      return onResolve(this._runAppTasks('beforeActivate'), () => {
         return onResolve(this.controller.activate(this.controller, null, LifecycleFlags.fromBind, void 0), () => {
-          return this.runAppTasks('afterActivate');
+          return this._runAppTasks('afterActivate');
         });
       });
     });
   }
 
   public deactivate(): void | Promise<void> {
-    return onResolve(this.runAppTasks('beforeDeactivate'), () => {
+    return onResolve(this._runAppTasks('beforeDeactivate'), () => {
       return onResolve(this.controller.deactivate(this.controller, null, LifecycleFlags.none), () => {
-        return this.runAppTasks('afterDeactivate');
+        return this._runAppTasks('afterDeactivate');
       });
     });
   }
 
   /** @internal */
-  public runAppTasks(slot: TaskSlot): void | Promise<void> {
+  private _runAppTasks(slot: TaskSlot): void | Promise<void> {
     return resolveAll(...this.container.getAll(IAppTask).reduce((results, task) => {
       if (task.slot === slot) {
         results.push(task.run());

--- a/packages/runtime-html/src/attribute-mapper.ts
+++ b/packages/runtime-html/src/attribute-mapper.ts
@@ -14,9 +14,9 @@ export class AttrMapper {
   /** @internal */
   private readonly fns: IsTwoWayPredicate[] = [];
   /** @internal */
-  private readonly tagAttrMap: Record<string, Record<string, PropertyKey>> = createLookup();
+  private readonly _tagAttrMap: Record<string, Record<string, PropertyKey>> = createLookup();
   /** @internal */
-  private readonly globalAttrMap: Record<string, PropertyKey> = createLookup();
+  private readonly _globalAttrMap: Record<string, PropertyKey> = createLookup();
 
   public constructor(
     private readonly svg: ISVGAnalyzer,
@@ -61,7 +61,7 @@ export class AttrMapper {
     let attr: string;
     for (tagName in config) {
       newAttrMapping = config[tagName];
-      targetAttrMapping = this.tagAttrMap[tagName] ??= createLookup();
+      targetAttrMapping = this._tagAttrMap[tagName] ??= createLookup();
       for (attr in newAttrMapping) {
         if (targetAttrMapping[attr] !== void 0) {
           throw createMappedError(attr, tagName);
@@ -76,7 +76,7 @@ export class AttrMapper {
    * for all elements
    */
   public useGlobalMapping(config: Record<string, PropertyKey>): void {
-    const mapper = this.globalAttrMap;
+    const mapper = this._globalAttrMap;
     for (const attr in config) {
       if (mapper[attr] !== void 0) {
         throw createMappedError(attr, '*');
@@ -105,8 +105,8 @@ export class AttrMapper {
    * Retrieves the mapping information this mapper have for an attribute on an element
    */
   public map(node: Element, attr: string): string | null {
-    return this.tagAttrMap[node.nodeName]?.[attr] as string
-      ?? this.globalAttrMap[attr]
+    return this._tagAttrMap[node.nodeName]?.[attr] as string
+      ?? this._globalAttrMap[attr]
       ?? (isDataAttribute(node, attr, this.svg)
         ? attr
         : null);

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -42,7 +42,7 @@ export class Aurelia implements IDisposable {
 
   private next: IAppRoot | undefined = void 0;
 
-  private readonly rootProvider: InstanceProvider<IAppRoot>;
+  private readonly _rootProvider: InstanceProvider<IAppRoot>;
 
   public constructor(
     public readonly container: IContainer = DI.createContainer(),
@@ -52,7 +52,7 @@ export class Aurelia implements IDisposable {
     }
 
     container.registerResolver(IAurelia, new InstanceProvider<IAurelia>('IAurelia', this));
-    container.registerResolver(IAppRoot, this.rootProvider = new InstanceProvider('IAppRoot'));
+    container.registerResolver(IAppRoot, this._rootProvider = new InstanceProvider('IAppRoot'));
   }
 
   public register(...params: any[]): this {
@@ -61,7 +61,7 @@ export class Aurelia implements IDisposable {
   }
 
   public app(config: ISinglePageApp): Omit<this, 'register' | 'app' | 'enhance'> {
-    this.next = new AppRoot(config, this.initPlatform(config.host), this.container, this.rootProvider);
+    this.next = new AppRoot(config, this._initPlatform(config.host), this.container, this._rootProvider);
     return this;
   }
 
@@ -71,7 +71,7 @@ export class Aurelia implements IDisposable {
   public enhance<T extends unknown, K = T extends Constructable<infer I> ? I : T>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController | null): ICustomElementController<K> | Promise<ICustomElementController<K>> {
     const ctn = config.container ?? this.container.createChild();
     const host = config.host as HTMLElement;
-    const p = this.initPlatform(host);
+    const p = this._initPlatform(host);
     const comp = config.component as K;
     let bc: ICustomElementViewModel & K;
     if (typeof comp === 'function') {
@@ -107,7 +107,7 @@ export class Aurelia implements IDisposable {
     await platform.taskQueue.yield();
   }
 
-  private initPlatform(host: HTMLElement): IPlatform {
+  private _initPlatform(host: HTMLElement): IPlatform {
     let p: IPlatform;
     if (!this.container.has(IPlatform, false)) {
       if (host.ownerDocument.defaultView === null) {
@@ -121,34 +121,34 @@ export class Aurelia implements IDisposable {
     return p;
   }
 
-  private startPromise: Promise<void> | void = void 0;
+  private _startPromise: Promise<void> | void = void 0;
   public start(root: IAppRoot | undefined = this.next): void | Promise<void> {
     if (root == null) {
       throw new Error(`There is no composition root`);
     }
 
-    if (this.startPromise instanceof Promise) {
-      return this.startPromise;
+    if (this._startPromise instanceof Promise) {
+      return this._startPromise;
     }
 
-    return this.startPromise = onResolve(this.stop(), () => {
+    return this._startPromise = onResolve(this.stop(), () => {
       Reflect.set(root.host, '$aurelia', this);
-      this.rootProvider.prepare(this._root = root);
+      this._rootProvider.prepare(this._root = root);
       this._isStarting = true;
 
       return onResolve(root.activate(), () => {
         this._isRunning = true;
         this._isStarting = false;
-        this.startPromise = void 0;
-        this.dispatchEvent(root, 'au-started', root.host);
+        this._startPromise = void 0;
+        this._dispatchEvent(root, 'au-started', root.host);
       });
     });
   }
 
-  private stopPromise: Promise<void> | void = void 0;
+  private _stopPromise: Promise<void> | void = void 0;
   public stop(dispose: boolean = false): void | Promise<void> {
-    if (this.stopPromise instanceof Promise) {
-      return this.stopPromise;
+    if (this._stopPromise instanceof Promise) {
+      return this._stopPromise;
     }
 
     if (this._isRunning === true) {
@@ -156,15 +156,15 @@ export class Aurelia implements IDisposable {
       this._isRunning = false;
       this._isStopping = true;
 
-      return this.stopPromise = onResolve(root.deactivate(), () => {
+      return this._stopPromise = onResolve(root.deactivate(), () => {
         Reflect.deleteProperty(root.host, '$aurelia');
         if (dispose) {
           root.dispose();
         }
         this._root = void 0;
-        this.rootProvider.dispose();
+        this._rootProvider.dispose();
         this._isStopping = false;
-        this.dispatchEvent(root, 'au-stopped', root.host);
+        this._dispatchEvent(root, 'au-stopped', root.host);
       });
     }
   }
@@ -176,7 +176,7 @@ export class Aurelia implements IDisposable {
     this.container.dispose();
   }
 
-  private dispatchEvent(root: IAppRoot, name: string, target: HTMLElement): void {
+  private _dispatchEvent(root: IAppRoot, name: string, target: HTMLElement): void {
     const ev = new root.platform.window.CustomEvent(name, { detail: this, bubbles: true, cancelable: true });
     target.dispatchEvent(ev);
   }

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -113,8 +113,9 @@ type B345 = B45 & B3<B45>;
 type B2345 = B345 & B2<B345>;
 type B12345 = B2345 & B1<B2345>;
 
+const baseName = Protocol.annotation.keyFor('bindable');
 export const Bindable = {
-  name: Protocol.annotation.keyFor('bindable'),
+  name: baseName,
   keyFrom(name: string): string {
     return `${Bindable.name}:${name}`;
   },
@@ -161,10 +162,10 @@ export const Bindable = {
         }
 
         def = BindableDefinition.create(prop, config) as Writable<BindableDefinition>;
-        if (!Metadata.hasOwn(Bindable.name, Type, prop)) {
+        if (!Metadata.hasOwn(baseName, Type, prop)) {
           Protocol.annotation.appendTo(Type, Bindable.keyFrom(prop));
         }
-        Metadata.define(Bindable.name, def, Type, prop);
+        Metadata.define(baseName, def, Type, prop);
 
         return builder;
       },
@@ -207,12 +208,13 @@ export const Bindable = {
     let keys: string[];
     let keysLen: number;
     let Class: Constructable;
+    let i: number;
     while (--iProto >= 0) {
       Class = prototypeChain[iProto];
       keys = Protocol.annotation.getKeys(Class).filter(isBindableAnnotation);
       keysLen = keys.length;
-      for (let i = 0; i < keysLen; ++i) {
-        defs[iDefs++] = Metadata.getOwn(Bindable.name, Class, keys[i].slice(propStart)) as BindableDefinition;
+      for (i = 0; i < keysLen; ++i) {
+        defs[iDefs++] = Metadata.getOwn(baseName, Class, keys[i].slice(propStart)) as BindableDefinition;
       }
     }
     return defs;

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -33,7 +33,7 @@ export function createElement<C extends Constructable = Constructable>(
  * RenderPlan. Todo: describe goal of this class
  */
 export class RenderPlan {
-  private lazyDef?: CustomElementDefinition = void 0;
+  private _lazyDef?: CustomElementDefinition = void 0;
 
   public constructor(
     private readonly node: Node,
@@ -42,8 +42,8 @@ export class RenderPlan {
   ) {}
 
   public get definition(): CustomElementDefinition {
-    if (this.lazyDef === void 0) {
-      this.lazyDef = CustomElementDefinition.create({
+    if (this._lazyDef === void 0) {
+      this._lazyDef = CustomElementDefinition.create({
         name: CustomElement.generateName(),
         template: this.node,
         needsCompile: typeof this.node === 'string',
@@ -51,7 +51,7 @@ export class RenderPlan {
         dependencies: this.dependencies,
       });
     }
-    return this.lazyDef;
+    return this._lazyDef;
   }
 
   public createView(parentContainer: IContainer): ISyntheticView {

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -483,25 +483,26 @@ export class AttributePatternResourceDefinition implements ResourceDefinition<Co
   }
 }
 
+const apBaseName = Protocol.resource.keyFor('attribute-pattern');
+const annotationKey = 'attribute-pattern-definitions';
 export const AttributePattern: AttributePattern = Object.freeze({
-  name: Protocol.resource.keyFor('attribute-pattern'),
-  definitionAnnotationKey: 'attribute-pattern-definitions',
+  name: apBaseName,
+  definitionAnnotationKey: annotationKey,
   define<TProto, TClass>(
     patternDefs: AttributePatternDefinition[],
     Type: DecoratableAttributePattern<TProto, TClass>,
   ) {
     const definition = new AttributePatternResourceDefinition(Type);
-    const { name, definitionAnnotationKey } = AttributePattern;
-    Metadata.define(name, definition, Type);
-    Protocol.resource.appendTo(Type, name);
+    Metadata.define(apBaseName, definition, Type);
+    Protocol.resource.appendTo(Type, apBaseName);
 
-    Protocol.annotation.set(Type, definitionAnnotationKey, patternDefs);
-    Protocol.annotation.appendTo(Type, definitionAnnotationKey);
+    Protocol.annotation.set(Type, annotationKey, patternDefs);
+    Protocol.annotation.appendTo(Type, annotationKey);
 
     return Type as DecoratedAttributePattern<TProto, TClass>;
   },
   getPatternDefinitions<TProto, TClass>(Type: DecoratedAttributePattern<TProto, TClass>) {
-    return Protocol.annotation.get(Type, AttributePattern.definitionAnnotationKey) as AttributePatternDefinition[];
+    return Protocol.annotation.get(Type, annotationKey) as AttributePatternDefinition[];
   }
 });
 

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -104,24 +104,25 @@ export class BindingCommandDefinition<T extends Constructable = Constructable> i
   }
 }
 
-export const BindingCommand: BindingCommandKind = {
-  name: Protocol.resource.keyFor('binding-command'),
+const cmdBaseName = Protocol.resource.keyFor('binding-command');
+export const BindingCommand: BindingCommandKind = Object.freeze({
+  name: cmdBaseName,
   keyFrom(name: string): string {
-    return `${BindingCommand.name}:${name}`;
+    return `${cmdBaseName}:${name}`;
   },
   isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never) {
-    return typeof value === 'function' && Metadata.hasOwn(BindingCommand.name, value);
+    return typeof value === 'function' && Metadata.hasOwn(cmdBaseName, value);
   },
   define<T extends Constructable<BindingCommandInstance>>(nameOrDef: string | PartialBindingCommandDefinition, Type: T): T & BindingCommandType<T> {
     const definition = BindingCommandDefinition.create(nameOrDef, Type as Constructable<BindingCommandInstance>);
-    Metadata.define(BindingCommand.name, definition, definition.Type);
-    Metadata.define(BindingCommand.name, definition, definition);
-    Protocol.resource.appendTo(Type, BindingCommand.name);
+    Metadata.define(cmdBaseName, definition, definition.Type);
+    Metadata.define(cmdBaseName, definition, definition);
+    Protocol.resource.appendTo(Type, cmdBaseName);
 
     return definition.Type as BindingCommandType<T>;
   },
   getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T> {
-    const def = Metadata.getOwn(BindingCommand.name, Type);
+    const def = Metadata.getOwn(cmdBaseName, Type);
     if (def === void 0) {
       throw new Error(`No definition found for type ${Type.name}`);
     }
@@ -134,7 +135,7 @@ export const BindingCommand: BindingCommandKind = {
   getAnnotation<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K): PartialBindingCommandDefinition[K] {
     return Metadata.getOwn(Protocol.annotation.keyFor(prop), Type);
   },
-};
+});
 
 @bindingCommand('one-time')
 export class OneTimeBindingCommand implements BindingCommandInstance {

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -139,27 +139,28 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
   }
 }
 
-export const CustomAttribute: CustomAttributeKind = {
-  name: Protocol.resource.keyFor('custom-attribute'),
+const caBaseName = Protocol.resource.keyFor('custom-attribute');
+export const CustomAttribute: CustomAttributeKind = Object.freeze({
+  name: caBaseName,
   keyFrom(name: string): string {
-    return `${CustomAttribute.name}:${name}`;
+    return `${caBaseName}:${name}`;
   },
   isType<T>(value: T): value is (T extends Constructable ? CustomAttributeType<T> : never) {
-    return typeof value === 'function' && Metadata.hasOwn(CustomAttribute.name, value);
+    return typeof value === 'function' && Metadata.hasOwn(caBaseName, value);
   },
   for<C extends ICustomAttributeViewModel = ICustomAttributeViewModel>(node: Node, name: string): ICustomAttributeController<C> | undefined {
     return (getRef(node, CustomAttribute.keyFrom(name)) ?? void 0) as ICustomAttributeController<C> | undefined;
   },
   define<T extends Constructable>(nameOrDef: string | PartialCustomAttributeDefinition, Type: T): CustomAttributeType<T> {
     const definition = CustomAttributeDefinition.create(nameOrDef, Type as Constructable);
-    Metadata.define(CustomAttribute.name, definition, definition.Type);
-    Metadata.define(CustomAttribute.name, definition, definition);
-    Protocol.resource.appendTo(Type, CustomAttribute.name);
+    Metadata.define(caBaseName, definition, definition.Type);
+    Metadata.define(caBaseName, definition, definition);
+    Protocol.resource.appendTo(Type, caBaseName);
 
     return definition.Type as CustomAttributeType<T>;
   },
   getDefinition<T extends Constructable>(Type: T): CustomAttributeDefinition<T> {
-    const def = Metadata.getOwn(CustomAttribute.name, Type) as CustomAttributeDefinition<T>;
+    const def = Metadata.getOwn(caBaseName, Type) as CustomAttributeDefinition<T>;
     if (def === void 0) {
       throw new Error(`No definition found for type ${Type.name}`);
     }
@@ -172,4 +173,4 @@ export const CustomAttribute: CustomAttributeKind = {
   getAnnotation<K extends keyof PartialCustomAttributeDefinition>(Type: Constructable, prop: K): PartialCustomAttributeDefinition[K] {
     return Metadata.getOwn(Protocol.annotation.keyFor(prop), Type);
   },
-};
+});

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -19,10 +19,10 @@ export class Focus implements ICustomAttributeViewModel {
   /**
    * Indicates whether `apply` should be called when `attached` callback is invoked
    */
-  private needsApply: boolean = false;
+  private _needsApply: boolean = false;
 
   public constructor(
-    @INode private readonly element: INode<HTMLElement>,
+    @INode private readonly _element: INode<HTMLElement>,
     @IPlatform private readonly p: IPlatform,
   ) {}
 
@@ -47,7 +47,7 @@ export class Focus implements ICustomAttributeViewModel {
       // If the element is not currently connect
       // toggle the flag to add pending work for later
       // in attached lifecycle
-      this.needsApply = true;
+      this._needsApply = true;
     }
   }
 
@@ -55,11 +55,11 @@ export class Focus implements ICustomAttributeViewModel {
    * Invoked when the attribute is attached to the DOM.
    */
   public attached(): void {
-    if (this.needsApply) {
-      this.needsApply = false;
+    if (this._needsApply) {
+      this._needsApply = false;
       this.apply();
     }
-    const el = this.element;
+    const el = this._element;
     el.addEventListener('focus', this);
     el.addEventListener('blur', this);
   }
@@ -68,7 +68,7 @@ export class Focus implements ICustomAttributeViewModel {
    * Invoked when the attribute is afterDetachChildren from the DOM.
    */
   public afterDetachChildren(): void {
-    const el = this.element;
+    const el = this._element;
     el.removeEventListener('focus', this);
     el.removeEventListener('blur', this);
   }
@@ -98,7 +98,7 @@ export class Focus implements ICustomAttributeViewModel {
    * Focus/blur based on current value
    */
   private apply(): void {
-    const el = this.element;
+    const el = this._element;
     const isFocused = this.isElFocused;
     const shouldFocus = this.value;
     if (shouldFocus && !isFocused) {
@@ -109,6 +109,6 @@ export class Focus implements ICustomAttributeViewModel {
   }
 
   private get isElFocused(): boolean {
-    return this.element === this.p.document.activeElement;
+    return this._element === this.p.document.activeElement;
   }
 }

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -405,17 +405,18 @@ const defaultForOpts: ForOpts = {
   optional: false,
 };
 
-export const CustomElement: CustomElementKind = {
-  name: Protocol.resource.keyFor('custom-element'),
+const ceBaseName = Protocol.resource.keyFor('custom-element');
+export const CustomElement: CustomElementKind = Object.freeze({
+  name: ceBaseName,
   keyFrom(name: string): string {
-    return `${CustomElement.name}:${name}`;
+    return `${ceBaseName}:${name}`;
   },
   isType<C>(value: C): value is (C extends Constructable ? CustomElementType<C> : never) {
-    return typeof value === 'function' && Metadata.hasOwn(CustomElement.name, value);
+    return typeof value === 'function' && Metadata.hasOwn(ceBaseName, value);
   },
   for<C extends ICustomElementViewModel = ICustomElementViewModel>(node: Node, opts: ForOpts = defaultForOpts): ICustomElementController<C> {
     if (opts.name === void 0 && opts.searchParents !== true) {
-      const controller = getRef(node, CustomElement.name) as Controller<C> | null;
+      const controller = getRef(node, ceBaseName) as Controller<C> | null;
       if (controller === null) {
         if (opts.optional === true) {
           return null!;
@@ -426,7 +427,7 @@ export const CustomElement: CustomElementKind = {
     }
     if (opts.name !== void 0) {
       if (opts.searchParents !== true) {
-        const controller = getRef(node, CustomElement.name) as Controller<C> | null;
+        const controller = getRef(node, ceBaseName) as Controller<C> | null;
         if (controller === null) {
           throw new Error(`The provided node is not a custom element or containerless host.`);
         }
@@ -441,7 +442,7 @@ export const CustomElement: CustomElementKind = {
       let cur = node as INode | null;
       let foundAController = false;
       while (cur !== null) {
-        const controller = getRef(cur, CustomElement.name) as Controller<C> | null;
+        const controller = getRef(cur, ceBaseName) as Controller<C> | null;
         if (controller !== null) {
           foundAController = true;
           if (controller.is(opts.name)) {
@@ -461,7 +462,7 @@ export const CustomElement: CustomElementKind = {
 
     let cur = node as INode | null;
     while (cur !== null) {
-      const controller = getRef(cur, CustomElement.name) as Controller<C> | null;
+      const controller = getRef(cur, ceBaseName) as Controller<C> | null;
       if (controller !== null) {
         return controller as unknown as ICustomElementController<C>;
       }
@@ -473,14 +474,14 @@ export const CustomElement: CustomElementKind = {
   },
   define<C extends Constructable>(nameOrDef: string | PartialCustomElementDefinition, Type?: C | null): CustomElementType<C> {
     const definition = CustomElementDefinition.create(nameOrDef, Type as Constructable | null);
-    Metadata.define(CustomElement.name, definition, definition.Type);
-    Metadata.define(CustomElement.name, definition, definition);
-    Protocol.resource.appendTo(definition.Type, CustomElement.name);
+    Metadata.define(ceBaseName, definition, definition.Type);
+    Metadata.define(ceBaseName, definition, definition);
+    Protocol.resource.appendTo(definition.Type, ceBaseName);
 
     return definition.Type as CustomElementType<C>;
   },
   getDefinition<C extends Constructable>(Type: C): CustomElementDefinition<C> {
-    const def = Metadata.getOwn(CustomElement.name, Type) as CustomElementDefinition<C>;
+    const def = Metadata.getOwn(ceBaseName, Type) as CustomElementDefinition<C>;
     if (def === void 0) {
       throw new Error(`No definition found for type ${Type.name}`);
     }
@@ -554,7 +555,7 @@ export const CustomElement: CustomElementKind = {
       return Type;
     };
   })(),
-};
+});
 
 type DecoratorFactoryMethod<TClass> = (target: Constructable<TClass>, propertyKey: string, descriptor: PropertyDescriptor) => void;
 type ProcessContentHook = (node: INode, platform: IPlatform) => boolean | void;
@@ -569,7 +570,7 @@ export function processContent<TClass>(hook?: ProcessContentHook): CustomElement
     }
     : function (target: Constructable<TClass>) {
       hook = ensureHook(target, hook!);
-      const def = Metadata.getOwn(CustomElement.name, target) as CustomElementDefinition<Constructable<TClass>>;
+      const def = Metadata.getOwn(ceBaseName, target) as CustomElementDefinition<Constructable<TClass>>;
       if (def !== void 0) {
         (def as Writable<CustomElementDefinition<Constructable<TClass>>>).processContent = hook;
       } else {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -60,9 +60,9 @@ export class AuCompose {
   /** @internal */
   public readonly $controller!: ICustomElementController<AuCompose>;
 
-  private _p?: Promise<void> | void;
+  private pd?: Promise<void> | void;
   public get pending(): Promise<void> | void {
-    return this._p;
+    return this.pd;
   }
 
   /** @internal */
@@ -91,11 +91,11 @@ export class AuCompose {
   }
 
   public attaching(initiator: IHydratedController, parent: IHydratedController, flags: LifecycleFlags): void | Promise<void> {
-    return this._p = onResolve(
+    return this.pd = onResolve(
       this.queue(new ChangeInfo(this.view, this.viewModel, this.model, initiator, void 0)),
       (context) => {
         if (this.contextFactory.isCurrent(context)) {
-          this._p = void 0;
+          this.pd = void 0;
         }
       }
     );
@@ -103,9 +103,9 @@ export class AuCompose {
 
   public detaching(initiator: IHydratedController): void | Promise<void> {
     const cmpstn = this.c;
-    const pending = this._p;
+    const pending = this.pd;
     this.contextFactory.invalidate();
-    this.c = this._p = void 0;
+    this.c = this.pd = void 0;
     return onResolve(pending, () => cmpstn?.deactivate(initiator));
   }
 
@@ -116,12 +116,12 @@ export class AuCompose {
       this.c.update(this.model);
       return;
     }
-    this._p = onResolve(this._p, () =>
+    this.pd = onResolve(this.pd, () =>
       onResolve(
         this.queue(new ChangeInfo(this.view!, this.viewModel, this.model, void 0, name)),
         (context) => {
           if (this.contextFactory.isCurrent(context)) {
-            this._p = void 0;
+            this.pd = void 0;
           }
         }
       )

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -19,9 +19,9 @@ export class AuSlot implements ICustomElementViewModel {
   public readonly view: ISyntheticView;
   public readonly $controller!: ICustomElementController<this>; // This is set by the controller after this instance is constructed
 
-  private parentScope: Scope | null = null;
-  private outerScope: Scope | null = null;
-  private readonly hasProjection: boolean;
+  private _parentScope: Scope | null = null;
+  private _outerScope: Scope | null = null;
+  private readonly _hasProjection: boolean;
 
   @bindable
   public expose: object | undefined;
@@ -37,10 +37,10 @@ export class AuSlot implements ICustomElementViewModel {
     const projection = hdrContext.instruction?.projections?.[slotInfo.name];
     if (projection == null) {
       factory = rendering.getViewFactory(slotInfo.fallback, hdrContext.controller.container);
-      this.hasProjection = false;
+      this._hasProjection = false;
     } else {
       factory = rendering.getViewFactory(projection, hdrContext.parent!.controller.container);
-      this.hasProjection = true;
+      this._hasProjection = true;
     }
     this.view = factory.create().setLocation(location);
   }
@@ -50,17 +50,17 @@ export class AuSlot implements ICustomElementViewModel {
     _parent: IHydratedParentController,
     _flags: LifecycleFlags,
   ): void | Promise<void> {
-    this.parentScope = this.$controller.scope.parentScope!;
+    this._parentScope = this.$controller.scope.parentScope!;
     let outerScope: Scope;
-    if (this.hasProjection) {
+    if (this._hasProjection) {
       // if there is a projection,
       // then the au-slot should connect the outer scope with the inner scope binding context
       // via overlaying the outerscope with another scope that has
       // - binding context & override context pointing to the outer scope binding & override context respectively
       // - override context has the $host pointing to inner scope binding context
       outerScope = this.hdrContext.controller.scope.parentScope!;
-      (this.outerScope = Scope.fromParent(outerScope, outerScope.bindingContext))
-        .overrideContext.$host = this.expose ?? this.parentScope.bindingContext;
+      (this._outerScope = Scope.fromParent(outerScope, outerScope.bindingContext))
+        .overrideContext.$host = this.expose ?? this._parentScope.bindingContext;
     }
   }
 
@@ -73,7 +73,7 @@ export class AuSlot implements ICustomElementViewModel {
       initiator,
       this.$controller,
       flags,
-      this.hasProjection ? this.outerScope! : this.parentScope!,
+      this._hasProjection ? this._outerScope! : this._parentScope!,
     );
   }
 
@@ -86,8 +86,8 @@ export class AuSlot implements ICustomElementViewModel {
   }
 
   public exposeChanged(v: object): void {
-    if (this.hasProjection && this.outerScope != null) {
-      this.outerScope.overrideContext.$host = v;
+    if (this._hasProjection && this._outerScope != null) {
+      this._outerScope.overrideContext.$host = v;
     }
   }
 

--- a/packages/runtime-html/src/template-element-factory.ts
+++ b/packages/runtime-html/src/template-element-factory.ts
@@ -14,12 +14,12 @@ const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 
 export class TemplateElementFactory {
   public static inject = [IPlatform];
-  private template: HTMLTemplateElement;
+  private _template: HTMLTemplateElement;
 
   public constructor(
     private readonly p: IPlatform,
   ) {
-    this.template = p.document.createElement('template');
+    this._template = p.document.createElement('template');
   }
 
   public createTemplate(markup: string): HTMLTemplateElement;
@@ -29,13 +29,13 @@ export class TemplateElementFactory {
     if (typeof input === 'string') {
       let result = markupCache[input];
       if (result === void 0) {
-        const template = this.template;
+        const template = this._template;
         template.innerHTML = input;
         const node = template.content.firstElementChild;
         // if the input is either not wrapped in a template or there is more than one node,
         // return the whole template that wraps it/them (and create a new one for the next input)
         if (node == null || node.nodeName !== 'TEMPLATE' || node.nextElementSibling != null) {
-          this.template = this.p.document.createElement('template');
+          this._template = this.p.document.createElement('template');
           result = template;
         } else {
           // the node to return is both a template and the only node, so return just the node

--- a/packages/runtime-html/src/templating/dialog/dialog-service.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-service.ts
@@ -42,9 +42,9 @@ export class DialogService implements IDialogService {
   protected static get inject() { return [IContainer, IPlatform, IDialogGlobalSettings]; }
 
   public constructor(
-    private readonly container: IContainer,
+    private readonly _ctn: IContainer,
     private readonly p: IPlatform,
-    private readonly defaultSettings: IDialogGlobalSettings,
+    private readonly _defaultSettings: IDialogGlobalSettings,
   ) {}
 
   public static register(container: IContainer) {
@@ -81,8 +81,8 @@ export class DialogService implements IDialogService {
    */
   public open(settings: IDialogSettings): DialogOpenPromise {
     return asDialogOpenPromise(new Promise<DialogOpenResult>(resolve => {
-      const $settings = DialogSettings.from(this.defaultSettings, settings);
-      const container = $settings.container ?? this.container.createChild();
+      const $settings = DialogSettings.from(this._defaultSettings, settings);
+      const container = $settings.container ?? this._ctn.createChild();
 
       resolve(onResolve(
         $settings.load(),

--- a/packages/runtime-html/src/templating/lifecycle-hooks.ts
+++ b/packages/runtime-html/src/templating/lifecycle-hooks.ts
@@ -59,15 +59,16 @@ export class LifecycleHooksDefinition<T extends Constructable = Constructable> {
 
 const containerLookup = new WeakMap<IContainer, LifecycleHooksLookup<any>>();
 
-export const LifecycleHooks = {
-  name: Protocol.annotation.keyFor('lifecycle-hooks'),
+const lhBaseName = Protocol.annotation.keyFor('lifecycle-hooks');
+export const LifecycleHooks = Object.freeze({
+  name: lhBaseName,
   /**
    * @param def - Placeholder for future extensions. Currently always an empty object.
    */
   define<T extends Constructable>(def: {}, Type: T): T {
     const definition = LifecycleHooksDefinition.create(def, Type);
-    Metadata.define(LifecycleHooks.name, definition, Type);
-    Protocol.resource.appendTo(Type, LifecycleHooks.name);
+    Metadata.define(lhBaseName, definition, Type);
+    Protocol.resource.appendTo(Type, lhBaseName);
     return definition.Type;
   },
   resolve(ctx: IContainer): LifecycleHooksLookup {
@@ -90,7 +91,7 @@ export const LifecycleHooks = {
       let entries: LifecycleHooksEntry[];
 
       for (instance of instances) {
-        definition = Metadata.getOwn(LifecycleHooks.name, instance.constructor);
+        definition = Metadata.getOwn(lhBaseName, instance.constructor);
         entry = new LifecycleHooksEntry(definition, instance);
         for (name of definition.propertyNames) {
           entries = lookup[name] as LifecycleHooksEntry[];
@@ -104,7 +105,7 @@ export const LifecycleHooks = {
     }
     return lookup;
   },
-};
+});
 
 class LifecycleHooksLookupImpl implements LifecycleHooksLookup {}
 

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -14,16 +14,16 @@ export interface IRendering extends Rendering { }
 
 export class Rendering {
   public static inject: unknown[] = [IContainer];
-  private readonly c: IContainer;
+  private readonly _ctn: IContainer;
   private rs: Record<string, IRenderer> | undefined;
-  private readonly p: IPlatform;
-  private readonly compilationCache: WeakMap<PartialCustomElementDefinition, CustomElementDefinition> = new WeakMap();
-  private readonly fragmentCache: WeakMap<CustomElementDefinition, DocumentFragment | null> = new WeakMap();
-  private readonly empty: INodeSequence;
+  private readonly _p: IPlatform;
+  private readonly _compilationCache: WeakMap<PartialCustomElementDefinition, CustomElementDefinition> = new WeakMap();
+  private readonly _fragmentCache: WeakMap<CustomElementDefinition, DocumentFragment | null> = new WeakMap();
+  private readonly _empty: INodeSequence;
 
   public get renderers(): Record<string, IRenderer> {
     return this.rs == null
-      ? (this.rs = this.c.getAll(IRenderer, false).reduce((all, r) => {
+      ? (this.rs = this._ctn.getAll(IRenderer, false).reduce((all, r) => {
           all[r.instructionType!] = r;
           return all;
         }, createLookup<IRenderer>()))
@@ -31,8 +31,8 @@ export class Rendering {
   }
 
   public constructor(container: IContainer) {
-    this.p = (this.c = container.root).get(IPlatform);
-    this.empty = new FragmentNodeSequence(this.p, this.p.document.createDocumentFragment());
+    this._p = (this._ctn = container.root).get(IPlatform);
+    this._empty = new FragmentNodeSequence(this._p, this._p.document.createDocumentFragment());
   }
 
   public compile(
@@ -41,7 +41,7 @@ export class Rendering {
     compilationInstruction: ICompliationInstruction | null,
   ): CustomElementDefinition {
     if (definition.needsCompile !== false) {
-      const compiledMap = this.compilationCache;
+      const compiledMap = this._compilationCache;
       const compiler = container.get(ITemplateCompiler);
       let compiled = compiledMap.get(definition);
       if (compiled == null) {
@@ -64,14 +64,14 @@ export class Rendering {
 
   public createNodes(definition: CustomElementDefinition): INodeSequence {
     if (definition.enhance === true) {
-      return new FragmentNodeSequence(this.p, definition.template as DocumentFragment);
+      return new FragmentNodeSequence(this._p, definition.template as DocumentFragment);
     }
     let fragment: DocumentFragment | null | undefined;
-    const cache = this.fragmentCache;
+    const cache = this._fragmentCache;
     if (cache.has(definition)) {
       fragment = cache.get(definition);
     } else {
-      const p = this.p;
+      const p = this._p;
       const doc = p.document;
       const template = definition.template;
       let tpl: HTMLTemplateElement;
@@ -93,8 +93,8 @@ export class Rendering {
       cache.set(definition, fragment);
     }
     return fragment == null
-      ? this.empty
-      : new FragmentNodeSequence(this.p, fragment.cloneNode(true) as DocumentFragment);
+      ? this._empty
+      : new FragmentNodeSequence(this._p, fragment.cloneNode(true) as DocumentFragment);
   }
 
   public render(

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -109,16 +109,17 @@ class WatchDefinition<T extends object> implements IWatchDefinition<T> {
 }
 
 const noDefinitions: IWatchDefinition[] = emptyArray;
+const watchBaseName = Protocol.annotation.keyFor('watch');
 export const Watch = {
-  name: Protocol.annotation.keyFor('watch'),
+  name: watchBaseName,
   add(Type: Constructable, definition: IWatchDefinition): void {
-    let watchDefinitions: IWatchDefinition[] = Metadata.getOwn(Watch.name, Type);
+    let watchDefinitions: IWatchDefinition[] = Metadata.getOwn(watchBaseName, Type);
     if (watchDefinitions == null) {
-      Metadata.define(Watch.name, watchDefinitions = [], Type);
+      Metadata.define(watchBaseName, watchDefinitions = [], Type);
     }
     watchDefinitions.push(definition);
   },
   getAnnotation(Type: Constructable): IWatchDefinition[] {
-    return Metadata.getOwn(Watch.name, Type) ?? noDefinitions;
+    return Metadata.getOwn(watchBaseName, Type) ?? noDefinitions;
   },
 };

--- a/packages/runtime/src/binding-behavior.ts
+++ b/packages/runtime/src/binding-behavior.ts
@@ -116,7 +116,7 @@ export class BindingBehaviorFactory<T extends Constructable = Constructable> {
   private readonly deps: readonly Key[];
 
   public constructor(
-    private readonly container: IContainer,
+    private readonly ctn: IContainer,
     private readonly Type: BindingBehaviorType<T>,
   ) {
     this.deps = DI.getDependencies(Type);
@@ -126,7 +126,7 @@ export class BindingBehaviorFactory<T extends Constructable = Constructable> {
     binding: IInterceptableBinding,
     expr: BindingBehaviorExpression,
   ): IInterceptableBinding {
-    const container = this.container;
+    const container = this.ctn;
     const deps = this.deps;
     switch (deps.length) {
       case 0:
@@ -217,24 +217,25 @@ export class BindingInterceptor implements IInterceptableBinding {
   }
 }
 
-export const BindingBehavior: BindingBehaviorKind = {
-  name: Protocol.resource.keyFor('binding-behavior'),
+const bbBaseName = Protocol.resource.keyFor('binding-behavior');
+export const BindingBehavior: BindingBehaviorKind = Object.freeze({
+  name: bbBaseName,
   keyFrom(name: string): string {
-    return `${BindingBehavior.name}:${name}`;
+    return `${bbBaseName}:${name}`;
   },
   isType<T>(value: T): value is (T extends Constructable ? BindingBehaviorType<T> : never) {
-    return typeof value === 'function' && Metadata.hasOwn(BindingBehavior.name, value);
+    return typeof value === 'function' && Metadata.hasOwn(bbBaseName, value);
   },
   define<T extends Constructable<BindingBehaviorInstance>>(nameOrDef: string | PartialBindingBehaviorDefinition, Type: T): BindingBehaviorType<T> {
     const definition = BindingBehaviorDefinition.create(nameOrDef, Type as Constructable<BindingBehaviorInstance>);
-    Metadata.define(BindingBehavior.name, definition, definition.Type);
-    Metadata.define(BindingBehavior.name, definition, definition);
-    Protocol.resource.appendTo(Type, BindingBehavior.name);
+    Metadata.define(bbBaseName, definition, definition.Type);
+    Metadata.define(bbBaseName, definition, definition);
+    Protocol.resource.appendTo(Type, bbBaseName);
 
     return definition.Type as BindingBehaviorType<T>;
   },
   getDefinition<T extends Constructable>(Type: T): BindingBehaviorDefinition<T> {
-    const def = Metadata.getOwn(BindingBehavior.name, Type) as BindingBehaviorDefinition<T>;
+    const def = Metadata.getOwn(bbBaseName, Type) as BindingBehaviorDefinition<T>;
     if (def === void 0) {
       throw new Error(`No definition found for type ${Type.name}`);
     }
@@ -247,4 +248,4 @@ export const BindingBehavior: BindingBehaviorKind = {
   getAnnotation<K extends keyof PartialBindingBehaviorDefinition>(Type: Constructable, prop: K): PartialBindingBehaviorDefinition[K] {
     return Metadata.getOwn(Protocol.annotation.keyFor(prop), Type) as PartialBindingBehaviorDefinition[K];
   },
-};
+});

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -43,9 +43,7 @@ function observe(this: IConnectableBinding, obj: object, key: PropertyKey): void
   this.obs.add(observer);
 }
 function getObserverRecord(this: IConnectableBinding): BindingObserverRecord {
-  const record = new BindingObserverRecord(this);
-  defineHiddenProp(this, 'obs', record);
-  return record;
+  return defineHiddenProp(this, 'obs', new BindingObserverRecord(this));
 }
 
 function observeCollection(this: IConnectableBinding, collection: Collection): void {

--- a/packages/runtime/src/observation/flush-queue.ts
+++ b/packages/runtime/src/observation/flush-queue.ts
@@ -28,20 +28,20 @@ export interface IWithFlushQueue {
 export class FlushQueue {
   public static readonly instance: FlushQueue = new FlushQueue();
 
-  private flushing: boolean = false;
-  private readonly items: Set<IFlushable> = new Set();
+  private _flushing: boolean = false;
+  private readonly _items: Set<IFlushable> = new Set();
 
   public get count(): number {
-    return this.items.size;
+    return this._items.size;
   }
 
   public add(callable: IFlushable): void {
-    this.items.add(callable);
-    if (this.flushing) {
+    this._items.add(callable);
+    if (this._flushing) {
       return;
     }
-    this.flushing = true;
-    const items = this.items;
+    this._flushing = true;
+    const items = this._items;
     let item: IFlushable;
     try {
       for (item of items) {
@@ -49,13 +49,13 @@ export class FlushQueue {
         item.flush();
       }
     } finally {
-      this.flushing = false;
+      this._flushing = false;
     }
   }
 
   public clear(): void {
-    this.items.clear();
-    this.flushing = false;
+    this._items.clear();
+    this._flushing = false;
   }
 }
 

--- a/packages/runtime/src/observation/signaler.ts
+++ b/packages/runtime/src/observation/signaler.ts
@@ -15,7 +15,8 @@ export class Signaler {
     if (listeners === undefined) {
       return;
     }
-    for (const listener of listeners.keys()) {
+    let listener: ISubscriber;
+    for (listener of listeners.keys()) {
       listener.handleChange(undefined, undefined, flags!);
     }
   }

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -208,9 +208,7 @@ export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRe
 }
 
 function getSubscriberRecord(this: ISubscriberCollection) {
-  const record = new SubscriberRecord();
-  defineHiddenProp(this, 'subs', record);
-  return record;
+  return defineHiddenProp(this, 'subs', new SubscriberRecord());
 }
 
 function addSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber): boolean {

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -1,12 +1,13 @@
 
 export const def = Reflect.defineProperty;
-export function defineHiddenProp(obj: object, key: PropertyKey, value: unknown): void {
+export function defineHiddenProp<T extends unknown>(obj: object, key: PropertyKey, value: T): T {
   def(obj, key, {
     enumerable: false,
     configurable: true,
     writable: true,
     value
   });
+  return value;
 }
 
 export function ensureProto<T extends object, K extends keyof T>(

--- a/packages/runtime/src/value-converter.ts
+++ b/packages/runtime/src/value-converter.ts
@@ -84,24 +84,25 @@ export class ValueConverterDefinition<T extends Constructable = Constructable> i
   }
 }
 
-export const ValueConverter: ValueConverterKind = {
-  name: Protocol.resource.keyFor('value-converter'),
+const vcBaseName = Protocol.resource.keyFor('value-converter');
+export const ValueConverter: ValueConverterKind = Object.freeze({
+  name: vcBaseName,
   keyFrom(name: string): string {
-    return `${ValueConverter.name}:${name}`;
+    return `${vcBaseName}:${name}`;
   },
   isType<T>(value: T): value is (T extends Constructable ? ValueConverterType<T> : never) {
-    return typeof value === 'function' && Metadata.hasOwn(ValueConverter.name, value);
+    return typeof value === 'function' && Metadata.hasOwn(vcBaseName, value);
   },
   define<T extends Constructable<ValueConverterInstance>>(nameOrDef: string | PartialValueConverterDefinition, Type: T): ValueConverterType<T> {
     const definition = ValueConverterDefinition.create(nameOrDef, Type as Constructable<ValueConverterInstance>);
-    Metadata.define(ValueConverter.name, definition, definition.Type);
-    Metadata.define(ValueConverter.name, definition, definition);
-    Protocol.resource.appendTo(Type, ValueConverter.name);
+    Metadata.define(vcBaseName, definition, definition.Type);
+    Metadata.define(vcBaseName, definition, definition);
+    Protocol.resource.appendTo(Type, vcBaseName);
 
     return definition.Type as ValueConverterType<T>;
   },
   getDefinition<T extends Constructable>(Type: T): ValueConverterDefinition<T> {
-    const def = Metadata.getOwn(ValueConverter.name, Type);
+    const def = Metadata.getOwn(vcBaseName, Type);
     if (def === void 0) {
       throw new Error(`No definition found for type ${Type.name}`);
     }
@@ -114,4 +115,4 @@ export const ValueConverter: ValueConverterKind = {
   getAnnotation<K extends keyof PartialValueConverterDefinition>(Type: Constructable, prop: K): PartialValueConverterDefinition[K] {
     return Metadata.getOwn(Protocol.annotation.keyFor(prop), Type);
   },
-};
+});


### PR DESCRIPTION
# Pull Request

## 📖 Description

As part of improving runtime bundle size and performance, we now mark all our internal & private symbols with a prefix `_` to let terser mangle them to single or 2 letter symbols. This is the first batch. Next all public symbols should be reconsidered and mark private where not really necessary to be private.