### PR TITLE
refactor(compiler): rename instructions to props on CE/CA instruction

### DIFF
--- a/docs/user-docs/developer-guides/the-template-compiler.md
+++ b/docs/user-docs/developer-guides/the-template-compiler.md
@@ -75,3 +75,25 @@ List of attributes that are considered expressions:
 * custom attribute
 * custom element bindables
 
+## Node APIs used
+
+The default template compiler will turn a template, either in string or already an element, into an element before the compilation. During the compilation, these APIs on the `Node` & `Element` classes are accessed and invoked:
+
+- `Node.prototype.nodeType`
+- `Node.prototype.nodeName`
+- `Node.prototype.childNodes`
+- `Node.prototype.childNode`
+- `Node.prototype.firstChild`
+- `Node.prototype.textContent`
+- `Node.prototype.parentNode`
+- `Node.prototype.appendChild`
+- `Node.prototype.insertBefore`
+- `Element.prototype.attributes`
+- `Element.prototype.hasAttribute`
+- `Element.prototype.getAttribute`
+- `Element.prototype.setAttribute`
+- `Element.prototype.classList.add`
+
+If it is desirable to use the default template compiler in any other environment other than HTML, make sure the template compiler can hydrate the input string or object into some object with the above APIs.
+
+TODO: examples of some hydrator for different environments

--- a/packages/__tests__/3-runtime-html/create-element.spec.ts
+++ b/packages/__tests__/3-runtime-html/create-element.spec.ts
@@ -134,17 +134,17 @@ describe(`createElement() creates element based on type`, function () {
         assert.strictEqual(actual['instructions'][0].length, 1, `actual['instructions'][0].length`);
         assert.strictEqual(instruction.type, InstructionType.hydrateElement, `instruction.type`);
         assert.strictEqual(instruction.res, definition, `instruction.res`);
-        assert.strictEqual(instruction.instructions.length, 2, `instruction.instructions.length`);
-        assert.strictEqual(instruction.instructions[0].type, InstructionType.setAttribute, `instruction.instructions[0].type`);
-        assert.strictEqual(instruction.instructions[0]['to'], 'title', `instruction.instructions[0]['to']`);
-        assert.strictEqual(instruction.instructions[0]['value'], 'asdf', `instruction.instructions[0]['value']`);
+        assert.strictEqual(instruction.props.length, 2, `instruction.props.length`);
+        assert.strictEqual(instruction.props[0].type, InstructionType.setAttribute, `instruction.props[0].type`);
+        assert.strictEqual(instruction.props[0]['to'], 'title', `instruction.props[0]['to']`);
+        assert.strictEqual(instruction.props[0]['value'], 'asdf', `instruction.props[0]['value']`);
         if (definition.bindables['foo']) {
-          assert.strictEqual(instruction.instructions[1].type, InstructionType.setProperty, `instruction.instructions[1].type`);
+          assert.strictEqual(instruction.props[1].type, InstructionType.setProperty, `instruction.props[1].type`);
         } else {
-          assert.strictEqual(instruction.instructions[1].type, InstructionType.setAttribute, `instruction.instructions[1].type`);
+          assert.strictEqual(instruction.props[1].type, InstructionType.setAttribute, `instruction.props[1].type`);
         }
-        assert.strictEqual(instruction.instructions[1]['to'], 'foo', `instruction.instructions[1]['to']`);
-        assert.strictEqual(instruction.instructions[1]['value'], 'bar', `instruction.instructions[1]['value']`);
+        assert.strictEqual(instruction.props[1]['to'], 'foo', `instruction.props[1]['to']`);
+        assert.strictEqual(instruction.props[1]['value'], 'bar', `instruction.props[1]['value']`);
         assert.strictEqual(node.getAttribute('class'), 'au', `node.getAttribute('class')`);
       });
 
@@ -159,7 +159,7 @@ describe(`createElement() creates element based on type`, function () {
 
           assert.strictEqual(actual['instructions'].length, 1, `actual['instructions'].length`);
           assert.strictEqual(actual['instructions'][0].length, 1, `actual['instructions'][0].length`);
-          assert.strictEqual(instruction.instructions.length, 0, `instruction.instructions.length`);
+          assert.strictEqual(instruction.props.length, 0, `instruction.props.length`);
           assert.strictEqual(node.getAttribute('class'), 'au', `node.getAttribute('class')`);
         });
       });
@@ -198,8 +198,8 @@ describe(`createElement() creates element based on type`, function () {
             assert.strictEqual(actual['instructions'][0].length, 1, `actual['instructions'][0].length`);
             assert.strictEqual(instruction.type, InstructionType.hydrateElement, `instruction.type`);
             assert.strictEqual(instruction.res, definition, `instruction.res`);
-            assert.strictEqual(instruction.instructions.length, 1, `instruction.instructions.length`);
-            assert.strictEqual(instruction.instructions[0].type, t, `instruction.instructions[0].type`);
+            assert.strictEqual(instruction.props.length, 1, `instruction.props.length`);
+            assert.strictEqual(instruction.props[0].type, t, `instruction.props[0].type`);
             assert.strictEqual(node.getAttribute('class'), 'au', `node.getAttribute('class')`);
           });
         });
@@ -231,7 +231,7 @@ describe(`createElement() creates element based on type`, function () {
           assert.strictEqual(actual['instructions'][0].length, 1, `actual['instructions'][0].length`);
           assert.strictEqual(instruction.type, InstructionType.hydrateElement, `instruction.type`);
           assert.strictEqual(instruction.res, definition, `instruction.res`);
-          assert.strictEqual(instruction.instructions.length, 0, `instruction.instructions.length`);
+          assert.strictEqual(instruction.props.length, 0, `instruction.props.length`);
           assert.strictEqual(node.getAttribute('class'), 'au', `node.getAttribute('class')`);
 
           assert.strictEqual(node.textContent, expected, `node.textContent`);

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -707,7 +707,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
     }
     node.setAttribute(attr, value);
     const rawMarkup = node.outerHTML;
-    const instruction: Partial<HydrateTemplateController> = {
+    const instruction: Partial<HydrateTemplateController & { def: PartialCustomElementDefinition & { key: string } }> = {
       type: TT.hydrateTemplateController,
       res: resolveRes ? ctx.container.find(CustomAttribute, target)! : target,
       def: {
@@ -719,7 +719,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
         needsCompile: false,
         enhance: false,
         processContent: null,
-      } as PartialCustomElementDefinition,
+      },
       props: createTplCtrlAttributeInstruction(attr, value),
     };
     const input: PartialCustomElementDefinition = {
@@ -745,7 +745,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
       compiledMarkup = `<${tagName}><au-m class="au"></au-m></${tagName}>`;
       instructions = [[childInstr]];
     }
-    const instruction: Partial<HydrateTemplateController> = {
+    const instruction: Partial<HydrateTemplateController & { def: PartialCustomElementDefinition & { key: string } }> = {
       type: TT.hydrateTemplateController,
       res: resolveRes ? ctx.container.find(CustomAttribute, target)! : target,
       def: {
@@ -757,7 +757,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
         needsCompile: false,
         enhance: false,
         processContent: null,
-      } as PartialCustomElementDefinition,
+      },
       props: createTplCtrlAttributeInstruction(attr, value),
     };
     const rawMarkup = `<${tagName} ${attr}="${value || ''}">${childTpl || ''}</${tagName}>`;

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -133,7 +133,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
     this._ensureKeyExpression();
     this.parameter?.$bind(flags, scope);
 
-    this.updateTranslations(flags);
+    this._updateTranslations(flags);
     this.isBound = true;
   }
 
@@ -164,24 +164,24 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
         : newValue as string;
     this.obs.clear(false);
     this._ensureKeyExpression();
-    this.updateTranslations(flags);
+    this._updateTranslations(flags);
   }
 
   public handleLocaleChange() {
     // todo:
     // no flag passed, so if a locale is updated during binding of a component
     // and the author wants to signal that locale change fromBind, then it's a bug
-    this.updateTranslations(LifecycleFlags.none);
+    this._updateTranslations(LifecycleFlags.none);
   }
 
   public useParameter(expr: IsExpression) {
     if (this.parameter != null) {
       throw new Error('This translation parameter has already been specified.');
     }
-    this.parameter = new ParameterBinding(this, expr, (flags: LifecycleFlags) => this.updateTranslations(flags));
+    this.parameter = new ParameterBinding(this, expr, (flags: LifecycleFlags) => this._updateTranslations(flags));
   }
 
-  private updateTranslations(flags: LifecycleFlags) {
+  private _updateTranslations(flags: LifecycleFlags) {
     const results = this.i18n.evaluate(this._keyExpression!, this.parameter?.value);
     const content: ContentValue = Object.create(null);
     const accessorUpdateTasks: AccessorUpdateTask[] = [];
@@ -278,20 +278,20 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
   private _prepareTemplate(content: ContentValue, marker: string, fallBackContents: ChildNode[]) {
     const template = this.platform.document.createElement('template');
 
-    this.addContentToTemplate(template, content.prepend, marker);
+    this._addContentToTemplate(template, content.prepend, marker);
 
     // build content: prioritize [html], then textContent, and falls back to original content
-    if (!this.addContentToTemplate(template, content.innerHTML ?? content.textContent, marker)) {
+    if (!this._addContentToTemplate(template, content.innerHTML ?? content.textContent, marker)) {
       for (const fallbackContent of fallBackContents) {
         template.content.append(fallbackContent);
       }
     }
 
-    this.addContentToTemplate(template, content.append, marker);
+    this._addContentToTemplate(template, content.append, marker);
     return template;
   }
 
-  private addContentToTemplate(template: HTMLTemplateElement, content: string | undefined, marker: string) {
+  private _addContentToTemplate(template: HTMLTemplateElement, content: string | undefined, marker: string) {
     if (content !== void 0 && content !== null) {
       const parser = this.platform.document.createElement('div');
       parser.innerHTML = content;

--- a/packages/runtime-html/src/binding-behaviors/throttle.ts
+++ b/packages/runtime-html/src/binding-behaviors/throttle.ts
@@ -10,8 +10,8 @@ const defaultDelay = 200;
 // - (v1) the rate at which the view-model is updated in two-way bindings, OR
 // - (v1 + v2) the rate at which the view is updated in to-view binding scenarios.
 export class ThrottleBindingBehavior extends BindingInterceptor {
-  private readonly taskQueue: TaskQueue;
-  private readonly platform: IPlatform;
+  private readonly _taskQueue: TaskQueue;
+  private readonly _platform: IPlatform;
   private readonly opts: QueueTaskOptions = { delay: defaultDelay };
   private readonly firstArg: IsAssign | null = null;
   private task: ITask | null = null;
@@ -23,15 +23,15 @@ export class ThrottleBindingBehavior extends BindingInterceptor {
     expr: BindingBehaviorExpression,
   ) {
     super(binding, expr);
-    this.platform = binding.locator.get(IPlatform);
-    this.taskQueue = this.platform.taskQueue;
+    this._platform = binding.locator.get(IPlatform);
+    this._taskQueue = this._platform.taskQueue;
     if (expr.args.length > 0) {
       this.firstArg = expr.args[0];
     }
   }
 
   public callSource(args: object): unknown {
-    this.queueTask(() => this.binding.callSource!(args));
+    this._queueTask(() => this.binding.callSource!(args));
     return void 0;
   }
 
@@ -41,25 +41,25 @@ export class ThrottleBindingBehavior extends BindingInterceptor {
     if (this.task !== null) {
       this.task.cancel();
       this.task = null;
-      this.lastCall = this.platform.performanceNow();
+      this.lastCall = this._platform.performanceNow();
     }
     this.binding.handleChange(newValue, oldValue, flags);
   }
 
   public updateSource(newValue: unknown, flags: LifecycleFlags): void {
-    this.queueTask(() => this.binding.updateSource!(newValue, flags));
+    this._queueTask(() => this.binding.updateSource!(newValue, flags));
   }
 
-  private queueTask(callback: () => void): void {
+  private _queueTask(callback: () => void): void {
     const opts = this.opts;
-    const platform = this.platform;
+    const platform = this._platform;
     const nextDelay = this.lastCall + opts.delay! - platform.performanceNow();
 
     if (nextDelay > 0) {
       // Queue the new one before canceling the old one, to prevent early yield
       const task = this.task;
       opts.delay = nextDelay;
-      this.task = this.taskQueue.queueTask(() => {
+      this.task = this._taskQueue.queueTask(() => {
         this.lastCall = platform.performanceNow();
         this.task = null;
         opts.delay = this.delay;

--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -66,7 +66,7 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
 
       const val = obj[propertyKey];
       this.value = hasSetter && val !== void 0 ? set(val) : val;
-      this.createGetterSetter();
+      this._createGetterSetter();
     }
   }
 
@@ -113,7 +113,7 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
       this.value = this.hasSetter
         ? this.set(currentValue)
         : currentValue;
-      this.createGetterSetter();
+      this._createGetterSetter();
     }
 
     this.subs.add(subscriber);
@@ -125,7 +125,7 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
     this.subs.notify(this.value, oV, this.f);
   }
 
-  private createGetterSetter(): void {
+  private _createGetterSetter(): void {
     Reflect.defineProperty(
       this.obj,
       this.propertyKey,

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -7,6 +7,8 @@ import {
   withFlushQueue,
 } from '@aurelia/runtime';
 import { getCollectionObserver } from './observer-locator.js';
+import { hasOwnProperty } from '../utilities-html.js';
+
 import type { INode } from '../dom.js';
 import type { EventSubscriber } from './event-delegator.js';
 import type { ValueAttributeObserver } from './value-attribute-observer.js';
@@ -76,23 +78,23 @@ export class CheckedObserver implements IObserver, IFlushable, IWithFlushQueue {
     this.value = newValue;
     this.oldValue = currentValue;
     this.f = flags;
-    this.observe();
-    this.synchronizeElement();
+    this._observe();
+    this._synchronizeElement();
     this.queue.add(this);
   }
 
   public handleCollectionChange(indexMap: IndexMap, flags: LifecycleFlags): void {
-    this.synchronizeElement();
+    this._synchronizeElement();
   }
 
   public handleChange(newValue: unknown, previousValue: unknown, flags: LifecycleFlags): void {
-    this.synchronizeElement();
+    this._synchronizeElement();
   }
 
-  public synchronizeElement(): void {
+  private _synchronizeElement(): void {
     const currentValue = this.value;
     const obj = this.obj;
-    const elementValue = Object.prototype.hasOwnProperty.call(obj, 'model') as boolean ? obj.model : obj.value;
+    const elementValue = hasOwnProperty.call(obj, 'model') as boolean ? obj.model : obj.value;
     const isRadio = obj.type === 'radio';
     const matcher = obj.matcher !== void 0 ? obj.matcher : defaultMatcher;
 
@@ -130,7 +132,7 @@ export class CheckedObserver implements IObserver, IFlushable, IWithFlushQueue {
   public handleEvent(): void {
     let currentValue = this.oldValue = this.value;
     const obj = this.obj;
-    const elementValue = Object.prototype.hasOwnProperty.call(obj, 'model') as boolean ? obj.model : obj.value;
+    const elementValue = hasOwnProperty.call(obj, 'model') as boolean ? obj.model : obj.value;
     const isChecked = obj.checked;
     const matcher = obj.matcher !== void 0 ? obj.matcher : defaultMatcher;
 
@@ -236,7 +238,7 @@ export class CheckedObserver implements IObserver, IFlushable, IWithFlushQueue {
 
   public start() {
     this.handler.subscribe(this.obj, this);
-    this.observe();
+    this._observe();
   }
 
   public stop(): void {
@@ -265,7 +267,7 @@ export class CheckedObserver implements IObserver, IFlushable, IWithFlushQueue {
     this.subs.notify(this.value, oV, this.f);
   }
 
-  private observe() {
+  private _observe() {
     const obj = this.obj;
 
     (this._valueObserver ??= obj.$observers?.model ?? obj.$observers?.value)?.subscribe(this);

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -116,8 +116,9 @@ export class EventSubscriber {
 
   public dispose(): void {
     const { target, handler } = this;
+    let event: string;
     if (target !== null && handler !== null) {
-      for (const event of this.config.events) {
+      for (event of this.config.events) {
         target.removeEventListener(event, handler);
       }
     }

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -91,7 +91,8 @@ export class StyleAttributeAccessor implements IAccessor {
     const len = currentValue.length;
     if (len > 0) {
       const styles: [string, string][] = [];
-      for (let i = 0; i < len; ++i) {
+      let i = 0;
+      for (; len > i; ++i) {
         styles.push(...this._getStyleTuples(currentValue[i]));
       }
       return styles;

--- a/packages/runtime-html/src/observation/svg-analyzer.ts
+++ b/packages/runtime-html/src/observation/svg-analyzer.ts
@@ -32,7 +32,7 @@ export class SVGAnalyzer {
     return Registration.singleton(ISVGAnalyzer, this).register(container);
   }
 
-  private readonly svgElements: Record<string, Record<string, true | undefined> | undefined> = Object.assign(createLookup<Record<string, true | undefined> | undefined>(), {
+  private readonly _svgElements: Record<string, Record<string, true | undefined> | undefined> = Object.assign(createLookup<Record<string, true | undefined> | undefined>(), {
     'a': o(['class', 'externalResourcesRequired', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'style', 'systemLanguage', 'target', 'transform', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space']),
     'altGlyph': o(['class', 'dx', 'dy', 'externalResourcesRequired', 'format', 'glyphRef', 'id', 'onactivate', 'onclick', 'onfocusin', 'onfocusout', 'onload', 'onmousedown', 'onmousemove', 'onmouseout', 'onmouseover', 'onmouseup', 'requiredExtensions', 'requiredFeatures', 'rotate', 'style', 'systemLanguage', 'x', 'xlink:actuate', 'xlink:arcrole', 'xlink:href', 'xlink:role', 'xlink:show', 'xlink:title', 'xlink:type', 'xml:base', 'xml:lang', 'xml:space', 'y']),
     'altglyph': createLookup<true | undefined>(),
@@ -119,7 +119,7 @@ export class SVGAnalyzer {
     'vkern': o(['g1', 'g2', 'id', 'k', 'u1', 'u2', 'xml:base', 'xml:lang', 'xml:space']),
   });
 
-  private readonly svgPresentationElements = o([
+  private readonly _svgPresentationElements = o([
     'a',
     'altGlyph',
     'animate',
@@ -173,7 +173,7 @@ export class SVGAnalyzer {
     'use',
   ]);
 
-  private readonly svgPresentationAttributes = o([
+  private readonly _svgPresentationAttributes = o([
     'alignment-baseline',
     'baseline-shift',
     'clip-path',
@@ -243,7 +243,7 @@ export class SVGAnalyzer {
     div.innerHTML = '<svg><altGlyph /></svg>';
     if (div.firstElementChild!.nodeName === 'altglyph') {
       // handle chrome casing inconsistencies.
-      const svg = this.svgElements;
+      const svg = this._svgElements;
       let tmp = svg.altGlyph;
       svg.altGlyph = svg.altglyph;
       svg.altglyph = tmp;
@@ -265,8 +265,8 @@ export class SVGAnalyzer {
     }
 
     return (
-      this.svgPresentationElements[node.nodeName] === true && this.svgPresentationAttributes[attributeName] === true ||
-      this.svgElements[node.nodeName]?.[attributeName] === true
+      this._svgPresentationElements[node.nodeName] === true && this._svgPresentationAttributes[attributeName] === true ||
+      this._svgElements[node.nodeName]?.[attributeName] === true
     );
   }
 }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -172,7 +172,7 @@ export class HydrateElementInstruction {
     /**
      * Bindable instructions for the custom element instance
      */
-    public instructions: IInstruction[],
+    public props: IInstruction[],
     /**
      * Indicates what projections are associated with the element usage
      */
@@ -196,7 +196,7 @@ export class HydrateAttributeInstruction {
     /**
      * Bindable instructions for the custom attribute instance
      */
-    public instructions: IInstruction[],
+    public props: IInstruction[],
   ) {}
 }
 
@@ -212,7 +212,7 @@ export class HydrateTemplateController {
     /**
      * Bindable instructions for the template controller instance
      */
-    public instructions: IInstruction[],
+    public props: IInstruction[],
   ) {}
 }
 
@@ -515,7 +515,7 @@ export class CustomElementRenderer implements IRenderer {
     setRef(target, def.key, childCtrl);
 
     const renderers = this.r.renderers;
-    const props = instruction.instructions;
+    const props = instruction.props;
     const ii = props.length;
     let i = 0;
     let propInst: IInstruction;
@@ -588,7 +588,7 @@ export class CustomAttributeRenderer implements IRenderer {
     setRef(target, def.key, childController);
 
     const renderers = this.r.renderers;
-    const props = instruction.instructions;
+    const props = instruction.props;
     const ii = props.length;
     let i = 0;
     let propInst: IInstruction;
@@ -662,7 +662,7 @@ export class TemplateControllerRenderer implements IRenderer {
     component.link?.(f, renderingCtrl, childController, target, instruction);
 
     const renderers = this.r.renderers;
-    const props = instruction.instructions;
+    const props = instruction.props;
     const ii = props.length;
     let i = 0;
     let propInst: IInstruction;

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -29,24 +29,24 @@ export class CharSpec implements ICharSpec {
     if (isInverted) {
       switch (chars.length) {
         case 0:
-          this.has = this.hasOfNoneInverse;
+          this.has = this._hasOfNoneInverse;
           break;
         case 1:
-          this.has = this.hasOfSingleInverse;
+          this.has = this._hasOfSingleInverse;
           break;
         default:
-          this.has = this.hasOfMultipleInverse;
+          this.has = this._hasOfMultipleInverse;
       }
     } else {
       switch (chars.length) {
         case 0:
-          this.has = this.hasOfNone;
+          this.has = this._hasOfNone;
           break;
         case 1:
-          this.has = this.hasOfSingle;
+          this.has = this._hasOfSingle;
           break;
         default:
-          this.has = this.hasOfMultiple;
+          this.has = this._hasOfMultiple;
       }
     }
   }
@@ -58,27 +58,27 @@ export class CharSpec implements ICharSpec {
       && this.isInverted === other.isInverted;
   }
 
-  private hasOfMultiple(char: string): boolean {
+  private _hasOfMultiple(char: string): boolean {
     return this.chars.includes(char);
   }
 
-  private hasOfSingle(char: string): boolean {
+  private _hasOfSingle(char: string): boolean {
     return this.chars === char;
   }
 
-  private hasOfNone(char: string): boolean {
+  private _hasOfNone(char: string): boolean {
     return false;
   }
 
-  private hasOfMultipleInverse(char: string): boolean {
+  private _hasOfMultipleInverse(char: string): boolean {
     return !this.chars.includes(char);
   }
 
-  private hasOfSingleInverse(char: string): boolean {
+  private _hasOfSingleInverse(char: string): boolean {
     return this.chars !== char;
   }
 
-  private hasOfNoneInverse(char: string): boolean {
+  private _hasOfNoneInverse(char: string): boolean {
     return true;
   }
 }

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -49,7 +49,7 @@ export class AuRender implements ICustomElementViewModel {
     @IHydrationContext hdrContext: IHydrationContext,
     @IRendering private readonly r: IRendering,
   ) {
-    this._properties = instruction.instructions.reduce(toLookup, {});
+    this._properties = instruction.props.reduce(toLookup, {});
     this._hdrContext = hdrContext;
   }
 

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -209,7 +209,7 @@ export class ChildrenObserver {
     if (!this.observing) {
       this.observing = true;
       this.children = this.get();
-      (this.observer ??= new this.controller.host.ownerDocument.defaultView!.MutationObserver(() => { this.onChildrenChanged(); }))
+      (this.observer ??= new this.controller.host.ownerDocument.defaultView!.MutationObserver(() => { this._onChildrenChanged(); }))
         .observe(this.controller.host, this.options);
     }
   }
@@ -222,7 +222,7 @@ export class ChildrenObserver {
     }
   }
 
-  private onChildrenChanged(): void {
+  private _onChildrenChanged(): void {
     this.children = this.get();
 
     if (this.callback !== void 0) {

--- a/packages/runtime-html/src/utilities-html.ts
+++ b/packages/runtime-html/src/utilities-html.ts
@@ -1,8 +1,10 @@
 import type { ISVGAnalyzer } from './observation/svg-analyzer';
 
+export const createLookup = <T = unknown>() => Object.create(null) as Record<string, T>;
+export const hasOwnProperty = Object.prototype.hasOwnProperty;
 const IsDataAttribute: Record<string, boolean> = createLookup();
 
-export function isDataAttribute(obj: Node, key: PropertyKey, svgAnalyzer: ISVGAnalyzer): boolean {
+export const isDataAttribute = (obj: Node, key: PropertyKey, svgAnalyzer: ISVGAnalyzer): boolean => {
   if (IsDataAttribute[key as string] === true) {
     return true;
   }
@@ -16,8 +18,4 @@ export function isDataAttribute(obj: Node, key: PropertyKey, svgAnalyzer: ISVGAn
     prefix === 'aria-' ||
     prefix === 'data-' ||
     svgAnalyzer.isStandardSvgAttribute(obj, key);
-}
-
-export function createLookup<T = unknown>(){
-  return Object.create(null) as Record<string, T>;
-}
+};

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -7,7 +7,7 @@ import { PrimitiveObserver } from './primitive-observer.js';
 import { PropertyAccessor } from './property-accessor.js';
 import { getSetObserver } from './set-observer.js';
 import { SetterObserver } from './setter-observer.js';
-import { def } from '../utilities-objects.js';
+import { def, hasOwnProp } from '../utilities-objects.js';
 
 import type {
   Collection,
@@ -210,4 +210,3 @@ export function getCollectionObserver(collection: RepeatableCollection): Collect
 
 const getProto = Object.getPrototypeOf;
 const getOwnPropDesc = Object.getOwnPropertyDescriptor;
-const hasOwnProp = Object.prototype.hasOwnProperty;

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -1,4 +1,8 @@
-
+/**
+ * A shortcut to Object.prototype.hasOwnProperty
+ * Needs to do explicit .call
+ */
+export const hasOwnProp = Object.prototype.hasOwnProperty;
 export const def = Reflect.defineProperty;
 export function defineHiddenProp<T extends unknown>(obj: object, key: PropertyKey, value: T): T {
   def(obj, key, {
@@ -16,7 +20,7 @@ export function ensureProto<T extends object, K extends keyof T>(
   defaultValue: unknown,
   force: boolean = false
 ): void {
-  if (force || !Object.prototype.hasOwnProperty.call(proto, key)) {
+  if (force || !hasOwnProp.call(proto, key)) {
     defineHiddenProp(proto, key, defaultValue);
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, `instructions` property on hydrate element/attribute/template controller doesn't sound as clear as it should. If it's about properties of CE/CA/TC then should just name it so.

- doc: Add some more doc related to how to use the default template compiler elsewhere.
- add some small comments explaining the main `_compileElement` function to balance between comprehensiveness & perf