### PR TITLE
fix(attr-parser): sort the patterns before building the states

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features/promise.bind.md
+++ b/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features/promise.bind.md
@@ -44,3 +44,7 @@ export class MyApp {
 {% endtab %}
 {% endtabs %}
 
+{% hint style="info" %}
+The parameter `i` passed to the method `fetchAdvice()` call in the template is for refreshing binding purposes. It is not used in the method itself.
+This is because method calls in Aurelia are considered pure, and will only called again if any of its parameter has changes.
+{% endhint %}

--- a/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
@@ -137,7 +137,20 @@ describe('@attributePattern', function () {
         ['value:bind',   null,           []],
         ['value@bind',   null,           []]
       ]
-    ]
+    ],
+    // overlapping characters for promise + i18n combo
+    [
+      [
+        { pattern: 't', symbols: '' },
+        { pattern: 'then', symbols: '' },
+        { pattern: 't-params.bind', symbols: '' },
+      ],
+      [
+        ['t', 't', ['t']],
+        ['then',  'then', ['then']],
+        ['t-params.bind', 't-params.bind', ['t-params.bind']],
+      ]
+    ],
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
     describe(`parse [${defs.map(d => d.pattern)}]`, function () {
       for (const [value, match, values] of tests) {
@@ -166,7 +179,7 @@ describe('@attributePattern', function () {
             assert.strictEqual(
               patternDefs.map(d => d.pattern).includes(result.pattern),
               true,
-              `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0`
+              `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0\n  result: ${result.pattern}`
             );
             attrPattern[result.pattern](value, 'foo', result.parts);
             assert.strictEqual(receivedRawName, value, `receivedRawName`);

--- a/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
@@ -139,21 +139,97 @@ describe('@attributePattern', function () {
       ]
     ],
     // overlapping characters for promise + i18n combo
+    // then before t to make sure it still terminates at the correct position
     [
       [
-        { pattern: 't', symbols: '' },
-        { pattern: 'then', symbols: '' },
-        { pattern: 't-params.bind', symbols: '' },
+        { pattern: "promise.resolve", symbols: '' },
+        { pattern: "then", symbols: '' },
+        { pattern: "catch", symbols: '' },
+        { pattern: "ref", symbols: '' },
+        { pattern: "PART.ref", symbols: '.' },
+        { pattern: "PART.PART", symbols: '.' },
+        { pattern: "PART.PART.PART", symbols: '.' },
+        { pattern: 't.PART', symbols: '.' },
+        { pattern: 'PART.t', symbols: '.' },
+        { pattern: "t", symbols: '' },
+        { pattern: "t.bind", symbols: '' },
+        { pattern: "t-params.bind", symbols: '' },
       ],
       [
         ['t', 't', ['t']],
-        ['then',  'then', ['then']],
+        ['tt.bind', 'PART.PART', ['tt', 'bind']],
+        ['t.bind', 't.PART', ['t', 'bind']],
+        ['then', 'then', ['then']],
         ['t-params.bind', 't-params.bind', ['t-params.bind']],
-      ]
+      ],
+    ],
+    [
+      [
+        { pattern: 'then', symbols: '' },
+        { pattern: 'the', symbols: '' },
+        { pattern: 'th', symbols: '' },
+        { pattern: 't', symbols: '' },
+        { pattern: 't.PART', symbols: '.' },
+      ],
+      [
+        ['tt', null, []],
+        ['t', 't', ['t']],
+        ['th', 'th', ['th']],
+        ['the', 'the', ['the']],
+        ['then', 'then', ['then']],
+      ],
+    ],
+    [
+      [
+        { pattern: 'then', symbols: '' },
+        { pattern: 'the', symbols: '' },
+        { pattern: 'th', symbols: '' },
+        { pattern: 't', symbols: '' },
+        { pattern: 't.PART', symbols: '.' },
+      ],
+      [
+        ['then', 'then', ['then']],
+        ['the', 'the', ['the']],
+        ['th', 'th', ['th']],
+        ['t', 't', ['t']],
+        ['tt', null, []],
+      ],
+    ],
+    [
+      [
+        { pattern: 't', symbols: '' },
+        { pattern: 'th', symbols: '' },
+        { pattern: 'the', symbols: '' },
+        { pattern: 'then', symbols: '' },
+        { pattern: 't.PART', symbols: '.' },
+      ],
+      [
+        ['then', 'then', ['then']],
+        ['the', 'the', ['the']],
+        ['th', 'th', ['th']],
+        ['t', 't', ['t']],
+        ['tt', null, []],
+      ],
+    ],
+    [
+      [
+        { pattern: 't', symbols: '' },
+        { pattern: 'th', symbols: '' },
+        { pattern: 'the', symbols: '' },
+        { pattern: 'then', symbols: '' },
+        { pattern: 't.PART', symbols: '.' },
+      ],
+      [
+        ['t', 't', ['t']],
+        ['th', 'th', ['th']],
+        ['the', 'the', ['the']],
+        ['then', 'then', ['then']],
+        ['tt', null, []],
+      ],
     ],
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
     describe(`parse [${defs.map(d => d.pattern)}]`, function () {
-      for (const [value, match, values] of tests) {
+      for (const [value, match, parts] of tests) {
         it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
           let receivedRawName: string;
           let receivedRawValue: string;
@@ -176,6 +252,7 @@ describe('@attributePattern', function () {
 
           const result = interpreter.interpret(value);
           if (match != null) {
+            assert.strictEqual(result.pattern, match);
             assert.strictEqual(
               patternDefs.map(d => d.pattern).includes(result.pattern),
               true,
@@ -193,7 +270,7 @@ describe('@attributePattern', function () {
             );
           }
 
-          assert.deepStrictEqual(result.parts, values, `result.parts`);
+          assert.deepStrictEqual(result.parts, parts, `result.parts`);
         });
       }
     });

--- a/packages/__tests__/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/i18n/t/translation-integration.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { I18N, I18nConfiguration, Signals } from '@aurelia/i18n';
 import { Class, IContainer } from '@aurelia/kernel';
-import { Aurelia, bindable, customElement, IAttributeParser, INode, IPlatform, ISignaler } from '@aurelia/runtime-html';
+import { Aurelia, bindable, customElement, INode, IPlatform, ISignaler } from '@aurelia/runtime-html';
 import { assert, PLATFORM, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../../util.js';
 

--- a/packages/__tests__/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/i18n/t/translation-integration.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { I18N, I18nConfiguration, Signals } from '@aurelia/i18n';
 import { Class, IContainer } from '@aurelia/kernel';
-import { Aurelia, bindable, customElement, INode, IPlatform, ISignaler } from '@aurelia/runtime-html';
+import { Aurelia, bindable, customElement, IAttributeParser, INode, IPlatform, ISignaler } from '@aurelia/runtime-html';
 import { assert, PLATFORM, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../../util.js';
 

--- a/packages/__tests__/importmap.js
+++ b/packages/__tests__/importmap.js
@@ -1,0 +1,24 @@
+// eslint-disable-next-line
+document.write(`<script type="importmap">${JSON.stringify({
+  imports: [
+    'aurelia',
+    'platform',
+    'platform-browser',
+    'metadata',
+    'kernel',
+    'runtime',
+    'runtime-html',
+    'route-recognizer',
+    'fetch-client',
+    'store-v1',
+    'i18n',
+    'router',
+    'testing',
+    'validation',
+    'validation-html',
+    'validation-i18n',
+  ].reduce((map, pkg) => {
+    map[`@aurelia/${pkg}`] = `/base/packages/${pkg}/dist/esm/index.js`;
+    return map;
+  }, {})
+})}</script>`);

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -78,6 +78,7 @@ module.exports = function (config) {
   //   Because they're not watched, they're also not cached, so that the browser will always serve the latest version from disk.
   //
   const files = [
+    { type: 'script', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/importmap.js` },
     { type: 'script', watched: false, included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
     { type: 'module', watched: true,  included: true,  nocache: false, pattern: `${baseUrl}/setup-browser.js` }, // 1.1
     { type: 'module', watched: true,  included: false, nocache: false, pattern: `${baseUrl}/setup-shared.js` }, // 1.2
@@ -150,6 +151,7 @@ module.exports = function (config) {
         timeout: 5000,
       }
     },
+    restartOnFileChange: true,
     logLevel: config.LOG_ERROR, // to disable the WARN 404 for image requests
     // logLevel: config.LOG_DEBUG,
   };

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -68,9 +68,9 @@ import {
   FulfilledTemplateController,
   RejectedTemplateController,
   // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-  // PromiseAttributePattern,
-  // FulfilledAttributePattern,
-  // RejectedAttributePattern,
+  PromiseAttributePattern,
+  FulfilledAttributePattern,
+  RejectedAttributePattern,
 } from './resources/template-controllers/promise.js';
 import { AuRender } from './resources/custom-elements/au-render.js';
 import { AuCompose } from './resources/custom-elements/au-compose.js';
@@ -183,9 +183,9 @@ export const PendingTemplateControllerRegistration = PendingTemplateController a
 export const FulfilledTemplateControllerRegistration = FulfilledTemplateController as unknown as IRegistry;
 export const RejectedTemplateControllerRegistration = RejectedTemplateController as unknown as IRegistry;
 // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-// export const PromiseAttributePatternRegistration = PromiseAttributePattern as unknown as IRegistry;
-// export const FulfilledAttributePatternRegistration = FulfilledAttributePattern as unknown as IRegistry;
-// export const RejectedAttributePatternRegistration = RejectedAttributePattern as unknown as IRegistry;
+export const PromiseAttributePatternRegistration = PromiseAttributePattern as unknown as IRegistry;
+export const FulfilledAttributePatternRegistration = FulfilledAttributePattern as unknown as IRegistry;
+export const RejectedAttributePatternRegistration = RejectedAttributePattern as unknown as IRegistry;
 export const AttrBindingBehaviorRegistration = AttrBindingBehavior as unknown as IRegistry;
 export const SelfBindingBehaviorRegistration = SelfBindingBehavior as unknown as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as unknown as IRegistry;
@@ -227,9 +227,9 @@ export const DefaultResources = [
   FulfilledTemplateControllerRegistration,
   RejectedTemplateControllerRegistration,
   // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-  // PromiseAttributePatternRegistration,
-  // FulfilledAttributePatternRegistration,
-  // RejectedAttributePatternRegistration,
+  PromiseAttributePatternRegistration,
+  FulfilledAttributePatternRegistration,
+  RejectedAttributePatternRegistration,
   AttrBindingBehaviorRegistration,
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -310,6 +310,7 @@ export class SyntaxInterpreter {
     const len = name.length;
     let states = this.initialStates;
     let i = 0;
+    let state: State;
     for (; i < len; ++i) {
       states = this.getNextStates(states, name.charAt(i), interpretation);
       if (states.length === 0) {
@@ -317,34 +318,11 @@ export class SyntaxInterpreter {
       }
     }
 
-    states.sort((a, b) => {
-      if (a.isEndpoint) {
-        if (!b.isEndpoint) {
-          return -1;
-        }
-      } else if (b.isEndpoint) {
-        return 1;
-      } else {
-        return 0;
-      }
-      // both a and b are endpoints
-      // compare them based on the number of static, then dynamic & symbol fragments
-      const aTypes = a.types!;
-      const bTypes = b.types!;
-      if (aTypes.statics !== bTypes.statics) {
-        return bTypes.statics - aTypes.statics;
-      }
-      if (aTypes.dynamics !== bTypes.dynamics) {
-        return bTypes.dynamics - aTypes.dynamics;
-      }
-      if (aTypes.symbols !== bTypes.symbols) {
-        return bTypes.symbols - aTypes.symbols;
-      }
-      return 0;
-    });
+    states = states.filter(isEndpoint);
 
     if (states.length > 0) {
-      const state = states[0];
+      states.sort(sortEndpoint);
+      state = states[0];
       if (!state.charSpec.isSymbol) {
         interpretation.next(state.pattern!);
       }
@@ -406,6 +384,27 @@ export class SyntaxInterpreter {
 
     return result;
   }
+}
+
+function isEndpoint(a: State) {
+  return a.isEndpoint;
+}
+
+function sortEndpoint(a: State, b: State) {
+  // both a and b are endpoints
+  // compare them based on the number of static, then dynamic & symbol fragments
+  const aTypes = a.types!;
+  const bTypes = b.types!;
+  if (aTypes.statics !== bTypes.statics) {
+    return bTypes.statics - aTypes.statics;
+  }
+  if (aTypes.dynamics !== bTypes.dynamics) {
+    return bTypes.dynamics - aTypes.dynamics;
+  }
+  if (aTypes.symbols !== bTypes.symbols) {
+    return bTypes.symbols - aTypes.symbols;
+  }
+  return 0;
 }
 
 export class AttrSyntax {

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -150,7 +150,8 @@ export class State {
     const nextStates = this.nextStates;
     const len = nextStates.length;
     let child: State = null!;
-    for (let i = 0; i < len; ++i) {
+    let i = 0;
+    for (; i < len; ++i) {
       child = nextStates[i];
       if (charSpec.equals(child.charSpec)) {
         return child;
@@ -306,9 +307,10 @@ export class SyntaxInterpreter {
 
   public interpret(name: string): Interpretation {
     const interpretation = new Interpretation();
-    let states = this.initialStates;
     const len = name.length;
-    for (let i = 0; i < len; ++i) {
+    let states = this.initialStates;
+    let i = 0;
+    for (; i < len; ++i) {
       states = this.getNextStates(states, name.charAt(i), interpretation);
       if (states.length === 0) {
         break;
@@ -325,6 +327,8 @@ export class SyntaxInterpreter {
       } else {
         return 0;
       }
+      // both a and b are endpoints
+      // compare them based on the number of static, then dynamic & symbol fragments
       const aTypes = a.types!;
       const bTypes = b.types!;
       if (aTypes.statics !== bTypes.statics) {
@@ -354,7 +358,8 @@ export class SyntaxInterpreter {
     const nextStates: State[] = [];
     let state: State = null!;
     const len = states.length;
-    for (let i = 0; i < len; ++i) {
+    let i = 0;
+    for (; i < len; ++i) {
       state = states[i];
       nextStates.push(...state.findMatches(ch, interpretation));
     }

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -210,8 +210,6 @@ export class State {
   }
 }
 
-const sortStatePattern = (p1: string, p2: string) => p2.length > p1.length ? -1 : 1;
-
 /** @internal */
 export interface ISegment {
   text: string;

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -16,7 +16,6 @@ export interface ICharSpec {
   equals(other: ICharSpec): boolean;
 }
 
-/** @internal */
 export class CharSpec implements ICharSpec {
   public has: (char: string) => boolean;
 
@@ -102,12 +101,15 @@ export class Interpretation {
       this.parts = this._partsRecord[value];
     }
   }
+  /** @internal */
   private _pattern: string = '';
+  /** @internal */
   private readonly _currentRecord: Record<string, string> = {};
+  /** @internal */
   private readonly _partsRecord: Record<string, string[]> = {};
 
   public append(pattern: string, ch: string): void {
-    const { _currentRecord: currentRecord } = this;
+    const currentRecord = this._currentRecord;
     if (currentRecord[pattern] === undefined) {
       currentRecord[pattern] = ch;
     } else {
@@ -116,9 +118,11 @@ export class Interpretation {
   }
 
   public next(pattern: string): void {
-    const { _currentRecord: currentRecord } = this;
+    const currentRecord = this._currentRecord;
+    let partsRecord: Interpretation['_partsRecord'];
+
     if (currentRecord[pattern] !== undefined) {
-      const { _partsRecord: partsRecord } = this;
+      partsRecord = this._partsRecord;
       if (partsRecord[pattern] === undefined) {
         partsRecord[pattern] = [currentRecord[pattern]];
       } else {
@@ -161,7 +165,7 @@ export class State {
   }
 
   public append(charSpec: ICharSpec, pattern: string): State {
-    const { patterns } = this;
+    const patterns = this.patterns;
     if (!patterns.includes(pattern)) {
       patterns.push(pattern);
     }
@@ -206,6 +210,8 @@ export class State {
   }
 }
 
+const sortStatePattern = (p1: string, p2: string) => p2.length > p1.length ? -1 : 1;
+
 /** @internal */
 export interface ISegment {
   text: string;
@@ -222,14 +228,17 @@ export class StaticSegment implements ISegment {
   ) {
     const len = this.len = text.length;
     const specs = this.specs = [] as CharSpec[];
-    for (let i = 0; i < len; ++i) {
+    let i = 0;
+    for (; len > i; ++i) {
       specs.push(new CharSpec(text[i], false, false, false));
     }
   }
 
   public eachChar(callback: (spec: CharSpec) => void): void {
-    const { len, specs } = this;
-    for (let i = 0; i < len; ++i) {
+    const len = this.len;
+    const specs = this.specs;
+    let i = 0;
+    for (; len > i; ++i) {
       callback(specs[i]);
     }
   }
@@ -264,7 +273,6 @@ export class SymbolSegment implements ISegment {
   }
 }
 
-/** @internal */
 export class SegmentTypes {
   public statics: number = 0;
   public dynamics: number = 0;
@@ -278,31 +286,36 @@ export class SyntaxInterpreter {
   public rootState: State = new State(null!);
   private readonly initialStates: State[] = [this.rootState];
 
-  public add(def: AttributePatternDefinition): void;
-  public add(defs: AttributePatternDefinition[]): void;
-  public add(defOrDefs: AttributePatternDefinition | AttributePatternDefinition[]): void {
+  // todo: this only works if this method is ever called only once
+  public add(defs: AttributePatternDefinition[]): void {
+    defs = defs.slice(0).sort((d1, d2) => d1.pattern > d2.pattern ? 1 : -1);
+    const ii = defs.length;
+    let currentState: State;
+    let def: AttributePatternDefinition;
+    let pattern: string;
+    let types: SegmentTypes;
+    let segments: ISegment[];
+    let len: number;
+    let charSpecCb: (ch: ICharSpec) => void;
     let i = 0;
-    if (Array.isArray(defOrDefs)) {
-      const ii = defOrDefs.length;
-      for (; i < ii; ++i) {
-        this.add(defOrDefs[i]);
+    let j: number;
+    while (ii > i) {
+      currentState = this.rootState;
+      def = defs[i];
+      pattern = def.pattern;
+      types = new SegmentTypes();
+      segments = this.parse(def, types);
+      len = segments.length;
+      charSpecCb = (ch: ICharSpec) => {
+        currentState = currentState.append(ch, pattern);
+      };
+      for (j = 0; len > j; ++j) {
+        segments[j].eachChar(charSpecCb);
       }
-      return;
+      currentState.types = types;
+      currentState.isEndpoint = true;
+      ++i;
     }
-    let currentState = this.rootState;
-    const def = defOrDefs;
-    const pattern = def.pattern;
-    const types = new SegmentTypes();
-    const segments = this.parse(def, types);
-    const len = segments.length;
-    const callback = (ch: ICharSpec): void => {
-      currentState = currentState.append(ch, pattern);
-    };
-    for (i = 0; i < len; ++i) {
-      segments[i].eachChar(callback);
-    }
-    currentState.types = types;
-    currentState.isEndpoint = true;
   }
 
   public interpret(name: string): Interpretation {
@@ -349,17 +362,18 @@ export class SyntaxInterpreter {
     const result = [];
     const pattern = def.pattern;
     const len = pattern.length;
+    const symbols = def.symbols;
     let i = 0;
     let start = 0;
     let c = '';
 
     while (i < len) {
       c = pattern.charAt(i);
-      if (!def.symbols.includes(c)) {
+      if (symbols.length === 0 || !symbols.includes(c)) {
         if (i === start) {
           if (c === 'P' && pattern.slice(i, i + 4) === 'PART') {
             start = i = (i + 4);
-            result.push(new DynamicSegment(def.symbols));
+            result.push(new DynamicSegment(symbols));
             ++types.dynamics;
           } else {
             ++i;
@@ -431,7 +445,12 @@ export class AttributeParser {
 
   /** @internal */
   private readonly _cache: Record<string, Interpretation> = {};
-  /** @internal */
+  /**
+   * A 2 level record with the same key on both levels.
+   * Just a trick to maintain `this` + have simple lookup + support multi patterns per class definition
+   *
+   * @internal
+   */
   private readonly _patterns: Record<string, IAttributePattern>;
   /** @internal */
   private readonly _interpreter: ISyntaxInterpreter;
@@ -442,13 +461,15 @@ export class AttributeParser {
   ) {
     this._interpreter = interpreter;
     const patterns: AttributeParser['_patterns'] = this._patterns = {};
-    attrPatterns.forEach(attrPattern => {
-      const defs = AttributePattern.getPatternDefinitions(attrPattern.constructor as Constructable);
-      interpreter.add(defs);
-      defs.forEach(def => {
-        patterns[def.pattern] = attrPattern as unknown as IAttributePattern;
-      });
-    });
+    const allDefs = attrPatterns.reduce<AttributePatternDefinition[]>(
+      (allDefs, attrPattern) => {
+        const patternDefs = AttributePattern.getPatternDefinitions(attrPattern.constructor as Constructable);
+        patternDefs.forEach(def => patterns[def.pattern] = attrPattern);
+        return allDefs.concat(patternDefs);
+      },
+      emptyArray
+    );
+    interpreter.add(allDefs);
   }
 
   public parse(name: string, value: string): AttrSyntax {

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -14,6 +14,7 @@ import {
   ISyntheticView
 } from '../../templating/controller.js';
 import { IViewFactory } from '../../templating/view.js';
+import { attributePattern, AttrSyntax } from '../attribute-pattern.js';
 import { templateController } from '../custom-attribute.js';
 
 @templateController('promise')
@@ -318,24 +319,23 @@ function getPromiseController(controller: IHydratableController) {
     throw new Error('AUR0813');
 }
 
-// TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-// @attributePattern({ pattern: 'promise.resolve', symbols: '' })
-// export class PromiseAttributePattern {
-//   public 'promise.resolve'(name: string, value: string, _parts: string[]): AttrSyntax {
-//     return new AttrSyntax(name, value, 'promise', 'bind');
-//   }
-// }
+@attributePattern({ pattern: 'promise.resolve', symbols: '' })
+export class PromiseAttributePattern {
+  public 'promise.resolve'(name: string, value: string, _parts: string[]): AttrSyntax {
+    return new AttrSyntax(name, value, 'promise', 'bind');
+  }
+}
 
-// @attributePattern({ pattern: 'then', symbols: '' })
-// export class FulfilledAttributePattern {
-//   public 'then'(name: string, value: string, _parts: string[]): AttrSyntax {
-//     return new AttrSyntax(name, value, 'then', 'from-view');
-//   }
-// }
+@attributePattern({ pattern: 'then', symbols: '' })
+export class FulfilledAttributePattern {
+  public 'then'(name: string, value: string, _parts: string[]): AttrSyntax {
+    return new AttrSyntax(name, value, 'then', 'from-view');
+  }
+}
 
-// @attributePattern({ pattern: 'catch', symbols: '' })
-// export class RejectedAttributePattern {
-//   public 'catch'(name: string, value: string, _parts: string[]): AttrSyntax {
-//     return new AttrSyntax(name, value, 'catch', 'from-view');
-//   }
-// }
+@attributePattern({ pattern: 'catch', symbols: '' })
+export class RejectedAttributePattern {
+  public 'catch'(name: string, value: string, _parts: string[]): AttrSyntax {
+    return new AttrSyntax(name, value, 'catch', 'from-view');
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, when having some patterns in the following order:
```ts
{ pattern: 'then'  },
{ pattern: 't' }
```
The interpreter would build a state machine that:
- is terminatable at `t` (because of the `{ pattern: 't' }`)
- has `then` as the first matching pattern for `t` (because `then` is registered before `t`)

A fix for this is to ensure that patterns are sorted based on length. This enables the tests for simple `then`/`catch` usage:
```html
<div promise.bind="...">
  <div then="data">...</div>
  <div catch="err">...</div>
</div>
```

## ⏭ Next Steps

Change default binding mode of `then` & `catch` from `to-view` to `from-view`, and add more tests for the simple binding usage above. cc @Sayan751 