### PR TITLE
refactor(template-compiler): let binding command control expression parsing work

### DIFF
--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -1,7 +1,6 @@
 import { I18nConfiguration, TranslationBinding, TranslationParametersAttributePattern, TranslationParametersBindingCommand, TranslationParametersBindingInstruction, TranslationParametersBindingRenderer, TranslationParametersInstructionType } from '@aurelia/i18n';
 import { DI } from '@aurelia/kernel';
 import {
-  AnyBindingExpression,
   BindingType,
   IExpressionParser,
   IRenderer,
@@ -59,7 +58,6 @@ describe('TranslationParametersBindingCommand', function () {
       attr: syntax,
       bindable: null,
       def: null,
-      expr: { syntax } as unknown as AnyBindingExpression
     });
 
     assert.instanceOf(actual, TranslationParametersBindingInstruction);

--- a/packages/__tests__/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-renderer.spec.ts
@@ -14,7 +14,6 @@ import {
 } from '@aurelia/i18n';
 import { Constructable } from '@aurelia/kernel';
 import {
-  AnyBindingExpression,
   BindingType,
   IBinding,
   IExpressionParser,
@@ -109,7 +108,6 @@ describe('TranslationBindingCommand', function () {
       attr: syntax,
       bindable: null,
       def: null,
-      expr: { syntax } as unknown as AnyBindingExpression
     });
 
     assert.instanceOf(actual, TranslationBindingInstruction);
@@ -250,7 +248,6 @@ describe('TranslationBindBindingCommand', function () {
       attr: syntax,
       bindable: null,
       def: null,
-      expr: { syntax } as unknown as AnyBindingExpression
     });
 
     assert.instanceOf(actual, TranslationBindBindingInstruction);

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -48,20 +48,24 @@ export class TranslationParametersBindingInstruction {
 export class TranslationParametersBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): TranslationParametersBindingInstruction {
-    let target: string;
+    const attr = info.attr;
+    let target = attr.target;
     if (info.bindable == null) {
-      target = this.m.map(info.node, info.attr.target)
+      target = this.m.map(info.node, target)
         // if the transformer doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(info.attr.target);
+        ?? camelCase(target);
     } else {
       target = info.bindable.property;
     }
-    return new TranslationParametersBindingInstruction(info.expr as IsBindingBehavior, target);
+    return new TranslationParametersBindingInstruction(this.xp.parse(attr.rawValue, BindingType.BindCommand), target);
   }
 }
 

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -14,6 +14,7 @@ import {
   IPlatform,
   IAttrMapper,
   ICommandBuildInfo,
+  CustomExpression,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -46,7 +47,7 @@ export class TranslationBindingInstruction {
 export class TranslationBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.CustomCommand = BindingType.CustomCommand;
 
-  public static get inject() { return [IAttrMapper]; }
+  public static inject = [IAttrMapper];
   public constructor(private readonly m: IAttrMapper) {}
 
   public build(info: ICommandBuildInfo): TranslationBindingInstruction {
@@ -59,7 +60,7 @@ export class TranslationBindingCommand implements BindingCommandInstance {
     } else {
       target = info.bindable.property;
     }
-    return new TranslationBindingInstruction(info.expr as IsBindingBehavior, target);
+    return new TranslationBindingInstruction(new CustomExpression(info.attr.rawValue) as IsBindingBehavior, target);
   }
 }
 
@@ -115,8 +116,11 @@ export class TranslationBindBindingInstruction {
 export class TranslationBindBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): TranslationBindingInstruction {
     let target: string;
@@ -128,7 +132,7 @@ export class TranslationBindBindingCommand implements BindingCommandInstance {
     } else {
       target = info.bindable.property;
     }
-    return new TranslationBindBindingInstruction(info.expr as IsBindingBehavior, target);
+    return new TranslationBindBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.BindCommand), target);
   }
 }
 

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -84,10 +84,12 @@ export class AppRoot implements IDisposable {
     this.host = config.host;
     this.work = container.get(IWorkTracker);
     rootProvider.prepare(this);
-    container.registerResolver(INode,
+
+    container.registerResolver(
+      platform.HTMLElement,
       container.registerResolver(
         platform.Element,
-        new InstanceProvider('ElementProvider', config.host)
+        container.registerResolver(INode, new InstanceProvider('ElementResolver', config.host))
       )
     );
 

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -87,8 +87,11 @@ export class Aurelia implements IDisposable {
     let bc: ICustomElementViewModel & K;
     if (typeof comp === 'function') {
       ctn.registerResolver(
-        p.Element,
-        ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+        p.HTMLElement,
+        ctn.registerResolver(
+          p.Element,
+          ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+        )
       );
       bc = ctn.invoke(comp as unknown as Constructable<ICustomElementViewModel & K>);
     } else {

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -434,6 +434,9 @@ export {
   AuSlotsInfo,
   IAuSlotsInfo,
 } from './resources/slot-injectables.js';
+export {
+  DefinitionType,
+} from './resources/resources-constants.js';
 
 export {
   containerless,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1091,7 +1091,6 @@ function addClasses(classList: DOMTokenList, className: string): void {
   }
 }
 
-const elProviderName = 'ElementProvider';
 const controllerProviderName = 'IController';
 const instructionProviderName = 'IInstruction';
 const locationProviderName = 'IRenderLocation';
@@ -1113,8 +1112,11 @@ function createElementContainer(
   // reason being some custom element can have `containerless` attribute on them
   // causing the host to disappear, and replace by a location instead
   ctn.registerResolver(
-    p.Element,
-    ctn.registerResolver(INode, new InstanceProvider<INode>(elProviderName, host))
+    p.HTMLElement,
+    ctn.registerResolver(
+      p.Element,
+      ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+    )
   );
   ctn.registerResolver(IController, new InstanceProvider(controllerProviderName, renderingCtrl));
   ctn.registerResolver(IInstruction, new InstanceProvider(instructionProviderName, instruction));
@@ -1174,8 +1176,11 @@ function invokeAttribute(
 ): ICustomAttributeViewModel {
   const ctn = renderingCtrl.container.createChild();
   ctn.registerResolver(
-    p.Element,
-    ctn.registerResolver(INode, new InstanceProvider<INode>(elProviderName, host))
+    p.HTMLElement,
+    ctn.registerResolver(
+      p.Element,
+      ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+    )
   );
   ctn.registerResolver(IController, new InstanceProvider(controllerProviderName, renderingCtrl));
   ctn.registerResolver(IInstruction, new InstanceProvider<IInstruction>(instructionProviderName, instruction));

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -1,5 +1,5 @@
 import { camelCase, Registration, mergeArrays, Protocol, firstDefined, Metadata } from '@aurelia/kernel';
-import { BindingMode, BindingType, DelegationStrategy, registerAliases } from '@aurelia/runtime';
+import { BindingMode, BindingType, DelegationStrategy, IExpressionParser, registerAliases } from '@aurelia/runtime';
 import { IAttrMapper } from '../attribute-mapper.js';
 import {
   AttributeBindingInstruction,
@@ -19,23 +19,31 @@ import type {
   PartialResourceDefinition,
 } from '@aurelia/kernel';
 import type { IInstruction } from '../renderer.js';
-import type { AnyBindingExpression, ForOfStatement, IsBindingBehavior } from '@aurelia/runtime';
 import type { AttrSyntax } from './attribute-pattern.js';
 import type { BindableDefinition } from '../bindable.js';
 import type { CustomAttributeDefinition } from './custom-attribute.js';
 import type { CustomElementDefinition } from './custom-element.js';
+import { DefinitionType } from './resources-constants.js';
 
 export type PartialBindingCommandDefinition = PartialResourceDefinition<{
   readonly type?: string | null;
 }>;
 
-export interface ICommandBuildInfo {
+export interface IPlainAttrCommandInfo {
   readonly node: Element;
   readonly attr: AttrSyntax;
-  readonly expr: AnyBindingExpression;
-  readonly bindable: BindableDefinition | null;
-  readonly def: CustomAttributeDefinition | CustomElementDefinition | null;
+  readonly bindable: null;
+  readonly def: null;
 }
+
+export interface IBindableCommandInfo {
+  readonly node: Element;
+  readonly attr: AttrSyntax;
+  readonly bindable: BindableDefinition;
+  readonly def: CustomAttributeDefinition | CustomElementDefinition;
+}
+
+export type ICommandBuildInfo = IPlainAttrCommandInfo | IBindableCommandInfo;
 
 export type BindingCommandInstance<T extends {} = {}> = {
   bindingType: BindingType;
@@ -106,7 +114,7 @@ export class BindingCommandDefinition<T extends Constructable = Constructable> i
 }
 
 const cmdBaseName = Protocol.resource.keyFor('binding-command');
-export const BindingCommand: BindingCommandKind = Object.freeze<BindingCommandKind>({
+export const BindingCommand = Object.freeze<BindingCommandKind>({
   name: cmdBaseName,
   keyFrom(name: string): string {
     return `${cmdBaseName}:${name}`;
@@ -145,20 +153,30 @@ export const BindingCommand: BindingCommandKind = Object.freeze<BindingCommandKi
 export class OneTimeBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.OneTimeCommand = BindingType.OneTimeCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
-    let target: string;
+    const attr = info.attr;
+    let target = attr.target;
+    let value = info.attr.rawValue;
     if (info.bindable == null) {
-      target = this.m.map(info.node, info.attr.target)
+      target = this.m.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(info.attr.target);
+        ?? camelCase(target);
     } else {
+      // if it looks like: <my-el value.bind>
+      // it means        : <my-el value.bind="value">
+      if (value === '' && info.def.type === DefinitionType.Element) {
+        value = camelCase(target);
+      }
       target = info.bindable.property;
     }
-    return new PropertyBindingInstruction(info.expr as IsBindingBehavior, target, BindingMode.oneTime);
+    return new PropertyBindingInstruction(this.xp.parse(value, BindingType.OneTimeCommand), target, BindingMode.oneTime);
   }
 }
 
@@ -166,20 +184,30 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
 export class ToViewBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.ToViewCommand = BindingType.ToViewCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
-    let target: string;
+    const attr = info.attr;
+    let target = attr.target;
+    let value = info.attr.rawValue;
     if (info.bindable == null) {
-      target = this.m.map(info.node, info.attr.target)
+      target = this.m.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(info.attr.target);
+        ?? camelCase(target);
     } else {
+      // if it looks like: <my-el value.bind>
+      // it means        : <my-el value.bind="value">
+      if (value === '' && info.def.type === DefinitionType.Element) {
+        value = camelCase(target);
+      }
       target = info.bindable.property;
     }
-    return new PropertyBindingInstruction(info.expr as IsBindingBehavior, target, BindingMode.toView);
+    return new PropertyBindingInstruction(this.xp.parse(value, BindingType.ToViewCommand), target, BindingMode.toView);
   }
 }
 
@@ -187,20 +215,30 @@ export class ToViewBindingCommand implements BindingCommandInstance {
 export class FromViewBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.FromViewCommand = BindingType.FromViewCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
-    let target: string;
+    const attr = info.attr;
+    let target = attr.target;
+    let value = attr.rawValue;
     if (info.bindable == null) {
-      target = this.m.map(info.node, info.attr.target)
+      target = this.m.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(info.attr.target);
+        ?? camelCase(target);
     } else {
+      // if it looks like: <my-el value.bind>
+      // it means        : <my-el value.bind="value">
+      if (value === '' && info.def.type === DefinitionType.Element) {
+        value = camelCase(target);
+      }
       target = info.bindable.property;
     }
-    return new PropertyBindingInstruction(info.expr as IsBindingBehavior, target, BindingMode.fromView);
+    return new PropertyBindingInstruction(this.xp.parse(value, BindingType.FromViewCommand), target, BindingMode.fromView);
   }
 }
 
@@ -208,20 +246,30 @@ export class FromViewBindingCommand implements BindingCommandInstance {
 export class TwoWayBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.TwoWayCommand = BindingType.TwoWayCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
-    let target: string;
+    const attr = info.attr;
+    let target = attr.target;
+    let value = attr.rawValue;
     if (info.bindable == null) {
-      target = this.m.map(info.node, info.attr.target)
+      target = this.m.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(info.attr.target);
+        ?? camelCase(target);
     } else {
+      // if it looks like: <my-el value.bind>
+      // it means        : <my-el value.bind="value">
+      if (value === '' && info.def.type === DefinitionType.Element) {
+        value = camelCase(target);
+      }
       target = info.bindable.property;
     }
-    return new PropertyBindingInstruction(info.expr as IsBindingBehavior, target, BindingMode.twoWay);
+    return new PropertyBindingInstruction(this.xp.parse(value, BindingType.TwoWayCommand), target, BindingMode.twoWay);
   }
 }
 
@@ -229,23 +277,32 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
 export class DefaultBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
 
-  public static get inject() { return [IAttrMapper]; }
-  public constructor(private readonly m: IAttrMapper) {}
+  public static inject = [IAttrMapper, IExpressionParser];
+  public constructor(
+    private readonly m: IAttrMapper,
+    private readonly xp: IExpressionParser,
+  ) {}
 
   public build(info: ICommandBuildInfo): PropertyBindingInstruction {
     type CA = CustomAttributeDefinition;
-    const attrName = info.attr.target;
+    const attr = info.attr;
     const bindable = info.bindable;
     let defaultMode: BindingMode;
     let mode: BindingMode;
-    let target: string;
+    let target = attr.target;
+    let value = attr.rawValue;
     if (bindable == null) {
-      mode = this.m.isTwoWay(info.node, attrName) ? BindingMode.twoWay : BindingMode.toView;
-      target = this.m.map(info.node, attrName)
+      mode = this.m.isTwoWay(info.node, target) ? BindingMode.twoWay : BindingMode.toView;
+      target = this.m.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
-        ?? camelCase(attrName);
+        ?? camelCase(target);
     } else {
+      // if it looks like: <my-el value.bind>
+      // it means        : <my-el value.bind="value">
+      if (value === '' && info.def!.type === DefinitionType.Element) {
+        value = camelCase(target);
+      }
       defaultMode = (info.def as CA).defaultBindingMode;
       mode = bindable.mode === BindingMode.default || bindable.mode == null
         ? defaultMode == null || defaultMode === BindingMode.default
@@ -254,7 +311,7 @@ export class DefaultBindingCommand implements BindingCommandInstance {
         : bindable.mode;
       target = bindable.property;
     }
-    return new PropertyBindingInstruction(info.expr as IsBindingBehavior, target, mode);
+    return new PropertyBindingInstruction(this.xp.parse(value, BindingType.BindCommand), target, mode);
   }
 }
 
@@ -262,11 +319,14 @@ export class DefaultBindingCommand implements BindingCommandInstance {
 export class CallBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.CallCommand = BindingType.CallCommand;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
     const target = info.bindable === null
       ? camelCase(info.attr.target)
       : info.bindable.property;
-    return new CallBindingInstruction(info.expr as IsBindingBehavior, target);
+    return new CallBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.CallCommand), target);
   }
 }
 
@@ -274,11 +334,14 @@ export class CallBindingCommand implements BindingCommandInstance {
 export class ForBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.ForCommand = BindingType.ForCommand;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
     const target = info.bindable === null
       ? camelCase(info.attr.target)
       : info.bindable.property;
-    return new IteratorBindingInstruction(info.expr as ForOfStatement, target);
+    return new IteratorBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.ForCommand), target);
   }
 }
 
@@ -286,8 +349,11 @@ export class ForBindingCommand implements BindingCommandInstance {
 export class TriggerBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.TriggerCommand = BindingType.TriggerCommand;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new ListenerBindingInstruction(info.expr as IsBindingBehavior, info.attr.target, true, DelegationStrategy.none);
+    return new ListenerBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.TriggerCommand), info.attr.target, true, DelegationStrategy.none);
   }
 }
 
@@ -295,8 +361,11 @@ export class TriggerBindingCommand implements BindingCommandInstance {
 export class DelegateBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.DelegateCommand = BindingType.DelegateCommand;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new ListenerBindingInstruction(info.expr as IsBindingBehavior, info.attr.target, false, DelegationStrategy.bubbling);
+    return new ListenerBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.DelegateCommand), info.attr.target, false, DelegationStrategy.bubbling);
   }
 }
 
@@ -304,8 +373,11 @@ export class DelegateBindingCommand implements BindingCommandInstance {
 export class CaptureBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.CaptureCommand = BindingType.CaptureCommand;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new ListenerBindingInstruction(info.expr as IsBindingBehavior, info.attr.target, false, DelegationStrategy.capturing);
+    return new ListenerBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.CaptureCommand), info.attr.target, false, DelegationStrategy.capturing);
   }
 }
 
@@ -316,8 +388,11 @@ export class CaptureBindingCommand implements BindingCommandInstance {
 export class AttrBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new AttributeBindingInstruction(info.attr.target, info.expr as IsBindingBehavior, info.attr.target);
+    return new AttributeBindingInstruction(info.attr.target, this.xp.parse(info.attr.rawValue, BindingType.IsProperty), info.attr.target);
   }
 }
 
@@ -328,8 +403,11 @@ export class AttrBindingCommand implements BindingCommandInstance {
 export class StyleBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new AttributeBindingInstruction('style', info.expr as IsBindingBehavior, info.attr.target);
+    return new AttributeBindingInstruction('style', this.xp.parse(info.attr.rawValue, BindingType.IsProperty), info.attr.target);
   }
 }
 
@@ -340,8 +418,11 @@ export class StyleBindingCommand implements BindingCommandInstance {
 export class ClassBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new AttributeBindingInstruction('class', info.expr as IsBindingBehavior, info.attr.target);
+    return new AttributeBindingInstruction('class', this.xp.parse(info.attr.rawValue, BindingType.IsProperty), info.attr.target);
   }
 }
 
@@ -352,7 +433,10 @@ export class ClassBindingCommand implements BindingCommandInstance {
 export class RefBindingCommand implements BindingCommandInstance {
   public readonly bindingType: BindingType.IsProperty | BindingType.IgnoreAttr = BindingType.IsProperty | BindingType.IgnoreAttr;
 
+  public static inject = [IExpressionParser];
+  public constructor(private readonly xp: IExpressionParser) {}
+
   public build(info: ICommandBuildInfo): IInstruction {
-    return new RefBindingInstruction(info.expr as IsBindingBehavior, info.attr.target);
+    return new RefBindingInstruction(this.xp.parse(info.attr.rawValue, BindingType.IsProperty), info.attr.target);
   }
 }

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -3,6 +3,7 @@ import { BindingMode, registerAliases } from '@aurelia/runtime';
 import { Bindable } from '../bindable.js';
 import { Watch } from '../watch.js';
 import { getRef } from '../dom.js';
+import { DefinitionType } from './resources-constants.js';
 
 import type {
   Constructable,
@@ -91,6 +92,9 @@ export function templateController(nameOrDef: string | Omit<PartialCustomAttribu
 }
 
 export class CustomAttributeDefinition<T extends Constructable = Constructable> implements ResourceDefinition<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition> {
+  // a simple marker to distinguish between Custom Element definition & Custom attribute definition
+  public get type(): DefinitionType.Attribute { return DefinitionType.Attribute; }
+
   private constructor(
     public readonly Type: CustomAttributeType<T>,
     public readonly name: string,

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -15,6 +15,7 @@ import { Bindable } from '../bindable.js';
 import { getEffectiveParentNode, getRef } from '../dom.js';
 import { Children } from '../templating/children.js';
 import { Watch } from '../watch.js';
+import { DefinitionType } from './resources-constants.js';
 
 import type {
   Constructable,
@@ -207,6 +208,7 @@ export function strict(target?: Constructable): void | ((target: Constructable) 
 const definitionLookup = new WeakMap<PartialCustomElementDefinition, CustomElementDefinition>();
 
 export class CustomElementDefinition<C extends Constructable = Constructable> implements ResourceDefinition<C, ICustomElementViewModel, PartialCustomElementDefinition> {
+  public get type(): DefinitionType.Element { return DefinitionType.Element; }
   private constructor(
     public readonly Type: CustomElementType<C>,
     public readonly name: string,

--- a/packages/runtime-html/src/resources/resources-constants.ts
+++ b/packages/runtime-html/src/resources/resources-constants.ts
@@ -1,0 +1,4 @@
+export const enum DefinitionType {
+  Element = 1,
+  Attribute = 2,
+}

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -140,17 +140,15 @@ export class TemplateCompiler implements ITemplateCompiler {
       }
 
       bindingCommand = context._createCommand(attrSyntax);
-      if (bindingCommand !== null && bindingCommand.bindingType & BindingType.IgnoreAttr) {
+      if (bindingCommand !== null && (bindingCommand.bindingType & BindingType.IgnoreAttr) > 0) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
         // active.class="..."
         // background.style="..."
         // my-attr.attr="..."
-        expr = exprParser.parse(realAttrValue, bindingCommand.bindingType);
 
         commandBuildInfo.node = el;
         commandBuildInfo.attr = attrSyntax;
-        commandBuildInfo.expr = expr;
         commandBuildInfo.bindable = null;
         commandBuildInfo.def = null;
         instructions.push(bindingCommand.build(commandBuildInfo));
@@ -198,11 +196,9 @@ export class TemplateCompiler implements ITemplateCompiler {
             // custom attribute with binding command:
             // my-attr.bind="..."
             // my-attr.two-way="..."
-            expr = exprParser.parse(realAttrValue, bindingCommand.bindingType);
 
             commandBuildInfo.node = el;
             commandBuildInfo.attr = attrSyntax;
-            commandBuildInfo.expr = expr;
             commandBuildInfo.bindable = primaryBindable;
             commandBuildInfo.def = attrDef;
             attrBindableInstructions = [bindingCommand.build(commandBuildInfo)];
@@ -253,11 +249,9 @@ export class TemplateCompiler implements ITemplateCompiler {
           }
         }
       } else {
-        expr = exprParser.parse(realAttrValue, bindingCommand.bindingType);
 
         commandBuildInfo.node = el;
         commandBuildInfo.attr = attrSyntax;
-        commandBuildInfo.expr = expr;
         commandBuildInfo.bindable = null;
         commandBuildInfo.def = null;
         instructions.push(bindingCommand.build(commandBuildInfo));
@@ -524,11 +518,9 @@ export class TemplateCompiler implements ITemplateCompiler {
         // active.class="..."
         // background.style="..."
         // my-attr.attr="..."
-        expr = exprParser.parse(attrValue, bindingCommand.bindingType);
 
         commandBuildInfo.node = el;
         commandBuildInfo.attr = attrSyntax;
-        commandBuildInfo.expr = expr;
         commandBuildInfo.bindable = null;
         commandBuildInfo.def = null;
         (plainAttrInstructions ??= []).push(bindingCommand.build(commandBuildInfo));
@@ -577,11 +569,9 @@ export class TemplateCompiler implements ITemplateCompiler {
             // custom attribute with binding command:
             // my-attr.bind="..."
             // my-attr.two-way="..."
-            expr = exprParser.parse(attrValue, bindingCommand.bindingType);
 
             commandBuildInfo.node = el;
             commandBuildInfo.attr = attrSyntax;
-            commandBuildInfo.expr = expr;
             commandBuildInfo.bindable = primaryBindable;
             commandBuildInfo.def = attrDef;
             attrBindableInstructions = [bindingCommand.build(commandBuildInfo)];
@@ -668,24 +658,8 @@ export class TemplateCompiler implements ITemplateCompiler {
         bindablesInfo = BindablesInfo.from(elDef, false);
         bindable = bindablesInfo.attrs[realAttrTarget];
         if (bindable !== void 0) {
-          // if it looks like: <my-el value.bind>
-          // it means        : <my-el value.bind="value">
-          // this is a shortcut
-          // and reuse attrValue variable
-          attrValue = attrValue.length === 0
-            && (bindingCommand.bindingType & (
-              BindingType.BindCommand
-              | BindingType.OneTimeCommand
-              | BindingType.ToViewCommand
-              | BindingType.TwoWayCommand
-            )) > 0
-              ? camelCase(attrName)
-              : attrValue;
-          expr = exprParser.parse(attrValue, bindingCommand.bindingType);
-
           commandBuildInfo.node = el;
           commandBuildInfo.attr = attrSyntax;
-          commandBuildInfo.expr = expr;
           commandBuildInfo.bindable = bindable;
           commandBuildInfo.def = elDef;
           (elBindableInstructions ??= []).push(bindingCommand.build(commandBuildInfo));
@@ -697,11 +671,8 @@ export class TemplateCompiler implements ITemplateCompiler {
       // + a plain attribute
       // + has binding command
 
-      expr = exprParser.parse(realAttrValue, bindingCommand.bindingType);
-
       commandBuildInfo.node = el;
       commandBuildInfo.attr = attrSyntax;
-      commandBuildInfo.expr = expr;
       commandBuildInfo.bindable = null;
       commandBuildInfo.def = null;
       (plainAttrInstructions ??= []).push(bindingCommand.build(commandBuildInfo));
@@ -1206,13 +1177,10 @@ export class TemplateCompiler implements ITemplateCompiler {
             : new InterpolationInstruction(expr, bindable.property)
           );
         } else {
-          expr = context._exprParser.parse(attrValue, command.bindingType);
           commandBuildInfo.node = node;
           commandBuildInfo.attr = attrSyntax;
-          commandBuildInfo.expr = expr;
           commandBuildInfo.bindable = bindable;
           commandBuildInfo.def = attrDef;
-          // instructions.push(command.compile(new BindingSymbol(command, bindable, expr, attrValue, attrName)));
           instructions.push(command.build(commandBuildInfo));
         }
 
@@ -1515,7 +1483,6 @@ function hasInlineBindings(rawValue: string): boolean {
 function resetCommandBuildInfo(): void {
   commandBuildInfo.node
     = commandBuildInfo.attr
-    = commandBuildInfo.expr
     = commandBuildInfo.bindable
     = commandBuildInfo.def = null!;
 }
@@ -1525,7 +1492,6 @@ const emptyCompilationInstructions: ICompliationInstruction = { projections: nul
 const voidDefinition: CustomElementDefinition = { name: 'unnamed' } as CustomElementDefinition;
 const commandBuildInfo: Writable<ICommandBuildInfo> = {
   node: null!,
-  expr: null!,
   attr: null!,
   bindable: null,
   def: null,

--- a/packages/runtime-html/src/templating/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/templating/dialog/dialog-controller.ts
@@ -249,8 +249,11 @@ export class DialogController implements IDialogController {
     const p = this.p;
 
     container.registerResolver(
-      INode,
-      container.registerResolver(p.Element, new InstanceProvider('ElementResolver', host))
+      p.HTMLElement,
+      container.registerResolver(
+        p.Element,
+        container.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+      )
     );
 
     return container.invoke(Component!);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently, template compiler turns attribute values into expressions before passing it to binding command to build corresponding instructions. This is sometimes inappropriate, as the template compiler sometimes needs to know what a binding command wants.

This PR changes it so that the expression parsing job is controlled by the binding commands themselves. This should make the abstraction more sound, and avoid wasteful work while enabling a better way to author custom binding binding commands.

This is a prerequisite work, to make things nicer and easier for syntax related features such as
- on binding command #1255 
- bindables targeted binding #1258 
- shorthand syntax for property binding #1259
- attribute transferring #1197 

## ⏭ Next Steps

Start implementing attribute transferring.