### PR TITLE
fix(href): avoid native href interference

### DIFF
--- a/packages/__tests__/3-runtime-html/binding-commands.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-commands.spec.ts
@@ -20,7 +20,7 @@ describe('binding-commands', function () {
     @bindingCommand({ name: 'woot1', aliases: ['woot13'] })
     @alias(...['woot11', 'woot12'])
     class WootCommand implements BindingCommandInstance {
-      public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
+      public readonly type: BindingType.BindCommand = BindingType.BindCommand;
 
       public static inject = [OneTimeBindingCommand];
       public constructor(private readonly oneTimeCmd: OneTimeBindingCommand) {}
@@ -33,7 +33,7 @@ describe('binding-commands', function () {
     @bindingCommand({ name: 'woot2', aliases: ['woot23'] })
     @alias('woot21', 'woot22')
     class WootCommand2 implements BindingCommandInstance {
-      public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
+      public readonly type: BindingType.BindCommand = BindingType.BindCommand;
 
       public static inject = [OneTimeBindingCommand];
       public constructor(private readonly oneTimeCmd: OneTimeBindingCommand) {}

--- a/packages/__tests__/router/smoke-tests.spec.ts
+++ b/packages/__tests__/router/smoke-tests.spec.ts
@@ -863,4 +863,31 @@ describe('router (smoke tests)', function () {
     await au.stop(true);
     assert.areTaskQueuesEmpty();
   });
+
+  it('does not interfere with standard "href" attribute', async function () {
+    const ctx = TestContext.create();
+    const { container } = ctx;
+
+    container.register(TestRouterConfiguration.for(ctx, LogLevel.debug));
+    container.register(RouterConfiguration);
+
+    const component = container.get(CustomElement.define(
+      { name: 'app', template: '<a href.bind="href">' },
+      class App { public href = 'abc'; }
+    ));
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+
+    await au.app({ component, host }).start();
+
+    assert.strictEqual(host.querySelector('a').getAttribute('href'), 'abc');
+
+    component.href = null;
+    ctx.platform.domWriteQueue.flush();
+
+    assert.strictEqual(host.querySelector('a').getAttribute('href'), null);
+
+    await au.stop();
+  });
 });

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -59,10 +59,13 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
   public isBound: boolean = false;
   public expr!: IsExpression;
   private readonly i18n: I18N;
+  /** @internal */
   private readonly _contentAttributes: readonly string[] = contentAttributes;
+  /** @internal */
   private _keyExpression: string | undefined | null;
   private scope!: Scope;
   private task: ITask | null = null;
+  /** @internal */
   private _isInterpolation!: boolean;
   private readonly _targetAccessors: Set<IAccessor>;
 

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -45,7 +45,7 @@ export class TranslationParametersBindingInstruction {
 
 @bindingCommand(attribute)
 export class TranslationParametersBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
+  public readonly type: BindingType.BindCommand = BindingType.BindCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -44,7 +44,7 @@ export class TranslationBindingInstruction {
 }
 
 export class TranslationBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.CustomCommand = BindingType.CustomCommand;
+  public readonly type: BindingType.CustomCommand = BindingType.CustomCommand;
 
   public static inject = [IAttrMapper];
   public constructor(private readonly m: IAttrMapper) {}
@@ -112,7 +112,7 @@ export class TranslationBindBindingInstruction {
 }
 
 export class TranslationBindBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
+  public readonly type: BindingType.BindCommand = BindingType.BindCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(

--- a/packages/router/src/resources/href.ts
+++ b/packages/router/src/resources/href.ts
@@ -54,20 +54,31 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
       this.isInitialized = true;
       this.isEnabled = this.isEnabled && getRef(this.el, CustomAttribute.getDefinition(LoadCustomAttribute).key) === null;
     }
-    if (this.isEnabled) {
+    if (this.value == null) {
+      this.el.removeAttribute('href');
+    } else {
       this.el.setAttribute('href', this.value as string);
     }
-    this.eventListener = this.delegator.addEventListener(this.target, this.el, 'click', this.onClick as EventListener);
+    this.eventListener = this.delegator.addEventListener(this.target, this.el, 'click', this);
   }
   public unbinding(): void {
     this.eventListener.dispose();
   }
 
   public valueChanged(newValue: unknown): void {
-    this.el.setAttribute('href', newValue as string);
+    if (newValue == null) {
+      this.el.removeAttribute('href');
+    } else {
+      this.el.setAttribute('href', newValue as string);
+    }
   }
 
-  private readonly onClick = (e: MouseEvent): void => {
+  public handleEvent(e: MouseEvent) {
+    this._onClick(e);
+  }
+
+  /** @internal */
+  private _onClick(e: MouseEvent): void {
     // Ensure this is an ordinary left-button click
     if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey || e.button !== 0
       // on an internally managed link
@@ -84,5 +95,5 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
       // Floating promises from `Router#load` are ok because the router keeps track of state and handles the errors, etc.
       void this.router.load(href, { context: this.ctx });
     }
-  };
+  }
 }

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -20,6 +20,8 @@ export class LetBinding implements IAstBasedBinding {
   public task: ITask | null = null;
 
   public target: (IObservable & IIndexable) | null = null;
+  /** @internal */
+  private readonly _toBindingContext: boolean;
   /**
    * A semi-private property used by connectable mixin
    *
@@ -32,9 +34,10 @@ export class LetBinding implements IAstBasedBinding {
     public targetProperty: string,
     observerLocator: IObserverLocator,
     public locator: IServiceLocator,
-    private readonly toBindingContext: boolean = false,
+    toBindingContext: boolean = false,
   ) {
     this.oL = observerLocator;
+    this._toBindingContext = toBindingContext;
   }
 
   public handleChange(newValue: unknown, _previousValue: unknown, flags: LifecycleFlags): void {
@@ -62,7 +65,7 @@ export class LetBinding implements IAstBasedBinding {
     }
 
     this.$scope = scope;
-    this.target = (this.toBindingContext ? scope.bindingContext : scope.overrideContext) as IIndexable;
+    this.target = (this._toBindingContext ? scope.bindingContext : scope.overrideContext) as IIndexable;
 
     const sourceExpression = this.sourceExpression;
     if (sourceExpression.hasBind) {

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -32,6 +32,7 @@ export function createElement<C extends Constructable = Constructable>(
  * RenderPlan. Todo: describe goal of this class
  */
 export class RenderPlan {
+  /** @internal */
   private _lazyDef?: CustomElementDefinition = void 0;
 
   public constructor(

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -4,13 +4,13 @@ import { AccessorType, LifecycleFlags } from '@aurelia/runtime';
 import type { IAccessor } from '@aurelia/runtime';
 
 export class ClassAttributeAccessor implements IAccessor {
+  public get doNotCache(): true { return true; }
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;
 
   public value: unknown = '';
   /** @internal */
   private _oldValue: unknown = '';
 
-  public readonly doNotCache: true = true;
   /** @internal */
   private _nameIndex: Record<string, number> = {};
   /** @internal */

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -47,7 +47,7 @@ export interface IBindableCommandInfo {
 export type ICommandBuildInfo = IPlainAttrCommandInfo | IBindableCommandInfo;
 
 export type BindingCommandInstance<T extends {} = {}> = {
-  bindingType: BindingType;
+  type: BindingType;
   build(info: ICommandBuildInfo): IInstruction;
 } & T;
 
@@ -153,7 +153,7 @@ export const BindingCommand = Object.freeze<BindingCommandKind>({
 
 @bindingCommand('one-time')
 export class OneTimeBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.OneTimeCommand = BindingType.OneTimeCommand;
+  public readonly type: BindingType.OneTimeCommand = BindingType.OneTimeCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(
@@ -184,7 +184,7 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('to-view')
 export class ToViewBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.ToViewCommand = BindingType.ToViewCommand;
+  public readonly type: BindingType.ToViewCommand = BindingType.ToViewCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(
@@ -215,7 +215,7 @@ export class ToViewBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('from-view')
 export class FromViewBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.FromViewCommand = BindingType.FromViewCommand;
+  public readonly type: BindingType.FromViewCommand = BindingType.FromViewCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(
@@ -246,7 +246,7 @@ export class FromViewBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('two-way')
 export class TwoWayBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.TwoWayCommand = BindingType.TwoWayCommand;
+  public readonly type: BindingType.TwoWayCommand = BindingType.TwoWayCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(
@@ -277,7 +277,7 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('bind')
 export class DefaultBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.BindCommand = BindingType.BindCommand;
+  public readonly type: BindingType.BindCommand = BindingType.BindCommand;
 
   public static inject = [IAttrMapper, IExpressionParser];
   public constructor(
@@ -319,7 +319,7 @@ export class DefaultBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('call')
 export class CallBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.CallCommand = BindingType.CallCommand;
+  public readonly type: BindingType.CallCommand = BindingType.CallCommand;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -334,7 +334,7 @@ export class CallBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('for')
 export class ForBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.ForCommand = BindingType.ForCommand;
+  public readonly type: BindingType.ForCommand = BindingType.ForCommand;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -349,7 +349,7 @@ export class ForBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('trigger')
 export class TriggerBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.TriggerCommand = BindingType.TriggerCommand;
+  public readonly type: BindingType.TriggerCommand = BindingType.TriggerCommand;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -361,7 +361,7 @@ export class TriggerBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('delegate')
 export class DelegateBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.DelegateCommand = BindingType.DelegateCommand;
+  public readonly type: BindingType.DelegateCommand = BindingType.DelegateCommand;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -373,7 +373,7 @@ export class DelegateBindingCommand implements BindingCommandInstance {
 
 @bindingCommand('capture')
 export class CaptureBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.CaptureCommand = BindingType.CaptureCommand;
+  public readonly type: BindingType.CaptureCommand = BindingType.CaptureCommand;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -388,7 +388,7 @@ export class CaptureBindingCommand implements BindingCommandInstance {
  */
 @bindingCommand('attr')
 export class AttrBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
+  public readonly type: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -403,7 +403,7 @@ export class AttrBindingCommand implements BindingCommandInstance {
  */
 @bindingCommand('style')
 export class StyleBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
+  public readonly type: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -418,7 +418,7 @@ export class StyleBindingCommand implements BindingCommandInstance {
  */
 @bindingCommand('class')
 export class ClassBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
+  public readonly type: BindingType.IsProperty = BindingType.IsProperty | BindingType.IgnoreAttr;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}
@@ -433,7 +433,7 @@ export class ClassBindingCommand implements BindingCommandInstance {
  */
 @bindingCommand('ref')
 export class RefBindingCommand implements BindingCommandInstance {
-  public readonly bindingType: BindingType.IsProperty | BindingType.IgnoreAttr = BindingType.IsProperty | BindingType.IgnoreAttr;
+  public readonly type: BindingType.IsProperty | BindingType.IgnoreAttr = BindingType.IsProperty | BindingType.IgnoreAttr;
 
   public static inject = [IExpressionParser];
   public constructor(private readonly xp: IExpressionParser) {}

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -141,7 +141,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       }
 
       bindingCommand = context._createCommand(attrSyntax);
-      if (bindingCommand !== null && (bindingCommand.bindingType & BindingType.IgnoreAttr) > 0) {
+      if (bindingCommand !== null && (bindingCommand.type & BindingType.IgnoreAttr) > 0) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
         // active.class="..."
@@ -343,11 +343,11 @@ export class TemplateCompiler implements ITemplateCompiler {
         // Onetime means it will not have appropriate value, but it's also a good thing,
         // since often one it's just a simple declaration
         // todo: consider supporting one-time for <let>
-        if (bindingCommand.bindingType === BindingType.ToViewCommand
-          || bindingCommand.bindingType === BindingType.BindCommand
+        if (bindingCommand.type === BindingType.ToViewCommand
+          || bindingCommand.type === BindingType.BindCommand
         ) {
           letInstructions.push(new LetBindingInstruction(
-            exprParser.parse(realAttrValue, bindingCommand.bindingType),
+            exprParser.parse(realAttrValue, bindingCommand.type),
             camelCase(realAttrTarget)
           ));
           continue;
@@ -513,7 +513,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       attrSyntax = context._attrParser.parse(attrName, attrValue);
 
       bindingCommand = context._createCommand(attrSyntax);
-      if (bindingCommand !== null && bindingCommand.bindingType & BindingType.IgnoreAttr) {
+      if (bindingCommand !== null && bindingCommand.type & BindingType.IgnoreAttr) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
         // active.class="..."


### PR DESCRIPTION
# Pull Request

## 📖 Description

Always reflect the value of href custom attribute on the host element.

Changes:
- rename `bindingType` on binding command to `type`