### PR TITLE
Fix typo in code sample in dialog.md

### DIFF
--- a/docs/user-docs/developer-guides/dialog.md
+++ b/docs/user-docs/developer-guides/dialog.md
@@ -248,10 +248,10 @@ An important feature of the dialog plugin is that it is possible to resolve and 
       // We get here when the dialog is opened,
       // and we are able to close dialog
       setTimeout(() => {
-        openDialogResult.dialog.cancel('Failed to finish editing after 3 seconds');
+        dialog.cancel('Failed to finish editing after 3 seconds');
       }, 3000);
 
-      const response = await openDialogResult.dialog.closed;
+      const response = await dialog.closed;
       if (response.status === DialogDeactivationStatuses.Ok) {
         console.log('good');
       } else {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix typo in code sample in dialog.md. The variable openDialogResult is used in the previous sample, in this one it is deconstructed into { dialog }

### 🎫 Issues

No issues were listed for this, just came across these while reading the docs.