### PR TITLE
feat(attr-transfer): support attributes spreading with ...$attrs

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -34,6 +34,7 @@
   * [Template references and variables](getting-to-know-aurelia/introduction/template-references-and-variables.md)
   * [Portalling elements](getting-to-know-aurelia/introduction/portalling-elements.md)
   * [Templating - Local Template](getting-to-know-aurelia/introduction/local-templates.md)
+  * [Attributes transferring](getting-to-know-aurelia/introduction/attributes-transferring.md)
 * [Components](getting-to-know-aurelia/components/README.md)
   * [Component lifecycles](getting-to-know-aurelia/components/component-lifecycles.md)
   * [Creating components](getting-to-know-aurelia/components/creating-components/README.md)

--- a/docs/user-docs/getting-to-know-aurelia/introduction/attributes-transfering.md
+++ b/docs/user-docs/getting-to-know-aurelia/introduction/attributes-transfering.md
@@ -1,0 +1,135 @@
+# Attributes transferring (or Spread Attributes)
+
+## Introduction
+
+Attribute transferring is a way to relay the binding(s) on a custom element to other element(s) inside it.
+
+As an application grows, the components inside it also grow. Something that starts simple like the following component
+
+```typescript
+export class FormInput {
+  @bindable label
+  @bindable value
+}
+```
+
+with the template
+
+```html
+<label>${label}
+  <input value.bind="value">
+</label>
+```
+can quickly grow out of hand with a number of needs for configuration: aria, type, min, max, pattern, tooltip, validation etc...
+
+After a while, the `FormInput` component above will be come more and more like a relayer to transfer the bindings from outside, to the elements inside it. This often results in the increase of the number of `@bindable`. This is completely fine except that it's quite some boilerplate code that is not always desirable:
+
+```typescript
+export class FormInput {
+  @bindable label
+  @bindable value
+  @bindable type
+  @bindable tooltip
+  @bindable arias
+  @bindable etc
+}
+```
+
+And the usage of such element may look like this
+
+```html
+<form-input
+  label.bind="label"
+  value.bind="message"
+  tooltip.bind="Did you know Aurelia syntax comes from an idea of an Angular community member? We greatly appreciate Angular and its community for this."
+  validation.bind="...">
+```
+
+to be repeated like this inside:
+
+```html
+<label>${label}
+  <input value.bind tooltip.bind validation.bind min.bind max.bind>
+</label>
+```
+
+To juggle all the relevant pieces for such relaying task isn't difficult, but somewhat tedious. With attribute transferring, which is roughly close to spreading in JavaScript, the above template should be as simple as:
+
+```html
+<label>${label}
+  <input ...$attrs>
+</label>
+```
+
+, which reads like this: for some bindings on `<form-input>`, change the targets of those bindings to the `<input>` element inside it.
+
+## Usage
+
+To transfer attributes & bindings from a custom element, there are two steps:
+
+- Set `capture` to `true` on a custom element via `@customElement` decorator:
+
+```typescript
+@customElement({
+  ...,
+  capture: true
+})
+```
+
+As the name suggests, this is to signal the template compiler that all the bindings & attributes, with some exceptions should be captured for future usages.
+
+- Spread the captured attributes onto an element:
+
+```html
+<input ...$attrs>
+```
+
+{% hint style="warning" %}
+It's recommended that this feature should not be overused in multi level capturing & transferring. This is often known as prop-drilling in React, and could have bad effect on overall & long term maintainability of a project. It's probably healthy to limit the max level of transferring to 2.
+{% endhint %}
+
+
+## How it works
+
+### What attributes are captured
+
+Everything except template controller and custom element bindables are captured. For the following example:
+
+View model:
+```typescript
+export class FormInput {
+  @bindable label
+}
+```
+
+Usage:
+```html
+<form-input if.bind="needsComment" label.bind="label" value.bind="extraComment" class="form-control" style="background: var(--theme-purple)" tooltip="Hello, ${tooltip}">
+```
+
+What are captured:
+  - `value.bind="extraComment"`
+  - `class="form-control"`
+  - `style="background: var(--theme-purple)"`
+  - `tooltip="Hello, ${tooltip}"`
+What are not captured:
+  - `if.bind="needsComment"` (`if` is a template controller)
+  - `label.bind="label"` (`label` is a bindable property)
+
+### How will attributes be applied in ...$attrs
+
+Attributes that are spread onto an element will be compiled as if it was declared on that element.
+
+This means `.bind` command will work as expected when it's transferred from some element onto some element that uses `.two-way` for `.bind`.
+
+It also means that spreading onto a custom element will also work: if a captured attribute is targeting a bindable property of the applied custom element. An example:
+
+```html
+app.html
+<input-field value.bind="message">
+
+input-field.html
+<my-input ...$attrs>
+```
+
+if `value` is a bindable property of `my-input`, the end result will be a binding that connect the `message` property of the corresponding `app.html` view model with `<my-input>` view model `value` property. Binding mode is also preserved like normal attributes.

--- a/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features/README.md
+++ b/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features/README.md
@@ -2,6 +2,12 @@
 
 This topic demonstrates how to work with Aurelia's built-in template commands which allow you to conditionally show and hide content, loop over collections of content, conditional rendering using switch/case syntax in your views and a trove of other built-in template features.
 
+{% hint style="info" %}
+
+Even though mentioned as built-in, the features here are implemented using the extensible core APIs. They can be used as examples of how to build your own equivalent features.
+{% endhint %}
+
+
 ## Explore template features
 
 {% page-ref page="if.bind.md" %}

--- a/docs/user-docs/reference/examples/integration/README.md
+++ b/docs/user-docs/reference/examples/integration/README.md
@@ -15,10 +15,12 @@ description: The basics of integrating web component libraries with Aurelia.
 ## Integrating with [Microsoft FAST web components](https://www.fast.design/)
 
 [The guide for the integration here](ms-fast.md)
+{% page-ref page="ms-fast.md" %}
 
 ## Integrating with [Ionic web components](https://ionicframework.com/docs/components)
 
 [The guide for the integration here](ionic.md)
+{% page-ref page="ionic.md" %}
 
 {% hint style="info" %}
 **For our community**

--- a/docs/user-docs/reference/examples/integration/ionic.md
+++ b/docs/user-docs/reference/examples/integration/ionic.md
@@ -2,7 +2,8 @@
 
 If the example doesn't seem obvious, the following prerequisite reads are recommended:
 
-* [extending templating syntax](https://github.com/aurelia/aurelia/tree/869a9ec4f2fedc41c333e0bd02c905de2ae709da/docs/user-docs/app-basics/extening-templating-syntax.md)
+{% page-ref page="../../../developer-guides/extending-templating-syntax.md" %}
+* [extending templating syntax](../../../developer-guides/extending-templating-syntax.md)
 
 The following is a code example of how to teach Aurelia to work seamlessly with [Ionic Framework](https://ionicframework.com/):
 

--- a/docs/user-docs/reference/examples/integration/ms-fast.md
+++ b/docs/user-docs/reference/examples/integration/ms-fast.md
@@ -2,7 +2,8 @@
 
 If the example doesn't seem obvious, the following prerequisite reads are recommended:
 
-* [extending templating syntax](https://docs.aurelia.io/app-basics/extending-templating-syntax)
+{% page-ref page="../../../developer-guides/extending-templating-syntax.md" %}
+* [extending templating syntax](../../../developer-guides/extending-templating-syntax.md)
 
 The following is a code example of how to teach Aurelia to work seamlessly with [Microsoft FAST](https://www.fast.design/):
 

--- a/packages/__tests__/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/3-runtime-html/spread.spec.ts
@@ -1,0 +1,281 @@
+import { Constructable } from '@aurelia/kernel';
+import { BindingMode, CustomAttribute, CustomElement, ICustomElementViewModel, INode } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+// all the tests are using a common <my-input/> with a spreat on its internal <input/>
+describe('3-runtime-html/spread.spec.ts', function () {
+  const $it = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, false);
+  $it.only = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, true);
+
+  $it('works single layer of ...attrs', {
+    template: '<my-input value.bind="message">',
+    component: { message: 'Aurelia' },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+    },
+  });
+
+  $it('preserves attr syntaxes', {
+    template: '<my-input value.bind="message">',
+    component: { message: 'Aurelia' },
+    assertFn: ({ ctx, component, appHost }) => {
+      ctx.type(appHost, 'input', 'hello');
+      assert.strictEqual(component.message, 'hello');
+      component.message = 'Aurelia';
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+    },
+  });
+
+  $it('does not throw when capture: false', {
+    template: '<no-capture-input value.bind="message">',
+    component: { message: 'Aurelia' },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, '');
+    },
+  });
+
+  $it('does not throw when there are nothing to capture', {
+    template: '<my-input>',
+    component: { message: 'Aurelia' },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, '');
+    },
+  });
+
+  $it('works with pass-through ...$attrs', {
+    template: '<input-field value.bind="message">',
+    component: { message: 'Aurelia' },
+    registrations: [
+      CustomElement.define({
+        name: 'input-field',
+        template: '<my-input ...$attrs>',
+        capture: true,
+      }),
+    ],
+    assertFn: ({ platform, component, appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      component.message = 'hello';
+      platform.domWriteQueue.flush();
+      assert.strictEqual(appHost.querySelector('input').value, 'hello');
+    },
+  });
+
+  $it('does not capture template controller', {
+    template: '<my-input value.bind="message" if.bind="hasInput">',
+    component: { hasInput: false, message: 'Aurelia' },
+    assertFn: ({ appHost }) => {
+      assert.html.innerEqual(appHost, '');
+    },
+  });
+
+  $it('spreads event bindings', {
+    template: '<my-input value.to-view="message" change.trigger="message = $event.target.value" focus.trigger="focused = true">',
+    component: { message: 'Aurelia', focused: false },
+    assertFn: ({ ctx, component, appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      ctx.type(appHost, 'input', 'hello');
+      assert.strictEqual(component.message, 'hello');
+      appHost.querySelector('input').dispatchEvent(new ctx.CustomEvent('focus'));
+      assert.strictEqual(component.focused, true);
+    },
+  });
+
+  $it('spreads interpolation', {
+    template: `<my-input value="\${message}">`,
+    component: { message: 'Aurelia', focused: false },
+    assertFn: ({ ctx, component, appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      ctx.type(appHost, 'input', 'hello');
+      assert.strictEqual(component.message, 'Aurelia');
+    },
+  });
+
+  $it('spreads plain class attribute', {
+    template: '<my-input class="abc">',
+    component: { message: 'Aurelia', focused: false },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').className, 'au abc');
+    },
+  });
+
+  $it('spreads plain style attribute', {
+    template: '<my-input style="display: block;">',
+    component: { message: 'Aurelia', focused: false },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').style.display, 'block');
+    },
+  });
+
+  $it('spreads plain attributes', {
+    template: '<my-input size="20" aria-label="input">',
+    component: { message: 'Aurelia', focused: false },
+    assertFn: ({ appHost }) => {
+      assert.strictEqual(appHost.querySelector('input').size, 20);
+      assert.strictEqual(appHost.querySelector('input').getAttribute('aria-label'), 'input');
+    },
+  });
+
+  describe('custom attribute', function () {
+    const MyAttr = CustomAttribute.define({ name: 'my-attr', bindables: ['value'] }, class {
+      public static inject = [INode];
+      public value: any;
+      public constructor(private readonly host: HTMLElement) { }
+      public binding() {
+        this.host.setAttribute('size', this.value);
+      }
+    });
+
+    $it('spreads custom attribute (with literal value)', {
+      template: '<my-input my-attr="20">',
+      component: { },
+      registrations: [MyAttr],
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+      }
+    });
+
+    $it('spreads custom attribute (with interpolation)', {
+      template: `<my-input my-attr="\${size}">`,
+      component: { size: 20 },
+      registrations: [MyAttr],
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+      }
+    });
+
+    $it('spreads custom attribute (primary binding syntax)', {
+      template: '<my-input my-attr.bind="size">',
+      component: { size: 20 },
+      registrations: [MyAttr],
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+      }
+    });
+
+    $it('spreads custom attribute (multi binding syntax)', {
+      template: '<my-input my-attr="value.bind: size">',
+      component: { size: 20 },
+      registrations: [MyAttr],
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+      }
+    });
+  });
+
+  describe('custom element', function () {
+    const testElements = [
+      CustomElement.define({
+        name: 'form-field',
+        template: '<form-input ...$attrs>',
+        capture: true,
+      }),
+      CustomElement.define({
+        name: 'form-input',
+        template: '<input value.bind="value">',
+        bindables: {
+          value: { property: 'value', attribute: 'value', mode: BindingMode.twoWay }
+        }
+      }),
+    ];
+
+    $it('spreads plain binding to custom element bindable', {
+      template: '<form-field value="Aurelia">',
+      component: {},
+      registrations: testElements,
+      assertFn: ({ appHost }) => {
+        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      },
+    });
+
+    $it('spreads binding to custom element bindables', {
+      template: '<form-field value.bind="message">',
+      component: { message: 'Aurelia' },
+      registrations: testElements,
+      assertFn: ({ appHost }) => {
+        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      },
+    });
+
+    $it('spreads interpolation to custom element bindables', {
+      template: `<form-field value="\${message}">`,
+      component: { message: 'Aurelia' },
+      registrations: testElements,
+      assertFn: ({ appHost }) => {
+        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+      },
+    });
+
+    $it('spreads shorthand element bindable props', {
+      template: '<form-field prop1.bind prop2.one-time prop3.to-view prop4.from-view>',
+      component: { prop1: 'prop 1', prop2: 'prop 2', prop3: 'prop 3', prop4: 'prop 4' },
+      registrations: [
+        CustomElement.define({
+          name: 'form-field',
+          template: '<form-input ...$attrs>',
+          capture: true,
+        }),
+        CustomElement.define({
+          name: 'form-input',
+          template: '<input value.bind="prop1">',
+          bindables: ['prop1', 'prop2', 'prop3', 'prop4']
+        }),
+      ],
+      assertFn: ({ component, appHost }) => {
+        const formInput = CustomElement.for(appHost.querySelector('form-input')).viewModel as typeof component;
+        assert.strictEqual(formInput.prop1, 'prop 1');
+        assert.strictEqual(formInput.prop2, 'prop 2');
+        assert.strictEqual(formInput.prop3, 'prop 3');
+        assert.strictEqual(formInput.prop4, undefined);
+        formInput.prop4 = 'prop 5';
+        assert.strictEqual(component.prop4, 'prop 5');
+      },
+    });
+  });
+
+  function runTest<T>(title: string, { template, assertFn, component, registrations }: ISpreadTestCase<T>, only?: boolean) {
+    return (only ? it.only : it)(title, async function () {
+      const fixture = createFixture(
+        template,
+        (typeof component === 'object'
+          ? class { public constructor() { Object.assign(this, component); } }
+          : component
+        ) as Constructable<T extends Constructable<infer O> ? Constructable<O> : Constructable<T>>,
+        [
+          ...(registrations ?? []),
+          CustomElement.define({
+            name: 'my-input',
+            template: '<input ...$attrs>',
+            capture: true,
+          }, class MyInput { }),
+          CustomElement.define({
+            name: 'no-capture-input',
+            template: '<input ...$attrs>',
+            capture: false,
+          }, class NoCaptureInput { })
+        ],
+      );
+      const { startPromise, tearDown } = fixture;
+
+      await startPromise;
+
+      await assertFn(fixture as any);
+
+      await tearDown();
+    });
+  }
+
+  interface ISpreadTestCase<T> {
+    component: Constructable<T> | T;
+    template: string;
+    registrations?: any[];
+    assertFn(arg: ReturnType<typeof createFixture> & { component: ICustomElementViewModel & T }): void | Promise<void>;
+  }
+});

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -720,6 +720,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
         instructions: [[childInstr]],
         needsCompile: false,
         enhance: false,
+        capture: false,
         processContent: null,
       },
       props: createTplCtrlAttributeInstruction(attr, value),
@@ -734,6 +735,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
       instructions: [[instruction]],
       needsCompile: false,
       enhance: false,
+      capture: false,
       processContent: null,
     } as unknown as PartialCustomElementDefinition;
     return [input, output];
@@ -758,6 +760,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
         instructions,
         needsCompile: false,
         enhance: false,
+        capture: false,
         processContent: null,
       },
       props: createTplCtrlAttributeInstruction(attr, value),
@@ -773,6 +776,7 @@ function createTemplateController(ctx: TestContext, resolveRes: boolean, attr: s
       instructions: [[instruction]],
       needsCompile: false,
       enhance: false,
+      capture: false,
       processContent: null,
     } as unknown as PartialCustomElementDefinition;
     return [input, output];
@@ -798,6 +802,7 @@ function createCustomElement(
     auSlot: null,
     containerless: false,
     projections: null,
+    captures: [],
   };
   const def = typeof tagNameOrDef === 'string'
     ? ctx.container.find(CustomElement, tagNameOrDef)
@@ -842,6 +847,7 @@ function createCustomElement(
     needsCompile: false,
     enhance: false,
     watches: [],
+    capture: false,
     processContent: null,
   };
   return [input, output];
@@ -877,7 +883,7 @@ function createCustomAttribute(
   // new behavior: if it's custom attribute, remove
   const outputMarkup = ctx.createElementFromMarkup(`<div>${(childOutput && childOutput.template.outerHTML) || ''}</div>`);
   outputMarkup.classList.add('au');
-  const output = {
+  const output: PartialCustomElementDefinition & { key: string } = {
     ...defaultCustomElementDefinitionProperties,
     name: 'unnamed',
     key: 'au:resource:custom-element:unnamed',
@@ -885,6 +891,7 @@ function createCustomAttribute(
     instructions: [[instruction, ...siblingInstructions], ...nestedElInstructions],
     needsCompile: false,
     enhance: false,
+    capture: false,
     watches: [],
     processContent: null,
   };
@@ -998,13 +1005,14 @@ describe(`TemplateCompiler - combinations`, function () {
             instructions: [],
             surrogates: [],
           } as unknown as PartialCustomElementDefinition;
-          const expected = {
+          const expected: PartialCustomElementDefinition = {
             ...defaultCustomElementDefinitionProperties,
             template: ctx.createElementFromMarkup(`<template><${el} plain data-attr="value" class="abc au" ${debugMode ? `${n1}="${v1}" ` : ''}></${el}></template>`),
             instructions: [[i1]],
             surrogates: [],
             needsCompile: false,
             enhance: false,
+            capture: false,
             processContent: null,
           };
 
@@ -1023,13 +1031,14 @@ describe(`TemplateCompiler - combinations`, function () {
             instructions: [],
             surrogates: [],
           } as unknown as PartialCustomElementDefinition;
-          const expected = {
+          const expected: PartialCustomElementDefinition = {
             ...defaultCustomElementDefinitionProperties,
             template: ctx.createElementFromMarkup(`<template><${el} plain data-attr="value" ${debugMode ? `${n1}="${v1}" ` : ''}class="au"></${el}></template>`),
             instructions: [[i1]],
             surrogates: [],
             needsCompile: false,
             enhance: false,
+            capture: false,
             processContent: null,
           };
 
@@ -1073,6 +1082,7 @@ describe(`TemplateCompiler - combinations`, function () {
           surrogates: [],
           needsCompile: false,
           enhance: false,
+          capture: false,
           processContent: null,
         };
 
@@ -1151,6 +1161,7 @@ describe(`TemplateCompiler - combinations`, function () {
             surrogates: [],
             needsCompile: false,
             enhance: false,
+            capture: false,
             watches: [],
             processContent: null,
           };
@@ -1448,12 +1459,13 @@ describe(`TemplateCompiler - combinations`, function () {
         );
         sut.resolveResources = resolveRes;
 
-        const output = {
+        const output: PartialCustomElementDefinition = {
           ...defaultCustomElementDefinitionProperties,
           template: ctx.createElementFromMarkup(`<template><div>${output1.template['outerHTML']}${output2.template['outerHTML']}${output3.template['outerHTML']}</div></template>`),
           instructions: [output1.instructions[0], output2.instructions[0], output3.instructions[0]],
           needsCompile: false,
           enhance: false,
+          capture: false,
           watches: [],
           processContent: null,
         };

--- a/packages/platform-browser/src/index.ts
+++ b/packages/platform-browser/src/index.ts
@@ -49,7 +49,7 @@ export class BrowserPlatform<TGlobal extends typeof globalThis = typeof globalTh
       });
 
     'fetch,requestAnimationFrame,cancelAnimationFrame'.split(',').forEach(prop => {
-      (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : (g as any)[prop].bind(g) ?? notImplemented(prop);
+      (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : ((g as any)[prop]?.bind(g) ?? notImplemented(prop));
     });
 
     this.flushDomRead = this.flushDomRead.bind(this);

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -2,6 +2,7 @@ import { DI, IContainer, IRegistry } from '@aurelia/kernel';
 import {
   AtPrefixedTriggerAttributePattern,
   ColonPrefixedBindAttributePattern,
+  SpreadAttributePattern,
   DotSeparatedAttributePattern,
   RefAttributePattern,
 } from './resources/attribute-pattern.js';
@@ -20,6 +21,7 @@ import {
   RefBindingCommand,
   StyleBindingCommand,
   TriggerBindingCommand,
+  SpreadBindingCommand,
 } from './resources/binding-command.js';
 import { TemplateCompiler } from './template-compiler.js';
 import {
@@ -40,6 +42,7 @@ import {
   TextBindingRenderer,
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
+  SpreadRenderer,
 } from './renderer.js';
 import {
   FromViewBindingBehavior,
@@ -107,6 +110,7 @@ export const AtPrefixedTriggerAttributePatternRegistration = AtPrefixedTriggerAt
 export const ColonPrefixedBindAttributePatternRegistration = ColonPrefixedBindAttributePattern as unknown as IRegistry;
 export const RefAttributePatternRegistration = RefAttributePattern as unknown as IRegistry;
 export const DotSeparatedAttributePatternRegistration = DotSeparatedAttributePattern as unknown as IRegistry;
+export const SpreadAttributePatternRegistration = SpreadAttributePattern as unknown as IRegistry;
 
 /**
  * Default binding syntax for the following attribute name patterns:
@@ -115,7 +119,8 @@ export const DotSeparatedAttributePatternRegistration = DotSeparatedAttributePat
  */
 export const DefaultBindingSyntax = [
   RefAttributePatternRegistration,
-  DotSeparatedAttributePatternRegistration
+  DotSeparatedAttributePatternRegistration,
+  SpreadAttributePatternRegistration,
 ];
 
 /**
@@ -142,6 +147,7 @@ export const CaptureBindingCommandRegistration = CaptureBindingCommand as unknow
 export const AttrBindingCommandRegistration = AttrBindingCommand as unknown as IRegistry;
 export const ClassBindingCommandRegistration = ClassBindingCommand as unknown as IRegistry;
 export const StyleBindingCommandRegistration = StyleBindingCommand as unknown as IRegistry;
+export const SpreadBindingCommandRegistration = SpreadBindingCommand as unknown as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) binding commands:
@@ -165,6 +171,7 @@ export const DefaultBindingLanguage = [
   ClassBindingCommandRegistration,
   StyleBindingCommandRegistration,
   AttrBindingCommandRegistration,
+  SpreadBindingCommandRegistration,
 ];
 
 export const SanitizeValueConverterRegistration = SanitizeValueConverter as unknown as IRegistry;
@@ -258,6 +265,7 @@ export const SetClassAttributeRendererRegistration = SetClassAttributeRenderer a
 export const SetStyleAttributeRendererRegistration = SetStyleAttributeRenderer as unknown as IRegistry;
 export const StylePropertyBindingRendererRegistration = StylePropertyBindingRenderer as unknown as IRegistry;
 export const TextBindingRendererRegistration = TextBindingRenderer as unknown as IRegistry;
+export const SpreadRendererRegistration = SpreadRenderer as unknown as IRegistry;
 
 /**
  * Default renderers for:
@@ -294,6 +302,7 @@ export const DefaultRenderers = [
   SetStyleAttributeRendererRegistration,
   StylePropertyBindingRendererRegistration,
   TextBindingRendererRegistration,
+  SpreadRendererRegistration,
 ];
 
 /**

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -125,7 +125,7 @@ function createElementForType(
     dependencies.push(Type);
   }
 
-  instructions.push(new HydrateElementInstruction(definition, void 0, childInstructions, null, false));
+  instructions.push(new HydrateElementInstruction(definition, void 0, childInstructions, null, false, void 0));
 
   if (props) {
     Object.keys(props)

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -580,3 +580,10 @@ export class AtPrefixedTriggerAttributePattern {
     return new AttrSyntax(rawName, rawValue, parts[0], 'trigger');
   }
 }
+
+@attributePattern({ pattern: '...$attrs', symbols: '' })
+export class SpreadAttributePattern {
+  public '...$attrs'(rawName: string, rawValue: string, parts: string[]): AttrSyntax {
+    return new AttrSyntax('', '', '', '...$attrs');
+  }
+}

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -8,9 +8,10 @@ import {
   IteratorBindingInstruction,
   RefBindingInstruction,
   ListenerBindingInstruction,
+  SpreadBindingInstruction,
 } from '../renderer.js';
 import { DefinitionType } from './resources-shared.js';
-import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
+import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor } from '../shared.js';
 
 import type {
   Constructable,
@@ -66,12 +67,12 @@ export type BindingCommandInstance<T extends {} = {}> = {
 
 export type BindingCommandType<T extends Constructable = Constructable> = ResourceType<T, BindingCommandInstance, PartialBindingCommandDefinition>;
 export type BindingCommandKind = IResourceKind<BindingCommandType, BindingCommandDefinition> & {
-  isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never);
+  // isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never);
   define<T extends Constructable>(name: string, Type: T): BindingCommandType<T>;
   define<T extends Constructable>(def: PartialBindingCommandDefinition, Type: T): BindingCommandType<T>;
   define<T extends Constructable>(nameOrDef: string | PartialBindingCommandDefinition, Type: T): BindingCommandType<T>;
-  getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T>;
-  annotate<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K, value: PartialBindingCommandDefinition[K]): void;
+  // getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T>;
+  // annotate<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K, value: PartialBindingCommandDefinition[K]): void;
   getAnnotation<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K): PartialBindingCommandDefinition[K];
 };
 
@@ -136,9 +137,9 @@ const getCommandAnnotation = <K extends keyof PartialBindingCommandDefinition>(
 export const BindingCommand = Object.freeze<BindingCommandKind>({
   name: cmdBaseName,
   keyFrom: getCommandKeyFrom,
-  isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never) {
-    return typeof value === 'function' && hasOwnMetadata(cmdBaseName, value);
-  },
+  // isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never) {
+  //   return typeof value === 'function' && hasOwnMetadata(cmdBaseName, value);
+  // },
   define<T extends Constructable<BindingCommandInstance>>(nameOrDef: string | PartialBindingCommandDefinition, Type: T): T & BindingCommandType<T> {
     const definition = BindingCommandDefinition.create(nameOrDef, Type as Constructable<BindingCommandInstance>);
     defineMetadata(cmdBaseName, definition, definition.Type);
@@ -147,20 +148,20 @@ export const BindingCommand = Object.freeze<BindingCommandKind>({
 
     return definition.Type as BindingCommandType<T>;
   },
-  getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T> {
-    const def = getOwnMetadata(cmdBaseName, Type);
-    if (def === void 0) {
-      if (__DEV__)
-        throw new Error(`No definition found for type ${Type.name}`);
-      else
-        throw new Error(`AUR0758:${Type.name}`);
-    }
+  // getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T> {
+  //   const def = getOwnMetadata(cmdBaseName, Type);
+  //   if (def === void 0) {
+  //     if (__DEV__)
+  //       throw new Error(`No definition found for type ${Type.name}`);
+  //     else
+  //       throw new Error(`AUR0758:${Type.name}`);
+  //   }
 
-    return def;
-  },
-  annotate<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K, value: PartialBindingCommandDefinition[K]): void {
-    defineMetadata(getAnnotationKeyFor(prop), value, Type);
-  },
+  //   return def;
+  // },
+  // annotate<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K, value: PartialBindingCommandDefinition[K]): void {
+  //   defineMetadata(getAnnotationKeyFor(prop), value, Type);
+  // },
   getAnnotation: getCommandAnnotation,
 });
 
@@ -525,7 +526,12 @@ export class RefBindingCommand implements BindingCommandInstance {
   }
 }
 
-// @bindingCommand('...$attrs')
-// export class SpreadCaptureBindingCommand implements BindingCommandInstance {
+@bindingCommand('...$attrs')
+export class SpreadBindingCommand implements BindingCommandInstance {
+  public readonly type: CommandType = CommandType.IgnoreAttr;
+  public get name(): string { return '...$attrs'; }
 
-// }
+  public build(info: ICommandBuildInfo): IInstruction {
+    return new SpreadBindingInstruction();
+  }
+}

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -44,6 +44,7 @@ declare module '@aurelia/kernel' {
 
 export type PartialCustomElementDefinition = PartialResourceDefinition<{
   readonly cache?: '*' | number;
+  readonly capture?: boolean;
   readonly template?: null | string | Node;
   readonly instructions?: readonly (readonly IInstruction[])[];
   readonly dependencies?: readonly Key[];
@@ -214,6 +215,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly aliases: string[],
     public readonly key: string,
     public readonly cache: '*' | number,
+    public readonly capture: boolean,
     public readonly template: null | string | Node,
     public readonly instructions: readonly (readonly IInstruction[])[],
     public readonly dependencies: readonly Key[],
@@ -273,6 +275,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         mergeArrays(def.aliases),
         fromDefinitionOrDefault('key', def as CustomElementDefinition, () => CustomElement.keyFrom(name)),
         fromDefinitionOrDefault('cache', def, returnZero),
+        fromDefinitionOrDefault('capture', def, returnFalse),
         fromDefinitionOrDefault('template', def, returnNull),
         mergeArrays(def.instructions),
         mergeArrays(def.dependencies),
@@ -301,6 +304,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         mergeArrays(getElementAnnotation(Type, 'aliases'), Type.aliases),
         CustomElement.keyFrom(nameOrDef),
         fromAnnotationOrTypeOrDefault('cache', Type, returnZero),
+        fromAnnotationOrTypeOrDefault('capture', Type, returnFalse),
         fromAnnotationOrTypeOrDefault('template', Type, returnNull),
         mergeArrays(getElementAnnotation(Type, 'instructions'), Type.instructions),
         mergeArrays(getElementAnnotation(Type, 'dependencies'), Type.dependencies),
@@ -339,6 +343,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       mergeArrays(getElementAnnotation(Type, 'aliases'), nameOrDef.aliases, Type.aliases),
       CustomElement.keyFrom(name),
       fromAnnotationOrDefinitionOrTypeOrDefault('cache', nameOrDef, Type, returnZero),
+      fromAnnotationOrDefinitionOrTypeOrDefault('capture', nameOrDef, Type, returnFalse),
       fromAnnotationOrDefinitionOrTypeOrDefault('template', nameOrDef, Type, returnNull),
       mergeArrays(getElementAnnotation(Type, 'instructions'), nameOrDef.instructions, Type.instructions),
       mergeArrays(getElementAnnotation(Type, 'dependencies'), nameOrDef.dependencies, Type.dependencies),

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -41,6 +41,7 @@ import type {
   IObservable,
   IsBindingBehavior,
 } from '@aurelia/runtime';
+import type { AttrSyntax } from '../resources/attribute-pattern.js';
 import type { IProjections } from '../resources/slot-injectables.js';
 import type { BindableDefinition } from '../bindable.js';
 import type { LifecycleHooksLookup } from './lifecycle-hooks.js';
@@ -1767,6 +1768,10 @@ export interface IControllerElementHydrationInstruction {
    */
   readonly hydrate?: boolean;
   readonly projections: IProjections | null;
+  /**
+   * A list of captured attributes/binding in raw format
+   */
+  readonly captures?: AttrSyntax[];
 }
 
 function callDispose(disposable: IDisposable): void {

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -88,6 +88,12 @@ export class TestContext {
     attr.value = value;
     return attr;
   }
+
+  public type(host: HTMLElement, selector: string, value: string): void {
+    const el = host.querySelector(selector) as HTMLElement & { value: string };
+    el.value = value;
+    el.dispatchEvent(new this.CustomEvent('change', { bubbles: true }));
+  }
 }
 
 // Note: our tests shouldn't rely directly on this global variable, but retrieve the platform from a container instead.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add support for transferring attributes with `...$attrs` syntax. Example:

```html
app.html
<my-input value.bind="message">

my-input.html
<input ...$attrs>
```

Attribute transferring is a way to relay the binding(s) on a custom element to other element(s) inside it.

As an application grows, the components inside it also grow. Something that starts simple like the following component

```typescript
export class FormInput {
  @bindable label
  @bindable value
}
```

with the template

```html
<label>${label}
  <input value.bind="value">
</label>
```
can gradually grow out of hand with a number of needs for configuration: aria, type, min, max, pattern, tooltip, validation etc...

After a while, the `FormInput` component above will be come more and more like a relayer to transfer the bindings from outside, to the elements inside it. This often results in the increase of the number of `@bindable`. This is completely fine except that it's quite some boilerplate code that is not always desirable:

```typescript
export class FormInput {
  @bindable label
  @bindable value
  @bindable type
  @bindable tooltip
  @bindable arias
  @bindable etc
}
```

And the usage of such element may look like this

```html
<form-input
  label.bind="label"
  value.bind="message"
  tooltip.bind="Did you know Aurelia syntax comes from an idea of an Angular community member? We greatly appreciate Angular and its community for this."
  validation.bind="...">
```

to be repeated like this inside:

```html
<label>${label}
  <input value.bind tooltip.bind validation.bind min.bind max.bind>
</label>
```

To juggle all the relevant pieces for such relaying task isn't difficult, but somewhat tedious. With attribute transferring, which is roughly close to spreading in JavaScript, the above template should be as simple as:

```html
<label>${label}
  <input ...$attrs>
</label>
```

, which reads like this: for some bindings on `<form-input>`, change the targets of those bindings to the `<input>` element inside it.

### 🎫 Issues

close #636
close #422
close #1009
close #668
close #319

## 👩‍💻 Reviewer Notes

There' two new instructions to deal with spreading, they are mostly internal to the new `SpreadRenderer`. While doing this, I had to come up with somewhat hackish-approach: making the spread binding work as a surrogate bindings for all the bindings created from the captured attributes. In the end, it still looks fine, but later, we can see whether we can improve anything around the renderers API to avoid such hack.
The `HydrateElementInstruction` has been enhanced with a new property `captures`, to store relevant information. And the template compiler has been also made aware of `capture` property on a custom element definition.

Note of what will be captured, and what will not be:

View model:
```typescript
export class FormInput {
  @bindable label
}
```

Usage:
```html
<form-input if.bind="needsComment" label.bind="label" value.bind="extraComment" class="form-control" style="background: var(--theme-purple)" tooltip="Hello, ${tooltip}">
```

What are captured:
  - `value.bind="extraComment"`
  - `class="form-control"`
  - `style="background: var(--theme-purple)"`
  - `tooltip="Hello, ${tooltip}"`
What are not captured:
  - `if.bind="needsComment"` (`if` is a template controller)
  - `label.bind="label"` (`label` is a bindable property)

## 📑 Test Plan

- multi level transferring
- interpolation transferring
- binding command preservation

## ⏭ Next Steps

N/A