### PR TITLE
feat(au-compose): works with au-slot

### DIFF
--- a/packages/__tests__/3-runtime-html/au-compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-compose.spec.ts
@@ -1018,4 +1018,46 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     await tearDown();
     assert.strictEqual(appHost.textContent, '');
   });
+
+  it('works with [au-slot] when composing custom element', async function () {
+    const El1 = CustomElement.define({
+      name: 'el1',
+      template: `<p><au-slot>`
+    }, class Element1 {});
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<au-compose view-model.bind="vm"><input value.bind="message" au-slot>`,
+      class App {
+        public message = 'Aurelia';
+        public vm: any = El1;
+      }
+    );
+
+    await startPromise;
+
+    assert.strictEqual((appHost.querySelector('p input') as HTMLInputElement).value, 'Aurelia');
+
+    await tearDown();
+  });
+
+  it('works with [au-slot] + [repeat] when composing custom element', async function () {
+    const El1 = CustomElement.define({
+      name: 'el1',
+      template: `<p><au-slot>`
+    }, class Element1 {});
+    const { appHost, startPromise, tearDown } = createFixture(
+      `<au-compose repeat.for="i of 3" view-model.bind="vm"><input value.to-view="message + i" au-slot>`,
+      class App {
+        public message = 'Aurelia';
+        public vm: any = El1;
+      }
+    );
+
+    await startPromise;
+
+    assert.deepStrictEqual(
+      Array.from(appHost.querySelectorAll('p input')).map((i: HTMLInputElement) => i.value),
+      ['Aurelia0', 'Aurelia1', 'Aurelia2']
+    );
+    await tearDown();
+  });
 });

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -32,8 +32,7 @@ export function createElement<C extends Constructable = Constructable>(
  * RenderPlan. Todo: describe goal of this class
  */
 export class RenderPlan {
-  /** @internal */
-  private _lazyDef?: CustomElementDefinition = void 0;
+  /** @internal */ private _lazyDef?: CustomElementDefinition = void 0;
 
   public constructor(
     private readonly node: Node,

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -24,8 +24,8 @@ function toLookup(
   return acc;
 }
 
-@customElement({ name: 'au-render', template: null, containerless: true })
 export class AuRender implements ICustomElementViewModel {
+  /** @internal */ protected static inject = [IPlatform, IInstruction, IHydrationContext, IRendering];
   public readonly id: number = nextId('au$component');
 
   @bindable
@@ -36,21 +36,19 @@ export class AuRender implements ICustomElementViewModel {
 
   public view?: ISyntheticView = void 0;
 
-  private readonly _properties: Record<string, IInstruction>;
-  private readonly _hdrContext: IHydrationContext;
+  /** @internal */ private readonly _properties: Record<string, IInstruction>;
 
-  private lastSubject?: MaybeSubjectPromise = void 0;
+  /** @internal */ private _lastSubject?: MaybeSubjectPromise = void 0;
 
   public readonly $controller!: ICustomElementController<this>; // This is set by the controller after this instance is constructed
 
   public constructor(
-    @IPlatform private readonly p: IPlatform,
-    @IInstruction instruction: HydrateElementInstruction,
-    @IHydrationContext hdrContext: IHydrationContext,
-    @IRendering private readonly r: IRendering,
+    /** @internal */ private readonly _platform: IPlatform,
+    /** @internal */ private readonly _instruction: HydrateElementInstruction,
+    /** @internal */ private readonly _hdrContext: IHydrationContext,
+    /** @internal */ private readonly _rendering: IRendering,
   ) {
-    this._properties = instruction.props.reduce(toLookup, {});
-    this._hdrContext = hdrContext;
+    this._properties = _instruction.props.reduce(toLookup, {});
   }
 
   public attaching(
@@ -59,8 +57,8 @@ export class AuRender implements ICustomElementViewModel {
     flags: LifecycleFlags,
   ): void | Promise<void> {
     const { component, view } = this;
-    if (view === void 0 || this.lastSubject !== component) {
-      this.lastSubject = component;
+    if (view === void 0 || this._lastSubject !== component) {
+      this._lastSubject = component;
       this.composing = true;
 
       return this.compose(void 0, component, initiator, flags);
@@ -86,11 +84,11 @@ export class AuRender implements ICustomElementViewModel {
     if (!$controller.isActive) {
       return;
     }
-    if (this.lastSubject === newValue) {
+    if (this._lastSubject === newValue) {
       return;
     }
 
-    this.lastSubject = newValue;
+    this._lastSubject = newValue;
     this.composing = true;
 
     flags |= $controller.flags;
@@ -172,7 +170,7 @@ export class AuRender implements ICustomElementViewModel {
       }
 
       if ('template' in comp) { // Raw Template Definition
-        return this.r.getViewFactory(CustomElementDefinition.getOrCreate(comp), ctxContainer).create();
+        return this._rendering.getViewFactory(CustomElementDefinition.getOrCreate(comp), ctxContainer).create();
       }
     }
 
@@ -189,7 +187,7 @@ export class AuRender implements ICustomElementViewModel {
 
     // Constructable (Custom Element Constructor)
     return createElement(
-      this.p,
+      this._platform,
       comp,
       this._properties,
       this.$controller.host.childNodes,
@@ -207,6 +205,8 @@ export class AuRender implements ICustomElementViewModel {
     }
   }
 }
+
+customElement({ name: 'au-render', template: null, containerless: true, capture: true })(AuRender);
 
 function isController(subject: Exclude<Subject, string>): subject is ISyntheticView {
   return 'lockScope' in subject;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue where `au-compose` does not work with `[au-slot]`. An example is the following

```html
<au-compose>
  <p au-slot>Hello</p>
</au-compose>
```

for custom element template
```html
<div><au-slot></au-slot></div>
```

Will not result in
```html
<div><p>Hello</p></div>
```