### PR TITLE
refactor(au-compose): move initiator out of change info, add tests for #1299

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "generate-tests:template-compiler.static": "node scripts/dist/scripts/generate-tests/template-compiler.static.js",
     "generate-tests:template-compiler.mutations": "ts-node -P tsconfig.json scripts/generate-tests/template-compiler.mutations.ts",
     "mermaid": "ts-node -P tsconfig.json scripts/generate-mermaid-diagrams.ts",
-    "rollup": "lage rollup"
+    "rollup": "lage rollup",
+    "test:debugger": "cd packages/__tests__ && npm run test-chrome:debugger"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/packages/__tests__/3-runtime-html/au-compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-compose.spec.ts
@@ -1061,47 +1061,49 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     await tearDown();
   });
 
-  it('works with promise in attach/detach', async function () {
-    const El1 = CustomElement.define({
-      name: 'el1',
-      template: `<template ref="host"><p>Heollo??`
-    }, class Element1 {
-      public host: HTMLElement;
-      public async attaching() {
-        return this.host.animate([{ color: 'red' }, { color: 'blue' }], 50).finished;
-      }
-      public async detaching() {
-        return this.host.animate([{ color: 'blue' }, { color: 'green' }], { duration: 50 }).finished;
-      }
+  if (typeof window !== 'undefined') {
+    it('works with promise in attach/detach', async function () {
+      const El1 = CustomElement.define({
+        name: 'el1',
+        template: `<template ref="host"><p>Heollo??`
+      }, class Element1 {
+        public host: HTMLElement;
+        public async attaching() {
+          return this.host.animate([{ color: 'red' }, { color: 'blue' }], 50).finished;
+        }
+        public async detaching() {
+          return this.host.animate([{ color: 'blue' }, { color: 'green' }], { duration: 50 }).finished;
+        }
+      });
+      const { component, startPromise, tearDown } = createFixture(
+        `<au-compose repeat.for="vm of components" view-model.bind="vm">`,
+        class App {
+          public message = 'Aurelia';
+          public components: any[] = [];
+          public vm = El1;
+
+          public render() {
+            this.components.push(El1);
+          }
+
+          public remove() {
+            this.components.pop();
+          }
+        }
+      );
+
+      await startPromise;
+
+      component.render();
+      await new Promise(r => setTimeout(r, 100));
+
+      component.render();
+      await new Promise(r => setTimeout(r, 100));
+
+      component.remove();
+      await new Promise(r => setTimeout(r, 150));
+
+      await tearDown();
     });
-    const { component, startPromise, tearDown } = createFixture(
-      `<au-compose repeat.for="vm of components" view-model.bind="vm">`,
-      class App {
-        public message = 'Aurelia';
-        public components: any[] = [];
-        public vm = El1;
-
-        public render() {
-          this.components.push(El1);
-        }
-
-        public remove() {
-          this.components.pop();
-        }
-      }
-    );
-
-    await startPromise;
-
-    component.render();
-    await new Promise(r => setTimeout(r, 100));
-
-    component.render();
-    await new Promise(r => setTimeout(r, 100));
-
-    component.remove();
-    await new Promise(r => setTimeout(r, 150));
-
-    await tearDown();
-  });
+  }
 });

--- a/packages/__tests__/3-runtime-html/au-compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-compose.spec.ts
@@ -1060,4 +1060,48 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     );
     await tearDown();
   });
+
+  it('works with promise in attach/detach', async function () {
+    const El1 = CustomElement.define({
+      name: 'el1',
+      template: `<template ref="host"><p>Heollo??`
+    }, class Element1 {
+      public host: HTMLElement;
+      public async attaching() {
+        return this.host.animate([{ color: 'red' }, { color: 'blue' }], 50).finished;
+      }
+      public async detaching() {
+        return this.host.animate([{ color: 'blue' }, { color: 'green' }], { duration: 50 }).finished;
+      }
+    });
+    const { component, startPromise, tearDown } = createFixture(
+      `<au-compose repeat.for="vm of components" view-model.bind="vm">`,
+      class App {
+        public message = 'Aurelia';
+        public components: any[] = [];
+        public vm = El1;
+
+        public render() {
+          this.components.push(El1);
+        }
+
+        public remove() {
+          this.components.pop();
+        }
+      }
+    );
+
+    await startPromise;
+
+    component.render();
+    await new Promise(r => setTimeout(r, 100));
+
+    component.render();
+    await new Promise(r => setTimeout(r, 100));
+
+    component.remove();
+    await new Promise(r => setTimeout(r, 150));
+
+    await tearDown();
+  });
 });

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -439,6 +439,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _hydrateCustomAttribute(): void {
     const definition = this.definition as CustomAttributeDefinition;
     const instance = this.viewModel!;
@@ -612,6 +613,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     this._attach();
   }
 
+  /** @internal */
   private _append(...nodes: Node[]): void {
     switch (this.mountTarget) {
       case MountTarget.host:
@@ -630,6 +632,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _attach(): void {
     if (__DEV__ && this.debug) { this.logger!.trace(`attach()`); }
 
@@ -850,6 +853,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   private $reject: ((err: unknown) => void) | undefined = void 0;
   private $promise: Promise<void> | undefined = void 0;
 
+  /** @internal */
   private _ensurePromise(): void {
     if (this.$promise === void 0) {
       this.$promise = new Promise((resolve, reject) => {
@@ -862,6 +866,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _resolve(): void {
     if (this.$promise !== void 0) {
       _resolve = this.$resolve!;
@@ -871,6 +876,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _reject(err: Error): void {
     if (this.$promise !== void 0) {
       _reject = this.$reject!;
@@ -883,13 +889,16 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _activatingStack: number = 0;
+  /** @internal */
   private _enterActivating(): void {
     ++this._activatingStack;
     if (this.$initiator !== this) {
       (this.parent as Controller)._enterActivating();
     }
   }
+  /** @internal */
   private _leaveActivating(): void {
     if (--this._activatingStack === 0) {
       if (this.hooks.hasAttached) {
@@ -923,10 +932,13 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _detachingStack: number = 0;
+  /** @internal */
   private _enterDetaching(): void {
     ++this._detachingStack;
   }
+  /** @internal */
   private _leaveDetaching(): void {
     if (--this._detachingStack === 0) {
       // Note: this controller is the initiator (detach is only ever called on the initiator)
@@ -966,10 +978,13 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
   }
 
+  /** @internal */
   private _unbindingStack: number = 0;
+  /** @internal */
   private _enterUnbinding(): void {
     ++this._unbindingStack;
   }
+  /** @internal */
   private _leaveUnbinding(): void {
     if (--this._unbindingStack === 0) {
       if (__DEV__ && this.debug) { this.logger!.trace(`unbind()`); }

--- a/packages/runtime-html/src/utilities-html.ts
+++ b/packages/runtime-html/src/utilities-html.ts
@@ -23,3 +23,6 @@ export const isDataAttribute = (obj: Node, key: PropertyKey, svgAnalyzer: ISVGAn
     prefix === 'data-' ||
     svgAnalyzer.isStandardSvgAttribute(obj, key);
 };
+
+/** @internal */
+export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;


### PR DESCRIPTION
# Pull Request

## 📖 Description

- `ChangeInfo` of au compose can be a little less polluted by moving initiator info out. Added a test for #1299, it's failing because of the promise of `animate` call not resolving, due to element/style property combo being un-animatable. The main causes by the repeat require a bit bigger refactoring. Will probably need to continue in another PR.
- Added a root level script to quickly run the tests