### PR TITLE
refactor: use common utilities for common checks

### DIFF
--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 import { DI } from './di.js';
 import { Constructable, IDisposable } from './interfaces.js';
+import { isString } from './utilities.js';
 
 /**
  * Represents a handler for an EventAggregator event.
@@ -56,7 +57,7 @@ export class EventAggregator {
       throw new Error(`Invalid channel name or instance: ${channelOrInstance}.`);
     }
 
-    if (typeof channelOrInstance === 'string') {
+    if (isString(channelOrInstance)) {
       let subscribers = this.eventLookup[channelOrInstance];
       if (subscribers !== void 0) {
         subscribers = subscribers.slice();
@@ -107,7 +108,7 @@ export class EventAggregator {
     let handler: unknown;
     let subscribers: unknown[];
 
-    if (typeof channelOrType === 'string') {
+    if (isString(channelOrType)) {
       if (this.eventLookup[channelOrType] === void 0) {
         this.eventLookup[channelOrType] = [];
       }

--- a/packages/kernel/src/logger.ts
+++ b/packages/kernel/src/logger.ts
@@ -4,7 +4,7 @@ import { Class, Constructable } from './interfaces.js';
 import { getAnnotationKeyFor } from './resource.js';
 import { Metadata } from '@aurelia/metadata';
 import { IPlatform } from './platform.js';
-import { defineMetadata } from './shared.js';
+import { defineMetadata, isFunction } from './utilities.js';
 
 export const enum LogLevel {
   /**
@@ -667,7 +667,7 @@ export class DefaultLogger {
   }
 
   private emit(sinks: ISink[], level: LogLevel, msgOrGetMsg: unknown, optionalParams: unknown[]): void {
-    const message = typeof msgOrGetMsg === 'function' ? msgOrGetMsg() : msgOrGetMsg;
+    const message = isFunction(msgOrGetMsg) ? msgOrGetMsg() : msgOrGetMsg;
     const event = this.factory.createLogEvent(this, level, message, optionalParams);
     for (let i = 0, ii = sinks.length; i < ii; ++i) {
       sinks[i].handleEvent(event);
@@ -709,7 +709,7 @@ export const LoggerConfiguration = toLookup({
           Registration.instance(ILogConfig, new LogConfig(colorOptions, level)),
         );
         for (const $sink of sinks) {
-          if (typeof $sink === 'function') {
+          if (isFunction($sink)) {
             container.register(Registration.singleton(ISink, $sink));
           } else {
             container.register($sink);

--- a/packages/kernel/src/module-loader.ts
+++ b/packages/kernel/src/module-loader.ts
@@ -1,6 +1,7 @@
 import { DI } from './di.js';
 import { emptyArray } from './platform.js';
 import { Protocol } from './resource.js';
+import { isFunction } from './utilities.js';
 
 import type { IRegistry } from './di.js';
 import type { Constructable, IDisposable, IIndexable } from './interfaces.js';
@@ -83,12 +84,12 @@ class ModuleTransformer<TMod extends IModule = IModule, TRet = AnalyzedModule<TM
           if (value === null) {
             continue;
           }
-          isRegistry = typeof (value as IIndexable).register === 'function';
+          isRegistry = isFunction((value as IIndexable).register);
           isConstructable = false;
           definitions = emptyArray;
           break;
         case 'function':
-          isRegistry = typeof (value as Constructable & IIndexable).register === 'function';
+          isRegistry = isFunction((value as Constructable & IIndexable).register);
           isConstructable = (value as Constructable).prototype !== void 0;
           definitions = Protocol.resource.getAll(value as Constructable);
           break;

--- a/packages/kernel/src/resource.ts
+++ b/packages/kernel/src/resource.ts
@@ -1,7 +1,7 @@
 import { IContainer } from './di.js';
 import { Constructable } from './interfaces.js';
 import { emptyArray } from './platform.js';
-import { defineMetadata, hasOwnMetadata, getOwnMetadata } from './shared.js';
+import { defineMetadata, hasOwnMetadata, getOwnMetadata } from './utilities.js';
 
 export type ResourceType<
   TUserType extends Constructable = Constructable,

--- a/packages/kernel/src/shared.ts
+++ b/packages/kernel/src/shared.ts
@@ -1,8 +1,0 @@
-import { Metadata } from '@aurelia/metadata';
-
-/** @internal */
-export const getOwnMetadata = Metadata.getOwn;
-/** @internal */
-export const hasOwnMetadata = Metadata.hasOwn;
-/** @internal */
-export const defineMetadata = Metadata.define;

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -1,0 +1,12 @@
+import { Metadata } from '@aurelia/metadata';
+
+/** @internal */ export const getOwnMetadata = Metadata.getOwn;
+/** @internal */ export const hasOwnMetadata = Metadata.hasOwn;
+/** @internal */ export const defineMetadata = Metadata.define;
+
+/** @internal */ export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+/** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
+
+/** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';

--- a/packages/runtime-html/src/app-task.ts
+++ b/packages/runtime-html/src/app-task.ts
@@ -1,5 +1,6 @@
 import { DI, Registration } from '@aurelia/kernel';
 import type { IContainer, IRegistry, Key, Resolved } from '@aurelia/kernel';
+import { isFunction } from './utilities.js';
 
 export type TaskSlot = (
   'beforeCreate' |
@@ -69,7 +70,7 @@ function createAppTaskSlotHook(slotName: TaskSlot) {
   function appTaskFactory<T extends Key = Key>(callback: AppTaskCallbackNoArg): IRegistry;
   function appTaskFactory<T extends Key = Key>(key: T, callback: AppTaskCallback<T>): IRegistry;
   function appTaskFactory<T extends Key = Key>(keyOrCallback: T | AppTaskCallback<T> | AppTaskCallbackNoArg, callback?: AppTaskCallback<T>): IRegistry {
-    if (typeof callback === 'function') {
+    if (isFunction(callback)) {
       return new $AppTask(slotName, keyOrCallback as T, callback);
     }
     return new $AppTask(slotName, null, keyOrCallback as Exclude<typeof keyOrCallback, T>);

--- a/packages/runtime-html/src/attribute-mapper.ts
+++ b/packages/runtime-html/src/attribute-mapper.ts
@@ -1,5 +1,5 @@
 import { DI } from '@aurelia/kernel';
-import { createLookup, isDataAttribute } from './utilities-html.js';
+import { createLookup, isDataAttribute } from './utilities.js';
 import { ISVGAnalyzer } from './observation/svg-analyzer.js';
 
 export interface IAttrMapper extends AttrMapper {}

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -6,6 +6,7 @@ import { IEventTarget, INode } from './dom.js';
 import { IPlatform } from './platform.js';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
 import { Controller, ICustomElementController, ICustomElementViewModel, IHydratedParentController } from './templating/controller.js';
+import { isFunction } from './utilities.js';
 
 import type {
   Constructable,
@@ -85,7 +86,7 @@ export class Aurelia implements IDisposable {
     const p = this._initPlatform(host);
     const comp = config.component as K;
     let bc: ICustomElementViewModel & K;
-    if (typeof comp === 'function') {
+    if (isFunction(comp)) {
       ctn.registerResolver(
         p.HTMLElement,
         ctn.registerResolver(

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -1,6 +1,7 @@
 import { kebabCase, firstDefined, getPrototypeChain, noop } from '@aurelia/kernel';
 import { BindingMode } from '@aurelia/runtime';
 import { appendAnnotationKey, defineMetadata, getAllAnnotations, getAnnotationKeyFor, getOwnMetadata, hasOwnMetadata } from './shared.js';
+import { isString } from './utilities.js';
 
 import type { Constructable, Writable } from '@aurelia/kernel';
 import type { InterceptorFunc } from '@aurelia/runtime';
@@ -62,7 +63,7 @@ export function bindable(configOrTarget?: PartialBindableDefinition | {}, prop?:
     config = {};
     decorator(configOrTarget!, prop!);
     return;
-  } else if (typeof configOrTarget === 'string') {
+  } else if (isString(configOrTarget)) {
     // ClassDecorator
     // - @bindable('bar')
     // Direct call:
@@ -153,7 +154,7 @@ export const Bindable = Object.freeze({
       add(configOrProp: string | PartialBindableDefinitionPropertyRequired): BFluent & B12345 {
         let prop: string;
         let config: PartialBindableDefinitionPropertyRequired;
-        if (typeof configOrProp === 'string') {
+        if (isString(configOrProp)) {
           prop = configOrProp;
           config = { property: prop };
         } else {

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -10,6 +10,7 @@ import { IPlatform } from './platform.js';
 import { CustomElement, CustomElementDefinition, CustomElementType } from './resources/custom-element.js';
 import { IViewFactory } from './templating/view.js';
 import { IRendering } from './templating/rendering.js';
+import { isString } from './utilities.js';
 
 import type { ISyntheticView } from './templating/controller.js';
 
@@ -19,7 +20,7 @@ export function createElement<C extends Constructable = Constructable>(
   props?: Record<string, string | IInstruction>,
   children?: ArrayLike<unknown>
 ): RenderPlan {
-  if (typeof tagOrType === 'string') {
+  if (isString(tagOrType)) {
     return createElementForTag(p, tagOrType, props, children);
   }
   if (CustomElement.isType(tagOrType)) {
@@ -47,7 +48,7 @@ export class RenderPlan {
       this._lazyDef = CustomElementDefinition.create({
         name: CustomElement.generateName(),
         template: this.node,
-        needsCompile: typeof this.node === 'string',
+        needsCompile: isString(this.node),
         instructions: this.instructions,
         dependencies: this._dependencies,
       });

--- a/packages/runtime-html/src/observation/attribute-ns-accessor.ts
+++ b/packages/runtime-html/src/observation/attribute-ns-accessor.ts
@@ -1,5 +1,5 @@
 import { AccessorType } from '@aurelia/runtime';
-import { createLookup } from '../utilities-html.js';
+import { createLookup } from '../utilities.js';
 
 import type { IAccessor, LifecycleFlags } from '@aurelia/runtime';
 

--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -1,5 +1,6 @@
 import { noop } from '@aurelia/kernel';
 import { subscriberCollection, AccessorType, LifecycleFlags, withFlushQueue } from '@aurelia/runtime';
+import { isFunction } from '../utilities.js';
 
 import type { IIndexable } from '@aurelia/kernel';
 import type {
@@ -70,8 +71,8 @@ export class BindableObserver implements IFlushable, IWithFlushQueue {
   ) {
     const cb = obj[cbName] as typeof BindableObserver.prototype.cb;
     const cbAll = (obj as IMayHavePropertyChangedCallback).propertyChanged!;
-    const hasCb = this._hasCb = typeof cb === 'function';
-    const hasCbAll = this._hasCbAll = typeof cbAll === 'function';
+    const hasCb = this._hasCb = isFunction(cb);
+    const hasCbAll = this._hasCbAll = isFunction(cbAll);
     const hasSetter = this._hasSetter = set !== noop;
     let val: unknown;
 

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -7,7 +7,7 @@ import {
   withFlushQueue,
 } from '@aurelia/runtime';
 import { getCollectionObserver } from './observer-locator.js';
-import { hasOwnProperty } from '../utilities-html.js';
+import { hasOwnProperty } from '../utilities.js';
 
 import type { INode } from '../dom.js';
 import type { EventSubscriber } from './event-delegator.js';

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -1,5 +1,6 @@
 import { emptyArray } from '@aurelia/kernel';
 import { AccessorType, LifecycleFlags } from '@aurelia/runtime';
+import { isString } from '../utilities.js';
 
 import type { IAccessor } from '@aurelia/runtime';
 
@@ -94,7 +95,7 @@ export class ClassAttributeAccessor implements IAccessor {
 }
 
 export function getClassesToAdd(object: Record<string, unknown> | [] | string): string[] {
-  if (typeof object === 'string') {
+  if (isString(object)) {
     return splitClassString(object);
   }
   if (typeof object !== 'object') {

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,4 +1,5 @@
 import { LifecycleFlags, subscriberCollection, AccessorType, withFlushQueue } from '@aurelia/runtime';
+import { isString } from '../utilities.js';
 
 import type {
   IObserver,
@@ -95,7 +96,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
         case 'style': {
           let priority = '';
           let newValue = this._value as string;
-          if (typeof newValue === 'string' && newValue.includes('!important')) {
+          if (isString(newValue) && newValue.includes('!important')) {
             priority = 'important';
             newValue = newValue.replace('!important', '');
           }

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -1,5 +1,5 @@
 import { DI } from '@aurelia/kernel';
-import { createLookup } from '../utilities-html.js';
+import { createLookup, isFunction } from '../utilities.js';
 import type { NodeObserverConfig } from './observer-locator.js';
 import type { IDisposable } from '@aurelia/kernel';
 
@@ -63,10 +63,10 @@ class ListenerTracker implements IDisposable {
       if (listener === void 0) {
         continue;
       }
-      if (typeof listener === 'function') {
+      if (isFunction(listener)) {
         listener(event);
       } else {
-        listener.handleEvent(event);
+        (listener as EventListenerObject).handleEvent(event);
       }
       if (event.cancelBubble === true) {
         return;

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -17,7 +17,7 @@ import { SelectValueObserver } from './select-value-observer.js';
 import { StyleAttributeAccessor } from './style-attribute-accessor.js';
 import { ISVGAnalyzer } from './svg-analyzer.js';
 import { ValueAttributeObserver } from './value-attribute-observer.js';
-import { createLookup, isDataAttribute } from '../utilities.js';
+import { createLookup, isDataAttribute, isString } from '../utilities.js';
 
 import type { IIndexable, IContainer } from '@aurelia/kernel';
 import type { IAccessor, IObserver, ICollectionObserver, CollectionKind } from '@aurelia/runtime';
@@ -168,7 +168,7 @@ export class NodeObserverLocator implements INodeObserverLocator {
   public useConfig(nodeNameOrConfig: string | Record<string, Record<string, INodeObserverConfig>>, key?: PropertyKey, eventsConfig?: INodeObserverConfig): void {
     const lookup = this._events;
     let existingMapping: Record<string, NodeObserverConfig>;
-    if (typeof nodeNameOrConfig === 'string') {
+    if (isString(nodeNameOrConfig)) {
       existingMapping = lookup[nodeNameOrConfig] ??= createLookup();
       if (existingMapping[key as string] == null) {
         existingMapping[key as string] = new NodeObserverConfig(eventsConfig!);
@@ -248,7 +248,7 @@ export class NodeObserverLocator implements INodeObserverLocator {
   public overrideAccessor(tagName: string, key: PropertyKey): void;
   public overrideAccessor(tagNameOrOverrides: string | Record<string, string[]>, key?: PropertyKey): void {
     let existingTagOverride: Record<string, true> | undefined;
-    if (typeof tagNameOrOverrides === 'string') {
+    if (isString(tagNameOrOverrides)) {
       existingTagOverride = this._overrides[tagNameOrOverrides] ??= createLookup();
       existingTagOverride[key as string] = true;
     } else {

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -17,7 +17,7 @@ import { SelectValueObserver } from './select-value-observer.js';
 import { StyleAttributeAccessor } from './style-attribute-accessor.js';
 import { ISVGAnalyzer } from './svg-analyzer.js';
 import { ValueAttributeObserver } from './value-attribute-observer.js';
-import { createLookup, isDataAttribute } from '../utilities-html.js';
+import { createLookup, isDataAttribute } from '../utilities.js';
 
 import type { IIndexable, IContainer } from '@aurelia/kernel';
 import type { IAccessor, IObserver, ICollectionObserver, CollectionKind } from '@aurelia/runtime';

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -1,5 +1,6 @@
 import { LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray, kebabCase } from '@aurelia/kernel';
+import { isFunction } from '../utilities.js';
 import type { IAccessor } from '@aurelia/runtime';
 
 const customPropertyPrefix: string = '--';
@@ -164,7 +165,7 @@ export class StyleAttributeAccessor implements IAccessor {
   public setProperty(style: string, value: string): void {
     let priority = '';
 
-    if (value != null && typeof value.indexOf === 'function' && value.includes('!important')) {
+    if (value != null && isFunction(value.indexOf) && value.includes('!important')) {
       priority = 'important';
       value = value.replace('!important', '');
     }

--- a/packages/runtime-html/src/observation/style-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/style-attribute-accessor.ts
@@ -1,6 +1,6 @@
 import { LifecycleFlags, AccessorType } from '@aurelia/runtime';
 import { emptyArray, kebabCase } from '@aurelia/kernel';
-import { isFunction } from '../utilities.js';
+import { isFunction, isString } from '../utilities.js';
 import type { IAccessor } from '@aurelia/runtime';
 
 const customPropertyPrefix: string = '--';
@@ -75,7 +75,7 @@ export class StyleAttributeAccessor implements IAccessor {
       if (value == null) {
         continue;
       }
-      if (typeof value === 'string') {
+      if (isString(value)) {
         // Custom properties should not be tampered with
         if (property.startsWith(customPropertyPrefix)) {
           styles.push([property, value]);
@@ -105,7 +105,7 @@ export class StyleAttributeAccessor implements IAccessor {
   }
 
   private _getStyleTuples(currentValue: unknown): [string, string][] {
-    if (typeof currentValue === 'string') {
+    if (isString(currentValue)) {
       return this._getStyleTuplesFromString(currentValue);
     }
 

--- a/packages/runtime-html/src/observation/svg-analyzer.ts
+++ b/packages/runtime-html/src/observation/svg-analyzer.ts
@@ -1,6 +1,6 @@
 import { DI, Registration } from '@aurelia/kernel';
 import { IPlatform } from '../platform.js';
-import { createLookup } from '../utilities-html.js';
+import { createLookup } from '../utilities.js';
 
 import type { IContainer, IResolver } from '@aurelia/kernel';
 import type { INode } from '../dom.js';

--- a/packages/runtime-html/src/plugins/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-controller.ts
@@ -12,13 +12,14 @@ import {
   DialogCloseError,
 } from './dialog-interfaces.js';
 import { IEventTarget, INode } from '../../dom.js';
+import { IPlatform } from '../../platform.js';
+import { CustomElement, CustomElementDefinition } from '../../resources/custom-element.js';
+import { isFunction } from '../../utilities.js';
 
 import type {
   IDialogComponent,
   IDialogLoadedSettings,
 } from './dialog-interfaces.js';
-import { IPlatform } from '../../platform.js';
-import { CustomElement, CustomElementDefinition } from '../../resources/custom-element.js';
 
 /**
  * A controller object for a Dialog instance.
@@ -259,7 +260,7 @@ export class DialogController implements IDialogController {
   }
 
   private getDefinition(component?: object | Constructable) {
-    const Ctor = (typeof component === 'function'
+    const Ctor = (isFunction(component)
       ? component
       : component?.constructor) as Constructable;
     return CustomElement.isType(Ctor)

--- a/packages/runtime-html/src/plugins/dialog/dialog-service.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-service.ts
@@ -11,13 +11,14 @@ import {
   IDialogLoadedSettings,
 } from './dialog-interfaces.js';
 import { DialogController } from './dialog-controller.js';
+import { AppTask } from '../../app-task.js';
+import { IPlatform } from '../../platform.js';
+import { isFunction } from '../../utilities.js';
 
 import type {
   DialogOpenPromise,
   IDialogSettings,
 } from './dialog-interfaces.js';
-import { AppTask } from '../../app-task.js';
-import { IPlatform } from '../../platform.js';
 
 /**
  * A default implementation for the dialog service allowing for the creation of dialogs.
@@ -193,7 +194,7 @@ class DialogSettings<T extends object = object> implements IDialogSettings<T> {
       cmp == null
         ? void 0
         : onResolve(cmp(), loadedCmp => { loaded.component = loadedCmp; }),
-      typeof template === 'function'
+      isFunction(template)
         ? onResolve(template(), loadedTpl => { loaded.template = loadedTpl; })
         : void 0
     ]);

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -28,6 +28,8 @@ import { IPlatform } from './platform.js';
 import { IViewFactory } from './templating/view.js';
 import { IRendering } from './templating/rendering.js';
 import { defineMetadata, getOwnMetadata } from './shared.js';
+import { AttrSyntax } from './resources/attribute-pattern.js';
+import { isString } from './utilities.js';
 
 import type { IServiceLocator, IContainer, Class, IRegistry, Constructable, IResolver } from '@aurelia/kernel';
 import type {
@@ -42,7 +44,6 @@ import type {
 } from '@aurelia/runtime';
 import type { IHydratableController } from './templating/controller.js';
 import type { PartialCustomElementDefinition } from './resources/custom-element.js';
-import { AttrSyntax } from './resources/attribute-pattern.js';
 
 export const enum InstructionType {
   hydrateElement = 'ra',
@@ -76,7 +77,7 @@ export const IInstruction = DI.createInterface<IInstruction>('Instruction');
 
 export function isInstruction(value: unknown): value is IInstruction {
   const type = (value as { type?: string }).type;
-  return typeof type === 'string' && type.length === 2;
+  return isString(type) && type.length === 2;
 }
 
 export class InterpolationInstruction {
@@ -402,7 +403,7 @@ export function renderer<TType extends string>(instructionType: TType): Instruct
 }
 
 function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TFrom, expressionType: ExpressionType): Exclude<TFrom, string> {
-  if (typeof srcOrExpr === 'string') {
+  if (isString(srcOrExpr)) {
     return parser.parse(srcOrExpr, expressionType) as unknown as Exclude<TFrom, string>;
   }
   return srcOrExpr as Exclude<TFrom, string>;
@@ -1330,7 +1331,7 @@ class ViewFactoryProvider implements IResolver {
       else
         throw new Error('AUR7055');
     }
-    if (typeof f.name !== 'string' || f.name.length === 0) {
+    if (!isString(f.name) || f.name.length === 0) {
       if (__DEV__)
         throw new Error('Cannot resolve ViewFactory without a (valid) name.');
       else

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -138,7 +138,7 @@ export const BindingCommand = Object.freeze<BindingCommandKind>({
   name: cmdBaseName,
   keyFrom: getCommandKeyFrom,
   // isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never) {
-  //   return typeof value === 'function' && hasOwnMetadata(cmdBaseName, value);
+  //   return isFunction(value) && hasOwnMetadata(cmdBaseName, value);
   // },
   define<T extends Constructable<BindingCommandInstance>>(nameOrDef: string | PartialBindingCommandDefinition, Type: T): T & BindingCommandType<T> {
     const definition = BindingCommandDefinition.create(nameOrDef, Type as Constructable<BindingCommandInstance>);

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -12,6 +12,7 @@ import {
 } from '../renderer.js';
 import { DefinitionType } from './resources-shared.js';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor } from '../shared.js';
+import { isString } from '../utilities.js';
 
 import type {
   Constructable,
@@ -102,7 +103,7 @@ export class BindingCommandDefinition<T extends Constructable = Constructable> i
 
     let name: string;
     let def: PartialBindingCommandDefinition;
-    if (typeof nameOrDef === 'string') {
+    if (isString(nameOrDef)) {
       name = nameOrDef;
       def = { name };
     } else {

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -5,6 +5,7 @@ import { Watch } from '../watch.js';
 import { getRef } from '../dom.js';
 import { DefinitionType } from './resources-shared.js';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
+import { isFunction } from '../utilities.js';
 
 import type {
   Constructable,
@@ -154,7 +155,7 @@ export const CustomAttribute = Object.freeze<CustomAttributeKind>({
   name: caBaseName,
   keyFrom: getAttributeKeyFrom,
   isType<T>(value: T): value is (T extends Constructable ? CustomAttributeType<T> : never) {
-    return typeof value === 'function' && hasOwnMetadata(caBaseName, value);
+    return isFunction(value) && hasOwnMetadata(caBaseName, value);
   },
   for<C extends ICustomAttributeViewModel = ICustomAttributeViewModel>(node: Node, name: string): ICustomAttributeController<C> | undefined {
     return (getRef(node, getAttributeKeyFrom(name)) ?? void 0) as ICustomAttributeController<C> | undefined;

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -5,7 +5,7 @@ import { Watch } from '../watch.js';
 import { getRef } from '../dom.js';
 import { DefinitionType } from './resources-shared.js';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
-import { isFunction } from '../utilities.js';
+import { isFunction, isString } from '../utilities.js';
 
 import type {
   Constructable,
@@ -85,7 +85,7 @@ export function templateController(nameOrDef: string | Omit<PartialCustomAttribu
 export function templateController(nameOrDef: string | Omit<PartialCustomAttributeDefinition, 'isTemplateController'>): CustomAttributeDecorator {
   return function (target) {
     return CustomAttribute.define(
-      typeof nameOrDef === 'string'
+      isString(nameOrDef)
         ? { isTemplateController: true, name: nameOrDef }
         : { isTemplateController: true, ...nameOrDef },
       target
@@ -115,7 +115,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
   ): CustomAttributeDefinition<T> {
     let name: string;
     let def: PartialCustomAttributeDefinition;
-    if (typeof nameOrDef === 'string') {
+    if (isString(nameOrDef)) {
       name = nameOrDef;
       def = { name };
     } else {

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -15,6 +15,7 @@ import { Children } from '../templating/children.js';
 import { Watch } from '../watch.js';
 import { DefinitionType } from './resources-shared.js';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
+import { isFunction } from '../utilities.js';
 
 import type {
   Constructable,
@@ -160,7 +161,7 @@ export function useShadowDOM(targetOrOptions?: Constructable | ShadowOptions): v
     };
   }
 
-  if (typeof targetOrOptions !== 'function') {
+  if (!isFunction(targetOrOptions)) {
     return function ($target: Constructable) {
       annotateElementMetadata($target, 'shadowOptions', targetOrOptions);
     };
@@ -259,7 +260,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       }
 
       const name = fromDefinitionOrDefault('name', def, generateElementName);
-      if (typeof (def as CustomElementDefinition).Type === 'function') {
+      if (isFunction((def as CustomElementDefinition).Type)) {
         // This needs to be a clone (it will usually be the compiler calling this signature)
 
         // TODO: we need to make sure it's documented that passing in the type via the definition (while passing in null
@@ -438,7 +439,7 @@ export const CustomElement = Object.freeze<CustomElementKind>({
   name: ceBaseName,
   keyFrom: getElementKeyFrom,
   isType<C>(value: C): value is (C extends Constructable ? CustomElementType<C> : never) {
-    return typeof value === 'function' && hasOwnMetadata(ceBaseName, value);
+    return isFunction(value) && hasOwnMetadata(ceBaseName, value);
   },
   for<C extends ICustomElementViewModel = ICustomElementViewModel>(node: Node, opts: ForOpts = defaultForOpts): ICustomElementController<C> {
     if (opts.name === void 0 && opts.searchParents !== true) {
@@ -618,7 +619,7 @@ function ensureHook<TClass>(target: Constructable<TClass>, hook: string | Proces
   }
 
   const hookType = typeof hook;
-  if (hookType !== 'function') {
+  if (!isFunction( hookType)) {
     if (__DEV__)
       throw new Error(`Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${hookType}.`);
     else

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -618,12 +618,11 @@ function ensureHook<TClass>(target: Constructable<TClass>, hook: string | Proces
     hook = (target as any)[hook] as ProcessContentHook;
   }
 
-  const hookType = typeof hook;
-  if (!isFunction( hookType)) {
+  if (!isFunction(hook)) {
     if (__DEV__)
-      throw new Error(`Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${hookType}.`);
+      throw new Error(`Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${typeof hook}.`);
     else
-      throw new Error(`AUR0766:${hookType}`);
+      throw new Error(`AUR0766:${typeof hook}`);
   }
   return hook;
 }

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -15,7 +15,7 @@ import { Children } from '../templating/children.js';
 import { Watch } from '../watch.js';
 import { DefinitionType } from './resources-shared.js';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
-import { isFunction } from '../utilities.js';
+import { isFunction, isString } from '../utilities.js';
 
 import type {
   Constructable,
@@ -252,7 +252,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
   ): CustomElementDefinition {
     if (Type === null) {
       const def = nameOrDef;
-      if (typeof def === 'string') {
+      if (isString(def)) {
         if (__DEV__)
           throw new Error(`Cannot create a custom element definition with only a name and no type: ${nameOrDef}`);
         else
@@ -298,7 +298,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     // If a type is passed in, we ignore the Type property on the definition if it exists.
     // TODO: document this behavior
 
-    if (typeof nameOrDef === 'string') {
+    if (isString(nameOrDef)) {
       return new CustomElementDefinition(
         Type,
         nameOrDef,
@@ -613,7 +613,7 @@ export function processContent<TClass>(hook?: ProcessContentHook): CustomElement
 }
 
 function ensureHook<TClass>(target: Constructable<TClass>, hook: string | ProcessContentHook): ProcessContentHook {
-  if (typeof hook === 'string') {
+  if (isString(hook)) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
     hook = (target as any)[hook] as ProcessContentHook;
   }

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -6,7 +6,7 @@ import { IPlatform } from '../../platform.js';
 import { HydrateElementInstruction, IInstruction } from '../../renderer.js';
 import { Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller.js';
 import { IRendering } from '../../templating/rendering.js';
-import { isPromise } from '../../utilities-html.js';
+import { isFunction, isPromise } from '../../utilities.js';
 import { CustomElement, customElement, CustomElementDefinition } from '../custom-element.js';
 
 /**
@@ -319,7 +319,7 @@ export class AuCompose {
 
   /** @internal */
   private getDef(component?: object | Constructable) {
-    const Ctor = (typeof component === 'function'
+    const Ctor = (isFunction(component)
       ? component
       : component?.constructor) as Constructable;
     return CustomElement.isType(Ctor)

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -8,6 +8,7 @@ import { CustomElement, customElement, CustomElementDefinition } from '../custom
 import { bindable } from '../../bindable.js';
 import { ControllerVisitor, ICustomElementController, ICustomElementViewModel, IHydratedController, IHydratedParentController, IHydrationContext, ISyntheticView } from '../../templating/controller.js';
 import { IRendering } from '../../templating/rendering.js';
+import { isString } from '../../utilities.js';
 
 export type Subject = string | IViewFactory | ISyntheticView | RenderPlan | Constructable | CustomElementDefinition;
 export type MaybeSubjectPromise = Subject | Promise<Subject> | undefined;
@@ -178,7 +179,7 @@ export class AuRender implements ICustomElementViewModel {
       }
     }
 
-    if (typeof comp === 'string') {
+    if (isString(comp)) {
       const def = ctxContainer.find(CustomElement, comp);
       if (def == null) {
         if (__DEV__)

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -5,6 +5,7 @@ import { IPlatform } from '../../platform.js';
 import { IViewFactory } from '../../templating/view.js';
 import { templateController } from '../custom-attribute.js';
 import { bindable } from '../../bindable.js';
+import { isString } from '../../utilities.js';
 import type { ControllerVisitor, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ISyntheticView } from '../../templating/controller.js';
 
 export type PortalTarget<T extends Node & ParentNode = Node & ParentNode> = string | T | null | undefined;
@@ -222,9 +223,9 @@ export class Portal<T extends Node & ParentNode = Node & ParentNode> implements 
       return $document.body as unknown as T;
     }
 
-    if (typeof target === 'string') {
+    if (isString( target)) {
       let queryContext: ParentNode = $document;
-      if (typeof context === 'string') {
+      if (isString(context)) {
         context = $document.querySelector(context) as ResolvedTarget;
       }
       if (context instanceof p.Node) {

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -223,7 +223,7 @@ export class Portal<T extends Node & ParentNode = Node & ParentNode> implements 
       return $document.body as unknown as T;
     }
 
-    if (isString( target)) {
+    if (isString(target)) {
       let queryContext: ParentNode = $document;
       if (isString(context)) {
         context = $document.querySelector(context) as ResolvedTarget;

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -24,7 +24,7 @@ import { AttrSyntax, IAttributeParser } from './resources/attribute-pattern.js';
 import { CustomAttribute } from './resources/custom-attribute.js';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
 import { BindingCommand, CommandType } from './resources/binding-command.js';
-import { createLookup } from './utilities-html.js';
+import { createLookup } from './utilities.js';
 import { allResources } from './utilities-di.js';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from './shared.js';
 

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -24,7 +24,7 @@ import { AttrSyntax, IAttributeParser } from './resources/attribute-pattern.js';
 import { CustomAttribute } from './resources/custom-attribute.js';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element.js';
 import { BindingCommand, CommandType } from './resources/binding-command.js';
-import { createLookup } from './utilities.js';
+import { createLookup, isString } from './utilities.js';
 import { allResources } from './utilities-di.js';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from './shared.js';
 
@@ -64,7 +64,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     compilationInstruction ??= emptyCompilationInstructions;
 
     const context = new CompilationContext(partialDefinition, container, compilationInstruction, null, null, void 0);
-    const template = typeof definition.template === 'string' || !partialDefinition.enhance
+    const template = isString(definition.template) || !partialDefinition.enhance
       ? context._templateFactory.createTemplate(definition.template)
       : definition.template as HTMLElement;
     const isTemplateElement = template.nodeName === 'TEMPLATE' && (template as HTMLTemplateElement).content != null;

--- a/packages/runtime-html/src/template-element-factory.ts
+++ b/packages/runtime-html/src/template-element-factory.ts
@@ -1,5 +1,6 @@
 import { DI } from '@aurelia/kernel';
 import { IPlatform } from './platform.js';
+import { isString } from './utilities.js';
 
 /**
  * Utility that creates a `HTMLTemplateElement` out of string markup or an existing DOM node.
@@ -26,7 +27,7 @@ export class TemplateElementFactory {
   public createTemplate(node: Node): HTMLTemplateElement;
   public createTemplate(input: string | Node): HTMLTemplateElement;
   public createTemplate(input: string | Node): HTMLTemplateElement {
-    if (typeof input === 'string') {
+    if (isString(input)) {
       let result = markupCache[input];
       if (result === void 0) {
         const template = this._template;

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -2,6 +2,7 @@ import { firstDefined, getPrototypeChain, emptyArray } from '@aurelia/kernel';
 import { LifecycleFlags, subscriberCollection } from '@aurelia/runtime';
 import { CustomElement } from '../resources/custom-element.js';
 import { appendAnnotationKey, defineMetadata, getAllAnnotations, getAnnotationKeyFor, getOwnMetadata } from '../shared.js';
+import { isString } from '../utilities.js';
 
 import type { IIndexable, Constructable } from '@aurelia/kernel';
 import type { ISubscriberCollection, IAccessor, ISubscribable, IObserver } from '@aurelia/runtime';
@@ -59,7 +60,7 @@ export function children(configOrTarget?: PartialChildrenDefinition | {}, prop?:
     config = {};
     decorator(configOrTarget!, prop!);
     return;
-  } else if (typeof configOrTarget === 'string') {
+  } else if (isString(configOrTarget)) {
     // ClassDecorator
     // - @children('bar')
     // Direct call:

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -27,7 +27,7 @@ import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles.js';
 import { ComputedWatcher, ExpressionWatcher } from './watchers.js';
 import { LifecycleHooks } from './lifecycle-hooks.js';
 import { IRendering } from './rendering.js';
-import { isFunction } from '../utilities.js';
+import { isFunction, isString } from '../utilities.js';
 
 import type {
   IContainer,
@@ -1268,7 +1268,7 @@ function createWatchers(
         true,
       ));
     } else {
-      ast = typeof expression === 'string'
+      ast = isString(expression)
         ? expressionParser.parse(expression, ExpressionType.IsProperty)
         : getAccessScopeAst(expression);
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -27,6 +27,7 @@ import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles.js';
 import { ComputedWatcher, ExpressionWatcher } from './watchers.js';
 import { LifecycleHooks } from './lifecycle-hooks.js';
 import { IRendering } from './rendering.js';
+import { isFunction } from '../utilities.js';
 
 import type {
   IContainer,
@@ -1247,16 +1248,16 @@ function createWatchers(
 
   for (; ii > i; ++i) {
     ({ expression, callback } = watches[i]);
-    callback = typeof callback === 'function'
+    callback = isFunction(callback)
       ? callback
       : Reflect.get(instance, callback) as IWatcherCallback<object>;
-    if (typeof callback !== 'function') {
+    if (!isFunction(callback)) {
       if (__DEV__)
         throw new Error(`Invalid callback for @watch decorator: ${String(callback)}`);
       else
         throw new Error(`AUR0506:${String(callback)}`);
     }
-    if (typeof expression === 'function') {
+    if (isFunction(expression)) {
       controller.addBinding(new ComputedWatcher(
         instance as IObservable,
         observerLocator,

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -5,7 +5,7 @@ import { FragmentNodeSequence, INode, INodeSequence } from '../dom.js';
 import { IPlatform } from '../platform.js';
 import { ICompliationInstruction, IInstruction, IRenderer, ITemplateCompiler } from '../renderer.js';
 import { CustomElementDefinition, PartialCustomElementDefinition } from '../resources/custom-element.js';
-import { createLookup } from '../utilities-html.js';
+import { createLookup } from '../utilities.js';
 import { IViewFactory, ViewFactory } from './view.js';
 import type { IHydratableController } from './controller.js';
 

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -5,7 +5,7 @@ import { FragmentNodeSequence, INode, INodeSequence } from '../dom.js';
 import { IPlatform } from '../platform.js';
 import { ICompliationInstruction, IInstruction, IRenderer, ITemplateCompiler } from '../renderer.js';
 import { CustomElementDefinition, PartialCustomElementDefinition } from '../resources/custom-element.js';
-import { createLookup } from '../utilities.js';
+import { createLookup, isString } from '../utilities.js';
 import { IViewFactory, ViewFactory } from './view.js';
 import type { IHydratableController } from './controller.js';
 
@@ -91,7 +91,7 @@ export class Rendering {
         }
       } else {
         tpl = doc.createElement('template');
-        if (typeof template === 'string') {
+        if (isString(template)) {
           tpl.innerHTML = template;
         }
         doc.adoptNode(fragment = tpl.content);

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -3,7 +3,7 @@ import { Scope } from '@aurelia/runtime';
 import { CustomElement, CustomElementDefinition } from '../resources/custom-element.js';
 import { Controller } from './controller.js';
 import { defineMetadata, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
-import { isFunction } from '../utilities.js';
+import { isFunction, isString } from '../utilities.js';
 
 import type { Constructable, ConstructableClass, IContainer } from '@aurelia/kernel';
 import type { LifecycleFlags } from '@aurelia/runtime';
@@ -47,7 +47,7 @@ export class ViewFactory implements IViewFactory {
     if (size) {
       if (size === '*') {
         size = ViewFactory.maxCacheSize;
-      } else if (typeof size === 'string') {
+      } else if (isString(size)) {
         size = parseInt(size, 10);
       }
 

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -3,6 +3,7 @@ import { Scope } from '@aurelia/runtime';
 import { CustomElement, CustomElementDefinition } from '../resources/custom-element.js';
 import { Controller } from './controller.js';
 import { defineMetadata, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../shared.js';
+import { isFunction } from '../utilities.js';
 
 import type { Constructable, ConstructableClass, IContainer } from '@aurelia/kernel';
 import type { LifecycleFlags } from '@aurelia/runtime';
@@ -107,10 +108,10 @@ const viewsBaseName = getResourceKeyFor('views');
 export const Views = Object.freeze({
   name: viewsBaseName,
   has(value: object): boolean {
-    return typeof value === 'function' && (hasOwnMetadata(viewsBaseName, value) || '$views' in value);
+    return isFunction(value) && (hasOwnMetadata(viewsBaseName, value) || '$views' in value);
   },
   get(value: object | Constructable): readonly CustomElementDefinition[] {
-    if (typeof value === 'function' && '$views' in value) {
+    if (isFunction(value) && '$views' in value) {
       // TODO: a `get` operation with side effects is not a good thing. Should refactor this to a proper resource kind.
       const $views = (value as { $views: PartialCustomElementDefinition[] }).$views;
       const definitions = $views.filter(notYetSeen).map(toCustomElementDefinition);
@@ -166,7 +167,7 @@ export class ViewLocator {
   ): ComposableObjectComponentType<T> | null {
     if (object) {
       const availableViews = Views.has(object.constructor) ? Views.get(object.constructor) : [];
-      const resolvedViewName = typeof viewNameOrSelector === 'function'
+      const resolvedViewName = isFunction(viewNameOrSelector)
         ? viewNameOrSelector(object, availableViews)
         : this._getViewName(availableViews, viewNameOrSelector);
 

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -24,7 +24,7 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
 
 /** @internal */ export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;
 
-// eslint-ignore-next-line
+// eslint-disable-next-line @typescript-eslint/ban-types
 /** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -1,14 +1,12 @@
 import type { ISVGAnalyzer } from './observation/svg-analyzer';
 
-/** @internal */
-export const createLookup = <T = unknown>() => Object.create(null) as Record<string, T>;
+/** @internal */ export const createLookup = <T = unknown>() => Object.create(null) as Record<string, T>;
 
-/** @internal */
-export const hasOwnProperty = Object.prototype.hasOwnProperty;
+/** @internal */ export const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const IsDataAttribute: Record<string, boolean> = createLookup();
-/** @internal */
-export const isDataAttribute = (obj: Node, key: PropertyKey, svgAnalyzer: ISVGAnalyzer): boolean => {
+
+/** @internal */ export const isDataAttribute = (obj: Node, key: PropertyKey, svgAnalyzer: ISVGAnalyzer): boolean => {
   if (IsDataAttribute[key as string] === true) {
     return true;
   }
@@ -24,5 +22,6 @@ export const isDataAttribute = (obj: Node, key: PropertyKey, svgAnalyzer: ISVGAn
     svgAnalyzer.isStandardSvgAttribute(obj, key);
 };
 
-/** @internal */
-export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;
+/** @internal */ export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;
+
+/** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -10,7 +10,7 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
   if (IsDataAttribute[key as string] === true) {
     return true;
   }
-  if (typeof key !== 'string') {
+  if (!isString(key)) {
     return false;
   }
   const prefix = key.slice(0, 5);
@@ -24,4 +24,7 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
 
 /** @internal */ export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;
 
+// eslint-ignore-next-line
 /** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
+
+/** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -2,6 +2,7 @@ import { emptyArray } from '@aurelia/kernel';
 import { CustomAttribute } from './resources/custom-attribute.js';
 import { CustomElement } from './resources/custom-element.js';
 import { defineMetadata, getAnnotationKeyFor, getOwnMetadata } from './shared.js';
+import { isFunction } from './utilities.js';
 
 import type { Constructable } from '@aurelia/kernel';
 import type { IConnectable } from '@aurelia/runtime';
@@ -75,7 +76,7 @@ export function watch<T extends object = object>(
 
     // basic validation
     if (isClassDecorator) {
-      if (typeof changeHandlerOrCallback !== 'function'
+      if (!isFunction(changeHandlerOrCallback)
         && (changeHandlerOrCallback == null || !(changeHandlerOrCallback in Type.prototype))
       ) {
         if (__DEV__)
@@ -83,7 +84,7 @@ export function watch<T extends object = object>(
         else
           throw new Error(`AUR0773:${String(changeHandlerOrCallback)}@${Type.name}}`);
       }
-    } else if (typeof descriptor?.value !== 'function') {
+    } else if (!isFunction(descriptor?.value)) {
       if (__DEV__)
         throw new Error(`decorated target ${String(key)} is not a class method.`);
       else

--- a/packages/runtime/src/binding-behavior.ts
+++ b/packages/runtime/src/binding-behavior.ts
@@ -8,7 +8,7 @@ import {
 } from '@aurelia/kernel';
 import { Collection, IndexMap, LifecycleFlags } from './observation.js';
 import { registerAliases } from './alias.js';
-import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from './utilities-objects.js';
+import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata, isFunction, isString } from './utilities-objects.js';
 
 import type {
   Constructable,
@@ -77,7 +77,7 @@ export class BindingBehaviorDefinition<T extends Constructable = Constructable> 
 
     let name: string;
     let def: PartialBindingBehaviorDefinition;
-    if (typeof nameOrDef === 'string') {
+    if (isString(nameOrDef)) {
       name = nameOrDef;
       def = { name };
     } else {
@@ -226,7 +226,7 @@ export const BindingBehavior = Object.freeze<BindingBehaviorKind>({
     return `${bbBaseName}:${name}`;
   },
   isType<T>(value: T): value is (T extends Constructable ? BindingBehaviorType<T> : never) {
-    return typeof value === 'function' && hasOwnMetadata(bbBaseName, value);
+    return isFunction(value) && hasOwnMetadata(bbBaseName, value);
   },
   define<T extends Constructable<BindingBehaviorInstance>>(nameOrDef: string | PartialBindingBehaviorDefinition, Type: T): BindingBehaviorType<T> {
     const definition = BindingBehaviorDefinition.create(nameOrDef, Type as Constructable<BindingBehaviorInstance>);

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -6,6 +6,8 @@ import { BindingContext } from '../observation/binding-context.js';
 import { ISignaler } from '../observation/signaler.js';
 import { BindingBehavior, BindingBehaviorInstance, BindingBehaviorFactory } from '../binding-behavior.js';
 import { ValueConverter, ValueConverterInstance } from '../value-converter.js';
+import { IConnectableBinding } from './connectable.js';
+import { isFunction, isString } from '../utilities-objects.js';
 
 import type { IIndexable, IServiceLocator, ResourceDefinition } from '@aurelia/kernel';
 import type {
@@ -17,7 +19,6 @@ import type {
   ISubscriber,
 } from '../observation.js';
 import type { Scope } from '../observation/binding-context.js';
-import { IConnectableBinding } from './connectable.js';
 
 export const enum ExpressionKind {
   CallsFunction        = 0b000000000100_00000, // Calls a function (CallFunction, CallScope, CallMember, TaggedTemplate) -> needs a valid function object returning from its lefthandside's evaluate()
@@ -176,7 +177,7 @@ export class Unparser implements IVisitor<void> {
 
   public visitPrimitiveLiteral(expr: PrimitiveLiteralExpression): void {
     this.text += '(';
-    if (typeof expr.value === 'string') {
+    if (isString(expr.value)) {
       const escaped = expr.value.replace(/'/g, '\\\'');
       this.text += `'${escaped}'`;
     } else {
@@ -425,7 +426,7 @@ export class BindingBehaviorExpression {
     const key = this.behaviorKey;
     const $b = b as BindingWithBehavior;
     if ($b[key] !== void 0) {
-      if (typeof $b[key]!.unbind === 'function') {
+      if (isFunction($b[key]!.unbind)) {
         $b[key]!.unbind(f, s, b);
       }
       $b[key] = void 0;
@@ -839,7 +840,7 @@ export class CallFunctionExpression {
 
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): unknown {
     const func = this.func.evaluate(f, s, l, c);
-    if (typeof func === 'function') {
+    if (isFunction(func)) {
       return func(...this.args.map(a => a.evaluate(f, s, l, c)));
     }
     if (!(f & LF.mustEvaluate) && (func == null)) {
@@ -893,7 +894,7 @@ export class BinaryExpression {
         return this.left.evaluate(f, s, l, c) !== this.right.evaluate(f, s, l, c);
       case 'instanceof': {
         const right = this.right.evaluate(f, s, l, c);
-        if (typeof right === 'function') {
+        if (isFunction(right)) {
           return this.left.evaluate(f, s, l, c) instanceof right;
         }
         return false;
@@ -1181,7 +1182,7 @@ export class TaggedTemplateExpression {
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): string {
     const results = this.expressions.map(e => e.evaluate(f, s, l, c));
     const func = this.func.evaluate(f, s, l, c);
-    if (typeof func !== 'function') {
+    if (!isFunction(func)) {
       if (__DEV__)
         throw new Error(`Left-hand side of tagged template expression is not a function.`);
       else
@@ -1418,7 +1419,7 @@ export class Interpolation {
 
 function getFunction(f: LF, obj: object, name: string): ((...args: unknown[]) => unknown) | null {
   const func = obj == null ? null : (obj as IIndexable)[name];
-  if (typeof func === 'function') {
+  if (isFunction(func)) {
     return func as (...args: unknown[]) => unknown;
   }
   if (!(f & LF.mustEvaluate) && func == null) {

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -19,7 +19,7 @@ import type {
   IndexMap,
   ISubscriber,
 } from '../observation.js';
-import { def, defineHiddenProp } from '../utilities-objects.js';
+import { def, defineHiddenProp, isFunction } from '../utilities-objects.js';
 
 const observerLookup = new WeakMap<unknown[], ArrayObserver>();
 
@@ -319,7 +319,7 @@ const observe = {
       }
       i++;
     }
-    if (compareFn === void 0 || typeof compareFn !== 'function'/* spec says throw a TypeError, should we do that too? */) {
+    if (compareFn === void 0 || !isFunction(compareFn)/* spec says throw a TypeError, should we do that too? */) {
       compareFn = sortCompare;
     }
     quickSort(this, o.indexMap, 0, i, compareFn);

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -7,7 +7,7 @@ import { subscriberCollection } from './subscriber-collection.js';
 import { enterConnectable, exitConnectable } from './connectable-switcher.js';
 import { connectable } from '../binding/connectable.js';
 import { wrap, unwrap } from './proxy-observation.js';
-import { def } from '../utilities-objects.js';
+import { def, isFunction } from '../utilities-objects.js';
 import { withFlushQueue } from './flush-queue.js';
 
 import type {
@@ -114,7 +114,7 @@ export class ComputedObserver implements
 
   // deepscan-disable-next-line
   public setValue(v: unknown, _flags: LifecycleFlags): void {
-    if (typeof this.set === 'function') {
+    if (isFunction(this.set)) {
       if (v !== this._value) {
         // setting running true as a form of batching
         this._isRunning = true;

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -10,7 +10,7 @@ export const hasOwnProp = Object.prototype.hasOwnProperty;
 
 /** @internal */ export const def = Reflect.defineProperty;
 
-// eslint-ignore-next-line
+// eslint-disable-next-line @typescript-eslint/ban-types
 /** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -8,14 +8,14 @@ import { Metadata, Protocol } from '@aurelia/kernel';
  */
 export const hasOwnProp = Object.prototype.hasOwnProperty;
 
-/** @internal */
-export const def = Reflect.defineProperty;
+/** @internal */ export const def = Reflect.defineProperty;
 
-/** @internal */
-export const isFunction = (v: unknown): v is (...args: unknown[]) => any => typeof v === 'function';
+// eslint-ignore-next-line
+/** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
 
-/** @internal */
-export function defineHiddenProp<T extends unknown>(obj: object, key: PropertyKey, value: T): T {
+/** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
+
+/** @internal */ export function defineHiddenProp<T extends unknown>(obj: object, key: PropertyKey, value: T): T {
   def(obj, key, {
     enumerable: false,
     configurable: true,
@@ -25,8 +25,7 @@ export function defineHiddenProp<T extends unknown>(obj: object, key: PropertyKe
   return value;
 }
 
-/** @internal */
-export function ensureProto<T extends object, K extends keyof T>(
+/** @internal */ export function ensureProto<T extends object, K extends keyof T>(
   proto: T,
   key: K,
   defaultValue: unknown,
@@ -37,18 +36,11 @@ export function ensureProto<T extends object, K extends keyof T>(
   }
 }
 
-/** @internal */
-export const createLookup = <T>(): Record<string, T> => Object.create(null);
+/** @internal */ export const createLookup = <T>(): Record<string, T> => Object.create(null);
 
-/** @internal */
-export const getOwnMetadata = Metadata.getOwn;
-/** @internal */
-export const hasOwnMetadata = Metadata.hasOwn;
-/** @internal */
-export const defineMetadata = Metadata.define;
-/** @internal */
-export const getAnnotationKeyFor = Protocol.annotation.keyFor;
-/** @internal */
-export const getResourceKeyFor = Protocol.resource.keyFor;
-/** @internal */
-export const appendResourceKey = Protocol.resource.appendTo;
+/** @internal */ export const getOwnMetadata = Metadata.getOwn;
+/** @internal */ export const hasOwnMetadata = Metadata.hasOwn;
+/** @internal */ export const defineMetadata = Metadata.define;
+/** @internal */ export const getAnnotationKeyFor = Protocol.annotation.keyFor;
+/** @internal */ export const getResourceKeyFor = Protocol.resource.keyFor;
+/** @internal */ export const appendResourceKey = Protocol.resource.appendTo;

--- a/packages/runtime/src/value-converter.ts
+++ b/packages/runtime/src/value-converter.ts
@@ -4,7 +4,7 @@ import {
   firstDefined,
 } from '@aurelia/kernel';
 import { registerAliases } from './alias.js';
-import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from './utilities-objects.js';
+import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata, isFunction, isString } from './utilities-objects.js';
 
 import type {
   Constructable,
@@ -59,7 +59,7 @@ export class ValueConverterDefinition<T extends Constructable = Constructable> i
 
     let name: string;
     let def: PartialValueConverterDefinition;
-    if (typeof nameOrDef === 'string') {
+    if (isString(nameOrDef)) {
       name = nameOrDef;
       def = { name };
     } else {
@@ -93,7 +93,7 @@ export const ValueConverter = Object.freeze<ValueConverterKind>({
   name: vcBaseName,
   keyFrom: (name: string): string => `${vcBaseName}:${name}`,
   isType<T>(value: T): value is (T extends Constructable ? ValueConverterType<T> : never) {
-    return typeof value === 'function' && hasOwnMetadata(vcBaseName, value);
+    return isFunction(value) && hasOwnMetadata(vcBaseName, value);
   },
   define<T extends Constructable<ValueConverterInstance>>(nameOrDef: string | PartialValueConverterDefinition, Type: T): ValueConverterType<T> {
     const definition = ValueConverterDefinition.create(nameOrDef, Type as Constructable<ValueConverterInstance>);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This should help reduce the bundle size slightly. Creating the utility locally to avoid overhead of managing cross package dependencies. The functions are all simple and probably inlined by any modern JS runtime.