### PR TITLE
fix(promise): suppressed TaskAbortError on cancellation

### DIFF
--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,4 +1,4 @@
-import { ILogger, nextId, onResolve, resolveAll, Task, TaskStatus } from '@aurelia/kernel';
+import { ILogger, nextId, onResolve, resolveAll, Task, TaskAbortError, TaskStatus } from '@aurelia/kernel';
 import { BindingMode, LifecycleFlags, Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable.js';
 import { INode, IRenderLocation } from '../../dom.js';
@@ -113,7 +113,11 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
               if (this.preSettledTask!.status === TaskStatus.running) {
                 void preSettlePromise.then(fulfill);
               } else {
-                this.preSettledTask!.cancel();
+                try {
+                  this.preSettledTask!.cancel();
+                } catch (err) {
+                  if (!(err instanceof TaskAbortError)) throw err;
+                }
                 fulfill();
               }
             },
@@ -132,7 +136,11 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
               if (this.preSettledTask!.status === TaskStatus.running) {
                 void preSettlePromise.then(reject);
               } else {
-                this.preSettledTask!.cancel();
+                try {
+                  this.preSettledTask!.cancel();
+                } catch (err) {
+                  if (!(err instanceof TaskAbortError)) throw err;
+                }
                 reject();
               }
             },

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -95,7 +95,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
             rejected?.deactivate(initiator, flags),
             pending?.activate(initiator, flags, s)
           );
-        }, defaultQueuingOptions)).result,
+        }, defaultQueuingOptions)).result.catch((err) => { if (!(err instanceof TaskAbortError)) throw err; }),
         value
           .then(
             (data) => {
@@ -113,11 +113,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
               if (this.preSettledTask!.status === TaskStatus.running) {
                 void preSettlePromise.then(fulfill);
               } else {
-                try {
-                  this.preSettledTask!.cancel();
-                } catch (err) {
-                  if (!(err instanceof TaskAbortError)) throw err;
-                }
+                this.preSettledTask!.cancel();
                 fulfill();
               }
             },
@@ -136,11 +132,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
               if (this.preSettledTask!.status === TaskStatus.running) {
                 void preSettlePromise.then(reject);
               } else {
-                try {
-                  this.preSettledTask!.cancel();
-                } catch (err) {
-                  if (!(err instanceof TaskAbortError)) throw err;
-                }
+                this.preSettledTask!.cancel();
                 reject();
               }
             },


### PR DESCRIPTION
The promise TC cancels any pre-settlement task if the promise is found to be settled and the pre-settlement task is not yet running. However, as the promise TC acquires the "task-promise" by doing `preSettledTask.result`, cancelling the task results in the rejection of the promise. This rejection on the users' end can be bit confusing. Thus, this error is suppressed in this PR.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
