### PR TITLE
fix(compiler): allowing syntax modification from attr pattern on some cases for custom attribute

### DIFF
--- a/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/3-runtime-html/attribute-pattern.spec.ts
@@ -228,7 +228,7 @@ describe('@attributePattern', function () {
       ],
     ],
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
-    describe(`parse [${defs.map(d => d.pattern)}]`, function () {
+    describe(`[UNIT] parse [${defs.map(d => d.pattern)}]`, function () {
       for (const [value, match, parts] of tests) {
         it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
           let receivedRawName: string;

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -1,3 +1,7 @@
+/* eslint-disable no-extra-boolean-cast */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 import {
   Constructable,
   IContainer,
@@ -13,6 +17,7 @@ import {
 import {
   ExpressionType,
   ForOfStatement,
+  Interpolation,
   parseExpression,
 } from '@aurelia/runtime';
 import {
@@ -48,6 +53,9 @@ import {
   HydrateAttributeInstruction,
   AttrSyntax,
   If,
+  attributePattern,
+  PropertyBindingInstruction,
+  InterpolationInstruction,
 } from '@aurelia/runtime-html';
 import {
   assert,
@@ -1735,6 +1743,126 @@ describe(`TemplateCompiler - combinations`, function () {
       );
     });
   });
+
+  describe.only('with attribute patterns', function () {
+    // all tests are using pattern that is `my-attr`
+    // and the template will have an element with an attribute `my-attr`
+    const createPattern = (createSyntax: (rawName: string, rawValue: string, parts: string[]) => AttrSyntax) => {
+      @attributePattern(
+        { pattern: 'my-attr', symbols: '' }
+      )
+      class MyAttrPattern {
+        public 'my-attr'(rawName: string, rawValue: string, parts: string[]) {
+          return createSyntax(rawName, rawValue, parts);
+        }
+      }
+      return MyAttrPattern;
+    };
+    const compileWithPattern = (Pattern: Constructable, extras: any[] = []) => {
+      const { sut, container } = createFixture(TestContext.create(), Pattern, ...extras);
+      const definition = sut.compile({
+        name: 'rando',
+        template: '<div my-attr>',
+      }, container, { projections: null });
+
+      return { sut, container, definition };
+    };
+
+    it('works with pattern returning command', function () {
+      const MyPattern = createPattern((name, val, _parts) => new AttrSyntax(name, val, 'id', 'bind'));
+      const { definition } = compileWithPattern(MyPattern);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        [new PropertyBindingInstruction(new PrimitiveLiteralExpression(''), 'id', BindingMode.toView)]
+      );
+    });
+
+    it('works when pattern returning interpolation', function () {
+      const MyPattern = createPattern((name, _val, _parts) => new AttrSyntax(name, `\${a}a`, 'id', null));
+      const { definition } = compileWithPattern(MyPattern);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        [new InterpolationInstruction(new Interpolation(['', 'a'], [new AccessScopeExpression('a')]), 'id')]
+      );
+    });
+
+    it('ignores when pattern DOES NOT return command or interpolation', function () {
+      const MyPattern = createPattern((name, val, _parts) => new AttrSyntax(name, val, 'id', null));
+      const { definition } = compileWithPattern(MyPattern);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        undefined
+      );
+      assert.deepStrictEqual(
+        (definition.template as HTMLTemplateElement).content.querySelector('div').className,
+        ''
+      );
+    });
+
+    it('lets pattern control the binding value', function () {
+      const MyPattern = createPattern((name, _val, _parts) => new AttrSyntax(name, 'bb', 'id', 'bind'));
+      const { definition } = compileWithPattern(MyPattern);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        // default value is '' attr pattern changed it to 'bb'
+        [new PropertyBindingInstruction(new AccessScopeExpression('bb'), 'id', BindingMode.toView)]
+      );
+    });
+
+    it('works with pattern returning custom attribute + command', function () {
+      @customAttribute({
+        name: 'my-attr'
+      })
+      class MyAttr {}
+      const MyPattern = createPattern((name, _val, _parts) => new AttrSyntax(name, 'bb', 'my-attr', 'bind'));
+      const { definition } = compileWithPattern(MyPattern, [MyAttr]);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        [new HydrateAttributeInstruction(CustomAttribute.getDefinition(MyAttr), undefined, [
+          new PropertyBindingInstruction(new AccessScopeExpression('bb'), 'value', BindingMode.toView)
+        ])]
+      );
+    });
+
+    it('works with pattern returning custom attribute + multi bindings', function () {
+      @customAttribute({
+        name: 'my-attr'
+      })
+      class MyAttr {}
+      const MyPattern = createPattern((name, _val, _parts) => new AttrSyntax(name, 'value.bind: bb', 'my-attr', null));
+      const { definition } = compileWithPattern(MyPattern, [MyAttr]);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        [new HydrateAttributeInstruction(CustomAttribute.getDefinition(MyAttr), undefined, [
+          new PropertyBindingInstruction(new AccessScopeExpression('bb'), 'value', BindingMode.toView)
+        ])]
+      );
+    });
+
+    it('works with pattern returning custom attribute + interpolation', function () {
+      @customAttribute({
+        name: 'my-attr'
+      })
+      class MyAttr {}
+      const MyPattern = createPattern((name, _val, _parts) =>
+        new AttrSyntax(name, `\${bb}`, 'my-attr', null)
+      );
+      const { definition } = compileWithPattern(MyPattern, [MyAttr]);
+
+      assert.deepStrictEqual(
+        definition.instructions[0],
+        [new HydrateAttributeInstruction(CustomAttribute.getDefinition(MyAttr), undefined, [
+          new InterpolationInstruction(new Interpolation(['', ''], [new AccessScopeExpression('bb')]), 'value')
+        ])]
+      );
+    });
+  });
 });
 
 describe('TemplateCompiler - local templates', function () {
@@ -2401,7 +2529,7 @@ class BindablesInfo<T extends 0 | 1 = 0> {
       primary = attrs.value = BindableDefinition.create('value', def.Type, { mode: defaultBindingMode });
     }
 
-    return new BindablesInfo(attrs, bindables, primary!);
+    return new BindablesInfo(attrs, bindables, primary);
   }
 
   protected constructor(

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -1744,7 +1744,7 @@ describe(`TemplateCompiler - combinations`, function () {
     });
   });
 
-  describe.only('with attribute patterns', function () {
+  describe('with attribute patterns', function () {
     // all tests are using pattern that is `my-attr`
     // and the template will have an element with an attribute `my-attr`
     const createPattern = (createSyntax: (rawName: string, rawValue: string, parts: string[]) => AttrSyntax) => {

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -769,19 +769,19 @@ export class TemplateCompiler implements ITemplateCompiler {
         //          Consider style attribute rule-value pair: <div style="rule: ruleValue">
         isMultiBindings = attrDef.noMultiBindings === false
           && bindingCommand === null
-          && hasInlineBindings(attrValue);
+          && hasInlineBindings(realAttrValue);
         if (isMultiBindings) {
-          attrBindableInstructions = this._compileMultiBindings(el, attrValue, attrDef, context);
+          attrBindableInstructions = this._compileMultiBindings(el, realAttrValue, attrDef, context);
         } else {
           primaryBindable = bindablesInfo.primary;
           // custom attribute + single value + WITHOUT binding command:
           // my-attr=""
           // my-attr="${}"
           if (bindingCommand === null) {
-            expr = exprParser.parse(attrValue, ExpressionType.Interpolation);
+            expr = exprParser.parse(realAttrValue, ExpressionType.Interpolation);
             attrBindableInstructions = [
               expr === null
-                ? new SetPropertyInstruction(attrValue, primaryBindable.property)
+                ? new SetPropertyInstruction(realAttrValue, primaryBindable.property)
                 : new InterpolationInstruction(expr, primaryBindable.property)
             ];
           } else {


### PR DESCRIPTION
# Pull Request

## 📖 Description

### 🎫 Issues

At the moment, when using attr pattern with custom attribute, if the new `AttrSyntax` does not have binding command, it will use the existing attribute value, instead of the value specified in the new `AttrSyntax`. Example:

```html
<div my-attr>
```

```ts
@attributePattern({ pattern: 'my-attr', symbols: '' })
class MyAttrPattern {
  public 'my-attr'(rawName: string, rawValue: string, parts: string[]) {

    // binding command works:
    return new AttrSyntax(rawName, rawValue, 'my-custom-attr', 'bind');

    // interpolation does not work
    return new AttrSyntax(rawName, `some wrapping text ${rawValue}`, 'my-custom-attr', null);

    // converting into multi binding mode does not work
    return new AttrSyntax(rawName, `value: ${rawValue}; label: Some label`, 'my-custom-attr', null)
  }
}
```

This inconsistency is fixed in this PR.