### PR TITLE
refactor(switch+promise): deferred view instantiation

### DIFF
--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -74,11 +74,11 @@ describe('promise template-controller', function () {
         @optional(Config) private readonly config: Config,
         @ILogger private readonly $logger: ILogger,
         @IContainer container: IContainer,
-        @INode node: HTMLElement,
+        @INode node: INode,
       ) {
-        if (node.dataset.logCtor !== void 0) {
+        if ((node as HTMLElement).dataset.logCtor !== void 0) {
           (this.logger = $logger.scopeTo(name)).debug('ctor');
-          delete node.dataset.logCtor;
+          delete (node as HTMLElement).dataset.logCtor;
         }
         if (config == null) {
           const lookup = container.get(configLookup);

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -1069,7 +1069,6 @@ describe('3-runtime-html/switch.spec.ts', function () {
         null,
         getDeactivationSequenceFor(['case-host-1', 'case-host-6']),
         (ctx) => {
-          // console.log(ctx.host.outerHTML);
           const switches = (ctx.controller.children[0] as Controller<Repeat>).viewModel
             .views
             .map((v) => v.children[0].viewModel as Switch);

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -86,12 +86,12 @@ describe('3-runtime-html/switch.spec.ts', function () {
       public constructor(
         private readonly config: Config,
         @ILogger private readonly $logger: ILogger,
-        @INode node: HTMLElement,
+        @INode node: INode,
       ) {
-        const ceId = node.dataset.ceId;
+        const ceId = (node as HTMLElement).dataset.ceId;
         if (ceId) {
           (this.logger = $logger.scopeTo(`${name}-${ceId}`)).debug('ctor');
-          delete node.dataset.ceId;
+          delete (node as HTMLElement).dataset.ceId;
         }
       }
 

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -34,7 +34,7 @@ const testDirs = [
   'validation-i18n',
 ];
 
-const baseKarmaArgs = 'karma start karma.conf.cjs  --browsers=ChromeDebugging --browsers=ChromeHeadlessOpt --browsers=FirefoxHeadless --single-run --coverage --watch-extensions js,html'.split(' ');
+const baseKarmaArgs = 'karma start karma.conf.cjs  --browsers=ChromeDebugging --browsers=ChromeHeadlessOpt --browsers=FirefoxHeadless --single-run --coverage --watch-extensions js,html --bail'.split(' ');
 const cliArgs = process.argv.slice(2).filter(arg => !baseKarmaArgs.includes(arg));
 
 const packageNames = [

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -170,10 +170,9 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
   public view: ISyntheticView | undefined = void 0;
 
   public constructor(
-    @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation private readonly location: IRenderLocation,
-  ) {
-  }
+    /** @internal */ @IViewFactory private readonly _factory: IViewFactory,
+    /** @internal */ @IRenderLocation private readonly _location: IRenderLocation,
+  ) { }
 
   public link(
     controller: IHydratableController,
@@ -185,7 +184,10 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
   }
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope): void | Promise<void> {
-    const view = this.view ??= this.factory.create().setLocation(this.location);
+    let view = this.view;
+    if(view === void 0) {
+      view = this.view = this._factory.create().setLocation(this._location);
+    }
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }
@@ -216,8 +218,8 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
   public view: ISyntheticView | undefined = void 0;
 
   public constructor(
-    @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation private readonly location: IRenderLocation,
+    /** @internal */ @IViewFactory private readonly _factory: IViewFactory,
+    /** @internal */ @IRenderLocation private readonly _location: IRenderLocation,
   ) { }
 
   public link(
@@ -231,7 +233,10 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope, resolvedValue: unknown): void | Promise<void> {
     this.value = resolvedValue;
-    const view = this.view ??= this.factory.create().setLocation(this.location);
+    let view = this.view;
+    if(view === void 0) {
+      view = this.view = this._factory.create().setLocation(this._location);
+    }
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }
@@ -262,8 +267,8 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
   public view: ISyntheticView | undefined = void 0;
 
   public constructor(
-    @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation private readonly location: IRenderLocation,
+    @IViewFactory private readonly _factory: IViewFactory,
+    @IRenderLocation private readonly _location: IRenderLocation,
   ) { }
 
   public link(
@@ -277,7 +282,10 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope, error: unknown): void | Promise<void> {
     this.value = error;
-    const view = this.view ??= this.factory.create().setLocation(this.location);
+    let view = this.view;
+    if(view === void 0) {
+      view = this.view = this._factory.create().setLocation(this._location);
+    }
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -167,7 +167,7 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.toView }) public value!: Promise<unknown>;
 
-  public view: ISyntheticView | null = null;
+  public view: ISyntheticView | undefined = void 0;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
@@ -192,7 +192,7 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (view == null || !view.isActive) { return; }
+    if (view === void 0 || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 
@@ -213,7 +213,7 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.fromView }) public value!: unknown;
 
-  public view: ISyntheticView | null = null;
+  public view: ISyntheticView | undefined = void 0;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
@@ -238,7 +238,7 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (view == null || !view.isActive) { return; }
+    if (view === void 0 || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 
@@ -259,7 +259,7 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.fromView }) public value!: unknown;
 
-  public view: ISyntheticView | null = null;
+  public view: ISyntheticView | undefined = void 0;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
@@ -284,7 +284,7 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (view == null || !view.isActive) { return; }
+    if (view === void 0 || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -167,13 +167,12 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.toView }) public value!: Promise<unknown>;
 
-  public view: ISyntheticView;
+  public view: ISyntheticView | null = null;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation location: IRenderLocation,
+    @IRenderLocation private readonly location: IRenderLocation,
   ) {
-    this.view = this.factory.create().setLocation(location);
   }
 
   public link(
@@ -186,14 +185,14 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
   }
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope): void | Promise<void> {
-    const view = this.view;
+    const view = this.view ??= this.factory.create().setLocation(this.location);
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (!view.isActive) { return; }
+    if (view == null || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 
@@ -214,14 +213,12 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.fromView }) public value!: unknown;
 
-  public view: ISyntheticView;
+  public view: ISyntheticView | null = null;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation location: IRenderLocation,
-  ) {
-    this.view = this.factory.create().setLocation(location);
-  }
+    @IRenderLocation private readonly location: IRenderLocation,
+  ) { }
 
   public link(
     controller: IHydratableController,
@@ -234,14 +231,14 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope, resolvedValue: unknown): void | Promise<void> {
     this.value = resolvedValue;
-    const view = this.view;
+    const view = this.view ??= this.factory.create().setLocation(this.location);
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (!view.isActive) { return; }
+    if (view == null || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 
@@ -262,14 +259,12 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   @bindable({ mode: BindingMode.fromView }) public value!: unknown;
 
-  public view: ISyntheticView;
+  public view: ISyntheticView | null = null;
 
   public constructor(
     @IViewFactory private readonly factory: IViewFactory,
-    @IRenderLocation location: IRenderLocation,
-  ) {
-    this.view = this.factory.create().setLocation(location);
-  }
+    @IRenderLocation private readonly location: IRenderLocation,
+  ) { }
 
   public link(
     controller: IHydratableController,
@@ -282,14 +277,14 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope, error: unknown): void | Promise<void> {
     this.value = error;
-    const view = this.view;
+    const view = this.view ??= this.factory.create().setLocation(this.location);
     if (view.isActive) { return; }
     return view.activate(view, this.$controller, flags, scope);
   }
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (!view.isActive) { return; }
+    if (view == null || !view.isActive) { return; }
     return view.deactivate(view, this.$controller, flags);
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -265,9 +265,9 @@ export class Case implements ICustomAttributeViewModel {
   /** @internal */ private _observer: ICollectionObserver<CollectionKind.array> | undefined;
 
   public constructor(
-    private readonly factory: IViewFactory,
+    /** @internal */ private readonly _factory: IViewFactory,
     /** @internal */ private readonly _locator: IObserverLocator,
-    private readonly location: IRenderLocation,
+    /** @internal */ private readonly _location: IRenderLocation,
     logger: ILogger,
   ) {
     this._debug = logger.config.level <= LogLevel.debug;
@@ -324,7 +324,10 @@ export class Case implements ICustomAttributeViewModel {
   }
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope): void | Promise<void> {
-    const view = this.view ??= this.factory.create().setLocation(this.location);
+    let view = this.view;
+    if(view === void 0) {
+      view = this.view = this._factory.create().setLocation(this._location);
+    }
     if (view.isActive) { return; }
     return view.activate(initiator ?? view, this.$controller, flags, scope);
   }

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -258,21 +258,20 @@ export class Case implements ICustomAttributeViewModel {
   })
   public fallThrough: boolean = false;
 
-  public view: ISyntheticView;
+  public view: ISyntheticView | null = null;
   private $switch!: Switch;
   /** @internal */ private readonly _debug: boolean;
   /** @internal */ private readonly _logger: ILogger;
   /** @internal */ private _observer: ICollectionObserver<CollectionKind.array> | undefined;
 
   public constructor(
-    factory: IViewFactory,
+    private readonly factory: IViewFactory,
     /** @internal */ private readonly _locator: IObserverLocator,
-    location: IRenderLocation,
+    private readonly location: IRenderLocation,
     logger: ILogger,
   ) {
     this._debug = logger.config.level <= LogLevel.debug;
     this._logger = logger.scopeTo(`${this.constructor.name}-#${this.id}`);
-    this.view = factory.create().setLocation(location);
   }
 
   public link(
@@ -325,14 +324,14 @@ export class Case implements ICustomAttributeViewModel {
   }
 
   public activate(initiator: IHydratedController | null, flags: LifecycleFlags, scope: Scope): void | Promise<void> {
-    const view = this.view;
+    const view = this.view ??= this.factory.create().setLocation(this.location);
     if (view.isActive) { return; }
     return view.activate(initiator ?? view, this.$controller, flags, scope);
   }
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (!view.isActive) { return; }
+    if (view == null || !view.isActive) { return; }
     return view.deactivate(initiator ?? view, this.$controller, flags);
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -258,7 +258,7 @@ export class Case implements ICustomAttributeViewModel {
   })
   public fallThrough: boolean = false;
 
-  public view: ISyntheticView | null = null;
+  public view: ISyntheticView | undefined = void 0;
   private $switch!: Switch;
   /** @internal */ private readonly _debug: boolean;
   /** @internal */ private readonly _logger: ILogger;
@@ -331,7 +331,7 @@ export class Case implements ICustomAttributeViewModel {
 
   public deactivate(initiator: IHydratedController | null, flags: LifecycleFlags): void | Promise<void> {
     const view = this.view;
-    if (view == null || !view.isActive) { return; }
+    if (view === void 0 || !view.isActive) { return; }
     return view.deactivate(initiator ?? view, this.$controller, flags);
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR addresses the reported issue on discourse (https://discourse.aurelia.io/t/switch-case-statements-in-templates/4702)
of the CE VM are being instantiated even if the cases are not matched. Previously, the controller was created in the `Case#ctor`. This commit defers it to the `Case#activate`; that is, when the case matches the switch condition and about to be activated.

It also defers the instantiations for promise-tc's VMs.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
