### PR TITLE
build: change dist extension to .cjs and .mjs, optimize CI caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,12 +643,13 @@ workflows:
           <<: *filter_ignore_develop_release
       - checkout_install_cache:
           <<: *filter_ignore_develop_release
+          name: checkout_install
           requires:
               - check_doc_abort
       - build_dev:
           <<: *filter_ignore_develop_release
           requires:
-              - checkout_install_cache
+              - checkout_install
       - unit_test_esm:
           <<: *filter_ignore_develop_release
           name: test_chrome
@@ -684,7 +685,7 @@ workflows:
       - lint_packages:
           <<: *filter_ignore_develop_release
           requires:
-            - checkout_install_cache
+            - checkout_install
       # - js_framework_benchmark:
       #     <<: *filter_ignore_develop_release
       #     requires:
@@ -699,13 +700,13 @@ workflows:
           name: webpack_conventions_ts
           path: "examples/jit-webpack-conventions-ts"
           requires:
-            - checkout_install_cache
+            - checkout_install
       - e2e_playwright:
           <<: *filter_ignore_develop_release
           name: webpack_vanilla_ts
           path: "examples/jit-webpack-vanilla-ts"
           requires:
-            - checkout_install_cache
+            - checkout_install
       - merge_and_dist:
           <<: *filter_only_master
           name: merge_and_dist_master
@@ -731,7 +732,7 @@ workflows:
           channel: dev
           dist_file_name: merge_and_dist_topic
           requires:
-            - checkout_install_cache
+            - checkout_install
       - publish_npm:
           <<: *filter_only_master
           name: publish_npm_dev
@@ -747,10 +748,11 @@ workflows:
     jobs:
       - checkout_install_cache:
           <<: *filter_only_tag
+          name: checkout_install
       - build_dev:
           <<: *filter_only_tag
           requires:
-            - checkout_install_cache
+            - checkout_install
       - unit_test_esm:
           <<: *filter_only_tag
           name: test_chrome
@@ -785,7 +787,7 @@ workflows:
       - lint_packages:
           <<: *filter_only_tag
           requires:
-            - checkout_install_cache
+            - checkout_install
       - merge_and_dist:
           <<: *filter_only_tag
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,15 @@ commands:
       #     install_drivers: false
       - checkout
       - restore_cache:
-          key: cache-{{ .Revision }}-install
-      - run: npm run build:release
+          key: cache-{{ checksum "package-lock.json" }}-install
+      - restore_cache:
+          name: "Restore build artifacts"
+          key: cache-{{ .Revision }}-build-true
+      # - run: npm run build:release
       # - run: npm run change-tsconfigs:invert
       # - run: npm run build:release
       # - run: npm run change-tsconfigs:restore
-      - run: npm run generate-native-modules
+      # - run: npm run generate-native-modules
       - clean_merge_commit_dist:
           from: << parameters.from >>
           to: << parameters.to >>
@@ -194,7 +197,7 @@ commands:
       - run: set -o pipefail && git add . && git status
       - run: set -o pipefail && git checkout stash -- . && git status
       - run: set -o pipefail && git add packages/*/dist packages-cjs/*/dist --force && git status
-      - run: set -o pipefail && npm run change-package-refs:release -- none
+      # - run: set -o pipefail && npm run change-package-refs:release -- none
       - when:
           condition: << parameters.bump_version >>
           steps:
@@ -209,10 +212,18 @@ jobs:
   checkout_install_cache:
     executor: docker-circleci
     steps:
-      - checkout_install:
-          install_drivers: false
+      - checkout
+      - restore_cache:
+          key: cache-{{ checksum "package-lock.json" }}-install
+      - run: |
+          # cache restored
+          if [[ $(ls -l node_modules | grep -c ^d) -gt 10 ]]; then
+            exit 0
+          else
+            npm ci
+          fi
       - save_cache:
-          key: cache-{{ .Revision }}-install
+          key: cache-{{ checksum "package-lock.json" }}-install
           paths:
             - node_modules
             - packages/__tests__/node_modules
@@ -228,15 +239,26 @@ jobs:
             - packages-cjs/ts-jest/node_modules
             - packages-cjs/webpack-loader/node_modules
 
-  build_dev:
+  build_and_cache:
     executor: docker-circleci
+    parameters:
+      command:
+        type: string
+        default: npm run build
+      generate_native_modules:
+        type: boolean
+        default: false
     steps:
       - checkout
       - restore_cache:
-          key: cache-{{ .Revision }}-install
-      - run: npm run build
+          key: cache-{{ checksum "package-lock.json" }}-install
+      - run: << parameters.command >>
+      - when:
+          condition: << parameters.generate_native_modules >>
+          steps:
+            - run: npm run generate-native-modules
       - save_cache:
-          key: cache-{{ .Revision }}-build
+          key: cache-{{ .Revision }}-build-<< parameters.generate_native_modules >>
           paths:
             - packages/__tests__/dist
             - packages/au/dist
@@ -294,9 +316,9 @@ jobs:
       # # - run: npm run build
       # just restore some cache from previous steps
       - restore_cache:
-          key: cache-{{ .Revision }}-install
+          key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:
-          key: cache-{{ .Revision }}-build
+          key: cache-{{ .Revision }}-build-false
       - run:
           name: "Split test glob"
           command: |
@@ -317,7 +339,7 @@ jobs:
                   node_modules/codecov/bin/codecov -f packages/__tests__/coverage/coverage-final.json
                 when: always
             - store_test_results:
-                path: packages/__tests__/coverage/coverage-final.json
+                path: packages/__tests__/coverage
 
   unit_test_esm_node:
     executor: docker-circleci
@@ -329,10 +351,10 @@ jobs:
           install: false
       - restore_cache:
           name: "Restore dependencies"
-          key: cache-{{ .Revision }}-install
+          key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:
           name: "Restore build artifacts"
-          key: cache-{{ .Revision }}-build
+          key: cache-{{ .Revision }}-build-false
       - run:
           name: "Split test glob"
           command: |
@@ -358,15 +380,15 @@ jobs:
       - checkout_install
       - restore_cache:
           name: "Restore dependencies"
-          key: cache-{{ .Revision }}-install
+          key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:
           name: "Restore build artifacts"
-          key: cache-{{ .Revision }}-build
+          key: cache-{{ .Revision }}-build-false
       # - run: npm run build
       # - run: npm run change-tsconfigs:invert
       # - run: npm run build
       # - run: npm run change-tsconfigs:restore
-      - run: npm run change-package-refs:release -- none
+      # - run: npm run change-package-refs:release -- none
       - when:
           condition: << parameters.submodules >>
           steps:
@@ -389,7 +411,7 @@ jobs:
           install: false
       - restore_cache:
           name: "Restore dependencies"
-          key: cache-{{ .Revision }}-install
+          key: cache-{{ checksum "package-lock.json" }}-install
       - run: npm run lint:packages:ci
       - run: npm run lint:other:ci
 
@@ -421,12 +443,15 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore dependencies"
-          key: cache-{{ .Revision }}-install
-      - run: set -o pipefail && npm run build:release
+          key: cache-{{ checksum "package-lock.json" }}-install
+      - restore_cache:
+          name: "Restore build artifacts"
+          key: cache-{{ .Revision }}-build-true
+      # - run: set -o pipefail && npm run build:release
       # - run: set -o pipefail && npm run change-tsconfigs:invert
       # - run: set -o pipefail && npm run build:release
       # - run: set -o pipefail && npm run change-tsconfigs:restore
-      - run: set -o pipefail && npm run generate-native-modules
+      # - run: set -o pipefail && npm run generate-native-modules
       - clean_merge_commit_dist:
           from: << parameters.from >>
           to: << parameters.to >>
@@ -646,8 +671,15 @@ workflows:
           name: checkout_install
           requires:
               - check_doc_abort
-      - build_dev:
+      - build_and_cache:
           <<: *filter_ignore_develop_release
+          name: build_dev
+          requires:
+              - checkout_install
+      - build_and_cache:
+          <<: *filter_ignore_develop_release
+          name: build_release
+          generate_native_modules: true
           requires:
               - checkout_install
       - unit_test_esm:
@@ -672,6 +704,7 @@ workflows:
             - build_dev
       - unit_test_cjs:
           <<: *filter_ignore_develop_release
+          name: test_toolings
           npm_command: "test-node"
           requires:
             - build_dev
@@ -700,21 +733,22 @@ workflows:
           name: webpack_conventions_ts
           path: "examples/jit-webpack-conventions-ts"
           requires:
-            - checkout_install
+            - build_release
       - e2e_playwright:
           <<: *filter_ignore_develop_release
           name: webpack_vanilla_ts
           path: "examples/jit-webpack-vanilla-ts"
           requires:
-            - checkout_install
+            - build_release
       - merge_and_dist:
           <<: *filter_only_master
           name: merge_and_dist_master
           requires:
+            - build_release
             - test_chrome
             - test_firefox
             - test_node
-            - unit_test_cjs
+            - test_toolings
             #- test_test262
             # - lint_packages
             - webpack_conventions_ts
@@ -732,7 +766,7 @@ workflows:
           channel: dev
           dist_file_name: merge_and_dist_topic
           requires:
-            - checkout_install
+            - build_release
       - publish_npm:
           <<: *filter_only_master
           name: publish_npm_dev
@@ -749,8 +783,15 @@ workflows:
       - checkout_install_cache:
           <<: *filter_only_tag
           name: checkout_install
-      - build_dev:
+      - build_and_cache:
           <<: *filter_only_tag
+          name: build_dev
+          requires:
+            - checkout_install
+      - build_and_cache:
+          <<: *filter_only_tag
+          name: build_release
+          generate_native_modules: true
           requires:
             - checkout_install
       - unit_test_esm:
@@ -775,6 +816,7 @@ workflows:
             - build_dev
       - unit_test_cjs:
           <<: *filter_only_tag
+          name: test_toolings
           npm_command: "test-node"
           requires:
             - build_dev
@@ -784,17 +826,22 @@ workflows:
       #   npm_command: "test-262"
       #   coverage: false
       #   submodules: true
-      - lint_packages:
-          <<: *filter_only_tag
-          requires:
-            - checkout_install
+
+      # - lint_packages:
+      #     <<: *filter_only_tag
+      #     requires:
+      #       - checkout_install
+
       - merge_and_dist:
           <<: *filter_only_tag
           requires:
+            # build release to get the build artifacts
+            - build_release
+            # and the rest for testings
             - test_chrome
             - test_firefox
             - test_node
-            - unit_test_cjs
+            - test_toolings
             #- test_test262
             # - lint_packages
           from: $CIRCLE_TAG

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm version](https://badge.fury.io/js/%40aurelia%2Fkernel.svg)](https://badge.fury.io/js/%40aurelia%2Fkernel)
 [![CircleCI](https://circleci.com/gh/aurelia/aurelia.svg?style=shield)](https://circleci.com/gh/aurelia/aurelia)
-[![Actions Status](https://github.com/aurelia/aurelia/workflows/Github%20Actions/badge.svg)](https://github.com/aurelia/aurelia/actions)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
 [![Twitter](https://img.shields.io/twitter/follow/aureliaeffect.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=aureliaeffect)
 
-[![Backers on Open Collective](https://opencollective.com/aurelia/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/aurelia/sponsors/badge.svg)](#sponsors)
+[![Backers on Open Collective](https://opencollective.com/aurelia/backers/badge.svg)](#backers)
+[![Sponsors on Open Collective](https://opencollective.com/aurelia/sponsors/badge.svg)](#sponsors)
 [![Discord Chat](https://img.shields.io/discord/448698263508615178.svg)](https://discord.gg/RBtyM6u)
 
 # Aurelia 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
       "devDependencies": {
         "@commitlint/cli": "^16.2.3",
         "@rollup/plugin-replace": "^4.0.0",
-        "@rollup/plugin-typescript": "^8.2.5",
+        "@rollup/plugin-typescript": "8.2.5",
         "@types/fancy-log": "^1.3.1",
         "@typescript-eslint/eslint-plugin": "^5.20.0",
         "@typescript-eslint/parser": "^5.20.0",

--- a/packages-cjs/aot/package.json
+++ b/packages-cjs/aot/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/babel-jest/package.json
+++ b/packages-cjs/babel-jest/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/parcel-transformer/package.json
+++ b/packages-cjs/parcel-transformer/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/plugin-conventions/package.json
+++ b/packages-cjs/plugin-conventions/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/plugin-gulp/package.json
+++ b/packages-cjs/plugin-gulp/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/ts-jest/package.json
+++ b/packages-cjs/ts-jest/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages-cjs/webpack-loader/package.json
+++ b/packages-cjs/webpack-loader/package.json
@@ -3,8 +3,10 @@
   "version": "2.0.0-alpha.29",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "commonjs",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages/__tests__/importmap.js
+++ b/packages/__tests__/importmap.js
@@ -19,9 +19,10 @@ document.write(`<script type="importmap">${JSON.stringify({
     'validation-html',
     'validation-i18n',
   ].reduce((map, pkg) => {
-    map[`@aurelia/${pkg}`] = `/base/packages/${pkg}/dist/esm/index.js`;
+    map[`@aurelia/${pkg}`] = `/base/packages/${pkg}/dist/esm/index.mjs`;
     return map;
   }, {
+    'i18next': '/base/node_modules/i18next/dist/esm/i18next.js',
     'rxjs': '/base/node_modules/rxjs/_esm5/index.js',
     'rxjs/operators': '/base/node_modules/rxjs/_esm5/operators/index.js',
   })

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -1,3 +1,4 @@
+// @ts-check
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 const path = require('path');
 const fs = require('fs');
@@ -5,62 +6,13 @@ const fs = require('fs');
 const basePath = path.resolve(__dirname, '..', '..');
 const smsPath = path.dirname(require.resolve('source-map-support'));
 
-const commonChromeFlags = [
-  '--no-default-browser-check',
-  '--no-first-run',
-  '--no-sandbox',
-  '--no-managed-user-acknowledgment-check',
-  '--disable-background-timer-throttling',
-  '--disable-backing-store-limit',
-  '--disable-boot-animation',
-  '--disable-cloud-import',
-  '--disable-contextual-search',
-  '--disable-default-apps',
-  '--disable-extensions',
-  '--disable-infobars',
-  '--disable-translate',
-];
 
-const testDirs = [
-  '1-kernel',
-  '2-runtime',
-  '3-runtime-html',
-  'fetch-client',
-  'i18n',
-  'integration',
-  'router',
-  'router-lite',
-  'store-v1',
-  'validation',
-  'validation-html',
-  'validation-i18n',
-];
-
-const baseKarmaArgs = 'karma start karma.conf.cjs  --browsers=ChromeDebugging --browsers=ChromeHeadlessOpt --browsers=FirefoxHeadless --single-run --coverage --watch-extensions js,html --bail --reporter=mocha --no-auto-watch'.split(' ');
+const baseKarmaArgs = 'karma start karma.conf.cjs  --browsers=ChromeDebugging --browsers=ChromeHeadlessOpt --browsers=FirefoxHeadless --browsers=Firefox --single-run --coverage --watch-extensions js,html --bail --reporter=mocha --no-auto-watch'.split(' ');
 const cliArgs = process.argv.slice(2).filter(arg => !baseKarmaArgs.includes(arg));
 const hasSingleRun = process.argv.slice(2).includes('--single-run');
 
-const packageNames = [
-  'fetch-client',
-  'i18n',
-  'kernel',
-  'metadata',
-  'platform',
-  'platform-browser',
-  'route-recognizer',
-  'router',
-  'router-lite',
-  'runtime',
-  'runtime-html',
-  'store-v1',
-  'testing',
-  'validation',
-  'validation-html',
-  'validation-i18n',
-];
-
 module.exports =
-/** @param {import('karma').Config} config */ function (config) {
+/** @param {import('karma').Config & { browsers: string[]; coverage: any; }} config */ function (config) {
   let browsers;
   if (process.env.BROWSERS) {
     browsers = [process.env.BROWSERS];
@@ -73,15 +25,15 @@ module.exports =
 
   const testFilePatterns = cliArgs.length > 0
     ? cliArgs.flatMap(arg => [
-        `${baseUrl}/**/*${arg.replace(/(?:\.[tj]s)?$/, '*.js')}`,
+        `${baseUrl}/**/*${arg.replace(/(?:\.[tj]s)?$/, '*.spec.js')}`,
         `${baseUrl}/**/${arg}/**/*.spec.js`,
     ])
     : [`${baseUrl}/**/*.spec.js`];
   const circleCiParallelismGlob = fs.existsSync('./tests.txt')
     ? fs.readFileSync('./tests.txt', { encoding: 'utf-8' })
     : null;
-
-  console.log('parallelism blob:', circleCiParallelismGlob);
+  const circleCiFiles = circleCiParallelismGlob?.split(' ') ?? [];
+  console.log(`parallelism blob (${circleCiFiles.length}):\n\t`, circleCiFiles.join('\n\t'));
   console.log('test patterns:', testFilePatterns);
 
   // Karma config reference: https://karma-runner.github.io/5.2/config/files.html
@@ -102,44 +54,43 @@ module.exports =
   //   Because they're not watched, they're also not cached, so that the browser will always serve the latest version from disk.
   //
   const files = [
-    { type: 'script', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/importmap.js` },
-    { type: 'script', watched: false, included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
-    { type: 'module', watched: true,  included: true,  nocache: false, pattern: `${baseUrl}/setup-browser.js` }, // 1.1
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `${baseUrl}/setup-shared.js` }, // 1.2
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `${baseUrl}/util.js` }, // 1.3
-    { type: 'module', watched: true,  included: false, nocache: false, pattern: `${baseUrl}/Spy.js` }, // 1.4
-    ...(
-      circleCiParallelismGlob
-        ? circleCiParallelismGlob
-          .split(' ')
-          .map(file => ({ type: 'module', watched: true,  included: true,  nocache: false, pattern: file })) // 2.1
-        : testFilePatterns.map(pattern =>
-            ({ type: 'module', watched: true,  included: true,  nocache: false, pattern: pattern }), // 2.1
-          )
+    // { type: 'script', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/importmap.js` },
+    { type: 'script', watched: false,           included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
+    { type: 'module', watched: !hasSingleRun,   included: true,  nocache: false, pattern: `${baseUrl}/setup-browser.js` }, // 1.1
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/setup-shared.js` }, // 1.2
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/util.js` }, // 1.3
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/Spy.js` }, // 1.4
+    ...(circleCiParallelismGlob
+      ? circleCiFiles
+        .map(file =>
+          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: file })) // 2.1
+      : testFilePatterns.map(pattern =>
+          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: pattern }), // 2.1
+        )
     ), // 2.1 (new)
     ...testDirs.flatMap(name => [
-      // { type: 'module', watched: false, included: false, nocache: true,  pattern: `${baseUrl}/${name}/**/*.spec.js` }, // 2.1 (old)
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `${baseUrl}/${name}/**/*.js.map` }, // 2.2
-      { type: 'module', watched: true,  included: false, nocache: false, pattern: `${baseUrl}/${name}/**/!(*.$au)*.js` }, // 2.3
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
+      // // { type: 'module', watched: false, included: false, nocache: true,  pattern: `${baseUrl}/${name}/**/*.spec.js` }, // 2.1 (old)
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: true,   pattern: `${baseUrl}/${name}/**/*.js.map` }, // 2.2
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: false,  pattern: `${baseUrl}/${name}/**/!(*.$au)*.js` }, // 2.3
+      { type: 'module', watched: false,         included: false, nocache: true,   pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
     ]),
     ...packageNames.flatMap(name => [
-      { type: 'module', watched: true,  included: false, nocache: false, pattern: `packages/${name}/dist/esm/**/!(*.$au)*.js` }, // 3.1
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/dist/esm/**/*.js.map` }, // 3.2
-      { type: 'module', watched: false, included: false, nocache: true,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: false, pattern: `packages/${name}/dist/esm/index.mjs` }, // 3.1
+      { type: 'module', watched: false,         included: false, nocache: true,  pattern: `packages/${name}/dist/esm/index.mjs.map` }, // 3.2
+      { type: 'module', watched: false,         included: false, nocache: true,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
     ]),
-    // for i18n tests
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/i18next/dist/esm/i18next.js` }, // 3.1
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/@babel/runtime/helpers/**/*.js` }, // 3.1
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js` }, // 3.1
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js.map` }, // 3.1
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.d.ts` }, // 3.1
-    { type: 'module', watched: false,  included: false, nocache: false, pattern: `node_modules/tslib/tslib.es6.js` }, // 3.1
+    // for i18n tests 
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/i18next/dist/esm/i18next.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/@babel/runtime/helpers/**/*.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js.map` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.d.ts` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/tslib/tslib.es6.js` }, // 3.1
   ];
 
   const preprocessors = files.reduce((p, file) => {
-    // Only process .js files (not .js.map or .ts files)
-    if (file.pattern.endsWith(".js")) {
+    // Only process .js/.mjs files (not .js.map or .ts files)
+    if (/\.m?js$/.test(file.pattern)) {
       // Only instrument core framework files (not the specs themselves, nor any test utils (for now))
       if (/__tests__|testing|node_modules/.test(file.pattern) || !config.coverage) {
         p[file.pattern] = ['aurelia'];
@@ -159,12 +110,14 @@ module.exports =
       'mocha',
     ],
     preprocessors,
+    // @ts-ignore
     files,
     mime: {
-      'text/x-typescript': ['ts']
+      'text/x-typescript': ['ts'],
     },
     reporters: [
       ...(hasSingleRun ? [] : ['clear-screen']),
+      // @ts-ignore
       config.reporter || (process.env.CI ? 'min' : 'progress'),
     ],
     browsers: browsers,
@@ -175,6 +128,7 @@ module.exports =
           ...commonChromeFlags,
           '--remote-debugging-port=9333'
         ],
+        // @ts-ignore
         debug: true
       },
       ChromeHeadlessOpt: {
@@ -219,10 +173,12 @@ module.exports =
 
   if (config.coverage) {
     options.reporters = ['coverage-istanbul', ...options.reporters];
+    // @ts-ignore
     options.coverageIstanbulReporter = {
       reports: ['html', 'text-summary', 'json', 'lcovonly', 'cobertura'],
       dir: 'coverage',
     };
+    // @ts-ignore
     options.coverageIstanbulInstrumenter = {
       // see https://github.com/monounity/karma-coverage-istanbul-instrumenter/blob/master/test/es6-native/karma.conf.js
       esModules: true,
@@ -236,3 +192,53 @@ module.exports =
 
   config.set(options);
 };
+
+const commonChromeFlags = [
+  '--no-default-browser-check',
+  '--no-first-run',
+  '--no-sandbox',
+  '--no-managed-user-acknowledgment-check',
+  '--disable-background-timer-throttling',
+  '--disable-backing-store-limit',
+  '--disable-boot-animation',
+  '--disable-cloud-import',
+  '--disable-contextual-search',
+  '--disable-default-apps',
+  '--disable-extensions',
+  '--disable-infobars',
+  '--disable-translate',
+];
+
+const testDirs = [
+  '1-kernel',
+  '2-runtime',
+  '3-runtime-html',
+  'fetch-client',
+  'i18n',
+  'integration',
+  'router',
+  'router-lite',
+  'store-v1',
+  'validation',
+  'validation-html',
+  'validation-i18n',
+];
+
+const packageNames = [
+  'fetch-client',
+  'i18n',
+  'kernel',
+  'metadata',
+  'platform',
+  'platform-browser',
+  'route-recognizer',
+  'router',
+  'router-lite',
+  'runtime',
+  'runtime-html',
+  'store-v1',
+  'testing',
+  'validation',
+  'validation-html',
+  'validation-i18n',
+];

--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -2,7 +2,6 @@
   "name": "@aurelia/__tests__",
   "private": true,
   "license": "MIT",
-  "type": "module",
   "engines": {
     "node": ">=14.15.0",
     "npm": ">=6.14.8"

--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -6,6 +6,7 @@
     "node": ">=14.15.0",
     "npm": ">=6.14.8"
   },
+  "type": "module",
   "scripts": {
     "lint": "eslint --cache --ext .js,.ts .",
     "lint:ci": "eslint --ext .js,.ts --quiet --report-unused-disable-directives .",
@@ -20,7 +21,7 @@
     "test-node:store-v1": "npm run ::mocha --  dist/esm/__tests__/store-v1/*.spec.js",
     "test-node:validation": "npm run ::mocha -- dist/esm/__tests__/validation*/**/*.spec.js",
     "test-chrome": "karma start karma.conf.cjs --browsers=ChromeHeadlessOpt --single-run --coverage --no-auto-watch",
-    "test-firefox": "karma start karma.conf.cjs --browsers=FirefoxHeadless --single-run --coverage",
+    "test-firefox": "karma start karma.conf.cjs --browsers=FirefoxHeadless --single-run --coverage --no-auto-watch",
     "test-firefox:verbose": "karma start karma.conf.cjs --browsers=FirefoxHeadless --single-run --coverage --reporter=mocha",
     "test-firefox:debugger": "karma start karma.conf.cjs --browsers=Firefox --watch-extensions js,html",
     "test-node:verbose": "cross-env NODE_ICU_DATA=../../node_modules/full-icu mocha ---ui bdd --reporter spec --colors --recursive --timeout 5000 --exit dist/esm/__tests__/setup-node.js dist/esm/__tests__/**/*.spec.js --exclude dist/esm/__tests__/integration/**/*.spec.js --exclude dist/esm/__tests__/store-v1/**/*.spec.js",

--- a/packages/au/package.json
+++ b/packages/au/package.json
@@ -1,11 +1,13 @@
 {
   "name": "au",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
-  "type": "module",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/au/package.json
+++ b/packages/au/package.json
@@ -1,11 +1,11 @@
 {
   "name": "au",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -1,12 +1,14 @@
 {
   "name": "aurelia",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -1,11 +1,11 @@
 {
   "name": "aurelia",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/fetch-client",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/fetch-client",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/http-server/bin/cli.js
+++ b/packages/http-server/bin/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --input-type=module
 /* eslint-disable import/extensions */
 
-import '../dist/esm/cli.js';
+require('../dist/cjs/cli.cjs');

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/http-server",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@aurelia/http-server",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "type": "module",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",

--- a/packages/http-server/rollup.config.js
+++ b/packages/http-server/rollup.config.js
@@ -8,12 +8,12 @@ export default [
     external: Object.keys(pkg.dependencies).concat('os', 'path', 'fs', 'http', 'https', 'http2', 'url', 'stream'),
     output: [
       {
-        file: 'dist/esm/index.js',
+        file: 'dist/esm/index.mjs',
         format: 'es',
         sourcemap: true
       },
       {
-        file: 'dist/cjs/index.js',
+        file: 'dist/cjs/index.cjs',
         format: 'cjs',
         sourcemap: true
       },
@@ -35,12 +35,12 @@ export default [
     external: Object.keys(pkg.dependencies).concat('os', 'path', 'fs', 'http', 'https', 'http2', 'url', 'stream'),
     output: [
       {
-        file: 'dist/esm/cli.js',
+        file: 'dist/esm/cli.mjs',
         format: 'es',
         sourcemap: true
       },
       {
-        file: 'dist/cjs/cli.js',
+        file: 'dist/cjs/cli.cjs',
         format: 'cjs',
         sourcemap: true
       },
@@ -49,12 +49,7 @@ export default [
       typescript({
         tsconfig: 'tsconfig.build.json',
         inlineSources: true,
-      }),
-      {
-        closeBundle() {
-          exec('npm run postrollup')
-        }
-      }
+      })
     ]
   }
 ];

--- a/packages/http-server/src/cli.ts
+++ b/packages/http-server/src/cli.ts
@@ -17,7 +17,18 @@ async function parseArgs(args: string[]): Promise<null | HttpServerOptions> {
     if (!existsSync(configurationFile)) {
       throw new Error(`Configuration file is missing or uneven amount of args: ${args}. Args must come in pairs of --key value`);
     } else {
-      const config = (await import(`file://${configurationFile}`)).default;
+      let config;
+      try {
+        config = (await import(`${configurationFile}`)).default;
+      } catch {
+        try {
+          config = (await import(`file://${configurationFile}`)).default;
+        } catch {
+          try {
+            config = (await import(`file:///${configurationFile}`)).default;
+          } catch {/*  */}
+        }
+      }
       configuration.applyConfig(config);
       args = args.slice(1);
     }

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/i18n",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/i18n",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/kernel",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/kernel",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/metadata",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/metadata",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/platform-browser",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/platform-browser",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/platform",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/platform",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/rollup-utils.js
+++ b/packages/rollup-utils.js
@@ -121,10 +121,10 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     NO_MINIFIED: process.env.NO_MINIFIED
   };
   const inputFile = 'src/index.ts';
-  const esmDevDist = 'dist/esm/index.dev.js';
-  const cjsDevDist = 'dist/cjs/index.dev.js';
-  const esmDist = 'dist/esm/index.js';
-  const cjsDist = 'dist/cjs/index.js';
+  const esmDevDist = 'dist/esm/index.dev.mjs';
+  const cjsDevDist = 'dist/cjs/index.dev.cjs';
+  const esmDist = 'dist/esm/index.mjs';
+  const cjsDist = 'dist/cjs/index.cjs';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
     if (warning.code === 'CIRCULAR_DEPENDENCY') return;

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/route-recognizer",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/route-recognizer",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/router-html/package.json
+++ b/packages/router-html/package.json
@@ -2,11 +2,11 @@
   "name": "@aurelia/router-html",
   "private": true,
   "version": "2.0.0-alpha.28",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/router-html/package.json
+++ b/packages/router-html/package.json
@@ -2,12 +2,14 @@
   "name": "@aurelia/router-html",
   "private": true,
   "version": "2.0.0-alpha.28",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/router-lite/package.json
+++ b/packages/router-lite/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/router-lite",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/router-lite/package.json
+++ b/packages/router-lite/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/router-lite",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/router",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/router",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/runtime-html",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/runtime-html",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/runtime",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/runtime",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/store-v1",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/store-v1",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/testing",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/testing",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/validation-html",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/validation-html",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/validation-i18n",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/validation-i18n",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@aurelia/validation",
   "version": "2.0.0-alpha.29",
-  "main": "dist/esm/index.js",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/types/index.d.ts",
+  "exports": {
+    "require": "./dist/cjs/index.js",
+    "import": "./dist/esm/index.js"
+  },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",
-  "type": "module",
   "homepage": "https://aurelia.io",
   "repository": {
     "type": "git",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@aurelia/validation",
   "version": "2.0.0-alpha.29",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js"
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
   },
   "typings": "dist/types/index.d.ts",
   "license": "MIT",

--- a/scripts/generate-native-modules.ts
+++ b/scripts/generate-native-modules.ts
@@ -50,7 +50,7 @@ const log = createLogger('generate-native-modules');
                 const end = statement.moduleSpecifier.getEnd(sourceFile);
 
                 const packageName = specifier.slice(9 /* '@aurelia/'.length */);
-                const packageEntryFilePath = path.join(project.path, `node_modules/@aurelia/${packageName}/dist/native-modules/index.js`);
+                const packageEntryFilePath = path.join(project.path, `node_modules/@aurelia/${packageName}/dist/native-modules/index.mjs`);
                 const normPath = file.path.replace(/\\/g, '/');
                 const origin = pkg.name.npm.includes('@aurelia')
                   ? normPath.replace(/packages[\\\/]([\w-]+)/, 'node_modules/@aurelia/$1')


### PR DESCRIPTION
- rename all dist extensions to `.mjs` and `.cjs`
- change `main` and `module` fields in `package.json` for all packages
- remove field `"type": "module"` in all packages
- Optimize our CircleCI caching, and remove unnecessary ci steps for so pipeline gets faster and uses fewer credits.

cc @3cp 