### PR TITLE
feat(events): expr as listener handler

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -216,7 +216,7 @@ module.exports = {
     '@typescript-eslint/require-array-sort-compare': 'warn',
     '@typescript-eslint/restrict-plus-operands': ['warn', { 'checkCompoundAssignments': true }],
     '@typescript-eslint/restrict-template-expressions': ['off', { 'allowNumber': true, 'allowBoolean': true, 'allowNullish': true, 'allowAny': true }],
-    '@typescript-eslint/strict-boolean-expressions': ['warn', { allowNullableBoolean: true }],
+    '@typescript-eslint/strict-boolean-expressions': ['warn', { 'allowNullableBoolean': true }],
     '@typescript-eslint/typedef': ['warn', { arrowParameter: false, parameter: false, variableDeclaration: false }],
     '@typescript-eslint/unbound-method': 'off', // Only false positives seen so far
     'jsdoc/check-examples': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -201,7 +201,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    '@typescript-eslint/no-unsafe-return': 'warn',
+    '@typescript-eslint/no-unsafe-return': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-this-alias': 'warn',
     '@typescript-eslint/no-unnecessary-condition': 'off', // Only false positives seen so far

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -52,12 +52,12 @@ module.exports = {
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/no-unnecessary-type-assertion': 'off',
     '@typescript-eslint/no-floating-promises': 'error',
+    '@typescript-eslint/explicit-member-accessibility': 'off',
   },
   overrides: [{ // Specific overrides for JS files as some TS rules don't make sense there.
     files: ['3-runtime-html/generated/**'],
     rules: {
       '@typescript-eslint/quotes': 'off',
-      '@typescript-eslint/explicit-member-accessibility': 'off',
       '@typescript-eslint/indent': 'off',
       'no-template-curly-in-string': 'off'
     }

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -4,7 +4,7 @@ import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/custom-elements.spec.ts', function () {
   it('works with multiple layers of change propagation & <input/>', async function () {
-    const { ctx, appHost, tearDown, startPromise } = createFixture(
+    const { ctx, appHost } = await createFixture(
       `<input value.bind="first_name | properCase">
       <form-input value.two-way="first_name | properCase"></form-input>`,
       class App {
@@ -31,9 +31,7 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
           }
         }),
       ],
-    );
-
-    await startPromise;
+    ).promise;
 
     const [, nestedInputEl] = Array.from(appHost.querySelectorAll('input'));
     nestedInputEl.value = 'aa bb';
@@ -41,8 +39,38 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
 
     ctx.platform.domWriteQueue.flush();
     assert.strictEqual(nestedInputEl.value, 'Aa Bb');
+  });
 
-    await tearDown();
+  it('renders containerless per element via "containerless" attribute', async function () {
+    const { appHost } = await createFixture(`<my-el containerless message="hello world">`, class App {}, [CustomElement.define({
+      name: 'my-el',
+      template: '${message}',
+      bindables: ['message']
+    })]).promise;
+
+    assert.visibleTextEqual(appHost, 'hello world');
+  });
+
+  it('renders element with @customElement({ containerness: true })', async function () {
+    const { appHost } = await createFixture(`<my-el message="hello world">`, class App {}, [CustomElement.define({
+      name: 'my-el',
+      template: '${message}',
+      bindables: ['message'],
+      containerless: true
+    })]).promise;
+
+    assert.visibleTextEqual(appHost, 'hello world');
+  });
+
+  it('renders elements with both "containerless" attribute and @customElement({ containerless: true })', async function () {
+    const { appHost } = await createFixture(`<my-el containerless message="hello world">`, class App {}, [CustomElement.define({
+      name: 'my-el',
+      template: '${message}',
+      bindables: ['message'],
+      containerless: true,
+    })]).promise;
+
+    assert.visibleTextEqual(appHost, 'hello world');
   });
 });
 // import {

--- a/packages/__tests__/3-runtime-html/listener.spec.ts
+++ b/packages/__tests__/3-runtime-html/listener.spec.ts
@@ -1,0 +1,27 @@
+import { AppTask, IListenerBehaviorOptions } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/listener.spec.ts', function () {
+  it('invokes expression', async function () {
+    let log = 0;
+    const { getBy } = await createFixture(
+      '<button click.trigger="onClick()">',
+      { onClick() { log++; } },
+    ).promise;
+
+    getBy('button').click();
+    assert.strictEqual(log, 1);
+  });
+
+  it('invoke handler after evaluating expression when expAsHandler = true', async function () {
+    let log = 0;
+    const { getBy } = await createFixture(
+      '<button click.trigger="onClick">',
+      { onClick() { log++; } },
+      [AppTask.beforeCreate(IListenerBehaviorOptions, o => { o.expAsHandler = true; })]
+    ).promise;
+
+    getBy('button').click();
+    assert.strictEqual(log, 1);
+  });
+});

--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -76,7 +76,7 @@ describe('TranslationParametersBindingRenderer', function () {
   it('instantiated with instruction type', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationParametersBindingRenderer(container.get(IExpressionParser), container.get(IObserverLocator), container.get(IPlatform));
-    assert.equal(sut.instructionType, TranslationParametersInstructionType);
+    assert.equal(sut.target, TranslationParametersInstructionType);
   });
 
   it('#render instantiates TranslationBinding if there are none existing', function () {

--- a/packages/__tests__/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-renderer.spec.ts
@@ -124,7 +124,7 @@ describe('TranslationBindingRenderer', function () {
   it('instantiated with instruction type', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationBindingRenderer(container.get(IExpressionParser), {} as unknown as IObserverLocator, container.get(IPlatform));
-    assert.equal(sut.instructionType, TranslationInstructionType);
+    assert.equal(sut.target, TranslationInstructionType);
   });
 
   it('#render instantiates TranslationBinding - simple string literal', function () {
@@ -264,7 +264,7 @@ describe('TranslationBindBindingRenderer', function () {
   it('instantiated with instruction type', function () {
     const container = createFixture();
     const sut: IRenderer = new TranslationBindBindingRenderer(container.get(IExpressionParser), {} as unknown as IObserverLocator, container.get(IPlatform));
-    assert.equal(sut.instructionType, TranslationBindInstructionType);
+    assert.equal(sut.target, TranslationBindInstructionType);
   });
 
   it('#render instantiates TranslationBinding - simple string literal', function () {

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -36,6 +36,8 @@ module.exports =
   console.log(`parallelism blob (${circleCiFiles.length}):\n\t`, circleCiFiles.join('\n\t'));
   console.log('test patterns:', testFilePatterns);
 
+  const customPattern = Symbol();
+
   // Karma config reference: https://karma-runner.github.io/5.2/config/files.html
   // --------------------------------------------------------------------------------
   // Summary of why the files are configured the way they are:
@@ -55,42 +57,42 @@ module.exports =
   //
   const files = [
     // { type: 'script', watched: true,  included: true,  nocache: false, pattern: `packages/__tests__/importmap.js` },
-    { type: 'script', watched: false,           included: true,  nocache: false, pattern: path.join(smsPath, 'browser-source-map-support.js') },
-    { type: 'module', watched: !hasSingleRun,   included: true,  nocache: false, pattern: `${baseUrl}/setup-browser.js` }, // 1.1
-    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/setup-shared.js` }, // 1.2
-    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/util.js` }, // 1.3
-    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false, pattern: `${baseUrl}/Spy.js` }, // 1.4
+    { type: 'script', watched: false,           included: true,  nocache: false,  pattern: path.join(smsPath, 'browser-source-map-support.js') },
+    { type: 'module', watched: !hasSingleRun,   included: true,  nocache: false,  pattern: `${baseUrl}/setup-browser.js` }, // 1.1
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false,  pattern: `${baseUrl}/setup-shared.js` }, // 1.2
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false,  pattern: `${baseUrl}/util.js` }, // 1.3
+    { type: 'module', watched: !hasSingleRun,   included: false, nocache: false,  pattern: `${baseUrl}/Spy.js` }, // 1.4
     ...(circleCiParallelismGlob
       ? circleCiFiles
         .map(file =>
-          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: file })) // 2.1
+          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: file,     [customPattern]: true })) // 2.1
       : testFilePatterns.map(pattern =>
-          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: pattern }), // 2.1
+          ({ type: 'module', watched: !hasSingleRun,  included: true,  nocache: false, pattern: pattern,  [customPattern]: true }), // 2.1
         )
     ), // 2.1 (new)
     ...testDirs.flatMap(name => [
       // // { type: 'module', watched: false, included: false, nocache: true,  pattern: `${baseUrl}/${name}/**/*.spec.js` }, // 2.1 (old)
-      { type: 'module', watched: !hasSingleRun, included: false, nocache: true,   pattern: `${baseUrl}/${name}/**/*.js.map` }, // 2.2
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: false,  pattern: `${baseUrl}/${name}/**/*.js.map` }, // 2.2
       { type: 'module', watched: !hasSingleRun, included: false, nocache: false,  pattern: `${baseUrl}/${name}/**/!(*.$au)*.js` }, // 2.3
-      { type: 'module', watched: false,         included: false, nocache: true,   pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
+      { type: 'module', watched: false,         included: false, nocache: false,  pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
     ]),
     ...packageNames.flatMap(name => [
-      { type: 'module', watched: !hasSingleRun, included: false, nocache: false, pattern: `packages/${name}/dist/esm/index.mjs` }, // 3.1
-      { type: 'module', watched: false,         included: false, nocache: true,  pattern: `packages/${name}/dist/esm/index.mjs.map` }, // 3.2
-      { type: 'module', watched: false,         included: false, nocache: true,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: false,  pattern: `packages/${name}/dist/esm/index.mjs` }, // 3.1
+      { type: 'module', watched: false,         included: false, nocache: false,  pattern: `packages/${name}/dist/esm/index.mjs.map` }, // 3.2
+      { type: 'module', watched: false,         included: false, nocache: false,  pattern: `packages/${name}/src/**/*.ts` }, // 3.3
     ]),
     // for i18n tests 
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/i18next/dist/esm/i18next.js` }, // 3.1
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/@babel/runtime/helpers/**/*.js` }, // 3.1
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js` }, // 3.1
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.js.map` }, // 3.1
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/rxjs/_esm5/**/*.d.ts` }, // 3.1
-    { type: 'module', watched: false,           included: false, nocache: false, pattern: `node_modules/tslib/tslib.es6.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/i18next/dist/esm/i18next.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/@babel/runtime/helpers/**/*.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/rxjs/_esm5/**/*.js` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/rxjs/_esm5/**/*.js.map` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/rxjs/_esm5/**/*.d.ts` }, // 3.1
+    { type: 'module', watched: false,           included: false, nocache: false,  pattern: `node_modules/tslib/tslib.es6.js` }, // 3.1
   ];
 
   const preprocessors = files.reduce((p, file) => {
     // Only process .js/.mjs files (not .js.map or .ts files)
-    if (/\.m?js$/.test(file.pattern)) {
+    if (/\.m?js$/.test(file.pattern) || file[customPattern]) {
       // Only instrument core framework files (not the specs themselves, nor any test utils (for now))
       if (/__tests__|testing|node_modules/.test(file.pattern) || !config.coverage) {
         p[file.pattern] = ['aurelia'];

--- a/packages/__tests__/setup-shared.ts
+++ b/packages/__tests__/setup-shared.ts
@@ -1,6 +1,7 @@
+import { IDisposable } from '@aurelia/kernel';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import { ConnectableSwitcher, FlushQueue } from '@aurelia/runtime';
-import { setPlatform, assert, ensureTaskQueuesEmpty } from '@aurelia/testing';
+import { setPlatform, assert, ensureTaskQueuesEmpty, onFixtureCreated, IFixture } from '@aurelia/testing';
 
 interface ExtendedSuite extends Mocha.Suite {
   $duration?: number;
@@ -23,6 +24,8 @@ export function $setup(platform: BrowserPlatform): void {
   let currentRootSuite: ExtendedSuite = (void 0)!;
   let currentSuite: ExtendedSuite = (void 0)!;
   let start: number;
+  let fixtures: IFixture<unknown>[] = [];
+  let fixtureHookHandler: IDisposable | undefined = void 0;
 
   // eslint-disable-next-line
   beforeEach(function() {
@@ -56,10 +59,24 @@ export function $setup(platform: BrowserPlatform): void {
       console.log(`[${ts}] > ${String(nextRootSuite.total()).padStart(5, ' ')} tests in "${nextRootSuite.fullTitle()}"`);
       currentRootSuite = nextRootSuite;
     }
+
+    fixtureHookHandler = onFixtureCreated(fixture => {
+      fixtures.push(fixture);
+    });
   });
 
   // eslint-disable-next-line
   afterEach(function() {
+    fixtureHookHandler?.dispose();
+    fixtureHookHandler = void 0;
+
+    fixtures.forEach(fixture => {
+      if (!fixture.torn) {
+        fixture.tearDown();
+      }
+    });
+    fixtures = [];
+
     const elapsed = platform.performanceNow() - start;
     let suite = currentSuite;
     do {

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -82,6 +82,7 @@ export class TranslationParametersBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: typeof TranslationParametersInstructionType;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -30,6 +30,7 @@ export class TranslationAttributePattern {
   [key: string]: ((rawName: string, rawValue: string, parts: string[]) => AttrSyntax);
 
   public static registerAlias(alias: string) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     this.prototype[alias] = function (rawName: string, rawValue: string, parts: string[]): AttrSyntax {
       return new AttrSyntax(rawName, rawValue, '', alias);
     };
@@ -78,6 +79,7 @@ export class TranslationBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: typeof TranslationInstructionType;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -157,6 +159,7 @@ export class TranslationBindBindingCommand implements BindingCommandInstance {
 
 @renderer(TranslationBindInstructionType)
 export class TranslationBindBindingRenderer implements IRenderer {
+  public target!: typeof TranslationBindInstructionType;
   public constructor(
     @IExpressionParser private readonly parser: IExpressionParser,
     @IObserverLocator private readonly oL: IObserverLocator,

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -269,7 +269,7 @@ export const DI = {
 
     if (configure != null) {
       Interface.register = function (container: IContainer, key?: Key): IResolver<K> {
-          return configure(new ResolverBuilder(container, key ?? Interface));
+        return configure(new ResolverBuilder(container, key ?? Interface));
       };
     }
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -141,6 +141,7 @@ export {
   RefBindingInstruction,
   SetPropertyInstruction,
   AttributeBindingInstruction,
+  IListenerBehaviorOptions,
   ListenerBindingInstruction,
   PropertyBindingInstruction,
   SetAttributeInstruction,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1,4 +1,3 @@
-import { Metadata } from '@aurelia/metadata';
 import { Registration, DI, emptyArray, InstanceProvider } from '@aurelia/kernel';
 import {
   BindingMode,
@@ -18,7 +17,7 @@ import { InterpolationBinding, InterpolationPartBinding, ContentBinding } from '
 import { LetBinding } from './binding/let-binding';
 import { PropertyBinding } from './binding/property-binding';
 import { RefBinding } from './binding/ref-binding';
-import { Listener } from './binding/listener';
+import { Listener, ListenerOptions } from './binding/listener';
 import { IEventDelegator } from './observation/event-delegator';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element';
 import { AuSlotsInfo, IAuSlotsInfo, IProjections } from './resources/slot-injectables';
@@ -28,9 +27,8 @@ import { Controller, ICustomElementController, ICustomElementViewModel, IControl
 import { IPlatform } from './platform';
 import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
-import { defineMetadata, getOwnMetadata } from './shared';
 import { AttrSyntax } from './resources/attribute-pattern';
-import { isString } from './utilities';
+import { defineProp, isString } from './utilities';
 
 import type { IServiceLocator, IContainer, Class, IRegistry, Constructable, IResolver } from '@aurelia/kernel';
 import type {
@@ -354,11 +352,11 @@ export interface ICompliationInstruction {
 }
 
 export interface IInstructionTypeClassifier<TType extends string = string> {
-  instructionType: TType;
+  target: TType;
 }
 export interface IRenderer<
   TType extends InstructionTypeName = InstructionTypeName
-> extends Partial<IInstructionTypeClassifier<TType>> {
+> extends IInstructionTypeClassifier<TType> {
   render(
     /**
      * The controller that is current invoking this renderer
@@ -378,28 +376,14 @@ type InstructionRendererDecorator<TType extends string> = <TProto, TClass>(targe
 
 export function renderer<TType extends string>(instructionType: TType): InstructionRendererDecorator<TType> {
   return function decorator<TProto, TClass>(target: DecoratableInstructionRenderer<TType, TProto, TClass>): DecoratedInstructionRenderer<TType, TProto, TClass> {
-    // wrap the constructor to set the instructionType to the instance (for better performance than when set on the prototype)
-    const decoratedTarget = function (...args: unknown[]): TProto {
-      const instance = new target(...args);
-      instance.instructionType = instructionType;
-      return instance;
-    } as unknown as DecoratedInstructionRenderer<TType, TProto, TClass>;
-    // make sure we register the decorated constructor with DI
-    decoratedTarget.register = function register(container: IContainer): void {
-      Registration.singleton(IRenderer, decoratedTarget).register(container);
+    target.register = function register(container: IContainer): void {
+      Registration.singleton(IRenderer, this).register(container);
     };
-    // copy over any metadata such as annotations (set by preceding decorators) as well as static properties set by the user
-    // also copy the name, to be less confusing to users (so they can still use constructor.name for whatever reason)
-    // the length (number of ctor arguments) is copied for the same reason
-    const metadataKeys = Metadata.getOwnKeys(target);
-    for (const key of metadataKeys) {
-      defineMetadata(key, getOwnMetadata(key, target), decoratedTarget);
-    }
-    const ownProperties = Object.getOwnPropertyDescriptors(target);
-    Object.keys(ownProperties).filter(prop => prop !== 'prototype').forEach(prop => {
-      Reflect.defineProperty(decoratedTarget, prop, ownProperties[prop]);
+    defineProp(target.prototype, 'target', {
+      configurable: true,
+      get: function () { return instructionType; }
     });
-    return decoratedTarget;
+    return target as DecoratedInstructionRenderer<TType, TProto, TClass>;
   };
 }
 
@@ -454,6 +438,8 @@ function getRefTarget(refHost: INode, refTargetName: string): object {
 @renderer(InstructionType.setProperty)
 /** @internal */
 export class SetPropertyRenderer implements IRenderer {
+  public target!: InstructionType.setProperty;
+
   public render(
     renderingCtrl: IHydratableController,
     target: IController,
@@ -474,6 +460,8 @@ export class CustomElementRenderer implements IRenderer {
   /** @internal */ protected static get inject(): unknown[] { return [IRendering, IPlatform]; }
   /** @internal */ private readonly _rendering: IRendering;
   /** @internal */ private readonly _platform: IPlatform;
+
+  public target!: InstructionType.hydrateElement;
 
   public constructor(rendering: IRendering, platform: IPlatform) {
     this._rendering = rendering;
@@ -557,6 +545,8 @@ export class CustomAttributeRenderer implements IRenderer {
   /** @internal */ private readonly _rendering: IRendering;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.hydrateAttribute;
+
   public constructor(rendering: IRendering, platform: IPlatform) {
     this._rendering = rendering;
     this._platform = platform;
@@ -634,6 +624,7 @@ export class TemplateControllerRenderer implements IRenderer {
   /** @internal */ private readonly _rendering: IRendering;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.hydrateTemplateController;
   public constructor(rendering: IRendering, platform: IPlatform) {
     this._rendering = rendering;
     this._platform = platform;
@@ -712,6 +703,7 @@ export class LetElementRenderer implements IRenderer {
   /** @internal */ private readonly _exprParser: IExpressionParser;
   /** @internal */ private readonly _observerLocator: IObserverLocator;
 
+  public target!: InstructionType.hydrateLetElement;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -755,6 +747,7 @@ export class CallBindingRenderer implements IRenderer {
   /** @internal */ private readonly _exprParser: IExpressionParser;
   /** @internal */ private readonly _observerLocator: IObserverLocator;
 
+  public target!: InstructionType.callBinding;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -783,6 +776,7 @@ export class RefBindingRenderer implements IRenderer {
   /** @internal */ protected static inject = [IExpressionParser];
   /** @internal */ private readonly _exprParser: IExpressionParser;
 
+  public target!: InstructionType.refBinding;
   public constructor(exprParser: IExpressionParser) {
     this._exprParser = exprParser;
   }
@@ -809,6 +803,7 @@ export class InterpolationBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.interpolation;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -861,6 +856,7 @@ export class PropertyBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.propertyBinding;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -893,6 +889,7 @@ export class IteratorBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.iteratorBinding;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -947,6 +944,7 @@ export class TextBindingRenderer implements IRenderer {
   /** @internal */ private readonly _observerLocator: IObserverLocator;
   /** @internal */ private readonly _platform: IPlatform;
 
+  public target!: InstructionType.textBinding;
   public constructor(
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
@@ -1010,22 +1008,38 @@ export class TextBindingRenderer implements IRenderer {
   }
 }
 
+export interface IListenerBehaviorOptions {
+  /**
+   * `true` if the expression specified in the template is meant to be treated as a handler
+   */
+  expAsHandler: boolean;
+}
+export const IListenerBehaviorOptions = DI.createInterface<IListenerBehaviorOptions>('IListenerBehaviorOptions', x => x.singleton(ListenerBehaviorOptions));
+
+class ListenerBehaviorOptions implements IListenerBehaviorOptions {
+  public expAsHandler = false;
+}
+
 @renderer(InstructionType.listenerBinding)
 /** @internal */
 export class ListenerBindingRenderer implements IRenderer {
-  /** @internal */ protected static inject = [IExpressionParser, IEventDelegator, IPlatform];
+  /** @internal */ protected static inject = [IExpressionParser, IEventDelegator, IPlatform, IListenerBehaviorOptions];
   /** @internal */ private readonly _exprParser: IExpressionParser;
   /** @internal */ private readonly _eventDelegator: IEventDelegator;
   /** @internal */ private readonly _platform: IPlatform;
+  /** @internal */ private readonly _listenerBehaviorOptions: IListenerBehaviorOptions;
 
+  public target!: InstructionType.listenerBinding;
   public constructor(
     parser: IExpressionParser,
     eventDelegator: IEventDelegator,
     p: IPlatform,
+    listenerBehaviorOptions: IListenerBehaviorOptions,
   ) {
     this._exprParser = parser;
     this._eventDelegator = eventDelegator;
     this._platform = p;
+    this._listenerBehaviorOptions = listenerBehaviorOptions;
   }
 
   public render(
@@ -1034,7 +1048,15 @@ export class ListenerBindingRenderer implements IRenderer {
     instruction: ListenerBindingInstruction,
   ): void {
     const expr = ensureExpression(this._exprParser, instruction.from, ExpressionType.IsFunction);
-    const binding = new Listener(this._platform, instruction.to, instruction.strategy, expr, target, instruction.preventDefault, this._eventDelegator, renderingCtrl.container);
+    const binding = new Listener(
+      this._platform,
+      instruction.to,
+      expr,
+      target,
+      this._eventDelegator,
+      renderingCtrl.container,
+      new ListenerOptions(instruction.preventDefault, instruction.strategy, this._listenerBehaviorOptions.expAsHandler),
+    );
     renderingCtrl.addBinding(expr.$kind === ExpressionKind.BindingBehavior
       ? applyBindingBehavior(binding, expr, renderingCtrl.container)
       : binding
@@ -1045,6 +1067,8 @@ export class ListenerBindingRenderer implements IRenderer {
 @renderer(InstructionType.setAttribute)
 /** @internal */
 export class SetAttributeRenderer implements IRenderer {
+
+  public target!: InstructionType.setAttribute;
   public render(
     _: IHydratableController,
     target: HTMLElement,
@@ -1056,6 +1080,7 @@ export class SetAttributeRenderer implements IRenderer {
 
 @renderer(InstructionType.setClassAttribute)
 export class SetClassAttributeRenderer implements IRenderer {
+  public target!: InstructionType.setClassAttribute;
   public render(
     _: IHydratableController,
     target: HTMLElement,
@@ -1067,6 +1092,7 @@ export class SetClassAttributeRenderer implements IRenderer {
 
 @renderer(InstructionType.setStyleAttribute)
 export class SetStyleAttributeRenderer implements IRenderer {
+  public target!: InstructionType.setStyleAttribute;
   public render(
     _: IHydratableController,
     target: HTMLElement,
@@ -1081,6 +1107,7 @@ export class SetStyleAttributeRenderer implements IRenderer {
 export class StylePropertyBindingRenderer implements IRenderer {
   /** @internal */ protected static inject = [IExpressionParser, IObserverLocator, IPlatform];
 
+  public target!: InstructionType.stylePropertyBinding;
   public constructor(
     /** @internal */ private readonly _exprParser: IExpressionParser,
     /** @internal */ private readonly _observerLocator: IObserverLocator,
@@ -1106,6 +1133,7 @@ export class StylePropertyBindingRenderer implements IRenderer {
 export class AttributeBindingRenderer implements IRenderer {
   /** @internal */ protected static inject = [IExpressionParser, IObserverLocator];
 
+  public target!: InstructionType.attributeBinding;
   public constructor(
     /** @internal */ private readonly _exprParser: IExpressionParser,
     /** @internal */ private readonly _observerLocator: IObserverLocator,
@@ -1136,6 +1164,8 @@ export class AttributeBindingRenderer implements IRenderer {
 @renderer(InstructionType.spreadBinding)
 export class SpreadRenderer implements IRenderer {
   /** @internal */ protected static get inject() { return [ITemplateCompiler, IRendering]; }
+
+  public target!: InstructionType.spreadBinding;
   public constructor(
     /** @internal */ private readonly _compiler: ITemplateCompiler,
     /** @internal */ private readonly _rendering: IRendering,

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -29,7 +29,7 @@ export class Rendering {
   public get renderers(): Record<string, IRenderer> {
     return this.rs == null
       ? (this.rs = this._ctn.getAll(IRenderer, false).reduce((all, r) => {
-          all[r.instructionType!] = r;
+          all[r.target] = r;
           return all;
         }, createLookup<IRenderer>()))
       : this.rs;

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -1,4 +1,4 @@
-import { DI, Resolved } from '@aurelia/kernel';
+import { DI, type Resolved } from '@aurelia/kernel';
 
 import type {
   Constructable,
@@ -23,6 +23,7 @@ import type {
 //       ? requestor.get(key)
 //       : requestor.root.get(key);
 //   };
+//   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 //   return Resolver as IResolver<T> & ((...args: unknown[]) => any);
 // };
 
@@ -44,5 +45,6 @@ export const allResources = function <T extends Key>(key: T) {
       ? requestor.getAll(key, false).concat(requestor.root.getAll(key, false))
       : requestor.root.getAll(key, false);
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return Resolver as IResolver<Resolved<T>[]> & ((...args: unknown[]) => any);
 };

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -28,3 +28,4 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
 /** @internal */ export const isFunction = <T, K extends Function>(v: unknown): v is K => typeof v === 'function';
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
+/** @internal */ export const defineProp = Object.defineProperty;

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -20,7 +20,7 @@ export {
 } from './h';
 export {
   createFixture,
-  IFixture,
+  type IFixture,
   onFixtureCreated,
 } from './startup';
 export {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -19,7 +19,9 @@ export {
   hJsx,
 } from './h';
 export {
-  createFixture
+  createFixture,
+  IFixture,
+  onFixtureCreated,
 } from './startup';
 export {
   TestContext,

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -1,19 +1,33 @@
-import { Constructable } from '@aurelia/kernel';
-import { CustomElement, Aurelia } from '@aurelia/runtime-html';
-import { TestContext } from './test-context';
+/* eslint-disable no-console */
+import { Constructable, EventAggregator, IContainer } from '@aurelia/kernel';
+import { IObserverLocator } from '@aurelia/runtime';
+import { CustomElement, Aurelia, IPlatform, ICustomElementViewModel } from '@aurelia/runtime-html';
+import { TestContext } from './test-context.js';
+
+const fixtureHooks = new EventAggregator();
+export const onFixtureCreated = <T>(callback: (fixture: IFixture<T>) => unknown) => {
+  return fixtureHooks.subscribe('fixture:created', (fixture: IFixture<T>) => {
+    try {
+      callback(fixture);
+    } catch(ex) {
+      console.log('(!) Error in fixture:created callback');
+      console.log(ex);
+    }
+  });
+};
 
 export function createFixture<T>(template: string | Node,
   $class?: Constructable<T>,
-  registrations: any[] = [],
+  registrations: unknown[] = [],
   autoStart: boolean = true,
   ctx: TestContext = TestContext.create(),
-) {
+): IFixture<T> {
   const { container, platform, observerLocator } = ctx;
   container.register(...registrations);
   const root = ctx.doc.body.appendChild(ctx.doc.createElement('div'));
   const host = root.appendChild(ctx.createElement('app'));
   const au = new Aurelia(container);
-  const App = CustomElement.define({ name: 'app', template }, $class || class { } as Constructable<T>);
+  const App = CustomElement.define({ name: 'app', template }, $class ?? class { } as Constructable<T>);
   if (container.has(App, true)) {
     throw new Error(
       'Container of the context cotains instance of the application root component. ' +
@@ -28,24 +42,64 @@ export function createFixture<T>(template: string | Node,
     startPromise = au.start();
   }
 
-  return {
-    startPromise,
-    ctx,
-    host: ctx.doc.firstElementChild,
-    container,
-    platform,
-    testHost: root,
-    appHost: host,
-    au,
-    component,
-    observerLocator,
-    start: async () => {
+  let tornCount = 0;
+
+  const fixture = new class Results {
+    public startPromise = startPromise;
+    public ctx = ctx;
+    public host = ctx.doc.firstElementChild as HTMLElement;
+    public container = container;
+    public platform = platform;
+    public testHost = root;
+    public appHost = host;
+    public au = au;
+    public component = component;
+    public observerLocator = observerLocator;
+
+    public async start() {
       await au.app({ host: host, component }).start();
-    },
-    tearDown: async () => {
+    }
+
+    public async tearDown() {
+      if (++tornCount === 2) {
+        console.log('(!) Fixture has already been torn down');
+        return;
+      }
       await au.stop();
       root.remove();
       au.dispose();
     }
-  };
+
+    public get torn() {
+      return tornCount > 0;
+    }
+
+    /**
+     * @returns a promise that resolves after the associated app has started
+     */
+    public get promise(): Promise<Results> {
+      return Promise.resolve(startPromise).then(() => this as Results);
+    }
+  }();
+
+  fixtureHooks.publish('fixture:created', fixture);
+
+  return fixture;
+}
+
+export interface IFixture<T> {
+  readonly startPromise: void | Promise<void>;
+  readonly ctx: TestContext;
+  readonly host: HTMLElement;
+  readonly container: IContainer;
+  readonly platform: IPlatform;
+  readonly testHost: HTMLElement;
+  readonly appHost: HTMLElement;
+  readonly au: Aurelia;
+  readonly component: ICustomElementViewModel & T;
+  readonly observerLocator: IObserverLocator;
+  readonly torn: boolean;
+  start(): Promise<void>;
+  tearDown(): Promise<void>;
+  readonly promise: Promise<this>;
 }


### PR DESCRIPTION
## Basic

There' times when the following way is preferred:
```html
<button click.trigger="onClick">
```
over
```html
<button click.trigger="onClick($event)">
```

This PR adds a way to let event expression behaves like a event handler.

To enable this behavior, add the an registration similar like the follow example:
```ts
import { AppTask, IListenerBehaviorOptions } from '@aurelia/runtime-html';
...

.register(
  AppTask.beforeCreate(IListenerBehaviorOptions, o => { o.expAsHandler = true; })
)
```

This is globally configured per application. In the future, we may want to consider an option to allow component to configure this individually.

## How it works

If `exprAsHandler` is set to true:
- In a listener binding, if the result of expression evaluation is a function, then assume that this is the handler intended to be called for the event, invoke the result function with the event as the only parameter. Pseudo code:
```ts
...
const result = listenerBinding.evaluate(expression, scope)
if (typeof result === 'function' && exprAsHandler) {
  result(event);
}
...
```

## With `value converter` / `binding behavior`
The existing behavior of value converter and binding behavior on expression evaluation will be kept as is.

Closes #1311 