### PR TITLE
refactor(testing): enable builder pattern for fixture creation

### DIFF
--- a/packages/__tests__/3-runtime-html/dialog/dialog-service.spec.ts
+++ b/packages/__tests__/3-runtime-html/dialog/dialog-service.spec.ts
@@ -90,9 +90,11 @@ describe('3-runtime-html/dialog/dialog-service.spec.ts', function () {
       });
 
       let err: Error;
-      await tearDown().catch(ex => {
+      try {
+        await tearDown();
+      } catch(ex) {
         err = ex;
-      });
+      }
       assert.notStrictEqual(err, undefined);
       assert.includes(err.message, 'AUR0901:1');
       // assert.includes(err.message, 'There are still 1 open dialog(s).');

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -118,14 +118,20 @@ export function createFixture<
       await au.app({ host: host, component }).start();
     }
 
-    public async tearDown() {
+    public tearDown() {
       if (++tornCount === 2) {
         console.log('(!) Fixture has already been torn down');
         return;
       }
-      await au.stop();
-      root.remove();
-      au.dispose();
+      const dispose = () => {
+        root.remove();
+        au.dispose();
+      };
+      const ret = au.stop();
+      if (ret instanceof Promise)
+        return ret.then(dispose);
+      else
+        return dispose();
     }
 
     public get torn() {
@@ -164,7 +170,7 @@ export interface IFixture<T> {
   readonly observerLocator: IObserverLocator;
   readonly torn: boolean;
   start(): Promise<void>;
-  tearDown(): Promise<void>;
+  tearDown(): void | Promise<void>;
   readonly promise: Promise<IFixture<T>>;
   getBy(selector: string): HTMLElement;
   getAllBy(selector: string): HTMLElement[];


### PR DESCRIPTION
To prepare to go beta, we need to provide a testing toolset that is easy enough to use to document & teach, also helps with bug repro reports. This PR enhances the `createFixture` method, so that it runs faster, and provides a builder pattern in case clarity of what being built is prefered.

Instead of having to write:
```ts
const {} = await createFixture('<div>', class AppRoot {}, [someConfig1, someConfig2]).promise
```
can also do
```ts
const {} = await createFixture
  .component(class AppRoot {})
  .deps(someConfig1, someConfig2)
  .html`<div>`)
  .build()
  .promise
```

When the parameters are compact, the former way is prefer, but can be refactored into the later if the parameters grow out of hand:
```ts
const { } = await createFixture(
  `Some big chunk of markup
  ...
  <my-el>`,
  class App {
    prop1
    prop2
    prop3
  },
  [
    CustomElement.define({
      name: 'my-el',
      template: '<input >',
      dependencies: [TemplateCompilerHooks.define(class {
        public compiling(template: HTMLTemplateElement) {
          template.content.querySelector('input').setAttribute('value.bind', 'value');
        }
      })]
    }, class MyEll {
      public value = 'hello';
    })
  ]
).promise;
```
vs
```ts
const {} = await createFixture
  .component(class App {
    prop1
    prop2
    prop3
  })
  .html`Some big chunk of markup
  ...
  <my-el>`
  .deps(
    CustomElement.define({
      name: 'my-el',
      template: '<input >',
      dependencies: [TemplateCompilerHooks.define(class {
        public compiling(template: HTMLTemplateElement) {
          template.content.querySelector('input').setAttribute('value.bind', 'value');
        }
      })]
    }, class MyEll {
      public value = 'hello';
    })
  )
```