### PR TITLE
feat(containerless): ability to override `containerless` config from view

### DIFF
--- a/packages/__tests__/3-runtime-html/au-compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-compose.spec.ts
@@ -755,7 +755,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       assert.strictEqual(appHost.innerHTML, '<!--au-start--><child><div>Hello world from Child</div></child><!--au-end-->');
 
       await tearDown();
-      assert.strictEqual(appHost.innerHTML, '<!--au-start--><!--au-end-->');
+      assert.strictEqual(appHost.innerHTML, '');
     });
 
     it('discards stale composition', async function () {

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -31,7 +31,7 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
           }
         }),
       ],
-    ).promise;
+    ).started;
 
     const [, nestedInputEl] = Array.from(appHost.querySelectorAll('input'));
     nestedInputEl.value = 'aa bb';
@@ -42,35 +42,57 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
   });
 
   it('renders containerless per element via "containerless" attribute', async function () {
-    const { appHost } = await createFixture(`<my-el containerless message="hello world">`, class App {}, [CustomElement.define({
-      name: 'my-el',
-      template: '${message}',
-      bindables: ['message']
-    })]).promise;
+    const { appHost } = await createFixture(
+      `<my-el containerless message="hello world">`,
+      class App {},
+      [CustomElement.define({
+        name: 'my-el',
+        template: '${message}',
+        bindables: ['message']
+      })]
+    ).started;
 
     assert.visibleTextEqual(appHost, 'hello world');
   });
 
   it('renders element with @customElement({ containerness: true })', async function () {
-    const { appHost } = await createFixture(`<my-el message="hello world">`, class App {}, [CustomElement.define({
+    const { assertText } = await createFixture(`<my-el message="hello world">`, class App {}, [CustomElement.define({
       name: 'my-el',
       template: '${message}',
       bindables: ['message'],
       containerless: true
-    })]).promise;
+    })]).started;
 
-    assert.visibleTextEqual(appHost, 'hello world');
+    assertText('hello world');
   });
 
   it('renders elements with both "containerless" attribute and @customElement({ containerless: true })', async function () {
-    const { appHost } = await createFixture(`<my-el containerless message="hello world">`, class App {}, [CustomElement.define({
-      name: 'my-el',
-      template: '${message}',
-      bindables: ['message'],
-      containerless: true,
-    })]).promise;
+    const { assertText } = await createFixture(
+      `<my-el containerless message="hello world">`,
+      class App {},
+      [CustomElement.define({
+        name: 'my-el',
+        template: '${message}',
+        bindables: ['message'],
+        containerless: true,
+      })]
+    ).started;
 
-    assert.visibleTextEqual(appHost, 'hello world');
+    assertText('hello world');
+  });
+
+  it('renders elements with template controller and containerless attribute on it', async function () {
+    const { assertText } = await createFixture(
+      `<my-el if.bind="true" containerless message="hello world">`,
+      class App {},
+      [CustomElement.define({
+        name: 'my-el',
+        template: '${message}',
+        bindables: ['message']
+      })]
+    ).started;
+
+    assertText('hello world');
   });
 });
 // import {

--- a/packages/__tests__/3-runtime-html/listener.spec.ts
+++ b/packages/__tests__/3-runtime-html/listener.spec.ts
@@ -8,7 +8,7 @@ describe('3-runtime-html/listener.spec.ts', function () {
     const { getBy } = await createFixture(
       '<button click.trigger="onClick()">',
       { onClick() { log++; } },
-    ).promise;
+    ).started;
 
     getBy('button').click();
     assert.strictEqual(log, 1);
@@ -26,7 +26,7 @@ describe('3-runtime-html/listener.spec.ts', function () {
           return a;
         }
       })]
-    ).promise;
+    ).started;
 
     trigger.click('button');
     assert.strictEqual(log, 1);
@@ -39,7 +39,7 @@ describe('3-runtime-html/listener.spec.ts', function () {
       '<button click.trigger="onClick">',
       { onClick() { log++; } },
       [AppTask.beforeCreate(IListenerBehaviorOptions, o => { o.expAsHandler = true; })]
-    ).promise;
+    ).started;
 
     trigger.click('button');
     assert.strictEqual(log, 1);
@@ -60,7 +60,7 @@ describe('3-runtime-html/listener.spec.ts', function () {
           }
         })
       ]
-    ).promise;
+    ).started;
 
     trigger.click('button');
     assert.strictEqual(log, 1);

--- a/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@aurelia/testing';
 
 describe('3-runtime-html/template-compiler.harmony.spec.ts \n\tharmoninous combination', function () {
+
   interface IHarmoniousCompilationTestCase {
     title: string;
     template: string | HTMLElement;
@@ -400,6 +401,8 @@ describe('3-runtime-html/template-compiler.harmony.spec.ts \n\tharmoninous combi
     }
     const $it = only ? it.only : it;
     $it(`\n\t(${idx + 1}). ${title}\n\t`, async function () {
+      this.retries(1).timeout(100);
+
       let host: HTMLElement;
       let body: HTMLElement;
       const ctx = TestContext.create();

--- a/packages/__tests__/state/state.spec.ts
+++ b/packages/__tests__/state/state.spec.ts
@@ -7,7 +7,7 @@ describe('state/state.spec.ts', function () {
     const { getBy } = await createFixture
       .html`<input value.state="text">`
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     assert.strictEqual(getBy('input').value, '123');
   });
@@ -17,7 +17,7 @@ describe('state/state.spec.ts', function () {
     const { getBy, ctx } = await createFixture
       .html('<input value.state="text">')
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     assert.strictEqual(getBy('input').value, '123');
 
@@ -32,7 +32,7 @@ describe('state/state.spec.ts', function () {
     const { getBy } = await createFixture
       .html('<input value.state="$state.text">')
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     assert.strictEqual(getBy('input').value, '123');
   });
@@ -43,7 +43,7 @@ describe('state/state.spec.ts', function () {
       .component({ text: '456' })
       .html('<input value.state="$parent.text">')
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     assert.strictEqual(getBy('input').value, '456');
   });
@@ -53,7 +53,7 @@ describe('state/state.spec.ts', function () {
     const { trigger } = await createFixture
       .html('<input value.state="text" input.trigger="$state.text = `456`">')
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     trigger('input', 'input');
     assert.strictEqual(state.text, '123');
@@ -69,7 +69,7 @@ describe('state/state.spec.ts', function () {
           return { text: s.text + value };
         }})
       )
-      .build().promise;
+      .build().started;
 
     assert.strictEqual(getBy('input').value, '1');
 
@@ -82,7 +82,7 @@ describe('state/state.spec.ts', function () {
     const { getBy } = await createFixture
       .html`<input value.state="data()">`
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
     await resolveAfter(2);
     assert.strictEqual(getBy('input').value, 'value-1-2');
@@ -106,7 +106,7 @@ describe('state/state.spec.ts', function () {
     const { getBy, tearDown } = await createFixture
       .html`<input value.state="data()">`
       .deps(StandardStateConfiguration.init(state))
-      .build().promise;
+      .build().started;
 
       assert.strictEqual(getBy('input').value, 'value-1');
 
@@ -134,7 +134,7 @@ describe('state/state.spec.ts', function () {
             return { text: s.text + value };
           }})
         )
-        .build().promise;
+        .build().started;
 
       trigger('input', 'input');
       assert.strictEqual(getBy('input').value, '1');
@@ -155,7 +155,7 @@ describe('state/state.spec.ts', function () {
             return { text: s.text + value };
           }})
         )
-        .build().promise;
+        .build().started;
 
       trigger('input', 'input');
       assert.strictEqual(getBy('input').value, '11');

--- a/packages/runtime-html/design-improvement-notes.md
+++ b/packages/runtime-html/design-improvement-notes.md
@@ -1,0 +1,4 @@
+1. renderer & node sequence & containerless
+    - during compilation, compiler replace containerless CE with `<au-m>` to mark it as a target, so node sequence can replace it with comment
+        node-sequence needs to do this early because it needs to acquire its targets early
+    - it'd be worth considering if renderer is given un-modified, original host element when there's a containerless setup on a CE

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -189,12 +189,12 @@ export class AuCompose {
     //       current: proceed
     const { view, viewModel, model } = context.change;
     const { _container: container, host, $controller, _location: loc } = this;
-    const srcDef = this.getDef(viewModel);
+    const vmDef = this.getDef(viewModel);
     const childCtn: IContainer = container.createChild();
     const parentNode = loc == null ? host.parentNode : loc.parentNode;
 
-    if (srcDef !== null) {
-      if (srcDef.containerless) {
+    if (vmDef !== null) {
+      if (vmDef.containerless) {
         if (__DEV__)
           throw new Error('Containerless custom element is not supported by <au-compose/>');
         else
@@ -208,7 +208,7 @@ export class AuCompose {
         };
       } else {
         // todo: should the host be appended later, during the activation phase instead?
-        compositionHost = parentNode!.insertBefore(this._platform.document.createElement(srcDef.name), loc);
+        compositionHost = parentNode!.insertBefore(this._platform.document.createElement(vmDef.name), loc);
         removeCompositionHost = () => {
           compositionHost.remove();
         };
@@ -222,13 +222,13 @@ export class AuCompose {
     }
     const compose: () => ICompositionController = () => {
       // custom element based composition
-      if (srcDef !== null) {
+      if (vmDef !== null) {
         const controller = Controller.$el(
           childCtn,
           comp,
           compositionHost as HTMLElement,
           { projections: this._instruction.projections },
-          srcDef,
+          vmDef,
         );
 
         return new CompositionController(

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,7 +1,7 @@
 import { Constructable, IContainer, InstanceProvider, onResolve, transient } from '@aurelia/kernel';
 import { LifecycleFlags, Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
-import { convertToRenderLocation, INode, IRenderLocation, isRenderLocation } from '../../dom';
+import { INode, IRenderLocation, isRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
 import { HydrateElementInstruction, IInstruction } from '../../renderer';
 import { Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller';
@@ -31,7 +31,7 @@ export class AuCompose {
 
   /** @internal */
   protected static get inject() {
-    return [IContainer, IController, INode, IPlatform, IInstruction, transient(CompositionContextFactory)];
+    return [IContainer, IController, INode, IRenderLocation, IPlatform, IInstruction, transient(CompositionContextFactory)];
   }
 
   /* determine what template used to compose the component */
@@ -75,7 +75,6 @@ export class AuCompose {
   }
 
   /** @internal */ private readonly _rendering: IRendering;
-  /** @internal */ private readonly _location: IRenderLocation | undefined;
   /** @internal */ private readonly _instruction: HydrateElementInstruction;
   /** @internal */ private readonly _contextFactory: CompositionContextFactory;
 
@@ -83,13 +82,13 @@ export class AuCompose {
     /** @internal */ private readonly _container: IContainer,
     /** @internal */ private readonly parent: ISyntheticView | ICustomElementController,
     /** @internal */ private readonly host: HTMLElement,
+    /** @internal */ private readonly _location: IRenderLocation,
     /** @internal */ private readonly _platform: IPlatform,
     // todo: use this to retrieve au-slot instruction
     //        for later enhancement related to <au-slot/> + compose
     instruction: HydrateElementInstruction,
     contextFactory: CompositionContextFactory,
   ) {
-    this._location = instruction.containerless ? convertToRenderLocation(this.host) : void 0;
     this._rendering = _container.get(IRendering);
     this._instruction = instruction;
     this._contextFactory = contextFactory;

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
+/* eslint-disable @typescript-eslint/prefer-optional-chain */
+/* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { DI, emptyArray, Registration, toArray, ILogger, camelCase, ResourceDefinition, ResourceType, noop, Key } from '@aurelia/kernel';
 import { BindingMode, ExpressionType, Char, IExpressionParser, PrimitiveLiteralExpression } from '@aurelia/runtime';
 import { IAttrMapper } from './attribute-mapper';
@@ -1098,7 +1101,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         elementInstruction!.projections = projections;
       }
 
-      if (elDef !== null && elDef.containerless) {
+      if (hasContainerless || elDef !== null && elDef.containerless) {
         this._replaceByMarker(el, context);
       }
 

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -1286,7 +1286,7 @@ export class TemplateCompiler implements ITemplateCompiler {
 
       // todo: shouldn't have to eagerly replace with a marker like this
       //       this should be the job of the renderer
-      if (elDef !== null && elDef.containerless) {
+      if (hasContainerless || elDef !== null && elDef.containerless) {
         this._replaceByMarker(el, context);
       }
 

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -76,12 +76,16 @@ export function createFixture<T, K = (T extends Constructable<infer U> ? U : T)>
     }
     return elements.length === 0 ? null : elements[0];
   };
-  const assertText = (selector: string, text: string): void => {
-    const el = queryBy(selector);
-    if (el === null) {
-      throw new Error(`No element found for selector "${selector}" to compare text content with "${text}"`);
+  const assertText = (selector: string, text?: string): void => {
+    if (arguments.length === 2) {
+      const el = queryBy(selector);
+      if (el === null) {
+        throw new Error(`No element found for selector "${selector}" to compare text content with "${text}"`);
+      }
+      assert.strictEqual(el.textContent, text);
+    } else {
+      assert.strictEqual(host.textContent, selector);
     }
-    assert.strictEqual(el.textContent, text);
   };
   const trigger = ((selector: string, event: string, init?: CustomEventInit): void => {
     const el = queryBy(selector);
@@ -139,7 +143,7 @@ export function createFixture<T, K = (T extends Constructable<infer U> ? U : T)>
     /**
      * @returns a promise that resolves after the associated app has started
      */
-    public get promise(): Promise<IFixture<K>> {
+    public get started(): Promise<IFixture<K>> {
       return Promise.resolve(startPromise).then(() => this as IFixture<K>);
     }
 
@@ -169,7 +173,7 @@ export interface IFixture<T> {
   readonly torn: boolean;
   start(): Promise<void>;
   tearDown(): void | Promise<void>;
-  readonly promise: Promise<IFixture<T>>;
+  readonly started: Promise<IFixture<T>>;
 
   /**
    * Returns the first element that is a descendant of node that matches selectors, and throw if there is more than one, or none found
@@ -189,6 +193,7 @@ export interface IFixture<T> {
   queryBy<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
   queryBy<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
   queryBy<E extends Element = Element>(selectors: string): E | null;
+  assertText(text: string): void;
   assertText(selector: string, text: string): void;
   trigger: ITrigger;
 }

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -53,7 +53,7 @@ const buildCmd = 'npm run build';
   'addons',
   'testing',
 ].forEach((pkgName) => {
-  if (isBuilt(pkgName) !== null) {
+  if (!isBuilt(pkgName)) {
     const start = Date.now();
     const pkgDisplay = c.green(pkgName);
     console.log(`${pkgDisplay} has not been built before, building...`);
@@ -89,8 +89,6 @@ concurrently([
 
 function isBuilt(name: string): boolean {
   return fs.existsSync(path.resolve(__dirname, `../packages/${name}/dist/esm/index.mjs`));
-    // ? null
-    // : { command: buildCmd, name, env: envVars, cwd: `packages/${name}` };
 }
 
  function getElapsed(now: number, then: number) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, `containerless` can only be configured from view model `@customElement` decorator. This is different with v1, where it can be configured via either view/view model. Make v2 behave similarly for now.

- rename `promise` -> `started` on `IFixture`