### PR TITLE
fix(plugin-conventions): upgrade deep-dep source-map to fix nodejs v18 issue

### DIFF
--- a/packages-tooling/plugin-conventions/package.json
+++ b/packages-tooling/plugin-conventions/package.json
@@ -48,7 +48,7 @@
     "@aurelia/platform": "2.0.0-alpha.31",
     "@aurelia/runtime": "2.0.0-alpha.31",
     "@aurelia/runtime-html": "2.0.0-alpha.31",
-    "modify-code": "^1.2.0",
+    "modify-code": "^2.0.0",
     "parse5": "^5.1.1",
     "typescript": "^4.6.3"
   },


### PR DESCRIPTION
https://github.com/mozilla/source-map/issues/454

Upgraded modify-code which upgraded source-map to 0.8.0-beta.0