### PR TITLE
feat(lifeycle-hooks): support hydrating/hydrated

### DIFF
--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -53,7 +53,8 @@ module.exports = {
     '@typescript-eslint/no-floating-promises': 'error',
     '@typescript-eslint/explicit-member-accessibility': 'off',
     '@typescript-eslint/require-array-sort-compare': 'off',
-    '@typescript-eslint/restrict-plus-operands': 'off'
+    '@typescript-eslint/restrict-plus-operands': 'off',
+    '@typescript-eslint/no-this-alias': 'off',
   },
   overrides: [{ // Specific overrides for JS files as some TS rules don't make sense there.
     files: ['3-runtime-html/generated/**'],

--- a/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
@@ -743,4 +743,17 @@ describe('custom-attributes', function () {
       });
     });
   });
+
+  describe('06.1 + with dependencies', function () {
+    it('registers dependencies', async function () {
+      let registerCallCount = 0;
+      @customAttribute({ name: 'foo5', dependencies: [
+        { register: () => { registerCallCount++; } }
+      ]})
+      class MyAttr {}
+
+      await createFixture.html`<div foo5>`.deps(MyAttr).build().started;
+      assert.strictEqual(registerCallCount, 1);
+    });
+  });
 });

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.created.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.created.spec.ts
@@ -1,15 +1,18 @@
 import {
+  customAttribute,
   CustomElement,
   IController,
+  ICustomAttributeController,
   lifecycleHooks,
 } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/lifecycle-hooks.created.spec.ts', function () {
+
   const hookSymbol = Symbol();
 
   @lifecycleHooks()
-  class Hooks<T> {
+  class CreatedLoggingHook<T> {
     created(vm: T, controller: IController) {
       vm[hookSymbol] = controller[hookSymbol] = hookSymbol;
       const tracker = controller.container.get(LifeycyleTracker);
@@ -18,44 +21,87 @@ describe('3-runtime-html/lifecycle-hooks.created.spec.ts', function () {
     }
   }
 
-  it('invokes global created hooks', async function () {
-    const { component, container } = await createFixture
-      .html`\${message}`
-      .deps(Hooks)
-      .build().started;
+  describe('custom elements', function () {
+    it('invokes global created hooks', async function () {
+      const { component, container } = await createFixture
+        .html`\${message}`
+        .deps(CreatedLoggingHook)
+        .build().started;
 
-    assert.strictEqual(component[hookSymbol], hookSymbol);
-    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(container.get(LifeycyleTracker).created, 1);
+      assert.strictEqual(component[hookSymbol], hookSymbol);
+      assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+      assert.strictEqual(container.get(LifeycyleTracker).created, 1);
+    });
+
+    it('invokes when registered both globally and locally', async function () {
+      const { component, container } = await createFixture
+        .component(CustomElement.define({ name: 'app', dependencies: [CreatedLoggingHook] }))
+        .html`\${message}`
+        .deps(CreatedLoggingHook)
+        .build().started;
+
+      assert.strictEqual(component[hookSymbol], hookSymbol);
+      assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+      assert.strictEqual(container.get(LifeycyleTracker).created, 2);
+      assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+    });
+
+    it('invokes before the view model lifecycle', async function () {
+      let createdCall = 0;
+      await createFixture
+        .component(class App {
+          created() {
+            assert.strictEqual(this[hookSymbol], hookSymbol);
+            createdCall++;
+          }
+        })
+        .html``
+        .deps(CreatedLoggingHook)
+        .build().started;
+
+      assert.strictEqual(createdCall, 1);
+    });
   });
 
-  it('invokes when registered both globally and locally', async function () {
-    const { component, container } = await createFixture
-      .component(CustomElement.define({ name: 'app', dependencies: [Hooks] }))
-      .html`\${message}`
-      .deps(Hooks)
-      .build().started;
+  describe('custom attributes', function () {
+    const caHooksSymbol = Symbol();
+    let current: Square | null = null;
 
-    assert.strictEqual(component[hookSymbol], hookSymbol);
-    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(container.get(LifeycyleTracker).created, 2);
-    assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
-  });
+    @customAttribute({
+      name: 'square',
+      dependencies: [CreatedLoggingHook]
+    })
+    class Square {
+      $controller: ICustomAttributeController;
+      created() {
+        assert.strictEqual(this[hookSymbol], hookSymbol);
+        this[caHooksSymbol] = true;
+        current = this;
+      }
+    }
 
-  it('invokes before the view model lifecycle', async function () {
-    let createdCall = 0;
-    await createFixture
-      .component(class App {
-        created() {
-          assert.strictEqual(this[hookSymbol], hookSymbol);
-          createdCall++;
-        }
-      })
-      .html``
-      .deps(Hooks)
-      .build().started;
+    const baseTemplate = `<div square>`;
 
-    assert.strictEqual(createdCall, 1);
+    it('invokes global created hooks', async function () {
+      await createFixture
+        .html`${baseTemplate}`
+        .deps(Square, CreatedLoggingHook)
+        .build().started;
+
+      assert.instanceOf(current, Square);
+      assert.strictEqual(current?.[caHooksSymbol], true);
+      assert.strictEqual(current?.[hookSymbol], hookSymbol);
+    });
+
+    it('invokes when registered both globally and locally', async function () {
+      const { component, container } = await createFixture
+        .html`${baseTemplate}`
+        .deps(Square, CreatedLoggingHook)
+        .build().started;
+
+      assert.strictEqual(container.get(LifeycyleTracker).created, 2);
+      assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [current.$controller, component.$controller]);
+    });
   });
 
   class LifeycyleTracker {

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrated.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrated.spec.ts
@@ -1,0 +1,91 @@
+import {
+  customAttribute,
+  CustomElement,
+  IController,
+  lifecycleHooks,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.hydrated.spec.ts', function () {
+
+  const hookSymbol = Symbol();
+
+  @lifecycleHooks()
+  class HydratedLoggingHook<T> {
+    hydrated(vm: T, controller: IController) {
+      vm[hookSymbol] = controller[hookSymbol] = hookSymbol;
+      const tracker = controller.container.get(LifeycyleTracker);
+      tracker.hydrated++;
+      tracker.controllers.push(controller);
+    }
+  }
+
+  it('invokes global created hooks', async function () {
+    const { component, container } = await createFixture
+      .html`\${message}`
+      .deps(HydratedLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrated, 1);
+  });
+
+  it('invokes when registered both globally and locally', async function () {
+    const { component, container } = await createFixture
+      .component(CustomElement.define({ name: 'app', dependencies: [HydratedLoggingHook] }))
+      .html`\${message}`
+      .deps(HydratedLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrated, 2);
+    assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+  });
+
+  it('invokes before the view model lifecycle', async function () {
+    let hydratedCallCount = 0;
+    await createFixture
+      .component(class App {
+        hydrated() {
+          assert.strictEqual(this[hookSymbol], hookSymbol);
+          hydratedCallCount++;
+        }
+      })
+      .html``
+      .deps(HydratedLoggingHook)
+      .build().started;
+
+    assert.strictEqual(hydratedCallCount, 1);
+  });
+
+  it('does not invoke hydrated hooks on Custom attribute', async function () {
+    let current: Square | null = null;
+    @customAttribute({
+      name: 'square',
+      dependencies: [HydratedLoggingHook]
+    })
+    class Square {
+      hydrated() {
+        throw new Error('No hydrated lifecycle on CA');
+      }
+      created() {
+        current = this;
+      }
+    }
+
+    const { container } = await createFixture
+      .html `<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrated, 0);
+  });
+
+  class LifeycyleTracker {
+    hydrated: number = 0;
+    controllers: IController[] = [];
+  }
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrating.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrating.spec.ts
@@ -1,0 +1,91 @@
+import {
+  customAttribute,
+  CustomElement,
+  IController,
+  lifecycleHooks,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.hydrating.spec.ts', function () {
+
+  const hookSymbol = Symbol();
+
+  @lifecycleHooks()
+  class HydratingLoggingHook<T> {
+    hydrating(vm: T, controller: IController) {
+      vm[hookSymbol] = controller[hookSymbol] = hookSymbol;
+      const tracker = controller.container.get(LifeycyleTracker);
+      tracker.hydrating++;
+      tracker.controllers.push(controller);
+    }
+  }
+
+  it('invokes global created hooks', async function () {
+    const { component, container } = await createFixture
+      .html`\${message}`
+      .deps(HydratingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 1);
+  });
+
+  it('invokes when registered both globally and locally', async function () {
+    const { component, container } = await createFixture
+      .component(CustomElement.define({ name: 'app', dependencies: [HydratingLoggingHook] }))
+      .html`\${message}`
+      .deps(HydratingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 2);
+    assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+  });
+
+  it('invokes before the view model lifecycle', async function () {
+    let hydratingCallCount = 0;
+    await createFixture
+      .component(class App {
+        hydrating() {
+          assert.strictEqual(this[hookSymbol], hookSymbol);
+          hydratingCallCount++;
+        }
+      })
+      .html``
+      .deps(HydratingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(hydratingCallCount, 1);
+  });
+
+  it('does not invoke hydrating hooks on Custom attribute', async function () {
+    let current: Square | null = null;
+    @customAttribute({
+      name: 'square',
+      dependencies: [HydratingLoggingHook]
+    })
+    class Square {
+      hydrating() {
+        throw new Error('No hydrating lifecycle on CA');
+      }
+      created() {
+        current = this;
+      }
+    }
+
+    const { container } = await createFixture
+      .html `<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 0);
+  });
+
+  class LifeycyleTracker {
+    hydrating: number = 0;
+    controllers: IController[] = [];
+  }
+});

--- a/packages/__tests__/Spy.ts
+++ b/packages/__tests__/Spy.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-this-alias */
 import { assert } from '@aurelia/testing';
 
 export class Spy {

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -58,7 +58,7 @@ module.exports =
     // and the preprocessor will no longer work, https://github.com/karma-runner/karma/issues/2264
     // this is a good enough work around
     // todo: probably will need something else to run the tests in the browser in the future
-    { type: 'script', watched: true,        included: true,  nocache: true,   pattern: `packages/__tests__/importmap.js` },
+    { type: 'script', watched: true,            included: true,  nocache: true,   pattern: `packages/__tests__/importmap.js` },
     { type: 'script', watched: false,           included: true,  nocache: false,  pattern: path.join(smsPath, 'browser-source-map-support.js') },
     { type: 'module', watched: !hasSingleRun,   included: true,  nocache: false,  pattern: `${baseUrl}/setup-browser.js` }, // 1.1
     { type: 'module', watched: !hasSingleRun,   included: false, nocache: false,  pattern: `${baseUrl}/setup-browser.js.map` }, // 1.1

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -15,6 +15,6 @@ import { Metadata } from '@aurelia/metadata';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any) => any;
 export type FunctionPropNames<T> = {
-    [K in keyof T]: K extends 'constructor' ? never : NonNullable<T[K]> extends AnyFunction ? K : never;
+  [K in keyof T]: K extends 'constructor' ? never : NonNullable<T[K]> extends AnyFunction ? K : never;
 }[keyof T];
 export type MaybePromise<T> = T | Promise<T>;

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -15,6 +15,6 @@ import { Metadata } from '@aurelia/metadata';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any) => any;
 export type FunctionPropNames<T> = {
-[K in keyof T]: K extends 'constructor' ? never : NonNullable<T[K]> extends AnyFunction ? K : never;
+    [K in keyof T]: K extends 'constructor' ? never : NonNullable<T[K]> extends AnyFunction ? K : never;
 }[keyof T];
 export type MaybePromise<T> = T | Promise<T>;

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -14,6 +14,7 @@ import type {
   ResourceDefinition,
   PartialResourceDefinition,
   ResourceType,
+  Key,
 } from '@aurelia/kernel';
 import type { BindableDefinition, PartialBindableDefinition } from '../bindable';
 import type { ICustomAttributeViewModel, ICustomAttributeController } from '../templating/controller';
@@ -44,6 +45,7 @@ export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
    */
   readonly noMultiBindings?: boolean;
   readonly watches?: IWatchDefinition[];
+  readonly dependencies?: readonly Key[];
 }>;
 
 export type CustomAttributeType<T extends Constructable = Constructable> = ResourceType<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition>;
@@ -107,6 +109,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
     public readonly bindables: Record<string, BindableDefinition>,
     public readonly noMultiBindings: boolean,
     public readonly watches: IWatchDefinition[],
+    public readonly dependencies: Key[],
   ) {}
 
   public static create<T extends Constructable = Constructable>(
@@ -133,6 +136,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
       Bindable.from(Type, ...Bindable.getAll(Type), getAttributeAnnotation(Type, 'bindables'), Type.bindables, def.bindables),
       firstDefined(getAttributeAnnotation(Type, 'noMultiBindings'), def.noMultiBindings, Type.noMultiBindings, false),
       mergeArrays(Watch.getAnnotation(Type), Type.watches),
+      mergeArrays(getAttributeAnnotation(Type, 'dependencies'), def.dependencies, Type.dependencies),
     );
   }
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -398,7 +398,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
   /** @internal */
   public _hydrate(hydrationInst: IControllerElementHydrationInstruction | null): void {
-    if (this.lifecycleHooks!.hydrating) {
+    if (this.lifecycleHooks!.hydrating !== void 0) {
       this.lifecycleHooks!.hydrating.forEach(callHydratingHook, this);
     }
     if (this.hooks.hasHydrating) {
@@ -438,6 +438,10 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     (this.viewModel as Writable<C>).$controller = this;
     this.nodes = this._rendering.createNodes(compiledDef);
+
+    if (this.lifecycleHooks!.hydrated !== void 0) {
+      this.lifecycleHooks!.hydrated.forEach(callHydratedHook, this);
+    }
 
     if (this.hooks.hasHydrated) {
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking hydrated() hook`); }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -293,6 +293,10 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     controllerLookup.set(viewModel, controller as Controller);
 
+    if (definition.dependencies.length > 0) {
+      ctn.register(...definition.dependencies);
+    }
+
     controller._hydrateCustomAttribute();
 
     return controller as unknown as ICustomAttributeController<C>;
@@ -471,6 +475,9 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     (instance as Writable<C>).$controller = this;
     this.lifecycleHooks = LifecycleHooks.resolve(this.container);
 
+    if (this.lifecycleHooks!.created !== void 0) {
+      this.lifecycleHooks!.created.forEach(callCreatedHook, this);
+    }
     if (this.hooks.hasCreated) {
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking created() hook`); }
       (this.viewModel as BindingContext<C>).created(this as ICustomAttributeController);

--- a/packages/runtime-html/src/templating/lifecycle-hooks.ts
+++ b/packages/runtime-html/src/templating/lifecycle-hooks.ts
@@ -2,13 +2,13 @@ import { DI, Registration } from '@aurelia/kernel';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata } from '../shared';
 import type { Constructable, IContainer, AnyFunction, FunctionPropNames } from '@aurelia/kernel';
 
-export type LifecycleHook<TViewModel, TKey extends keyof TViewModel, P extends TViewModel[TKey] = TViewModel[TKey]> =
-  P extends AnyFunction
-    ? (vm: TViewModel, ...args: Parameters<NonNullable<P>>) => ReturnType<NonNullable<P>>
+export type LifecycleHook<TViewModel, TKey extends keyof TViewModel> =
+  TViewModel[TKey] extends (AnyFunction | undefined)
+    ? (vm: TViewModel, ...args: Parameters<NonNullable<TViewModel[TKey]>>) => ReturnType<NonNullable<TViewModel[TKey]>>
     : never;
 
 export type ILifecycleHooks<TViewModel = {}, TKey extends keyof TViewModel = keyof TViewModel> = { [K in TKey]-?: LifecycleHook<TViewModel, K>; };
-export const ILifecycleHooks = DI.createInterface<ILifecycleHooks>('ILifecycleHooks');
+export const ILifecycleHooks = DI.createInterface<ILifecycleHooks<object>>('ILifecycleHooks');
 
 export type LifecycleHooksLookup<TViewModel = {}> = {
   [K in FunctionPropNames<TViewModel>]?: readonly LifecycleHooksEntry<TViewModel, K>[];


### PR DESCRIPTION
Call the following lifecycle hooks:
- hydrating for CE
- hydrated for CE
- created for CE/CA

The hooks will be called before the main view model corresponding hook.

part of #1044 