### PR TITLE
chore(dev): add tooling dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "test:ci": "npm ci && npm run test",
     "test:watch": "cd packages/__tests__ && npm run test-chrome:watch",
     "test:debugger": "cd packages/__tests__ && npm run test-chrome:debugger",
-    "dev": "ts-node scripts/dev.ts"
+    "dev": "ts-node scripts/dev.ts",
+    "dev:tooling": "ts-node scripts/dev-tooling.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.2.3",
@@ -204,6 +205,6 @@
   },
   "volta": {
     "node": "16.14.2",
-    "npm": "8.1.2"
+    "npm": "8.12.1"
   }
 }

--- a/packages-tooling/__tests__/esbuild.dev.cjs
+++ b/packages-tooling/__tests__/esbuild.dev.cjs
@@ -1,0 +1,79 @@
+/* eslint-disable */
+const fs = require('fs');
+const { resolve, join } = require('path');
+const { build } = require('esbuild');
+const { exec, execSync } = require('child_process');
+
+/**
+ * @param {string} startPath
+ * @param {RegExp | string} filter
+ * @param {string[]} found
+ * @returns {string[]}
+ */
+function findByExt(startPath, filter, found = []) {
+  if (!fs.existsSync(startPath)) {
+    console.log("no dir ", startPath);
+    return;
+  }
+
+  const files = fs.readdirSync(startPath);
+  for (let i = 0; i < files.length; i++) {
+    const filename = join(startPath, files[i]);
+    const stat = fs.lstatSync(filename);
+    if (stat.isDirectory()) {
+      // recurse
+      findByExt(filename, filter, found);
+    }
+    else if (filter instanceof RegExp) {
+      if (filter.test(filename)) {
+        found.push(filename);
+      }
+    }
+    else if (filename.endsWith(filter)) {
+      found.push(filename);
+    }
+  }
+  return found;
+};
+
+build({
+  entryPoints: findByExt('./', /\.tsx?$/),
+  outdir: resolve(__dirname, 'dist/cjs/__tests__'),
+  sourcemap: true,
+  watch: /^true$/.test(process.env.DEV_MODE),
+  keepNames: true,
+  format: 'cjs',
+  plugins: [
+    {
+      name: 'example',
+      setup(build) {
+        let now;
+        build.onStart(result => {
+          now = Date.now();
+        });
+        build.onEnd(result => {
+          console.log(`Build done in ${getElapsed(Date.now(), now)}s, with ${result.errors.length} errors.`);
+          now = Date.now();
+          console.log('verifying typings');
+          try {
+            execSync('npm run verify');
+            console.log(`verified typings done in ${getElapsed(Date.now(), now)}.`);
+          } catch (ex) {
+            process.stdout.write(ex.stdout);
+          }
+        });
+      }
+    }
+  ]
+}).catch(err => {
+  process.stderr.write(err.stderr);
+  process.exit(1);
+});
+
+/**
+ * @param {number} now
+ * @param {number} then
+ */
+const getElapsed = (now, then) => {
+  return ((now - then) / 1000).toFixed(2);
+}

--- a/packages-tooling/__tests__/package.json
+++ b/packages-tooling/__tests__/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@aurelia/__tests__cjs",
+  "version": "2.0.0-alpha.34",
   "private": true,
   "license": "MIT",
   "engines": {
@@ -20,9 +21,9 @@
     "test-node:ts-jest": "npm run ::mocha -- dist/cjs/__tests__/ts-jest/**/*.spec.js",
     "test-node:parcel-transformer": "npm run ::mocha -- dist/cjs/__tests__/parcel-transformer/**/*.spec.js",
     "build": "tsc --build",
-    "dev": "tsc --build -w --preserveWatchOutput",
+    "dev": "cross-env DEV_MODE=true node esbuild.dev.cjs",
     "rollup": "npm run build",
-    "build:packages-tooling": "npm run build"
+    "verify": "tsc --noEmit"
   },
   "dependencies": {
     "@aurelia/aot": "2.0.0-alpha.34",
@@ -59,5 +60,8 @@
     "tsconfig-paths": "^3.9.0",
     "vinyl": "^2.2.0"
   },
-  "version": "2.0.0-alpha.34"
+  "volta": {
+    "node": "16.14.2",
+    "npm": "8.12.1"
+  }
 }

--- a/packages/kernel/src/module-loader.ts
+++ b/packages/kernel/src/module-loader.ts
@@ -39,6 +39,7 @@ class ModuleTransformer<TMod extends IModule = IModule, TRet = AnalyzedModule<TM
     }
   }
 
+  /** @internal */
   private _transformPromise(promise: Promise<TMod>): TRet | Promise<TRet> {
     if (this._promiseCache.has(promise)) {
       return this._promiseCache.get(promise) as TRet | Promise<TRet>;
@@ -55,6 +56,7 @@ class ModuleTransformer<TMod extends IModule = IModule, TRet = AnalyzedModule<TM
     return ret;
   }
 
+  /** @internal */
   private _transformObject(obj: TMod): TRet | Promise<TRet> {
     if (this._objectCache.has(obj)) {
       return this._objectCache.get(obj) as TRet | Promise<TRet>;
@@ -71,6 +73,7 @@ class ModuleTransformer<TMod extends IModule = IModule, TRet = AnalyzedModule<TM
     return ret;
   }
 
+  /** @internal */
   private _analyze(m: TMod): AnalyzedModule<TMod> {
     let value: unknown;
     let isRegistry: boolean;

--- a/scripts/dev-tooling.ts
+++ b/scripts/dev-tooling.ts
@@ -1,0 +1,134 @@
+/* eslint-disable no-console */
+import concurrently from 'concurrently';
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { c } from './logger';
+
+const args = yargs
+  .usage('$0 <cmd> [args]')
+  .option('d', {
+    alias: 'dev',
+    describe: 'add extra packages to development',
+    array: true,
+  })
+  .option('t', {
+    alias: 'test',
+    describe: 'add extra test folders to development',
+    array: true,
+  })
+  .option('a', {
+    alias: 'app',
+    describe: 'add extra example apps to development',
+    array: true,
+  })
+  .argv;
+
+const envVars = { DEV_MODE: true };
+const testPatterns = (args.t ?? []).join(' ');
+
+if (testPatterns === '') {
+  console.log(
+    `There are no test pattern specified. This will run all tests if go ahead. Aborting...
+If it is intended to run all test, then specified --test *
+`);
+  process.exit(0);
+}
+
+const devCmd = 'npm run dev';
+const buildCmd = 'npm run build';
+
+const baseToolingPath = 'packages-tooling';
+const basePackages = [
+  'kernel',
+];
+
+const validToolingPackages = [
+  'plugin-conventions',
+  'plugin-gulp',
+  'ts-jest',
+  'babel-jest',
+  'parcel-transformer',
+  'webpack-loader',
+];
+
+const devPackages = (args.d ?? []) as string[];
+if (devPackages.some(d => !validToolingPackages.includes(d))) {
+  throw new Error(`Invalid package config, valid packages are: ${validToolingPackages}`);
+}
+
+const baseUrl = 'dist/cjs/__tests__';
+const testFilePatterns = testPatterns === '*'
+  ? [`${baseUrl}/**/*.spec.js`]
+  : testPatterns.split(' ').flatMap(pattern => [
+    `${baseUrl}/**/*${pattern.replace(/(?:\.spec)?(?:\.[tj]s)?$/, '*.spec.js')}`,
+    `${baseUrl}/**/${pattern}/**/*.spec.js`,
+  ]);
+
+console.log('test patterns preprocess:', testPatterns, 'post-process:', testFilePatterns);
+
+basePackages
+  .filter(pkg => !isEsmBuilt(path.resolve(__dirname, `../packages/${pkg}`)))
+  .forEach(pkg => buildPackage(pkg, `packages/${pkg}`));
+validToolingPackages
+  .filter(pkg => !isCjsBuilt(path.resolve(__dirname, `../${baseToolingPath}/${pkg}`)))
+  .forEach((pkgName) => buildPackage(pkgName, `${baseToolingPath}/${pkgName}`));
+
+concurrently([
+  { command: devCmd, cwd: 'packages/kernel', name: 'kernel', env: envVars },
+  // always watch plugin-convention by default, since this is the base line of all the things
+  { command: devCmd, cwd: `${baseToolingPath}/plugin-conventions`, name: 'plugin-conventions', env: envVars },
+  { command: devCmd, cwd: `${baseToolingPath}/__tests__`, name: '__tests__(build)', env: envVars },
+  ...devPackages
+    .filter(pkg => pkg !== 'plugin-conventions').
+    map((folder: string) => ({
+      command: devCmd,
+      cwd: `${baseToolingPath}/${folder}`,
+      name: folder,
+      env: envVars
+    })),
+  {
+    command: `npm run ::mocha -- --watch-files ${Array.from(new Set(['plugin-conventions', ...devPackages])).map(pkg => getToolingPackageDist(pkg)).join(',')} -w ${testFilePatterns.join(' ')}`,
+    cwd: `${baseToolingPath}/__tests__`,
+    name: '__tests__(run)',
+    env: envVars
+  },
+], {
+  prefix: '[{name}]',
+  killOthers: 'failure',
+  prefixColors: [
+    'green',
+    'blue',
+    'cyan',
+    'greenBright',
+    'blueBright',
+    'magentaBright',
+    'cyanBright',
+    'white',
+  ]
+});
+
+function getToolingPackageDist(pkg: string) {
+  return `${process.cwd()}/${baseToolingPath}/${pkg}/dist/cjs/index.cjs`;
+}
+
+function isEsmBuilt(pkgPath: string): boolean {
+  return fs.existsSync(`${pkgPath}/dist/esm/index.mjs`);
+}
+
+function isCjsBuilt(pkgPath: string): boolean {
+  return fs.existsSync(`${pkgPath}/dist/cjs/index.cjs`);
+}
+
+function getElapsed(now: number, then: number) {
+  return ((now - then) / 1000).toFixed(2);
+}
+
+function buildPackage(pkgName: string, path: string) {
+  const start = Date.now();
+  const pkgDisplay = c.green(pkgName);
+  console.log(`${pkgDisplay} has not been built before, building...`);
+  execSync(buildCmd, { cwd: path });
+  console.log(`${pkgDisplay} built in ${getElapsed(Date.now(), start)}s`);
+}


### PR DESCRIPTION
Similar to core packages, tooling packages development should have a simple script to build, watch and run tests based on file name pattern. Add a new script `dev:tooling` that can be used like this:
```shell
npm run dev:tooling -- --dev [tooling package name] --test [test file pattern]
# with shorthand

npm run dev:tooling -- -d [tooling package name] -t [test file pattern]
```
By default, plugin convention is auto built & watched for changes to rerun tests.

An example of auto build `plugin-conventions` on change, and run `preprocess-resource` tests:
```
npm run dev:tooling -- -t preprocess
```