### PR TITLE
feat(lifecycle-hooks): add attaching

### DIFF
--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -37,6 +37,7 @@ module.exports = {
     'no-extra-boolean-cast': 'off',
     'no-template-curly-in-string': 'off',
     'no-inner-declarations': 'off',
+    'no-await-in-loop': 'off',
     'require-atomic-updates': 'off',
 
     // Things we maybe need to fix some day, so are marked as off for now as they're quite noisy:

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.attaching.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.attaching.spec.ts
@@ -1,0 +1,220 @@
+import { Registration } from '@aurelia/kernel';
+import {
+  customAttribute,
+  CustomElement,
+  IController,
+  lifecycleHooks,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.attaching.spec.ts [synchronous]', function () {
+
+  const hookSymbol = Symbol();
+
+  @lifecycleHooks()
+  class AttachingLoggingHook<T> {
+    attaching(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      const tracker = initiator.container.get(LifeycyleTracker);
+      tracker.attaching++;
+      tracker.controllers.push(initiator);
+    }
+  }
+
+  it('invokes global created hooks', async function () {
+    const { component, container } = await createFixture
+      .html`\${message}`
+      .deps(AttachingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).attaching, 1);
+  });
+
+  it('invokes when registered both globally and locally', async function () {
+    const { component, container } = await createFixture
+      .component(CustomElement.define({ name: 'app', dependencies: [AttachingLoggingHook] }))
+      .html`\${message}`
+      .deps(AttachingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(container.get(LifeycyleTracker).attaching, 2);
+    assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+  });
+
+  it('invokes before the view model lifecycle', async function () {
+    let attachingCallCount = 0;
+    await createFixture
+      .component(class App {
+        attaching() {
+          assert.strictEqual(this[hookSymbol], hookSymbol);
+          attachingCallCount++;
+        }
+      })
+      .html``
+      .deps(AttachingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(attachingCallCount, 1);
+  });
+
+  it('invokes global attaching hooks for Custom attribute controller', async function () {
+    let current: Square | null = null;
+    @customAttribute('square')
+    class Square {
+      created() { current = this; }
+    }
+
+    const { container } = await createFixture
+      .html `<div square>`
+      .deps(AttachingLoggingHook, Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(container.get(LifeycyleTracker).attaching, 2);
+  });
+
+  it('invokes attaching hooks on Custom attribute', async function () {
+    let current: Square | null = null;
+    @customAttribute({ name: 'square', dependencies: [AttachingLoggingHook] })
+    class Square {
+      created() { current = this; }
+    }
+
+    const { container } = await createFixture
+      .html `<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(container.get(LifeycyleTracker).attaching, 1);
+  });
+
+  it('does not invokes attaching hooks on synthetic controller of repeat', async function () {
+    const { container } = await createFixture
+      .html('<div repeat.for="i of 2">')
+      .deps(AttachingLoggingHook)
+      .build().started;
+    assert.strictEqual(container.get(LifeycyleTracker).attaching, /* root CE + repeat CA */ 2);
+  });
+
+  class LifeycyleTracker {
+    attaching: number = 0;
+    controllers: IController[] = [];
+  }
+});
+
+describe('3-runtime-html/lifecycle-hooks.attaching.spec.ts [asynchronous]', function () {
+
+  const hookSymbol = Symbol();
+  let tracker: AsyncLifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = null;
+  });
+
+  @lifecycleHooks()
+  class AttachingLoggingHook<T> {
+    async attaching(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      tracker.trace('lch.start');
+      return waitForTicks(5).then(() => tracker.trace('lch.end'));
+    }
+  }
+
+  it('invokes global hook in parallel', async function () {
+    await createFixture
+      .component(class {
+        attaching() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .deps(AsyncLifeycyleTracker, AttachingLoggingHook)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes local hooks in parallel', async function () {
+    await createFixture
+      .component(class {
+        static dependencies = [AttachingLoggingHook];
+        attaching() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .deps(AsyncLifeycyleTracker)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes global hooks in parallel for CA', async function () {
+    @customAttribute('square')
+    class Square {
+      attaching() {
+        tracker.trace('square.start');
+        return waitForTicks(1).then(() => tracker.trace('square.end'));
+      }
+    }
+
+    await createFixture
+      .component(class {
+        static dependencies = [AttachingLoggingHook];
+        attaching() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html`<div square>`
+      .deps(AsyncLifeycyleTracker, Square)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'square.start',
+      'comp.end',
+      'square.end',
+      'lch.end',
+    ]);
+  });
+
+  const waitForTicks = async (count: number) => {
+    while (count-- > 0) {
+      await Promise.resolve();
+    }
+  };
+
+  class AsyncLifeycyleTracker {
+    static register(c) {
+      return c.register(Registration.instance(AsyncLifeycyleTracker, new AsyncLifeycyleTracker()));
+    }
+
+    logs: string[] = [];
+    private constructor() {
+      tracker = this;
+    }
+
+    trace(msg: string): void {
+      this.logs.push(msg);
+    }
+  }
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.resolve.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.resolve.spec.ts
@@ -81,29 +81,27 @@ describe('3-runtime-html/lifecycle-hooks.resolve.spec.ts', function () {
 
   describe('<App/> -> <Child/> -> <Grand Child/>', function () {
     it('does not retrieve hooks in the middle layer', async function () {
-      let hooksCall = 0;
-      let differentHooksCall = 0;
       class Hooks {
         public attaching() {
-          hooksCall++;
+          // empty
         }
       }
       class Hooks2 {
         public attaching() {
-          hooksCall++;
+          // empty
         }
       }
       class DifferentHooks {
         public attaching() {
-          differentHooksCall++;
+          // empty
         }
       }
       class DifferentHooks2 {
         public attaching() {
-          differentHooksCall++;
+          // empty
         }
       }
-      const { au, component, startPromise, tearDown } = createFixture(
+      const { au, component } = await createFixture(
         `<el view-model.ref="el">`,
         class App {
           public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
@@ -125,8 +123,7 @@ describe('3-runtime-html/lifecycle-hooks.resolve.spec.ts', function () {
             ]
           }),
         ],
-      );
-      await startPromise;
+      ).started;
 
       const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
       assert.notStrictEqual(hooks.attaching?.length, 0);
@@ -137,51 +134,40 @@ describe('3-runtime-html/lifecycle-hooks.resolve.spec.ts', function () {
       const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
       assert.strictEqual(grandChildHooks.attaching.length, 2);
 
-      assert.strictEqual(hooksCall, 0);
-      assert.strictEqual(differentHooksCall, 0);
-
-      childHooks.attaching.forEach(x => x.instance.attaching(null!));
-      grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
-
-      assert.strictEqual(hooksCall, 2);
-      assert.strictEqual(differentHooksCall, 2);
-
-      await tearDown();
+      assert.strictEqual(childHooks.attaching.every(x => x.instance instanceof Hooks || x.instance instanceof Hooks2), true);
+      assert.strictEqual(grandChildHooks.attaching.every(x => x.instance instanceof DifferentHooks || x.instance instanceof DifferentHooks2), true);
     });
 
     it('retrieves the same hooks Type twice as declaration', async function () {
-      let hooksCall = 0;
-      let differentHooksCall = 0;
-
       @lifecycleHooks()
       class Hooks {
         public attaching() {
-          hooksCall++;
+          // empty
         }
       }
 
       @lifecycleHooks()
       class Hooks2 {
         public attaching() {
-          hooksCall++;
+          // empty
         }
       }
 
       @lifecycleHooks()
       class DifferentHooks {
         public attaching() {
-          differentHooksCall++;
+          // empty
         }
       }
 
       @lifecycleHooks()
       class DifferentHooks2 {
         public attaching() {
-          differentHooksCall++;
+          // empty
         }
       }
 
-      const { au, component, startPromise, tearDown } = createFixture(
+      const { au, component } = await createFixture(
         `<el view-model.ref="el">`,
         class App {
           public el: ICustomElementViewModel & { elChild: ICustomElementViewModel };
@@ -207,8 +193,7 @@ describe('3-runtime-html/lifecycle-hooks.resolve.spec.ts', function () {
             ]
           }),
         ],
-      );
-      await startPromise;
+      ).started;
 
       const hooks = (au.root.controller as IHydratedComponentController).lifecycleHooks as LifecycleHooksLookup<Hooks>;
       assert.notStrictEqual(hooks.attaching?.length, 0);
@@ -219,16 +204,8 @@ describe('3-runtime-html/lifecycle-hooks.resolve.spec.ts', function () {
       const grandChildHooks = component.el.elChild.$controller!.lifecycleHooks as LifecycleHooksLookup<DifferentHooks>;
       assert.strictEqual(grandChildHooks.attaching.length, 4);
 
-      assert.strictEqual(hooksCall, 0);
-      assert.strictEqual(differentHooksCall, 0);
-
-      childHooks.attaching.forEach(x => x.instance.attaching(null!));
-      grandChildHooks.attaching.forEach(x => x.instance.attaching(null!));
-
-      assert.strictEqual(hooksCall, 4);
-      assert.strictEqual(differentHooksCall, 4);
-
-      await tearDown();
+      assert.strictEqual(childHooks.attaching.every(x => x.instance instanceof Hooks || x.instance instanceof Hooks2), true);
+      assert.strictEqual(grandChildHooks.attaching.every(x => x.instance instanceof DifferentHooks || x.instance instanceof DifferentHooks2), true);
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/repeat.vc.bb.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeat.vc.bb.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import { IContainer } from '@aurelia/kernel';
 import { valueConverter, bindingBehavior } from '@aurelia/runtime';
 import { Aurelia, CustomElement, ICustomElementController, IPlatform } from '@aurelia/runtime-html';


### PR DESCRIPTION
# Pull Request

## 📖 Description

Continue the work on lifecycle hooks, part of #1044, add `attaching` lifecycle hooks. It'll be working similarly like other lifecycle:
- invoked before the view model attaching lifecycle
- invoked in parallel with the view model attaching lifecycle. Promises returned here will be aggregated together with view model promise returned from attaching lifecycle (if any)