### PR TITLE
feat(lifecycle-hooks): detaching

### DIFF
--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.created.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.created.spec.ts
@@ -10,12 +10,16 @@ import { assert, createFixture } from '@aurelia/testing';
 describe('3-runtime-html/lifecycle-hooks.created.spec.ts', function () {
 
   const hookSymbol = Symbol();
+  let tracker: LifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new LifeycyleTracker();
+  });
 
   @lifecycleHooks()
   class CreatedLoggingHook<T> {
     created(vm: T, controller: IController) {
       vm[hookSymbol] = controller[hookSymbol] = hookSymbol;
-      const tracker = controller.container.get(LifeycyleTracker);
       tracker.created++;
       tracker.controllers.push(controller);
     }
@@ -23,18 +27,18 @@ describe('3-runtime-html/lifecycle-hooks.created.spec.ts', function () {
 
   describe('custom elements', function () {
     it('invokes global created hooks', async function () {
-      const { component, container } = await createFixture
+      const { component } = await createFixture
         .html`\${message}`
         .deps(CreatedLoggingHook)
         .build().started;
 
       assert.strictEqual(component[hookSymbol], hookSymbol);
       assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-      assert.strictEqual(container.get(LifeycyleTracker).created, 1);
+      assert.strictEqual(tracker.created, 1);
     });
 
     it('invokes when registered both globally and locally', async function () {
-      const { component, container } = await createFixture
+      const { component } = await createFixture
         .component(CustomElement.define({ name: 'app', dependencies: [CreatedLoggingHook] }))
         .html`\${message}`
         .deps(CreatedLoggingHook)
@@ -42,8 +46,8 @@ describe('3-runtime-html/lifecycle-hooks.created.spec.ts', function () {
 
       assert.strictEqual(component[hookSymbol], hookSymbol);
       assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-      assert.strictEqual(container.get(LifeycyleTracker).created, 2);
-      assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+      assert.strictEqual(tracker.created, 2);
+      assert.deepStrictEqual(tracker.controllers, [component.$controller, component.$controller]);
     });
 
     it('invokes before the view model lifecycle', async function () {

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.detaching.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.detaching.spec.ts
@@ -1,4 +1,3 @@
-import { Registration } from '@aurelia/kernel';
 import {
   customAttribute,
   CustomElement,
@@ -132,7 +131,7 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   let tracker: AsyncLifeycyleTracker | null = null;
 
   this.beforeEach(function () {
-    tracker = null;
+    tracker = new AsyncLifeycyleTracker();
   });
 
   @lifecycleHooks()
@@ -162,7 +161,7 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
         }
       })
       .html``
-      .deps(AsyncLifeycyleTracker, DetachingLoggingHook)
+      .deps(DetachingLoggingHook)
       .build().started;
 
     await tearDown();
@@ -185,7 +184,6 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
         }
       })
       .html``
-      .deps(AsyncLifeycyleTracker)
       .build().started;
 
     await tearDown();
@@ -216,7 +214,7 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
         }
       })
       .html`<div square>`
-      .deps(AsyncLifeycyleTracker, Square)
+      .deps(Square)
       .build().started;
 
     await tearDown();
@@ -241,7 +239,6 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
         }
       })
       .html``
-      .deps(AsyncLifeycyleTracker)
       .build().started;
 
     await tearDown();
@@ -263,15 +260,7 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   };
 
   class AsyncLifeycyleTracker {
-    static register(c) {
-      return c.register(Registration.instance(AsyncLifeycyleTracker, new AsyncLifeycyleTracker()));
-    }
-
     logs: string[] = [];
-    private constructor() {
-      tracker = this;
-    }
-
     trace(msg: string): void {
       this.logs.push(msg);
     }

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrating.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.hydrating.spec.ts
@@ -9,30 +9,34 @@ import { assert, createFixture } from '@aurelia/testing';
 describe('3-runtime-html/lifecycle-hooks.hydrating.spec.ts', function () {
 
   const hookSymbol = Symbol();
+  let tracker: LifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new LifeycyleTracker();
+  });
 
   @lifecycleHooks()
   class HydratingLoggingHook<T> {
     hydrating(vm: T, controller: IController) {
       vm[hookSymbol] = controller[hookSymbol] = hookSymbol;
-      const tracker = controller.container.get(LifeycyleTracker);
       tracker.hydrating++;
       tracker.controllers.push(controller);
     }
   }
 
   it('invokes global created hooks', async function () {
-    const { component, container } = await createFixture
+    const { component } = await createFixture
       .html`\${message}`
       .deps(HydratingLoggingHook)
       .build().started;
 
     assert.strictEqual(component[hookSymbol], hookSymbol);
     assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 1);
+    assert.strictEqual(tracker.hydrating, 1);
   });
 
   it('invokes when registered both globally and locally', async function () {
-    const { component, container } = await createFixture
+    const { component } = await createFixture
       .component(CustomElement.define({ name: 'app', dependencies: [HydratingLoggingHook] }))
       .html`\${message}`
       .deps(HydratingLoggingHook)
@@ -40,8 +44,8 @@ describe('3-runtime-html/lifecycle-hooks.hydrating.spec.ts', function () {
 
     assert.strictEqual(component[hookSymbol], hookSymbol);
     assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 2);
-    assert.deepStrictEqual(container.get(LifeycyleTracker).controllers, [component.$controller, component.$controller]);
+    assert.strictEqual(tracker.hydrating, 2);
+    assert.deepStrictEqual(tracker.controllers, [component.$controller, component.$controller]);
   });
 
   it('invokes before the view model lifecycle', async function () {
@@ -72,13 +76,13 @@ describe('3-runtime-html/lifecycle-hooks.hydrating.spec.ts', function () {
       }
     }
 
-    const { container } = await createFixture
+    await createFixture
       .html `<div square>`
       .deps(Square)
       .build().started;
 
     assert.instanceOf(current, Square);
-    assert.strictEqual(container.get(LifeycyleTracker).hydrating, 0);
+    assert.strictEqual(tracker.hydrating, 0);
   });
 
   class LifeycyleTracker {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Continue the work on lifecycle hooks, part of #1044, add `deataching` lifecycle hooks. It'll be working similarly like other lifecycles:

* invoked before the view model `detaching` lifecycle
* invoked in parallel with the view model `detaching` lifecycle. Promises returned here will be aggregated together with view model promise returned from `detaching` lifecycle (if any)