### PR TITLE
feat(lifecycle-hooks): binding + unbinding + bound

### DIFF
--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.all-in-one.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.all-in-one.spec.ts
@@ -1,0 +1,281 @@
+import {
+  IController,
+  ILifecycleHooks,
+  lifecycleHooks
+} from '@aurelia/runtime-html';
+import { IActivationHooks, ICompileHooks, IHydratedController } from '@aurelia/runtime-html/dist/types/templating/controller';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.all-in-one.spec.ts [synchronous]', function () {
+  let tracker: LifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new LifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class LoggingHook implements ILifecycleHooks<ICompileHooks & IActivationHooks<IHydratedController>> {
+
+    hydrating() {
+      tracker.hydrating++;
+    }
+
+    hydrated(): void {
+      tracker.hydrated++;
+    }
+
+    created() {
+      tracker.created++;
+    }
+
+    binding() {
+      tracker.binding++;
+    }
+
+    bound() {
+      tracker.bound++;
+    }
+
+    attaching() {
+      tracker.attaching++;
+    }
+
+    attached() {
+      tracker.attached++;
+    }
+
+    detaching() {
+      tracker.detaching++;
+    }
+
+    unbinding() {
+      tracker.unbinding++;
+    }
+
+    define() {
+      throw new Error('ni');
+    }
+
+    dispose() {
+      throw new Error('ni');
+    }
+
+    accept() {
+      throw new Error('ni');
+    }
+  }
+
+  it('invokes global bound hooks', async function () {
+    const { tearDown } = await createFixture
+      .html`\${message}`
+      .deps(LoggingHook)
+      .build().started;
+
+    assert.strictEqual(tracker.hydrating, 1);
+    assert.strictEqual(tracker.hydrated, 1);
+    assert.strictEqual(tracker.created, 1);
+    assert.strictEqual(tracker.binding, 1);
+    assert.strictEqual(tracker.bound, 1);
+    assert.strictEqual(tracker.attaching, 1);
+    assert.strictEqual(tracker.attached, 1);
+
+    await tearDown();
+
+    assert.strictEqual(tracker.hydrating, 1);
+    assert.strictEqual(tracker.hydrated, 1);
+    assert.strictEqual(tracker.created, 1);
+    assert.strictEqual(tracker.binding, 1);
+    assert.strictEqual(tracker.bound, 1);
+    assert.strictEqual(tracker.attaching, 1);
+    assert.strictEqual(tracker.attached, 1);
+    assert.strictEqual(tracker.detaching, 1);
+    assert.strictEqual(tracker.unbinding, 1);
+  });
+
+  class LifeycyleTracker {
+    hydrating = 0;
+    hydrated = 0;
+    created = 0;
+    binding = 0;
+    bound = 0;
+    attaching = 0;
+    attached = 0;
+    detaching = 0;
+    unbinding = 0;
+    controllers: IController[] = [];
+  }
+});
+
+describe('3-runtime-html/lifecycle-hooks.all-in-one.spec.ts [asynchronous]', function () {
+  let tracker: AsyncLifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new AsyncLifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class AllLoggingHook {
+
+    hydrating() {
+      tracker.trace('lch.hydrating');
+    }
+
+    hydrated() {
+      tracker.trace('lch.hydrated');
+    }
+
+    created() {
+      tracker.trace('lch.created');
+    }
+
+    binding() {
+      return logAndWait('lch.binding');
+    }
+
+    bound() {
+      return logAndWait('lch.bound');
+    }
+
+    attaching() {
+      return logAndWait('lch.attaching');
+    }
+
+    attached() {
+      return logAndWait('lch.attached');
+    }
+
+    detaching() {
+      return logAndWait('lch.detaching');
+    }
+
+    unbinding() {
+      return logAndWait('lch.unbinding');
+    }
+  }
+
+  it('invokes global hook in the right order', async function () {
+    const { tearDown } = await createFixture
+      .component(class {
+        hydrating() {
+          tracker.trace('comp.hydrating');
+        }
+
+        hydrated() {
+          tracker.trace('comp.hydrated');
+        }
+
+        created() {
+          tracker.trace('comp.created');
+        }
+
+        binding() {
+          return logAndWait('comp.binding');
+        }
+
+        bound() {
+          return logAndWait('comp.bound');
+        }
+
+        attaching() {
+          return logAndWait('comp.attaching');
+        }
+
+        attached() {
+          return logAndWait('comp.attached');
+        }
+
+        detaching() {
+          return logAndWait('comp.detaching');
+        }
+
+        unbinding() {
+          return logAndWait('comp.unbinding');
+        }
+      })
+      .html``
+      .deps(AllLoggingHook)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.hydrating',
+      'comp.hydrating',
+      'lch.hydrated',
+      'comp.hydrated',
+      'lch.created',
+      'comp.created',
+      'lch.binding.start',
+      'comp.binding.start',
+      'lch.binding.end',
+      'comp.binding.end',
+      'lch.bound.start',
+      'comp.bound.start',
+      'lch.bound.end',
+      'comp.bound.end',
+      'lch.attaching.start',
+      'comp.attaching.start',
+      'lch.attaching.end',
+      'comp.attaching.end',
+      'lch.attached.start',
+      'comp.attached.start',
+      'lch.attached.end',
+      'comp.attached.end',
+    ]);
+
+    await tearDown();
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.hydrating',
+      'comp.hydrating',
+      'lch.hydrated',
+      'comp.hydrated',
+      'lch.created',
+      'comp.created',
+      'lch.binding.start',
+      'comp.binding.start',
+      'lch.binding.end',
+      'comp.binding.end',
+      'lch.bound.start',
+      'comp.bound.start',
+      'lch.bound.end',
+      'comp.bound.end',
+      'lch.attaching.start',
+      'comp.attaching.start',
+      'lch.attaching.end',
+      'comp.attaching.end',
+      'lch.attached.start',
+      'comp.attached.start',
+      'lch.attached.end',
+      'comp.attached.end',
+
+      // tear down phases
+
+      'lch.detaching.start',
+      'comp.detaching.start',
+      'lch.detaching.end',
+      'comp.detaching.end',
+
+      'lch.unbinding.start',
+      'comp.unbinding.start',
+      'lch.unbinding.end',
+      'comp.unbinding.end',
+    ]);
+  });
+
+  const waitForTicks = async (count: number) => {
+    while (count-- > 0) {
+      await Promise.resolve();
+    }
+  };
+
+  const logAndWait = (name: string, count = 5) => {
+    tracker.trace(`${name}.start`);
+    return waitForTicks(count).then(() => tracker.trace(`${name}.end`));
+  };
+
+  class AsyncLifeycyleTracker {
+    logs: string[] = [];
+    trace(msg: string): void {
+      this.logs.push(msg);
+    }
+  }
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.binding.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.binding.spec.ts
@@ -1,0 +1,217 @@
+import {
+  customAttribute,
+  CustomElement,
+  IController,
+  lifecycleHooks,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.binding.spec.ts [synchronous]', function () {
+
+  const hookSymbol = Symbol();
+  let tracker: LifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new LifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class BindingLoggingHook<T> {
+    binding(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      tracker.binding++;
+      tracker.controllers.push(initiator);
+    }
+  }
+
+  it('invokes global binding hooks', async function () {
+    const { component } = await createFixture
+      .html`\${message}`
+      .deps(BindingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(tracker.binding, 1);
+  });
+
+  it('invokes when registered both globally and locally', async function () {
+    const { component } = await createFixture
+      .component(CustomElement.define({ name: 'app', dependencies: [BindingLoggingHook] }))
+      .html`\${message}`
+      .deps(BindingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(tracker.binding, 2);
+    assert.deepStrictEqual(tracker.controllers, [component.$controller, component.$controller]);
+  });
+
+  it('invokes before the view model lifecycle', async function () {
+    let bindingCallCount = 0;
+    await createFixture
+      .component(class App {
+        binding() {
+          assert.strictEqual(this[hookSymbol], hookSymbol);
+          bindingCallCount++;
+        }
+      })
+      .html``
+      .deps(BindingLoggingHook)
+      .build().started;
+
+    assert.strictEqual(bindingCallCount, 1);
+  });
+
+  it('invokes global binding hooks for Custom attribute controller', async function () {
+    let current: Square | null = null;
+    @customAttribute('square')
+    class Square {
+      created() { current = this; }
+    }
+
+    await createFixture
+      .html`<div square>`
+      .deps(BindingLoggingHook, Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(tracker.binding, 2);
+  });
+
+  it('invokes binding hooks on Custom attribute', async function () {
+    let current: Square | null = null;
+    @customAttribute({ name: 'square', dependencies: [BindingLoggingHook] })
+    class Square {
+      created() { current = this; }
+    }
+
+    await createFixture
+      .html`<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(tracker.binding, 1);
+  });
+
+  it('does not invokes binding hooks on synthetic controller of repeat', async function () {
+    await createFixture
+      .html('<div repeat.for="i of 2">')
+      .deps(BindingLoggingHook)
+      .build().started;
+    assert.strictEqual(tracker.binding, /* root CE + repeat CA */ 2);
+  });
+
+  class LifeycyleTracker {
+    binding: number = 0;
+    controllers: IController[] = [];
+  }
+});
+
+describe('3-runtime-html/lifecycle-hooks.binding.spec.ts [asynchronous]', function () {
+
+  const hookSymbol = Symbol();
+  let tracker: AsyncLifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new AsyncLifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class BindingLoggingHook<T> {
+    binding(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      tracker.trace('lch.start');
+      return waitForTicks(5).then(() => tracker.trace('lch.end'));
+    }
+  }
+
+  it('invokes global hook in parallel', async function () {
+    await createFixture
+      .component(class {
+        binding() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .deps(BindingLoggingHook)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes local hooks in parallel', async function () {
+    await createFixture
+      .component(class {
+        static dependencies = [BindingLoggingHook];
+        binding() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes global hooks in parallel for CA', async function () {
+    @customAttribute('square')
+    class Square {
+      binding() {
+        tracker.trace('square.start');
+        return waitForTicks(1).then(() => tracker.trace('square.end'));
+      }
+    }
+
+    await createFixture
+      .component(class {
+        static dependencies = [BindingLoggingHook];
+        binding() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html`<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      // binding lifecycle resolves top down sequentially
+      // means children (square CA) will only be invoked
+      // after parent (hooks + root CE) have been resolved
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+      'square.start',
+      'square.end',
+    ]);
+  });
+
+  const waitForTicks = async (count: number) => {
+    while (count-- > 0) {
+      await Promise.resolve();
+    }
+  };
+
+  class AsyncLifeycyleTracker {
+    logs: string[] = [];
+    trace(msg: string): void {
+      this.logs.push(msg);
+    }
+  }
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.bound.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.bound.spec.ts
@@ -1,0 +1,217 @@
+import {
+  customAttribute,
+  CustomElement,
+  IController,
+  lifecycleHooks,
+} from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/lifecycle-hooks.bound.spec.ts [synchronous]', function () {
+
+  const hookSymbol = Symbol();
+  let tracker: LifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new LifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class BoundLoggingHook<T> {
+    bound(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      tracker.bound++;
+      tracker.controllers.push(initiator);
+    }
+  }
+
+  it('invokes global bound hooks', async function () {
+    const { component } = await createFixture
+      .html`\${message}`
+      .deps(BoundLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(tracker.bound, 1);
+  });
+
+  it('invokes when registered both globally and locally', async function () {
+    const { component } = await createFixture
+      .component(CustomElement.define({ name: 'app', dependencies: [BoundLoggingHook] }))
+      .html`\${message}`
+      .deps(BoundLoggingHook)
+      .build().started;
+
+    assert.strictEqual(component[hookSymbol], hookSymbol);
+    assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
+    assert.strictEqual(tracker.bound, 2);
+    assert.deepStrictEqual(tracker.controllers, [component.$controller, component.$controller]);
+  });
+
+  it('invokes before the view model lifecycle', async function () {
+    let boundCallCount = 0;
+    await createFixture
+      .component(class App {
+        bound() {
+          assert.strictEqual(this[hookSymbol], hookSymbol);
+          boundCallCount++;
+        }
+      })
+      .html``
+      .deps(BoundLoggingHook)
+      .build().started;
+
+    assert.strictEqual(boundCallCount, 1);
+  });
+
+  it('invokes global bound hooks for Custom attribute controller', async function () {
+    let current: Square | null = null;
+    @customAttribute('square')
+    class Square {
+      created() { current = this; }
+    }
+
+    await createFixture
+      .html`<div square>`
+      .deps(BoundLoggingHook, Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(tracker.bound, 2);
+  });
+
+  it('invokes bound hooks on Custom attribute', async function () {
+    let current: Square | null = null;
+    @customAttribute({ name: 'square', dependencies: [BoundLoggingHook] })
+    class Square {
+      created() { current = this; }
+    }
+
+    await createFixture
+      .html`<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.instanceOf(current, Square);
+    assert.strictEqual(tracker.bound, 1);
+  });
+
+  it('does not invokes bound hooks on synthetic controller of repeat', async function () {
+    await createFixture
+      .html('<div repeat.for="i of 2">')
+      .deps(BoundLoggingHook)
+      .build().started;
+    assert.strictEqual(tracker.bound, /* root CE + repeat CA */ 2);
+  });
+
+  class LifeycyleTracker {
+    bound: number = 0;
+    controllers: IController[] = [];
+  }
+});
+
+describe('3-runtime-html/lifecycle-hooks.bound.spec.ts [asynchronous]', function () {
+
+  const hookSymbol = Symbol();
+  let tracker: AsyncLifeycyleTracker | null = null;
+
+  this.beforeEach(function () {
+    tracker = new AsyncLifeycyleTracker();
+  });
+
+  @lifecycleHooks()
+  class boundLoggingHook<T> {
+    bound(vm: T, initiator: IController) {
+      vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
+      tracker.trace('lch.start');
+      return waitForTicks(5).then(() => tracker.trace('lch.end'));
+    }
+  }
+
+  it('invokes global hook in parallel', async function () {
+    await createFixture
+      .component(class {
+        bound() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .deps(boundLoggingHook)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes local hooks in parallel', async function () {
+    await createFixture
+      .component(class {
+        static dependencies = [boundLoggingHook];
+        bound() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html``
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+    ]);
+  });
+
+  it('invokes global hooks in parallel for CA', async function () {
+    @customAttribute('square')
+    class Square {
+      bound() {
+        tracker.trace('square.start');
+        return waitForTicks(1).then(() => tracker.trace('square.end'));
+      }
+    }
+
+    await createFixture
+      .component(class {
+        static dependencies = [boundLoggingHook];
+        bound() {
+          tracker.trace('comp.start');
+          return waitForTicks(1).then(() => tracker.trace('comp.end'));
+        }
+      })
+      .html`<div square>`
+      .deps(Square)
+      .build().started;
+
+    assert.deepStrictEqual(tracker.logs, [
+      // bound lifecycle resolves top down sequentially similiarly like binding
+      // means children (square CA) will only be invoked
+      // after parent (hooks + root CE) have been resolved
+      'lch.start',
+      'comp.start',
+      'comp.end',
+      'lch.end',
+      'square.start',
+      'square.end',
+    ]);
+  });
+
+  const waitForTicks = async (count: number) => {
+    while (count-- > 0) {
+      await Promise.resolve();
+    }
+  };
+
+  class AsyncLifeycyleTracker {
+    logs: string[] = [];
+    trace(msg: string): void {
+      this.logs.push(msg);
+    }
+  }
+});

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.unbinding.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.unbinding.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
-describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [synchronous]', function () {
+describe('3-runtime-html/lifecycle-hooks.unbinding.spec.ts [synchronous]', function () {
   let tracker: LifeycyleTracker | null = null;
   this.beforeEach(function () {
     tracker = new LifeycyleTracker();
@@ -15,61 +15,61 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [synchronous]', funct
   const hookSymbol = Symbol();
 
   @lifecycleHooks()
-  class DetachingLoggingHook<T> {
-    detaching(vm: T, initiator: IController) {
+  class UnbindingLoggingHook<T> {
+    unbinding(vm: T, initiator: IController) {
       vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
-      tracker.detaching++;
+      tracker.unbinding++;
       tracker.controllers.push(initiator);
     }
   }
 
-  it('invokes global detaching hooks', async function () {
+  it('invokes global unbinding hooks', async function () {
     const { component, tearDown } = await createFixture
       .html`\${message}`
-      .deps(DetachingLoggingHook)
+      .deps(UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
 
     assert.strictEqual(component[hookSymbol], hookSymbol);
     assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(tracker.detaching, 1);
+    assert.strictEqual(tracker.unbinding, 1);
   });
 
   it('invokes when registered both globally and locally', async function () {
     const { component, tearDown } = await createFixture
-      .component(CustomElement.define({ name: 'app', dependencies: [DetachingLoggingHook] }))
+      .component(CustomElement.define({ name: 'app', dependencies: [UnbindingLoggingHook] }))
       .html`\${message}`
-      .deps(DetachingLoggingHook)
+      .deps(UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
 
     assert.strictEqual(component[hookSymbol], hookSymbol);
     assert.strictEqual(component.$controller[hookSymbol], hookSymbol);
-    assert.strictEqual(tracker.detaching, 2);
+    assert.strictEqual(tracker.unbinding, 2);
     assert.deepStrictEqual(tracker.controllers, [component.$controller, component.$controller]);
   });
 
   it('invokes before the view model lifecycle', async function () {
-    let detachingCallCount = 0;
+    let unbindingCallCount = 0;
     const { tearDown } = await createFixture
       .component(class App {
-        detaching() {
+        unbinding() {
           assert.strictEqual(this[hookSymbol], hookSymbol);
-          detachingCallCount++;
+          unbindingCallCount++;
         }
       })
       .html``
-      .deps(DetachingLoggingHook)
+      .deps(UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
 
-    assert.strictEqual(detachingCallCount, 1);
+    assert.strictEqual(unbindingCallCount, 1);
   });
 
-  it('invokes global detaching hooks for Custom attribute controller', async function () {
+  it('invokes global unbinding hooks for Custom attribute controller', async function () {
     let current: Square | null = null;
     @customAttribute('square')
     class Square {
@@ -78,20 +78,23 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [synchronous]', funct
 
     const { tearDown } = await createFixture
       .html`<div square>`
-      .deps(DetachingLoggingHook, Square)
+      .deps(UnbindingLoggingHook, Square)
       .build().started;
 
     await tearDown();
 
     assert.instanceOf(current, Square);
-    assert.strictEqual(tracker.detaching, 2);
+    assert.strictEqual(tracker.unbinding, 2);
   });
 
-  it('invokes detaching hooks on Custom attribute', async function () {
+  it('invokes unbinding hooks on Custom attribute', async function () {
     let current: Square | null = null;
-    @customAttribute({ name: 'square', dependencies: [DetachingLoggingHook] })
+    @customAttribute({ name: 'square', dependencies: [UnbindingLoggingHook] })
     class Square {
       created() { current = this; }
+      unbinding() {
+        console.log('?????????');
+      }
     }
 
     const { tearDown } = await createFixture
@@ -102,27 +105,27 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [synchronous]', funct
     await tearDown();
 
     assert.instanceOf(current, Square);
-    assert.strictEqual(tracker.detaching, 1);
+    assert.strictEqual(tracker.unbinding, 1);
   });
 
-  it('does not invokes detaching hooks on synthetic controller of repeat', async function () {
+  it('does not invokes unbinding hooks on synthetic controller of repeat', async function () {
     const { tearDown } = await createFixture
       .html('<div repeat.for="i of 2">')
-      .deps(DetachingLoggingHook)
+      .deps(UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
 
-    assert.strictEqual(tracker.detaching, /* root CE + repeat CA */ 2);
+    assert.strictEqual(tracker.unbinding, /* root CE + repeat CA */ 2);
   });
 
   class LifeycyleTracker {
-    detaching: number = 0;
+    unbinding: number = 0;
     controllers: IController[] = [];
   }
 });
 
-describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', function () {
+describe('3-runtime-html/lifecycle-hooks.unbinding.spec.ts [asynchronous]', function () {
 
   const hookSymbol = Symbol();
   let tracker: AsyncLifeycyleTracker | null = null;
@@ -132,8 +135,8 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   });
 
   @lifecycleHooks()
-  class DetachingLoggingHook<T> {
-    async detaching(vm: T, initiator: IController) {
+  class UnbindingLoggingHook<T> {
+    unbinding(vm: T, initiator: IController) {
       vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
       tracker.trace('lch.start');
       return waitForTicks(5).then(() => tracker.trace('lch.end'));
@@ -141,8 +144,8 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   }
 
   @lifecycleHooks()
-  class DetachingLoggingHook2<T> {
-    async detaching(vm: T, initiator: IController) {
+  class UnbindingLoggingHook2<T> {
+    unbinding(vm: T, initiator: IController) {
       vm[hookSymbol] = initiator[hookSymbol] = hookSymbol;
       tracker.trace('lch2.start');
       return waitForTicks(5).then(() => tracker.trace('lch2.end'));
@@ -152,13 +155,13 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   it('invokes global hook in parallel', async function () {
     const { tearDown } = await createFixture
       .component(class {
-        detaching() {
+        unbinding() {
           tracker.trace('comp.start');
           return waitForTicks(1).then(() => tracker.trace('comp.end'));
         }
       })
       .html``
-      .deps(DetachingLoggingHook)
+      .deps(UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
@@ -174,8 +177,8 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   it('invokes local hooks in parallel', async function () {
     const { tearDown } = await createFixture
       .component(class {
-        static dependencies = [DetachingLoggingHook];
-        detaching() {
+        static dependencies = [UnbindingLoggingHook];
+        unbinding() {
           tracker.trace('comp.start');
           return waitForTicks(1).then(() => tracker.trace('comp.end'));
         }
@@ -196,7 +199,7 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   it('invokes global hooks in parallel for CA', async function () {
     @customAttribute('square')
     class Square {
-      detaching() {
+      unbinding() {
         tracker.trace('square.start');
         return waitForTicks(1).then(() => tracker.trace('square.end'));
       }
@@ -204,19 +207,19 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
 
     const { tearDown } = await createFixture
       .component(class {
-        detaching() {
+        unbinding() {
           tracker.trace('comp.start');
           return waitForTicks(1).then(() => tracker.trace('comp.end'));
         }
       })
       .html`<div square>`
-      .deps(DetachingLoggingHook, Square)
+      .deps(Square, UnbindingLoggingHook)
       .build().started;
 
     await tearDown();
 
     assert.deepStrictEqual(tracker.logs, [
-      // detaching executes bottom up
+      // unbinding starts bottom up
       'lch.start',
       'square.start',
       'lch.start',
@@ -231,8 +234,8 @@ describe('3-runtime-html/lifecycle-hooks.detaching.spec.ts [asynchronous]', func
   it('invokes hooks in the same order with registration', async function () {
     const { tearDown } = await createFixture
       .component(class {
-        static dependencies = [DetachingLoggingHook2, DetachingLoggingHook];
-        detaching() {
+        static dependencies = [UnbindingLoggingHook2, UnbindingLoggingHook];
+        unbinding() {
           tracker.trace('comp.start');
           return waitForTicks(1).then(() => tracker.trace('comp.end'));
         }

--- a/packages/__tests__/3-runtime-html/lifecycle-hooks.unbinding.spec.ts
+++ b/packages/__tests__/3-runtime-html/lifecycle-hooks.unbinding.spec.ts
@@ -92,9 +92,6 @@ describe('3-runtime-html/lifecycle-hooks.unbinding.spec.ts [synchronous]', funct
     @customAttribute({ name: 'square', dependencies: [UnbindingLoggingHook] })
     class Square {
       created() { current = this; }
-      unbinding() {
-        console.log('?????????');
-      }
     }
 
     const { tearDown } = await createFixture


### PR DESCRIPTION
Continue the work on lifecycle hooks, part of #1044, add `binding`/`bound`/`unbinding` lifecycle hooks. It'll be working similarly like other lifecycles:

| # | invocation timing | sequence | direction |
| - | - | - | - |
| binding | before view model `binding` | parallel | top down - sequential |
| bound | before view model `bound` | parallel | top down - sequential |
| unbinding| before view model `unbinding` | parallel | bottom up - parallel |
