### PR TITLE
fix(router-lite): better handling of parameters and querystring

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -153,6 +153,31 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch mocha router-lite tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceRoot}/packages/__tests__/tsconfig.json"
+      },
+      "args": [
+        "--ui",
+        "bdd",
+        "--reporter",
+        "min",
+        "--colors",
+        "--recursive",
+        "--timeout",
+        "5000",
+        "--watch-extensions",
+        "js",
+        "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/setup-node.js",
+        "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/router-lite/**/*.spec.js"
+      ],
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch mocha scheduler tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "env": {

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -49,7 +49,6 @@ describe('load custom-attribute', function () {
       template: `
     <a load="route:foo; params.bind:{id: 1}; active.bind:active1" active.class="active1"></a>
     <a load="route:foo/2; active.bind:active2" active.class="active2"></a>
-    <a load="route:foo; params.bind:{id: 3, a: 2}; active.bind:active3" active.class="active3"></a>
     <au-viewport></au-viewport>`
     })
     class Root { }
@@ -61,26 +60,43 @@ describe('load custom-attribute', function () {
     const anchors = host.querySelectorAll('a');
     const a1 = { href: 'foo/1', active: false };
     const a2 = { href: 'foo/2', active: false };
-    const a3 = { href: 'foo/3?a=2', active: false };
-    assertAnchors(anchors, [a1, a2, a3], 'round#1');
+    assertAnchors(anchors, [a1, a2], 'round#1');
 
     anchors[1].click();
     await queue.yield();
     a2.active = true;
-    assertAnchors(anchors, [a1, a2, a3], 'round#2');
+    assertAnchors(anchors, [a1, a2], 'round#2');
 
     anchors[0].click();
     await queue.yield();
     a1.active = true;
     a2.active = false;
-    assertAnchors(anchors, [a1, a2, a3], 'round#3');
+    assertAnchors(anchors, [a1, a2], 'round#3');
 
-    anchors[2].click();
+    await au.stop();
+  });
+
+  it('un-configured parameters are added to the querystring', async function () {
+    @customElement({ name: 'fo-o', template: '' })
+    class Foo { }
+
+    @route({
+      routes: [
+        { id: 'foo', path: 'foo/:id', component: Foo }
+      ]
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `<a load="route:foo; params.bind:{id: 3, a: 2};"></a><au-viewport></au-viewport>`
+    })
+    class Root { }
+
+    const { au, host, container } = await start(Root, Foo);
+    const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
-    a1.active = false;
-    a3.active = true;
-    assertAnchors(anchors, [a1, a2, a3], 'round#4');
 
+    const anchor = host.querySelector('a');
+    assert.match(anchor.href, /foo\/3\?a=2/);
     await au.stop();
   });
 });

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -49,6 +49,7 @@ describe('load custom-attribute', function () {
       template: `
     <a load="route:foo; params.bind:{id: 1}; active.bind:active1" active.class="active1"></a>
     <a load="route:foo/2; active.bind:active2" active.class="active2"></a>
+    <a load="route:foo; params.bind:{id: 3, a: 2}; active.bind:active3" active.class="active3"></a>
     <au-viewport></au-viewport>`
     })
     class Root { }
@@ -60,18 +61,25 @@ describe('load custom-attribute', function () {
     const anchors = host.querySelectorAll('a');
     const a1 = { href: 'foo/1', active: false };
     const a2 = { href: 'foo/2', active: false };
-    assertAnchors(anchors, [a1, a2]);
+    const a3 = { href: 'foo/3?a=2', active: false };
+    assertAnchors(anchors, [a1, a2, a3], 'round#1');
 
     anchors[1].click();
     await queue.yield();
     a2.active = true;
-    assertAnchors(anchors, [a1, a2]);
+    assertAnchors(anchors, [a1, a2, a3], 'round#2');
 
     anchors[0].click();
     await queue.yield();
     a1.active = true;
     a2.active = false;
-    assertAnchors(anchors, [a1, a2]);
+    assertAnchors(anchors, [a1, a2, a3], 'round#3');
+
+    anchors[2].click();
+    await queue.yield();
+    a1.active = false;
+    a3.active = true;
+    assertAnchors(anchors, [a1, a2, a3], 'round#4');
 
     await au.stop();
   });

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -1098,7 +1098,7 @@ describe('router (smoke tests)', function () {
     const a1Params: Params[] = [];
     const a2Params: Params[] = [];
     const b1Params: Params[] = [];
-    const b2arams: Params[] = [];
+    const b2Params: Params[] = [];
     @customElement({ name: 'b1', template: null })
     class B1 {
       public load(params: Params) {
@@ -1108,7 +1108,7 @@ describe('router (smoke tests)', function () {
     @customElement({ name: 'b2', template: null })
     class B2 {
       public load(params: Params) {
-        b2arams.push(params);
+        b2Params.push(params);
       }
     }
     @route({
@@ -1172,13 +1172,12 @@ describe('router (smoke tests)', function () {
     await router.load('a1/a/b1/b+a2/c/b2/d');
     await router.load('a1/1/b1/2+a2/3/b2/4');
 
-    // TODO(sayan): avoid adding parent parameters; or add those to a separate property.
     assert.deepStrictEqual(
       [
         a1Params,
         b1Params,
         a2Params,
-        b2arams,
+        b2Params,
       ],
       [
         [
@@ -1186,16 +1185,16 @@ describe('router (smoke tests)', function () {
           { a: '1' },
         ],
         [
-          { a: 'a', b: 'b' },
-          { a: '1', b: '2' },
+          { b: 'b' },
+          { b: '2' },
         ],
         [
           { c: 'c' },
           { c: '3' },
         ],
         [
-          { c: 'c', d: 'd' },
-          { c: '3', d: '4' },
+          { d: 'd' },
+          { d: '4' },
         ],
       ],
     );

--- a/packages/router-lite/src/index.ts
+++ b/packages/router-lite/src/index.ts
@@ -88,6 +88,7 @@ export {
   type ResolutionMode,
   type HistoryStrategy,
   type SameUrlStrategy,
+  type LoadOptions,
 } from './router';
 
 export {

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -104,7 +104,6 @@ export class ViewportInstruction<TComponent extends ITypedNavigationInstruction_
   }
 
   public contains(other: ViewportInstruction): boolean {
-    // TODO: short-circuit for recognized-route
     const thisChildren = this.children;
     const otherChildren = other.children;
     if (thisChildren.length < otherChildren.length) {
@@ -127,7 +126,6 @@ export class ViewportInstruction<TComponent extends ITypedNavigationInstruction_
   }
 
   public equals(other: ViewportInstruction): boolean {
-    // TODO: short-circuit for recognized-route
     const thisChildren = this.children;
     const otherChildren = other.children;
     if (thisChildren.length !== otherChildren.length) {

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -3,12 +3,10 @@ import { BindingMode } from '@aurelia/runtime';
 import { customAttribute, bindable, ICustomAttributeViewModel, IEventDelegator, IEventTarget, INode, CustomElement } from '@aurelia/runtime-html';
 
 import { IRouter } from '../router';
-import { $RecognizedRoute, IRouteContext } from '../route-context';
+import { IRouteContext } from '../route-context';
 import { NavigationInstruction, Params, ViewportInstructionTree } from '../instructions';
 import { IRouterEvents } from '../router-events';
-import { RouteDefinition } from '../route-definition';
 import { ILocationManager } from '../location-manager';
-import { ConfigurableRoute, Endpoint, RecognizedRoute } from '@aurelia/route-recognizer';
 
 @customAttribute('load')
 export class LoadCustomAttribute implements ICustomAttributeViewModel {

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -3,11 +3,12 @@ import { BindingMode } from '@aurelia/runtime';
 import { customAttribute, bindable, ICustomAttributeViewModel, IEventDelegator, IEventTarget, INode, CustomElement } from '@aurelia/runtime-html';
 
 import { IRouter } from '../router';
-import { IRouteContext } from '../route-context';
+import { $RecognizedRoute, IRouteContext } from '../route-context';
 import { NavigationInstruction, Params, ViewportInstructionTree } from '../instructions';
 import { IRouterEvents } from '../router-events';
 import { RouteDefinition } from '../route-definition';
 import { ILocationManager } from '../location-manager';
+import { ConfigurableRoute, Endpoint, RecognizedRoute } from '@aurelia/route-recognizer';
 
 @customAttribute('load')
 export class LoadCustomAttribute implements ICustomAttributeViewModel {
@@ -15,7 +16,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   public route: unknown;
 
   @bindable({ mode: BindingMode.toView, callback: 'valueChanged' })
-  public params: unknown;
+  public params?: Params;
 
   @bindable({ mode: BindingMode.toView })
   public attribute: string = 'href';
@@ -71,41 +72,16 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   public valueChanged(): void {
     const useHash = this.router.options.useUrlFragmentHash;
     if (this.route !== null && this.route !== void 0 && this.ctx.allResolved === null) {
-      const def = (this.ctx.childRoutes as RouteDefinition[]).find(x => x.id === this.route);
-      if (def !== void 0) {
-        // TODO(fkleuver): massive temporary hack. Will not work for siblings etc. Need to fix.
-        const parentPath = this.ctx.node.computeAbsolutePath();
-        // Note: This is very much preliminary just to fill the feature gap of v1's `generate`. It probably misses a few edge cases.
-        // TODO(fkleuver): move this logic to RouteExpression and expose via public api, add tests etc
-        let path = def.path[0];
-        if (typeof this.params === 'object' && this.params !== null) {
-          const keys = Object.keys(this.params);
-          for (const key of keys) {
-            const value = (this.params as Params)[key];
-            if (value != null && String(value).length > 0) {
-              path = path.replace(new RegExp(`[*:]${key}[?]?`), value);
-            }
-          }
-        }
-        // Remove leading and trailing optional param parts
-        path = path.replace(/\/[*:][^/]+[?]/g, '').replace(/[*:][^/]+[?]\//g, '');
-        if (parentPath) {
-          if (path) {
-            this.href = `${useHash ? '#' : ''}${[parentPath, path].join('/')}`;
-          } else {
-            this.href = `${useHash ? '#' : ''}${parentPath}`;
-          }
-        } else {
-          this.href = `${useHash ? '#' : ''}${path}`;
-        }
-        this.instructions = this.router.createViewportInstructions(`${useHash ? '#' : ''}${path}`, { context: this.ctx });
+      const instructions = this.ctx.generateTree(this.route as string, this.params as Params);
+      if (instructions !== null) {
+        this.href = (this.instructions = instructions).toUrl(useHash);
       } else {
         if (typeof this.params === 'object' && this.params !== null) {
           this.instructions = this.router.createViewportInstructions({ component: this.route as NavigationInstruction, params: this.params as Params }, { context: this.ctx });
         } else {
           this.instructions = this.router.createViewportInstructions(this.route as NavigationInstruction, { context: this.ctx });
         }
-        this.href = this.instructions.toUrl(this.router.options.useUrlFragmentHash);
+        this.href = this.instructions.toUrl(useHash);
       }
     } else {
       this.instructions = null;

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -457,6 +457,7 @@ export class RouteContext {
   }
 
   // this is separate method might be helpful if we need to create a public path generation utility function in future.
+  /** @internal */
   private _generatePathInternal(id: string, params?: Params | null): PathGenerationResult | null {
     if (id == null) return null;
 

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -1,6 +1,6 @@
 import { IContainer, ResourceDefinition, DI, InstanceProvider, Registration, ILogger, IModuleLoader, IModule, onResolve, noop } from '@aurelia/kernel';
 import { CustomElementDefinition, CustomElement, ICustomElementController, IController, isCustomElementViewModel, isCustomElementController, IAppRoot, IPlatform } from '@aurelia/runtime-html';
-import { RouteRecognizer, RecognizedRoute } from '@aurelia/route-recognizer';
+import { RouteRecognizer, RecognizedRoute, ConfigurableRoute, Endpoint } from '@aurelia/route-recognizer';
 
 import { RouteDefinition } from './route-definition';
 import { ViewportAgent, ViewportRequest } from './viewport-agent';
@@ -11,13 +11,15 @@ import { IViewport } from './resources/viewport';
 import { Routeable } from './route';
 import { isPartialChildRouteConfig } from './validation';
 import { ensureArrayOfStrings } from './util';
-import { Params } from './instructions';
+import { IViewportInstruction, Params, ViewportInstructionTree } from './instructions';
 import { IRouterEvents } from './router-events';
 
-export interface IRouteContext extends RouteContext {}
+export interface IRouteContext extends RouteContext { }
 export const IRouteContext = DI.createInterface<IRouteContext>('IRouteContext');
 
 export const RESIDUE = 'au$residue' as const;
+
+type PathGenerationResult = { path: string; def: RouteDefinition; consumed: Params; unconsumed: Params | null };
 
 /**
  * Holds the information of a component in the context of a specific container.
@@ -126,7 +128,7 @@ export class RouteContext {
     public readonly component: CustomElementDefinition,
     public readonly definition: RouteDefinition,
     public readonly parentContainer: IContainer,
-    router: IRouter,
+    private readonly _router: IRouter,
   ) {
     this._vpa = viewportAgent;
     if (parent === null) {
@@ -167,7 +169,7 @@ export class RouteContext {
     // If need be we can optimize it later.
     container
       .get(IRouterEvents)
-      .subscribe('au:router:navigation-end', () => navModel.setIsActive(router, this));
+      .subscribe('au:router:navigation-end', () => navModel.setIsActive(_router, this));
     this.processDefinition(definition);
   }
 
@@ -306,7 +308,6 @@ export class RouteContext {
   public dispose(): void {
     this.container.dispose();
   }
-  // #endregion
 
   public resolveViewportAgent(req: ViewportRequest): ViewportAgent {
     this.logger.trace(`resolveViewportAgent(req:%s)`, req);
@@ -453,6 +454,69 @@ export class RouteContext {
       }
       return defaultExport;
     });
+  }
+
+  // this is separate method might be helpful if we need to create a public path generation utility function in future.
+  private _generatePathInternal(id: string, params?: Params | null): PathGenerationResult | null {
+    if (id == null) return null;
+
+    const def = (this.childRoutes as RouteDefinition[]).find(x => x.id === id);
+    if (def === void 0) return null;
+
+    let path = def.path[0]; // [Sayan]: we probably should select the "most" matched path
+    const consumed: Params = Object.create(null);
+    const unconsumed: Params = Object.create(null);
+    let hasUnconsumedParams = false;
+    if (typeof params === 'object' && params !== null) {
+      const keys = Object.keys(params);
+      for (const key of keys) {
+        const value = params[key];
+        const re = new RegExp(`[*:]${key}[?]?`);
+        const matches = re.exec(path);
+        if (matches === null) {
+          unconsumed[key] = value;
+          hasUnconsumedParams = true;
+          continue;
+        }
+        if (value != null && String(value).length > 0) {
+          path = path.replace(matches[0], value);
+          consumed[key] = value;
+        }
+      }
+    }
+    // Remove leading and trailing optional param parts
+    return {
+      path: path.replace(/\/[*:][^/]+[?]/g, '').replace(/[*:][^/]+[?]\//g, ''),
+      def,
+      consumed,
+      unconsumed: hasUnconsumedParams ? unconsumed : null,
+    };
+  }
+
+  /** @internal */
+  public generateTree(id: string, params: Params | null | undefined): ViewportInstructionTree | null {
+    const val = this._generatePathInternal(id, params);
+    if(val === null) return null;
+
+    const { path, def, consumed, unconsumed } = val;
+
+    // TODO(Sayan): Investigate why we need params in so many places; probably it will be less hairy when the URL pattern is used.
+    // we don't necessarily need to add the # to the path here.
+    const route = new ConfigurableRoute(path, def.caseSensitive, def);
+    const endpoint = new Endpoint(route, Object.keys(consumed));
+    const rr = new RecognizedRoute(endpoint, consumed);
+    const instruction: Partial<IViewportInstruction> = {
+      recognizedRoute: new $RecognizedRoute(rr, null),
+      component: path,
+      context: this,
+    };
+    return this._router.createViewportInstructions(
+        [instruction],
+        {
+          context: this,
+          queryParams: unconsumed
+        }
+      );
   }
 
   public toString(): string {

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -627,8 +627,7 @@ function createConfiguredNode(
         instruction: vi,
         originalInstruction: originalVi,
         params: {
-          ...node.params,
-          ...rr.route.params
+          ...rr.route.params,
         },
         queryParams: rt.queryParams,
         fragment: rt.fragment,

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -523,8 +523,12 @@ function createNode(
   append: boolean,
 ): RouteNode | Promise<RouteNode> | null {
   const ctx = node.context;
-  let collapse: number = 0;
   const originalInstruction = vi.clone();
+  let rr = vi.recognizedRoute;
+  // early return; we already have a recognized route, don't bother with the rest.
+  if (rr !== null) return createConfiguredNode(log, node, vi, append, rr, originalInstruction);
+
+  let collapse: number = 0;
   let path = vi.component.value;
   let cur = vi as ViewportInstruction;
   while (cur.children.length === 1) {
@@ -537,7 +541,7 @@ function createNode(
     }
   }
 
-  const rr = ctx.recognize(path);
+  rr = ctx.recognize(path);
   log.trace('createNode recognized route: %s', rr);
   const residue = rr?.residue ?? null;
   log.trace('createNode residue:', residue);

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -131,6 +131,7 @@ export class RouterOptions {
   }
 }
 
+export type LoadOptions = INavigationOptions & { params?: Params };
 export interface INavigationOptions extends Partial<NavigationOptions> { }
 export class NavigationOptions extends RouterOptions {
   public static get DEFAULT(): NavigationOptions { return NavigationOptions.create({}); }
@@ -461,7 +462,7 @@ export class Router {
    * router.load('product-detail/37', { context: this });
    * ```
    */
-  public load(path: string, options?: INavigationOptions): Promise<boolean>;
+  public load(path: string, options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided paths as siblings.
    *
@@ -471,7 +472,7 @@ export class Router {
    * router.load(['category/50/product/20', 'widget/30']);
    * ```
    */
-  public load(paths: readonly string[], options?: INavigationOptions): Promise<boolean>;
+  public load(paths: readonly string[], options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided component type. Must be a custom element.
    *
@@ -482,7 +483,7 @@ export class Router {
    * router.load(CustomElement.define({ name: 'greeter', template: 'Hello!' }));
    * ```
    */
-  public load(componentType: RouteType, options?: INavigationOptions): Promise<boolean>;
+  public load(componentType: RouteType, options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided component types. Must be custom elements.
    *
@@ -492,7 +493,7 @@ export class Router {
    * router.load([MemberList, OrganizationList]);
    * ```
    */
-  public load(componentTypes: readonly RouteType[], options?: INavigationOptions): Promise<boolean>;
+  public load(componentTypes: readonly RouteType[], options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided component definition. May or may not be pre-compiled.
    *
@@ -502,7 +503,7 @@ export class Router {
    * router.load({ name: 'greeter', template: 'Hello!' });
    * ```
    */
-  public load(componentDefinition: PartialCustomElementDefinition, options?: INavigationOptions): Promise<boolean>;
+  public load(componentDefinition: PartialCustomElementDefinition, options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided component instance.
    *
@@ -515,7 +516,7 @@ export class Router {
    * router.load(greeter);
    * ```
    */
-  public load(componentInstance: IRouteViewModel, options?: INavigationOptions): Promise<boolean>;
+  public load(componentInstance: IRouteViewModel, options?: LoadOptions): Promise<boolean>;
   /**
    * Loads the provided ViewportInstruction, with component specified in any of the ways as described
    * in the other method overloads, and optional additional properties.
@@ -540,10 +541,16 @@ export class Router {
    * })
    * ```
    */
-  public load(viewportInstruction: IViewportInstruction, options?: INavigationOptions): boolean | Promise<boolean>;
-  public load(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options?: INavigationOptions): boolean | Promise<boolean>;
-  public load(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options?: INavigationOptions): boolean | Promise<boolean> {
-    const instructions = this.createViewportInstructions(instructionOrInstructions, options);
+  public load(viewportInstruction: IViewportInstruction, options?: LoadOptions): boolean | Promise<boolean>;
+  public load(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options?: LoadOptions): boolean | Promise<boolean>;
+  public load(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options?: LoadOptions): boolean | Promise<boolean> {
+    let instructions: ViewportInstructionTree | null = null;
+    const params = options?.params;
+    if(typeof instructionOrInstructions === 'string' && typeof params === 'object' && params !== null) {
+      const ctx = this.resolveContext(options?.context ?? null);
+      instructions = ctx.generateTree(instructionOrInstructions, params);
+    }
+    instructions ??= this.createViewportInstructions(instructionOrInstructions, options);
 
     this.logger.trace('load(instructions:%s)', instructions);
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This closes the issue #1347. That is, the router now supports `router.load('route/:id/as-configured', {params:{id:'foo'}})`. Any additional un-configured parameters are added to the query string.
This same behaviour is now also applicable for the `load` CA.

Finally, it removes the inclusion of parent node's parameters to the child node's parameter collection, in a hierarchical routing configuration.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
