### PR TITLE
Capture shortcut

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,12 +739,12 @@ workflows:
           path: "examples/jit-webpack-conventions-ts"
           requires:
             - build_release
-      - e2e_playwright:
-          <<: *filter_ignore_develop_release
-          name: webpack_vanilla_ts
-          path: "examples/jit-webpack-vanilla-ts"
-          requires:
-            - build_release
+      # - e2e_playwright:
+      #     <<: *filter_ignore_develop_release
+      #     name: webpack_vanilla_ts
+      #     path: "examples/jit-webpack-vanilla-ts"
+      #     requires:
+      #       - build_release
       - merge_and_dist:
           <<: *filter_only_master
           name: merge_and_dist_master
@@ -757,7 +757,7 @@ workflows:
             #- test_test262
             # - lint_packages
             - webpack_conventions_ts
-            - webpack_vanilla_ts
+            # - webpack_vanilla_ts
           from: master
           to: develop
           channel: dev

--- a/docs/user-docs/getting-to-know-aurelia/components/attributes-transferring.md
+++ b/docs/user-docs/getting-to-know-aurelia/components/attributes-transferring.md
@@ -77,6 +77,22 @@ To transfer attributes & bindings from a custom element, there are two steps:
 })
 ```
 
+Or use the `capture` decorator from `aurelia` package:
+```typescript
+import { capture } from 'aurelia';
+
+@capture
+export class MyCustomElement {
+  ...
+}
+
+// either form is valid
+@capture()
+export class MyCustomElement {
+  ...
+}
+```
+
 As the name suggests, this is to signal the template compiler that all the bindings & attributes, with some exceptions, should be captured for future usages.
 
 * Spread the captured attributes onto an element:
@@ -97,6 +113,15 @@ So as a safe practice, keep attribute spreading left-most in order to avoid pote
 {% hint style="warning" %}
 It's recommended that this feature should not be overused in multi level capturing & transferring. This is often known as prop-drilling in React, and could have bad effect on overall & long term maintainability of a project. It's probably healthy to limit the max level of transferring to 2.
 {% endhint %}
+
+## Usage with conventions
+
+Aurelia conventions enables the setting of `capture` metadata from the template via `<capture>` tag, like the following example:
+```markup
+<capture>
+
+<input ...$attrs>
+```
 
 ## How it works
 

--- a/examples/jit-webpack-conventions-ts/src/app.html
+++ b/examples/jit-webpack-conventions-ts/src/app.html
@@ -1,2 +1,4 @@
 <import from="./identity"></import>
+<import from="./components/jit-input"></import>
 <div>${message | identity}</div>
+<jit-input label="First name" aria-label="First name"></jit-input>

--- a/examples/jit-webpack-conventions-ts/src/components/jit-input.html
+++ b/examples/jit-webpack-conventions-ts/src/components/jit-input.html
@@ -1,0 +1,5 @@
+<capture />
+<label>
+  ${label}
+  <input ...$attrs>
+</label>

--- a/examples/jit-webpack-conventions-ts/src/components/jit-input.ts
+++ b/examples/jit-webpack-conventions-ts/src/components/jit-input.ts
@@ -1,0 +1,6 @@
+import { bindable } from 'aurelia';
+
+export class JitInput {
+  @bindable
+  label;
+}

--- a/packages-tooling/__tests__/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/plugin-conventions/preprocess-html-template.spec.ts
@@ -663,6 +663,48 @@ export function register(container) {
     assert.equal(result.code, expected);
   });
 
+  it('emits capture with <capture> element', function () {
+    const html = '<capture><template></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import "./foo-bar.css";
+export const name = "foo-bar";
+export const template = "<template></template>";
+export default template;
+export const dependencies = [  ];
+export const capture = true;
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, capture });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocessHtmlTemplate({ path: path.join('lo', 'foo-bar.html'), contents: html, filePair: 'foo-bar.css' }, preprocessOptions({ hmr: false }));
+    assert.equal(result.code, expected);
+  });
+
+  it('emits capture [capture] attribute on <template>', function () {
+    const html = '<template capture></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import "./foo-bar.css";
+export const name = "foo-bar";
+export const template = "<template ></template>";
+export default template;
+export const dependencies = [  ];
+export const capture = true;
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, capture });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocessHtmlTemplate({ path: path.join('lo', 'foo-bar.html'), contents: html, filePair: 'foo-bar.css' }, preprocessOptions({ hmr: false }));
+    assert.equal(result.code, expected);
+  });
+
   it('processes template with multiple css dependencies in cssModule mode', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"><require from="./foo-bar2.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime-html';

--- a/packages-tooling/__tests__/plugin-conventions/strip-meta-data.spec.ts
+++ b/packages-tooling/__tests__/plugin-conventions/strip-meta-data.spec.ts
@@ -1,6 +1,6 @@
 import { BindingMode } from '@aurelia/runtime';
 import { stripMetaData } from '@aurelia/plugin-conventions';
-import { assert } from '@aurelia/testing';
+import * as assert from 'assert';
 
 describe('stripMetaData', function () {
   it('returns empty html', function () {
@@ -11,6 +11,7 @@ describe('stripMetaData', function () {
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -34,6 +35,7 @@ describe('stripMetaData', function () {
       deps: ['./a'],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -61,6 +63,7 @@ ${'  ' /* leading space is untouched */}
       deps: ['./a', 'b', './c.css'],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -84,6 +87,7 @@ ${'  ' /* leading space is untouched */}
       deps: ['./a'],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -111,6 +115,7 @@ ${'  ' /* leading space is untouched */}
       deps: ['./a', 'foo', 'b', './c.css'],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -131,6 +136,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -154,6 +160,7 @@ ${'  ' /* leading space is untouched */}
       shadowMode: 'closed',
       deps: ['./a'],
       containerless: false,
+      capture: false,
       hasSlot: true,
       bindables: {}
     });
@@ -173,6 +180,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -193,6 +201,7 @@ ${'  ' /* leading space is untouched */}
       deps: ['./a'],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -212,6 +221,7 @@ ${'  ' /* leading space is untouched */}
       shadowMode: null,
       deps: [],
       containerless: true,
+      capture: false,
       hasSlot: false,
       bindables: {}
     });
@@ -232,6 +242,7 @@ ${'  ' /* leading space is untouched */}
       shadowMode: null,
       deps: [],
       containerless: true,
+      capture: false,
       hasSlot: false,
       bindables: {}
     });
@@ -250,9 +261,45 @@ ${'  ' /* leading space is untouched */}
       shadowMode: null,
       deps: [],
       containerless: true,
+      capture: false,
       hasSlot: false,
       bindables: {}
     });
+  });
+
+  it('strips capture with only open tag', function () {
+    const input = `<capture>`;
+    const expected = ``;
+    const { html, capture } = stripMetaData(input);
+    assert.deepStrictEqual({ html, capture }, { html: expected, capture: true });
+  });
+
+  it('strips capture with self closing tag', function () {
+    const input = `<capture/>`;
+    const expected = ``;
+    const { html, capture } = stripMetaData(input);
+    assert.deepStrictEqual({ html, capture }, { html: expected, capture: true });
+  });
+
+  it('strips capture with closing tag', function () {
+    const input = `<capture></capture>`;
+    const expected = ``;
+    const { html, capture } = stripMetaData(input);
+    assert.deepStrictEqual({ html, capture }, { html: expected, capture: true });
+  });
+
+  it('strips capture attribute on template', function () {
+    const input = `<template capture></template>`;
+    const expected = `<template ></template>`;
+    const { html, capture } = stripMetaData(input);
+    assert.deepStrictEqual({ html, capture }, { html: expected, capture: true });
+  });
+
+  it('strips capture attribute, ignores value on template', function () {
+    const input = `<template capture=false></template>`;
+    const expected = `<template ></template>`;
+    const { html, capture } = stripMetaData(input);
+    assert.deepStrictEqual({ html, capture }, { html: expected, capture: true });
   });
 
   it('strips bindable tag', function () {
@@ -271,6 +318,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: { firstName: {} }
     });
   });
@@ -299,6 +347,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {
         firstName: { mode: BindingMode.toView },
         lastName: { mode: BindingMode.twoWay, attribute: 'surname' },
@@ -323,6 +372,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: { firstName: {} }
     });
   });
@@ -341,6 +391,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: { firstName: {}, lastName: {} }
     });
   });
@@ -361,6 +412,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: { firstName: {}, lastName: {}, age: {} }
     });
   });
@@ -380,6 +432,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -398,6 +451,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -416,6 +470,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -434,6 +489,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -452,6 +508,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -470,6 +527,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -488,6 +546,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: {}
     });
   });
@@ -507,6 +566,7 @@ ${'  ' /* leading space is untouched */}
       shadowMode: null,
       deps: [],
       containerless: false,
+      capture: false,
       hasSlot: true,
       bindables: {}
     });
@@ -534,6 +594,7 @@ ${'  ' /* leading space is untouched */}
       deps: [],
       containerless: false,
       hasSlot: false,
+      capture: false,
       bindables: { firstName: {} }
     });
   });

--- a/packages-tooling/plugin-conventions/src/strip-meta-data.ts
+++ b/packages-tooling/plugin-conventions/src/strip-meta-data.ts
@@ -73,6 +73,7 @@ export function stripMetaData(rawHtml: string): IStrippedHtml {
 }
 
 function traverse(tree: any, cb: (node: DefaultTreeElement) => void) {
+  // eslint-disable-next-line
   tree.childNodes.forEach((n: any) => {
     const ne = n as DefaultTreeElement;
     // skip <template as-custom-element="..">

--- a/packages/__tests__/3-runtime-html/custom-elements.decorator.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.decorator.spec.ts
@@ -1,0 +1,14 @@
+import { capture, CustomElementDefinition } from '@aurelia/runtime-html';
+import { assert } from '@aurelia/testing';
+
+describe('3-runtime-html/custom-elements.decorator.spec.ts', function () {
+  describe('@capture', function () {
+    it('retrieves capture on class annonated', function () {
+      @capture
+      class El {}
+
+      const { capture: $capture } = CustomElementDefinition.create('el', El);
+      assert.deepStrictEqual($capture, true);
+    });
+  });
+});

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -508,6 +508,8 @@ export {
   containerless,
   customElement,
   CustomElement,
+  strict,
+  capture,
   // CustomElementDecorator,
   // CustomElementKind,
   // CustomElementType,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -272,6 +272,7 @@ export {
 } from './resources/resources-shared';
 
 export {
+  capture,
   containerless,
   customElement,
   CustomElement,
@@ -280,6 +281,7 @@ export {
   type CustomElementType,
   CustomElementDefinition,
   type PartialCustomElementDefinition,
+  strict,
   useShadowDOM,
   processContent,
 } from './resources/custom-element';

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -113,10 +113,10 @@ export type CustomElementKind = IResourceKind<CustomElementType, CustomElementDe
    */
   for<C extends ICustomElementViewModel = ICustomElementViewModel>(node: Node, opts: { optional: true }): ICustomElementController<C> | null;
   isType<C>(value: C): value is (C extends Constructable ? CustomElementType<C> : never);
-  define<C extends Constructable >(name: string, Type: C): CustomElementType<C>;
-  define<C extends Constructable >(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
-  define<C extends Constructable >(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
-  define<C extends Constructable >(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(name: string, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(def: PartialCustomElementDefinition, Type: C): CustomElementType<C>;
+  define<C extends Constructable>(def: PartialCustomElementDefinition, Type?: null): CustomElementType<C>;
+  define<C extends Constructable>(nameOrDef: string | PartialCustomElementDefinition, Type: C): CustomElementType<C>;
   getDefinition<C extends Constructable>(Type: C): CustomElementDefinition<C>;
   // eslint-disable-next-line
   getDefinition<C extends Constructable>(Type: Function): CustomElementDefinition<C>;
@@ -235,7 +235,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly enhance: boolean,
     public readonly watches: IWatchDefinition[],
     public readonly processContent: ProcessContentHook | null,
-  ) {}
+  ) { }
 
   public static create(
     def: PartialCustomElementDefinition,
@@ -574,13 +574,13 @@ export const CustomElement = Object.freeze<CustomElementKind>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const defaultProto = {} as any;
 
-    return function <P extends {} = {}> (
+    return function <P extends {} = {}>(
       name: string,
       proto: P = defaultProto,
     ): CustomElementType<Constructable<P>> {
       // Anonymous class ensures that minification cannot cause unintended side-effects, and keeps the class
       // looking similarly from the outside (when inspected via debugger, etc).
-      const Type = class {} as CustomElementType<Constructable<P>>;
+      const Type = class { } as CustomElementType<Constructable<P>>;
 
       // Define the name property so that Type.name can be used by end users / plugin authors if they really need to,
       // even when minified.
@@ -633,4 +633,22 @@ function ensureHook<TClass>(target: Constructable<TClass>, hook: string | Proces
       throw new Error(`AUR0766:${typeof hook}`);
   }
   return hook;
+}
+
+/**
+ * Decorator: Indicates that the custom element should capture all attributes and bindings that are not template controllers or bindables
+ */
+export function capture(target: Constructable): void;
+/**
+ * Decorator: Indicates that the custom element should be rendered with the strict binding option. undefined/null -> 0 or '' based on type
+ */
+export function capture(): (target: Constructable) => void;
+export function capture(target?: Constructable): void | ((target: Constructable) => void) {
+  if (target === void 0) {
+    return function ($target: Constructable) {
+      annotateElementMetadata($target, 'capture', true);
+    };
+  }
+
+  annotateElementMetadata(target, 'capture', true);
 }

--- a/packages/testing/src/inspect.ts
+++ b/packages/testing/src/inspect.ts
@@ -1615,7 +1615,7 @@ export function formatRaw(
   try {
     output = formatter(ctx, value, recurseTimes, keys, braces);
     let $key: PropertyKey;
-    const isNotNode = !(value instanceof PLATFORM.Node);
+    const isNotNode = PLATFORM?.Node != null && !(value instanceof PLATFORM.Node);
     for (i = 0; i < keys.length; i++) {
       $key = keys[i];
       if (

--- a/scripts/dev-tooling.ts
+++ b/scripts/dev-tooling.ts
@@ -58,12 +58,13 @@ if (devPackages.some(d => !validToolingPackages.includes(d))) {
   throw new Error(`Invalid package config, valid packages are: ${validToolingPackages}`);
 }
 
-const baseUrl = '.';
+// const baseUrl = '.';
+const baseUrl = './dist/cjs/__tests__/';
 const testFilePatterns = testPatterns === '*'
-  ? [`${baseUrl}/**/*.spec.ts`]
+  ? [`${baseUrl}/**/*.spec.js`]
   : testPatterns.split(' ').flatMap(pattern => [
-    `${baseUrl}/**/*${pattern.replace(/(?:\.spec)?(?:\.[tj]s)?$/, '*.spec.ts')}`,
-    `${baseUrl}/**/${pattern}/**/*.spec.ts`,
+    `${baseUrl}/**/*${pattern.replace(/(?:\.spec)?(?:\.[tj]s)?$/, '*.spec.js')}`,
+    `${baseUrl}/**/${pattern}/**/*.spec.js`,
   ]);
 
 console.log('test patterns preprocess:', testPatterns, 'post-process:', testFilePatterns);
@@ -79,7 +80,7 @@ concurrently([
   { command: devCmd, cwd: 'packages/kernel', name: 'kernel', env: envVars },
   // always watch plugin-convention by default, since this is the base line of all the things
   { command: devCmd, cwd: `${baseToolingPath}/plugin-conventions`, name: 'plugin-conventions', env: envVars },
-  // { command: devCmd, cwd: `${baseToolingPath}/__tests__`, name: '__tests__(build)', env: envVars },
+  { command: devCmd, cwd: `${baseToolingPath}/__tests__`, name: '__tests__(build)', env: envVars },
   ...devPackages
     .filter(pkg => pkg !== 'plugin-conventions').
     map((folder: string) => ({

--- a/test/playwright/src/examples.spec.ts
+++ b/test/playwright/src/examples.spec.ts
@@ -8,6 +8,8 @@ describe('examples', function () {
   for (const browserType of browserTypes) {
     describe(browserType, function () {
       it(`renders 'Hello World!'`, async function () {
+        this.timeout(5000);
+
         const browser = await playwright[browserType].launch();
         const context = await browser.newContext();
         const page = await context.newPage();
@@ -18,6 +20,9 @@ describe('examples', function () {
         const text = await (await page.$('app>div'))!.textContent();
 
         assert.strictEqual(text, 'Hello World!');
+
+        const input = await page.$('jit-input input');
+        assert.strictEqual(await input?.getAttribute('aria-label'), 'First name');
 
         await browser.close();
       });


### PR DESCRIPTION
# Pull Request

## 📖 Description

Closes #1465 

Add `<capture>` for conventions and `@capture` for standalone usage.
```html
<capture>
or
<template capture>
```
vm:
```ts
import { capture } from 'aurelia';

@capture
export class Field {
  ...
}
```

Also updated our pipeline so only convention is running now. If we want to test vanilla, probably it's best to put that into the same app with convention instead of running 2 independently.