### PR TITLE
docs(aurelia/state): Fix error in aurelia/state setup docs.

### DIFF
--- a/docs/user-docs/developer-guides/state/README.md
+++ b/docs/user-docs/developer-guides/state/README.md
@@ -77,8 +77,10 @@ import { keywordsHandler } from './action-handlers';
 
 Aurelia
   .register(
-    StateDefaultConfiguration.init(initialState),
-    keywordsHandler
+    StateDefaultConfiguration.init(
+      initialState,
+      keywordsHandler
+    )
   )
   .app(MyApp)
   .start();


### PR DESCRIPTION
# Pull Request

## 📖 Description
Improvement for [aurelia/state](https://docs.aurelia.io/developer-guides/state) documentation.

Aurelia/State has a typo in the initial setup documentation. Following the current documentation leads to a situation where the state is created, but the state isn't updated when using dispatch.  
Additionally, no warning is shown to the user that reducers are not registered.

### Change
Change made in `docs/user-docs/developer-guides/state/README.md`

```diff
Aurelia
  .register(
-   StateDefaultConfiguration.init(initialState),
-   keywordsHandler
+   StateDefaultConfiguration.init(
+     initialState,
+     keywordsHandler
+   )
  )
  .app(MyApp)
  .start();
```


### 🎫 Issues

Could not find an issue on this at the time of writing.

## 📑 Test Plan

Tests are not affected by this change.

## ⏭ Next Steps

Consider showing a warning to the user when a store is created, but no reducers have been registered. This would make debugging much easier.