### PR TITLE
docs(attributes): update docs to include explicit bindable call

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/custom-attributes.md
+++ b/docs/user-docs/getting-to-know-aurelia/custom-attributes.md
@@ -102,16 +102,16 @@ In some instances, you want a custom attribute that only has one bindable proper
   }
 ```
 
-The `value` property is automatically populated if a value is supplied to a custom attribute, without the need to explicitly define the value property as a bindable.
+The `value` property is automatically populated if a value is supplied to a custom attribute, however requires you to explicitly define the value property as a bindable.
 
 When the value is changed, we can access it like this:
 
 ```
-  import { customAttribute, INode } from 'aurelia-framework';
+  import { bindable, customAttribute, INode } from 'aurelia-framework';
   
   @customAttribute('red-square') 
   export class RedSquareCustomAttribute {
-    private value;
+    @bindable() private value;
     
     constructor(@INode private element: HTMLElement){
         this.element.style.width = this.element.style.height = '100px';


### PR DESCRIPTION
Per Discord discussions:
https://discord.com/channels/448698263508615178/448699158052864001/1005682444839682100

# Pull Request

## 📖 Description

```typescript
import { customAttribute, inject, INode } from 'aurelia';

@inject(Element)
@customAttribute('my-cool-attr')
export class MyCoolAttribute {
  private value: string;

  constructor(@INode private element: Element) {
    console.log('Attaching to an element'); // ✅
  }

  public bound() {
    console.log('Initial value set', this.value) // ✅;
  }

  public valueChanged(): void {
    console.log('Value just changed', this.value) // ❌;
  }
}
```

I had this simple example of a custom attribute, but "valueChanged" was not being called when the binding was updated.

@Sayan751 suggested trying `@bindable()` which fixed the issue and so I was encouraged to update docs. When I've come through to update the docs, I'm now wondering whether this is actually a bug - and the code above was expected to be correct?

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

* refer to above example

## 📑 Test Plan

n/a

## ⏭ Next Steps

* work out whether this is a bug (close this PR), or the expected behaviour (merge this PR)