### PR TITLE
Check full and mangled method names in HMR

### DIFF
--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -89,7 +89,11 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
         controller.definition = newDefinition;
         Object.assign(controller.viewModel, values);
         controller.hooks = new controller.hooks.constructor(controller.viewModel);
-        controller._hydrateCustomElement(hydrationInst, hydrationContext);
+        if (controller._hydrateCustomElement) {
+          controller._hydrateCustomElement(hydrationInst, hydrationContext);
+        } else {
+          controller.hE(hydrationInst, hydrationContext);
+        }
         h.parentNode.replaceChild(controller.host, h);
         controller.hostController = null;
         controller.deactivate(controller, controller.parent ?? null, LifecycleFlags.none);


### PR DESCRIPTION
# Pull Request

## 📖 Description

When using dev app build one must configure aliases to include dev Aurelia build for HMR to work. This add checks for original and mangled private method name to avoid this requirement.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
