### PR TITLE
build(tests): make test runs on firefox less brittle

### DIFF
--- a/packages/__tests__/3-runtime-html/event-manager.spec.ts
+++ b/packages/__tests__/3-runtime-html/event-manager.spec.ts
@@ -433,7 +433,6 @@ describe('EventDelegator', function () {
         for (const opts of [{ capture: true }, { capture: false }] as AddEventListenerOptions[]) {
           for (const stopPropagation of [true, false]) {
             for (const returnValue of [true, false, undefined]) {
-              // TODO: for firefox this won't work because ShadowDOM is not implemented yet. The webcomponents polyfill won't make it work either. Need to investigate what we can or cannot support.
               for (const shadow of hasShadow ? [null, 'open', 'closed'] : [null]) { // TODO: 'open' should probably work in some way, so we need to try and fix this
                 for (const listenerObj of [null, { handleEvent: null }]) {
                   it(_`opts=${opts}, eventName=${eventName}, bubbles=${bubbles}, stopPropagation=${stopPropagation}, returnValue=${returnValue}, shadow=${shadow}, listener=${listenerObj}`, function () {

--- a/packages/__tests__/3-runtime-html/target-observers.spec.ts
+++ b/packages/__tests__/3-runtime-html/target-observers.spec.ts
@@ -8,6 +8,7 @@ import {
   StyleAttributeAccessor
 } from '@aurelia/runtime-html';
 import { assert, createSpy, CSS_PROPERTIES, globalAttributeNames, TestContext } from '@aurelia/testing';
+import { isFirefox } from '../util.js';
 
 function createSvgUseElement(ctx: TestContext, name: string, value: string) {
   return ctx.createElementFromMarkup(`<svg>
@@ -168,8 +169,6 @@ describe('StyleAccessor', function () {
     });
   }
 
-  const isFirefox = TestContext.create().wnd.navigator.userAgent.includes('Firefox');
-
   const specs: Partial<IStyleSpec>[] = [
     {
       title: 'getValue - style="display: block;"',
@@ -250,7 +249,7 @@ describe('StyleAccessor', function () {
       expected: 'display: block; background-color: red; height: 32px;',
     },
     ...(
-      isFirefox
+      isFirefox()
       ? []
       // TODO: figure out why these fail in firefox and fix them?
       : [

--- a/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.harmony.spec.ts
@@ -6,12 +6,11 @@ import {
 } from '@aurelia/runtime-html';
 import {
   assert,
-  PLATFORM,
   TestContext,
 } from '@aurelia/testing';
+import { isFirefox, isNode } from '../util.js';
 
 describe('3-runtime-html/template-compiler.harmony.spec.ts', function () {
-
   interface IHarmoniousCompilationTestCase {
     title: string;
     template: string | HTMLElement;
@@ -396,10 +395,11 @@ describe('3-runtime-html/template-compiler.harmony.spec.ts', function () {
 
   testCases.forEach((testCase, idx) => {
     const { title, template, resources = [], only, browserOnly, assertFn } = testCase;
-    if (PLATFORM.navigator.userAgent.includes('jsdom') && browserOnly) {
+    if (isNode() && browserOnly) {
       return;
     }
-    if (PLATFORM.navigator.userAgent.includes('firefox')) {
+    if (isFirefox()) {
+      console.log('Tests sensitive to timing issues are only run in Chrome');
       return;
     }
     const $it = only ? it.only : it;

--- a/packages/__tests__/import-env-vars.js
+++ b/packages/__tests__/import-env-vars.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+document.write('<script src="env-variables.js"></script>');

--- a/packages/__tests__/importmap.js
+++ b/packages/__tests__/importmap.js
@@ -1,9 +1,8 @@
-// eslint-disable-next-line
+/* eslint-disable */
 document.write(`<script type="importmap">${JSON.stringify({
   imports: {
     ...([
       'addons',
-      'aurelia',
       'platform',
       'platform-browser',
       'metadata',
@@ -25,7 +24,9 @@ document.write(`<script type="importmap">${JSON.stringify({
     ].reduce((map, pkg) => {
       map[`@aurelia/${pkg}`] = `/base/packages/${pkg}/dist/esm/index.mjs`;
       return map;
-    }, {})),
+    }, {
+      'aurelia': `/base/packages/aurelia/dist/esm/index.mjs`
+    })),
     'i18next': '/base/node_modules/i18next/dist/esm/i18next.js',
     'tslib': '/base/node_modules/tslib/tslib.es6.js',
     ...([

--- a/packages/__tests__/router-lite/.eslintrc.cjs
+++ b/packages/__tests__/router-lite/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: ['../.eslintrc.cjs'],
+  overrides: [{ // Specific overrides for JS files as some TS rules don't make sense there.
+    files: ['*.ts'],
+    rules: {
+      '@typescript-eslint/prefer-nullish-coalescing': 'off'
+    }
+  }]
+};

--- a/packages/__tests__/router-lite/hook-tests.spec.ts
+++ b/packages/__tests__/router-lite/hook-tests.spec.ts
@@ -27,6 +27,7 @@ import {
 import { assert, TestContext } from '@aurelia/testing';
 
 import { TestRouterConfiguration } from './_shared/configuration.js';
+import { isFirefox } from '../util.js';
 
 function join(sep: string, ...parts: string[]): string {
   return parts.filter(function (x) {
@@ -1886,10 +1887,8 @@ describe('router hooks', function () {
     }
   });
 
-  const isFirefox = TestContext.create().wnd.navigator.userAgent.includes('Firefox');
-
   // TODO: make these pass in firefox (firefox for some reason uses different type of stack trace - see https://app.circleci.com/pipelines/github/aurelia/aurelia/7569/workflows/60a7fb9f-e8b0-47e4-b753-eaa9b5da42c2/jobs/64147)
-  if (!isFirefox) {
+  if (!isFirefox()) {
     forEachRouterOptions('error handling', function (opts) {
       interface IErrorSpec {
         createCes: () => CustomElementType[];

--- a/packages/__tests__/util.ts
+++ b/packages/__tests__/util.ts
@@ -68,3 +68,7 @@ export class TickLogger {
     this.cb = cb;
   }
 }
+
+export const isFirefox = () => TestContext.create().wnd.navigator.userAgent.includes('Firefox');
+export const isChrome = () => TestContext.create().wnd.navigator.userAgent.includes('Chrome');
+export const isNode = () => !isFirefox() && !isChrome();


### PR DESCRIPTION
## 📖 Description

Tests related to focus/blur states often fail on firefox and require manual reruns. Just disable them and let Chrome handle it.
