### PR TITLE
fix(repeater): re attaching when using the same array with if

### DIFF
--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -6,7 +6,7 @@ import { IEventTarget, INode } from './dom';
 import { IPlatform } from './platform';
 import { CustomElement, CustomElementDefinition } from './resources/custom-element';
 import { Controller, ICustomElementController, ICustomElementViewModel, IHydratedParentController } from './templating/controller';
-import { isFunction } from './utilities';
+import { isFunction, isPromise } from './utilities';
 
 import type {
   Constructable,
@@ -149,7 +149,7 @@ export class Aurelia implements IDisposable {
         throw new Error(`AUR0770`);
     }
 
-    if (this._startPromise instanceof Promise) {
+    if (isPromise(this._startPromise)) {
       return this._startPromise;
     }
 
@@ -170,7 +170,7 @@ export class Aurelia implements IDisposable {
   /** @internal */
   private _stopPromise: Promise<void> | void = void 0;
   public stop(dispose: boolean = false): void | Promise<void> {
-    if (this._stopPromise instanceof Promise) {
+    if (isPromise(this._stopPromise)) {
       return this._stopPromise;
     }
 

--- a/packages/runtime-html/src/plugins/dialog/dialog-service.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-service.ts
@@ -13,7 +13,7 @@ import {
 import { DialogController } from './dialog-controller';
 import { AppTask } from '../../app-task';
 import { IPlatform } from '../../platform';
-import { isFunction } from '../../utilities';
+import { isFunction, isPromise } from '../../utilities';
 
 import type {
   DialogOpenPromise,
@@ -198,7 +198,7 @@ class DialogSettings<T extends object = object> implements IDialogSettings<T> {
         ? onResolve(template(), loadedTpl => { loaded.template = loadedTpl; })
         : void 0
     ]);
-    return maybePromise instanceof Promise
+    return isPromise(maybePromise)
       ? maybePromise.then(() => loaded)
       : loaded;
   }

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -8,7 +8,7 @@ import { CustomElement, customElement, CustomElementDefinition } from '../custom
 import { bindable } from '../../bindable';
 import { ControllerVisitor, ICustomElementController, ICustomElementViewModel, IHydratedController, IHydratedParentController, IHydrationContext, ISyntheticView } from '../../templating/controller';
 import { IRendering } from '../../templating/rendering';
-import { isString } from '../../utilities';
+import { isPromise, isString } from '../../utilities';
 
 export type Subject = string | IViewFactory | ISyntheticView | RenderPlan | Constructable | CustomElementDefinition;
 export type MaybeSubjectPromise = Subject | Promise<Subject> | undefined;
@@ -100,7 +100,7 @@ export class AuRender implements ICustomElementViewModel {
         return this.compose(void 0, newValue, null, flags);
       },
     );
-    if (ret instanceof Promise) { ret.catch(err => { throw err; }); }
+    if (isPromise(ret)) { ret.catch(err => { throw err; }); }
   }
 
   private compose(
@@ -156,7 +156,7 @@ export class AuRender implements ICustomElementViewModel {
 
   /** @internal */
   private _provideViewFor(comp: Subject | undefined, _flags: LifecycleFlags): ISyntheticView | undefined {
-    if (!comp) {
+    if (comp == null) {
       return void 0;
     }
 

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -5,7 +5,7 @@ import { IPlatform } from '../../platform';
 import { IViewFactory } from '../../templating/view';
 import { templateController } from '../custom-attribute';
 import { bindable } from '../../bindable';
-import { isString } from '../../utilities';
+import { isPromise, isString } from '../../utilities';
 import type { ControllerVisitor, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ISyntheticView } from '../../templating/controller';
 
 export type PortalTarget<T extends Node & ParentNode = Node & ParentNode> = string | T | null | undefined;
@@ -106,7 +106,7 @@ export class Portal<T extends Node & ParentNode = Node & ParentNode> implements 
         return this._activating(null, newTarget, $controller.flags);
       },
     );
-    if (ret instanceof Promise) { ret.catch(err => { throw err; }); }
+    if (isPromise(ret)) { ret.catch(err => { throw err; }); }
   }
 
   /** @internal */

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -17,6 +17,7 @@ import {
 import { IViewFactory } from '../../templating/view';
 import { attributePattern, AttrSyntax } from '../attribute-pattern';
 import { templateController } from '../custom-attribute';
+import { isPromise } from '../../utilities';
 
 @templateController('promise')
 export class PromiseTemplateController implements ICustomAttributeViewModel {
@@ -72,7 +73,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
 
   private swap(initiator: IHydratedController | null, flags: LifecycleFlags): void {
     const value = this.value;
-    if (!(value instanceof Promise)) {
+    if (!isPromise(value)) {
       this.logger.warn(`The value '${String(value)}' is not a promise. No change will be done.`);
       return;
     }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -28,7 +28,7 @@ import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles';
 import { ComputedWatcher, ExpressionWatcher } from './watchers';
 import { LifecycleHooks, LifecycleHooksEntry } from './lifecycle-hooks';
 import { IRendering } from './rendering';
-import { isFunction, isString } from '../utilities';
+import { isFunction, isPromise, isString } from '../utilities';
 
 import type {
   IContainer,
@@ -592,7 +592,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = resolveAll(ret, this.viewModel!.binding(this.$initiator, this.parent, this.$flags));
     }
 
-    if (ret instanceof Promise) {
+    if (isPromise(ret)) {
       this._ensurePromise();
       ret.then(() => {
         this.bind();
@@ -645,7 +645,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = resolveAll(ret, this.viewModel!.bound(this.$initiator, this.parent, this.$flags));
     }
 
-    if (ret instanceof Promise) {
+    if (isPromise(ret)) {
       this._ensurePromise();
       ret.then(() => {
         this.isBound = true;
@@ -728,7 +728,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = resolveAll(ret, this.viewModel!.attaching(this.$initiator, this.parent, this.$flags));
     }
 
-    if (ret instanceof Promise) {
+    if (isPromise(ret)) {
       this._ensurePromise();
       this._enterActivating();
       ret.then(() => {
@@ -812,7 +812,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = resolveAll(ret, this.viewModel!.detaching(this.$initiator, this.parent, this.$flags));
     }
 
-    if (ret instanceof Promise) {
+    if (isPromise(ret)) {
       this._ensurePromise();
       (initiator as Controller)._enterDetaching();
       ret.then(() => {
@@ -975,7 +975,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         _retPromise = resolveAll(_retPromise, this.viewModel!.attached!(this.$initiator, this.$flags));
       }
 
-      if (_retPromise instanceof Promise) {
+      if (isPromise(_retPromise)) {
         this._ensurePromise();
         _retPromise.then(() => {
           this.state = State.activated;
@@ -1036,7 +1036,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
           ret = resolveAll(ret, cur.viewModel!.unbinding(cur.$initiator, cur.parent, cur.$flags));
         }
 
-        if (ret instanceof Promise) {
+        if (isPromise(ret)) {
           this._ensurePromise();
           this._enterUnbinding();
           ret.then(() => {

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { emptyArray } from '@aurelia/kernel';
 import { CustomAttribute } from './resources/custom-attribute';
 import { CustomElement } from './resources/custom-element';
@@ -18,7 +19,7 @@ export interface IWatchDefinition<T extends object = object> {
 
 type AnyMethod<R = unknown> = (...args: unknown[]) => R;
 type WatchClassDecorator<T extends object> = <K extends Constructable<T>>(target: K) => void;
-type WatchMethodDecorator<T> = <R, K extends AnyMethod<R> = AnyMethod<R>>(target: T, key: string | symbol, descriptor: PropertyDescriptor) => PropertyDescriptor;
+type WatchMethodDecorator<T> = (target: T, key: string | symbol, descriptor: PropertyDescriptor) => PropertyDescriptor;
 type MethodsOf<Type> = {
   [Key in keyof Type]: Type[Key] extends AnyMethod ? Key : never
 }[keyof Type];
@@ -58,7 +59,7 @@ export function watch<T extends object = object>(
   expressionOrPropertyAccessFn: PropertyKey | IDepCollectionFn<object>,
   changeHandlerOrCallback?: PropertyKey | IWatcherCallback<T>,
 ): WatchClassDecorator<T> | WatchMethodDecorator<T> {
-  if (!expressionOrPropertyAccessFn) {
+  if (expressionOrPropertyAccessFn == null) {
     if (__DEV__)
       throw new Error(`AUR0772: Invalid watch config. Expected an expression or a fn`);
     else

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -462,7 +462,7 @@ export class BindingBehaviorExpression {
     if (!(behavior instanceof BindingBehaviorFactory)) {
       if ((b as BindingWithBehavior)[this.behaviorKey] === void 0) {
         (b as BindingWithBehavior)[this.behaviorKey] = behavior;
-        (behavior.bind.call as (...args: unknown[]) => void)(behavior, f, s, b, ...this.args.map(a => a.evaluate(f, s, b.locator, null)));
+        behavior.bind(f, s, b, ...this.args.map(a => a.evaluate(f, s, b.locator, null) as {}[]));
       } else {
         if (__DEV__)
           throw new Error(`AUR0102: BindingBehavior named '${this.name}' already applied.`);

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -18,8 +18,6 @@ import type {
 } from '../observation';
 import type { IObserverLocator } from '../observation/observer-locator';
 
-// TODO: add connect-queue (or something similar) back in when everything else is working, to improve startup time
-
 export interface IObserverLocatorBasedConnectable extends IBinding, ISubscriber, ICollectionSubscriber {
   oL: IObserverLocator;
 }
@@ -76,9 +74,9 @@ function noopHandleChange() {
 
 function noopHandleCollectionChange() {
   if (__DEV__)
-    throw new Error(`AUR2012: method "handleCollectionChange" not implemented`);
+    throw new Error(`AUR2011: method "handleCollectionChange" not implemented`);
   else
-    throw new Error(`AUR2012:handleCollectionChange`);
+    throw new Error(`AUR2011:handleCollectionChange`);
 }
 
 type ObservationRecordImplType = {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently, the repeater does not unsubscribe the collection when getting detached, resulting in double work when:
1. it becomes attached again and
2. the collection getting updated at the same time

The template for the 2 above conditions to happen at the same time looks like this:
```html
<div if.bind="items.length">
  <p repeat.for="i of items">...
```
Reproduction:
1. start with an array of 1 item
2. remove the only item in the array, this will trigger detaching lifecycle on the repeat without unsubscribing to the array `items`
3. add a new item into the array `items` -> 💥

This PR fixes this.

Thanks to @bravius for reporting this issue in #1119