### PR TITLE
fix(router-lite): navigation to routes configured in ancestor nodes

### DIFF
--- a/packages/__tests__/router-lite/_shared/create-fixture.ts
+++ b/packages/__tests__/router-lite/_shared/create-fixture.ts
@@ -1,4 +1,4 @@
-import { Constructable, LogLevel, Registration, ILogConfig, DI, LoggerConfiguration, ConsoleSink, IContainer, Resolved, IPlatform } from '@aurelia/kernel';
+import { Constructable, LogLevel, Registration, ILogConfig, DI, LoggerConfiguration, ConsoleSink, IContainer, Resolved, IPlatform, Class } from '@aurelia/kernel';
 import { Aurelia } from '@aurelia/runtime-html';
 import { IRouterOptions, RouterConfiguration, IRouter } from '@aurelia/router-lite';
 import { TestContext } from '@aurelia/testing';
@@ -88,4 +88,25 @@ export async function createFixture<T extends Constructable>(
       await au.stop(true);
     },
   };
+}
+
+/**
+ * Simpler fixture creation.
+ */
+export async function start<TAppRoot>(appRoot: Class<TAppRoot>, ...registrations: any[]) {
+  const ctx = TestContext.create();
+  const { container } = ctx;
+
+  container.register(
+    TestRouterConfiguration.for(LogLevel.warn),
+    RouterConfiguration,
+    ...registrations,
+  );
+
+  const au = new Aurelia(container);
+  const host = ctx.createElement('div');
+
+  await au.app({ component: appRoot, host }).start();
+  const rootVm = au.root.controller.viewModel as TAppRoot;
+  return { host, au, container, rootVm };
 }

--- a/packages/__tests__/router-lite/resources/href.spec.ts
+++ b/packages/__tests__/router-lite/resources/href.spec.ts
@@ -115,4 +115,110 @@ describe('href custom-attribute', function () {
 
     await au.stop();
   });
+
+  it('allow navigating to route defined in grand-parent context using ../../ prefix', async function () {
+    @customElement({ name: 'l-21', template: `l21 \${id} <a href="../../l12"></a>` })
+    class L21 { }
+    @customElement({ name: 'l-22', template: `l22 \${id} <a href="../../l11"></a>` })
+    class L22 { }
+
+    @route({
+      routes: [
+        { id: 'l21', path: ['', 'l21'], component: L21 },
+      ]
+    })
+    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
+    class L11 { }
+
+    @route({
+      routes: [
+        { id: 'l22', path: ['', 'l22'], component: L22 },
+      ]
+    })
+    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
+    class L12 { }
+
+    @route({
+      routes: [
+        { id: 'l11', path: ['', 'l11'], component: L11 },
+        { id: 'l12', path: 'l12', component: L12 },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l22');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    await au.stop();
+  });
+
+  it('allow navigating to route defined in grand-parent context using explicit routing context', async function () {
+    @customElement({ name: 'l-21', template: `l21 <a href="value:l12; context.bind:rtCtx.parent.parent"></a>` })
+    class L21 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+    @customElement({ name: 'l-22', template: `l22 <a href="value:l11; context.bind:rtCtx.parent.parent"></a>` })
+    class L22 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'l21', path: ['', 'l21'], component: L21 },
+      ]
+    })
+    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
+    class L11 { }
+
+    @route({
+      routes: [
+        { id: 'l22', path: ['', 'l22'], component: L22 },
+      ]
+    })
+    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
+    class L12 { }
+
+    @route({
+      routes: [
+        { id: 'l11', path: ['', 'l11'], component: L11 },
+        { id: 'l12', path: 'l12', component: L12 },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l22');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    await au.stop();
+  });
 });

--- a/packages/__tests__/router-lite/resources/href.spec.ts
+++ b/packages/__tests__/router-lite/resources/href.spec.ts
@@ -1,0 +1,61 @@
+import { Params, route, RouteNode } from '@aurelia/router-lite';
+import { customElement, IPlatform } from '@aurelia/runtime-html';
+import { assert } from '@aurelia/testing';
+import { start } from '../_shared/create-fixture.js';
+
+describe('href custom-attribute', function () {
+
+  it('allow navigating to route defined in parent context using ../ prefix', async function () {
+    @customElement({ name: 'pro-duct', template: `product \${id} <a href="../products"></a>` })
+    class Product {
+      id: unknown;
+      public canLoad(params: Params, _next: RouteNode, _current: RouteNode): boolean {
+        this.id = params.id;
+        return true;
+      }
+    }
+
+    @customElement({ name: 'pro-ducts', template: `<a href="../product/1"></a><a href="../product/2"></a> products` })
+    class Products { }
+
+    @route({
+      routes: [
+        { id: 'products', path: ['', 'products'], component: Products },
+        { id: 'product', path: 'product/:id', component: Product },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, Products, Product);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+
+    assert.html.textContent(host, 'products');
+    const anchors = Array.from(host.querySelectorAll('a'));
+    const hrefs = anchors.map(a => a.href);
+    assert.match(hrefs[0], /product\/1$/);
+    assert.match(hrefs[1], /product\/2$/);
+
+    anchors[0].click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 1');
+    // go back
+    const back = host.querySelector<HTMLAnchorElement>('a');
+    assert.match(back.href, /products$/);
+    back.click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    // 2nd round
+    host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 2');
+    // go back
+    host.querySelector<HTMLAnchorElement>('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    await au.stop();
+  });
+});

--- a/packages/__tests__/router-lite/resources/href.spec.ts
+++ b/packages/__tests__/router-lite/resources/href.spec.ts
@@ -59,63 +59,6 @@ describe('href custom-attribute', function () {
     await au.stop();
   });
 
-  it('allow navigating to route defined in parent context using explicit routing context', async function () {
-    @customElement({ name: 'pro-duct', template: `product \${id} <a href="value:products; context.bind:rtCtx.parent"></a>` })
-    class Product {
-      id: unknown;
-      private rtCtx: IRouteContext;
-      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
-        this.id = params.id;
-        this.rtCtx = next.context;
-        return true;
-      }
-    }
-
-    @customElement({ name: 'pro-ducts', template: `<a href="value:product/1; context.bind:rtCtx.parent"></a><a href="value:product/2; context.bind:rtCtx.parent"></a> products` })
-    class Products {
-      private rtCtx: IRouteContext;
-      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
-        this.rtCtx = next.context;
-        return true;
-      }
-    }
-
-    @route({
-      routes: [
-        { id: 'products', path: ['', 'products'], component: Products },
-        { id: 'product', path: 'product/:id', component: Product },
-      ]
-    })
-    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
-    class Root { }
-
-    const { au, host, container } = await start(Root, Products, Product);
-    const queue = container.get(IPlatform).domWriteQueue;
-    await queue.yield();
-
-    assert.html.textContent(host, 'products');
-    host.querySelector('a').click();
-    await queue.yield();
-    assert.html.textContent(host, 'product 1');
-    // go back
-    const back = host.querySelector<HTMLAnchorElement>('a');
-    assert.match(back.href, /products$/);
-    back.click();
-    await queue.yield();
-    assert.html.textContent(host, 'products');
-
-    // 2nd round
-    host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
-    await queue.yield();
-    assert.html.textContent(host, 'product 2');
-    // go back
-    host.querySelector<HTMLAnchorElement>('a').click();
-    await queue.yield();
-    assert.html.textContent(host, 'products');
-
-    await au.stop();
-  });
-
   it('allow navigating to route defined in grand-parent context using ../../ prefix', async function () {
     @customElement({ name: 'l-21', template: `l21 \${id} <a href="../../l12"></a>` })
     class L21 { }
@@ -163,8 +106,9 @@ describe('href custom-attribute', function () {
     await au.stop();
   });
 
-  it('allow navigating to route defined in grand-parent context using explicit routing context', async function () {
-    @customElement({ name: 'l-21', template: `l21 <a href="value:l12; context.bind:rtCtx.parent.parent"></a>` })
+  // slightly more complex use-case
+  it('cross children navigation with multiple hierarchical routing configuration', async function () {
+    @customElement({ name: 'l-21', template: `l21 <a href="../l22"></a>` })
     class L21 {
       private rtCtx: IRouteContext;
       public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
@@ -172,7 +116,7 @@ describe('href custom-attribute', function () {
         return true;
       }
     }
-    @customElement({ name: 'l-22', template: `l22 <a href="value:l11; context.bind:rtCtx.parent.parent"></a>` })
+    @customElement({ name: 'l-22', template: `l22 <a href="../../l12"></a>` })
     class L22 {
       private rtCtx: IRouteContext;
       public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
@@ -180,66 +124,7 @@ describe('href custom-attribute', function () {
         return true;
       }
     }
-
-    @route({
-      routes: [
-        { id: 'l21', path: ['', 'l21'], component: L21 },
-      ]
-    })
-    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
-    class L11 { }
-
-    @route({
-      routes: [
-        { id: 'l22', path: ['', 'l22'], component: L22 },
-      ]
-    })
-    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
-    class L12 { }
-
-    @route({
-      routes: [
-        { id: 'l11', path: ['', 'l11'], component: L11 },
-        { id: 'l12', path: 'l12', component: L12 },
-      ]
-    })
-    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
-    class Root { }
-
-    const { au, host, container } = await start(Root, L11, L12, L21, L22);
-    const queue = container.get(IPlatform).domWriteQueue;
-    await queue.yield();
-    assert.html.textContent(host, 'l11 l21');
-
-    host.querySelector('a').click();
-    await queue.yield();
-    assert.html.textContent(host, 'l12 l22');
-
-    host.querySelector('a').click();
-    await queue.yield();
-    assert.html.textContent(host, 'l11 l21');
-
-    await au.stop();
-  });
-
-  it('allow explicitly binding the routing context to null to perform navigation from root', async function () {
-    @customElement({ name: 'l-21', template: `l21 <a href="value:l22; context.bind:rtCtx.parent"></a>` })
-    class L21 {
-      private rtCtx: IRouteContext;
-      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
-        this.rtCtx = next.context;
-        return true;
-      }
-    }
-    @customElement({ name: 'l-22', template: `l22 <a href="value:l12; context.bind:null"></a>` })
-    class L22 {
-      private rtCtx: IRouteContext;
-      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
-        this.rtCtx = next.context;
-        return true;
-      }
-    }
-    @customElement({ name: 'l-23', template: `l23 <a href="value:l24; context.bind:rtCtx.parent"></a>` })
+    @customElement({ name: 'l-23', template: `l23 <a href="../l24"></a>` })
     class L23 {
       private rtCtx: IRouteContext;
       public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
@@ -247,7 +132,7 @@ describe('href custom-attribute', function () {
         return true;
       }
     }
-    @customElement({ name: 'l-24', template: `l24 <a href="value:l11; context.bind:null"></a>` })
+    @customElement({ name: 'l-24', template: `l24 <a href="../../l11"></a>` })
     class L24 {
       private rtCtx: IRouteContext;
       public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {

--- a/packages/__tests__/router-lite/resources/href.spec.ts
+++ b/packages/__tests__/router-lite/resources/href.spec.ts
@@ -1,4 +1,4 @@
-import { Params, route, RouteNode } from '@aurelia/router-lite';
+import { IRouteContext, Params, route, RouteNode } from '@aurelia/router-lite';
 import { customElement, IPlatform } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 import { start } from '../_shared/create-fixture.js';
@@ -38,6 +38,63 @@ describe('href custom-attribute', function () {
     assert.match(hrefs[1], /product\/2$/);
 
     anchors[0].click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 1');
+    // go back
+    const back = host.querySelector<HTMLAnchorElement>('a');
+    assert.match(back.href, /products$/);
+    back.click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    // 2nd round
+    host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 2');
+    // go back
+    host.querySelector<HTMLAnchorElement>('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    await au.stop();
+  });
+
+  it('allow navigating to route defined in parent context using explicit routing context', async function () {
+    @customElement({ name: 'pro-duct', template: `product \${id} <a href="value:products; context.bind:rtCtx.parent"></a>` })
+    class Product {
+      id: unknown;
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.id = params.id;
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @customElement({ name: 'pro-ducts', template: `<a href="value:product/1; context.bind:rtCtx.parent"></a><a href="value:product/2; context.bind:rtCtx.parent"></a> products` })
+    class Products {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'products', path: ['', 'products'], component: Products },
+        { id: 'product', path: 'product/:id', component: Product },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, Products, Product);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+
+    assert.html.textContent(host, 'products');
+    host.querySelector('a').click();
     await queue.yield();
     assert.html.textContent(host, 'product 1');
     // go back

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -1,4 +1,4 @@
-import { Params, route, RouteNode } from '@aurelia/router-lite';
+import { IRouteContext, Params, route, RouteNode } from '@aurelia/router-lite';
 import { customElement, IPlatform } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 import { start } from '../_shared/create-fixture.js';
@@ -125,6 +125,68 @@ describe('load custom-attribute', function () {
 
     @customElement({ name: 'pro-ducts', template: `<a load="../product/1"></a><a load="../product/2"></a> products` })
     class Products { }
+
+    @route({
+      routes: [
+        { id: 'products', path: ['', 'products'], component: Products },
+        { id: 'product', path: 'product/:id', component: Product },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, Products, Product);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+
+    assert.html.textContent(host, 'products');
+    const anchors = Array.from(host.querySelectorAll('a'));
+    const hrefs = anchors.map(a => a.href);
+    assert.match(hrefs[0], /product\/1$/);
+    assert.match(hrefs[1], /product\/2$/);
+
+    anchors[0].click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 1');
+    // go back
+    const back = host.querySelector<HTMLAnchorElement>('a');
+    assert.match(back.href, /products$/);
+    back.click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    // 2nd round
+    host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
+    await queue.yield();
+    assert.html.textContent(host, 'product 2');
+    // go back
+    host.querySelector<HTMLAnchorElement>('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'products');
+
+    await au.stop();
+  });
+
+  it('allow navigating to route defined in parent context using explicit routing context', async function () {
+    @customElement({ name: 'pro-duct', template: `product \${id} <a load="route:products; context.bind:rtCtx.parent"></a>` })
+    class Product {
+      id: unknown;
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.id = params.id;
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @customElement({ name: 'pro-ducts', template: `<a load="route:product/1; context.bind:rtCtx.parent"></a><a load="route:product; params.bind:{id: 2}; context.bind:rtCtx.parent"></a> products` })
+    class Products {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
 
     @route({
       routes: [

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -228,4 +228,110 @@ describe('load custom-attribute', function () {
 
     await au.stop();
   });
+
+  it('allow navigating to route defined in grand-parent context using ../../ prefix', async function () {
+    @customElement({ name: 'l-21', template: `l21 <a load="../../l12"></a>` })
+    class L21 { }
+    @customElement({ name: 'l-22', template: `l22 <a load="../../l11"></a>` })
+    class L22 { }
+
+    @route({
+      routes: [
+        { id: 'l21', path: ['', 'l21'], component: L21 },
+      ]
+    })
+    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
+    class L11 { }
+
+    @route({
+      routes: [
+        { id: 'l22', path: ['', 'l22'], component: L22 },
+      ]
+    })
+    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
+    class L12 { }
+
+    @route({
+      routes: [
+        { id: 'l11', path: ['', 'l11'], component: L11 },
+        { id: 'l12', path: 'l12', component: L12 },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l22');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    await au.stop();
+  });
+
+  it('allow navigating to route defined in grand-parent context using explicit routing context', async function () {
+    @customElement({ name: 'l-21', template: `l21 <a load="route:l12; context.bind:rtCtx.parent.parent"></a>` })
+    class L21 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+    @customElement({ name: 'l-22', template: `l22 <a load="route:l11; context.bind:rtCtx.parent.parent"></a>` })
+    class L22 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'l21', path: ['', 'l21'], component: L21 },
+      ]
+    })
+    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
+    class L11 { }
+
+    @route({
+      routes: [
+        { id: 'l22', path: ['', 'l22'], component: L22 },
+      ]
+    })
+    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
+    class L12 { }
+
+    @route({
+      routes: [
+        { id: 'l11', path: ['', 'l11'], component: L11 },
+        { id: 'l12', path: 'l12', component: L12 },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l22');
+
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21');
+
+    await au.stop();
+  });
 });

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -334,4 +334,93 @@ describe('load custom-attribute', function () {
 
     await au.stop();
   });
+
+  it('allow explicitly binding the routing context to null to perform navigation from root', async function () {
+    @customElement({ name: 'l-21', template: `l21 <a load="route:l22; context.bind:rtCtx.parent"></a>` })
+    class L21 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+    @customElement({ name: 'l-22', template: `l22 <a load="route:l12; context.bind:null"></a>` })
+    class L22 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+    @customElement({ name: 'l-23', template: `l23 <a load="route:l24; context.bind:rtCtx.parent"></a>` })
+    class L23 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+    @customElement({ name: 'l-24', template: `l24 <a load="route:l11; context.bind:null"></a>` })
+    class L24 {
+      private rtCtx: IRouteContext;
+      public canLoad(params: Params, next: RouteNode, _current: RouteNode): boolean {
+        this.rtCtx = next.context;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'l21', path: ['', 'l21'], component: L21 },
+        { id: 'l22', path: 'l22', component: L22 },
+      ]
+    })
+    @customElement({ name: 'l-11', template: `l11 <au-viewport></au-viewport>` })
+    class L11 { }
+
+    @route({
+      routes: [
+        { id: 'l23', path: ['', 'l23'], component: L23 },
+        { id: 'l24', path: 'l24', component: L24 },
+      ]
+    })
+    @customElement({ name: 'l-12', template: `l12 <au-viewport></au-viewport>` })
+    class L12 { }
+
+    @route({
+      routes: [
+        { id: 'l11', path: ['', 'l11'], component: L11 },
+        { id: 'l12', path: 'l12', component: L12 },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, host, container } = await start(Root, L11, L12, L21, L22, L23, L24);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21', 'init');
+
+    // l21 -> l22
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l22', '#2 l21 -> l22');
+
+    // l22 -> l12
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l23', '#3 l22 -> l12');
+
+    // l23 -> l24
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l12 l24', '#4 l23 -> l24');
+
+    // l24 -> l11
+    host.querySelector('a').click();
+    await queue.yield();
+    assert.html.textContent(host, 'l11 l21', '#5 l24 -> l11');
+
+    await au.stop();
+  });
 });

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -6,10 +6,16 @@ import { IRouter } from '../router';
 import { LoadCustomAttribute } from '../configuration';
 import { IRouteContext } from '../route-context';
 
-@customAttribute({ name: 'href', noMultiBindings: true })
+@customAttribute('href')
 export class HrefCustomAttribute implements ICustomAttributeViewModel {
   @bindable({ mode: BindingMode.toView })
   public value: unknown;
+
+  /**
+   * When not bound, it defaults to the injected instance of the router context.
+   */
+  @bindable({ mode: BindingMode.toView, callback: 'valueChanged' })
+  public context?: IRouteContext;
 
   private eventListener!: IDisposable;
   private isInitialized: boolean = false;
@@ -67,6 +73,7 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
   }
 
   public valueChanged(newValue: unknown): void {
+    this.context ??= this.ctx;
     if (newValue == null) {
       this.el.removeAttribute('href');
     } else {
@@ -94,7 +101,7 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
     if (href !== null) {
       e.preventDefault();
       // Floating promises from `Router#load` are ok because the router keeps track of state and handles the errors, etc.
-      void this.router.load(href, { context: this.ctx });
+      void this.router.load(href, { context: this.context });
     }
   }
 }

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -73,7 +73,12 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
   }
 
   public valueChanged(newValue: unknown): void {
-    this.context ??= this.ctx;
+    // this allows binding context to null for navigation from root; unbound vs explicit null binding
+    if(this.context === void 0) {
+      this.context = this.ctx;
+    } else if(this.context === null) {
+      this.context = this.ctx.root;
+    }
     if (newValue == null) {
       this.el.removeAttribute('href');
     } else {

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -6,16 +6,23 @@ import { IRouter } from '../router';
 import { LoadCustomAttribute } from '../configuration';
 import { IRouteContext } from '../route-context';
 
-@customAttribute('href')
+/*
+ * Note: Intentionally, there is no bindable `context` here.
+ * Otherwise this CA needs to be turned into a multi-binding CA.
+ * Which means that the following simplest case won't work any longer:
+ *
+ * ```html
+ * <a href="https://bla.bla.com/bla" data-external>bla</a>
+ * ```
+ * Because the template compiler will think that `https` is a bindable property in this CA,
+ * and will fail as it won't find a bindable property `https` here in this CA.
+ * Therefore, till the template compiler can handle that correctly, introduction of a bindable context is intentionally omitted.
+ */
+
+@customAttribute({ name: 'href', noMultiBindings: true })
 export class HrefCustomAttribute implements ICustomAttributeViewModel {
   @bindable({ mode: BindingMode.toView })
   public value: unknown;
-
-  /**
-   * When not bound, it defaults to the injected instance of the router context.
-   */
-  @bindable({ mode: BindingMode.toView, callback: 'valueChanged' })
-  public context?: IRouteContext;
 
   private eventListener!: IDisposable;
   private isInitialized: boolean = false;
@@ -73,12 +80,6 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
   }
 
   public valueChanged(newValue: unknown): void {
-    // this allows binding context to null for navigation from root; unbound vs explicit null binding
-    if(this.context === void 0) {
-      this.context = this.ctx;
-    } else if(this.context === null) {
-      this.context = this.ctx.root;
-    }
     if (newValue == null) {
       this.el.removeAttribute('href');
     } else {
@@ -106,7 +107,7 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
     if (href !== null) {
       e.preventDefault();
       // Floating promises from `Router#load` are ok because the router keeps track of state and handles the errors, etc.
-      void this.router.load(href, { context: this.context });
+      void this.router.load(href, { context: this.ctx });
     }
   }
 }

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -22,6 +22,12 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   @bindable({ mode: BindingMode.fromView })
   public active: boolean = false;
 
+  /**
+   * When not bound, it defaults to the injected instance of the router context.
+   */
+  @bindable({ mode: BindingMode.toView, callback: 'valueChanged' })
+  public context?: IRouteContext;
+
   private href: string | null = null;
   private instructions: ViewportInstructionTree | null = null;
   private eventListener: IDisposable | null = null;
@@ -48,13 +54,14 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     this.valueChanged();
     this.navigationEndListener = this.events.subscribe('au:router:navigation-end', _e => {
       this.valueChanged();
-      this.active = this.instructions !== null && this.router.isActive(this.instructions, this.ctx);
+      this.active = this.instructions !== null && this.router.isActive(this.instructions, this.context!);
     });
   }
 
   public attaching(): void | Promise<void> {
-    if (this.ctx.allResolved !== null) {
-      return this.ctx.allResolved.then(() => {
+    const promise = this.context!.allResolved;
+    if (promise !== null) {
+      return promise.then(() => {
         this.valueChanged();
       });
     }
@@ -71,13 +78,14 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     const router = this.router;
     const useHash = router.options.useUrlFragmentHash;
     const component = this.route as NavigationInstruction;
-    if (component != null && this.ctx.allResolved === null) {
+    const ctx = this.context ??= this.ctx;
+    if (component != null && ctx.allResolved === null) {
       const params = this.params;
       const instructions = this.instructions = router.createViewportInstructions(
         typeof params === 'object' && params !== null
           ? { component, params }
           : component,
-        { context: this.ctx });
+        { context: ctx });
       this.href = instructions.toUrl(useHash);
     } else {
       this.instructions = null;
@@ -109,6 +117,6 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
 
     e.preventDefault();
     // Floating promises from `Router#load` are ok because the router keeps track of state and handles the errors, etc.
-    void this.router.load(this.instructions, { context: this.ctx });
+    void this.router.load(this.instructions, { context: this.context });
   };
 }

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -59,7 +59,8 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   }
 
   public attaching(): void | Promise<void> {
-    const promise = this.context!.allResolved;
+    const ctx = this.context;
+    const promise = ctx!.allResolved;
     if (promise !== null) {
       return promise.then(() => {
         this.valueChanged();
@@ -78,7 +79,13 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     const router = this.router;
     const useHash = router.options.useUrlFragmentHash;
     const component = this.route as NavigationInstruction;
-    const ctx = this.context ??= this.ctx;
+    // this allows binding context to null for navigation from root; unbound vs explicit null binding
+    let ctx = this.context;
+    if (ctx === void 0) {
+      ctx = this.context = this.ctx;
+    } else if (ctx === null) {
+      ctx = this.context = this.ctx.root;
+    }
     if (component != null && ctx.allResolved === null) {
       const params = this.params;
       const instructions = this.instructions = router.createViewportInstructions(

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -605,7 +605,7 @@ export class ViewportAgent {
     });
   }
 
-  public scheduleUpdate(options: NavigationOptions, next: RouteNode): void | Promise<void> {
+  public scheduleUpdate(options: NavigationOptions, next: RouteNode): void {
     switch (this.nextState) {
       case State.nextIsEmpty:
         this.nextNode = next;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

This fixes the issue reported here: https://discourse.aurelia.io/t/the-aurelia-2-book/4874
This support navigating to the routes defined in the ancestor view-models. The support for `../`-prefix was partially present, but was not tested. In this the tests are added and the bug is also fixed. That is, the following use-case is now supported:

```ts
@customElement({ 
  name: 'pro-duct', 
  template: `product \${id} <a load="../products"></a>`  //<-- navigation to the route defined in parent context
})
class Product {
  private id: unknown;
  public canLoad(params: Params, _next: RouteNode, _current: RouteNode): boolean {
    this.id = params.id;
    return true;
  }
}

@customElement({ name: 'pro-ducts', template: `<a load="../product/1"></a><a load="../product/2"></a> products` })
class Products { }

@route({
  routes: [
    { id: 'products', path: ['', 'products'], component: Products },
    { id: 'product', path: 'product/:id', component: Product },
  ]
})
@customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
class Root { }
```

Moreover, it adds support for binding a routing context explicitly for more fine-grained control.

The support is added for both `load` and `href` attributes.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->

---

cc: @Vheissu just in case you are in the process of maintaining the docs for router-lite as well. No stress, if not; I can later later fill up the gaps.
