### PR TITLE
fix(hmr): add ts-ignore to fix hmr in strict TS

### DIFF
--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -52,6 +52,7 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
       }
     }
 
+    // @ts-ignore
     hot.dispose(function (data) {
       // @ts-ignore
       data.controllers = controllers;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix for "TS7006: Parameter 'data' implicitly has an 'any' type. " on every compontent.ts file when using HMR with typescript in strict mode

### 🎫 Issues
## 👩‍💻 Reviewer Notes
## 📑 Test Plan
## ⏭ Next Steps