### PR TITLE
fix(validation-html): transient injection symbol for presenter service

### DIFF
--- a/docs/user-docs/developer-guides/validation/displaying-errors.md
+++ b/docs/user-docs/developer-guides/validation/displaying-errors.md
@@ -70,7 +70,7 @@ Aurelia
 
 This is useful if you have a custom attribute of the same name, and want to use that over this out-of-the-box custom attribute.
 
-### `validation-container` custom element
+## `validation-container` custom element
 
 The `validation-container`custom element also has similar goal of capturing the validation errors for the children target elements. Additionally, it provides a template to display the errors as well. This helps in reducing the boilerplate created by the `validation-errors` custom attribute. For example, using this custom element, displaying the errors reduces to the following.
 
@@ -104,22 +104,21 @@ It is quite understandable that the CSS-containment of the Shadow DOM can come i
 
 There is another aspect of this configuration option. When a `null`, `undefined`, or '' \(empty string\) is used as the value for this configuration option, it deactivates the usage of this custom element. This is in sense similar to the `UseSubscriberCustomAttribute` configuration option.
 
-### `ValidationResultPresenterService`
+## `ValidationResultPresenterService`
 
 Unlike the previous two approaches, this is a standalone service that manipulates the DOM directly. That it adds elements to DOM for every new errors and removes elements from DOM that are associated with old errors.
 
 To use this, you need to instantiate it and register it with the validation controller.
 
 ```typescript
-import { IValidationController, ValidationResultPresenterService } from '@aurelia/validation';
+import { IValidationController, IValidationResultPresenterService } from '@aurelia/validation';
 
 export class MyApp {
-  private presenter: ValidationResultPresenterService;
 
   public constructor(
-     @newInstanceForScope(IValidationController) private validationController: IValidationController,
+    @newInstanceForScope(IValidationController) private readonly validationController: IValidationController,
+    @IValidationResultPresenterService private readonly presenter: IValidationResultPresenterService;
   ) {
-      this.presenter = new ValidationResultPresenterService();
       this.validationController.addSubscriber(this.presenter);
   }
 }

--- a/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
@@ -11,6 +11,7 @@ import {
   ValidationHtmlConfiguration,
   ValidationResultsSubscriber,
   ValidationResultPresenterService,
+  IValidationResultPresenterService as $IValidationResultPresenterService,
 } from '@aurelia/validation-html';
 import { Person } from '../../validation/_test-resources.js';
 import { TestFunction, TestExecutionContext, ToNumberValueConverter, createSpecFunction } from '../../util.js';
@@ -66,7 +67,7 @@ describe('validation-html/subscribers/validation-result-presenter-service.spec.t
   }
   async function runTest(
     testFunction: TestFunction<TestExecutionContext<App>>,
-    { template, presenterService = new ValidationResultPresenterService(PLATFORM) }: TestSetupContext
+    { template, presenterService }: TestSetupContext
   ) {
     const ctx = TestContext.create();
     const container = ctx.container;
@@ -78,7 +79,10 @@ describe('validation-html/subscribers/validation-result-presenter-service.spec.t
         ValidationHtmlConfiguration,
         ToNumberValueConverter,
         CustomValidationContainer,
-        Registration.instance(IValidationResultPresenterService, presenterService),
+        Registration.cachedCallback(
+          IValidationResultPresenterService,
+          (x) => presenterService ?? x.get($IValidationResultPresenterService)
+        ),
       )
       .app({
         host,

--- a/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
+++ b/packages/__tests__/validation-html/subscribers/validation-result-presenter-service.spec.ts
@@ -18,7 +18,7 @@ import { TestFunction, TestExecutionContext, ToNumberValueConverter, createSpecF
 
 describe('validation-html/subscribers/validation-result-presenter-service.spec.ts/validation-result-presenter-service', function () {
 
-  const IValidationResultPresenterService = DI.createInterface<ValidationResultPresenterService>('ValidationResultPresenterService');
+  const IValidationResultPresenterService = DI.createInterface<$IValidationResultPresenterService>('ValidationResultPresenterService');
 
   class App {
     public person: Person = new Person((void 0)!, (void 0)!);
@@ -63,7 +63,7 @@ describe('validation-html/subscribers/validation-result-presenter-service.spec.t
   }
   interface TestSetupContext {
     template: string;
-    presenterService?: ValidationResultPresenterService;
+    presenterService?: $IValidationResultPresenterService;
   }
   async function runTest(
     testFunction: TestFunction<TestExecutionContext<App>>,

--- a/packages/validation-html/src/subscribers/validation-result-presenter-service.ts
+++ b/packages/validation-html/src/subscribers/validation-result-presenter-service.ts
@@ -1,9 +1,13 @@
+import { DI } from '@aurelia/kernel';
 import { IPlatform } from '@aurelia/runtime-html';
 import { ValidationResult } from '@aurelia/validation';
 import { ValidationEvent, ValidationResultsSubscriber, ValidationResultTarget } from '../validation-controller';
 
 const resultIdAttribute = 'validation-result-id';
 const resultContainerAttribute = 'validation-result-container';
+
+export interface IValidationResultPresenterService extends ValidationResultPresenterService { }
+export const IValidationResultPresenterService = DI.createInterface<IValidationResultPresenterService>('IValidationResultPresenterService', (x) => x.transient(ValidationResultPresenterService));
 
 export class ValidationResultPresenterService implements ValidationResultsSubscriber {
   public constructor(


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the issue reported by @Vheissu that the `ValidationResultPresenterService` now needs a ctor argument. This was missing in the docs. Also, it slightly compromises the previous ease of use. As the ctor arg cannot be avoided for the presenter service, this PR adds an injection symbol for the presenter service that facilitates transient injection of the presenter service. The docs and tests have been updated to reflect the change.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
