### PR TITLE
implement arrow function syntax

### DIFF
--- a/docs/user-docs/reference/examples/binding-and-templating/README.md
+++ b/docs/user-docs/reference/examples/binding-and-templating/README.md
@@ -171,6 +171,25 @@ Exponentiation (`a**b`) and bitwise operators are not supported.
 * `foo = bar`
 * `foo = bar = baz`
 
+### Lambda Expressions
+
+Lambda expressions can be used to call methods like `Array#filter`, `Array#sort`, but can also be passed in as an argument to a method on your ViewModel or even invoked as an IIFE.
+
+* `() => 42`
+* `x => x.name` (e.g. `${items.map(x => x.name).join(', ')}`)
+* `(...args) => args.join(', ')`
+* `(a => b => c => a + b + c)(1)(2)(3)` (renders '6')
+* `items.reduce((sum, x) => sum + x, 0)`
+
+{% hint style="warning" %}
+**Warning**
+
+- Wrapping the expression body in braces (`(a, b) => { ... }`) is not supported.
+- Default parameters (`(a = 42) => ...`) are not supported.
+- Destructuring parameters (`({a}) => ...` or `([a]) => ...`) is not supported.
+
+{% endhint %}
+
 ### Member and Call Expressions
 
 Member expressions with special meaning in Aurelia:

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -45,6 +45,8 @@ import {
   DestructuringAssignmentSingleExpression,
   DestructuringAssignmentRestExpression,
   DestructuringAssignmentExpression,
+  ArrowFunction,
+  BindingIdentifier,
 } from '@aurelia/runtime';
 import {
   PropertyBinding,
@@ -2874,6 +2876,35 @@ describe('DestructuringAssignmentExpression', function () {
       assert.deepStrictEqual(bc, { a:42, c:42});
     });
   });
-
 });
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+
+describe('arrow function unparsing', function () {
+  it('unparses arrow fn', function () {
+    assert.strictEqual(
+      new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a')).toString(),
+      '(a) => a'
+    );
+  });
+
+  it('unparses arrow fn with single rest parameter', function () {
+    assert.strictEqual(
+      new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a'), true).toString(),
+      '(...a) => a'
+    );
+  });
+
+  it('unparses arrow fn with 2 params', function () {
+    assert.strictEqual(
+      new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a')).toString(),
+      '(a, b) => a'
+    );
+  });
+
+  it('unparses arrow fn with 2 params with rest', function () {
+    assert.strictEqual(
+      new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a'), true).toString(),
+      '(a, ...b) => a'
+    );
+  });
+});

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -30,6 +30,7 @@ import {
   DestructuringAssignmentExpression,
   DestructuringAssignmentSingleExpression,
   IsBindingBehavior,
+  ArrowFunction,
 } from '@aurelia/runtime';
 import {
   assert,
@@ -410,9 +411,16 @@ describe('ExpressionParser', function () {
   const SimpleAssignList: [string, any][] = [
     [`a=b`, new AssignExpression($a, $b)]
   ];
+  const SimpleArrowList: [string, any][] = [
+    [`(a) => a`, new ArrowFunction([new BindingIdentifier('a')], $a)],
+    [`(a, b) => a`, new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], $a)],
+    [`a => a`, new ArrowFunction([new BindingIdentifier('a')], $a)],
+    [`() => 0`, new ArrowFunction([], $num0)],
+  ];
   const SimpleIsAssignList: [string, any][] = [
     ...SimpleIsConditionalList,
-    ...SimpleAssignList
+    ...SimpleArrowList,
+    ...SimpleAssignList,
   ];
 
   // This forms the group Precedence.Variadic
@@ -1471,7 +1479,11 @@ describe('ExpressionParser', function () {
     for (const [input] of SimpleIsAssignList) {
       for (const op of ['(', '[']) {
         it(`throw 'Missing expected token' on "${op}${input}"`, function () {
-          verifyResultOrError(`${op}${input}`, null, 'AUR0167');
+          if (`${op}${input}` === '(a => a') {
+            verifyResultOrError(`${op}${input}`, null, 'AUR0173');
+          } else {
+            verifyResultOrError(`${op}${input}`, null, 'AUR0167');
+          }
           // verifyResultOrError(`${op}${input}`, null, 'Missing expected token');
         });
       }

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -1365,52 +1365,66 @@ describe('ExpressionParser', function () {
     ]) {
       it(`throw 'Invalid start of expression' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0151');
-        // verifyResultOrError(input, null, 'Invalid start of expression');
       });
     }
 
-    for (const input of ['..', '...', '..a', '...a', '..1', '...1', '.a.', '.a..']) {
-      it(`throw 'Unconsumed token' on "${input}"`, function () {
-        verifyResultOrError(input, null, 'AUR0156');
-        // verifyResultOrError(input, null, 'Unconsumed token');
-      });
-    }
     it(`throw 'Unconsumed token' on "$this!"`, function () {
       verifyResultOrError(`$this!`, null, 'AUR0156');
-      // verifyResultOrError(`$this!`, null, 'Unconsumed token');
     });
     for (const [input] of SimpleIsAssignList) {
       for (const op of [')', ']', '}']) {
         it(`throw 'Unconsumed token' on "${input}${op}"`, function () {
           verifyResultOrError(`${input}${op}`, null, 'AUR0156');
-          // verifyResultOrError(`${input}${op}`, null, 'Unconsumed token');
         });
       }
     }
 
-    for (const start of ['$parent', '$parent.$parent']) {
-      for (const middle of ['..', '...']) {
-        for (const end of ['', 'bar', '$parent']) {
-          const expr = `${start}${middle}${end}`;
-          it(`throw 'Double dot and spread operators are not supported' on "${expr}"`, function () {
-            verifyResultOrError(expr, null, 'AUR0152');
-            // verifyResultOrError(expr, null, 'Double dot and spread operators are not supported');
-          });
-        }
+    for (const input of ['..', '..a', '..1']) {
+      it(`throw unexpectedDoubleDot on "${input}"`, function () {
+        verifyResultOrError(input, null, 'AUR0174');
+      });
+    }
+    for (const input of ['.a.', '.a..']) {
+      it(`throw unconsumedToken on "${input}"`, function () {
+        verifyResultOrError(input, null, 'AUR0156');
+      });
+    }
+    for (const input of ['...', '...a', '...1']) {
+      it(`throw invalidSpreadOp on "${input}"`, function () {
+        verifyResultOrError(input, null, 'AUR0152');
+      });
+    }
+
+    for (const start of ['$this', '$parent', '$parent.$parent', 'a', '.1']) {
+      for (const end of ['', 'a', '$parent', '1']) {
+        it(`throw expectedIdentifier on "${start}..${end}"`, function () {
+          verifyResultOrError(`${start}..${end}`, null, 'AUR0153');
+        });
+
+        it(`throw expectedIdentifier on "${start}...${end}"`, function () {
+          verifyResultOrError(`${start}...${end}`, null, 'AUR0153');
+        });
       }
+    }
+
+    for (const [input] of SimpleIsNativeLeftHandSideList) {
+      it(`throw expectedIdentifier on "${input}.."`, function () {
+        verifyResultOrError(`${input}..`, null, 'AUR0153');
+      });
+      it(`throw expectedIdentifier on "${input}..."`, function () {
+        verifyResultOrError(`${input}...`, null, 'AUR0153');
+      });
     }
 
     for (const nonTerminal of ['!', ' of', ' typeof', '=']) {
       it(`throw 'Invalid member expression' on "$parent${nonTerminal}"`, function () {
         verifyResultOrError(`$parent${nonTerminal}`, null, 'AUR0154');
-        // verifyResultOrError(`$parent${nonTerminal}`, null, 'Invalid member expression');
       });
     }
 
     for (const op of ['!', '(', '+', '-', '.', '[', 'typeof']) {
       it(`throw 'Unexpected end of expression' on "${op}"`, function () {
         verifyResultOrError(op, null, 'AUR0155');
-        // verifyResultOrError(op, null, 'Unexpected end of expression');
       });
     }
 
@@ -1418,32 +1432,21 @@ describe('ExpressionParser', function () {
       it(`throw 'Expected identifier' on "${input}."`, function () {
         if (typeof expr['value'] !== 'number' || input.includes('.')) { // only non-float numbers are allowed to end on a dot
           verifyResultOrError(`${input}.`, null, 'AUR0153');
-          // verifyResultOrError(`${input}.`, null, 'Expected identifier');
         } else {
           verifyResultOrError(`${input}.`, expr, null);
         }
       });
     }
 
-    for (const [input] of SimpleIsNativeLeftHandSideList) {
-      for (const dots of ['..', '...']) {
-        it(`throw 'Expected identifier' on "${input}${dots}"`, function () {
-          verifyResultOrError(`${input}${dots}`, null, 'AUR0153');
-          // verifyResultOrError(`${input}${dots}`, null, 'Expected identifier');
-        });
-      }
-    }
     for (const input of ['.1.', '.1..']) {
       it(`throw'Expected identifier' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0153');
-        // verifyResultOrError(input, null, 'Expected identifier');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList) {
       it(`throw 'Invalid BindingIdentifier at left hand side of "of"' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0163', ExpressionType.IsIterator);
-        // verifyResultOrError(input, null, 'Invalid BindingIdentifier at left hand side of "of"', ExpressionType.IsIterator);
       });
     }
     for (const [input] of [
@@ -1451,28 +1454,24 @@ describe('ExpressionParser', function () {
     ] as [string, any][]) {
       it(`throw 'Invalid BindingIdentifier at left hand side of "of"' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0163', ExpressionType.IsIterator);
-        // verifyResultOrError(input, null, 'Invalid BindingIdentifier at left hand side of "of"', ExpressionType.IsIterator);
       });
     }
 
     for (const input of ['{', '{[]}', '{[}', '{[a]}', '{[a}', '{{', '{(']) {
       it(`throw 'Invalid or unsupported property definition in object literal' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0164');
-        // verifyResultOrError(input, null, 'Invalid or unsupported property definition in object literal');
       });
     }
 
     for (const input of ['"', '\'']) {
       it(`throw 'Unterminated quote in string literal' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0165');
-        // verifyResultOrError(input, null, 'Unterminated quote in string literal');
       });
     }
 
     for (const input of ['`', '` ', `\`\${a}`]) {
       it(`throw 'Unterminated template string' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0166');
-        // verifyResultOrError(input, null, 'Unterminated template string');
       });
     }
 
@@ -1484,53 +1483,45 @@ describe('ExpressionParser', function () {
           } else {
             verifyResultOrError(`${op}${input}`, null, 'AUR0167');
           }
-          // verifyResultOrError(`${op}${input}`, null, 'Missing expected token');
         });
       }
     }
     for (const [input] of SimpleIsConditionalList) {
       it(`throw 'Missing expected token' on "${input}?${input}"`, function () {
         verifyResultOrError(`${input}?${input}`, null, 'AUR0167');
-        // verifyResultOrError(`${input}?${input}`, null, 'Missing expected token');
       });
     }
     for (const [input] of AccessScopeList) {
       it(`throw 'Missing expected token' on "{${input}"`, function () {
         verifyResultOrError(`{${input}`, null, 'AUR0167');
-        // verifyResultOrError(`{${input}`, null, 'Missing expected token');
       });
     }
     for (const [input] of SimpleStringLiteralList) {
       it(`throw 'Missing expected token' on "{${input}}"`, function () {
         verifyResultOrError(`{${input}}`, null, `AUR0167`);
-        // verifyResultOrError(`{${input}}`, null, 'Missing expected token');
       });
     }
     for (const input of ['{24}', '{24, 24}', '{\'\'}', '{a.b}', '{a[b]}', '{a()}']) {
       it(`throw 'Missing expected token' on "${input}"`, function () {
         verifyResultOrError(input, null, `AUR0167:${input}`);
-        // verifyResultOrError(input, null, 'Missing expected token');
       });
     }
 
     for (const input of ['#', ';', '@', '^', '~', '\\', 'foo;']) {
       it(`throw 'Unexpected character' on "${input}"`, function () {
         verifyResultOrError(input, null, 'AUR0168');
-        // verifyResultOrError(input, null, 'Unexpected character');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
       it(`throw 'Expected identifier to come after ValueConverter operator' on "${input}|"`, function () {
         verifyResultOrError(`${input}|`, null, 'AUR0159');
-        // verifyResultOrError(`${input}|`, null, 'Expected identifier to come after ValueConverter operator');
       });
     }
 
     for (const [input] of SimpleIsAssignList) {
       it(`throw 'Expected identifier to come after BindingBehavior operator' on "${input}&"`, function () {
         verifyResultOrError(`${input}&`, null, 'AUR0160');
-        // verifyResultOrError(`${input}&`, null, 'Expected identifier to come after BindingBehavior operator');
       });
     }
 
@@ -1541,14 +1532,12 @@ describe('ExpressionParser', function () {
     ]) {
       it(`throw 'Left hand side of expression is not assignable' on "${input}=a"`, function () {
         verifyResultOrError(`${input}=a`, null, `AUR0158:${input}=a`);
-        // verifyResultOrError(`${input}=a`, null, 'Left hand side of expression is not assignable');
       });
     }
 
     for (const [input] of SimpleIsBindingBehaviorList.filter(([, e]) => !e.ancestor)) {
       it(`throw 'Unexpected keyword "of"' on "${input} of"`, function () {
         verifyResultOrError(`${input} of`, null, 'AUR0161');
-        // verifyResultOrError(`${input} of`, null, 'Unexpected keyword "of"');
       });
     }
   });
@@ -1558,7 +1547,6 @@ describe('ExpressionParser', function () {
       it(char, function () {
         const identifier = `$${char}`;
         verifyResultOrError(identifier, null, 'AUR0168');
-        // verifyResultOrError(identifier, null, 'Unexpected character');
       });
     }
   });

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -1376,13 +1376,13 @@ describe('ExpressionParser', function () {
       });
     }
     it(`throw 'Unconsumed token' on "$this!"`, function () {
-      verifyResultOrError(`$this!`, null, 'AUR0162');
+      verifyResultOrError(`$this!`, null, 'AUR0156');
       // verifyResultOrError(`$this!`, null, 'Unconsumed token');
     });
     for (const [input] of SimpleIsAssignList) {
       for (const op of [')', ']', '}']) {
         it(`throw 'Unconsumed token' on "${input}${op}"`, function () {
-          verifyResultOrError(`${input}${op}`, null, 'AUR0162');
+          verifyResultOrError(`${input}${op}`, null, 'AUR0156');
           // verifyResultOrError(`${input}${op}`, null, 'Unconsumed token');
         });
       }

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -1216,6 +1216,7 @@ describe('ExpressionParser', function () {
         (expr as any).ancestor += count;
         break;
       case ExpressionKind.AccessScope:
+        // eslint-disable-next-line no-useless-escape
         if (expr.ancestor > 0 || input.search(new RegExp(`\\$this[?]?\\.[a-zA-Z\$\.]*${expr.name.replaceAll('$', '\\$')}`)) > -1) {
           (expr as any).ancestor += count;
         }
@@ -1239,6 +1240,7 @@ describe('ExpressionParser', function () {
         adjustAncestor(count, expr.expression, input);
         break;
       case ExpressionKind.CallScope:
+        // eslint-disable-next-line no-useless-escape
         if (expr.ancestor > 0 || input.search(new RegExp(`\\$this[?]?\\.[a-zA-Z\$\.]*${expr.name.replaceAll('$', '\\$')}`)) > -1) {
           (expr as any).ancestor += count;
         }

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -205,6 +205,8 @@ describe('ExpressionParser', function () {
     [`(a?b:c)`,           new ConditionalExpression($a, $b, new AccessScopeExpression('c'))],
     [`(a=b)`,             new AssignExpression($a, $b)],
     [`(a=>a)`,            new ArrowFunction([new BindingIdentifier('a')], $a)],
+    [`({})`,              new ObjectLiteralExpression([], [])],
+    [`({a})`,             new ObjectLiteralExpression(['a'], [$a])],
   ];
   // concatenation of 1 through 7 (all Primary expressions)
   // This forms the group Precedence.Primary
@@ -1208,6 +1210,8 @@ describe('ExpressionParser', function () {
   const ConciseBodySimpleIsAssignList = SimpleIsAssignList.filter(([i1]) => !i1.startsWith('{'));
   const ComplexArrowFunctionList: [number, string, ArrowFunction][] = [
     ...ConciseBodySimpleIsAssignList.map(([i1, e1]) => [1, `()=>${i1}`, new ArrowFunction([], e1)] as [number, string, any]),
+    ...ConciseBodySimpleIsAssignList.map(([i1, e1]) => [1, `(a)=>${i1}`, new ArrowFunction([new BindingIdentifier('a')], e1)] as [number, string, any]),
+    ...ConciseBodySimpleIsAssignList.map(([i1, e1]) => [1, `a=>${i1}`, new ArrowFunction([new BindingIdentifier('a')], e1)] as [number, string, any]),
     ...ConciseBodySimpleIsAssignList.map(([i1, e1]) => [2, `()=>()=>${i1}`, new ArrowFunction([], new ArrowFunction([], e1))] as [number, string, any]),
   ];
   function adjustAncestor(count: number, expr: IsAssign, input: string) {
@@ -1291,7 +1295,7 @@ describe('ExpressionParser', function () {
         break;
     }
   }
-  describe('parse ComplexArrowFunctionList', function () {
+  describe.only('parse ComplexArrowFunctionList', function () {
     for (const [depth, input, expected] of ComplexArrowFunctionList) {
       it(input, function () {
         try {

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -1295,7 +1295,7 @@ describe('ExpressionParser', function () {
         break;
     }
   }
-  describe.only('parse ComplexArrowFunctionList', function () {
+  describe('parse ComplexArrowFunctionList', function () {
     for (const [depth, input, expected] of ComplexArrowFunctionList) {
       it(input, function () {
         try {

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -1381,7 +1381,7 @@ describe('ExpressionParser', function () {
 
     for (const input of ['..', '..a', '..1']) {
       it(`throw unexpectedDoubleDot on "${input}"`, function () {
-        verifyResultOrError(input, null, 'AUR0174');
+        verifyResultOrError(input, null, 'AUR0179');
       });
     }
     for (const input of ['.a.', '.a..']) {
@@ -1540,6 +1540,101 @@ describe('ExpressionParser', function () {
         verifyResultOrError(`${input} of`, null, 'AUR0161');
       });
     }
+
+    // missing => (need to verify when __DEV__ is enabled in test env)
+    it(`throw missingExpectedToken on "()"`, function () {
+      verifyResultOrError(`()`, null, 'AUR0167');
+    });
+
+    for (const input of [
+      `(a[b]) => a`,
+      `(a?.[b]) => a`,
+      `(a.b) => a`,
+      `(a?.b) => a`,
+      `(a\`\`) => a`,
+      `($this()) => a`,
+      `(a()) => a`,
+      `(a?.()) => a`,
+      `(!a) => a`,
+      `(a+b) => a`,
+      `(a?b:c) => a`,
+
+      `(a,a[b]) => a`,
+      `(a,a?.[b]) => a`,
+      `(a,a.b) => a`,
+      `(a,a?.b) => a`,
+      `(a,a\`\`) => a`,
+      `(a,$this()) => a`,
+      `(a,a()) => a`,
+      `(a,a?.()) => a`,
+      `(a,!a) => a`,
+      `(a,a+b) => a`,
+      `(a,a?b:c) => a`,
+      `(a,b?) => a`,
+
+      `(,) => a`,
+      `(a,,) => a`,
+      `(,a) => a`,
+    ])
+    it(`throw invalidArrowParameterList on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0173');
+    });
+
+    for (const input of [
+      // TODO: identify this as optional param?
+      `(a?) => a`,
+    ])
+    it(`throw unconsumedToken on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0156');
+    });
+
+    for (const input of [
+      `(a=b) => a`,
+      `(a,a=b) => a`,
+    ])
+    it(`throw defaultParamsInArrowFn on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0174');
+    });
+
+    for (const input of [
+      `({a}) => a`,
+      `(a,{a}) => a`,
+      `([a]) => a`,
+      `(a,[a]) => a`,
+    ])
+    it(`throw destructuringParamsInArrowFn on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0175');
+    });
+
+    for (const input of [
+      `(a,...b) => a`,
+    ])
+    it(`throw restParamsInArrowFn on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0176');
+    });
+
+    for (const input of [
+      // note: this should ideally throw 'restParamsInArrowFn' as well, but we may impl spread relatively soon anyway
+      `(...a) => a`,
+    ])
+    it(`throw invalidSpreadOp on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0152');
+    });
+
+    for (const input of [
+      `() => {}`,
+      `a => {}`,
+      `(a) => {}`,
+      `(a,b) => {}`,
+
+      `() => {a}`,
+      `a => {a}`,
+      `(a) => {a}`,
+      `(a,b) => {a}`,
+    ])
+    it(`throw functionBodyInArrowFN on "${input}"`, function () {
+      verifyResultOrError(input, null, 'AUR0178');
+    });
   });
 
   describe('unknown unicode IdentifierPart', function () {

--- a/packages/__tests__/2-runtime/expression-parser.spec.ts
+++ b/packages/__tests__/2-runtime/expression-parser.spec.ts
@@ -414,7 +414,9 @@ describe('ExpressionParser', function () {
   ];
   const SimpleArrowList: [string, any][] = [
     [`(a) => a`, new ArrowFunction([new BindingIdentifier('a')], $a)],
+    [`(...a) => a`, new ArrowFunction([new BindingIdentifier('a')], $a, true)],
     [`(a, b) => a`, new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], $a)],
+    [`(a, ...b) => a`, new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], $a, true)],
     [`a => a`, new ArrowFunction([new BindingIdentifier('a')], $a)],
     [`() => 0`, new ArrowFunction([], $num0)],
   ];
@@ -1608,18 +1610,11 @@ describe('ExpressionParser', function () {
     });
 
     for (const input of [
-      `(a,...b) => a`,
+      `(...a,) => a`,
+      `(...a,b) => a`,
     ])
-    it(`throw restParamsInArrowFn on "${input}"`, function () {
+    it(`throw restParamsMustBeLastParam on "${input}"`, function () {
       verifyResultOrError(input, null, 'AUR0176');
-    });
-
-    for (const input of [
-      // note: this should ideally throw 'restParamsInArrowFn' as well, but we may impl spread relatively soon anyway
-      `(...a) => a`,
-    ])
-    it(`throw invalidSpreadOp on "${input}"`, function () {
-      verifyResultOrError(input, null, 'AUR0152');
     });
 
     for (const input of [

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -4,6 +4,13 @@ import { assert, createFixture } from "@aurelia/testing";
 
 describe("arrow-fn", function () {
 
+  it("works with paren wrapping {}", function () {
+    const { assertText } = createFixture
+      .html`\${((e) => ({ a: e.v })({ v: 1 })).a}`
+      .build();
+    assertText('1');
+  });
+
   it("can sort number array", function () {
     const { assertText } = createFixture
       .html`<div repeat.for="i of items.sort((a, b) => a - b)">\${i}</div>`

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -24,6 +24,17 @@ describe("arrow-fn", function () {
     assertText('0567');
   });
 
+  it("can observe property accessed in each parameter", function () {
+    const { component, assertText } = createFixture
+      .component({ items: [{ v: 0 }, { v: 1 }] })
+      .html`<div repeat.for="i of items.filter(i => i.v > 0)">\${i.v}</div>`
+      .build();
+    assertText('1');
+
+    component.items[0].v = 1;
+    assertText('11');
+  });
+
   it("can reduce number array", function () {
     const { assertText } = createFixture
       .html`\${items.reduce((sum, x) => sum + x, 0)}`

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -178,4 +178,124 @@ describe("arrow-fn", function () {
 
     au.dispose();
   });
+
+  it("can access the correct scope via $this", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => $this.a)('fn')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'vm');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can access the correct scope via $this in nested arrow", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => a => $this.a)('fn2')('fn1')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'vm');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can access the correct scope via $parent", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => $parent.a)('fn')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'vm');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can access the correct scope via $parent in nested arrow", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => a => $parent.a)('fn1')('fn2')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'fn1');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can access the correct scope via $parent.$parent in nested arrow", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => a => $parent.$parent.a)('fn1')('fn2')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'vm');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("stays in the correct scope via $parent in nested arrow", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(b => a => $parent.a)('fn1')('fn2')}`
+      },
+      class {
+        a = 'vm';
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '');
+    await au.stop();
+
+    au.dispose();
+  });
 });

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -142,7 +142,7 @@ describe("arrow-fn", function () {
         items = [
           { name: 'a1', children: [{ name: 'b1', children: [{ name: 'c1' }] }] },
           { name: 'a2', children: [{ name: 'b2', children: [{ name: 'c2' }] }] }
-        ]
+        ];
       }
     );
     const component = new App();
@@ -167,7 +167,7 @@ describe("arrow-fn", function () {
         items = [
           { name: 'a1', children: [{ name: 'b1', children: [{ name: 'c1' }] }] },
           { name: 'a2', children: [{ name: 'b2', children: [{ name: 'c2' }] }] }
-        ]
+        ];
       }
     );
     const component = new App();

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -111,6 +111,24 @@ describe("arrow-fn", function () {
     au.dispose();
   });
 
+  it("can call arrow inline with rest", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${((...args) => args[0] + args[1] + args[2])(1, 2, 3)}`
+      },
+      class {}
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '6');
+    await au.stop();
+
+    au.dispose();
+  });
+
   it("can flatMap nested fn", async function () {
     const { au, host } = createFixture();
     const App = CustomElement.define(

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -1,0 +1,163 @@
+import { Aurelia, CustomElement } from '@aurelia/runtime-html';
+import { TestContext, assert } from "@aurelia/testing";
+
+describe("arrow-fn", function () {
+  function createFixture() {
+    const ctx = TestContext.create();
+    const au = new Aurelia(ctx.container);
+    const host = ctx.createElement("div");
+    return { au, host };
+  }
+
+  it("can sort number array", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `<div repeat.for="i of items.sort((a, b) => a - b)">\${i}</div>`
+      },
+      class {
+        items = [5, 7, 1, 3, 2, 8, 4, 6];
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '12345678');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it.skip("can reactively sort number array", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `<div repeat.for="i of items.sort((a, b) => a - b)">\${i}</div>`
+      },
+      class {
+        items = [5, 7, 1, 3, 2, 8, 4, 6];
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '12345678');
+    component.items.push(0);
+    assert.strictEqual(host.textContent, '012345678');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can reduce number array", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${items.reduce((sum, x) => sum + x, 0)}`
+      },
+      class {
+        items = [5, 7, 1, 3, 2, 8, 4, 6];
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '36');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it.skip("can reactively reduce number array", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${items.reduce((sum, x) => sum + x, 0)}`
+      },
+      class {
+        items = [5, 7, 1, 3, 2, 8, 4, 6];
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '36');
+    component.items.push(4);
+    assert.strictEqual(host.textContent, '40');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can call nested arrow inline", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `\${(a => b => a + b)(1)(2)}`
+      },
+      class {}
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, '3');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can flatMap nested fn", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `
+          <div repeat.for="item of items.flatMap(x => [x].concat(x.children.flatMap(y => [y].concat(y.children))))">\${item.name}-</div>
+        `.trim()
+      },
+      class {
+        items = [
+          { name: 'a1', children: [{ name: 'b1', children: [{ name: 'c1' }] }] },
+          { name: 'a2', children: [{ name: 'b2', children: [{ name: 'c2' }] }] }
+        ]
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'a1-b1-c1-a2-b2-c2-');
+    await au.stop();
+
+    au.dispose();
+  });
+
+  it("can flatMap nested fn and access parent scope", async function () {
+    const { au, host } = createFixture();
+    const App = CustomElement.define(
+      {
+        name: "app",
+        template: `
+          <div repeat.for="item of items.flatMap(x => x.children.flatMap(y => ([x, y].concat(y.children))))">\${item.name}-</div>
+        `.trim()
+      },
+      class {
+        items = [
+          { name: 'a1', children: [{ name: 'b1', children: [{ name: 'c1' }] }] },
+          { name: 'a2', children: [{ name: 'b2', children: [{ name: 'c2' }] }] }
+        ]
+      }
+    );
+    const component = new App();
+    au.app({ host, component });
+    await au.start();
+    assert.strictEqual(host.textContent, 'a1-b1-c1-a2-b2-c2-');
+    await au.stop();
+
+    au.dispose();
+  });
+});

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -184,16 +184,16 @@ describe("arrow-fn", function () {
     const App = CustomElement.define(
       {
         name: "app",
-        template: `\${(a => $this.a)('fn')}`
+        template: `\${(a => $this.a)('2')}`
       },
       class {
-        a = 'vm';
+        a = '1';
       }
     );
     const component = new App();
     au.app({ host, component });
     await au.start();
-    assert.strictEqual(host.textContent, 'vm');
+    assert.strictEqual(host.textContent, '1');
     await au.stop();
 
     au.dispose();
@@ -204,16 +204,16 @@ describe("arrow-fn", function () {
     const App = CustomElement.define(
       {
         name: "app",
-        template: `\${(a => a => $this.a)('fn2')('fn1')}`
+        template: `\${(a => a => $this.a)('3')('2')}`
       },
       class {
-        a = 'vm';
+        a = '1';
       }
     );
     const component = new App();
     au.app({ host, component });
     await au.start();
-    assert.strictEqual(host.textContent, 'vm');
+    assert.strictEqual(host.textContent, '1');
     await au.stop();
 
     au.dispose();
@@ -224,16 +224,16 @@ describe("arrow-fn", function () {
     const App = CustomElement.define(
       {
         name: "app",
-        template: `\${(a => $parent.a)('fn')}`
+        template: `<div with.bind="{a:2}"><div with.bind="{a:3}"><div with.bind="{a:4}">\${(a => $parent.a)('5')}</div></div></div>`
       },
       class {
-        a = 'vm';
+        a = '1';
       }
     );
     const component = new App();
     au.app({ host, component });
     await au.start();
-    assert.strictEqual(host.textContent, 'vm');
+    assert.strictEqual(host.textContent, '3');
     await au.stop();
 
     au.dispose();
@@ -244,16 +244,16 @@ describe("arrow-fn", function () {
     const App = CustomElement.define(
       {
         name: "app",
-        template: `\${(a => a => $parent.a)('fn1')('fn2')}`
+        template: `<div with.bind="{a:2}"><div with.bind="{a:3}"><div with.bind="{a:4}">\${(a => a => $parent.a)('6')('5')}</div></div></div>`
       },
       class {
-        a = 'vm';
+        a = '1';
       }
     );
     const component = new App();
     au.app({ host, component });
     await au.start();
-    assert.strictEqual(host.textContent, 'fn1');
+    assert.strictEqual(host.textContent, '3');
     await au.stop();
 
     au.dispose();
@@ -264,36 +264,16 @@ describe("arrow-fn", function () {
     const App = CustomElement.define(
       {
         name: "app",
-        template: `\${(a => a => $parent.$parent.a)('fn1')('fn2')}`
+        template: `<div with.bind="{a:2}"><div with.bind="{a:3}"><div with.bind="{a:4}">\${(a => a => $parent.$parent.a)('6')('5')}</div></div></div>`
       },
       class {
-        a = 'vm';
+        a = '1';
       }
     );
     const component = new App();
     au.app({ host, component });
     await au.start();
-    assert.strictEqual(host.textContent, 'vm');
-    await au.stop();
-
-    au.dispose();
-  });
-
-  it("stays in the correct scope via $parent in nested arrow", async function () {
-    const { au, host } = createFixture();
-    const App = CustomElement.define(
-      {
-        name: "app",
-        template: `\${(b => a => $parent.a)('fn1')('fn2')}`
-      },
-      class {
-        a = 'vm';
-      }
-    );
-    const component = new App();
-    au.app({ host, component });
-    await au.start();
-    assert.strictEqual(host.textContent, '');
+    assert.strictEqual(host.textContent, '2');
     await au.stop();
 
     au.dispose();

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -1,5 +1,5 @@
 import { BindingBehavior, ValueConverter } from '@aurelia/runtime';
-import { CustomAttribute, INode } from '@aurelia/runtime-html';
+import { AppTask, CustomAttribute, IListenerBehaviorOptions, INode } from '@aurelia/runtime-html';
 import { assert, createFixture } from "@aurelia/testing";
 
 describe("arrow-fn", function () {
@@ -178,6 +178,19 @@ describe("arrow-fn", function () {
 
     assert.strictEqual(getBy('div').getAttribute('data-color-light'), 'lightred');
     assert.strictEqual(getBy('div').getAttribute('data-color-dark'), 'darkgreen');
+  });
+
+  it('works with event', function () {
+    let i = 0;
+    const { getBy } = createFixture
+      .html`<button click.trigger="() => clicked()">`
+      .component({ clicked: () => i = 1 })
+      // todo: maybe just make it understand function by default
+      .deps(AppTask.creating(IListenerBehaviorOptions, o => o.expAsHandler = true))
+      .build();
+
+    getBy('button').click();
+    assert.strictEqual(i, 1);
   });
 
   it('works with binding behavior', function () {

--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -4,9 +4,29 @@ import { assert, createFixture } from "@aurelia/testing";
 
 describe("arrow-fn", function () {
 
+  // leave this test at the top - if any tests below this one fail for unknown reasons, then corrupted parser state may not be properly recovered
+  it("corrupt the parser state to ensure it's correctly reset afterwards", function () {
+    let err: Error;
+    try {
+      createFixture
+        .html`\${((e) => ({ e.v })({ v: 1 }))}`
+        .build();
+    } catch (e) {
+      err = e;
+    }
+    assert.match(err.message, /AUR0167/);
+  });
+
+  it("works with IIFE", function () {
+    const { assertText } = createFixture
+      .html`\${(a => a)(1)}`
+      .build();
+    assertText('1');
+  });
+
   it("works with paren wrapping {}", function () {
     const { assertText } = createFixture
-      .html`\${((e) => ({ a: e.v })({ v: 1 })).a}`
+      .html`\${(((e) => ({ a: e.v }))({ v: 1 })).a}`
       .build();
     assertText('1');
   });

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1643,12 +1643,20 @@ export class ArrowFunction {
   public constructor(
     public parameters: BindingIdentifier[],
     public body: IsAssign,
+    public rest: boolean = false,
   ) {}
 
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): unknown {
     const func = (...args: unknown[]) => {
-      const context = this.parameters.reduce<IIndexable>((map, param, i) => {
-        map[param.name] = args[i];
+      const params = this.parameters;
+      const rest = this.rest;
+      const lastIdx = params.length - 1;
+      const context = params.reduce<IIndexable>((map, param, i) => {
+        if (rest && i === lastIdx) {
+          map[param.name] = args.slice(i);
+        } else {
+          map[param.name] = args[i];
+        }
         return map;
       }, {});
       const functionScope = Scope.fromParent(s, context);

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1647,10 +1647,10 @@ export class ArrowFunction {
 
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): unknown {
     const func = (...args: unknown[]) => {
-      const context = this.parameters.reduce((map, param, i) => {
+      const context = this.parameters.reduce<IIndexable>((map, param, i) => {
         map[param.name] = args[i];
         return map;
-      }, {} as IIndexable);
+      }, {});
       const functionScope = Scope.fromParent(s, context);
       return this.body.evaluate(f, functionScope, l, c);
     };

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -169,7 +169,24 @@ export class Unparser implements IVisitor<void> {
   }
 
   public visitArrowFunction(expr: ArrowFunction): void {
-    // TODO
+    const args = expr.args;
+    const ii = args.length;
+    let i = 0;
+    let text = '(';
+    let name: string;
+    for (; i < ii; ++i) {
+      name = args[i].name;
+      if (i > 0) {
+        text += ', ';
+      }
+      if (i < ii - 1) {
+        text += name;
+      } else {
+        text += expr.rest ? `...${name}` : name;
+      }
+    }
+    this.text += `${text}) => `;
+    expr.body.accept(this);
   }
 
   public visitObjectLiteral(expr: ObjectLiteralExpression): void {
@@ -1641,14 +1658,14 @@ export class ArrowFunction {
   public get hasUnbind(): false { return false; }
 
   public constructor(
-    public parameters: BindingIdentifier[],
+    public args: BindingIdentifier[],
     public body: IsAssign,
     public rest: boolean = false,
   ) {}
 
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): unknown {
     const func = (...args: unknown[]) => {
-      const params = this.parameters;
+      const params = this.args;
       const rest = this.rest;
       const lastIdx = params.length - 1;
       const context = params.reduce<IIndexable>((map, param, i) => {

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1647,12 +1647,11 @@ export class ArrowFunction {
 
   public evaluate(f: LF, s: Scope, l: IServiceLocator, c: IConnectable | null): unknown {
     const func = (...args: unknown[]) => {
-      const functionScope = Scope.create({
-        ...this.parameters.reduce((map: IIndexable, param, i) => {
-          map[param.name] = args[i];
-          return map;
-        }, {})
-      });
+      const context = this.parameters.reduce((map, param, i) => {
+        map[param.name] = args[i];
+        return map;
+      }, {} as IIndexable);
+      const functionScope = Scope.fromParent(s, context);
       return this.body.evaluate(f, functionScope, l, c);
     };
     return func;

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -939,10 +939,10 @@ function parseMemberExpressionLHS(lhs: IsLeftHandSide, optional: boolean) {
 /**
  * https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList
  * CoverParenthesizedExpressionAndArrowParameterList :
- *   ( Expression )
- *   ( )
- *   ( BindingIdentifier )
- *   ( Expression , BindingIdentifier )
+ * ( Expression )
+ * ( )
+ * ( BindingIdentifier )
+ * ( Expression , BindingIdentifier )
  */
 function parseCoverParenthesizedExpressionAndArrowParameterList(expressionType: ExpressionType): IsAssign {
   nextToken();

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -95,9 +95,15 @@ export class ExpressionParser {
   private $parse(expression: string, expressionType: Exclude<ExpressionType, ExpressionType.IsIterator | ExpressionType.Interpolation>): IsBindingBehavior;
   private $parse(expression: string, expressionType: ExpressionType): AnyBindingExpression {
     $input = expression;
-    $length = expression.length;
     $index = 0;
+    $length = expression.length;
+    $scopeDepth = 0;
+    $startIndex = 0;
+    $currentToken = Token.EOF;
+    $tokenValue = '';
     $currentChar = expression.charCodeAt(0);
+    $assignable = true;
+    $optional = false;
     return parse(Precedence.Variadic, expressionType === void 0 ? ExpressionType.IsProperty : expressionType);
   }
 }
@@ -340,9 +346,15 @@ function $tokenRaw(): string {
 
 export function parseExpression(input: string, expressionType?: ExpressionType): AnyBindingExpression {
   $input = input;
-  $length = input.length;
   $index = 0;
+  $length = input.length;
+  $scopeDepth = 0;
+  $startIndex = 0;
+  $currentToken = Token.EOF;
+  $tokenValue = '';
   $currentChar = input.charCodeAt(0);
+  $assignable = true;
+  $optional = false;
   return parse(Precedence.Variadic, expressionType === void 0 ? ExpressionType.IsProperty : expressionType);
 }
 

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -267,42 +267,44 @@ const enum Token {
   OpenParen               = 0b0101001000001_0000_000111,
   OpenBrace               = 0b0001000000000_0000_001000,
   Dot                     = 0b0000001000000_0000_001001,
-  QuestionDot             = 0b0100001000000_0000_001010,
-  CloseBrace              = 0b1110000000000_0000_001011,
-  CloseParen              = 0b1110000000000_0000_001100,
-  Comma                   = 0b1100000000000_0000_001101,
-  OpenBracket             = 0b0101001000001_0000_001110,
-  CloseBracket            = 0b1110000000000_0000_001111,
-  Colon                   = 0b1100000000000_0000_010000,
-  Question                = 0b1100000000000_0000_010011,
-  Ampersand               = 0b1100000000000_0000_010100,
-  Bar                     = 0b1100000000000_0000_010101,
-  QuestionQuestion        = 0b1100100000000_0010_010110,
-  BarBar                  = 0b1100100000000_0011_010111,
-  AmpersandAmpersand      = 0b1100100000000_0100_011000,
-  EqualsEquals            = 0b1100100000000_0101_011001,
-  ExclamationEquals       = 0b1100100000000_0101_011010,
-  EqualsEqualsEquals      = 0b1100100000000_0101_011011,
-  ExclamationEqualsEquals = 0b1100100000000_0101_011100,
-  LessThan                = 0b1100100000000_0110_011101,
-  GreaterThan             = 0b1100100000000_0110_011110,
-  LessThanEquals          = 0b1100100000000_0110_011111,
-  GreaterThanEquals       = 0b1100100000000_0110_100000,
-  InKeyword               = 0b1100100001000_0110_100001,
-  InstanceOfKeyword       = 0b1100100001000_0110_100010,
-  Plus                    = 0b0100110000000_0111_100011,
-  Minus                   = 0b0100110000000_0111_100100,
-  TypeofKeyword           = 0b0000010001000_0000_100101,
-  VoidKeyword             = 0b0000010001000_0000_100110,
-  Asterisk                = 0b1100100000000_1000_100111,
-  Percent                 = 0b1100100000000_1000_101000,
-  Slash                   = 0b1100100000000_1000_101001,
-  Equals                  = 0b1000000000000_0000_101010,
-  Exclamation             = 0b0000010000000_0000_101011,
-  TemplateTail            = 0b0100001000001_0000_101100,
-  TemplateContinuation    = 0b0100001000001_0000_101101,
-  OfKeyword               = 0b1000000001010_0000_101110,
-  Arrow                   = 0b0000000000000_0000_101111,
+  DotDot                  = 0b0000000000000_0000_001010,
+  DotDotDot               = 0b0000000000000_0000_001011,
+  QuestionDot             = 0b0100001000000_0000_001100,
+  CloseBrace              = 0b1110000000000_0000_001101,
+  CloseParen              = 0b1110000000000_0000_001110,
+  Comma                   = 0b1100000000000_0000_001111,
+  OpenBracket             = 0b0101001000001_0000_010000,
+  CloseBracket            = 0b1110000000000_0000_010011,
+  Colon                   = 0b1100000000000_0000_010100,
+  Question                = 0b1100000000000_0000_010101,
+  Ampersand               = 0b1100000000000_0000_010110,
+  Bar                     = 0b1100000000000_0000_010111,
+  QuestionQuestion        = 0b1100100000000_0010_011000,
+  BarBar                  = 0b1100100000000_0011_011001,
+  AmpersandAmpersand      = 0b1100100000000_0100_011010,
+  EqualsEquals            = 0b1100100000000_0101_011011,
+  ExclamationEquals       = 0b1100100000000_0101_011100,
+  EqualsEqualsEquals      = 0b1100100000000_0101_011101,
+  ExclamationEqualsEquals = 0b1100100000000_0101_011110,
+  LessThan                = 0b1100100000000_0110_011111,
+  GreaterThan             = 0b1100100000000_0110_100000,
+  LessThanEquals          = 0b1100100000000_0110_100001,
+  GreaterThanEquals       = 0b1100100000000_0110_100010,
+  InKeyword               = 0b1100100001000_0110_100011,
+  InstanceOfKeyword       = 0b1100100001000_0110_100100,
+  Plus                    = 0b0100110000000_0111_100101,
+  Minus                   = 0b0100110000000_0111_100110,
+  TypeofKeyword           = 0b0000010001000_0000_100111,
+  VoidKeyword             = 0b0000010001000_0000_101000,
+  Asterisk                = 0b1100100000000_1000_101001,
+  Percent                 = 0b1100100000000_1000_101010,
+  Slash                   = 0b1100100000000_1000_101011,
+  Equals                  = 0b1000000000000_0000_101100,
+  Exclamation             = 0b0000010000000_0000_101101,
+  TemplateTail            = 0b0100001000001_0000_101110,
+  TemplateContinuation    = 0b0100001000001_0000_101111,
+  OfKeyword               = 0b1000000001010_0000_110000,
+  Arrow                   = 0b0000000000000_0000_110001,
 }
 
 const $false = PrimitiveLiteralExpression.$false;
@@ -432,25 +434,31 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
         do {
           nextToken();
           ++ancestor;
-          if (consumeOpt(Token.Dot)) {
-            if (($currentToken as Token) === Token.Dot) {
-              throw invalidDoubleDotOrSpread();
-            } else if (($currentToken as Token) === Token.EOF) {
+          switch (($currentToken as Token)) {
+            case Token.Dot:
+              nextToken();
+              if (($currentToken & Token.IdentifierName) === 0) {
+                throw expectedIdentifier();
+              }
+              break;
+            case Token.DotDot:
+            case Token.DotDotDot:
               throw expectedIdentifier();
-            }
-          } else if (($currentToken as Token) === Token.QuestionDot) {
-            $optional = true;
-            nextToken();
-            if (($currentToken & Token.IdentifierName) === 0) {
-              result = ancestor === 0 ? $this : ancestor === 1 ? $parent : new AccessThisExpression(ancestor);
-              optionalThisTail = true;
-              break primary;
-            }
-          } else if ($currentToken & Token.AccessScopeTerminal) {
-            result = ancestor === 0 ? $this : ancestor === 1 ? $parent : new AccessThisExpression(ancestor);
-            break primary;
-          } else {
-            throw invalidMemberExpression();
+            case Token.QuestionDot:
+              $optional = true;
+              nextToken();
+              if (($currentToken & Token.IdentifierName) === 0) {
+                result = ancestor === 0 ? $this : ancestor === 1 ? $parent : new AccessThisExpression(ancestor);
+                optionalThisTail = true;
+                break primary;
+              }
+              break;
+            default:
+              if ($currentToken & Token.AccessScopeTerminal) {
+                result = ancestor === 0 ? $this : ancestor === 1 ? $parent : new AccessThisExpression(ancestor);
+                break primary;
+              }
+              throw invalidMemberExpression();
           }
         } while ($currentToken === Token.ParentScope);
         // falls through
@@ -472,6 +480,10 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
         }
         break;
       }
+      case Token.DotDot:
+        throw unexpectedDoubleDot();
+      case Token.DotDotDot:
+        throw invalidSpreadOp();
       case Token.ThisScope: // $this
         $assignable = false;
         nextToken();
@@ -525,6 +537,10 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
       return result as any;
     }
 
+    if (($currentToken as Token) === Token.DotDot || ($currentToken as Token) === Token.DotDotDot) {
+      throw expectedIdentifier();
+    }
+
     if (result.$kind === ExpressionKind.AccessThis) {
       switch ($currentToken as Token) {
         case Token.QuestionDot:
@@ -555,6 +571,9 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
           result = new AccessScopeExpression($tokenValue as string, result.ancestor);
           nextToken();
           break;
+        case Token.DotDot:
+        case Token.DotDotDot:
+          throw expectedIdentifier();
         case Token.OpenParen:
           result = new CallFunctionExpression(result as IsLeftHandSide, parseArguments(), optionalThisTail);
           break;
@@ -608,6 +627,9 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
           }
           result = parseMemberExpressionLHS(result as IsLeftHandSide, false);
           break;
+        case Token.DotDot:
+        case Token.DotDotDot:
+          throw expectedIdentifier();
         case Token.OpenParen:
           if (result.$kind === ExpressionKind.AccessScope) {
             result = new CallScopeExpression(result.name, parseArguments(), result.ancestor, false);
@@ -634,6 +656,10 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
           break;
       }
     }
+  }
+
+  if (($currentToken as Token) === Token.DotDot || ($currentToken as Token) === Token.DotDotDot) {
+    throw expectedIdentifier();
   }
 
   if (Precedence.Binary < minPrecedence) {
@@ -1408,9 +1434,9 @@ function invalidStartOfExpression() {
   }
 }
 
-function invalidDoubleDotOrSpread() {
+function invalidSpreadOp() {
   if (__DEV__) {
-    return new Error(`AUR0152: Double dot and spread operators are not supported: '${$input}'`);
+    return new Error(`AUR0152: Spread operator is not supported: '${$input}'`);
   } else {
     return new Error(`AUR0152:${$input}`);
   }
@@ -1569,6 +1595,14 @@ function invalidArrowParameterList() {
   }
 }
 
+function unexpectedDoubleDot() {
+  if (__DEV__) {
+    return new Error(`AUR0174: Unexpected token '.' at position ${$index - 1} in ${$input}`);
+  } else {
+    return new Error(`AUR0174:${$input}`);
+  }
+}
+
 // #endregion
 
 /**
@@ -1581,7 +1615,7 @@ function invalidArrowParameterList() {
 const TokenValues = [
   $false, $true, $null, $undefined, '$this', null/* '$host' */, '$parent',
 
-  '(', '{', '.', '?.', '}', ')', ',', '[', ']', ':', '?', '\'', '"',
+  '(', '{', '.', '..', '...', '?.', '}', ')', ',', '[', ']', ':', '?', '\'', '"',
 
   '&', '|', '??', '||', '&&', '==', '!=', '===', '!==', '<', '>',
   '<=', '>=', 'in', 'instanceof', '+', '-', 'typeof', 'void', '*', '%', '/', '=', '!',
@@ -1743,10 +1777,18 @@ CharScanners[Char.Question] = () => {
   return Token.QuestionQuestion;
 };
 
-// .
+// ., ...
 CharScanners[Char.Dot] = () => {
   if (nextChar() <= Char.Nine && $currentChar >= Char.Zero) {
     return scanNumber(true);
+  }
+  if ($currentChar === Char.Dot) {
+    const peek = $input.charCodeAt($index + 1);
+    if (peek !== Char.Dot) {
+      return Token.DotDot;
+    }
+    nextChar();
+    return Token.DotDotDot;
   }
   return Token.Dot;
 };

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -431,6 +431,7 @@ export function parse(minPrecedence: Precedence, expressionType: ExpressionType)
      */
     primary: switch ($currentToken) {
       case Token.ParentScope: // $parent
+        ancestor = $scopeDepth;
         $assignable = false;
         do {
           nextToken();

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -1924,7 +1924,7 @@ CharScanners[Char.Dot] = () => {
     if (nextChar() !== Char.Dot) {
       return Token.DotDot;
     }
-    nextChar()
+    nextChar();
     return Token.DotDotDot;
   }
   return Token.Dot;

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -893,7 +893,7 @@ function parseOptionalChainLHS(lhs: IsLeftHandSide) {
 function parseMemberExpressionLHS(lhs: IsLeftHandSide, optional: boolean) {
   const rhs = $tokenValue as string;
   switch (($currentToken as Token)) {
-    case Token.QuestionDot:
+    case Token.QuestionDot: {
       $optional = true;
       $assignable = false;
 
@@ -923,17 +923,18 @@ function parseMemberExpressionLHS(lhs: IsLeftHandSide, optional: boolean) {
       $optional = optionalSave;
 
       return new AccessMemberExpression(lhs, rhs, optional);
-    case Token.OpenParen:
+    }
+    case Token.OpenParen: {
       $assignable = false;
       return new CallMemberExpression(lhs, rhs, parseArguments(), optional, false);
-    default:
+    }
+    default: {
       $assignable = !$optional;
       nextToken();
       return new AccessMemberExpression(lhs, rhs, optional);
+    }
   }
 }
-
-
 
 /**
  * https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList
@@ -957,6 +958,7 @@ function parseCoverParenthesizedExpressionAndArrowParameterList(expressionType: 
   const arrowParams: BindingIdentifier[] = [];
   let invalid = false;
 
+// eslint-disable-next-line no-constant-condition
   loop: while (true) {
     switch ($currentToken as Token) {
       case Token.Identifier:
@@ -1395,7 +1397,6 @@ function consume(token: Token): void {
     throw missingExpectedToken(token);
   }
 }
-
 
 // #region errors
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -33,6 +33,7 @@ export {
   DestructuringAssignmentExpression,
   DestructuringAssignmentSingleExpression,
   DestructuringAssignmentRestExpression,
+  ArrowFunction,
 
   // ast typing helpers
   type AnyBindingExpression,

--- a/packages/validation/src/ast-serialization.ts
+++ b/packages/validation/src/ast-serialization.ts
@@ -257,7 +257,7 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${expr.target.accept(this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
   }
   public visitArrowFunction(expr: AST.ArrowFunction): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.parameters)},"body":${expr.body.accept(this)},"rest":${serializePrimitive(expr.rest)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.args)},"body":${expr.body.accept(this)},"rest":${serializePrimitive(expr.rest)}}`;
   }
   private serializeExpressions(args: readonly AST.IsExpressionOrStatement[]): string {
     let text = '[';

--- a/packages/validation/src/ast-serialization.ts
+++ b/packages/validation/src/ast-serialization.ts
@@ -28,6 +28,7 @@ enum ASTExpressionTypes {
   DestructuringAssignment = 'DestructuringAssignment',
   DestructuringSingleAssignment = 'DestructuringSingleAssignment',
   DestructuringRestAssignment = 'DestructuringRestAssignment',
+  ArrowFunction = 'ArrowFunction',
 }
 
 export class Deserializer implements IExpressionHydrator {
@@ -144,6 +145,9 @@ export class Deserializer implements IExpressionHydrator {
       case ASTExpressionTypes.DestructuringRestAssignment: {
         return new AST.DestructuringAssignmentRestExpression(this.hydrate(raw.target), this.hydrate(raw.indexOrProperties));
       }
+      case ASTExpressionTypes.ArrowFunction: {
+        return new AST.ArrowFunction(this.hydrate(raw.parameters), this.hydrate(raw.body), this.hydrate(raw.rest));
+      }
       default:
         if (Array.isArray(raw)) {
           if (typeof raw[0] === 'object') {
@@ -251,6 +255,9 @@ export class Serializer implements AST.IVisitor<string> {
   }
   public visitDestructuringAssignmentRestExpression(expr: AST.DestructuringAssignmentRestExpression): string {
     return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${expr.target.accept(this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
+  }
+  public visitArrowFunction(expr: AST.ArrowFunction): string {
+    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.parameters)},"body":${expr.body.accept(this)},"rest":${serializePrimitive(expr.rest)}}`;
   }
   private serializeExpressions(args: readonly AST.IsExpressionOrStatement[]): string {
     let text = '[';


### PR DESCRIPTION
## Context:

One of the commonly requested features in Aurelia is the ability to use arrow function in templates. It can be handy in many ways: filtering items for a repeat, passing a callback to a child component, handling an event, etc... Additionally, it is a good way to avoid having to create a view model to accommodate some code that can only be expressed via a function.

With the arrow function, the following code
```html
<my-input change.call="updateValue($event)">
<my-button click.trigger="handleClick">
```
 can be rewritten with simpler, closer to JavaScript syntax:
```html
<my-input change.bind="v => updateValue(v)">
<my-button click.trigger="e => handleClick(e)">
```

It also enables us to have an easier time dealing with ad-hoc collection filtering/sorting:
```html
<div repeat.for="i of list | specialFilterBy">
```
can now be rewritten as
```html
<div repeat.for="i of list.filter(item => isGood(item))">
```

Recently, it's been requested again at #1503 , we decided to take this opportunity to finally add the support, albeit not full range of syntax, for the arrow function/lambda.

The subset of the Arrow Function syntax in Aurelia template support simple and rest parameters list, and simple concise function body expression. Which means if the arrow function body starts with a `{`, it'll not be supported.

## Examples

### Valid usages:
```ts
() => 42
```
```ts
(a) => a
```
```ts
(...a) => a[0]
```
```ts
a => a
```
```ts
(a, b) => `${a}${b}`
```
```ts
(a, ...rest) => `${a}${rest.join('')}`
```
```ts
a => b => a + b
```

### Invalid usages:
```ts
() => {} // no function body
```
```ts
(a = 42) => a // no default parameters
```
```ts
([a]) => a // no destructuring parameters
```
```ts
({a}) => a // no destructuring parameters
```

### Practical examples:
```html
<div repeat.for="item of items.filter(x => x.selected).sort((a, b) => a.pos - b.pos)">
  ${item.name}
</div>
```
Observation wise, Aurelia knows to only observe `selected` property of every item in `items`, as well as `pos` property of every **selected item**. This means changing the value of `selected` property of any item will result in the re-evaluation of the above expression. Changing the value of `pos` property of any **selected item** will also trigger the re-evaluation.

```html
<p>Total: ${items.reduce((sum, item) => sum + item.count, 0)}</p>
```
Similar to the above practical example, the `count` property of every item will be observed and changing the value of any `count` will result in re-evaluation.

## Next step

Since now we have a better way to express a function in the template, the following syntaxes are going to be deprecated:
- `.call`

Close #1503 