### PR TITLE
refactor(router): rename load, unload to loading, unloading

### DIFF
--- a/examples/doc-example/src/double-slow.ts
+++ b/examples/doc-example/src/double-slow.ts
@@ -15,11 +15,11 @@ export class DoubleSlow {
     this.element = controller.host;
   }
 
-  public load(_params, _instruction, navigation) {
+  public loading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation.back;
     return new Promise(r => setTimeout(r, 2000));
   }
-  public unload(_instruction, navigation) {
+  public unloading(_instruction, navigation) {
     this.backwards = navigation.navigation.back;
   }
 

--- a/examples/doc-example/src/fast.ts
+++ b/examples/doc-example/src/fast.ts
@@ -6,7 +6,7 @@ import { customElement } from '@aurelia/runtime-html';
 Fast
 `})
 export class Fast {
-  public load(parameters, instruction, navigation) {
+  public loading(parameters, instruction, navigation) {
     console.log('Fast load:', parameters, instruction, navigation);
   }
   // public detaching() {

--- a/examples/doc-example/src/slow-attach-parent.ts
+++ b/examples/doc-example/src/slow-attach-parent.ts
@@ -27,10 +27,10 @@ export class SlowAttachParent {
     setInterval(() => { _this.seconds++; }, 1000);
   }
 
-  public load(_params, _instruction, navigation) {
+  public loading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation.back;
   }
-  public unload(_params, _instruction, navigation) {
+  public unloading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation?.back;
   }
 

--- a/examples/doc-example/src/slow.ts
+++ b/examples/doc-example/src/slow.ts
@@ -6,7 +6,7 @@ import { customElement } from '@aurelia/runtime-html';
 Slow
 `})
 export class Slow {
-  public load(params) {
+  public loading(params) {
     console.log('Slow params', params);
   }
 

--- a/examples/lazy-loading-config/src/five.ts
+++ b/examples/lazy-loading-config/src/five.ts
@@ -9,11 +9,11 @@ export class Five {
     return true;
   }
 
-  load(...args) {
+  loading(...args) {
     console.log('In Five load hook', ...args);
   }
 
-  unload(...args) {
-    console.log('In Five unload hook', ...args);
+  unloading(...args) {
+    console.log('In Five unloading hook', ...args);
   }
 }

--- a/examples/lazy-loading-config/src/main.ts
+++ b/examples/lazy-loading-config/src/main.ts
@@ -20,12 +20,12 @@ class NoopHandler {
     return true;
   }
 
-  load(...args) {
+  loading(...args) {
     console.log('In load shared hook', ...args);
   }
 
-  unload(...args) {
-    console.log('In unload shared hook', ...args);
+  unloading(...args) {
+    console.log('In unloading shared hook', ...args);
   }
 }
 
@@ -41,12 +41,12 @@ class SecondHandler {
     return true;
   }
 
-  load(vm, params, instruction, navigation) {
+  loading(vm, params, instruction, navigation) {
     console.log('In load second handler', vm, params, instruction, navigation);
   }
 
-  unload(vm, instruction, navigation) {
-    console.log('In unload second handler', vm, instruction, navigation);
+  unloading(vm, instruction, navigation) {
+    console.log('In unloading second handler', vm, instruction, navigation);
   }
 }
 

--- a/examples/realworld-advanced/src/article/index.ts
+++ b/examples/realworld-advanced/src/article/index.ts
@@ -31,7 +31,7 @@ export class ArticleViewCustomElement implements IRouteViewModel {
     @IArticleState readonly $article: IArticleState,
   ) {}
 
-  load({ slug }: Params): void {
+  loading({ slug }: Params): void {
     this.p.taskQueue.queueTask(async () => {
       await Promise.all([
         this.$article.load(slug),

--- a/examples/realworld-advanced/src/auth/index.ts
+++ b/examples/realworld-advanced/src/auth/index.ts
@@ -45,7 +45,7 @@ export class AuthViewCustomElement implements IRouteViewModel {
     @IUserState readonly $user: IUserState,
   ) {}
 
-  load(params: Params, next: RouteNode): void {
+  loading(params: Params, next: RouteNode): void {
     this.mode = next.instruction!.component.value as 'login' | 'register';
   }
 

--- a/examples/realworld-advanced/src/editor/index.ts
+++ b/examples/realworld-advanced/src/editor/index.ts
@@ -20,7 +20,7 @@ export class EditorViewCustomElement implements IRouteViewModel {
     this.local = $article.current.clone();
   }
 
-  load({ slug }: Params): void {
+  loading({ slug }: Params): void {
     this.p.taskQueue.queueTask(async () => {
       await this.$article.load(slug);
     });

--- a/examples/realworld-advanced/src/profile/index.ts
+++ b/examples/realworld-advanced/src/profile/index.ts
@@ -11,7 +11,7 @@ class AuthorArticlesCustomElement implements IRouteViewModel {
     @IArticleListState readonly $articles: IArticleListState,
   ) {}
 
-  load({ name }: Params): void {
+  loading({ name }: Params): void {
     this.p.taskQueue.queueTask(async () => {
       const params = ArticleListQueryParams.create({
         ...this.$articles.params,
@@ -30,7 +30,7 @@ class FavoritedArticlesCustomElement implements IRouteViewModel {
     @IArticleListState readonly $articles: IArticleListState,
   ) {}
 
-  load({ name }: Params): void {
+  loading({ name }: Params): void {
     this.p.taskQueue.queueTask(async () => {
       const params = ArticleListQueryParams.create({
         ...this.$articles.params,
@@ -59,7 +59,7 @@ export class ProfileViewCustomElement implements IRouteViewModel {
     @IUserState readonly $user: IUserState,
   ) {}
 
-  load({ name }: Params): void {
+  loading({ name }: Params): void {
     this.p.taskQueue.queueTask(async () => {
       await this.$profile.load(name as string);
     });

--- a/examples/realworld-conventions/src/_shared/article-list.ts
+++ b/examples/realworld-conventions/src/_shared/article-list.ts
@@ -27,7 +27,7 @@ export class ArticleList implements IRouteableComponent {
     return this.tag !== undefined ? `tag=${this.tag},` : '';
   }
 
-  async load({ mode, page, tag, name }: Parameters, instruction: RoutingInstruction): Promise<void> {
+  async loading({ mode, page, tag, name }: Parameters, instruction: RoutingInstruction): Promise<void> {
     // Component serves as three so set the right name
     this.componentName = instruction.component.name ?? 'article-list';
 

--- a/examples/realworld-conventions/src/article/article.ts
+++ b/examples/realworld-conventions/src/article/article.ts
@@ -32,7 +32,7 @@ export class Article implements IRouteableComponent {
     @IArticleState readonly $article: IArticleState,
   ) { }
 
-  async load({ slug }: Parameters) {
+  async loading({ slug }: Parameters) {
     await Promise.all([
       this.$article.load(slug as string),
       this.$article.loadComments(slug as string),

--- a/examples/realworld-conventions/src/auth/index.ts
+++ b/examples/realworld-conventions/src/auth/index.ts
@@ -46,7 +46,7 @@ export class AuthViewCustomElement implements IRouteableComponent {
     @IUserState readonly $user: IUserState,
   ) { }
 
-  load(params: Parameters, instruction: RoutingInstruction): void {
+  loading(params: Parameters, instruction: RoutingInstruction): void {
     this.mode = instruction.component.name as 'login' | 'register';
   }
 

--- a/examples/realworld-conventions/src/editor/editor.ts
+++ b/examples/realworld-conventions/src/editor/editor.ts
@@ -19,7 +19,7 @@ export class Editor implements IRouteableComponent {
     this.local = $article.current.clone();
   }
 
-  async load({ slug }: Parameters) {
+  async loading({ slug }: Parameters) {
     await this.$article.load(slug as string);
   }
 

--- a/examples/realworld-conventions/src/home/home.ts
+++ b/examples/realworld-conventions/src/home/home.ts
@@ -18,7 +18,7 @@ export class Home implements IRouteableComponent {
     @IUserState readonly $user: IUserState,
   ) { }
 
-  load() {
+  loading() {
     if (this.$articleList.params instanceof ArticleListQueryParams) {
       this.$articleList.params.author = undefined;
       this.$articleList.params.favorited = undefined;

--- a/examples/realworld-conventions/src/profile/profile.ts
+++ b/examples/realworld-conventions/src/profile/profile.ts
@@ -23,7 +23,7 @@ export class Profile implements IRouteableComponent {
     @IUserState readonly $user: IUserState,
   ) { }
 
-  async load({ name }: Parameters) {
+  async loading({ name }: Parameters) {
     await this.$profile.load(name as string);
   }
 

--- a/examples/realworld/src/article/index.ts
+++ b/examples/realworld/src/article/index.ts
@@ -29,7 +29,7 @@ export class ArticleViewCustomElement implements IRouteViewModel {
     @IArticleState readonly $article: IArticleState,
   ) {}
 
-  async load({ slug }: Params) {
+  async loading({ slug }: Params) {
     await Promise.all([
       this.$article.load(slug),
       this.$article.loadComments(slug!),

--- a/examples/realworld/src/auth/index.ts
+++ b/examples/realworld/src/auth/index.ts
@@ -45,7 +45,7 @@ export class AuthViewCustomElement implements IRouteViewModel {
     @IUserState readonly $user: IUserState,
   ) {}
 
-  load(params: Params, next: RouteNode): void {
+  loading(params: Params, next: RouteNode): void {
     this.mode = next.instruction!.component.value as 'login' | 'register';
   }
 

--- a/examples/realworld/src/editor/index.ts
+++ b/examples/realworld/src/editor/index.ts
@@ -18,7 +18,7 @@ export class EditorViewCustomElement implements IRouteViewModel {
     this.local = $article.current.clone();
   }
 
-  async load({ slug }: Params) {
+  async loading({ slug }: Params) {
     await this.$article.load(slug);
   }
 

--- a/examples/realworld/src/profile/index.ts
+++ b/examples/realworld/src/profile/index.ts
@@ -12,7 +12,7 @@ class AuthorArticlesCustomElement implements IRouteViewModel {
     @IArticleListState readonly $articles: IArticleListState,
   ) {}
 
-  async load({ name }: Params) {
+  async loading({ name }: Params) {
     const params = ArticleListQueryParams.create({
       ...this.$articles.params,
       favorited: undefined,
@@ -29,7 +29,7 @@ class FavoritedArticlesCustomElement implements IRouteViewModel {
     @IArticleListState readonly $articles: IArticleListState,
   ) {}
 
-  async load({ name }: Params) {
+  async loading({ name }: Params) {
     const params = ArticleListQueryParams.create({
       ...this.$articles.params,
       author: undefined,
@@ -55,7 +55,7 @@ export class ProfileViewCustomElement implements IRouteViewModel {
     @IUserState readonly $user: IUserState,
   ) {}
 
-  async load({ name }: Params) {
+  async loading({ name }: Params) {
     await this.$profile.load(name as string);
   }
 

--- a/examples/router-animation/src/animation-hooks.ts
+++ b/examples/router-animation/src/animation-hooks.ts
@@ -1,35 +1,23 @@
 import { lifecycleHooks } from '@aurelia/runtime-html';
+import { slideIn, slideOut } from './animations';
 
 @lifecycleHooks()
 export class AnimationHooks {
-  // Only routing hooks are yet supported
-  //public created(vm, controller): void {
-  //  vm.element = controller.host;
-  //}
+  public created(vm, controller): void {
+   vm.element = controller.host;
+  }
 
   public loading(vm, _params, _instruction, navigation) {
-    console.log('loading', vm.backwards);
-    vm.backwards = navigation.navigation.back;
-  }
-  public load(vm, _params, _instruction, navigation) {
-    console.log('load', vm.backwards);
-    vm.backwards = navigation.navigation.back;
-  }
-  public unload(vm, _instruction, navigation) {
-    console.log('unload', vm.backwards);
     vm.backwards = navigation.navigation.back;
   }
   public unloading(vm, _instruction, navigation) {
-    console.log('unloading', vm.backwards);
     vm.backwards = navigation.navigation.back;
   }
 
-  // Only routing hooks are yet supported
-  //public attaching() {
-  //  return slideIn(vm.element, 750, vm.backwards ? 'left' : 'right');
-  //}
-  // Only routing hooks are yet supported
-  //public detaching() {
-  //  return slideOut(vm.element, 750, vm.backwards ? 'right' : 'left');
-  //}
+  public attaching(vm) {
+   return slideIn(vm.element, 750, vm.backwards ? 'left' : 'right');
+  }
+  public detaching(vm) {
+   return slideOut(vm.element, 750, vm.backwards ? 'right' : 'left');
+  }
 }

--- a/examples/router-animation/src/fallback.ts
+++ b/examples/router-animation/src/fallback.ts
@@ -1,12 +1,14 @@
 import { customElement } from 'aurelia';
+import { AnimationHooks } from './animation-hooks';
 
 @customElement({
   name: 'fallback',
   template: 'Fallback for: ${missing}',
+  dependencies: [AnimationHooks],
 })
 export class Fallback {
   public missing: string;
-  public load(parameters) {
+  public loading(parameters) {
     this.missing = parameters[0];
   }
 }

--- a/examples/router-animation/src/my-app.html
+++ b/examples/router-animation/src/my-app.html
@@ -15,7 +15,11 @@ html template:
 
 <a load="one">One</a>
 <a load="two">Two</a>
-<a load="three/four">Three/four (missing)</a>
+<a load="three">Three</a>
+<a load="tre">Tre</a>
+<a load="ett/tva/tre">Ett/tva/tre</a>
+<a load="/page/1">/page/1</a>
+<a load="four/five">Four/five (missing)</a>
 
 <au-viewport></au-viewport>
 

--- a/examples/router-animation/src/my-app.ts
+++ b/examples/router-animation/src/my-app.ts
@@ -5,17 +5,22 @@ import './my-app.css';
 
 import { One } from './one';
 import { Two } from './two';
+import { Three } from './three';
 import { AnimationHooks } from './animation-hooks';
 
 @customElement({
   name: 'my-app',
   template,
-  dependencies: [One, Two, AnimationHooks],
+  dependencies: [One, Two, Three, AnimationHooks],
 })
 export class MyApp {
 
   public static routes = [
     { path: '', component: 'one' },
+    { path: 'ett/tva/tre', component: 'one' },
+    { path: 'tre', component: 'three' },
+    { path: "/page/1", component: import('./pages/page-1'), title: 'Page 1', },
+
   ];
 
   public message: string = 'Hello Aurelia 2!';

--- a/examples/router-animation/src/one.ts
+++ b/examples/router-animation/src/one.ts
@@ -1,5 +1,4 @@
-import { customElement, lifecycleHooks } from 'aurelia';
-import { slideIn, slideOut } from './animations';
+import { customElement } from 'aurelia';
 import template from './one.html';
 import { AnimationHooks } from './animation-hooks';
 
@@ -8,30 +7,4 @@ import { AnimationHooks } from './animation-hooks';
   template,
   dependencies: [AnimationHooks],
 })
-export class One {
-  public backwards: boolean;
-  public element: Element;
-
-  // Once support is there, this would also move to animation-hooks.ts
-  public created(controller): void {
-    console.log('created', controller.lifecycleHooks);
-    this.element = controller.host;
-  }
-
-  //public load(_params, _instruction, navigation) {
-  //  this.backwards = navigation.navigation.back;
-  //}
-  // After the next router release, this method can also be moved to animation-hooks.ts
-  public unload(_instruction, navigation) {
-    this.backwards = navigation.navigation.back;
-  }
-
-  // Once support is there, this would also move to animation-hooks.ts
-  public attaching() {
-    return slideIn(this.element, 750, this.backwards ? 'left' : 'right');
-  }
-  // Once support is there, this would also move to animation-hooks.ts
-  public detaching() {
-    return slideOut(this.element, 750, this.backwards ? 'right' : 'left');
-  }
-}
+export class One { }

--- a/examples/router-animation/src/pages/page-1.ts
+++ b/examples/router-animation/src/pages/page-1.ts
@@ -1,0 +1,9 @@
+import { customElement } from "aurelia";
+import { AnimationHooks } from '../animation-hooks';
+
+@customElement({
+  name: 'page-1',
+  template: `I'm a page. I'm the first one`,
+  dependencies: [AnimationHooks],
+})
+export class Page1 { }

--- a/examples/router-animation/src/three.html
+++ b/examples/router-animation/src/three.html
@@ -1,0 +1,6 @@
+<div>Three</div>
+<nav>
+  <a load="ett">Ett</a>
+  <a load="two">Two</a>
+</nav>
+<au-viewport></au-viewport>

--- a/examples/router-animation/src/three.ts
+++ b/examples/router-animation/src/three.ts
@@ -1,14 +1,14 @@
 import { customElement } from 'aurelia';
-import template from './two.html';
+import template from './three.html';
 import { AnimationHooks } from './animation-hooks';
 
 @customElement({
-  name: 'two',
+  name: 'three',
   template,
   dependencies: [AnimationHooks],
 })
-export class Two {
-  canLoad() {
-    return '/ett/tva/tre';
-  }
+export class Three {
+  public static routes = [
+    { path: 'ett/tva/tre', component: 'one' },
+  ];
 }

--- a/packages/__e2e__/router/src/pages/fallback.ts
+++ b/packages/__e2e__/router/src/pages/fallback.ts
@@ -1,6 +1,6 @@
 export class Fallback {
   public missing: string;
-  public load(parameters) {
+  public loading(parameters) {
     this.missing = parameters[0];
   }
 }

--- a/packages/__tests__/router/_shared/hook-invocation-tracker.ts
+++ b/packages/__tests__/router/_shared/hook-invocation-tracker.ts
@@ -13,9 +13,9 @@ export type HookName = (
   'dispose' |
 
   'canLoad' |
-  'load' |
+  'loading' |
   'canUnload' |
-  'unload'
+  'unloading'
 );
 
 export type MaybeHookName = HookName | '';
@@ -112,9 +112,9 @@ export class HookInvocationAggregator {
   public readonly $$dispose: HookInvocationTracker = new HookInvocationTracker(this, 'dispose');
 
   public readonly canLoad: HookInvocationTracker = new HookInvocationTracker(this, 'canLoad');
-  public readonly load: HookInvocationTracker = new HookInvocationTracker(this, 'load');
+  public readonly loading: HookInvocationTracker = new HookInvocationTracker(this, 'loading');
   public readonly canUnload: HookInvocationTracker = new HookInvocationTracker(this, 'canUnload');
-  public readonly unload: HookInvocationTracker = new HookInvocationTracker(this, 'unload');
+  public readonly unloading: HookInvocationTracker = new HookInvocationTracker(this, 'unloading');
 
   public notify(
     componentName: string,
@@ -145,9 +145,9 @@ export class HookInvocationAggregator {
     this.unbinding.dispose();
     this.$$dispose.dispose();
     this.canLoad.dispose();
-    this.load.dispose();
+    this.loading.dispose();
     this.canUnload.dispose();
-    this.unload.dispose();
+    this.unloading.dispose();
 
     const $this = this as Partial<Writable<this>>;
     $this.notifyHistory = void 0;
@@ -162,8 +162,8 @@ export class HookInvocationAggregator {
     $this.unbinding = void 0;
     $this.$$dispose = void 0;
     $this.canLoad = void 0;
-    $this.load = void 0;
+    $this.loading = void 0;
     $this.canUnload = void 0;
-    $this.unload = void 0;
+    $this.unloading = void 0;
   }
 }

--- a/packages/__tests__/router/_shared/hook-rules.ts
+++ b/packages/__tests__/router/_shared/hook-rules.ts
@@ -2,7 +2,7 @@ import { SwapStrategy } from './create-fixture.js';
 import { HookName } from './hook-invocation-tracker.js';
 import { Viewport } from './viewport.js';
 
-export const routingHooks: HookName[] = ['canUnload', 'canLoad', 'unload', 'load'];
+export const routingHooks: HookName[] = ['canUnload', 'canLoad', 'unloading', 'loading'];
 export const addHooks: HookName[] = ['binding', 'bound', 'attaching', 'attached'];
 export const removeHooks: HookName[] = ['detaching', 'unbinding', 'dispose'];
 
@@ -126,12 +126,12 @@ function getViewportHooks(swapStrategy: SwapStrategy, phase: string, viewport: V
         hooks.push(`${phase}:${viewport.name}.${viewport.to.name}.canLoad.leave`);
       }
       if (!viewport.from.isEmpty) {
-        hooks.push(`${phase}:${viewport.name}.${viewport.from.name}.unload.enter`);
-        hooks.push(`${phase}:${viewport.name}.${viewport.from.name}.unload.leave`);
+        hooks.push(`${phase}:${viewport.name}.${viewport.from.name}.unloading.enter`);
+        hooks.push(`${phase}:${viewport.name}.${viewport.from.name}.unloading.leave`);
       }
       if (!viewport.to.isEmpty) {
-        hooks.push(`${phase}:${viewport.name}.${viewport.to.name}.load.enter`);
-        hooks.push(`${phase}:${viewport.name}.${viewport.to.name}.load.leave`);
+        hooks.push(`${phase}:${viewport.name}.${viewport.to.name}.loading.enter`);
+        hooks.push(`${phase}:${viewport.name}.${viewport.to.name}.loading.leave`);
       }
 
       switch (swapStrategy) {
@@ -266,13 +266,13 @@ function getViewports(root: string, from: string, to: string): {
 // export function* getStopHooks(root: string, p: string, c: string = '', c3 = '', c4 = '') {
 //   yield `stop.${root}.detaching`;
 
-//   if (p) { yield* prepend('stop', p, 'unload', 'detaching'); }
+//   if (p) { yield* prepend('stop', p, 'unloading', 'detaching'); }
 
 //   yield `stop.${root}.unbinding`;
 
-//   if (c) { yield* prepend('stop', c, 'unload', 'detaching'); }
-//   if (c3) { yield* prepend('stop', c3, 'unload', 'detaching'); }
-//   if (c4) { yield* prepend('stop', c4, 'unload', 'detaching'); }
+//   if (c) { yield* prepend('stop', c, 'unloading', 'detaching'); }
+//   if (c3) { yield* prepend('stop', c3, 'unloading', 'detaching'); }
+//   if (c4) { yield* prepend('stop', c4, 'unloading', 'detaching'); }
 
 //   if (p) { yield* prepend('stop', p, 'unbinding'); }
 //   if (c) { yield* prepend('stop', c, 'unbinding'); }

--- a/packages/__tests__/router/_shared/hook-spec.ts
+++ b/packages/__tests__/router/_shared/hook-spec.ts
@@ -93,9 +93,9 @@ export const hookSpecsMap = {
   dispose: getHookSpecs('dispose').sync,
 
   canLoad: getHookSpecs('canLoad'),
-  load: getHookSpecs('load'),
+  loading: getHookSpecs('loading'),
   canUnload: getHookSpecs('canUnload'),
-  unload: getHookSpecs('unload'),
+  unloading: getHookSpecs('unloading'),
 };
 
 function groupByPrefix(list: string[]): Record<string, string[]> {
@@ -139,6 +139,6 @@ function filterHooks(hooks: string[]): string[] {
     && !hook.endsWith('.tick')
     // && !hook.endsWith('.dispose')
     // && !hook.startsWith('stop.')
-    && (hook.includes('canUnload') || hook.includes('canLoad') || hook.includes('unload') || hook.includes('load'))
+    && (hook.includes('canUnload') || hook.includes('canLoad') || hook.includes('unloading') || hook.includes('loading'))
   ).map(hook => hook.replace(/:.*?\./gi, '.').replace(/\.enter$/, ''));
 }

--- a/packages/__tests__/router/_shared/hooks.ts
+++ b/packages/__tests__/router/_shared/hooks.ts
@@ -4,7 +4,7 @@ import { TransitionComponent } from './component.js';
 import { Transition } from './transition.js';
 import { TransitionViewport } from './transition-viewport.js';
 
-export const routingHooks: HookName[] = ['canUnload', 'canLoad', 'unload', 'load'];
+export const routingHooks: HookName[] = ['canUnload', 'canLoad', 'unloading', 'loading'];
 export const addHooks: HookName[] = ['binding', 'bound', 'attaching', 'attached'];
 export const removeHooks: HookName[] = ['detaching', 'unbinding', 'dispose'];
 
@@ -18,13 +18,13 @@ export function* getStartHooks(root: string) {
 export function* getStopHooks(root: string, p: string, c: string = '', c3 = '', c4 = '') {
   yield `stop.${root}.detaching`;
 
-  if (p) { yield* prepend('stop', p, 'unload', 'detaching'); }
+  if (p) { yield* prepend('stop', p, 'unloading', 'detaching'); }
 
   yield `stop.${root}.unbinding`;
 
-  if (c) { yield* prepend('stop', c, 'unload', 'detaching'); }
-  if (c3) { yield* prepend('stop', c3, 'unload', 'detaching'); }
-  if (c4) { yield* prepend('stop', c4, 'unload', 'detaching'); }
+  if (c) { yield* prepend('stop', c, 'unloading', 'detaching'); }
+  if (c3) { yield* prepend('stop', c3, 'unloading', 'detaching'); }
+  if (c4) { yield* prepend('stop', c4, 'unloading', 'detaching'); }
 
   if (p) { yield* prepend('stop', p, 'unbinding'); }
   if (c) { yield* prepend('stop', c, 'unbinding'); }
@@ -150,11 +150,11 @@ export function getHooks(deferUntil, swapStrategy, phase, ...siblingTransitions)
     }
 
     // for (let i = 0; i <= siblingHooks.length - 2; i++) {
-    //   TransitionViewport.delayHook(siblingHooks[i], siblingHooks[i + 1], 'unload');
+    //   TransitionViewport.delayHook(siblingHooks[i], siblingHooks[i + 1], 'unloading');
     // }
 
     for (let i = 0; i <= siblingHooks.length - 2; i++) {
-      TransitionViewport.delayHook(siblingHooks[i], siblingHooks[i + 1], 'load');
+      TransitionViewport.delayHook(siblingHooks[i], siblingHooks[i + 1], 'loading');
     }
   }
 
@@ -502,7 +502,7 @@ export function getNonSiblingHooks(deferUntil, swapStrategy, phase, transitionCo
   // } while (delayed && guard > 0);
 
   // for (let i = 0; i <= removeViewports.length - 2; i++) {
-  //   if (delayHooks(removeViewports, `${removeViewports[i].from.name}.unload`, `${removeViewports[i + 1].from.name}.unload`)) {
+  //   if (delayHooks(removeViewports, `${removeViewports[i].from.name}.unloading`, `${removeViewports[i + 1].from.name}.unloading`)) {
   //     console.log('delaying unload', removeViewports[i].from.name, removeViewports);
   //   }
   // }
@@ -684,8 +684,8 @@ export function getPrepended(prefix: string, component: string, ...hooks: (HookN
 export function* getSingleHooks(deferUntil, swapStrategy, componentKind, phase, from, to) {
   if (from) { yield `${phase}.${from}.canUnload`; }
   if (to) { yield `${phase}.${to}.canLoad`; }
-  if (from) { yield `${phase}.${from}.unload`; }
-  if (to) { yield `${phase}.${to}.load`; }
+  if (from) { yield `${phase}.${from}.unloading`; }
+  if (to) { yield `${phase}.${to}.loading`; }
   switch (swapStrategy) {
     case 'parallel-remove-first':
       switch (componentKind) {
@@ -718,8 +718,8 @@ export function* getSingleHooks(deferUntil, swapStrategy, componentKind, phase, 
 
 export function* getParentChildHooks(deferUntil, swapStrategy, componentKind, phase, from, to) {
   const parentAdd: HookName[] = [...addHooks];
-  const childAdd: HookName[] = ['canLoad', 'load', ...addHooks];
-  const parentRemove: HookName[] = ['unload', ...removeHooks];
+  const childAdd: HookName[] = ['canLoad', 'loading', ...addHooks];
+  const parentRemove: HookName[] = ['unloading', ...removeHooks];
   const childRemove: HookName[] = [...removeHooks];
 
   if (from.c) { yield `${phase}.${from.c}.canUnload`; }
@@ -733,16 +733,16 @@ export function* getParentChildHooks(deferUntil, swapStrategy, componentKind, ph
     childAdd.shift();
   }
 
-  if (from.c) { yield `${phase}.${from.c}.unload`; }
+  if (from.c) { yield `${phase}.${from.c}.unloading`; }
 
-  if (from.p) { yield `${phase}.${from.p}.unload`; }
+  if (from.p) { yield `${phase}.${from.p}.unloading`; }
 
   parentRemove.shift();
 
-  yield `${phase}.${to.p}.load`;
+  yield `${phase}.${to.p}.loading`;
 
   if (deferUntil === 'load-hooks') {
-    if (to.c) { yield `${phase}.${to.c}.load`; }
+    if (to.c) { yield `${phase}.${to.c}.loading`; }
 
     childAdd.shift();
   }
@@ -1039,7 +1039,7 @@ export function assertHooks(actual: any, expected: any): void {
 function filterHooks(hooks: string[]): string[] {
   return hooks.filter(hook => hook
     && !hook.startsWith('stop.')
-    // && (hook.endsWith('canUnload') || hook.endsWith('canLoad') || hook.endsWith('unload') || hook.endsWith('load'))
+    // && (hook.endsWith('canUnload') || hook.endsWith('canLoad') || hook.endsWith('unloading') || hook.endsWith('loading'))
   ).map(hook => hook.replace(/<.*?>/gi, ''));
 }
 

--- a/packages/__tests__/router/_shared/transition-viewport.ts
+++ b/packages/__tests__/router/_shared/transition-viewport.ts
@@ -8,11 +8,11 @@ export class TransitionViewport {
 
   public canUnload: boolean = true;
   public canLoad: boolean = true;
-  public unload: boolean = true;
-  public load: boolean = true;
+  public unloading: boolean = true;
+  public loading: boolean = true;
   public deactivate: boolean = true;
 
-  public static routingHooks: HookName[] = ['canUnload', 'canLoad', 'unload', 'load'];
+  public static routingHooks: HookName[] = ['canUnload', 'canLoad', 'unloading', 'loading'];
   public static addHooks: HookName[] = ['binding', 'bound', 'attaching', 'attached'];
   public static removeHooks: HookName[] = ['detaching', 'unbinding', 'dispose'];
 
@@ -95,12 +95,12 @@ export class TransitionViewport {
   public constructor(public readonly transition: Transition, public readonly isTop: boolean) {
     if (transition.from.isEmpty) {
       this.canUnload = false;
-      this.unload = false;
+      this.unloading = false;
       this.deactivate = false;
     }
     if (transition.to.isEmpty) {
       this.canLoad = false;
-      this.load = false;
+      this.loading = false;
     }
   }
 
@@ -143,7 +143,7 @@ export class TransitionViewport {
   //         }
   //       }
   //       break;
-  //     case 'unload':
+  //     case 'unloading':
   //       if (deferUntil === 'load-hooks') {
   //         for (let i = transitions.length - 1; i >= 0; i--) {
   //           const { from } = transitions[i];
@@ -167,7 +167,7 @@ export class TransitionViewport {
   //         }
   //       }
   //       break;
-  //     case 'load':
+  //     case 'loading':
   //       {
   //         const len = deferUntil === 'load-hooks' ? transitions.length : 1;
   //         for (let i = 0; i < len; i++) {
@@ -203,25 +203,25 @@ export class TransitionViewport {
       this.canLoad = false;
     }
 
-    if (!routingStep || deferUntil === 'load-hooks' && this.unload) {
+    if (!routingStep || deferUntil === 'load-hooks' && this.unloading) {
       //   if (deferUntil === 'guard-hooks') {
-      //     this.setRoutingHook(phase, 'unload');
+      //     this.setRoutingHook(phase, 'unloading');
       //     this.hooks.push('');
       // } else {
       if (this.isTop) {
-        // TransitionViewport.setRemoveHooks(deferUntil, phase, 'unload', false, topViewport, removeViewports);
-        TransitionViewport.getRemoveHooks(deferUntil, phase, 'unload', topViewport, removeViewports).forEach(hooks => this.hooks.push(...hooks));
+        // TransitionViewport.setRemoveHooks(deferUntil, phase, 'unloading', false, topViewport, removeViewports);
+        TransitionViewport.getRemoveHooks(deferUntil, phase, 'unloading', topViewport, removeViewports).forEach(hooks => this.hooks.push(...hooks));
       }
       // }
-      this.unload = false;
+      this.unloading = false;
     }
 
-    if (!routingStep || deferUntil === 'load-hooks' && this.load) {
-      this.setRoutingHook(phase, 'load');
+    if (!routingStep || deferUntil === 'load-hooks' && this.loading) {
+      this.setRoutingHook(phase, 'loading');
       if (deferUntil === 'load-hooks') {
         this.hooks.push('');
       }
-      this.load = false;
+      this.loading = false;
     }
   }
 
@@ -275,7 +275,7 @@ export class TransitionViewport {
 
   private setRoutingHook(phase: string, hook: HookName, onlyDelay = false): string[] {
     if (this[hook] as boolean) {
-      const component = hook === 'canUnload' || hook === 'unload' ? this.from : this.to;
+      const component = hook === 'canUnload' || hook === 'unloading' ? this.from : this.to;
       const hooks = TransitionViewport.getPrepended(phase, component.name, ...component.getTimed(hook));
       if (onlyDelay) {
         this.hooks.push('', ...hooks.slice(1));
@@ -360,8 +360,8 @@ export class TransitionViewport {
     let delayed = false;
 
     delayed = TransitionViewport.delayHooks(viewports, 'canUnload', 'canLoad') || delayed;
-    delayed = TransitionViewport.delayHooks(viewports, 'canUnload', 'unload') || delayed;
-    delayed = TransitionViewport.delayHooks(viewports, 'canUnload', 'load') || delayed;
+    delayed = TransitionViewport.delayHooks(viewports, 'canUnload', 'unloading') || delayed;
+    delayed = TransitionViewport.delayHooks(viewports, 'canUnload', 'loading') || delayed;
 
     // for (let i = 0; i <= removeViewports.length - 2; i++) {
     //   if (delayHooks(removeViewports, `${removeViewports[i].from.name}.canUnload`, `${removeViewports[i + 1].from.name}.canUnload`)) {
@@ -371,8 +371,8 @@ export class TransitionViewport {
     // }
 
     if (deferUntil === 'guard-hooks' || deferUntil === 'load-hooks') {
-      delayed = TransitionViewport.delayHooks(viewports, 'canLoad', 'unload') || delayed;
-      delayed = TransitionViewport.delayHooks(viewports, 'canLoad', 'load') || delayed;
+      delayed = TransitionViewport.delayHooks(viewports, 'canLoad', 'unloading') || delayed;
+      delayed = TransitionViewport.delayHooks(viewports, 'canLoad', 'loading') || delayed;
 
       for (let i = 0; i <= addViewports.length - 2; i++) {
         delayed = TransitionViewport.delayHook(addViewports[i], addViewports[i + 1], 'canLoad') || delayed;
@@ -380,16 +380,16 @@ export class TransitionViewport {
     }
 
     if (deferUntil === 'load-hooks') {
-      delayed = TransitionViewport.delayHooks(viewports, 'unload', 'load') || delayed;
+      delayed = TransitionViewport.delayHooks(viewports, 'unloading', 'loading') || delayed;
 
       // for (let i = 0; i <= removeViewports.length - 2; i++) {
-      //   if (delayHooks(removeViewports, `${removeViewports[i].from.name}.unload`, `${removeViewports[i + 1].from.name}.unload`)) {
+      //   if (delayHooks(removeViewports, `${removeViewports[i].from.name}.unloading`, `${removeViewports[i + 1].from.name}.unloading`)) {
       //     // console.log('delaying unload', removeViewports[i].from.name, removeViewports);
       //   }
       // }
 
       for (let i = 0; i <= addViewports.length - 2; i++) {
-        delayed = TransitionViewport.delayHook(addViewports[i], addViewports[i + 1], 'load') || delayed;
+        delayed = TransitionViewport.delayHook(addViewports[i], addViewports[i + 1], 'loading') || delayed;
       }
       for (let i = 0; i <= addViewports.length - 2; i++) {
         delayed = TransitionViewport.delayHook(addViewports[i], addViewports[i + 1], 'binding') || delayed;
@@ -406,8 +406,8 @@ export class TransitionViewport {
     // Start at 1 and -2 since first viewport is (if applicable) both add and remove and don't need processing
     for (let i = 1, j = removeViewports.length - 2; i < minLength; i++, j--) {
       delayed = TransitionViewport.delayHooks([removeViewports[j], addViewports[i]], 'canUnload', 'canLoad') || delayed;
-      delayed = TransitionViewport.delayHooks([removeViewports[j], addViewports[i]], 'canLoad', 'unload') || delayed;
-      delayed = TransitionViewport.delayHooks([removeViewports[j], addViewports[i]], 'unload', 'load') || delayed;
+      delayed = TransitionViewport.delayHooks([removeViewports[j], addViewports[i]], 'canLoad', 'unloading') || delayed;
+      delayed = TransitionViewport.delayHooks([removeViewports[j], addViewports[i]], 'unloading', 'loading') || delayed;
     }
     return delayed;
   }

--- a/packages/__tests__/router/_shared/view-models.ts
+++ b/packages/__tests__/router/_shared/view-models.ts
@@ -23,7 +23,7 @@ export interface ITestRouteViewModel extends IRouteableComponent {
     instruction: RoutingInstruction,
     navigation: Navigation,
   ): boolean | LoadInstruction | LoadInstruction[] | Promise<boolean | LoadInstruction | LoadInstruction[]>;
-  load(
+  loading(
     params: Parameters,
     instruction: RoutingInstruction,
     navigation: Navigation,
@@ -32,7 +32,7 @@ export interface ITestRouteViewModel extends IRouteableComponent {
     instruction: RoutingInstruction,
     navigation: Navigation,
   ): boolean | Promise<boolean>;
-  unload(
+  unloading(
     instruction: RoutingInstruction,
     navigation: Navigation,
   ): void | Promise<void>;
@@ -55,9 +55,9 @@ export class HookSpecs {
     public readonly $dispose: IHookSpec<'dispose'>,
 
     public readonly canLoad: IHookSpec<'canLoad'>,
-    public readonly load: IHookSpec<'load'>,
+    public readonly loading: IHookSpec<'loading'>,
     public readonly canUnload: IHookSpec<'canUnload'>,
-    public readonly unload: IHookSpec<'unload'>,
+    public readonly unloading: IHookSpec<'unloading'>,
   ) { }
 
   public static create(
@@ -76,9 +76,9 @@ export class HookSpecs {
       hookSpecsMap.dispose,
 
       input.canLoad || hookSpecsMap.canLoad.sync,
-      input.load || hookSpecsMap.load.sync,
+      input.loading || hookSpecsMap.loading.sync,
       input.canUnload || hookSpecsMap.canUnload.sync,
-      input.unload || hookSpecsMap.unload.sync,
+      input.unloading || hookSpecsMap.unloading.sync,
     );
   }
 
@@ -96,9 +96,9 @@ export class HookSpecs {
     $this.$dispose = void 0;
 
     $this.canLoad = void 0;
-    $this.load = void 0;
+    $this.loading = void 0;
     $this.canUnload = void 0;
-    $this.unload = void 0;
+    $this.unloading = void 0;
   }
 
   public toString(exclude?: string): string {
@@ -123,9 +123,9 @@ const hookNames = [
   'unbinding',
 
   'canLoad',
-  'load',
+  'loading',
   'canUnload',
-  'unload',
+  'unloading',
 ] as const;
 
 export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
@@ -281,21 +281,21 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
     );
   }
 
-  public load(
+  public loading(
     params: Parameters,
     instruction: RoutingInstruction,
     navigation: Navigation,
   ): void | Promise<void> {
     this.viewport = instruction.viewport.instance as Viewport;
-    // console.log('TestViewModel load', this.name);
-    // this.hia.load.notify(`${this.viewport?.name}.${this.name}`);
-    return this.specs.load.invoke(
+    // console.log('TestViewModel loading', this.name);
+    // this.hia.loading.notify(`${this.viewport?.name}.${this.name}`);
+    return this.specs.loading.invoke(
       this,
       () => {
-        // this.hia.load.notify(`${this.viewport?.name}.${this.name}`);
-        return this.$load(params, instruction, navigation);
+        // this.hia.loading.notify(`${this.viewport?.name}.${this.name}`);
+        return this.$loading(params, instruction, navigation);
       },
-      this.hia.load,
+      this.hia.loading,
     );
   }
 
@@ -319,20 +319,20 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
     );
   }
 
-  public unload(
+  public unloading(
     instruction: RoutingInstruction,
     navigation: Navigation,
   ): void | Promise<void> {
     this.viewport = instruction.viewport.instance as Viewport;
-    // console.log('TestViewModel unload', this.name);
-    // this.hia.unload.notify(`${this.viewport?.name}.${this.name}`);
-    return this.specs.unload.invoke(
+    // console.log('TestViewModel unloading', this.name);
+    // this.hia.unloading.notify(`${this.viewport?.name}.${this.name}`);
+    return this.specs.unloading.invoke(
       this,
       () => {
-        // this.hia.unload.notify(`${this.viewport?.name}.${this.name}`);
-        return this.$unload(instruction, navigation);
+        // this.hia.unloading.notify(`${this.viewport?.name}.${this.name}`);
+        return this.$unloading(instruction, navigation);
       },
-      this.hia.unload,
+      this.hia.unloading,
     );
   }
 
@@ -391,7 +391,7 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
     return true;
   }
 
-  protected $load(
+  protected $loading(
     _params: Parameters,
     _instruction: RoutingInstruction,
     _navigation: Navigation,
@@ -406,7 +406,7 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
     return true;
   }
 
-  protected $unload(
+  protected $unloading(
     _instruction: RoutingInstruction,
     _navigation: Navigation,
   ): void | Promise<void> {

--- a/packages/__tests__/router/config-tests.spec.ts
+++ b/packages/__tests__/router/config-tests.spec.ts
@@ -46,7 +46,7 @@ export function* prependDeferrable(
 ) {
   if (deferUntil === 'none') {
     yield `${prefix}.${component}.canLoad`;
-    yield `${prefix}.${component}.load`;
+    yield `${prefix}.${component}.loading`;
   }
 
   for (const call of calls) {
@@ -144,9 +144,9 @@ describe('router config', function () {
           unbinding: hookSpecsMap.unbinding.sync,
 
           canLoad: hookSpecsMap.canLoad.sync,
-          load: hookSpecsMap.load.sync,
+          loading: hookSpecsMap.loading.sync,
           canUnload: hookSpecsMap.canUnload.sync,
-          unload: hookSpecsMap.unload.sync,
+          unloading: hookSpecsMap.unloading.sync,
         }),
       },
       {
@@ -262,7 +262,7 @@ describe('router config', function () {
                     yield `start.root1.attaching`;
                     yield `start.root1.attached`;
 
-                    yield* prepend(phase1, t1c, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                    yield* prepend(phase1, t1c, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
 
                     for (const [phase, { $t1c, $t2c }] of [
                       [phase2, { $t1c: t1c, $t2c: t2c }],
@@ -271,8 +271,8 @@ describe('router config', function () {
                     ] as const) {
                       yield `${phase}.${$t1c}.canUnload`;
                       yield `${phase}.${$t2c}.canLoad`;
-                      yield `${phase}.${$t1c}.unload`;
-                      yield `${phase}.${$t2c}.load`;
+                      yield `${phase}.${$t1c}.unloading`;
+                      yield `${phase}.${$t2c}.loading`;
 
                       switch (routerOptionsSpec.swapStrategy) {
                         case 'parallel-remove-first':
@@ -774,9 +774,9 @@ function getAllAsyncSpecs(count: number): HookSpecs {
     unbinding: hookSpecsMap.unbinding.async(count),
 
     canLoad: hookSpecsMap.canLoad.async(count),
-    load: hookSpecsMap.load.async(count),
+    loading: hookSpecsMap.loading.async(count),
     canUnload: hookSpecsMap.canUnload.async(count),
-    unload: hookSpecsMap.unload.async(count),
+    unloading: hookSpecsMap.unloading.async(count),
   });
 }
 

--- a/packages/__tests__/router/configuration.spec.ts
+++ b/packages/__tests__/router/configuration.spec.ts
@@ -84,7 +84,7 @@ describe('Configuration', function () {
     const App = CustomElement.define({ name: 'app', template: '<au-viewport default="foo"></au-viewport>' });
     const Foo = CustomElement.define({ name: 'foo', template: `<div>foo: \${message}</div>` }, class {
       public message: string = '';
-      public async load() {
+      public async loading() {
         await new Promise(resolve => setTimeout(resolve, 250));
         this.message = 'Hello, World!';
       }

--- a/packages/__tests__/router/history-navigations.spec.ts
+++ b/packages/__tests__/router/history-navigations.spec.ts
@@ -69,7 +69,7 @@ describe('History navigations', function () {
   });
   const Foo = CustomElement.define({ name: 'foo', template: `foo`, }, class {
     public static parameters: string[] = ['id'];
-    public load(parameters) {
+    public loading(parameters) {
       result.parameters = { ...parameters };
     }
   });

--- a/packages/__tests__/router/hook-tests.spec.ts
+++ b/packages/__tests__/router/hook-tests.spec.ts
@@ -31,7 +31,7 @@ function join(sep: string, ...parts: string[]): string {
   }).join(sep);
 }
 
-const hookNames = ['binding', 'bound', 'attaching', 'attached', 'detaching', 'unbinding', 'canLoad', 'load', 'canUnload', 'unload'] as const;
+const hookNames = ['binding', 'bound', 'attaching', 'attached', 'detaching', 'unbinding', 'canLoad', 'loading', 'canUnload', 'unloading'] as const;
 type HookName = typeof hookNames[number] | 'dispose';
 
 class DelayedInvokerFactory<T extends HookName> {
@@ -61,9 +61,9 @@ export class HookSpecs {
     public readonly dispose: DelayedInvokerFactory<'dispose'>,
 
     public readonly canLoad: DelayedInvokerFactory<'canLoad'>,
-    public readonly load: DelayedInvokerFactory<'load'>,
+    public readonly loading: DelayedInvokerFactory<'loading'>,
     public readonly canUnload: DelayedInvokerFactory<'canUnload'>,
-    public readonly unload: DelayedInvokerFactory<'unload'>,
+    public readonly unloading: DelayedInvokerFactory<'unloading'>,
 
     public readonly ticks: number,
   ) { }
@@ -84,9 +84,9 @@ export class HookSpecs {
       DelayedInvoker.dispose(),
 
       input.canLoad || DelayedInvoker.canLoad(ticks),
-      input.load || DelayedInvoker.load(ticks),
+      input.loading || DelayedInvoker.loading(ticks),
       input.canUnload || DelayedInvoker.canUnload(ticks),
-      input.unload || DelayedInvoker.unload(ticks),
+      input.unloading || DelayedInvoker.unloading(ticks),
 
       ticks,
     );
@@ -106,9 +106,9 @@ export class HookSpecs {
     $this.dispose = void 0;
 
     $this.canLoad = void 0;
-    $this.load = void 0;
+    $this.loading = void 0;
     $this.canUnload = void 0;
-    $this.unload = void 0;
+    $this.unloading = void 0;
   }
 
   public toString(exclude: number = this.ticks): string {
@@ -133,9 +133,9 @@ abstract class TestVM implements IViewModel {
   public readonly detachingDI: DelayedInvoker<'detaching'>;
   public readonly unbindingDI: DelayedInvoker<'unbinding'>;
   public readonly canLoadDI: DelayedInvoker<'canLoad'>;
-  public readonly loadDI: DelayedInvoker<'load'>;
+  public readonly loadingDI: DelayedInvoker<'loading'>;
   public readonly canUnloadDI: DelayedInvoker<'canUnload'>;
-  public readonly unloadDI: DelayedInvoker<'unload'>;
+  public readonly unloadingDI: DelayedInvoker<'unloading'>;
   public readonly disposeDI: DelayedInvoker<'dispose'>;
 
   public constructor(mgr: INotifierManager, p: IPlatform, specs: HookSpecs) {
@@ -146,9 +146,9 @@ abstract class TestVM implements IViewModel {
     this.detachingDI = specs.detaching.create(mgr, p);
     this.unbindingDI = specs.unbinding.create(mgr, p);
     this.canLoadDI = specs.canLoad.create(mgr, p);
-    this.loadDI = specs.load.create(mgr, p);
+    this.loadingDI = specs.loading.create(mgr, p);
     this.canUnloadDI = specs.canUnload.create(mgr, p);
-    this.unloadDI = specs.unload.create(mgr, p);
+    this.unloadingDI = specs.unloading.create(mgr, p);
     this.disposeDI = specs.dispose.create(mgr, p);
   }
 
@@ -159,9 +159,9 @@ abstract class TestVM implements IViewModel {
   public detaching(i: HC, p: HPC, f: LF): void | Promise<void> { return this.detachingDI.invoke(this, () => { return this.$detaching(i, p, f); }); }
   public unbinding(i: HC, p: HPC, f: LF): void | Promise<void> { return this.unbindingDI.invoke(this, () => { return this.$unbinding(i, p, f); }); }
   public canLoad(p: P, n: Navigation, c: Navigation | null): boolean | RoutingInstruction | RoutingInstruction[] | Promise<boolean | RoutingInstruction | RoutingInstruction[]> { return this.canLoadDI.invoke(this, () => { return this.$canLoad(p, n, c); }); }
-  public load(p: P, n: Navigation, c: Navigation | null): void | Promise<void> { return this.loadDI.invoke(this, () => { return this.$load(p, n, c); }); }
+  public loading(p: P, n: Navigation, c: Navigation | null): void | Promise<void> { return this.loadingDI.invoke(this, () => { return this.$loading(p, n, c); }); }
   public canUnload(n: Navigation | null, c: Navigation): boolean | Promise<boolean> { return this.canUnloadDI.invoke(this, () => { return this.$canUnload(n, c); }); }
-  public unload(n: Navigation | null, c: Navigation): void | Promise<void> { return this.unloadDI.invoke(this, () => { return this.$unload(n, c); }); }
+  public unloading(n: Navigation | null, c: Navigation): void | Promise<void> { return this.unloadingDI.invoke(this, () => { return this.$unloading(n, c); }); }
   public dispose(): void { void this.disposeDI.invoke(this, () => { this.$dispose(); }); }
 
   protected $binding(_i: HC, _p: HPC, _f: LF): void { /* do nothing */ }
@@ -171,9 +171,9 @@ abstract class TestVM implements IViewModel {
   protected $detaching(_i: HC, _p: HPC, _f: LF): void { /* do nothing */ }
   protected $unbinding(_i: HC, _p: HPC, _f: LF): void { /* do nothing */ }
   protected $canLoad(_p: P, _n: Navigation, _c: Navigation | null): boolean | RoutingInstruction | RoutingInstruction[] | Promise<boolean | RoutingInstruction | RoutingInstruction[]> { return true; }
-  protected $load(_p: P, _n: Navigation, _c: Navigation | null): void | Promise<void> { /* do nothing */ }
+  protected $loading(_p: P, _n: Navigation, _c: Navigation | null): void | Promise<void> { /* do nothing */ }
   protected $canUnload(_n: Navigation | null, _c: Navigation): boolean | Promise<boolean> { return true; }
-  protected $unload(_n: Navigation | null, _c: Navigation): void | Promise<void> { /* do nothing */ }
+  protected $unloading(_n: Navigation | null, _c: Navigation): void | Promise<void> { /* do nothing */ }
   protected $dispose(this: Partial<Writable<this>>): void {
     this.bindingDI = void 0;
     this.boundDI = void 0;
@@ -245,9 +245,9 @@ class NotifierManager {
   public readonly detaching: Notifier = new Notifier(this, 'detaching');
   public readonly unbinding: Notifier = new Notifier(this, 'unbinding');
   public readonly canLoad: Notifier = new Notifier(this, 'canLoad');
-  public readonly load: Notifier = new Notifier(this, 'load');
+  public readonly loading: Notifier = new Notifier(this, 'loading');
   public readonly canUnload: Notifier = new Notifier(this, 'canUnload');
-  public readonly unload: Notifier = new Notifier(this, 'unload');
+  public readonly unloading: Notifier = new Notifier(this, 'unloading');
   public readonly dispose: Notifier = new Notifier(this, 'dispose');
 
   public enter(vm: TestVM, tracker: Notifier): void {
@@ -276,9 +276,9 @@ class NotifierManager {
     this.detaching.dispose();
     this.unbinding.dispose();
     this.canLoad.dispose();
-    this.load.dispose();
+    this.loading.dispose();
     this.canUnload.dispose();
-    this.unload.dispose();
+    this.unloading.dispose();
     this.dispose.dispose();
 
     this.entryNotifyHistory = void 0;
@@ -292,9 +292,9 @@ class NotifierManager {
     this.detaching = void 0;
     this.unbinding = void 0;
     this.canLoad = void 0;
-    this.load = void 0;
+    this.loading = void 0;
     this.canUnload = void 0;
-    this.unload = void 0;
+    this.unloading = void 0;
     this.$dispose = void 0;
   }
 }
@@ -313,9 +313,9 @@ class DelayedInvoker<T extends HookName> {
   public static detaching(ticks: number = 0): DelayedInvokerFactory<'detaching'> { return new DelayedInvokerFactory('detaching', ticks); }
   public static unbinding(ticks: number = 0): DelayedInvokerFactory<'unbinding'> { return new DelayedInvokerFactory('unbinding', ticks); }
   public static canLoad(ticks: number = 0): DelayedInvokerFactory<'canLoad'> { return new DelayedInvokerFactory('canLoad', ticks); }
-  public static load(ticks: number = 0): DelayedInvokerFactory<'load'> { return new DelayedInvokerFactory('load', ticks); }
+  public static loading(ticks: number = 0): DelayedInvokerFactory<'loading'> { return new DelayedInvokerFactory('loading', ticks); }
   public static canUnload(ticks: number = 0): DelayedInvokerFactory<'canUnload'> { return new DelayedInvokerFactory('canUnload', ticks); }
-  public static unload(ticks: number = 0): DelayedInvokerFactory<'unload'> { return new DelayedInvokerFactory('unload', ticks); }
+  public static unloading(ticks: number = 0): DelayedInvokerFactory<'unloading'> { return new DelayedInvokerFactory('unloading', ticks); }
   public static dispose(ticks: number = 0): DelayedInvokerFactory<'dispose'> { return new DelayedInvokerFactory('dispose', ticks); }
 
   public invoke(vm: TestVM, cb: () => any): any { // TODO(fkleuver): get rid of `any`
@@ -658,7 +658,7 @@ describe('router hooks', function () {
                 switch (ticks) {
                   case 0:
                     yield* $('start', 'root1', ticks, 'binding', 'bound', 'attaching', 'attached');
-                    yield* $(phase1, t1, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                    yield* $(phase1, t1, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
 
                     for (const [phase, { $t1, $t2 }] of [
                       [phase2, { $t1: t1, $t2: t2 }],
@@ -667,8 +667,8 @@ describe('router hooks', function () {
                     ] as const) {
                       yield* $(phase, $t1, ticks, 'canUnload');
                       yield* $(phase, $t2, ticks, 'canLoad');
-                      yield* $(phase, $t1, ticks, 'unload');
-                      yield* $(phase, $t2, ticks, 'load');
+                      yield* $(phase, $t1, ticks, 'unloading');
+                      yield* $(phase, $t2, ticks, 'loading');
 
                       switch (opts.swapStrategy) {
                         case 'parallel-remove-first':
@@ -689,7 +689,7 @@ describe('router hooks', function () {
                     break;
                   case 1:
                     yield* $('start', 'root1', ticks, 'binding', 'bound', 'attaching', 'attached');
-                    yield* $(phase1, t1, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                    yield* $(phase1, t1, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
 
                     for (const [phase, { $t1, $t2 }] of [
                       [phase2, { $t1: t1, $t2: t2 }],
@@ -698,8 +698,8 @@ describe('router hooks', function () {
                     ] as const) {
                       yield* $(phase, $t1, ticks, 'canUnload');
                       yield* $(phase, $t2, ticks, 'canLoad');
-                      yield* $(phase, $t1, ticks, 'unload');
-                      yield* $(phase, $t2, ticks, 'load');
+                      yield* $(phase, $t1, ticks, 'unloading');
+                      yield* $(phase, $t2, ticks, 'loading');
 
                       switch (opts.swapStrategy) {
                         case 'parallel-remove-first':
@@ -823,11 +823,11 @@ describe('router hooks', function () {
 
                     switch (opts.resolutionMode) {
                       case 'dynamic':
-                        yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                        yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                         break;
                       case 'static':
                         yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'canLoad');
-                        yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'load');
+                        yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'loading');
                         yield* $(phase1, [t1.vp0, t1.vp1], ticks, 'binding', 'bound', 'attaching', 'attached');
                         break;
                     }
@@ -846,8 +846,8 @@ describe('router hooks', function () {
                       switch (opts.resolutionMode) {
                         case 'dynamic':
                           if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'canLoad'); }
-                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unload'); }
-                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'load'); }
+                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unloading'); }
+                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'loading'); }
 
                           switch (opts.swapStrategy) {
                             case 'parallel-remove-first':
@@ -862,8 +862,8 @@ describe('router hooks', function () {
                           }
 
                           if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'canLoad'); }
-                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unload'); }
-                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'load'); }
+                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unloading'); }
+                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'loading'); }
 
                           switch (opts.swapStrategy) {
                             case 'parallel-remove-first':
@@ -881,11 +881,11 @@ describe('router hooks', function () {
                           if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'canLoad'); }
                           if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'canLoad'); }
 
-                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unload'); }
-                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unload'); }
+                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unloading'); }
+                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unloading'); }
 
-                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'load'); }
-                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'load'); }
+                          if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'loading'); }
+                          if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'loading'); }
 
                           switch (opts.swapStrategy) {
                             case 'parallel-remove-first':
@@ -922,8 +922,8 @@ describe('router hooks', function () {
                     yield* $('start', 'root2', ticks, 'binding', 'bound', 'attaching', 'attached');
 
                     yield* interleave(
-                      $(phase1, t1.vp0, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached'),
-                      $(phase1, t1.vp1, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached'),
+                      $(phase1, t1.vp0, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached'),
+                      $(phase1, t1.vp1, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached'),
                     );
 
                     for (const [phase, { $t1, $t2 }] of [
@@ -948,8 +948,8 @@ describe('router hooks', function () {
                                 const t2 = action === 'add' ? $t2[vp] : ($t2[vp] ? '-' : '');
 
                                 if ($t1[vp] !== $t2[vp]) { yield* $(phase, t2, ticks, 'canLoad'); }
-                                if ($t1[vp] !== $t2[vp]) { yield* $(phase, t1, ticks, 'unload'); }
-                                if ($t1[vp] !== $t2[vp]) { yield* $(phase, t2, ticks, 'load'); }
+                                if ($t1[vp] !== $t2[vp]) { yield* $(phase, t1, ticks, 'unloading'); }
+                                if ($t1[vp] !== $t2[vp]) { yield* $(phase, t2, ticks, 'loading'); }
                               }
 
                               yield* interleave(
@@ -980,16 +980,16 @@ describe('router hooks', function () {
                               yield* interleave(
                                 (function* () {
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'canLoad'); }
-                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unload'); }
-                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'load'); }
+                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unloading'); }
+                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'loading'); }
 
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'detaching', 'unbinding', 'dispose'); }
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'binding', 'bound', 'attaching', 'attached'); }
                                 })(),
                                 (function* () {
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'canLoad'); }
-                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unload'); }
-                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'load'); }
+                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unloading'); }
+                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'loading'); }
 
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'detaching', 'unbinding', 'dispose'); }
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'binding', 'bound', 'attaching', 'attached'); }
@@ -1000,16 +1000,16 @@ describe('router hooks', function () {
                               yield* interleave(
                                 (function* () {
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'canLoad'); }
-                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unload'); }
-                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'load'); }
+                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unloading'); }
+                                  if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'loading'); }
 
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'binding', 'bound', 'attaching', 'attached'); }
                                   if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'detaching', 'unbinding', 'dispose'); }
                                 })(),
                                 (function* () {
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'canLoad'); }
-                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unload'); }
-                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'load'); }
+                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unloading'); }
+                                  if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'loading'); }
 
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'binding', 'bound', 'attaching', 'attached'); }
                                   if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'detaching', 'unbinding', 'dispose'); }
@@ -1024,12 +1024,12 @@ describe('router hooks', function () {
                             (function* () { if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'canLoad'); } })(),
                           );
                           yield* interleave(
-                            (function* () { if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unload'); } })(),
-                            (function* () { if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unload'); } })(),
+                            (function* () { if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t1[firstVp], ticks, 'unloading'); } })(),
+                            (function* () { if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t1[secondVp], ticks, 'unloading'); } })(),
                           );
                           yield* interleave(
-                            (function* () { if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'load'); } })(),
-                            (function* () { if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'load'); } })(),
+                            (function* () { if ($t1[firstVp] !== $t2[firstVp]) { yield* $(phase, $t2[firstVp], ticks, 'loading'); } })(),
+                            (function* () { if ($t1[secondVp] !== $t2[secondVp]) { yield* $(phase, $t2[secondVp], ticks, 'loading'); } })(),
                           );
 
                           switch (opts.swapStrategy) {
@@ -1165,11 +1165,11 @@ describe('router hooks', function () {
 
                     switch (opts.resolutionMode) {
                       case 'dynamic':
-                        yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                        yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                         break;
                       case 'static':
                         yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad');
-                        yield* $(phase1, [t1.p, t1.c], ticks, 'load');
+                        yield* $(phase1, [t1.p, t1.c], ticks, 'loading');
 
                         yield* $(phase1, [t1.p, t1.c], ticks, 'binding', 'bound', 'attaching', 'attached');
                         break;
@@ -1184,8 +1184,8 @@ describe('router hooks', function () {
                       if ($t1.p === $t2.p) {
                         yield* $(phase, $t1.c, ticks, 'canUnload');
                         yield* $(phase, $t2.c, ticks, 'canLoad');
-                        yield* $(phase, $t1.c, ticks, 'unload');
-                        yield* $(phase, $t2.c, ticks, 'load');
+                        yield* $(phase, $t1.c, ticks, 'unloading');
+                        yield* $(phase, $t2.c, ticks, 'loading');
 
                         switch (opts.swapStrategy) {
                           case 'parallel-remove-first':
@@ -1204,13 +1204,13 @@ describe('router hooks', function () {
 
                         switch (opts.resolutionMode) {
                           case 'dynamic':
-                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unload');
-                            yield* $(phase, $t2.p, ticks, 'load');
+                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unloading');
+                            yield* $(phase, $t2.p, ticks, 'loading');
                             break;
                           case 'static':
                             yield* $(phase, $t2.c, ticks, 'canLoad');
-                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unload');
-                            yield* $(phase, [$t2.p, $t2.c], ticks, 'load');
+                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unloading');
+                            yield* $(phase, [$t2.p, $t2.c], ticks, 'loading');
                             break;
                         }
 
@@ -1232,7 +1232,7 @@ describe('router hooks', function () {
 
                         switch (opts.resolutionMode) {
                           case 'dynamic':
-                            yield* $(phase, $t2.c, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                            yield* $(phase, $t2.c, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                             break;
                           case 'static':
                             yield* $(phase, $t2.c, ticks, 'binding', 'bound', 'attaching', 'attached');
@@ -1250,11 +1250,11 @@ describe('router hooks', function () {
 
                     switch (opts.resolutionMode) {
                       case 'dynamic':
-                        yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                        yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                         break;
                       case 'static':
                         yield* $(phase1, [t1.p, t1.c], ticks, 'canLoad');
-                        yield* $(phase1, [t1.p, t1.c], ticks, 'load');
+                        yield* $(phase1, [t1.p, t1.c], ticks, 'loading');
 
                         yield* $(phase1, t1.p, ticks, 'binding', 'bound', 'attaching');
                         yield* interleave(
@@ -1273,8 +1273,8 @@ describe('router hooks', function () {
                       if ($t1.p === $t2.p) {
                         yield* $(phase, $t1.c, ticks, 'canUnload');
                         yield* $(phase, $t2.c, ticks, 'canLoad');
-                        yield* $(phase, $t1.c, ticks, 'unload');
-                        yield* $(phase, $t2.c, ticks, 'load');
+                        yield* $(phase, $t1.c, ticks, 'unloading');
+                        yield* $(phase, $t2.c, ticks, 'loading');
 
                         switch (opts.swapStrategy) {
                           case 'parallel-remove-first':
@@ -1298,13 +1298,13 @@ describe('router hooks', function () {
 
                         switch (opts.resolutionMode) {
                           case 'dynamic':
-                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unload');
-                            yield* $(phase, $t2.p, ticks, 'load');
+                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unloading');
+                            yield* $(phase, $t2.p, ticks, 'loading');
                             break;
                           case 'static':
                             yield* $(phase, $t2.c, ticks, 'canLoad');
-                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unload');
-                            yield* $(phase, [$t2.p, $t2.c], ticks, 'load');
+                            yield* $(phase, [$t1.c, $t1.p], ticks, 'unloading');
+                            yield* $(phase, [$t2.p, $t2.c], ticks, 'loading');
                             break;
                         }
 
@@ -1329,7 +1329,7 @@ describe('router hooks', function () {
                                   $(phase, $t2.p, ticks, 'attaching'),
                                 );
                                 yield* $(phase, $t2.p, ticks, 'attached');
-                                yield* $(phase, $t2.c, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                                yield* $(phase, $t2.c, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                                 break;
                               case 'static':
                                 yield* interleave(
@@ -1354,7 +1354,7 @@ describe('router hooks', function () {
                                 yield* $(phase, [$t1.p, $t1.c], ticks, 'dispose');
 
                                 yield* $(phase, $t2.p, ticks, 'binding', 'bound', 'attaching', 'attached');
-                                yield* $(phase, $t2.c, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                                yield* $(phase, $t2.c, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                                 break;
                               case 'static':
                                 yield* interleave(
@@ -1382,7 +1382,7 @@ describe('router hooks', function () {
                                 );
                                 yield* $(phase, [$t1.p, $t1.c], ticks, 'dispose');
 
-                                yield* $(phase, $t2.c, ticks, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                                yield* $(phase, $t2.c, ticks, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                                 break;
                               case 'static':
                                 yield* $(phase, $t2.p, ticks, 'binding', 'bound', 'attaching');
@@ -1429,13 +1429,13 @@ describe('router hooks', function () {
         canUnload: DelayedInvoker.canUnload(1),
       }),
       HookSpecs.create(0, {
-        unload: DelayedInvoker.unload(1),
+        unloading: DelayedInvoker.unloading(1),
       }),
       HookSpecs.create(0, {
         canLoad: DelayedInvoker.canLoad(1),
       }),
       HookSpecs.create(0, {
-        load: DelayedInvoker.load(1),
+        loading: DelayedInvoker.loading(1),
       }),
 
       HookSpecs.create(0, {
@@ -1488,42 +1488,42 @@ describe('router hooks', function () {
           const hookName = hookSpec.toString().slice(0, -3) as typeof hookNames[number];
           switch (opts.resolutionMode) {
             case 'dynamic':
-              yield* $(phase1, ['a', 'b'], 0, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+              yield* $(phase1, ['a', 'b'], 0, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
               switch (hookName) {
                 case 'canLoad':
                   yield* $(phase1, 'c', 1, 'canLoad');
-                  yield* $(phase1, 'c', 0, 'load', 'binding', 'bound', 'attaching', 'attached');
+                  yield* $(phase1, 'c', 0, 'loading', 'binding', 'bound', 'attaching', 'attached');
                   break;
-                case 'load':
+                case 'loading':
                   yield* $(phase1, 'c', 0, 'canLoad');
-                  yield* $(phase1, 'c', 1, 'load');
+                  yield* $(phase1, 'c', 1, 'loading');
                   yield* $(phase1, 'c', 0, 'binding', 'bound', 'attaching', 'attached');
                   break;
                 case 'binding':
-                  yield* $(phase1, 'c', 0, 'canLoad', 'load');
+                  yield* $(phase1, 'c', 0, 'canLoad', 'loading');
                   yield* $(phase1, 'c', 1, 'binding');
                   yield* $(phase1, 'c', 0, 'bound', 'attaching', 'attached');
                   break;
                 case 'bound':
-                  yield* $(phase1, 'c', 0, 'canLoad', 'load', 'binding');
+                  yield* $(phase1, 'c', 0, 'canLoad', 'loading', 'binding');
                   yield* $(phase1, 'c', 1, 'bound');
                   yield* $(phase1, 'c', 0, 'attaching', 'attached');
                   break;
                 case 'attaching':
-                  yield* $(phase1, 'c', 0, 'canLoad', 'load', 'binding', 'bound');
+                  yield* $(phase1, 'c', 0, 'canLoad', 'loading', 'binding', 'bound');
                   yield* $(phase1, 'c', 1, 'attaching');
                   yield* $(phase1, 'c', 0, 'attached');
                   break;
                 case 'attached':
-                  yield* $(phase1, 'c', 0, 'canLoad', 'load', 'binding', 'bound', 'attaching');
+                  yield* $(phase1, 'c', 0, 'canLoad', 'loading', 'binding', 'bound', 'attaching');
                   yield* $(phase1, 'c', 1, 'attached');
                   break;
                 default:
-                  yield* $(phase1, 'c', 0, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+                  yield* $(phase1, 'c', 0, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
                   break;
               }
 
-              yield* $(phase1, 'd', 0, 'canLoad', 'load', 'binding', 'bound', 'attaching', 'attached');
+              yield* $(phase1, 'd', 0, 'canLoad', 'loading', 'binding', 'bound', 'attaching', 'attached');
               break;
             case 'static':
               switch (hookName) {
@@ -1531,19 +1531,19 @@ describe('router hooks', function () {
                   yield* $(phase1, ['a', 'b'], 0, 'canLoad');
                   yield* $(phase1, 'c', 1, 'canLoad');
                   yield* $(phase1, 'd', 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'binding', 'bound', 'attaching', 'attached');
                   break;
-                case 'load':
+                case 'loading':
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b'], 0, 'load');
-                  yield* $(phase1, 'c', 1, 'load');
-                  yield* $(phase1, 'd', 0, 'load');
+                  yield* $(phase1, ['a', 'b'], 0, 'loading');
+                  yield* $(phase1, 'c', 1, 'loading');
+                  yield* $(phase1, 'd', 0, 'loading');
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'binding', 'bound', 'attaching', 'attached');
                   break;
                 case 'binding':
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b'], 0, 'binding', 'bound', 'attaching', 'attached');
                   yield* $(phase1, 'c', 1, 'binding');
                   yield* $(phase1, 'c', 0, 'bound', 'attaching', 'attached');
@@ -1551,7 +1551,7 @@ describe('router hooks', function () {
                   break;
                 case 'bound':
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b'], 0, 'binding', 'bound', 'attaching', 'attached');
                   yield* $(phase1, 'c', 0, 'binding');
                   yield* $(phase1, 'c', 1, 'bound');
@@ -1560,7 +1560,7 @@ describe('router hooks', function () {
                   break;
                 case 'attaching':
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b'], 0, 'binding', 'bound', 'attaching', 'attached');
                   yield* $(phase1, 'c', 0, 'binding', 'bound');
                   yield* $(phase1, 'c', 0, 'attaching.enter');
@@ -1569,7 +1569,7 @@ describe('router hooks', function () {
                   break;
                 case 'attached':
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b'], 0, 'binding', 'bound', 'attaching', 'attached');
                   yield* $(phase1, 'c', 0, 'binding', 'bound', 'attaching');
                   yield* $(phase1, 'c', 0, 'attached.enter');
@@ -1578,7 +1578,7 @@ describe('router hooks', function () {
                   break;
                 default:
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'canLoad');
-                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'load');
+                  yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'loading');
                   yield* $(phase1, ['a', 'b', 'c', 'd'], 0, 'binding', 'bound', 'attaching', 'attached');
                   break;
               }
@@ -1590,21 +1590,21 @@ describe('router hooks', function () {
               yield* $(phase2, 'd', 0, 'canUnload');
               yield* $(phase2, 'c', 1, 'canUnload');
               yield* $(phase2, 'b', 0, 'canUnload');
-              yield* $(phase2, ['d', 'c', 'b'], 0, 'unload');
+              yield* $(phase2, ['d', 'c', 'b'], 0, 'unloading');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'detaching');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'unbinding');
               break;
-            case 'unload':
+            case 'unloading':
               yield* $(phase2, ['d', 'c', 'b'], 0, 'canUnload');
-              yield* $(phase2, 'd', 0, 'unload');
-              yield* $(phase2, 'c', 1, 'unload');
-              yield* $(phase2, 'b', 0, 'unload');
+              yield* $(phase2, 'd', 0, 'unloading');
+              yield* $(phase2, 'c', 1, 'unloading');
+              yield* $(phase2, 'b', 0, 'unloading');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'detaching');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'unbinding');
               break;
             case 'detaching':
               yield* $(phase2, ['d', 'c', 'b'], 0, 'canUnload');
-              yield* $(phase2, ['d', 'c', 'b'], 0, 'unload');
+              yield* $(phase2, ['d', 'c', 'b'], 0, 'unloading');
               yield* $(phase2, 'd', 0, 'detaching');
               yield* $(phase2, 'c', 0, 'detaching.enter');
               yield* $(phase2, 'b', 0, 'detaching');
@@ -1614,7 +1614,7 @@ describe('router hooks', function () {
               break;
             case 'unbinding':
               yield* $(phase2, ['d', 'c', 'b'], 0, 'canUnload');
-              yield* $(phase2, ['d', 'c', 'b'], 0, 'unload');
+              yield* $(phase2, ['d', 'c', 'b'], 0, 'unloading');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'detaching');
               yield* $(phase2, 'd', 0, 'unbinding');
               yield* $(phase2, 'c', 0, 'unbinding.enter');
@@ -1624,7 +1624,7 @@ describe('router hooks', function () {
               break;
             default:
               yield* $(phase2, ['d', 'c', 'b'], 0, 'canUnload');
-              yield* $(phase2, ['d', 'c', 'b'], 0, 'unload');
+              yield* $(phase2, ['d', 'c', 'b'], 0, 'unloading');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'detaching');
               yield* $(phase2, ['d', 'c', 'b'], 0, 'unbinding');
               break;
@@ -1679,11 +1679,11 @@ describe('router hooks', function () {
       const spec: ISiblingTransitionSpec = {
         a: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(aCanLoad),
-          load: DelayedInvoker.load(aLoad),
+          loading: DelayedInvoker.loading(aLoad),
         }),
         b: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(bCanLoad),
-          load: DelayedInvoker.load(bLoad),
+          loading: DelayedInvoker.loading(bLoad),
         }),
       };
 
@@ -1715,12 +1715,12 @@ describe('router hooks', function () {
               yield* interleave(
                 (function* () {
                   yield* $(phase1, 'a', aCanLoad, 'canLoad');
-                  yield* $(phase1, 'a', aLoad, 'load');
+                  yield* $(phase1, 'a', aLoad, 'loading');
                   yield* $(phase1, 'a', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
                 (function* () {
                   yield* $(phase1, 'b', bCanLoad, 'canLoad');
-                  yield* $(phase1, 'b', bLoad, 'load');
+                  yield* $(phase1, 'b', bLoad, 'loading');
                   yield* $(phase1, 'b', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
               );
@@ -1731,8 +1731,8 @@ describe('router hooks', function () {
                 $(phase1, 'b', bCanLoad, 'canLoad'),
               );
               yield* interleave(
-                $(phase1, 'a', aLoad, 'load'),
-                $(phase1, 'b', bLoad, 'load'),
+                $(phase1, 'a', aLoad, 'loading'),
+                $(phase1, 'b', bLoad, 'loading'),
               );
               yield* interleave(
                 $(phase1, 'a', 1, 'binding', 'bound', 'attaching', 'attached'),
@@ -1779,11 +1779,11 @@ describe('router hooks', function () {
       const spec: IParentChildTransitionSpec = {
         a1: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(a1CanLoad),
-          load: DelayedInvoker.load(a1Load),
+          loading: DelayedInvoker.loading(a1Load),
         }),
         a2: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(a2CanLoad),
-          load: DelayedInvoker.load(a2Load),
+          loading: DelayedInvoker.loading(a2Load),
         }),
       };
 
@@ -1819,19 +1819,19 @@ describe('router hooks', function () {
           switch (opts.resolutionMode) {
             case 'dynamic':
               yield* $(phase1, 'a1', a1CanLoad, 'canLoad');
-              yield* $(phase1, 'a1', a1Load, 'load');
+              yield* $(phase1, 'a1', a1Load, 'loading');
               yield* $(phase1, 'a1', 1, 'binding', 'bound', 'attaching', 'attached');
 
               yield* $(phase1, 'a2', a2CanLoad, 'canLoad');
-              yield* $(phase1, 'a2', a2Load, 'load');
+              yield* $(phase1, 'a2', a2Load, 'loading');
               yield* $(phase1, 'a2', 1, 'binding', 'bound', 'attaching', 'attached');
               break;
             case 'static':
               yield* $(phase1, 'a1', a1CanLoad, 'canLoad');
               yield* $(phase1, 'a2', a2CanLoad, 'canLoad');
 
-              yield* $(phase1, 'a1', a1Load, 'load');
-              yield* $(phase1, 'a2', a2Load, 'load');
+              yield* $(phase1, 'a1', a1Load, 'loading');
+              yield* $(phase1, 'a2', a2Load, 'loading');
 
               yield* $(phase1, 'a1', 1, 'binding', 'bound', 'attaching');
               yield* interleave(
@@ -1977,19 +1977,19 @@ describe('router hooks', function () {
       const spec: IParentSiblingsChildSiblingsTransitionSpec = {
         a1: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(a1CanLoad),
-          load: DelayedInvoker.load(a1Load),
+          loading: DelayedInvoker.loading(a1Load),
         }),
         a2: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(a2CanLoad),
-          load: DelayedInvoker.load(a2Load),
+          loading: DelayedInvoker.loading(a2Load),
         }),
         b1: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(b1CanLoad),
-          load: DelayedInvoker.load(b1Load),
+          loading: DelayedInvoker.loading(b1Load),
         }),
         b2: HookSpecs.create(1, {
           canLoad: DelayedInvoker.canLoad(b2CanLoad),
-          load: DelayedInvoker.load(b2Load),
+          loading: DelayedInvoker.loading(b2Load),
         }),
       };
 
@@ -2035,24 +2035,24 @@ describe('router hooks', function () {
               yield* interleave(
                 (function* () {
                   yield* $(phase1, 'a1', a1CanLoad, 'canLoad');
-                  yield* $(phase1, 'a1', a1Load, 'load');
+                  yield* $(phase1, 'a1', a1Load, 'loading');
                   yield* $(phase1, 'a1', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
                 (function* () {
                   yield* $(phase1, 'b1', b1CanLoad, 'canLoad');
-                  yield* $(phase1, 'b1', b1Load, 'load');
+                  yield* $(phase1, 'b1', b1Load, 'loading');
                   yield* $(phase1, 'b1', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
               );
               yield* interleave(
                 (function* () {
                   yield* $(phase1, 'a2', a2CanLoad, 'canLoad');
-                  yield* $(phase1, 'a2', a2Load, 'load');
+                  yield* $(phase1, 'a2', a2Load, 'loading');
                   yield* $(phase1, 'a2', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
                 (function* () {
                   yield* $(phase1, 'b2', b2CanLoad, 'canLoad');
-                  yield* $(phase1, 'b2', b2Load, 'load');
+                  yield* $(phase1, 'b2', b2Load, 'loading');
                   yield* $(phase1, 'b2', 1, 'binding', 'bound', 'attaching', 'attached');
                 })(),
               );
@@ -2078,19 +2078,19 @@ describe('router hooks', function () {
 
               yield* interleave(
                 (function* () {
-                  yield* $(phase1, 'a1', a1Load, 'load');
+                  yield* $(phase1, 'a1', a1Load, 'loading');
                 })(),
                 (function* () {
-                  yield* $(phase1, 'b1', b1Load, 'load');
+                  yield* $(phase1, 'b1', b1Load, 'loading');
                 })(),
                 (function* () {
-                  yield* $(phase1, '-', a1Load, 'load');
-                  yield* $(phase1, 'a2', a2Load, 'load');
+                  yield* $(phase1, '-', a1Load, 'loading');
+                  yield* $(phase1, 'a2', a2Load, 'loading');
                 })(),
                 (function* () {
-                  yield* $(phase1, '-', b1Load, 'load');
+                  yield* $(phase1, '-', b1Load, 'loading');
                   if (a1Load > 2) { yield ''; }
-                  yield* $(phase1, 'b2', b2Load, 'load');
+                  yield* $(phase1, 'b2', b2Load, 'loading');
                 })(),
               );
 
@@ -2188,7 +2188,7 @@ describe('router hooks', function () {
       'attaching',
       'attached',
       'canLoad',
-      'load',
+      'loading',
     ] as HookName[]) {
       runTest({
         async action(router, container) {
@@ -2213,7 +2213,7 @@ describe('router hooks', function () {
       'detaching',
       'unbinding',
       'canUnload',
-      'unload',
+      'unloading',
     ] as HookName[]) {
       const throwsInTarget1 = ['canUnload'].includes(hookName);
 
@@ -2231,7 +2231,7 @@ describe('router hooks', function () {
             public async attaching() { throw new Error(`error in attaching`); }
             public async attached() { throw new Error(`error in attached`); }
             public async canLoad() { throw new Error(`error in canLoad`); }
-            public async load() { throw new Error(`error in load`); }
+            public async loading() { throw new Error(`error in load`); }
           });
 
           container.register(target1, target2);
@@ -2250,9 +2250,9 @@ describe('router hooks', function () {
       'detaching',
       'unbinding',
       'canUnload',
-      'unload',
+      'unloading',
     ] as HookName[]) {
-      const throwsInTarget1 = ['canUnload', 'unload'].includes(hookName);
+      const throwsInTarget1 = ['canUnload', 'unloading'].includes(hookName);
 
       runTest({
         async action(router, container) {
@@ -2267,15 +2267,15 @@ describe('router hooks', function () {
             public async bound() { throw new Error(`error in bound`); }
             public async attaching() { throw new Error(`error in attaching`); }
             public async attached() { throw new Error(`error in attached`); }
-            public async load() { throw new Error(`error in load`); }
+            public async loading() { throw new Error(`error in load`); }
           });
 
           container.register(target1, target2);
           await router.load(target1);
           await router.load(target2);
         },
-        messageMatcher: new RegExp(`error in ${throwsInTarget1 ? hookName : 'load'}`),
-        stackMatcher: new RegExp(`${throwsInTarget1 ? 'Target1' : 'Target2'}.${throwsInTarget1 ? hookName : 'load'}`),
+        messageMatcher: new RegExp(`error in ${throwsInTarget1 ? hookName : 'loading'}`),
+        stackMatcher: new RegExp(`${throwsInTarget1 ? 'Target1' : 'Target2'}.${throwsInTarget1 ? hookName : 'loading'}`),
         toString() {
           return `${String(this.messageMatcher)} with load,binding,bound,attaching`;
         },

--- a/packages/__tests__/router/router.spec.ts
+++ b/packages/__tests__/router/router.spec.ts
@@ -58,7 +58,7 @@ describe('Router', function () {
       //   console.log('canLoad', 'closest viewport', this.router.getClosestViewport(this));
       //   return true;
       // }
-      public load(params) {
+      public loading(params) {
         // console.log('load', 'closest viewport', this.router.getClosestViewport(this));
         if (params.id) { this.id = params.id; }
         if (params.name) { this.name = params.name; }
@@ -70,7 +70,7 @@ describe('Router', function () {
     const Baz = CustomElement.define({ name: 'baz', template: `<template>Viewport: baz Parameter id: [\${id}] <au-viewport name="baz"></au-viewport></template>` }, class {
       public static parameters = ['id'];
       public id = 'no id';
-      public load(params) { if (params.id) { this.id = params.id; } }
+      public loading(params) { if (params.id) { this.id = params.id; } }
     });
     const Qux = CustomElement.define({ name: 'qux', template: '<template>Viewport: qux<au-viewport name="qux"></au-viewport></template>' }, class {
       public canLoad() { return true; }
@@ -82,8 +82,8 @@ describe('Router', function () {
           return true;
         }
       }
-      public load() { return true; }
-      public unload() { return true; }
+      public loading() { return true; }
+      public unloading() { return true; }
     });
     const Quux = CustomElement.define({ name: 'quux', template: '<template>Viewport: quux<au-viewport name="quux" scope></au-viewport></template>' });
     const Corge = CustomElement.define({ name: 'corge', template: '<template>Viewport: corge<au-viewport name="corge" used-by="baz"></au-viewport>Viewport: dummy<au-viewport name="dummy"></au-viewport></template>' });
@@ -122,7 +122,7 @@ describe('Router', function () {
         public param: number;
         public entry: number = 0;
         public reloadBehavior: string = plughReloadBehavior;
-        public load(params) {
+        public loading(params) {
           console.log('plugh.load', this.entry, this.reloadBehavior, plughReloadBehavior);
           this.param = +params[0];
           this.entry++;
@@ -485,7 +485,7 @@ describe('Router', function () {
       public static parameters = ['id', 'name'];
       public id = 'no id';
       public name = 'no name';
-      public load(params) {
+      public loading(params) {
         if (params.id) { this.id = params.id; }
         if (params.name) { this.name = params.name; }
       }
@@ -1277,7 +1277,7 @@ describe('Router', function () {
           dependencies.push(CustomElement.define({ name, template }, class {
             public static parameters = ['id'];
             public param: string;
-            public load(params) {
+            public loading(params) {
               if (params.id !== void 0) {
                 this.param = params.id;
               }
@@ -1399,7 +1399,7 @@ describe('Router', function () {
         { path: 'grandchild-config', instructions: [{ component: 'grandchild', viewport: 'child' }], title: 'GrandchildConfig' },
       ];
       public param: string;
-      public load(params) {
+      public loading(params) {
         if (params.id !== void 0) {
           this.param = params.id;
         }
@@ -1412,7 +1412,7 @@ describe('Router', function () {
       public static parameters = ['id'];
       public static title = (vm) => vm.param !== void 0 ? vm.param : 'Child2';
       public param: string;
-      public load(params) {
+      public loading(params) {
         if (params.id !== void 0) {
           this.param = params.id;
         }
@@ -1616,7 +1616,7 @@ describe('Router', function () {
     const Child = CustomElement.define({ name: 'my-child', template: `!my-child\${param ? ":" + param : ""}!<au-viewport name="child"></au-viewport>` }, class {
       public static title = (vm) => `TheChild${vm.param !== void 0 ? `(${vm.param})` : ''}`;
       public param: string;
-      public load(params) {
+      public loading(params) {
         if (params.id !== void 0) {
           this.param = params.id;
         }
@@ -1626,7 +1626,7 @@ describe('Router', function () {
       public static parameters: string[] = ['id'];
       public static title = (vm) => `TheChild2${vm.param !== void 0 ? `(${vm.param})` : ''}`;
       public param: string;
-      public load(params) {
+      public loading(params) {
         if (params.id !== void 0) {
           this.param = params.id;
         }
@@ -1779,9 +1779,9 @@ describe('Router', function () {
     class Hooks {
       public name = 'Hooks';
       public canLoad(vm) { calledHooks.push(`${this.name}:${vm.name}:canLoad`); return true; }
-      public load(vm) { calledHooks.push(`${this.name}:${vm.name}:load`); }
+      public loading(vm) { calledHooks.push(`${this.name}:${vm.name}:load`); }
       public canUnload(vm) { calledHooks.push(`${this.name}:${vm.name}:canUnload`); return true; }
-      public unload(vm) { calledHooks.push(`${this.name}:${vm.name}:unload`); }
+      public unloading(vm) { calledHooks.push(`${this.name}:${vm.name}:unload`); }
 
       // TODO: Put these in once core supports them
       // public binding(vm) { calledHooks.push(`${this.name}:${vm.name}:binding`); }

--- a/packages/router/src/endpoints/viewport-content.ts
+++ b/packages/router/src/endpoints/viewport-content.ts
@@ -398,21 +398,36 @@ export class ViewportContent extends EndpointContent {
         const parameters = this.instruction.typeParameters(this.router);
         const merged = { ...this.navigation.parameters, ...parentParameters, ...parameters };
 
-        const hooks = this.getLifecycleHooks(instance, 'load').map(hook =>
+        const hooks = this.getLifecycleHooks(instance, 'loading').map(hook =>
           () => hook(instance, merged, this.instruction, this.navigation));
+
+        hooks.push(...this.getLifecycleHooks(instance, 'load').map(hook =>
+          () => {
+            console.warn(`[Deprecated] Found deprecated hook name "load" in ${this.instruction.component.name}. Please use the new name "loading" instead.`);
+            return hook(instance, merged, this.instruction, this.navigation);
+          }));
 
         if (hooks.length !== 0) {
           // Add hook in component
-          if (instance.load != null) {
-            hooks.push(() => instance.load!(merged, this.instruction, this.navigation));
+          if (instance.loading != null) {
+            hooks.push(() => instance.loading!(merged, this.instruction, this.navigation));
+          }
+          if ((instance as any).load != null) {
+            console.warn(`[Deprecated] Found deprecated hook name "load" in ${this.instruction.component.name}. Please use the new name "loading" instead.`);
+            hooks.push(() => (instance as any).load!(merged, this.instruction, this.navigation));
           }
 
           return Runner.run(null, ...hooks);
         }
 
         // Skip if there's no hook in component
-        if (instance.load != null) {
-          return instance.load(merged, this.instruction, this.navigation);
+        if (instance.loading != null) {
+          return instance.loading(merged, this.instruction, this.navigation);
+        }
+        // Skip if there's no hook in component
+        if ((instance as any).load != null) {
+          console.warn(`[Deprecated] Found deprecated hook name "load" in ${this.instruction.component.name}. Please use the new name "loading" instead.`);
+          return (instance as any).load(merged, this.instruction, this.navigation);
         }
       }
     ) as Step<void>;
@@ -441,21 +456,35 @@ export class ViewportContent extends EndpointContent {
       });
     }
 
-    const hooks = this.getLifecycleHooks(instance, 'unload').map(hook =>
+    const hooks = this.getLifecycleHooks(instance, 'unloading').map(hook =>
       () => hook(instance, this.instruction, navigation));
+
+    hooks.push(...this.getLifecycleHooks(instance, 'unload').map(hook =>
+      () => {
+        console.warn(`[Deprecated] Found deprecated hook name "unload" in ${this.instruction.component.name}. Please use the new name "unloading" instead.`);
+        return hook(instance, this.instruction, navigation);
+      }));
 
     if (hooks.length !== 0) {
       // Add hook in component
-      if (instance.unload != null) {
-        hooks.push(() => instance.unload!(this.instruction, navigation));
+      if (instance.unloading != null) {
+        hooks.push(() => instance.unloading!(this.instruction, navigation));
+      }
+      if ((instance as any).unload != null) {
+        console.warn(`[Deprecated] Found deprecated hook name "unload" in ${this.instruction.component.name}. Please use the new name "unloading" instead.`);
+        hooks.push(() => (instance as any).unload!(this.instruction, navigation));
       }
 
       return Runner.run(null, ...hooks) as void | Promise<void>;
     }
 
     // Skip if there's no hook in component
-    if (instance.unload != null) {
-      return instance.unload(this.instruction, navigation);
+    if (instance.unloading != null) {
+      return instance.unloading(this.instruction, navigation);
+    }
+    if ((instance as any).unload != null) {
+      console.warn(`[Deprecated] Found deprecated hook name "unload" in ${this.instruction.component.name}. Please use the new name "unloading" instead.`);
+      return (instance as any).unload(this.instruction, navigation);
     }
   }
 

--- a/packages/router/src/endpoints/viewport.ts
+++ b/packages/router/src/endpoints/viewport.ts
@@ -528,7 +528,7 @@ export class Viewport extends Endpoint {
       },
     ];
 
-    // The transition routing hooks, unload and load
+    // The transition routing hooks, unloading and loading
     const routingSteps = [
       () => coordinator.waitForSyncState('guarded', this),
       (step: Step<void>) => {

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -38,9 +38,9 @@ export type TitleFunction = (viewModel: IRouteableComponent, instruction: Naviga
 export interface IRouteableComponent extends ICustomElementViewModel {
   reloadBehavior?: ReloadBehavior;
   canLoad?(parameters: Parameters, instruction: RoutingInstruction, navigation: Navigation): boolean | LoadInstruction | LoadInstruction[] | Promise<boolean | LoadInstruction | LoadInstruction[]>;
-  load?(parameters: Parameters, instruction: RoutingInstruction, navigation: Navigation): void | Promise<void>;
+  loading?(parameters: Parameters, instruction: RoutingInstruction, navigation: Navigation): void | Promise<void>;
   canUnload?(instruction: RoutingInstruction, navigation: Navigation | null): boolean | Promise<boolean>;
-  unload?(instruction: RoutingInstruction, navigation: Navigation | null): void | Promise<void>;
+  unloading?(instruction: RoutingInstruction, navigation: Navigation | null): void | Promise<void>;
   readonly $controller?: ICustomElementController<this>;
 }
 

--- a/packages/router/src/navigation-coordinator.ts
+++ b/packages/router/src/navigation-coordinator.ts
@@ -32,8 +32,8 @@ export type NavigationState =
   'guardedUnload' | // fulfilled when canUnload (if any) has been called
   'guardedLoad' | // fulfilled when canLoad (if any) has been called
   'guarded' | // fulfilled when check hooks canUnload and canLoad (if any) have been called
-  'unloaded' | // fulfilled when unload (if any) has been called
-  'loaded' | // fulfilled when load (if any) has been called
+  'unloaded' | // fulfilled when unloading (if any) has been called
+  'loaded' | // fulfilled when loading (if any) has been called
   'routed' | // fulfilled when initial routing hooks (if any) have been called
   'bound' | // fulfilled when bind has been called
   'swapped' |

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -85,8 +85,8 @@ export class Route {
     // TODO: Look into adding these:
     // public readonly canLoad: readonly CanLoad[],
     // public readonly canUnload: readonly CanUnload[],
-    // public readonly load: readonly Load[],
-    // public readonly unload: readonly Unload[],
+    // public readonly loading: readonly Load[],
+    // public readonly unloading: readonly Unload[],
   ) { }
 
   /**

--- a/packages/router/src/routing-scope.ts
+++ b/packages/router/src/routing-scope.ts
@@ -787,7 +787,7 @@ export class RoutingScope {
   }
 
   private findMatchingRouteInRoutes(path: string, routes: Route[]): FoundRoute | null {
-    if (!Array.isArray(routes) || routes.length === 0) {
+    if (routes.length === 0) {
       return null;
     }
 

--- a/test/doc-example/app/src/double-slow.ts
+++ b/test/doc-example/app/src/double-slow.ts
@@ -15,11 +15,11 @@ export class DoubleSlow {
     this.element = controller.host;
   }
 
-  public load(_params, _instruction, navigation) {
+  public loading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation.back;
     return new Promise(r => setTimeout(r, 2000));
   }
-  public unload(_instruction, navigation) {
+  public unloading(_instruction, navigation) {
     this.backwards = navigation.navigation.back;
   }
 

--- a/test/doc-example/app/src/fast.ts
+++ b/test/doc-example/app/src/fast.ts
@@ -6,7 +6,7 @@ import { customElement } from '@aurelia/runtime-html';
 Fast
 `})
 export class Fast {
-  public load(parameters, instruction, navigation) {
+  public loading(parameters, instruction, navigation) {
     console.log('Fast load:', parameters, instruction, navigation);
   }
   // public detaching() {

--- a/test/doc-example/app/src/slow-attach-parent.ts
+++ b/test/doc-example/app/src/slow-attach-parent.ts
@@ -27,10 +27,10 @@ export class SlowAttachParent {
     setInterval(() => { _this.seconds++; }, 1000);
   }
 
-  public load(_params, _instruction, navigation) {
+  public loading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation.back;
   }
-  public unload(_params, _instruction, navigation) {
+  public unloading(_params, _instruction, navigation) {
     this.backwards = navigation.navigation?.back;
   }
 

--- a/test/doc-example/app/src/slow.ts
+++ b/test/doc-example/app/src/slow.ts
@@ -6,7 +6,7 @@ import { customElement } from '@aurelia/runtime-html';
 Slow
 `})
 export class Slow {
-  public load(params) {
+  public loading(params) {
     console.log('Slow params', params);
   }
 

--- a/test/routing-tutorial-part-3/src/books/book-details.ts
+++ b/test/routing-tutorial-part-3/src/books/book-details.ts
@@ -23,7 +23,7 @@ export class BookDetails {
 
   }
 
-  public load(parameters) {
+  public loading(parameters) {
     this.book = this.bookService.getBook(parameters.id);
   }
 }

--- a/test/routing-tutorial-part-3/src/books/books.ts
+++ b/test/routing-tutorial-part-3/src/books/books.ts
@@ -17,7 +17,7 @@ export class Books {
 
     }
 
-    public load() {
+    public loading() {
         this.books = this.bookService.getBooks();
     }
 }

--- a/test/routing-tutorial-part-3/src/books/description.ts
+++ b/test/routing-tutorial-part-3/src/books/description.ts
@@ -17,7 +17,7 @@ export class Description {
 
     }
 
-    public load(parameters) {
+    public loading(parameters) {
         this.book = this.bookService.getBook(parameters.id);
     }
 }

--- a/test/routing-tutorial-part-3/src/main/missing.ts
+++ b/test/routing-tutorial-part-3/src/main/missing.ts
@@ -9,7 +9,7 @@ export class Missing {
     public static parameters: string[] = ['id'];
     public missingComponent: string;
 
-    public load(parameters) {
+    public loading(parameters) {
         this.missingComponent = parameters.id;
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR changes the names of the routing hooks `load` and `unload` to `loading` and `unloading` respectively in order to follow the naming convention of the other lifecycle hooks.

**BREAKING CHANGES**: After a short grace period, hooks named `load` and `unload` will no longer work. Instead, their new names `loading` and `unloading` will have to be used.

### 🎫 Issues

Resolves https://github.com/aurelia/aurelia/issues/1509. 

## 👩‍💻 Reviewer Notes

There are a couple of instances in `/examples/validation-with-router` and `/test/benchmarking-apps` that I have not updated since I'm unfamiliar with those apps. I have also not updated `router-lite` for the same reason.

## 📑 Test Plan

- Make sure existing tests pass

## ⏭ Next Steps

- Update the remaining instances mentioned above
