### PR TITLE
Fix bindables reset after HMR component reload

### DIFF
--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -73,17 +73,14 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
 
       // @ts-ignore
       previousControllers.forEach(controller => {
-        const values = { ...controller.viewModel };
         const hydrationContext = controller.container.get(IHydrationContext)
         const hydrationInst = hydrationContext.instruction;
 
-        // @ts-ignore
-        Object.keys(values).forEach(key => {
-          // @ts-ignore
-          if (!controller.bindings?.some(y => y.sourceExpression?.name === key && y.targetProperty)) {
-            delete values[key];
-          }
+        const values = {};
+        Object.keys(controller.definition.bindables).forEach(property => {
+          values[property] = controller.viewModel[property];
         });
+
         const h = controller.host;
         delete controller._compiledDef;
         controller.viewModel = controller.container.invoke(currentClassType);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Wrong filtering of bindables (comparison was with template bindings, not bindable properties) caused values loss, so component state was wrong after hot reload

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
