### PR TITLE
feat(router): multiple bindable props for load attribute

### DIFF
--- a/packages/__e2e__/router/src/app.css
+++ b/packages/__e2e__/router/src/app.css
@@ -1,0 +1,3 @@
+.active {
+  background-color: gold;
+}

--- a/packages/__e2e__/router/src/app.html
+++ b/packages/__e2e__/router/src/app.html
@@ -5,7 +5,7 @@
 
 <div class="message">${message}</div>
 <nav>
-  <a load="home">Home</a>
+  <a load="/">Home</a>
   <a load="auth">Register</a>
   <a load="child">Child</a>
   <a load="something/missing">Something missing</a>

--- a/packages/router/src/found-route.ts
+++ b/packages/router/src/found-route.ts
@@ -24,7 +24,7 @@ export class FoundRoute {
     return this.match !== null;
   }
   public get foundInstructions(): boolean {
-    return this.instructions.length > 0;
+    return this.instructions.some(instruction => !instruction.component.none);
   }
   public get hasRemaining(): boolean {
     return this.instructions.some(instruction => instruction.hasNextScopeInstructions);

--- a/packages/router/src/interfaces.ts
+++ b/packages/router/src/interfaces.ts
@@ -57,6 +57,7 @@ export interface IRoutingInstruction {
   parameters?: ComponentParameters;
   children?: LoadInstruction[];
   options?: ILoadOptions;
+  id?: string;
 }
 
 // export interface IRoute extends Partial<IRoutingInstruction> {

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -1,15 +1,29 @@
+import { FoundRoute } from '../found-route';
+import { IRoutingInstruction } from '../interfaces';
 import { IDisposable, IEventAggregator } from '@aurelia/kernel';
 import { BindingMode } from '@aurelia/runtime';
 import { customAttribute, INode, bindable, CustomAttribute, ICustomAttributeViewModel } from '@aurelia/runtime-html';
 import { ILinkHandler } from './link-handler';
 import { IRouter, RouterNavigationEndEvent } from '../router';
 import { getConsideredActiveInstructions, getLoadIndicator } from './utils';
+import { Parameters } from '../instructions/instruction-parameters';
+import { RoutingInstruction } from '../instructions/routing-instruction';
+import { RoutingScope } from '../routing-scope';
+import { IRoute } from '../route';
 
 @customAttribute('load')
 export class LoadCustomAttribute implements ICustomAttributeViewModel {
-  @bindable({ mode: BindingMode.toView })
-  public value: unknown;
+  @bindable({ mode: BindingMode.toView }) public value: unknown;
+  @bindable public component?: string;
+  @bindable public parameters?: Parameters;
+  @bindable public viewport?: string;
 
+  /*
+   * The id for a configured route
+   */
+  @bindable public id?: string;
+
+  private separateProperties = false;
   private hasHref: boolean | null = null;
 
   private routerNavigationSubscription!: IDisposable;
@@ -26,9 +40,12 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   }
 
   public binding(): void {
+    if (this.value == null) {
+      this.separateProperties = true;
+    }
     this.element.addEventListener('click', this.linkHandler);
     this.updateValue();
-    this.updateActive();
+    void this.updateActive();
 
     this.routerNavigationSubscription = this.ea.subscribe(RouterNavigationEndEvent.eventName, this.navigationEndHandler);
   }
@@ -40,16 +57,32 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
 
   public valueChanged(_newValue: unknown): void {
     this.updateValue();
-    this.updateActive();
+    void this.updateActive();
   }
 
   private updateValue(): void {
+    if (this.separateProperties) {
+      this.value = {
+        component: this.component,
+        parameters: this.parameters,
+        viewport: this.viewport,
+        id: this.id,
+      };
+    }
+
     if (this.hasHref === null) {
       this.hasHref = this.element.hasAttribute('href');
     }
     if (!this.hasHref) {
-      // TODO: Figure out a better value here for non-strings (using RoutingInstruction?)
-      let value = typeof this.value === 'string' ? this.value : JSON.stringify(this.value);
+      let value = this.value as string;
+      if (typeof this.value !== 'string') {
+        const instruction = RoutingInstruction.from(this.router, this.value as IRoutingInstruction).shift() as RoutingInstruction;
+        const found = this.findRoute(this.value as IRoute);
+        if (found.foundConfiguration) {
+          instruction.route = found.matching;
+        }
+        value = RoutingInstruction.stringify(this.router, [instruction]);
+      }
       if (this.router.configuration.options.useUrlFragmentHash && !value.startsWith('#')) {
         value = `#${value}`;
       }
@@ -57,14 +90,38 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     }
   }
   private readonly navigationEndHandler = (_navigation: RouterNavigationEndEvent): void => {
-    this.updateActive();
+    void this.updateActive();
   };
 
-  private updateActive(): void {
+  private async updateActive(): Promise<void> {
     const controller = CustomAttribute.for(this.element, 'load')!.parent!;
-    const instructions = getConsideredActiveInstructions(this.router, controller, this.element as HTMLElement, this.value);
+    const routeValue = typeof this.value === 'string' ? { id: this.value, path: this.value } : this.value;
+    const found = this.findRoute(routeValue as IRoute);
+    const instructions = found.foundConfiguration
+      ? found.instructions
+      : getConsideredActiveInstructions(this.router, controller, this.element as HTMLElement, this.value);
     const element = getLoadIndicator(this.element as HTMLElement);
 
+    const unresolvedPromise = RoutingInstruction.resolve(instructions);
+    if (unresolvedPromise instanceof Promise) {
+      await unresolvedPromise;
+    }
+
     element.classList.toggle(this.activeClass, this.router.checkActive(instructions, { context: controller }));
+  }
+
+  private findRoute(value: string | IRoute): FoundRoute {
+    if (typeof value === 'string') {
+      return new FoundRoute();
+    }
+    const scope = RoutingScope.for(this.element) ?? this.router.rootScope!.scope;
+    if (value.id != null) {
+      return scope.findMatchingRoute(value.id, value.parameters as Parameters ?? {});
+    }
+    const path = value.path as string;
+    if (path != null) {
+      return scope.findMatchingRoute(path, value.parameters as Parameters ?? {});
+    }
+    return new FoundRoute();
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes it possible to use multiple bindable properties for the `load` attribute as well as adds configured route `id` as an option to select configured route with. So given a configured route
```ts
  { id: 'thing-params', path: 'thing/:id', component: MyThing, title: 'The Thing!' },
```
it will be possible to use the following options to `load`
```html
  <a load="thing/123">
  <a load="id: thing-params; parameters.bind: { id: 123 };">
  <a load.bind="{ id: 'thing-params', parameters: { id: 123 } }">
```

## 📑 Test Plan

- Make tests for the new options
- Make sure existing tests pass
