### PR TITLE
refactor(binding): move BindingMode to runtime-html

### DIFF
--- a/packages-tooling/__tests__/plugin-conventions/strip-meta-data.spec.ts
+++ b/packages-tooling/__tests__/plugin-conventions/strip-meta-data.spec.ts
@@ -1,4 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
+import { BindingMode } from '@aurelia/runtime-html';
 import { stripMetaData } from '@aurelia/plugin-conventions';
 import * as assert from 'assert';
 

--- a/packages-tooling/plugin-conventions/src/strip-meta-data.ts
+++ b/packages-tooling/plugin-conventions/src/strip-meta-data.ts
@@ -1,6 +1,5 @@
 import { kebabCase } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { PartialBindableDefinition } from '@aurelia/runtime-html';
+import { BindingMode, PartialBindableDefinition } from '@aurelia/runtime-html';
 import { DefaultTreeElement, ElementLocation, parseFragment } from 'parse5';
 
 interface IStrippedHtml {

--- a/packages/__tests__/2-runtime/ast.integration.spec.ts
+++ b/packages/__tests__/2-runtime/ast.integration.spec.ts
@@ -1,10 +1,10 @@
 import {
   AccessScopeExpression,
-  BindingMode,
   ConditionalExpression,
   LifecycleFlags
 } from '@aurelia/runtime';
 import {
+  BindingMode,
   IPlatform,
   LetBinding,
   PropertyBinding,

--- a/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
@@ -3,8 +3,8 @@ import {
   IContainer,
   Registration,
 } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
 import {
+  BindingMode,
   PropertyBinding,
   FromViewBindingBehavior,
   OneTimeBindingBehavior,

--- a/packages/__tests__/2-runtime/let-binding.spec.ts
+++ b/packages/__tests__/2-runtime/let-binding.spec.ts
@@ -1,5 +1,6 @@
 // import { DI, IContainer } from '@aurelia/kernel';
-// import { LetBinding, LifecycleFlags, BindingMode, ExpressionKind, IBindingTarget, IExpression, IObserverLocator, Scope, Scope, State } from '@aurelia/runtime';
+// import { LetBinding, LifecycleFlags, ExpressionKind, IBindingTarget, IExpression, IObserverLocator, Scope, Scope, State } from '@aurelia/runtime';
+// import { BindingMode } from '@aurelia/runtime-html';
 // import { MockExpression } from '../mock.js';
 // import { assert } from '@aurelia/testing';
 

--- a/packages/__tests__/2-runtime/signals.spec.ts
+++ b/packages/__tests__/2-runtime/signals.spec.ts
@@ -4,7 +4,6 @@
 // } from '@aurelia/kernel';
 // import {
 //   Binding,
-//   BindingMode,
 //   IObserverLocator,
 //   IsBindingBehavior,
 //   Scope,
@@ -12,6 +11,7 @@
 //   LifecycleFlags,
 //   SignalBindingBehavior
 // } from '@aurelia/runtime';
+// import { BindingMode } from '@aurelia/runtime-html';
 
 // describe('SignalBindingBehavior', function () {
 //   const container: IContainer = DI.createContainer();

--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -1,6 +1,5 @@
 import { IContainer } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { Aurelia, AuSlotsInfo, bindable, customElement, CustomElement, IAuSlotsInfo, IPlatform } from '@aurelia/runtime-html';
+import { BindingMode, Aurelia, AuSlotsInfo, bindable, customElement, CustomElement, IAuSlotsInfo, IPlatform } from '@aurelia/runtime-html';
 import { assert, createFixture, hJsx, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../util.js';
 

--- a/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
@@ -1,6 +1,5 @@
 import { Constructable } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { Aurelia, IEventDelegator, StandardConfiguration, CustomElement, IPlatform } from '@aurelia/runtime-html';
+import { BindingMode, Aurelia, IEventDelegator, StandardConfiguration, CustomElement, IPlatform } from '@aurelia/runtime-html';
 import { TestContext, eachCartesianJoin, eachCartesianJoinAsync, assert } from '@aurelia/testing';
 import { ClassAttributePattern } from './attribute-pattern.js';
 

--- a/packages/__tests__/3-runtime-html/binding-resources.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-resources.spec.ts
@@ -1,6 +1,5 @@
 import { TestContext, assert, createFixture } from '@aurelia/testing';
-import { customElement, bindable, Aurelia } from '@aurelia/runtime-html';
-import { BindingMode } from '@aurelia/runtime';
+import { BindingMode, customElement, bindable, Aurelia } from '@aurelia/runtime-html';
 
 async function wait(ms: number): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, ms));

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -1,5 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
-import { CustomElement, ValueConverter } from '@aurelia/runtime-html';
+import { BindingMode, CustomElement, ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/custom-elements.spec.ts', function () {

--- a/packages/__tests__/3-runtime-html/decorator-watch.expression.spec.ts
+++ b/packages/__tests__/3-runtime-html/decorator-watch.expression.spec.ts
@@ -1,5 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
-import { bindable, customAttribute, customElement, watch } from '@aurelia/runtime-html';
+import { BindingMode, bindable, customAttribute, customElement, watch } from '@aurelia/runtime-html';
 import { assert, createFixture, TestContext } from '@aurelia/testing';
 
 describe('3-runtime-html/decorator-watch.expression.spec.ts', function () {

--- a/packages/__tests__/3-runtime-html/integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/integration.spec.ts
@@ -4,8 +4,6 @@ import {
 } from '@aurelia/kernel';
 import {
   BindingMode,
-} from '@aurelia/runtime';
-import {
   Aurelia,
   Controller,
   CustomElement,

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -5,8 +5,9 @@ import {
   createObserverLocator,
   createScopeForTest,
 } from '@aurelia/testing';
-import { Interpolation, ConditionalExpression, AccessScopeExpression, BindingMode, LifecycleFlags } from '@aurelia/runtime';
+import { Interpolation, ConditionalExpression, AccessScopeExpression, LifecycleFlags } from '@aurelia/runtime';
 import {
+  BindingMode,
   CustomElement,
   InterpolationBinding,
   SVGAnalyzerRegistration,

--- a/packages/__tests__/3-runtime-html/process-content.spec.ts
+++ b/packages/__tests__/3-runtime-html/process-content.spec.ts
@@ -1,6 +1,6 @@
 import { IContainer, noop, toArray } from '@aurelia/kernel';
-import { LifecycleFlags, BindingMode } from '@aurelia/runtime';
-import { Aurelia, bindable, CustomElement, customElement, INode, IPlatform, processContent } from '@aurelia/runtime-html';
+import { LifecycleFlags } from '@aurelia/runtime';
+import { Aurelia, BindingMode, bindable, CustomElement, customElement, INode, IPlatform, processContent } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext as $TestExecutionContext, TestFunction } from '../util.js';
 

--- a/packages/__tests__/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/3-runtime-html/spread.spec.ts
@@ -1,6 +1,5 @@
 import { Constructable } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { CustomAttribute, CustomElement, ICustomElementViewModel, INode } from '@aurelia/runtime-html';
+import { BindingMode, CustomAttribute, CustomElement, ICustomElementViewModel, INode } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 // all the tests are using a common <my-input/> with a spreat on its internal <input/>

--- a/packages/__tests__/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -1,8 +1,5 @@
 import {
-  BindingMode
-} from '@aurelia/runtime';
-import {
-  AuSlot, CustomElement, CustomElementDefinition, CustomElementType, HydrateElementInstruction, InstructionType
+  BindingMode, AuSlot, CustomElement, CustomElementDefinition, CustomElementType, HydrateElementInstruction, InstructionType
 } from '@aurelia/runtime-html';
 import {
   assert, TestContext

--- a/packages/__tests__/3-runtime-html/template-compiler.convention.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.convention.spec.ts
@@ -1,7 +1,5 @@
 import {
   BindingMode,
-} from '@aurelia/runtime';
-import {
   ITemplateCompiler,
   IInstruction,
   InstructionType as TT,

--- a/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
@@ -2,9 +2,7 @@ import {
   DefaultLogger, IContainer, ILogEvent, ISink, kebabCase, LoggerConfiguration, LogLevel
 } from '@aurelia/kernel';
 import {
-  BindingMode
-} from '@aurelia/runtime';
-import {
+  BindingMode,
   Aurelia, bindable,
   BindableDefinition, CustomAttributeDefinition, customElement,
   CustomElement, CustomElementDefinition, HydrateElementInstruction

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -11,13 +11,13 @@ import {
   parseExpression,
   AccessScopeExpression,
   BindingIdentifier,
-  BindingMode,
   DelegationStrategy,
   PrimitiveLiteralExpression,
   IExpressionParser,
 } from '@aurelia/runtime';
 import {
   bindable,
+  BindingMode,
   BindableDefinition,
   customAttribute,
   CustomAttribute,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -412,7 +412,6 @@ export {
   // IRendererRegistration,
   // RuntimeConfiguration,
 
-  BindingMode,
   // ExpressionKind,
   // Hooks,
   LifecycleFlags,
@@ -520,6 +519,8 @@ export {
   AppTask,
   // TaskStatus,
   // QueueTaskTargetOptions,
+
+  BindingMode,
 
   bindable,
   type PartialBindableDefinition,

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -4,10 +4,10 @@ import {
   ExpressionType,
   IExpressionParser,
   IObserverLocator,
-  BindingMode,
   type IsBindingBehavior,
 } from '@aurelia/runtime';
 import {
+  BindingMode,
   CommandType,
   IHydratableController,
   IRenderer,

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -6,9 +6,9 @@ import {
   IExpressionParser,
   IObserverLocator,
   type IsBindingBehavior,
-  BindingMode,
 } from '@aurelia/runtime';
 import {
+  BindingMode,
   CommandType,
   IRenderer,
   renderer,

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -1,6 +1,5 @@
 import { IDisposable } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { customAttribute, bindable, ICustomAttributeViewModel, ICustomAttributeController, IEventDelegator, IEventTarget, INode, IWindow, getRef, CustomAttribute } from '@aurelia/runtime-html';
+import { BindingMode, customAttribute, bindable, ICustomAttributeViewModel, ICustomAttributeController, IEventDelegator, IEventTarget, INode, IWindow, getRef, CustomAttribute } from '@aurelia/runtime-html';
 
 import { IRouter } from '../router';
 import { LoadCustomAttribute } from '../configuration';

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -1,6 +1,5 @@
 import { IDisposable, IIndexable } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { customAttribute, bindable, ICustomAttributeViewModel, IEventDelegator, IEventTarget, INode, CustomElement } from '@aurelia/runtime-html';
+import { BindingMode, customAttribute, bindable, ICustomAttributeViewModel, IEventDelegator, IEventTarget, INode, CustomElement } from '@aurelia/runtime-html';
 
 import { IRouter } from '../router';
 import { IRouteContext } from '../route-context';

--- a/packages/router/src/resources/considered-active.ts
+++ b/packages/router/src/resources/considered-active.ts
@@ -1,5 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
-import { customAttribute, bindable, ICustomAttributeViewModel } from '@aurelia/runtime-html';
+import { BindingMode, customAttribute, bindable, ICustomAttributeViewModel } from '@aurelia/runtime-html';
 
 @customAttribute('considered-active')
 export class ConsideredActiveCustomAttribute implements ICustomAttributeViewModel {

--- a/packages/router/src/resources/href.ts
+++ b/packages/router/src/resources/href.ts
@@ -1,6 +1,5 @@
 import { IDisposable, IEventAggregator } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { customAttribute, INode, bindable, ViewModelKind, ICustomAttributeViewModel, ICustomAttributeController, CustomAttribute } from '@aurelia/runtime-html';
+import { BindingMode, customAttribute, INode, bindable, ViewModelKind, ICustomAttributeViewModel, ICustomAttributeController, CustomAttribute } from '@aurelia/runtime-html';
 import { IRouter, RouterNavigationEndEvent } from '../router';
 import { LoadCustomAttribute } from '../index';
 import { ILinkHandler } from './link-handler';

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -1,6 +1,5 @@
 import { IDisposable, IEventAggregator } from '@aurelia/kernel';
-import { BindingMode } from '@aurelia/runtime';
-import { customAttribute, INode, bindable, CustomAttribute, ICustomAttributeViewModel } from '@aurelia/runtime-html';
+import { BindingMode, customAttribute, INode, bindable, CustomAttribute, ICustomAttributeViewModel } from '@aurelia/runtime-html';
 import { ILinkHandler } from './link-handler';
 import { IRouter, RouterNavigationEndEvent } from '../router';
 import { getConsideredActiveInstructions, getLoadIndicator } from './utils';

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -1,5 +1,6 @@
 import { kebabCase, firstDefined, getPrototypeChain, noop, Class } from '@aurelia/kernel';
-import { BindingMode, ICoercionConfiguration } from '@aurelia/runtime';
+import { ICoercionConfiguration } from '@aurelia/runtime';
+import { BindingMode } from './binding/interfaces-bindings';
 import { appendAnnotationKey, defineMetadata, getAllAnnotations, getAnnotationKeyFor, getOwnMetadata, hasOwnMetadata } from './utilities-metadata';
 import { isString } from './utilities';
 

--- a/packages/runtime-html/src/binding-behaviors/binding-mode.ts
+++ b/packages/runtime-html/src/binding-behaviors/binding-mode.ts
@@ -1,5 +1,6 @@
-import { BindingBehaviorInstance, BindingMode, LifecycleFlags } from '@aurelia/runtime';
+import { BindingBehaviorInstance, LifecycleFlags } from '@aurelia/runtime';
 import { bindingBehavior } from '../resources/binding-behavior';
+import { BindingMode } from '../binding/interfaces-bindings';
 
 import type { Scope } from '@aurelia/runtime';
 import type { PropertyBinding } from '../binding/property-binding';

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -1,6 +1,5 @@
 import { IServiceLocator } from '@aurelia/kernel';
 import {
-  BindingMode,
   ExpressionKind,
   LifecycleFlags,
   AccessorType,
@@ -8,6 +7,7 @@ import {
   connectable,
 } from '@aurelia/runtime';
 
+import { BindingMode } from './interfaces-bindings';
 import { AttributeObserver } from '../observation/element-attribute-observer';
 import { BindingTargetSubscriber, astEvaluator } from './binding-utils';
 import { State } from '../templating/controller';

--- a/packages/runtime-html/src/binding/interfaces-bindings.ts
+++ b/packages/runtime-html/src/binding/interfaces-bindings.ts
@@ -1,6 +1,26 @@
 import { AnyBindingExpression, IAstEvaluator, IConnectableBinding } from '@aurelia/runtime';
 import { State } from '../templating/controller';
 
+// Note: the oneTime binding now has a non-zero value for 2 reasons:
+//  - plays nicer with bitwise operations (more consistent code, more explicit settings)
+//  - allows for potentially having something like BindingMode.oneTime | BindingMode.fromView, where an initial value is set once to the view but updates from the view also propagate back to the view model
+//
+// Furthermore, the "default" mode would be for simple ".bind" expressions to make it explicit for our logic that the default is being used.
+// This essentially adds extra information which binding could use to do smarter things and allows bindingBehaviors that add a mode instead of simply overwriting it
+/**
+ * Mode of a binding to operate
+ */
+export enum BindingMode {
+  oneTime  = 0b0001,
+  toView   = 0b0010,
+  fromView = 0b0100,
+  twoWay   = 0b0110,
+  /**
+   * Unspecified mode, bindings may act differently with this mode
+   */
+  default  = 0b1000
+}
+
 export type IAstBasedBinding = IAstEvaluator & IConnectableBinding & {
   ast: AnyBindingExpression;
 };

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -1,11 +1,11 @@
 import {
   AccessorOrObserver,
   AccessorType,
-  BindingMode,
   ExpressionKind,
   LifecycleFlags,
   connectable,
 } from '@aurelia/runtime';
+import { BindingMode } from './interfaces-bindings';
 import { astEvaluator } from './binding-utils';
 import { State } from '../templating/controller';
 

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -1,6 +1,7 @@
-import { AccessorType, BindingMode, connectable, ExpressionKind, IndexMap, LifecycleFlags } from '@aurelia/runtime';
+import { AccessorType, connectable, ExpressionKind, IndexMap, LifecycleFlags } from '@aurelia/runtime';
 import { astEvaluator, BindingTargetSubscriber } from './binding-utils';
 import { State } from '../templating/controller';
+import { BindingMode } from './interfaces-bindings';
 
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import type { IServiceLocator } from '@aurelia/kernel';

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -115,6 +115,7 @@ export {
   type IsTwoWayPredicate,
 } from './attribute-mapper';
 export {
+  BindingMode,
   IAstBasedBinding,
   IBindingController,
 } from './binding/interfaces-bindings';

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1,6 +1,5 @@
 import { DI, emptyArray, InstanceProvider, Key } from '@aurelia/kernel';
 import {
-  BindingMode,
   ExpressionType,
   IExpressionParser,
   IObserverLocator,
@@ -10,6 +9,7 @@ import {
   IBinding,
   Scope,
 } from '@aurelia/runtime';
+import { BindingMode } from './binding/interfaces-bindings';
 import { CallBinding } from './binding/call-binding';
 import { AttributeBinding } from './binding/attribute';
 import { InterpolationBinding, InterpolationPartBinding, ContentBinding } from './binding/interpolation-binding';

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -1,5 +1,6 @@
 import { DI, firstDefined, fromAnnotationOrDefinitionOrTypeOrDefault, mergeArrays, Registration, Resolved, ResourceType } from '@aurelia/kernel';
-import { BindingBehaviorInstance, BindingMode, Collection, IAstEvaluator, IndexMap, LifecycleFlags, ValueConverterInstance } from '@aurelia/runtime';
+import { BindingBehaviorInstance, Collection, IAstEvaluator, IndexMap, LifecycleFlags, ValueConverterInstance } from '@aurelia/runtime';
+import { BindingMode } from '../binding/interfaces-bindings';
 import { def, isFunction, isString } from '../utilities';
 import { registerAliases } from '../utilities-di';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -1,4 +1,5 @@
-import { BindingMode, IObserverLocator, LifecycleFlags } from '@aurelia/runtime';
+import { IObserverLocator, LifecycleFlags } from '@aurelia/runtime';
+import { BindingMode } from '../../binding/interfaces-bindings';
 import { EventSubscriber } from '../../observation/event-delegator';
 import { NodeObserverConfig } from '../../observation/observer-locator';
 import { bindingBehavior } from '../binding-behavior';

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -1,5 +1,6 @@
 import { camelCase, mergeArrays, firstDefined } from '@aurelia/kernel';
-import { BindingMode, ExpressionType, DelegationStrategy, IExpressionParser, IsBindingBehavior } from '@aurelia/runtime';
+import { ExpressionType, DelegationStrategy, IExpressionParser, IsBindingBehavior } from '@aurelia/runtime';
+import { BindingMode } from '../binding/interfaces-bindings';
 import { IAttrMapper } from '../attribute-mapper';
 import {
   AttributeBindingInstruction,

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -6,6 +6,7 @@ import { DefinitionType } from './resources-shared';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
 import { isFunction, isString } from '../utilities';
 import { aliasRegistration, registerAliases, transientRegistration } from '../utilities-di';
+import { BindingMode } from '../binding/interfaces-bindings';
 
 import type {
   Constructable,
@@ -18,7 +19,6 @@ import type {
 import type { BindableDefinition, PartialBindableDefinition } from '../bindable';
 import type { ICustomAttributeViewModel, ICustomAttributeController } from '../templating/controller';
 import type { IWatchDefinition } from '../watch';
-import { BindingMode } from '@aurelia/runtime';
 
 declare module '@aurelia/kernel' {
   interface IContainer {

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -1,4 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
+import { BindingMode } from '../../binding/interfaces-bindings';
 import { INode } from '../../dom';
 import { IPlatform } from '../../platform';
 import { customAttribute } from '../custom-attribute';

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -1,5 +1,5 @@
 import { Constructable, nextId, onResolve } from '@aurelia/kernel';
-import { BindingMode, LifecycleFlags } from '@aurelia/runtime';
+import { LifecycleFlags } from '@aurelia/runtime';
 import { createElement, RenderPlan } from '../../create-element';
 import { HydrateElementInstruction, IInstruction } from '../../renderer';
 import { IPlatform } from '../../platform';
@@ -9,6 +9,7 @@ import { bindable } from '../../bindable';
 import { ControllerVisitor, ICustomElementController, ICustomElementViewModel, IHydratedController, IHydratedParentController, IHydrationContext, ISyntheticView } from '../../templating/controller';
 import { IRendering } from '../../templating/rendering';
 import { isPromise, isString } from '../../utilities';
+import { BindingMode } from '../../binding/interfaces-bindings';
 
 export type Subject = string | IViewFactory | ISyntheticView | RenderPlan | Constructable | CustomElementDefinition;
 export type MaybeSubjectPromise = Subject | Promise<Subject> | undefined;

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,10 +1,11 @@
 import { Task, TaskAbortError, TaskStatus } from '@aurelia/platform';
 import { ILogger, nextId, onResolve, resolveAll } from '@aurelia/kernel';
-import { BindingMode, LifecycleFlags, Scope } from '@aurelia/runtime';
+import { LifecycleFlags, Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
 import { INode, IRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
 import { IInstruction } from '../../renderer';
+import { BindingMode } from '../../binding/interfaces-bindings';
 import {
   Controller,
   ICustomAttributeController,

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -8,7 +8,6 @@ import {
 } from '@aurelia/kernel';
 import {
   LifecycleFlags,
-  BindingMode,
   ICollectionObserver,
   CollectionKind,
   IObserverLocator,
@@ -19,6 +18,7 @@ import { IRenderLocation } from '../../dom';
 import { templateController } from '../custom-attribute';
 import { IViewFactory } from '../../templating/view';
 import { bindable } from '../../bindable';
+import { BindingMode } from '../../binding/interfaces-bindings';
 
 import type { Controller, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, IHydratableController, ISyntheticView, ControllerVisitor } from '../../templating/controller';
 import type { INode } from '../../dom';

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/prefer-optional-chain */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import { DI, emptyArray, toArray, ILogger, camelCase, ResourceDefinition, ResourceType, noop, Key } from '@aurelia/kernel';
-import { BindingMode, ExpressionType, Char, IExpressionParser, PrimitiveLiteralExpression } from '@aurelia/runtime';
+import { ExpressionType, Char, IExpressionParser, PrimitiveLiteralExpression } from '@aurelia/runtime';
 import { IAttrMapper } from './attribute-mapper';
 import { ITemplateElementFactory } from './template-element-factory';
 import {
@@ -30,6 +30,7 @@ import { BindingCommand, CommandType } from './resources/binding-command';
 import { createLookup, isString } from './utilities';
 import { allResources, singletonRegistration } from './utilities-di';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from './utilities-metadata';
+import { BindingMode } from './binding/interfaces-bindings';
 
 import type {
   IContainer,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -151,7 +151,6 @@ export {
 } from './observation/connectable-switcher';
 
 export {
-  BindingMode,
   LifecycleFlags,
   type AccessorOrObserver,
   type IBinding,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -23,22 +23,6 @@ export interface ICoercionConfiguration {
 
 export type InterceptorFunc<TInput = unknown, TOutput = unknown> = (value: TInput, coercionConfig: ICoercionConfiguration | null) => TOutput;
 
-/*
-* Note: the oneTime binding now has a non-zero value for 2 reasons:
-*  - plays nicer with bitwise operations (more consistent code, more explicit settings)
-*  - allows for potentially having something like BindingMode.oneTime | BindingMode.fromView, where an initial value is set once to the view but updates from the view also propagate back to the view model
-*
-* Furthermore, the "default" mode would be for simple ".bind" expressions to make it explicit for our logic that the default is being used.
-* This essentially adds extra information which binding could use to do smarter things and allows bindingBehaviors that add a mode instead of simply overwriting it
-*/
-export enum BindingMode {
-  oneTime  = 0b0001,
-  toView   = 0b0010,
-  fromView = 0b0100,
-  twoWay   = 0b0110,
-  default  = 0b1000
-}
-
 export const enum LifecycleFlags {
   none                          = 0b0000_000_00_0,
   // Bitmask for flags that need to be stored on a binding during $bind for mutation

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -3,14 +3,13 @@ import { IDisposable, type IServiceLocator, type Writable } from '@aurelia/kerne
 import { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import {
   AccessorType,
-  BindingMode,
   connectable,
   LifecycleFlags,
   Scope,
   type IAccessor,
   type IObserverLocator, type IOverrideContext, type IsBindingBehavior
 } from '@aurelia/runtime';
-import { type IBindingController, type IAstBasedBinding, State, astEvaluator } from '@aurelia/runtime-html';
+import { BindingMode, type IBindingController, type IAstBasedBinding, State, astEvaluator } from '@aurelia/runtime-html';
 import {
   IStore,
   type IStoreSubscriber

--- a/packages/validation-html/src/subscribers/validation-errors-custom-attribute.ts
+++ b/packages/validation-html/src/subscribers/validation-errors-custom-attribute.ts
@@ -1,5 +1,4 @@
-import { BindingMode } from '@aurelia/runtime';
-import { bindable, customAttribute, INode } from '@aurelia/runtime-html';
+import { BindingMode, bindable, customAttribute, INode } from '@aurelia/runtime-html';
 import { IValidationController, ValidationResultsSubscriber, ValidationEvent, ValidationResultTarget } from '../validation-controller';
 import { compareDocumentPositionFlat } from './common';
 import { optional } from '@aurelia/kernel';


### PR DESCRIPTION
# Pull Request

## 📖 Description

With all binding and resources related APIs/infra moved to runtime html, BindingMode should be there too.