### PR TITLE
refactor(router): add route compare to active check

### DIFF
--- a/packages/router/src/instructions/routing-instruction.ts
+++ b/packages/router/src/instructions/routing-instruction.ts
@@ -406,10 +406,10 @@ export class RoutingInstruction {
       return false;
     }
     if (typeof thisRoute === 'string' || typeof otherRoute === 'string') {
-      return (thisRoute ?? '') === (otherRoute ?? '');
+      return thisRoute === otherRoute;
     }
 
-    return ((thisRoute as Route).id ?? '') === ((otherRoute as Route).id ?? '');
+    return (thisRoute as Route).id === (otherRoute as Route).id;
   }
 
   /**

--- a/packages/router/src/instructions/routing-instruction.ts
+++ b/packages/router/src/instructions/routing-instruction.ts
@@ -8,7 +8,7 @@ import { FoundRoute } from '../found-route';
 import { Endpoint, EndpointType } from '../endpoints/endpoint';
 import { Viewport } from '../endpoints/viewport';
 import { CustomElement } from '@aurelia/runtime-html';
-import { IRouter, IRouterConfiguration, Navigation } from '../index';
+import { IRouter, IRouterConfiguration, Navigation, Route } from '../index';
 import { EndpointHandle, InstructionEndpoint } from './instruction-endpoint';
 import { Separators } from '../router-options';
 import { IContainer } from '@aurelia/kernel';
@@ -394,6 +394,25 @@ export class RoutingInstruction {
   }
 
   /**
+   * Compare the routing instruction's route with the route of another routing
+   * instruction.
+   *
+   * @param other - The routing instruction to compare to
+   */
+  public sameRoute(other: RoutingInstruction): boolean {
+    const thisRoute = this.route?.match;
+    const otherRoute = other.route?.match;
+    if (thisRoute == null || otherRoute == null) {
+      return false;
+    }
+    if (typeof thisRoute === 'string' || typeof otherRoute === 'string') {
+      return (thisRoute ?? '') === (otherRoute ?? '');
+    }
+
+    return ((thisRoute as Route).id ?? '') === ((otherRoute as Route).id ?? '');
+  }
+
+  /**
    * Compare the routing instruction's component with the component of another routing
    * instruction. Compares on name unless `compareType` is `true`.
    *
@@ -554,8 +573,16 @@ export class RoutingInstruction {
   public isIn(context: IRouterConfiguration | IRouter | IContainer, searchIn: RoutingInstruction[], deep: boolean): boolean {
     // Get all instructions with matching component.
     const matching = searchIn.filter(instruction => {
-      if (!instruction.sameComponent(context, this)) {
-        return false;
+      // Match either routes...
+      if (this.route != null || instruction.route != null) {
+        if (!instruction.sameRoute(this)) {
+          return false;
+        }
+      } else {
+        // ... or components
+        if (!instruction.sameComponent(context, this)) {
+          return false;
+        }
       }
       // Use own type if we have it, the other's type if not
       const instructionType = instruction.component.type ?? this.component.type;

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -22,7 +22,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
    */
   @bindable public id?: string;
 
-  private separateProperties = false;
+  private _separateProperties = false;
   private hasHref: boolean | null = null;
 
   private routerNavigationSubscription!: IDisposable;
@@ -40,7 +40,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
 
   public binding(): void {
     if (this.value == null) {
-      this.separateProperties = true;
+      this._separateProperties = true;
     }
     this.element.addEventListener('click', this.linkHandler);
     this.updateValue();
@@ -60,7 +60,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   }
 
   private updateValue(): void {
-    if (this.separateProperties) {
+    if (this._separateProperties) {
       this.value = {
         component: this.component,
         parameters: this.parameters,
@@ -74,9 +74,9 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     }
     if (!this.hasHref) {
       let value = this.value as string;
-      if (typeof this.value !== 'string') {
-        const instruction = RoutingInstruction.from(this.router, this.value as IRoutingInstruction).shift() as RoutingInstruction;
-        const found = this.findRoute(this.value as IRoute);
+      if (typeof value !== 'string') {
+        const instruction = RoutingInstruction.from(this.router, value as IRoutingInstruction).shift() as RoutingInstruction;
+        const found = this._findRoute(value as IRoute);
         if (found.foundConfiguration) {
           instruction.route = found.matching;
         }
@@ -95,21 +95,16 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
   private async updateActive(): Promise<void> {
     const controller = CustomAttribute.for(this.element, 'load')!.parent!;
     const routeValue = typeof this.value === 'string' ? { id: this.value, path: this.value } : this.value;
-    const found = this.findRoute(routeValue as IRoute);
+    const found = this._findRoute(routeValue as IRoute);
     const instructions = found.foundConfiguration
       ? found.instructions
       : getConsideredActiveInstructions(this.router, controller, this.element as HTMLElement, this.value);
     const element = getLoadIndicator(this.element as HTMLElement);
 
-    const unresolvedPromise = RoutingInstruction.resolve(instructions);
-    if (unresolvedPromise instanceof Promise) {
-      await unresolvedPromise;
-    }
-
     element.classList.toggle(this.activeClass, this.router.checkActive(instructions, { context: controller }));
   }
 
-  private findRoute(value: string | IRoute): FoundRoute {
+  private _findRoute(value: string | IRoute): FoundRoute {
     if (typeof value === 'string') {
       return new FoundRoute();
     }

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -22,7 +22,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
    */
   @bindable public id?: string;
 
-  private _separateProperties = false;
+  /** @internal */ private _separateProperties = false;
   private hasHref: boolean | null = null;
 
   private routerNavigationSubscription!: IDisposable;
@@ -104,6 +104,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     element.classList.toggle(this.activeClass, this.router.checkActive(instructions, { context: controller }));
   }
 
+  /** @internal */
   private _findRoute(value: string | IRoute): FoundRoute {
     if (typeof value === 'string') {
       return new FoundRoute();


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a compare route step to the active link check, removing the need to resolve instructions in `load`, as well as addresses some feedback on https://github.com/aurelia/aurelia/pull/1554.

## 📑 Test Plan

- Make sure existing tests pass
