### PR TITLE
refactor(bindings): remove flags from bind/unbind

### DIFF
--- a/packages/__tests__/2-runtime/ast.integration.spec.ts
+++ b/packages/__tests__/2-runtime/ast.integration.spec.ts
@@ -1,7 +1,6 @@
 import {
   AccessScopeExpression,
   ConditionalExpression,
-  LifecycleFlags
 } from '@aurelia/runtime';
 import {
   BindingMode,
@@ -37,7 +36,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           BindingMode.toView,
         );
 
-        binding.$bind(LifecycleFlags.none, createScopeForTest(source));
+        binding.$bind(createScopeForTest(source));
 
         assert.strictEqual(target.name, 'hello');
 
@@ -77,7 +76,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
             return handleChange.apply(this, args);
           };
         })(binding.handleChange);
-        binding.$bind(LifecycleFlags.none, scope);
+        binding.$bind(scope);
 
         assert.strictEqual(target.value, 'no');
 
@@ -130,7 +129,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           true
         );
 
-        binding.$bind(LifecycleFlags.none, scope);
+        binding.$bind(scope);
 
         assert.strictEqual(source.value, 'hello');
 
@@ -167,7 +166,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
             return handleChange.apply(this, args);
           };
         })(binding.handleChange);
-        binding.$bind(LifecycleFlags.none, scope);
+        binding.$bind(scope);
 
         assert.strictEqual(source.value, 'no');
         assert.strictEqual(handleChangeCallCount, 0);

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -28,7 +28,6 @@ import {
   IsLeftHandSide,
   // IsPrimary,
   // IsUnary,
-  LifecycleFlags as LF,
   ObjectLiteralExpression,
   OverrideContext,
   PrimitiveLiteralExpression,
@@ -408,7 +407,7 @@ describe('AST', function () {
     describe('bind() throws when returned behavior is null', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
         it(`${text}, undefined`, function () {
-          throwsOn(expr, 'bind', `AUR0101:b`, LF.none, dummyScope, dummyBindingWithLocatorThatReturnsNull);
+          throwsOn(expr, 'bind', `AUR0101:b`, dummyScope, dummyBindingWithLocatorThatReturnsNull);
           // throwsOn(expr, 'bind', `BindingBehavior named 'b' could not be found. Did you forget to register it as a dependency?`, LF.none, dummyScope, dummyBindingWithLocatorThatReturnsNull);
         });
       }

--- a/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
@@ -46,7 +46,7 @@ describe('2-runtime/binding-mode-behavior.spec.ts', function () {
             undefined,
             initMode,
           );
-          sut.bind(undefined, undefined, binding);
+          sut.bind(undefined, binding);
         });
 
         it(`bind()   should apply  bindingMode ${mode}`, function () {
@@ -54,7 +54,7 @@ describe('2-runtime/binding-mode-behavior.spec.ts', function () {
         });
 
         it(`unbind() should revert bindingMode ${initMode}`, function () {
-          sut.unbind(undefined, undefined, binding);
+          sut.unbind(undefined, binding);
           assert.strictEqual(binding.mode, initMode, `binding.mode`);
         });
       });

--- a/packages/__tests__/2-runtime/call.spec.ts
+++ b/packages/__tests__/2-runtime/call.spec.ts
@@ -5,7 +5,6 @@ import {
   ExpressionKind,
   IsBindingBehavior,
   Scope,
-  LifecycleFlags as LF,
   SetterObserver
 } from '@aurelia/runtime';
 import {
@@ -68,7 +67,6 @@ describe.skip('CallBinding', function () {
       it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
-        const flags = LF.none;
         const targetObserver = observerLocator.getObserver(target, prop);
 
         // massSpy(scope.bindingContext, 'theFunc');
@@ -80,7 +78,7 @@ describe.skip('CallBinding', function () {
         // expr['unbind'] = spy();
 
         // - Act -
-        sut.$bind(flags, scope);
+        sut.$bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -110,7 +108,7 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$bind(flags, scope);
+        sut.$bind(scope);
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
@@ -164,7 +162,6 @@ describe.skip('CallBinding', function () {
       it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
-        const flags = LF.none;
         const targetObserver = observerLocator.getObserver(target, prop);
 
         // massSpy(scope.bindingContext, 'theFunc');
@@ -176,7 +173,7 @@ describe.skip('CallBinding', function () {
         // expr['unbind'] = spy();
 
         // - Act -
-        sut.$bind(flags, scope);
+        sut.$bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -202,7 +199,7 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$unbind(flags);
+        sut.$unbind();
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
@@ -220,7 +217,7 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$unbind(flags);
+        sut.$unbind();
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
@@ -268,7 +265,6 @@ describe.skip('CallBinding', function () {
       it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
-        const flags = LF.none;
         const targetObserver = observerLocator.getObserver(target, prop);
 
         // massSpy(scope.bindingContext, 'theFunc');
@@ -277,7 +273,7 @@ describe.skip('CallBinding', function () {
         // massSpy(expr, 'evaluate', 'assign', 'connect');
 
         // - Act -
-        sut.$bind(flags, scope);
+        sut.$bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -314,7 +310,7 @@ describe.skip('CallBinding', function () {
         // massRestore(expr);
 
         // - Act -
-        sut.$unbind(flags);
+        sut.$unbind();
 
         // - Assert -
         assert.strictEqual(target[prop], null, `target[prop]`);

--- a/packages/__tests__/3-runtime-html/attr-binding-behavior.spec.ts
+++ b/packages/__tests__/3-runtime-html/attr-binding-behavior.spec.ts
@@ -1,6 +1,6 @@
 import { IContainer } from '@aurelia/kernel';
 import { PropertyBinding, AttrBindingBehavior, DataAttributeAccessor } from '@aurelia/runtime-html';
-import { TestContext, assert } from '@aurelia/testing';
+import { TestContext, assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/attr-binding-behavior.spec.ts', function () {
   let target: any;
@@ -26,14 +26,20 @@ describe('3-runtime-html/attr-binding-behavior.spec.ts', function () {
       targetProperty,
       {} as any
     );
-    sut.bind(undefined, undefined, binding);
+    sut.bind(undefined, binding);
   });
 
-  it('bind()   should put a DataAttributeObserver on the binding', function () {
+  it('[UNIT] bind()   should put a DataAttributeObserver on the binding', function () {
     assert.strictEqual(binding.targetObserver instanceof DataAttributeAccessor, true, `binding.targetObserver instanceof DataAttributeAccessor`);
   });
 
   // it('unbind() should clear the DataAttributeObserver from the binding', function () {
   //   // TODO: it doesn't actually do, and it should
   // });
+  it('works with property binding', function () {
+    const { getBy } = createFixture
+      .html`<div bla.bind="1 & attr">`
+      .build();
+    assert.strictEqual(getBy('div').getAttribute('bla'), '1');
+  });
 });

--- a/packages/__tests__/3-runtime-html/binding-behaviors.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-behaviors.spec.ts
@@ -1,4 +1,4 @@
-import { BindingBehaviorInstance, LifecycleFlags, Scope, IBinding } from '@aurelia/runtime';
+import { BindingBehaviorInstance, Scope, IBinding } from '@aurelia/runtime';
 import {
   bindingBehavior,
   alias,
@@ -23,10 +23,10 @@ describe('binding-behaviors', function () {
     @bindingBehavior({ name: 'woot1', aliases: ['woot13'] })
     @alias(...['woot11', 'woot12'])
     class WootBehavior implements BindingBehaviorInstance {
-      public bind(_flags: LifecycleFlags, _scope: Scope, binding: PropertyBinding, func: (param: string) => void): void {
+      public bind(_scope: Scope, binding: PropertyBinding, func: (param: string) => void): void {
         func(binding.target[binding.targetProperty]);
       }
-      public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding, _func: () => void): void {
+      public unbind(_scope: Scope, _binding: IBinding, _func: () => void): void {
         return;
       }
     }
@@ -34,10 +34,10 @@ describe('binding-behaviors', function () {
     @bindingBehavior({ name: 'woot2', aliases: ['woot23'] })
     @alias('woot21', 'woot22')
     class WootBehavior2 implements BindingBehaviorInstance {
-      public bind(_flags: LifecycleFlags, _scope: Scope, binding: PropertyBinding, _func: (param: string) => void, func2: (param: string) => void): void {
+      public bind(_scope: Scope, binding: PropertyBinding, _func: (param: string) => void, func2: (param: string) => void): void {
         func2(binding.target[binding.targetProperty]);
       }
-      public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+      public unbind(_scope: Scope, _binding: IBinding): void {
         return;
       }
     }

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -5,7 +5,7 @@ import {
   createObserverLocator,
   createScopeForTest,
 } from '@aurelia/testing';
-import { Interpolation, ConditionalExpression, AccessScopeExpression, LifecycleFlags } from '@aurelia/runtime';
+import { Interpolation, ConditionalExpression, AccessScopeExpression } from '@aurelia/runtime';
 import {
   BindingMode,
   CustomElement,
@@ -318,7 +318,7 @@ describe('3-runtime/interpolation.spec.ts -- [UNIT]interpolation', function () {
           return handleChange.apply(this, args);
         };
       })(binding.partBindings[0].handleChange);
-      binding.$bind(LifecycleFlags.fromBind, createScopeForTest(source));
+      binding.$bind(createScopeForTest(source));
 
       assert.strictEqual(target.value, 'no');
       assert.deepStrictEqual(
@@ -416,7 +416,7 @@ describe('3-runtime/interpolation.spec.ts -- [UNIT]interpolation', function () {
           return handleChange.apply(this, args);
         };
       })(binding.partBindings[1].handleChange);
-      binding.$bind(LifecycleFlags.fromBind, createScopeForTest(source));
+      binding.$bind(createScopeForTest(source));
 
       assert.strictEqual(target.value, 'no1--no2');
       assert.deepStrictEqual(

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -16,7 +16,7 @@ import {
   optional,
   Class,
 } from '@aurelia/kernel';
-import { BindingBehaviorInstance, LifecycleFlags, Scope, IBinding } from '@aurelia/runtime';
+import { BindingBehaviorInstance, Scope, IBinding } from '@aurelia/runtime';
 import {
   valueConverter,
   bindingBehavior,
@@ -295,10 +295,10 @@ describe('promise template-controller', function () {
 
   @bindingBehavior('noop')
   class NoopBindingBehavior implements BindingBehaviorInstance {
-    public bind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public bind(_scope: Scope, _binding: IBinding): void {
       return;
     }
-    public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public unbind(_scope: Scope, _binding: IBinding): void {
       return;
     }
   }

--- a/packages/__tests__/3-runtime-html/self-binding-behavior.spec.ts
+++ b/packages/__tests__/3-runtime-html/self-binding-behavior.spec.ts
@@ -1,8 +1,8 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
 import { PropertyBinding, IPlatform, SelfBindingBehavior } from '@aurelia/runtime-html';
-import { assert } from '@aurelia/testing';
+import { assert, createFixture } from '@aurelia/testing';
 
-describe('SelfBindingBehavior', function () {
+describe('3-runtime-html/self-binding-behavior.spec.ts', function () {
   let container: IContainer;
   let sut: SelfBindingBehavior;
   let binding: PropertyBinding;
@@ -16,19 +16,40 @@ describe('SelfBindingBehavior', function () {
     binding = new PropertyBinding({ state: 0 }, undefined, undefined, undefined, undefined, undefined, container as any, {} as any);
     originalCallSource = binding['callSource'] = function () { return; };
     binding['targetEvent'] = 'foo';
-    sut.bind(undefined, undefined, binding as any);
+    sut.bind(undefined, binding as any);
   });
 
   // TODO: test properly (different binding types)
-  it('bind()   should apply the correct behavior', function () {
+  it('[UNIT] bind()   should apply the correct behavior', function () {
     assert.strictEqual(binding['selfEventCallSource'] === originalCallSource, true, `binding['selfEventCallSource'] === originalCallSource`);
     assert.strictEqual(binding['callSource'] === originalCallSource, false, `binding['callSource'] === originalCallSource`);
     assert.strictEqual(typeof binding['callSource'], 'function', `typeof binding['callSource']`);
   });
 
-  it('unbind() should revert the original behavior', function () {
-    sut.unbind(undefined, undefined, binding as any);
+  it('[UNIT] unbind() should revert the original behavior', function () {
+    sut.unbind(undefined, binding as any);
     assert.strictEqual(binding['selfEventCallSource'], null, `binding['selfEventCallSource']`);
     assert.strictEqual(binding['callSource'] === originalCallSource, true, `binding['callSource'] === originalCallSource`);
+  });
+
+  it('works with event binding', function () {
+    let count = 0;
+    const { getBy } = createFixture
+      .component({
+        call() {
+          count++;
+        },
+        call2() {
+          count = 2;
+        }
+      })
+      .html`<div click.trigger="call() & self"><button click.trigger="call2()">Click me</button></div>`
+      .build();
+
+    getBy('button').click();
+    assert.strictEqual(count, 2);
+
+    getBy('div').click();
+    assert.strictEqual(count, 3);
   });
 });

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -14,7 +14,6 @@ import {
   BindingBehaviorInstance,
   IBinding,
   Scope,
-  LifecycleFlags,
 } from '@aurelia/runtime';
 import {
   AuSlot,
@@ -323,10 +322,10 @@ describe('3-runtime-html/switch.spec.ts', function () {
 
   @bindingBehavior('noop')
   class NoopBindingBehavior implements BindingBehaviorInstance {
-    public bind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public bind(_scope: Scope, _binding: IBinding): void {
       return;
     }
-    public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public unbind(_scope: Scope, _binding: IBinding): void {
       return;
     }
   }

--- a/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-parameters-renderer.spec.ts
@@ -111,6 +111,6 @@ describe('TranslationParametersBindingRenderer', function () {
       callBindingInstruction,
     );
 
-    assert.equal(binding['parameter'].expr, paramExpr);
+    assert.equal(binding['parameter'].ast, paramExpr);
   });
 });

--- a/packages/__tests__/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/i18n/t/translation-renderer.spec.ts
@@ -160,7 +160,7 @@ describe('TranslationBindingRenderer', function () {
       callBindingInstruction,
     );
 
-    assert.equal(binding.expr, from);
+    assert.equal(binding.ast, from);
   });
 });
 
@@ -317,6 +317,6 @@ describe('TranslationBindBindingRenderer', function () {
       callBindingInstruction,
     );
 
-    assert.equal(binding.expr, from);
+    assert.equal(binding.ast, from);
   });
 });

--- a/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
@@ -5,7 +5,6 @@ import {
   IBinding,
   IObserverLocator,
   Scope,
-  LifecycleFlags,
 } from '@aurelia/runtime';
 import {
   bindable,
@@ -239,10 +238,10 @@ describe('validation-html/validate-binding-behavior.spec.ts/validate-binding-beh
   }
   @bindingBehavior('vanilla')
   class VanillaBindingBehavior implements BindingBehaviorInstance {
-    public bind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public bind(_scope: Scope, _binding: IBinding): void {
       return;
     }
-    public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: IBinding): void {
+    public unbind(_scope: Scope, _binding: IBinding): void {
       return;
     }
   }

--- a/packages/i18n/src/df/date-format-binding-behavior.ts
+++ b/packages/i18n/src/df/date-format-binding-behavior.ts
@@ -1,13 +1,13 @@
-import { LifecycleFlags } from '@aurelia/runtime';
-import { BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
+import { type BindingBehaviorInstance } from '@aurelia/runtime';
+import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
 
 import type { Scope } from '@aurelia/runtime';
 import { bindingBehavior } from '@aurelia/runtime-html';
 
 @bindingBehavior(ValueConverters.dateFormatValueConverterName)
-export class DateFormatBindingBehavior {
+export class DateFormatBindingBehavior implements BindingBehaviorInstance {
 
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: BindingWithBehavior) {
+  public bind(_scope: Scope, binding: BindingWithBehavior) {
     createIntlFormatValueConverterExpression(ValueConverters.dateFormatValueConverterName, binding);
   }
 }

--- a/packages/i18n/src/nf/number-format-binding-behavior.ts
+++ b/packages/i18n/src/nf/number-format-binding-behavior.ts
@@ -1,13 +1,13 @@
-import { LifecycleFlags } from '@aurelia/runtime';
-import { BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
+import { type BindingBehaviorInstance } from '@aurelia/runtime';
+import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
 
 import type { Scope } from '@aurelia/runtime';
 import { bindingBehavior } from '@aurelia/runtime-html';
 
 @bindingBehavior(ValueConverters.numberFormatValueConverterName)
-export class NumberFormatBindingBehavior {
+export class NumberFormatBindingBehavior implements BindingBehaviorInstance {
 
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: BindingWithBehavior) {
+  public bind(_scope: Scope, binding: BindingWithBehavior) {
     createIntlFormatValueConverterExpression(ValueConverters.numberFormatValueConverterName, binding);
   }
 }

--- a/packages/i18n/src/rt/relative-time-binding-behavior.ts
+++ b/packages/i18n/src/rt/relative-time-binding-behavior.ts
@@ -1,13 +1,13 @@
-import { LifecycleFlags } from '@aurelia/runtime';
-import { BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
+import { type BindingBehaviorInstance } from '@aurelia/runtime';
+import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters } from '../utils';
 
 import type { Scope } from '@aurelia/runtime';
 import { bindingBehavior } from '@aurelia/runtime-html';
 
 @bindingBehavior(ValueConverters.relativeTimeValueConverterName)
-export class RelativeTimeBindingBehavior {
+export class RelativeTimeBindingBehavior implements BindingBehaviorInstance {
 
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: BindingWithBehavior) {
+  public bind(_scope: Scope, binding: BindingWithBehavior) {
     createIntlFormatValueConverterExpression(ValueConverters.relativeTimeValueConverterName, binding);
   }
 }

--- a/packages/i18n/src/t/translation-binding-behavior.ts
+++ b/packages/i18n/src/t/translation-binding-behavior.ts
@@ -1,14 +1,14 @@
-import { Writable } from '@aurelia/kernel';
-import { BindingBehaviorExpression, IsValueConverter, LifecycleFlags, ValueConverterExpression } from '@aurelia/runtime';
+import { type Writable } from '@aurelia/kernel';
+import { type BindingBehaviorExpression, type BindingBehaviorInstance, type IsValueConverter, ValueConverterExpression } from '@aurelia/runtime';
 import { bindingBehavior } from '@aurelia/runtime-html';
-import { BindingWithBehavior, ValueConverters } from '../utils';
+import { type BindingWithBehavior, ValueConverters } from '../utils';
 
 import type { Scope } from '@aurelia/runtime';
 
 @bindingBehavior(ValueConverters.translationValueConverterName)
-export class TranslationBindingBehavior {
+export class TranslationBindingBehavior implements BindingBehaviorInstance {
 
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: BindingWithBehavior) {
+  public bind(_scope: Scope, binding: BindingWithBehavior) {
     const expression = binding.ast.expression;
 
     if (!(expression instanceof ValueConverterExpression)) {

--- a/packages/runtime-html/src/binding-behaviors/binding-mode.ts
+++ b/packages/runtime-html/src/binding-behaviors/binding-mode.ts
@@ -1,4 +1,4 @@
-import { BindingBehaviorInstance, LifecycleFlags } from '@aurelia/runtime';
+import { BindingBehaviorInstance } from '@aurelia/runtime';
 import { bindingBehavior } from '../resources/binding-behavior';
 import { BindingMode } from '../binding/interfaces-bindings';
 
@@ -13,12 +13,12 @@ export abstract class BindingModeBehavior implements BindingBehaviorInstance {
     private readonly mode: BindingMode,
   ) {}
 
-  public bind(flags: LifecycleFlags, scope: Scope, binding: PropertyBinding): void {
+  public bind(scope: Scope, binding: PropertyBinding): void {
     originalModesMap.set(binding, binding.mode);
     binding.mode = this.mode;
   }
 
-  public unbind(flags: LifecycleFlags, scope: Scope, binding: PropertyBinding): void {
+  public unbind(scope: Scope, binding: PropertyBinding): void {
     binding.mode = originalModesMap.get(binding)!;
     originalModesMap.delete(binding);
   }

--- a/packages/runtime-html/src/binding-behaviors/debounce.ts
+++ b/packages/runtime-html/src/binding-behaviors/debounce.ts
@@ -1,5 +1,4 @@
 import { IPlatform } from '@aurelia/kernel';
-import { LifecycleFlags } from '@aurelia/runtime';
 import { bindingBehavior, BindingInterceptor, IInterceptableBinding } from '../resources/binding-behavior';
 
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
@@ -59,18 +58,18 @@ export class DebounceBindingBehavior extends BindingInterceptor {
     task?.cancel();
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.firstArg !== null) {
       const delay = Number(this.firstArg.evaluate(scope, this, null));
       this.opts.delay = isNaN(delay) ? defaultDelay : delay;
     }
-    this.binding.$bind(flags, scope);
+    this.binding.$bind(scope);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     this.task?.cancel();
     this.task = null;
-    this.binding.$unbind(flags);
+    this.binding.$unbind();
   }
 }
 

--- a/packages/runtime-html/src/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/binding-behaviors/signals.ts
@@ -1,4 +1,4 @@
-import { ISignaler, LifecycleFlags } from '@aurelia/runtime';
+import { ISignaler } from '@aurelia/runtime';
 import { bindingBehavior } from '../resources/binding-behavior';
 import type { BindingBehaviorInstance, IBinding, IConnectableBinding, Scope } from '@aurelia/runtime';
 
@@ -14,7 +14,7 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
     this._signaler = signaler;
   }
 
-  public bind(flags: LifecycleFlags, scope: Scope, binding: IConnectableBinding, ...names: string[]): void {
+  public bind(scope: Scope, binding: IConnectableBinding, ...names: string[]): void {
     if (!('handleChange' in binding)) {
       if (__DEV__)
         throw new Error(`AUR0817: The signal behavior can only be used with bindings that have a "handleChange" method`);
@@ -35,7 +35,7 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
     }
   }
 
-  public unbind(flags: LifecycleFlags, scope: Scope, binding: IConnectableBinding): void {
+  public unbind(scope: Scope, binding: IConnectableBinding): void {
     const names = this._lookup.get(binding)!;
     this._lookup.delete(binding);
     let name: string;

--- a/packages/runtime-html/src/binding-behaviors/throttle.ts
+++ b/packages/runtime-html/src/binding-behaviors/throttle.ts
@@ -1,5 +1,4 @@
 import { IPlatform } from '@aurelia/kernel';
-import { LifecycleFlags } from '@aurelia/runtime';
 import { bindingBehavior, BindingInterceptor, IInterceptableBinding } from '../resources/binding-behavior';
 
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
@@ -75,18 +74,18 @@ export class ThrottleBindingBehavior extends BindingInterceptor {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.firstArg !== null) {
       const delay = Number(this.firstArg.evaluate(scope, this, null));
       this.opts.delay = this.delay = isNaN(delay) ? defaultDelay : delay;
     }
-    this.binding.$bind(flags, scope);
+    this.binding.$bind(scope);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     this.task?.cancel();
     this.task = null;
-    super.$unbind(flags);
+    super.$unbind();
   }
 }
 

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -1,7 +1,6 @@
 import { IServiceLocator } from '@aurelia/kernel';
 import {
   ExpressionKind,
-  LifecycleFlags,
   AccessorType,
   IObserver,
   connectable,
@@ -139,19 +138,19 @@ export class AttributeBinding implements IAstBasedBinding {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
 
     let ast = this.ast;
     if (ast.hasBind) {
-      ast.bind(flags, scope, this.interceptor);
+      ast.bind(scope, this.interceptor);
     }
 
     let targetObserver = this.targetObserver;
@@ -184,13 +183,13 @@ export class AttributeBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
 
     if (this.ast.hasUnbind) {
-      this.ast.unbind(flags, this.$scope, this.interceptor);
+      this.ast.unbind(this.$scope, this.interceptor);
     }
     this.$scope = null!;
     this.value = void 0;

--- a/packages/runtime-html/src/binding/call-binding.ts
+++ b/packages/runtime-html/src/binding/call-binding.ts
@@ -1,5 +1,3 @@
-import { LifecycleFlags } from '@aurelia/runtime';
-
 import type { IServiceLocator } from '@aurelia/kernel';
 import type { IAccessor, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IAstBasedBinding } from './interfaces-bindings';
@@ -36,19 +34,19 @@ export class CallBinding implements IAstBasedBinding {
     return result;
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
 
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
 
     if (this.ast.hasBind) {
-      this.ast.bind(flags, scope, this.interceptor);
+      this.ast.bind(scope, this.interceptor);
     }
 
     this.targetObserver.setValue(($args: object) => this.interceptor.callSource($args), this.target, this.targetProperty);
@@ -57,13 +55,13 @@ export class CallBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
 
     if (this.ast.hasUnbind) {
-      this.ast.unbind(flags, this.$scope!, this.interceptor);
+      this.ast.unbind(this.$scope!, this.interceptor);
     }
 
     this.$scope = void 0;

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -2,7 +2,6 @@ import {
   AccessorOrObserver,
   AccessorType,
   ExpressionKind,
-  LifecycleFlags,
   connectable,
 } from '@aurelia/runtime';
 import { BindingMode } from './interfaces-bindings';
@@ -114,12 +113,12 @@ export class InterpolationBinding implements IBinding {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags);
+      this.interceptor.$unbind();
     }
     this.isBound = true;
     this.$scope = scope;
@@ -128,12 +127,12 @@ export class InterpolationBinding implements IBinding {
     const ii = partBindings.length;
     let i = 0;
     for (; ii > i; ++i) {
-      partBindings[i].$bind(flags, scope);
+      partBindings[i].$bind(scope);
     }
     this.updateTarget(void 0);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
@@ -143,7 +142,7 @@ export class InterpolationBinding implements IBinding {
     const ii = partBindings.length;
     let i = 0;
     for (; ii > i; ++i) {
-      partBindings[i].interceptor.$unbind(flags);
+      partBindings[i].interceptor.$unbind();
     }
     this.task?.cancel();
     this.task = null;
@@ -215,19 +214,19 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
     this.owner.updateTarget(void 0);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags);
+      this.interceptor.$unbind();
     }
 
     this.isBound = true;
     this.$scope = scope;
 
     if (this.ast.hasBind) {
-      this.ast.bind(flags, scope, this.interceptor as IIndexable & this);
+      this.ast.bind(scope, this.interceptor as IIndexable & this);
     }
 
     this.value = this.ast.evaluate(
@@ -240,14 +239,14 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
     }
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
     this.isBound = false;
 
     if (this.ast.hasUnbind) {
-      this.ast.unbind(flags, this.$scope!, this.interceptor);
+      this.ast.unbind(this.$scope!, this.interceptor);
     }
 
     this.$scope = void 0;
@@ -372,19 +371,19 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags);
+      this.interceptor.$unbind();
     }
 
     this.isBound = true;
     this.$scope = scope;
 
     if (this.ast.hasBind) {
-      this.ast.bind(flags, scope, this.interceptor as IIndexable & this);
+      this.ast.bind(scope, this.interceptor);
     }
 
     const v = this.value = this.ast.evaluate(
@@ -398,14 +397,14 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
     this.updateTarget(v);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
     this.isBound = false;
 
     if (this.ast.hasUnbind) {
-      this.ast.unbind(flags, this.$scope!, this.interceptor);
+      this.ast.unbind(this.$scope!, this.interceptor);
     }
 
     // TODO: should existing value (either connected node, or a string)

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -1,4 +1,4 @@
-import { connectable, LifecycleFlags } from '@aurelia/runtime';
+import { connectable } from '@aurelia/runtime';
 import { astEvaluator } from './binding-utils';
 
 import type { ITask } from '@aurelia/platform';
@@ -72,12 +72,12 @@ export class LetBinding implements IAstBasedBinding {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
@@ -85,7 +85,7 @@ export class LetBinding implements IAstBasedBinding {
 
     const ast = this.ast;
     if (ast.hasBind) {
-      ast.bind(flags, scope, this.interceptor);
+      ast.bind(scope, this.interceptor);
     }
     // ast might have been changed during bind
     this.target[this.targetProperty]
@@ -95,14 +95,14 @@ export class LetBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
 
     const ast = this.ast;
     if (ast.hasUnbind) {
-      ast.unbind(flags, this.$scope!, this.interceptor);
+      ast.unbind(this.$scope!, this.interceptor);
     }
     this.$scope = void 0;
     this.obs.clearAll();

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -1,6 +1,5 @@
 import {
   DelegationStrategy,
-  LifecycleFlags,
 } from '@aurelia/runtime';
 
 import { IEventTarget } from '../dom';
@@ -76,20 +75,20 @@ export class Listener implements IAstBasedBinding {
     this.interceptor.callSource(event);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
 
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
 
     const ast = this.ast;
     if (ast.hasBind) {
-      ast.bind(flags, scope, this.interceptor);
+      ast.bind(scope, this.interceptor);
     }
 
     if (this._options.strategy === DelegationStrategy.none) {
@@ -108,14 +107,13 @@ export class Listener implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
 
-    const ast = this.ast;
-    if (ast.hasUnbind) {
-      ast.unbind(flags, this.$scope, this.interceptor);
+    if (this.ast.hasUnbind) {
+      this.ast.unbind(this.$scope, this.interceptor);
     }
 
     this.$scope = null!;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -1,4 +1,4 @@
-import { AccessorType, connectable, ExpressionKind, IndexMap, LifecycleFlags } from '@aurelia/runtime';
+import { AccessorType, connectable, ExpressionKind, IndexMap } from '@aurelia/runtime';
 import { astEvaluator, BindingTargetSubscriber } from './binding-utils';
 import { State } from '../templating/controller';
 import { BindingMode } from './interfaces-bindings';
@@ -134,19 +134,19 @@ export class PropertyBinding implements IAstBasedBinding {
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
 
     let ast = this.ast;
     if (ast.hasBind) {
-      ast.bind(flags, scope, this.interceptor);
+      ast.bind(scope, this.interceptor);
     }
 
     const observerLocator = this.oL;
@@ -183,13 +183,13 @@ export class PropertyBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
 
     if (this.ast.hasUnbind) {
-      this.ast.unbind(flags, this.$scope!, this.interceptor);
+      this.ast.unbind(this.$scope!, this.interceptor);
     }
 
     this.$scope = void 0;

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -1,5 +1,3 @@
-import { LifecycleFlags } from '@aurelia/runtime';
-
 import type { IIndexable, IServiceLocator } from '@aurelia/kernel';
 import type { IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IAstBasedBinding } from './interfaces-bindings';
@@ -17,19 +15,19 @@ export class RefBinding implements IAstBasedBinding {
     public target: object,
   ) {}
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       if (this.$scope === scope) {
         return;
       }
 
-      this.interceptor.$unbind(flags | LifecycleFlags.fromBind);
+      this.interceptor.$unbind();
     }
 
     this.$scope = scope;
 
     if (this.ast.hasBind) {
-      this.ast.bind(flags, scope, this);
+      this.ast.bind(scope, this);
     }
 
     this.ast.assign(this.$scope, this, this.target);
@@ -38,7 +36,7 @@ export class RefBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this.isBound) {
       return;
     }
@@ -52,7 +50,7 @@ export class RefBinding implements IAstBasedBinding {
     // deepscan-disable-next-line
     ast = this.ast;
     if (ast.hasUnbind) {
-      ast.unbind(flags, this.$scope!, this.interceptor);
+      ast.unbind(this.$scope!, this.interceptor);
     }
 
     this.$scope = void 0;

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -3,7 +3,6 @@ import {
   ExpressionType,
   IExpressionParser,
   IObserverLocator,
-  LifecycleFlags,
   BindingBehaviorExpression,
   ExpressionKind,
   IBinding,
@@ -1294,7 +1293,7 @@ class SpreadBinding implements IBinding {
     return this.locator.get(key);
   }
 
-  public $bind(flags: LifecycleFlags, _scope: Scope): void {
+  public $bind(_scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -1304,11 +1303,11 @@ class SpreadBinding implements IBinding {
       throw new Error('Invalid spreading. Context scope is null/undefined');
     }
 
-    this._innerBindings.forEach(b => b.$bind(flags, innerScope));
+    this._innerBindings.forEach(b => b.$bind(innerScope));
   }
 
-  public $unbind(flags: LifecycleFlags): void {
-    this._innerBindings.forEach(b => b.$unbind(flags));
+  public $unbind(): void {
+    this._innerBindings.forEach(b => b.$unbind());
     this.isBound = false;
   }
 

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -1,5 +1,5 @@
 import { DI, firstDefined, fromAnnotationOrDefinitionOrTypeOrDefault, mergeArrays, Registration, Resolved, ResourceType } from '@aurelia/kernel';
-import { BindingBehaviorInstance, Collection, IAstEvaluator, IndexMap, LifecycleFlags, ValueConverterInstance } from '@aurelia/runtime';
+import { BindingBehaviorInstance, Collection, IAstEvaluator, IndexMap, ValueConverterInstance } from '@aurelia/runtime';
 import { BindingMode } from '../binding/interfaces-bindings';
 import { def, isFunction, isString } from '../utilities';
 import { registerAliases } from '../utilities-di';
@@ -186,11 +186,11 @@ export class BindingInterceptor implements IInterceptableBinding {
     this.binding.observeCollection(observer);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
-    this.binding.$bind(flags, scope);
+  public $bind(scope: Scope): void {
+    this.binding.$bind(scope);
   }
-  public $unbind(flags: LifecycleFlags): void {
-    this.binding.$unbind(flags);
+  public $unbind(): void {
+    this.binding.$unbind();
   }
 }
 

--- a/packages/runtime-html/src/resources/binding-behaviors/attr.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/attr.ts
@@ -1,16 +1,16 @@
-import { LifecycleFlags } from '@aurelia/runtime';
+import { BindingBehaviorInstance } from '@aurelia/runtime';
 import { attrAccessor } from '../../observation/data-attribute-accessor';
 import { bindingBehavior } from '../binding-behavior';
 
 import type { Scope } from '@aurelia/runtime';
 import type { PropertyBinding } from '../../binding/property-binding';
 
-export class AttrBindingBehavior {
-  public bind(_flags: LifecycleFlags, _scope: Scope, binding: PropertyBinding): void {
+export class AttrBindingBehavior implements BindingBehaviorInstance {
+  public bind(_scope: Scope, binding: PropertyBinding): void {
     binding.targetObserver = attrAccessor;
   }
 
-  public unbind(_flags: LifecycleFlags, _scope: Scope, _binding: PropertyBinding): void {
+  public unbind(_scope: Scope, _binding: PropertyBinding): void {
     return;
   }
 }

--- a/packages/runtime-html/src/resources/binding-behaviors/self.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/self.ts
@@ -1,4 +1,4 @@
-import { LifecycleFlags } from '@aurelia/runtime';
+import { type BindingBehaviorInstance } from '@aurelia/runtime';
 import { Listener } from '../../binding/listener';
 import { bindingBehavior } from '../binding-behavior';
 
@@ -19,8 +19,8 @@ export type SelfableBinding = Listener & {
   selfEventCallSource: Listener['callSource'];
 };
 
-export class SelfBindingBehavior {
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: SelfableBinding): void {
+export class SelfBindingBehavior implements BindingBehaviorInstance {
+  public bind(_scope: Scope, binding: SelfableBinding): void {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!binding.callSource || !binding.targetEvent) {
       if (__DEV__)
@@ -33,7 +33,7 @@ export class SelfBindingBehavior {
     binding.callSource = handleSelfEvent;
   }
 
-  public unbind(flags: LifecycleFlags, _scope: Scope, binding: SelfableBinding): void {
+  public unbind(_scope: Scope, binding: SelfableBinding): void {
     binding.callSource = binding.selfEventCallSource;
     binding.selfEventCallSource = null!;
   }

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -1,4 +1,4 @@
-import { IObserverLocator, LifecycleFlags } from '@aurelia/runtime';
+import { type BindingBehaviorInstance, IObserverLocator } from '@aurelia/runtime';
 import { BindingMode } from '../../binding/interfaces-bindings';
 import { EventSubscriber } from '../../observation/event-delegator';
 import { NodeObserverConfig } from '../../observation/observer-locator';
@@ -23,7 +23,7 @@ export type UpdateTriggerableBinding = PropertyBinding & {
   targetObserver: UpdateTriggerableObserver;
 };
 
-export class UpdateTriggerBindingBehavior {
+export class UpdateTriggerBindingBehavior implements BindingBehaviorInstance {
   public static inject = [IObserverLocator];
   private readonly oL: IObserverLocator;
   public constructor(
@@ -32,7 +32,7 @@ export class UpdateTriggerBindingBehavior {
     this.oL = observerLocator;
   }
 
-  public bind(flags: LifecycleFlags, _scope: Scope, binding: UpdateTriggerableBinding, ...events: string[]): void {
+  public bind(_scope: Scope, binding: UpdateTriggerableBinding, ...events: string[]): void {
     if (events.length === 0) {
       if (__DEV__)
         throw new Error(`AUR0802: The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`);
@@ -71,7 +71,7 @@ export class UpdateTriggerBindingBehavior {
     }));
   }
 
-  public unbind(flags: LifecycleFlags, _scope: Scope, binding: UpdateTriggerableBinding): void {
+  public unbind(_scope: Scope, binding: UpdateTriggerableBinding): void {
     // restore the state of the binding.
     binding.targetObserver.handler.dispose();
     (binding.targetObserver as Writable<typeof binding.targetObserver>).handler = binding.targetObserver.originalHandler!;

--- a/packages/runtime-html/src/resources/template-controllers/with.ts
+++ b/packages/runtime-html/src/resources/template-controllers/with.ts
@@ -36,7 +36,7 @@ export class With implements ICustomAttributeViewModel {
     if ($controller.isActive && bindings != null) {
       scope = Scope.fromParent($controller.scope, newValue === void 0 ? {} : newValue as object);
       for (ii = bindings.length; ii > i; ++i) {
-        bindings[i].$bind(LifecycleFlags.fromBind, scope);
+        bindings[i].$bind(scope);
       }
     }
   }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -631,7 +631,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       i = 0;
       ii = this.bindings.length;
       while (ii > i) {
-        this.bindings[i].$bind(this.$flags, this.scope!);
+        this.bindings[i].$bind(this.scope!);
         ++i;
       }
     }
@@ -880,7 +880,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     if (this.bindings !== null) {
       for (; i < this.bindings.length; ++i) {
-        this.bindings[i].$unbind(flags);
+        this.bindings[i].$unbind();
       }
     }
 

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -460,8 +460,8 @@ export class CustomExpression {
 
 export type BindingBehaviorInstance<T extends {} = {}> = {
   type?: 'instance' | 'factory';
-  bind(flags: LF, scope: Scope, binding: IBinding, ...args: T[]): void;
-  unbind(flags: LF, scope: Scope, binding: IBinding, ...args: T[]): void;
+  bind?(scope: Scope, binding: IBinding, ...args: T[]): void;
+  unbind?(scope: Scope, binding: IBinding, ...args: T[]): void;
 } & T;
 
 export class BindingBehaviorExpression {
@@ -491,7 +491,7 @@ export class BindingBehaviorExpression {
     return this.expression.assign(s, e, val);
   }
 
-  public bind(f: LF, s: Scope, b: IAstEvaluator & IConnectableBinding): void {
+  public bind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
     const name = this.name;
     const key = this._key;
     const behavior = b.getBehavior?.<BindingBehaviorInstance>(name);
@@ -500,24 +500,24 @@ export class BindingBehaviorExpression {
     }
     if ((b as BindingWithBehavior)[key] === void 0) {
       (b as BindingWithBehavior)[key] = behavior;
-      behavior.bind?.(f, s, b, ...this.args.map(a => a.evaluate(s, b, null) as {}[]));
+      behavior.bind?.(s, b, ...this.args.map(a => a.evaluate(s, b, null) as {}[]));
     } else {
       throw duplicateBehaviorAppliedError(name);
     }
     if (this.expression.hasBind) {
-      this.expression.bind(f, s, b);
+      this.expression.bind(s, b);
     }
   }
 
-  public unbind(f: LF, s: Scope, b: IAstEvaluator & IConnectableBinding): void {
+  public unbind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
     const internalKey = this._key;
     const $b = b as BindingWithBehavior;
     if ($b[internalKey] !== void 0) {
-      $b[internalKey]!.unbind?.(f, s, b);
+      $b[internalKey]!.unbind?.(s, b);
       $b[internalKey] = void 0;
     }
     if (this.expression.hasUnbind) {
-      this.expression.unbind(f, s, b);
+      this.expression.unbind(s, b);
     }
   }
 
@@ -581,7 +581,7 @@ export class ValueConverterExpression {
     return this.expression.assign(s, e, val);
   }
 
-  public bind(f: LF, s: Scope, b: IAstEvaluator & IConnectableBinding): void {
+  public bind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
     const name = this.name;
     const vc = b.getConverter?.(name);
     if (vc == null) {
@@ -602,11 +602,11 @@ export class ValueConverterExpression {
       }
     }
     if (this.expression.hasBind) {
-      this.expression.bind(f, s, b);
+      this.expression.bind(s, b);
     }
   }
 
-  public unbind(_f: LF, _s: Scope, b: IAstEvaluator & IConnectableBinding): void {
+  public unbind(_s: Scope, b: IAstEvaluator & IConnectableBinding): void {
     const vc = b.getConverter?.(this.name);
     if (vc?.signals === void 0) {
       return;
@@ -1493,15 +1493,15 @@ export class ForOfStatement {
     }
   }
 
-  public bind(f: LF, s: Scope, b: IConnectableBinding): void {
+  public bind(s: Scope, b: IConnectableBinding): void {
     if (this.iterable.hasBind) {
-      this.iterable.bind(f, s, b);
+      this.iterable.bind(s, b);
     }
   }
 
-  public unbind(f: LF, s: Scope, b: IConnectableBinding): void {
+  public unbind(s: Scope, b: IConnectableBinding): void {
     if (this.iterable.hasUnbind) {
-      this.iterable.unbind(f, s, b);
+      this.iterable.unbind(s, b);
     }
   }
 

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -1092,6 +1092,7 @@ function parseCoverParenthesizedExpressionAndArrowParameterList(expressionType: 
         break;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     switch ($currentToken as Token) {
       case Token.Comma:
         nextToken();

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -9,8 +9,8 @@ export interface IBinding {
   readonly locator: IServiceLocator;
   readonly $scope?: Scope;
   readonly isBound: boolean;
-  $bind(flags: LifecycleFlags, scope: Scope): void;
-  $unbind(flags: LifecycleFlags): void;
+  $bind(scope: Scope): void;
+  $unbind(): void;
   get: IServiceLocator['get'];
 }
 

--- a/packages/state/src/state-binding-behavior.ts
+++ b/packages/state/src/state-binding-behavior.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Writable } from '@aurelia/kernel';
-import { BindingBehaviorExpression, IOverrideContext, LifecycleFlags, Scope } from '@aurelia/runtime';
+import { BindingBehaviorExpression, IOverrideContext, Scope } from '@aurelia/runtime';
 import { bindingBehavior, BindingInterceptor, IInterceptableBinding, } from '@aurelia/runtime-html';
 import { IStore, IStoreSubscriber } from './interfaces';
 import { StateBinding } from './state-binding';
@@ -23,20 +23,20 @@ export class StateBindingBehavior extends BindingInterceptor implements IStoreSu
     this._isStateBinding = binding instanceof StateBinding;
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     const binding = this.binding;
     const $scope = this._isStateBinding ? scope : createStateBindingScope(this._store.getState(), scope);
     if (!this._isStateBinding) {
       this._store.subscribe(this);
     }
-    binding.$bind(flags, $scope);
+    binding.$bind($scope);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
+  public $unbind(): void {
     if (!this._isStateBinding) {
       this._store.unsubscribe(this);
     }
-    this.binding.$unbind(flags);
+    this.binding.$unbind();
   }
 
   public handleStateChange(state: object): void {

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -4,7 +4,6 @@ import { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import {
   AccessorType,
   connectable,
-  LifecycleFlags,
   Scope,
   type IAccessor,
   type IObserverLocator, type IOverrideContext, type IsBindingBehavior
@@ -92,7 +91,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     targetAccessor.setValue(value, target, prop);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -2,7 +2,6 @@
 import { type Writable, type IServiceLocator } from '@aurelia/kernel';
 import {
   type IOverrideContext,
-  LifecycleFlags,
   Scope,
   type IsBindingBehavior,
   connectable
@@ -58,7 +57,7 @@ export class StateDispatchBinding implements IAstBasedBinding {
     this.interceptor.callSource(e);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -2,7 +2,6 @@
 import { IDisposable, IIndexable, type IServiceLocator, type Writable } from '@aurelia/kernel';
 import {
   connectable,
-  LifecycleFlags,
   Scope,
   type IConnectableBinding,
   type IOverrideContext,
@@ -75,7 +74,7 @@ export class StateGetterBinding implements IConnectableBinding, IStoreSubscriber
     target[prop] = value;
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
+  public $bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -94,7 +94,7 @@ export class DispatchBindingInstruction {
   public readonly type = 'sd';
   public constructor(
     public from: string,
-    public expr: string | IsBindingBehavior,
+    public ast: string | IsBindingBehavior,
   ) {}
 }
 
@@ -144,7 +144,7 @@ export class DispatchBindingInstructionRenderer implements IRenderer {
     target: HTMLElement,
     instruction: DispatchBindingInstruction,
   ): void {
-    const expr = ensureExpression(this._exprParser, instruction.expr, ExpressionType.IsProperty);
+    const expr = ensureExpression(this._exprParser, instruction.ast, ExpressionType.IsProperty);
     const binding = new StateDispatchBinding(
       renderingCtrl.container,
       expr,

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -71,12 +71,12 @@ export class MockBinding implements IConnectableBinding {
     this.trace('subscribeTo', subscribable);
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope): void {
-    this.trace('$bind', flags, scope);
+  public $bind(scope: Scope): void {
+    this.trace('$bind', scope);
   }
 
-  public $unbind(flags: LifecycleFlags): void {
-    this.trace('$unbind', flags);
+  public $unbind(): void {
+    this.trace('$unbind');
   }
 
   public trace(fnName: keyof MockBinding, ...args: any[]): void {
@@ -91,12 +91,12 @@ export class MockBinding implements IConnectableBinding {
 export class MockBindingBehavior {
   public calls: [keyof MockBindingBehavior, ...any[]][] = [];
 
-  public bind(flags: LifecycleFlags, scope: Scope, binding: IBinding, ...rest: any[]): void {
-    this.trace('bind', flags, scope, binding, ...rest);
+  public bind(scope: Scope, binding: IBinding, ...rest: any[]): void {
+    this.trace('bind', scope, binding, ...rest);
   }
 
-  public unbind(flags: LifecycleFlags, scope: Scope, binding: IBinding, ...rest: any[]): void {
-    this.trace('unbind', flags, scope, binding, ...rest);
+  public unbind(scope: Scope, binding: IBinding, ...rest: any[]): void {
+    this.trace('unbind', scope, binding, ...rest);
   }
 
   public trace(fnName: keyof MockBindingBehavior, ...args: any[]): void {

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -6,7 +6,6 @@ import {
   IBinding,
   IConnectableBinding,
   IObserverLocator,
-  LifecycleFlags,
   Scope
 } from '@aurelia/runtime';
 import {
@@ -118,15 +117,15 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
     }
   }
 
-  public $bind(flags: LifecycleFlags, scope: Scope) {
+  public $bind(scope: Scope) {
     this.scope = scope;
-    this.binding.$bind(flags, scope);
+    this.binding.$bind(scope);
     this._setTarget();
-    const delta = this._processBindingExpressionArgs(flags);
+    const delta = this._processBindingExpressionArgs();
     this._processDelta(delta);
   }
 
-  public $unbind(flags: LifecycleFlags) {
+  public $unbind() {
     this.task?.cancel();
     this.task = null;
 
@@ -136,7 +135,7 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
     }
     this.controller?.removeSubscriber(this);
     this.controller?.unregisterBinding(this.propertyBinding);
-    this.binding.$unbind(flags);
+    this.binding.$unbind();
   }
 
   public handleTriggerChange(newValue: unknown, _previousValue: unknown): void {
@@ -164,7 +163,7 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
   }
 
   /** @internal */
-  private _processBindingExpressionArgs(_flags: LifecycleFlags): ValidateArgumentsDelta {
+  private _processBindingExpressionArgs(): ValidateArgumentsDelta {
     const scope: Scope = this.scope;
     let rules: PropertyRule[] | undefined;
     let trigger: ValidationTrigger | undefined;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Continue the work on flags removal, remove all usages of flags on bindings, behaviors and ast. Our binding signatures will be around scope only:
```ts
interface Binding {
  bind(scope)
  unbind()
}
```
Also added some more tests for a few binding behaviors.

## ⏭ Next Steps

Remove flags from controllers.