### PR TITLE
refactor: always handle event handler as fn

### DIFF
--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -1,4 +1,4 @@
-import { BindingBehavior, ValueConverter, AppTask, CustomAttribute, IListenerBehaviorOptions, INode } from '@aurelia/runtime-html';
+import { BindingBehavior, ValueConverter, CustomAttribute, INode } from '@aurelia/runtime-html';
 import { assert, createFixture } from "@aurelia/testing";
 
 describe("arrow-fn", function () {
@@ -187,8 +187,6 @@ describe("arrow-fn", function () {
     const { getBy } = createFixture
       .html`<button click.trigger="() => clicked()">`
       .component({ clicked: () => i = 1 })
-      // todo: maybe just make it understand function by default
-      .deps(AppTask.creating(IListenerBehaviorOptions, o => o.expAsHandler = true))
       .build();
 
     getBy('button').click();
@@ -508,6 +506,7 @@ describe("arrow-fn", function () {
 
     // the follow results in a infinite loop,
     // because sort mutate the existing array causing the binding & repeat to update infinitely
+    // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('observes on .sort', function () {
       const { component, flush, assertText } = createFixture
         .component({ items: [{ id: 4, }, { id: 5, }, { id: 3, }, { id: 1 }] })

--- a/packages/__tests__/3-runtime-html/listener.spec.ts
+++ b/packages/__tests__/3-runtime-html/listener.spec.ts
@@ -1,4 +1,4 @@
-import { AppTask, IListenerBehaviorOptions, ValueConverter } from '@aurelia/runtime-html';
+import { ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('3-runtime-html/listener.spec.ts', function () {
@@ -32,37 +32,14 @@ describe('3-runtime-html/listener.spec.ts', function () {
     assert.strictEqual(vcLog, 1);
   });
 
-  it('invoke handler after evaluating expression when expAsHandler = true', async function () {
+  it('invoke handler after evaluating expression', async function () {
     let log = 0;
     const { trigger } = await createFixture(
       '<button click.trigger="onClick">',
       { onClick() { log++; } },
-      [AppTask.creating(IListenerBehaviorOptions, o => { o.expAsHandler = true; })]
     ).started;
 
     trigger.click('button');
     assert.strictEqual(log, 1);
-  });
-
-  it('expAsHandler = true + value converter', async function () {
-    let log = 0;
-    let vcLog = 0;
-    const { trigger } = await createFixture(
-      '<button click.trigger="onClick | identity">',
-      { onClick() { log++; } },
-      [
-        AppTask.creating(IListenerBehaviorOptions, o => { o.expAsHandler = true; }),
-        ValueConverter.define('identity', class {
-          toView(a: any) {
-            vcLog++;
-            return a;
-          }
-        })
-      ]
-    ).started;
-
-    trigger.click('button');
-    assert.strictEqual(log, 1);
-    assert.strictEqual(vcLog, 1);
   });
 });

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -841,7 +841,6 @@ export {
   // IInstruction,
   // InstructionType,
   // IAttributeBindingInstruction,
-  // IListenerBindingInstruction,
   // ISetAttributeInstruction,
   // isInstruction,
   // IStylePropertyBindingInstruction,

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -20,7 +20,6 @@ export class ListenerOptions {
   public constructor(
     public readonly prevent: boolean,
     public readonly strategy: DelegationStrategy,
-    public readonly expAsHandler: boolean,
   ) {}
 }
 
@@ -57,10 +56,7 @@ export class Listener implements IAstBasedBinding {
 
     delete overrideContext.$event;
 
-    if (this._options.expAsHandler) {
-      if (!isFunction(result)) {
-        throw new Error(`Handler of "${this.targetEvent}" event is not a function.`);
-      }
+    if (isFunction(result)) {
       result = result(event);
     }
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -163,7 +163,6 @@ export {
   RefBindingInstruction,
   SetPropertyInstruction,
   AttributeBindingInstruction,
-  IListenerBehaviorOptions,
   ListenerBindingInstruction,
   PropertyBindingInstruction,
   SetAttributeInstruction,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1031,38 +1031,20 @@ export class TextBindingRenderer implements IRenderer {
   }
 }
 
-export interface IListenerBehaviorOptions {
-  /**
-   * `true` if the expression specified in the template is meant to be treated as a handler
-   */
-  expAsHandler: boolean;
-}
-export const IListenerBehaviorOptions = DI.createInterface<IListenerBehaviorOptions>('IListenerBehaviorOptions', x => x.singleton(ListenerBehaviorOptions));
-
-class ListenerBehaviorOptions implements IListenerBehaviorOptions {
-  public expAsHandler = false;
-}
-
 @renderer(InstructionType.listenerBinding)
 /** @internal */
 export class ListenerBindingRenderer implements IRenderer {
-  /** @internal */ protected static inject = [IExpressionParser, IEventDelegator, IPlatform, IListenerBehaviorOptions];
+  /** @internal */ protected static inject = [IExpressionParser, IEventDelegator];
   /** @internal */ private readonly _exprParser: IExpressionParser;
   /** @internal */ private readonly _eventDelegator: IEventDelegator;
-  /** @internal */ private readonly _platform: IPlatform;
-  /** @internal */ private readonly _listenerBehaviorOptions: IListenerBehaviorOptions;
 
   public target!: InstructionType.listenerBinding;
   public constructor(
     parser: IExpressionParser,
     eventDelegator: IEventDelegator,
-    p: IPlatform,
-    listenerBehaviorOptions: IListenerBehaviorOptions,
   ) {
     this._exprParser = parser;
     this._eventDelegator = eventDelegator;
-    this._platform = p;
-    this._listenerBehaviorOptions = listenerBehaviorOptions;
   }
 
   public render(
@@ -1077,7 +1059,7 @@ export class ListenerBindingRenderer implements IRenderer {
       target,
       instruction.to,
       this._eventDelegator,
-      new ListenerOptions(instruction.preventDefault, instruction.strategy, this._listenerBehaviorOptions.expAsHandler),
+      new ListenerOptions(instruction.preventDefault, instruction.strategy),
     );
     renderingCtrl.addBinding(expr.$kind === ExpressionKind.BindingBehavior
       ? applyBindingBehavior(binding, expr, renderingCtrl.container)


### PR DESCRIPTION
# Pull Request

## 📖 Description

In a previous PR, an option was introduced to make listener able to accept function. Though it came with a cumbersome configuration. Remove the need for configuration and let the event handler call function by default, if the expression returns a function.

Thanks @jwx @brandonseydel for the suggestion