### PR TITLE
Finalise commonly used <input> "dangerous" attributes

### DIFF
--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -227,8 +227,9 @@ export class NodeObserverLocator implements INodeObserverLocator {
       case 'minLength':
       case 'maxLength':
       case 'placeholder':
-      case 'type':
       case 'size':
+      case 'pattern':
+      case 'title':
         // assigning null/undefined to size on input is an error
         // though it may be fine on other elements.
         // todo: make an effort to distinguish properties based on element name


### PR DESCRIPTION
Add "pattern" and "title", remove "type"

In fact "pattern", "title", "placeholder" are also recoverable (as id is) via placeholder.bind="prop || ''" or placeholder="${prop}", but that may be confusing for developers, so i would leave them here.