### PR TITLE
refactor: cleanup runtime 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ jobs:
           paths:
             - packages/__tests__/dist
             - packages/aurelia/dist
+            - packages/compat-v1/dist
             - packages/addons/dist
             - packages/fetch-client/dist
             - packages/i18n/dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ jobs:
           command: |
             cd packages/__tests__
             npm run ::mocha -- $(cat tests.txt)
-          no_output_timeout: "3m"
+          no_output_timeout: "1m"
 
   unit_test_cjs:
     parameters:
@@ -517,7 +517,7 @@ jobs:
           command: |
             npx playwright install chromium
             npm run test
-          no_output_timeout: "3m"
+          no_output_timeout: "1m"
 
   # Standalone playwright test jobs
   e2e_playwright:
@@ -806,7 +806,9 @@ workflows:
             #- test_test262
             # - lint_packages
             - webpack_conventions_ts
-            # - webpack_vanilla_ts
+            - e2e_hmr_webpack
+            - e2e_router_lite
+            - e2e_router
           from: master
           to: develop
           channel: dev
@@ -878,7 +880,13 @@ workflows:
 
       - e2e_test:
           <<: *filter_ignore_develop_release
-          name: e2e_router_lite_configured
+          name: e2e_hmr_webpack
+          path: "packages/__e2e__/hmr-webpack"
+          requires:
+            - build_release
+      - e2e_test:
+          <<: *filter_ignore_develop_release
+          name: e2e_router_lite
           path: "packages/__e2e__/router-lite"
           requires:
             - build_release
@@ -911,7 +919,8 @@ workflows:
             - test_firefox
             - test_node
             - test_toolings
-            - e2e_router_lite_configured
+            - e2e_hmr_webpack
+            - e2e_router_lite
             - e2e_router
             #- test_test262
             # - lint_packages

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -12,6 +12,10 @@ In v2, when trying to bind with a non-existent property, the closest boundary sc
 
 In v1, if you happen to use `.observeProperty` method from bindings in your application/library, then change it to `observe` instead. The parameters of the signature remain the same.
 
+### Internal binding property `sourceExpression` has been renamed to `ast`
+
+In v1, if you happen to use `.sourceExpression` property from bindings in your application/library, then change it to `ast` instead. The type of the property remains the same.
+
 ### Enhance API changes:
 
 In v1, `enhance` method on an `Aurelia` instance has the signature:

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -266,17 +266,17 @@ Every component instance has a life-cycle that you can tap into. This makes it e
 | Name        | Aurelia 1   | Asyncable | Description |
 | ----------- | ----------- | --------- | ----------- |
 | constructor | constructor | **✗**     |             |
-| define      | **✗**       | **✓**     |             |
-| hydrating   | **✗**       | **✓**     |             |
-| hydrated    | **✗**       | **✓**     |             |
-| created     | created     | **✓**     |             |
+| define      | **✗**       | **✗**     |             |
+| hydrating   | **✗**       | **✗**     |             |
+| hydrated    | **✗**       | **✗**     |             |
+| created     | created     | **✗**     |             |
 | binding     | bind        | **✓**     |             |
 | bound       | **✗**       | **✓**     |             |
 | attaching   | **✗**       | **✓**     |             |
 | attached    | attached    | **✓**     |             |
 | detaching   | **✗**       | **✓**     |             |
 | unbinding   | unbind      | **✓**     |             |
-| dispose     | detached    | **✓**     |             |
+| dispose     | **✗**       | **✗**     |             |
 
 {% hint style="info" %}
 Aurelia 1 has a restriction and the community made an [afterAttached](https://github.com/aurelia-ui-toolkits/aurelia-after-attached-plugin) plugin that is called after all child components are attached, and after all two-way bindings have completed. The`attached`life-cycle in version 2 covers this scenario.
@@ -507,9 +507,9 @@ export class MyApp {
 | Name      | Aurelia 1     | Asyncable | Description |
 | --------- | ------------- | --------- | ----------- |
 | canLoad   | canActivate   | **✓**     |             |
-| load      | activate      | **✓**     |             |
+| loading   | activate      | **✓**     |             |
 | canUnload | canDeactivate | **✓**     |             |
-| unload    | deactivate    | **✓**     |             |
+| unloading | deactivate    | **✓**     |             |
 {% endtab %}
 {% endtabs %}
 
@@ -537,6 +537,7 @@ export class MyApp {
 | Name | Aurelia 1 & 2 | Description |
 | ---- | ------------- | ----------- |
 | ref  | **✓**         |             |
+| view-model.ref  | **✓**         |             |
 
 ### Passing Function References
 

--- a/examples/1kcomponents/rollup.config.js
+++ b/examples/1kcomponents/rollup.config.js
@@ -1,0 +1,12 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+    input: './app',
+    output: {
+        file: 'dist/bundle.js',
+        sourcemap: true
+    },
+    plugins: [nodeResolve(), terser()]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "packages/__e2e__/ui-virtualization",
         "packages/addons",
         "packages/aurelia",
+        "packages/compat-v1",
         "packages/fetch-client",
         "packages/i18n",
         "packages/kernel",
@@ -425,6 +426,10 @@
     },
     "node_modules/@aurelia/babel-jest": {
       "resolved": "packages-tooling/babel-jest",
+      "link": true
+    },
+    "node_modules/@aurelia/compat-v1": {
+      "resolved": "packages/compat-v1",
       "link": true
     },
     "node_modules/@aurelia/fetch-client": {
@@ -20343,7 +20348,8 @@
       "license": "MIT"
     },
     "packages/__e2e__/ui-virtualization": {
-      "version": "2.0.0-alpha.31",
+      "name": "@__e2e__/ui-virtualization",
+      "version": "2.0.0-alpha.41",
       "license": "MIT",
       "dependencies": {
         "@aurelia/kernel": "2.0.0-alpha.41",
@@ -20469,6 +20475,24 @@
         "@aurelia/route-recognizer": "2.0.0-alpha.41",
         "@aurelia/router": "2.0.0-alpha.41",
         "@aurelia/router-lite": "2.0.0-alpha.41",
+        "@aurelia/runtime": "2.0.0-alpha.41",
+        "@aurelia/runtime-html": "2.0.0-alpha.41"
+      },
+      "devDependencies": {
+        "typescript": "4.7.3"
+      },
+      "engines": {
+        "node": ">=14.17.0"
+      }
+    },
+    "packages/compat-v1": {
+      "version": "2.0.0-alpha.41",
+      "license": "MIT",
+      "dependencies": {
+        "@aurelia/kernel": "2.0.0-alpha.41",
+        "@aurelia/metadata": "2.0.0-alpha.41",
+        "@aurelia/platform": "2.0.0-alpha.41",
+        "@aurelia/platform-browser": "2.0.0-alpha.41",
         "@aurelia/runtime": "2.0.0-alpha.41",
         "@aurelia/runtime-html": "2.0.0-alpha.41"
       },
@@ -21305,6 +21329,18 @@
             "babel-preset-current-node-syntax": "^1.0.0"
           }
         }
+      }
+    },
+    "@aurelia/compat-v1": {
+      "version": "file:packages/compat-v1",
+      "requires": {
+        "@aurelia/kernel": "2.0.0-alpha.41",
+        "@aurelia/metadata": "2.0.0-alpha.41",
+        "@aurelia/platform": "2.0.0-alpha.41",
+        "@aurelia/platform-browser": "2.0.0-alpha.41",
+        "@aurelia/runtime": "2.0.0-alpha.41",
+        "@aurelia/runtime-html": "2.0.0-alpha.41",
+        "typescript": "4.7.3"
       }
     },
     "@aurelia/fetch-client": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "rebuild": "npm run clean && npm run build",
     "build": "lage build --scope @aurelia/* --scope aurelia --scope au --no-cache --verbose --no-deps",
     "build:test": "lage run rollup --scope @aurelia/* --scope aurelia --scope au --no-cache --verbose --no-deps",
-    "build:release": "lage run rollup --scope aurelia --scope au --scope @aurelia/a* --scope @aurelia/b* --scope @aurelia/f* --scope @aurelia/h* --scope @aurelia/i* --scope @aurelia/k* --scope @aurelia/m* --scope @aurelia/p* --scope @aurelia/r* --scope @aurelia/s* --scope @aurelia/t* --scope @aurelia/u* --scope @aurelia/v* --scope @aurelia/w* --no-cache --verbose --no-deps",
+    "build:release": "lage run rollup --scope aurelia --scope au --scope @aurelia/a* --scope @aurelia/b* --scope @aurelia/c* --scope @aurelia/f* --scope @aurelia/h* --scope @aurelia/i* --scope @aurelia/k* --scope @aurelia/m* --scope @aurelia/p* --scope @aurelia/r* --scope @aurelia/s* --scope @aurelia/t* --scope @aurelia/u* --scope @aurelia/v* --scope @aurelia/w* --no-cache --verbose --no-deps",
     "postbuild:release": "npm run clean:tsconfig-build-cache",
     "build:release:full": "npm run build:release && npm run change-tsconfigs:invert && npm run build:release && npm run change-tsconfigs:restore",
     "build:release-script": "tsc --project scripts/tsconfig.release-script.json",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages/__e2e__/ui-virtualization",
     "packages/addons",
     "packages/aurelia",
+    "packages/compat-v1",
     "packages/fetch-client",
     "packages/i18n",
     "packages/kernel",

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -41,6 +41,9 @@ import {
   BindingIdentifier,
   IAstEvaluator,
   Unparser,
+  astEvaluate,
+  astAssign,
+  astBind,
 } from '@aurelia/runtime';
 
 const $false = PrimitiveLiteralExpression.$false;
@@ -74,19 +77,19 @@ function assignDoesNotThrow(inputs: [string, IsBindingBehavior][]) {
   describe('assign() does not throw / is a no-op', function () {
     for (const [text, expr] of inputs) {
       it(`${text}, null`, function () {
-        expr.assign(null, null, null);
+        astAssign(expr, null, null, null);
       });
     }
   });
 }
 
 function throwsOn<
-  TExpr extends IsBindingBehavior,
-  TMethod extends keyof TExpr,
-  >(expr: TExpr, method: TMethod, msg: string, ...args: TExpr[TMethod] extends ((...args: infer TArgs) => any) ? TArgs : never): void {
+  TMethod extends typeof astEvaluate | typeof astAssign | typeof astBind,
+>(method: TMethod, msg: string, ...args: Parameters<TMethod>): void {
   let err = null;
   try {
-    (expr as any)[method](...args);
+    // (expr as any)[method](...args);
+    (method as any)(...args);
   } catch (e) {
     err = e;
   }
@@ -311,22 +314,22 @@ describe('AST', function () {
         ...KeywordLiteralList
       ]) {
         it(text, function () {
-          assert.strictEqual(expr.evaluate(undefined, undefined, null), expr.value, `expr.evaluate(undefined, undefined)`);
+          assert.strictEqual(astEvaluate(expr, undefined, undefined, null), expr.value, `astEvaluate(expr, undefined, undefined)`);
         });
       }
       for (const [text, expr] of TemplateLiteralList) {
         it(text, function () {
-          assert.strictEqual(expr.evaluate(undefined, undefined, null), '', `expr.evaluate(undefined, undefined)`);
+          assert.strictEqual(astEvaluate(expr, undefined, undefined, null), '', `astEvaluate(expr, undefined, undefined)`);
         });
       }
       for (const [text, expr] of ArrayLiteralList) {
         it(text, function () {
-          assert.instanceOf(expr.evaluate(undefined, undefined, null), Array, 'expr.evaluate(undefined, undefined)');
+          assert.instanceOf(astEvaluate(expr, undefined, undefined, null), Array, 'astEvaluate(expr, undefined, undefined)');
         });
       }
       for (const [text, expr] of ObjectLiteralList) {
         it(text, function () {
-          assert.instanceOf(expr.evaluate(undefined, undefined, null), Object, 'expr.evaluate(undefined, undefined)');
+          assert.instanceOf(astEvaluate(expr, undefined, undefined, null), Object, 'astEvaluate(expr, undefined, undefined)');
         });
       }
     });
@@ -384,10 +387,10 @@ describe('AST', function () {
   // });
 
   describe('ValueConverterExpression', function () {
-    describe('evaluate() throws when returned converter is nil', function () {
+    describe('evaluate() throws when returned converter is null', function () {
       for (const [text, expr] of SimpleValueConverterList) {
         it(`${text}, undefined`, function () {
-          throwsOn(expr, 'evaluate', `AUR0103:b`, dummyScope, dummyLocatorThatReturnsNull, null);
+          throwsOn(astEvaluate, `AUR0103:b`, expr, dummyScope, dummyLocatorThatReturnsNull, null);
           // throwsOn(expr, 'evaluate', `ValueConverter named 'b' could not be found. Did you forget to register it as a dependency?`, LF.none, dummyScope, dummyLocatorThatReturnsNull, null);
         });
       }
@@ -396,7 +399,7 @@ describe('AST', function () {
     describe('assign() throws when returned converter is null', function () {
       for (const [text, expr] of SimpleValueConverterList) {
         it(`${text}, null`, function () {
-          throwsOn(expr, 'assign', `AUR0103:b`, dummyScope, dummyLocatorThatReturnsNull, null);
+          throwsOn(astAssign, `AUR0103:b`, expr, dummyScope, dummyLocatorThatReturnsNull, null);
           // throwsOn(expr, 'assign', `ValueConverter named 'b' could not be found. Did you forget to register it as a dependency?`, LF.none, dummyScope, dummyLocatorThatReturnsNull, null);
         });
       }
@@ -407,7 +410,7 @@ describe('AST', function () {
     describe('bind() throws when returned behavior is null', function () {
       for (const [text, expr] of SimpleBindingBehaviorList) {
         it(`${text}, undefined`, function () {
-          throwsOn(expr, 'bind', `AUR0101:b`, dummyScope, dummyBindingWithLocatorThatReturnsNull);
+          throwsOn(astBind, `AUR0101:b`, expr, dummyScope, dummyBindingWithLocatorThatReturnsNull);
           // throwsOn(expr, 'bind', `BindingBehavior named 'b' could not be found. Did you forget to register it as a dependency?`, LF.none, dummyScope, dummyBindingWithLocatorThatReturnsNull);
         });
       }
@@ -425,43 +428,43 @@ describe('AccessKeyedExpression', function () {
 
   it('evaluates member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
-    assert.strictEqual(expression.evaluate(scope, null, null), 'baz', `expression.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'baz', `astEvaluate(expression, scope, null)`);
   });
 
   it('evaluates member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
-    assert.strictEqual(expression.evaluate(scope, null, null), 'baz', `expression.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'baz', `astEvaluate(expression, scope, null)`);
   });
 
   it('assigns member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
-    expression.assign(scope, null, 'bang');
+    astAssign(expression, scope, null, 'bang');
     assert.strictEqual((scope.bindingContext.foo as IIndexable).bar, 'bang', `(scope.bindingContext.foo as IIndexable).bar`);
   });
 
   it('assigns member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
-    expression.assign(scope, null, 'bang');
+    astAssign(expression, scope, null, 'bang');
     assert.strictEqual((scope.overrideContext.foo as IIndexable).bar, 'bang', `(scope.overrideContext.foo as IIndexable).bar`);
   });
 
   it('evaluates null/undefined object', function () {
     let scope = createScopeForTest({ foo: null });
-    assert.strictEqual(expression.evaluate(scope, null, null), undefined, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), undefined, `astEvaluate(expression, scope, null, null)`);
     scope = createScopeForTest({ foo: undefined });
-    assert.strictEqual(expression.evaluate(scope, null, null), undefined, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), undefined, `astEvaluate(expression, scope, null, null)`);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), undefined, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), undefined, `astEvaluate(expression, scope, null, null)`);
   });
 
   it('does not observes property in keyed object access when key is number', function () {
     const scope = createScopeForTest({ foo: { '0': 'hello world' } });
     const expression2 = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), new PrimitiveLiteralExpression(0));
-    assert.strictEqual(expression2.evaluate(scope, null, null), 'hello world', `expression2.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate(expression2, scope, null, null), 'hello world', `astEvaluate(expression2, scope, null)`);
     const binding = new MockBinding();
-    expression2.evaluate(scope, dummyLocator, binding);
+    astEvaluate(expression2, scope, dummyLocator, binding);
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'foo'], 'binding.calls[0]');
     assert.deepStrictEqual(binding.calls[1], ['observe', scope.bindingContext.foo, 0], 'binding.calls[1]');
     assert.strictEqual(binding.calls.length, 2, 'binding.calls.length');
@@ -470,9 +473,9 @@ describe('AccessKeyedExpression', function () {
   it('observes property in keyed array access when key is number', function () {
     const scope = createScopeForTest({ foo: ['hello world'] });
     const expression3 = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), new PrimitiveLiteralExpression(0));
-    assert.strictEqual(expression3.evaluate(scope, null, null), 'hello world', `expression3.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate(expression3,scope, null, null), 'hello world', `astEvaluate(expression3,scope, null)`);
     const binding = new MockBinding();
-    expression3.evaluate(scope, dummyLocator, binding);
+    astEvaluate(expression3,scope, dummyLocator, binding);
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'foo'], 'binding.calls[0]');
     assert.strictEqual(binding.calls.length, 2, 'binding.calls.length');
   });
@@ -498,7 +501,7 @@ describe('AccessKeyedExpression', function () {
         const scope = createScopeForTest({ foo: obj });
         const sut = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), key);
         const binding = new MockBinding();
-        sut.evaluate(scope, dummyLocator, binding);
+        astEvaluate(sut, scope, dummyLocator, binding);
         assert.strictEqual(binding.calls.length, 1);
         assert.strictEqual(binding.calls[0][0], 'observe');
       });
@@ -600,11 +603,11 @@ describe('AccessMemberExpression', function () {
   const expression: AccessMemberExpression = new AccessMemberExpression(new AccessScopeExpression('foo', 0), 'bar');
 
   eachCartesianJoinFactory.call(this, inputs, (([t1, obj, _isFalsey, canHaveProperty], [t2, prop, value]) => {
-    it(`STRICT - ${t1}.${t2}.evaluate() -> connect -> assign`, function () {
+    it(`STRICT - ${t1}.${t2} evaluate() -> eval + connect -> assign`, function () {
       const scope = createScopeForTest({ foo: obj });
       const evaluator = { strict: true } as unknown as IAstEvaluator;
       const sut = new AccessMemberExpression(new AccessScopeExpression('foo', 0), prop);
-      const actual = sut.evaluate(scope, evaluator , null);
+      const actual = astEvaluate(sut, scope, evaluator , null);
       if (canHaveProperty) {
         assert.strictEqual(actual, value, `actual`);
       } else {
@@ -615,7 +618,7 @@ describe('AccessMemberExpression', function () {
         }
       }
       const binding = new MockBinding();
-      sut.evaluate(scope, dummyLocator, binding);
+      astEvaluate(sut, scope, dummyLocator, binding);
       if (canHaveProperty) {
         assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 2, `binding.calls.filter(c => c[0] === 'observe').length`);
       } else {
@@ -624,17 +627,17 @@ describe('AccessMemberExpression', function () {
 
       if (!(obj instanceof Object)) {
         assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-        sut.assign(scope, null, 42);
+        astAssign(sut, scope, null, 42);
         assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
         assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
       }
     });
 
-    it(`${t1}.${t2}.evaluate() + connect() -> assign`, function () {
+    it(`${t1}.${t2} evaluate() + connect() -> assign`, function () {
       const scope = createScopeForTest({ foo: obj });
       const evaluator = { strict: false } as unknown as IAstEvaluator;
       const sut = new AccessMemberExpression(new AccessScopeExpression('foo', 0), prop);
-      const actual = sut.evaluate(scope, evaluator, null);
+      const actual = astEvaluate(sut, scope, evaluator, null);
       if (canHaveProperty) {
         if (obj == null) {
           assert.strictEqual(actual, '', `actual`);
@@ -647,7 +650,7 @@ describe('AccessMemberExpression', function () {
         }
       }
       const binding = new MockBinding();
-      sut.evaluate(scope, dummyLocator, binding);
+      astEvaluate(sut, scope, dummyLocator, binding);
       if (canHaveProperty) {
         assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 2, `binding.calls.filter(c => c[0] === 'observe').length`);
       } else {
@@ -656,7 +659,7 @@ describe('AccessMemberExpression', function () {
 
       if (!(obj instanceof Object)) {
         assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-        sut.assign(scope, null, 42);
+        astAssign(sut, scope, null, 42);
         assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
         assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
       }
@@ -667,31 +670,31 @@ describe('AccessMemberExpression', function () {
 
   it('evaluates member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
-    assert.strictEqual(expression.evaluate(scope, null, null), 'baz', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'baz', `astEvaluate(expression, scope, null, null)`);
   });
 
   it('evaluates member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
-    assert.strictEqual(expression.evaluate(scope, null, null), 'baz', `expression.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'baz', `astEvaluate(expression, scope, null)`);
   });
 
   it('assigns member on bindingContext', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
-    expression.assign(scope, null, 'bang');
+    astAssign(expression, scope, null, 'bang');
     assert.strictEqual((scope.bindingContext.foo as IIndexable).bar, 'bang', `(scope.bindingContext.foo as IIndexable).bar`);
   });
 
   it('assigns member on overrideContext', function () {
     const scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
-    expression.assign(scope, null, 'bang');
+    astAssign(expression, scope, null, 'bang');
     assert.strictEqual((scope.overrideContext.foo as IIndexable).bar, 'bang', `(scope.overrideContext.foo as IIndexable).bar`);
   });
 
   it('returns the assigned value', function () {
     const scope = createScopeForTest({ foo: { bar: 'baz' } });
-    assert.strictEqual(expression.assign(scope, null, 'bang'), 'bang', `expression.assign(scope, null, 'bang')`);
+    assert.strictEqual(astAssign(expression, scope, null, 'bang'), 'bang', `astAssign(expression, scope, null, 'bang')`);
   });
 
   describe('does not attempt to observe property when object is falsey', function () {
@@ -712,7 +715,7 @@ describe('AccessMemberExpression', function () {
         const scope = createScopeForTest({ foo: obj });
         const sut = new AccessMemberExpression(new AccessScopeExpression('foo', 0), prop);
         const binding = new MockBinding();
-        sut.evaluate(scope, dummyLocator, binding);
+        astEvaluate(sut, scope, dummyLocator, binding);
         assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 1, `binding.calls.filter(c => c[0] === 'observe').length`);
       });
     }));
@@ -737,7 +740,7 @@ describe('AccessMemberExpression', function () {
         const scope = createScopeForTest({ foo: obj });
         const expression2 = new AccessMemberExpression(new AccessScopeExpression('foo', 0), prop);
         const binding = new MockBinding();
-        expression2.evaluate(scope, dummyLocator, binding);
+        astEvaluate(expression2, scope, dummyLocator, binding);
         assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 1, `binding.calls.filter(c => c[0] === 'observe').length`);
       });
     }));
@@ -750,38 +753,38 @@ describe('AccessScopeExpression', function () {
 
   it(`evaluates defined property on bindingContext`, function () {
     const scope: Scope = createScopeForTest({ foo: 'bar' });
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
   });
 
   it(`evaluates defined property on overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
   });
 
   it(`assigns defined property on bindingContext`, function () {
     const scope = createScopeForTest({ foo: 'bar' });
-    foo.assign(scope, null, 'baz');
+    astAssign(foo, scope, null, 'baz');
     assert.strictEqual(scope.bindingContext.foo, 'baz', `scope.bindingContext.foo`);
   });
 
   it(`assigns undefined property to bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' });
-    foo.assign(scope, null, 'baz');
+    astAssign(foo, scope, null, 'baz');
     assert.strictEqual(scope.bindingContext.foo, 'baz', `scope.bindingContext.foo`);
   });
 
   it(`assigns defined property on overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
-    foo.assign(scope, null, 'baz');
+    astAssign(foo, scope, null, 'baz');
     assert.strictEqual(scope.overrideContext.foo, 'baz', `scope.overrideContext.foo`);
   });
 
   it(`connects defined property on bindingContext`, function () {
     const scope = createScopeForTest({ foo: 'bar' });
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'foo'], 'binding.calls[0]');
   });
@@ -790,7 +793,7 @@ describe('AccessScopeExpression', function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     scope.overrideContext.foo = 'bar';
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.overrideContext, 'foo'], 'binding.calls[0]');
   });
@@ -798,49 +801,49 @@ describe('AccessScopeExpression', function () {
   it(`connects undefined property on bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' });
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'foo'], 'binding.calls[0]');
   });
 
   it(`evaluates defined property on first ancestor bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(LF.none, scope, null, null)`);
-    assert.strictEqual($parentfoo.evaluate(scope, null, null), 'bar', `$parentfoo.evaluate(LF.none, scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
+    assert.strictEqual(astEvaluate($parentfoo, scope, null, null), 'bar', `astEvaluate($parentfoo, scope, null, null)`);
   });
 
   it(`evaluates defined property on first ancestor overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.parent.overrideContext.foo = 'bar';
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(LF.none, scope, null)`);
-    assert.strictEqual($parentfoo.evaluate(scope, null, null), 'bar', `$parentfoo.evaluate(LF.none, scope, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null)`);
+    assert.strictEqual(astEvaluate($parentfoo, scope, null, null), 'bar', `astEvaluate($parentfoo, scope, null)`);
   });
 
   it(`assigns defined property on first ancestor bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
-    foo.assign(scope, null, 'baz');
+    astAssign(foo, scope, null, 'baz');
     assert.strictEqual(scope.parent.bindingContext.foo, 'baz', `scope.parent.bindingContext.foo`);
-    $parentfoo.assign(scope, null, 'beep');
+    astAssign($parentfoo, scope, null, 'beep');
     assert.strictEqual(scope.parent.bindingContext.foo, 'beep', `scope.parent.bindingContext.foo`);
   });
 
   it(`assigns defined property on first ancestor overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.parent.overrideContext.foo = 'bar';
-    foo.assign(scope, null, 'baz');
+    astAssign(foo, scope, null, 'baz');
     assert.strictEqual(scope.parent.overrideContext.foo, 'baz', `scope.parent.overrideContext.foo`);
-    $parentfoo.assign(scope, null, 'beep');
+    astAssign($parentfoo, scope, null, 'beep');
     assert.strictEqual(scope.parent.overrideContext.foo, 'beep', `scope.parent.overrideContext.foo`);
   });
 
   it(`connects defined property on first ancestor bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     let binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
     binding = new MockBinding();
-    $parentfoo.evaluate(scope, dummyLocator, binding);
+    astEvaluate($parentfoo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
   });
@@ -849,11 +852,11 @@ describe('AccessScopeExpression', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
     scope.parent.overrideContext.foo = 'bar';
     let binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'foo'], 'binding.calls[0]');
     binding = new MockBinding();
-    $parentfoo.evaluate(scope, dummyLocator, binding);
+    astEvaluate($parentfoo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'foo'], 'binding.calls[0]');
   });
@@ -862,7 +865,7 @@ describe('AccessScopeExpression', function () {
     const scope = createScopeForTest({ abc: 'xyz' }, {});
     (scope.parent as Writable<Scope>).parent = Scope.create({}, { foo: 'bar' });
     const binding = new MockBinding();
-    $parentfoo.evaluate(scope, dummyLocator, binding);
+    astEvaluate($parentfoo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
   });
@@ -879,24 +882,24 @@ describe('AccessThisExpression', function () {
     const c = { c: 'c' };
     const d = { d: 'd' };
     let scope: Scope = Scope.create(a);
-    assert.strictEqual($parent.evaluate(scope, null, null), undefined, `$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent.evaluate(scope, null, null), undefined, `$parent$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent$parent.evaluate(scope, null, null), undefined, `$parent$parent$parent.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate($parent, scope, null, null), undefined, `astEvaluate($parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent, scope, null, null), undefined, `astEvaluate($parent$parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent$parent, scope, null, null), undefined, `astEvaluate($parent$parent$parent, scope, null)`);
 
     scope = Scope.fromParent(Scope.create(b), a);
-    assert.strictEqual($parent.evaluate(scope, null, null), b, `$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent.evaluate(scope, null, null), undefined, `$parent$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent$parent.evaluate(scope, null, null), undefined, `$parent$parent$parent.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate($parent, scope, null, null), b, `astEvaluate($parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent, scope, null, null), undefined, `astEvaluate($parent$parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent$parent, scope, null, null), undefined, `astEvaluate($parent$parent$parent, scope, null)`);
 
     scope = Scope.fromParent(Scope.fromParent(Scope.create(c), b), a);
-    assert.strictEqual($parent.evaluate(scope, null, null), b, `$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent.evaluate(scope, null, null), c, `$parent$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent$parent.evaluate(scope, null, null), undefined, `$parent$parent$parent.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate($parent, scope, null, null), b, `astEvaluate($parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent, scope, null, null), c, `astEvaluate($parent$parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent$parent, scope, null, null), undefined, `astEvaluate($parent$parent$parent, scope, null)`);
 
     scope = Scope.fromParent(Scope.fromParent(Scope.fromParent(Scope.create(d), c), b), a);
-    assert.strictEqual($parent.evaluate(scope, null, null), b, `$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent.evaluate(scope, null, null), c, `$parent$parent.evaluate(scope, null)`);
-    assert.strictEqual($parent$parent$parent.evaluate(scope, null, null), d, `$parent$parent$parent.evaluate(scope, null)`);
+    assert.strictEqual(astEvaluate($parent, scope, null, null), b, `astEvaluate($parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent, scope, null, null), c, `astEvaluate($parent$parent, scope, null)`);
+    assert.strictEqual(astEvaluate($parent$parent$parent, scope, null, null), d, `astEvaluate($parent$parent$parent, scope, null)`);
   });
 });
 
@@ -904,7 +907,7 @@ describe('AssignExpression', function () {
   it('can chain assignments', function () {
     const foo = new AssignExpression(new AccessScopeExpression('foo', 0), new AccessScopeExpression('bar', 0));
     const scope = Scope.create({});
-    foo.assign(scope, null, 1);
+    astAssign(foo, scope, null, 1);
     assert.strictEqual(scope.bindingContext.foo, 1, `scope.overrideContext.foo`);
     assert.strictEqual(scope.bindingContext.bar, 1, `scope.overrideContext.bar`);
   });
@@ -917,7 +920,7 @@ describe('ConditionalExpression', function () {
     const no = new MockTracingExpression($obj);
     const sut = new ConditionalExpression(condition, yes as any, no as any);
 
-    sut.evaluate(null, null, null);
+    astEvaluate(sut, null, null, null);
     assert.strictEqual(yes.calls.length, 1, `yes.calls.length`);
     assert.strictEqual(no.calls.length, 0, `no.calls.length`);
   });
@@ -928,7 +931,7 @@ describe('ConditionalExpression', function () {
     const no = new MockTracingExpression($obj);
     const sut = new ConditionalExpression(condition, yes as any, no as any);
 
-    sut.evaluate(null, null, null);
+    astEvaluate(sut, null, null, null);
     assert.strictEqual(yes.calls.length, 0, `yes.calls.length`);
     assert.strictEqual(no.calls.length, 1, `no.calls.length`);
   });
@@ -939,7 +942,7 @@ describe('ConditionalExpression', function () {
     const no = new MockTracingExpression($obj);
     const sut = new ConditionalExpression(condition, yes as any, no as any);
 
-    sut.evaluate(null, dummyLocator, dummyBinding);
+    astEvaluate(sut, null, dummyLocator, dummyBinding);
     assert.strictEqual(yes.calls.length, 1, `yes.calls.length`);
     assert.strictEqual(no.calls.length, 0, `no.calls.length`);
   });
@@ -950,7 +953,7 @@ describe('ConditionalExpression', function () {
     const no = new MockTracingExpression($obj);
     const sut = new ConditionalExpression(condition, yes as any, no as any);
 
-    sut.evaluate(null, dummyLocator, dummyBinding);
+    astEvaluate(sut, null, dummyLocator, dummyBinding);
     assert.strictEqual(yes.calls.length, 0, `yes.calls.length`);
     assert.strictEqual(no.calls.length, 1, `no.calls.length`);
   });
@@ -960,89 +963,89 @@ describe('BinaryExpression', function () {
   it(`concats strings`, function () {
     let expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), new PrimitiveLiteralExpression('b'));
     let scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 'ab', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'ab', `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $null);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 'a', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'a', `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', $null, new PrimitiveLiteralExpression('b'));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 'b', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'b', `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $undefined);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 'a', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'a', `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression('b'));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 'b', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'b', `astEvaluate(expression, scope, null, null)`);
   });
 
   it(`adds numbers`, function () {
     let expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(2));
     let scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 3, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 3, `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), $null);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 1, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 1, `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', $null, new PrimitiveLiteralExpression(2));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, null, null), 2, `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 2, `astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), $undefined);
     scope = createScopeForTest({});
-    assert.strictEqual(isNaN(expression.evaluate(scope, null, null) as number), false, `isNaN(expression.evaluate(scope, null, null)`);
+    assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), false, `isNaN(astEvaluate(expression, scope, null, null)`);
 
     expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression(2));
     scope = createScopeForTest({});
-    assert.strictEqual(isNaN(expression.evaluate(scope, null, null) as number), false, `isNaN(expression.evaluate(scope, null, null)`);
+    assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), false, `isNaN(astEvaluate(expression, scope, null, null)`);
   });
 
   it(`concats strings - STRICT`, function () {
     let expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), new PrimitiveLiteralExpression('b'));
     let scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 'ab', `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 'ab', `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $null);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 'anull', `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 'anull', `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', $null, new PrimitiveLiteralExpression('b'));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 'nullb', `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 'nullb', `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $undefined);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 'aundefined', `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 'aundefined', `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression('b'));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 'undefinedb', `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 'undefinedb', `astEvaluate(expression, scope, { strict: true }, null)`);
   });
 
   it(`adds numbers - STRICT`, function () {
     let expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(2));
     let scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 3, `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 3, `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), $null);
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 1, `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 1, `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', $null, new PrimitiveLiteralExpression(2));
     scope = createScopeForTest({});
-    assert.strictEqual(expression.evaluate(scope, { strict: true }, null), 2, `expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, { strict: true }, null), 2, `astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), $undefined);
     scope = createScopeForTest({});
-    assert.strictEqual(isNaN(expression.evaluate(scope, { strict: true }, null) as number), true, `isNaN(expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(isNaN(astEvaluate(expression, scope, { strict: true }, null) as number), true, `isNaN(astEvaluate(expression, scope, { strict: true }, null)`);
 
     expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression(2));
     scope = createScopeForTest({});
-    assert.strictEqual(isNaN(expression.evaluate(scope, { strict: true }, null) as number), true, `isNaN(expression.evaluate(scope, { strict: true }, null)`);
+    assert.strictEqual(isNaN(astEvaluate(expression, scope, { strict: true }, null) as number), true, `isNaN(astEvaluate(expression, scope, { strict: true }, null)`);
   });
 
   class TestData {
@@ -1077,7 +1080,7 @@ describe('BinaryExpression', function () {
 
     for (const item of getTestData()) {
       it(item.toString(), function () {
-        assert.strictEqual(item.expr.evaluate(item.scope, null, null), item.expected, `expr.evaluate(scope, null, null)`);
+        assert.strictEqual(astEvaluate(item.expr, item.scope, null, null), item.expected, `astEvaluate(expr, scope, null, null)`);
       });
     }
   });
@@ -1145,7 +1148,7 @@ describe('BinaryExpression', function () {
 
     for (const item of getTestData()) {
       it(item.toString(), function () {
-        assert.strictEqual(item.expr.evaluate(item.scope, null, null), item.expected, `expr.evaluate(scope, null, null)`);
+        assert.strictEqual(astEvaluate(item.expr, item.scope, null, null), item.expected, `astEvaluate(expr, scope, null, null)`);
       });
     }
   });
@@ -1164,7 +1167,7 @@ describe('CallMemberExpression', function () {
       }
     };
     const scope = createScopeForTest(bindingContext);
-    assert.strictEqual(expression.evaluate(scope, null, null), 'baz', `expression.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 'baz', `astEvaluate(expression, scope, null, null)`);
     assert.strictEqual(callCount, 1, 'callCount');
   });
 
@@ -1173,9 +1176,9 @@ describe('CallMemberExpression', function () {
     const s1: Scope = createScopeForTest({ foo: {} });
     const s2: Scope = createScopeForTest({ foo: { bar: undefined } });
     const s3: Scope = createScopeForTest({ foo: { bar: null } });
-    assert.strictEqual(expression.evaluate(s1, null, null), undefined, `expression.evaluate(createScopeForTest({ foo: {} }), null, null)`);
-    assert.strictEqual(expression.evaluate(s2, null, null), undefined, `expression.evaluate(createScopeForTest({ foo: { bar: undefined } }), null, null)`);
-    assert.strictEqual(expression.evaluate(s3, null, null), undefined, `expression.evaluate(createScopeForTest({ foo: { bar: null } }), null, null)`);
+    assert.strictEqual(astEvaluate(expression, s1, null, null), undefined, `astEvaluate(expression, createScopeForTest({ foo: {} }), null, null)`);
+    assert.strictEqual(astEvaluate(expression, s2, null, null), undefined, `astEvaluate(expression, createScopeForTest({ foo: { bar: undefined } }), null, null)`);
+    assert.strictEqual(astEvaluate(expression, s3, null, null), undefined, `astEvaluate(expression, createScopeForTest({ foo: { bar: null } }), null, null)`);
   });
 
   it(`evaluate throws when mustEvaluate and member is null or undefined`, function () {
@@ -1184,10 +1187,10 @@ describe('CallMemberExpression', function () {
     const s2 = createScopeForTest({ foo: {} });
     const s3 = createScopeForTest({ foo: { bar: undefined } });
     const s4 = createScopeForTest({ foo: { bar: null } });
-    assert.throws(() => expression.evaluate(s1, { strictFnCall: true }, null));
-    assert.throws(() => expression.evaluate(s2, { strictFnCall: true }, null));
-    assert.throws(() => expression.evaluate(s3, { strictFnCall: true }, null));
-    assert.throws(() => expression.evaluate(s4, { strictFnCall: true }, null));
+    assert.throws(() => astEvaluate(expression, s1, { strictFnCall: true }, null));
+    assert.throws(() => astEvaluate(expression, s2, { strictFnCall: true }, null));
+    assert.throws(() => astEvaluate(expression, s3, { strictFnCall: true }, null));
+    assert.throws(() => astEvaluate(expression, s4, { strictFnCall: true }, null));
   });
 });
 
@@ -1201,8 +1204,8 @@ describe('CallScopeExpression', function () {
 
   it(`evaluates defined property on bindingContext`, function () {
     const [scope] = getScopes(createScopeForTest({ foo: () => 'bar', hello: arg => arg, arg: 'world' }));
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
-    assert.strictEqual(hello.evaluate(scope, null, null), 'world', `hello.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
+    assert.strictEqual(astEvaluate(hello, scope, null, null), 'world', `astEvaluate(hello, scope, null, null)`);
   });
 
   it(`evaluates defined property on overrideContext`, function () {
@@ -1211,16 +1214,16 @@ describe('CallScopeExpression', function () {
     s.overrideContext.hello = arg => arg;
     s.overrideContext.arg = 'world';
     const [scope] = getScopes(s);
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
-    assert.strictEqual(hello.evaluate(scope, null, null), 'world', `hello.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
+    assert.strictEqual(astEvaluate(hello, scope, null, null), 'world', `astEvaluate(hello, scope, null, null)`);
   });
 
   it(`evaluate with connects defined property on bindingContext`, function () {
     const [scope] = getScopes(createScopeForTest({ foo: () => 'bar' }));
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
-    hello.evaluate(scope, dummyLocator, binding);
+    astEvaluate(hello, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'arg'], 'binding.calls[0]');
   });
@@ -1232,9 +1235,9 @@ describe('CallScopeExpression', function () {
     s1.overrideContext.arg = 'world';
     const [scope] = getScopes(s1);
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
-    hello.evaluate(scope, dummyLocator, binding);
+    astEvaluate(hello, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.overrideContext, 'arg'], 'binding.calls[0]');
   });
@@ -1242,17 +1245,17 @@ describe('CallScopeExpression', function () {
   it(`connects undefined property on bindingContext`, function () {
     const [scope] = getScopes(createScopeForTest({ abc: 'xyz' }));
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
-    hello.evaluate(scope, dummyLocator, binding);
+    astEvaluate(hello, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.bindingContext, 'arg'], 'binding.calls[0]');
   });
 
   it(`evaluates defined property on first ancestor bindingContext`, function () {
     const [scope] = getScopes(createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' }));
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
-    assert.strictEqual(hello.evaluate(scope, null, null), 'world', `hello.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
+    assert.strictEqual(astEvaluate(hello, scope, null, null), 'world', `astEvaluate(hello, scope, null, null)`);
   });
 
   it(`evaluates defined property on first ancestor overrideContext`, function () {
@@ -1261,16 +1264,16 @@ describe('CallScopeExpression', function () {
     s1.parent.overrideContext.hello = arg => arg;
     s1.parent.overrideContext.arg = 'world';
     const [scope] = getScopes(s1);
-    assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
-    assert.strictEqual(hello.evaluate(scope, null, null), 'world', `hello.evaluate(scope, null, null)`);
+    assert.strictEqual(astEvaluate(foo, scope, null, null), 'bar', `astEvaluate(foo, scope, null, null)`);
+    assert.strictEqual(astEvaluate(hello, scope, null, null), 'world', `astEvaluate(hello, scope, null, null)`);
   });
 
   it(`connects defined property on first ancestor bindingContext`, function () {
     const [scope] = getScopes(createScopeForTest({ abc: 'xyz' }, { foo: () => 'bar', hello: arg => arg, arg: 'world' }));
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
-    hello.evaluate(scope, dummyLocator, binding);
+    astEvaluate(hello, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'arg'], 'binding.calls[0]');
   });
@@ -1282,9 +1285,9 @@ describe('CallScopeExpression', function () {
     s1.parent.overrideContext.arg = 'world';
     const [scope] = getScopes(s1);
     const binding = new MockBinding();
-    foo.evaluate(scope, dummyLocator, binding);
+    astEvaluate(foo, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
-    hello.evaluate(scope, dummyLocator, binding);
+    astEvaluate(hello, scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
     assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'arg'], 'binding.calls[0]');
   });
@@ -1402,7 +1405,7 @@ describe('LiteralTemplate', function () {
   for (const item of getTestData()) {
     const $it = item.only ? it.only : it;
     $it(`${item.expr} evaluates ${item.expected}`, function () {
-      assert.strictEqual(item.expr.evaluate(item.scope, null, null), item.expected, `expr.evaluate(scope, null, null)`);
+      assert.strictEqual(astEvaluate(item.expr, item.scope, null, null), item.expected, `astEvaluate(item.expr, scope, null, null)`);
     });
   }
 });
@@ -1426,7 +1429,7 @@ describe('UnaryExpression', function () {
 
     for (const { expr, expected } of tests) {
       it(expr.toString(), function () {
-        assert.strictEqual(expr.evaluate(scope, null, null), expected, `expr.evaluate(scope, null)`);
+        assert.strictEqual(astEvaluate(expr, scope, null, null), expected, `astEvaluate(expr, scope, null)`);
       });
     }
   });
@@ -1449,7 +1452,7 @@ describe('UnaryExpression', function () {
 
     for (const { expr } of tests) {
       it(expr.toString(), function () {
-        assert.strictEqual(expr.evaluate(scope, null, null), undefined, `expr.evaluate(scope, null)`);
+        assert.strictEqual(astEvaluate(expr, scope, null, null), undefined, `astEvaluate(expr, scope, null)`);
       });
     }
 
@@ -1458,7 +1461,7 @@ describe('UnaryExpression', function () {
       const foo = () => (fooCalled = true);
       scope = createScopeForTest({ foo });
       const expr = new UnaryExpression('void', new CallScopeExpression('foo', [], 0));
-      assert.strictEqual(expr.evaluate(scope, null, null), undefined, `expr.evaluate(scope, null)`);
+      assert.strictEqual(astEvaluate(expr, scope, null, null), undefined, `astEvaluate(expr, scope, null)`);
       assert.strictEqual(fooCalled, true, `fooCalled`);
     });
   });
@@ -1470,165 +1473,165 @@ describe('DestructuringAssignmentExpression', function () {
 
     it('{a} = {a:42}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'a'),
         void 0,
-      ).assign(Scope.create(bc), null, { a: 42 });
+      ), Scope.create(bc), null, { a: 42 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('{1:a} = {1:"42"}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, '1'),
         void 0,
-      ).assign(Scope.create(bc), null, { 1: '42' });
+      ), Scope.create(bc), null, { 1: '42' });
       assert.strictEqual(bc.a, '42');
     });
 
     it('{x:a} = {x:"42"}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'x'),
         void 0,
-      ).assign(Scope.create(bc), null, { x: '42' });
+      ), Scope.create(bc), null, { x: '42' });
       assert.strictEqual(bc.a, '42');
     });
 
     it('{a=42} = {b:404}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'a'),
         new PrimitiveLiteralExpression(42),
-      ).assign(Scope.create(bc), null, { b: 404 });
+      ), Scope.create(bc), null, { b: 404 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('{1:a=42} = {2:"404"}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, '1'),
         new PrimitiveLiteralExpression(42),
-      ).assign(Scope.create(bc), null, { 2: "404" });
+      ), Scope.create(bc), null, { 2: "404" });
       assert.strictEqual(bc.a, 42);
     });
 
     it('{x:a=42} = {b:404}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'x'),
         new PrimitiveLiteralExpression(42),
-      ).assign(Scope.create(bc), null, { b: 404 });
+      ), Scope.create(bc), null, { b: 404 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('{a=404} = {a:42}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'a'),
         new PrimitiveLiteralExpression(404),
-      ).assign(Scope.create(bc), null, { a: 42 });
+      ), Scope.create(bc), null, { a: 42 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('{1:a=404} = {1:"42"}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, '1'),
         new PrimitiveLiteralExpression(404),
-      ).assign(Scope.create(bc), null, { 1: '42' });
+      ), Scope.create(bc), null, { 1: '42' });
       assert.strictEqual(bc.a, '42');
     });
 
     it('{x:a=404} = {x:"42"}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'x'),
         new PrimitiveLiteralExpression(404),
-      ).assign(Scope.create(bc), null, { x: '42' });
+      ), Scope.create(bc), null, { x: '42' });
       assert.strictEqual(bc.a, '42');
     });
 
     it('[a] = [42]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessKeyedExpression($this, new PrimitiveLiteralExpression(0)),
         void 0,
-      ).assign(Scope.create(bc), null, [42]);
+      ), Scope.create(bc), null, [42]);
       assert.strictEqual(bc.a, 42);
     });
 
     it('[a=42] = []', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessKeyedExpression($this, new PrimitiveLiteralExpression(0)),
         new PrimitiveLiteralExpression(42),
-      ).assign(Scope.create(bc), null, []);
+      ), Scope.create(bc), null, []);
       assert.strictEqual(bc.a, 42);
     });
 
     it('[,a=42] = [404]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessKeyedExpression($this, new PrimitiveLiteralExpression(1)),
         new PrimitiveLiteralExpression(42),
-      ).assign(Scope.create(bc), null, [404]);
+      ), Scope.create(bc), null, [404]);
       assert.strictEqual(bc.a, 42);
     });
 
     it('{a=vm_prop} = {x:404}', function () {
       const ps = Scope.create({ prop: 42 });
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'a'),
         new AccessScopeExpression('prop', 0),
-      ).assign(Scope.fromParent(ps, bc), null, { x: 404 });
+      ), Scope.fromParent(ps, bc), null, { x: 404 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('[,a=vm_prop] = [404]', function () {
       const ps = Scope.create({ prop: 42 });
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessKeyedExpression($this, new PrimitiveLiteralExpression(1)),
         new AccessScopeExpression('prop', 0),
-      ).assign(Scope.fromParent(ps, bc), null, [404]);
+      ), Scope.fromParent(ps, bc), null, [404]);
       assert.strictEqual(bc.a, 42);
     });
 
     it('{a=$parent.vm_prop} = {x:404}', function () {
       const ps = Scope.create({ prop: 42 });
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessMemberExpression($this, 'a'),
         new AccessScopeExpression('prop', 2),
-      ).assign(Scope.fromParent(Scope.fromParent(ps, Object.create(null)), bc), null, { x: 404 });
+      ), Scope.fromParent(Scope.fromParent(ps, Object.create(null)), bc), null, { x: 404 });
       assert.strictEqual(bc.a, 42);
     });
 
     it('[,a=$parent.vm_prop] = [404]', function () {
       const ps = Scope.create({ prop: 42 });
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentSingleExpression(
+      astAssign(new DestructuringAssignmentSingleExpression(
         new AccessMemberExpression($this, 'a'),
         new AccessKeyedExpression($this, new PrimitiveLiteralExpression(1)),
         new AccessScopeExpression('prop', 2),
-      ).assign(Scope.fromParent(Scope.fromParent(ps, Object.create(null)), bc), null, [404]);
+      ), Scope.fromParent(Scope.fromParent(ps, Object.create(null)), bc), null, [404]);
       assert.strictEqual(bc.a, 42);
     });
   });
@@ -1637,64 +1640,64 @@ describe('DestructuringAssignmentExpression', function () {
 
     it('{...rest} = {a:1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         [],
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc, { rest: { a: 1, b: 2 } });
     });
 
     it('{a, ...rest} = {a:1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         ['a'],
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc, { rest: { b: 2 } });
     });
 
     it('{a, b, ...rest} = {a:1, b:2, c:3}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         ['a', 'b'],
-      ).assign(Scope.create(bc), null, { a: 1, b: 2, c: 3 });
+      ), Scope.create(bc), null, { a: 1, b: 2, c: 3 });
       assert.deepStrictEqual(bc, { rest: { c: 3 } });
     });
 
     it('{a, b, ...rest} = {a:1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         ['a', 'b'],
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc, { rest: {} });
     });
 
     it('[...rest] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         0,
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { rest: [1, 2] });
     });
 
     it('[,...rest] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         1,
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { rest: [2] });
     });
 
     it('[,,...rest] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentRestExpression(
+      astAssign(new DestructuringAssignmentRestExpression(
         new AccessMemberExpression($this, 'rest'),
         3,
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { rest: [] });
     });
   });
@@ -1703,7 +1706,7 @@ describe('DestructuringAssignmentExpression', function () {
 
     it('{a} = {a: 1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1714,13 +1717,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc, { a: 1 });
     });
 
     it('{a, b} = {a: 1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1736,13 +1739,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc, { a: 1, b: 2 });
     });
 
     it('{...rest} = {a: 1, b:2}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentRestExpression(
@@ -1752,13 +1755,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, { a: 1, b: 2 });
+      ), Scope.create(bc), null, { a: 1, b: 2 });
       assert.deepStrictEqual(bc.rest, { a: 1, b: 2 });
     });
 
     it('[a] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1769,13 +1772,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { a: 1 });
     });
 
     it('[a, b] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1791,13 +1794,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { a: 1, b: 2 });
     });
 
     it('[...rest] = [1, 2]', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentRestExpression(
@@ -1807,13 +1810,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0
-      ).assign(Scope.create(bc), null, [1, 2]);
+      ), Scope.create(bc), null, [1, 2]);
       assert.deepStrictEqual(bc, { rest: [1, 2] });
     });
 
     it('{prop1, prop2:{prop21}} = {prop1: "foo", prop2: {prop21: 123}}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1836,13 +1839,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-      ).assign(Scope.create(bc), null, { prop1: 'foo', prop2: { prop21: 123 } });
+      ), Scope.create(bc), null, { prop1: 'foo', prop2: { prop21: 123 } });
       assert.deepStrictEqual(bc, { prop1: 'foo', prop21: 123 });
     });
 
     it('{prop1, prop2:{prop21:{prop212:newProp212}, prop22}} = {prop1: "foo", prop2: {prop21: {prop211: 123, prop212: 456}, prop22: "bar" }}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1877,13 +1880,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-      ).assign(Scope.create(bc), null, { prop1: 'foo', prop2: { prop21: { prop211: 123, prop212: 456 }, prop22: 'bar' } });
+      ), Scope.create(bc), null, { prop1: 'foo', prop2: { prop21: { prop211: 123, prop212: 456 }, prop22: 'bar' } });
       assert.deepStrictEqual(bc, { prop1: 'foo', newProp212: 456, prop22: 'bar' });
     });
 
     it('{prop1,coll:[,{p2:item2p2}]} = {prop1:"foo",coll:[{p1:1,p2:2},{p1:3,p2:4}]}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1913,13 +1916,13 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-        ).assign(Scope.create(bc), null, { prop1: 'foo', coll: [{ p1: 1, p2: 2 }, { p1: 3, p2: 4 }] });
+        ), Scope.create(bc), null, { prop1: 'foo', coll: [{ p1: 1, p2: 2 }, { p1: 3, p2: 4 }] });
       assert.deepStrictEqual(bc, { prop1: 'foo', item2p2: 4 });
     });
 
     it('{prop1,coll:[,{p:[item21]}]} = {prop1:"foo",coll:[{p:[1,2]},{p:[3,4]}]}', function () {
       const bc: Record<string, any> = {};
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1956,14 +1959,14 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-      ).assign(Scope.create(bc), null, { prop1: "foo", coll: [{ p: [1, 2] }, { p: [3, 4] }] });
+      ), Scope.create(bc), null, { prop1: "foo", coll: [{ p: [1, 2] }, { p: [3, 4] }] });
       assert.deepStrictEqual(bc, { prop1: 'foo', item21: 3 });
     });
 
     it('[k, {prop1, prop2:{prop21}}] = ["key",{prop1: "foo", prop2: {prop21: 123}}]', function () {
       const bc: Record<string, any> = {};
 
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ArrayDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -1998,14 +2001,14 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-        ).assign(Scope.create(bc), null, ['key', { prop1: 'foo', prop2: { prop21: 123 } }]);
+        ), Scope.create(bc), null, ['key', { prop1: 'foo', prop2: { prop21: 123 } }]);
       assert.deepStrictEqual(bc, { k: 'key', prop1: 'foo', prop21: 123 });
     });
 
     it('[k, [,item2]] = ["key",[1,2]]', function () {
       const bc: Record<string, any> = {};
 
-      new DestructuringAssignmentExpression(
+      astAssign(new DestructuringAssignmentExpression(
         ExpressionKind.ArrayDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -2028,14 +2031,14 @@ describe('DestructuringAssignmentExpression', function () {
         ],
         void 0,
         void 0,
-        ).assign(Scope.create(bc), null, ['key', [1,2]]);
+        ), Scope.create(bc), null, ['key', [1,2]]);
       assert.deepStrictEqual(bc, { k: 'key', item2: 2 });
     });
 
     it('{a,b:{c}={c:42}} = {a:42}', function () {
       const bc: Record<string, any> = {};
 
-      new DestructuringAssignmentExpression(
+      const expr = new DestructuringAssignmentExpression(
         ExpressionKind.ObjectDestructuring,
         [
           new DestructuringAssignmentSingleExpression(
@@ -2050,15 +2053,16 @@ describe('DestructuringAssignmentExpression', function () {
                 new AccessMemberExpression($this, 'c'),
                 new AccessMemberExpression($this, 'c'),
                 void 0
-                )
+              )
             ],
             new AccessMemberExpression($this, 'b'),
-            new ObjectLiteralExpression(['c'], [new PrimitiveLiteralExpression(42)]),
+            new ObjectLiteralExpression(['c'], [new PrimitiveLiteralExpression(42)])
           )
         ],
         void 0,
-        void 0,
-        ).assign(Scope.create(bc), null, {a:42});
+        void 0
+      );
+      astAssign(expr, Scope.create(bc), null, {a:42});
       assert.deepStrictEqual(bc, { a:42, c:42});
     });
   });

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -1048,6 +1048,66 @@ describe('BinaryExpression', function () {
     assert.strictEqual(isNaN(astEvaluate(expression, scope, { strict: true }, null) as number), true, `isNaN(astEvaluate(expression, scope, { strict: true }, null)`);
   });
 
+  it('handles 1 >= 1', function () {
+    const expression = new BinaryExpression('>=', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), true);
+  });
+
+  it('handles 2 >= 1', function () {
+    const expression = new BinaryExpression('>=', new PrimitiveLiteralExpression(2), new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), true);
+  });
+
+  it('handles 1 >= 2', function () {
+    const expression = new BinaryExpression('>=', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(2));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), false);
+  });
+
+  it('handles 1 <= 1', function () {
+    const expression = new BinaryExpression('<=', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), true);
+  });
+
+  it('handles 2 <= 1', function () {
+    const expression = new BinaryExpression('<=', new PrimitiveLiteralExpression(2), new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), false);
+  });
+
+  it('handles 1 <= 2', function () {
+    const expression = new BinaryExpression('<=', new PrimitiveLiteralExpression(1), new PrimitiveLiteralExpression(2));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), true);
+  });
+
+  it('handles undefined ?? 1', function () {
+    const expression = new BinaryExpression('??', PrimitiveLiteralExpression.$undefined, new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 1);
+  });
+
+  it('handles null ?? 1', function () {
+    const expression = new BinaryExpression('??', PrimitiveLiteralExpression.$null, new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 1);
+  });
+
+  it('handles false ?? 1', function () {
+    const expression = new BinaryExpression('??', PrimitiveLiteralExpression.$false, new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), false);
+  });
+
+  it('handles 0 ?? 1', function () {
+    const expression = new BinaryExpression('??', new PrimitiveLiteralExpression(0), new PrimitiveLiteralExpression(1));
+    const scope = createScopeForTest({ });
+    assert.strictEqual(astEvaluate(expression, scope, null, null), 0);
+  });
+
   class TestData {
     public constructor(
       public expr: BinaryExpression,

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -40,6 +40,7 @@ import {
   ArrowFunction,
   BindingIdentifier,
   IAstEvaluator,
+  Unparser,
 } from '@aurelia/runtime';
 
 const $false = PrimitiveLiteralExpression.$false;
@@ -2067,28 +2068,28 @@ describe('DestructuringAssignmentExpression', function () {
 describe('arrow function unparsing', function () {
   it('unparses arrow fn', function () {
     assert.strictEqual(
-      new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a')).toString(),
+      Unparser.unparse(new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a'))),
       '(a) => a'
     );
   });
 
   it('unparses arrow fn with single rest parameter', function () {
     assert.strictEqual(
-      new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a'), true).toString(),
+      Unparser.unparse(new ArrowFunction([new BindingIdentifier('a')], new AccessScopeExpression('a'), true)),
       '(...a) => a'
     );
   });
 
   it('unparses arrow fn with 2 params', function () {
     assert.strictEqual(
-      new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a')).toString(),
+      Unparser.unparse(new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a'))),
       '(a, b) => a'
     );
   });
 
   it('unparses arrow fn with 2 params with rest', function () {
     assert.strictEqual(
-      new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a'), true).toString(),
+      Unparser.unparse(new ArrowFunction([new BindingIdentifier('a'), new BindingIdentifier('b')], new AccessScopeExpression('a'), true)),
       '(a, ...b) => a'
     );
   });

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -811,7 +811,7 @@ describe('AccessScopeExpression', function () {
 
   it(`evaluates defined property on first ancestor overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
-    scope.parentScope.overrideContext.foo = 'bar';
+    scope.parent.overrideContext.foo = 'bar';
     assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(LF.none, scope, null)`);
     assert.strictEqual($parentfoo.evaluate(scope, null, null), 'bar', `$parentfoo.evaluate(LF.none, scope, null)`);
   });
@@ -819,18 +819,18 @@ describe('AccessScopeExpression', function () {
   it(`assigns defined property on first ancestor bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { foo: 'bar' });
     foo.assign(scope, null, 'baz');
-    assert.strictEqual(scope.parentScope.bindingContext.foo, 'baz', `scope.parentScope.bindingContext.foo`);
+    assert.strictEqual(scope.parent.bindingContext.foo, 'baz', `scope.parent.bindingContext.foo`);
     $parentfoo.assign(scope, null, 'beep');
-    assert.strictEqual(scope.parentScope.bindingContext.foo, 'beep', `scope.parentScope.bindingContext.foo`);
+    assert.strictEqual(scope.parent.bindingContext.foo, 'beep', `scope.parent.bindingContext.foo`);
   });
 
   it(`assigns defined property on first ancestor overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
-    scope.parentScope.overrideContext.foo = 'bar';
+    scope.parent.overrideContext.foo = 'bar';
     foo.assign(scope, null, 'baz');
-    assert.strictEqual(scope.parentScope.overrideContext.foo, 'baz', `scope.parentScope.overrideContext.foo`);
+    assert.strictEqual(scope.parent.overrideContext.foo, 'baz', `scope.parent.overrideContext.foo`);
     $parentfoo.assign(scope, null, 'beep');
-    assert.strictEqual(scope.parentScope.overrideContext.foo, 'beep', `scope.parentScope.overrideContext.foo`);
+    assert.strictEqual(scope.parent.overrideContext.foo, 'beep', `scope.parent.overrideContext.foo`);
   });
 
   it(`connects defined property on first ancestor bindingContext`, function () {
@@ -838,33 +838,33 @@ describe('AccessScopeExpression', function () {
     let binding = new MockBinding();
     foo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.bindingContext, 'foo'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
     binding = new MockBinding();
     $parentfoo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.bindingContext, 'foo'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
   });
 
   it(`connects defined property on first ancestor overrideContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
-    scope.parentScope.overrideContext.foo = 'bar';
+    scope.parent.overrideContext.foo = 'bar';
     let binding = new MockBinding();
     foo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.overrideContext, 'foo'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'foo'], 'binding.calls[0]');
     binding = new MockBinding();
     $parentfoo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.overrideContext, 'foo'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'foo'], 'binding.calls[0]');
   });
 
   it(`connects undefined property on first ancestor bindingContext`, function () {
     const scope = createScopeForTest({ abc: 'xyz' }, {});
-    (scope.parentScope as Writable<Scope>).parentScope = Scope.create({}, { foo: 'bar' });
+    (scope.parent as Writable<Scope>).parent = Scope.create({}, { foo: 'bar' });
     const binding = new MockBinding();
     $parentfoo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.bindingContext, 'foo'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'foo'], 'binding.calls[0]');
   });
 
 });
@@ -1257,9 +1257,9 @@ describe('CallScopeExpression', function () {
 
   it(`evaluates defined property on first ancestor overrideContext`, function () {
     const s1 = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
-    s1.parentScope.overrideContext.foo = () => 'bar';
-    s1.parentScope.overrideContext.hello = arg => arg;
-    s1.parentScope.overrideContext.arg = 'world';
+    s1.parent.overrideContext.foo = () => 'bar';
+    s1.parent.overrideContext.hello = arg => arg;
+    s1.parent.overrideContext.arg = 'world';
     const [scope] = getScopes(s1);
     assert.strictEqual(foo.evaluate(scope, null, null), 'bar', `foo.evaluate(scope, null, null)`);
     assert.strictEqual(hello.evaluate(scope, null, null), 'world', `hello.evaluate(scope, null, null)`);
@@ -1272,21 +1272,21 @@ describe('CallScopeExpression', function () {
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
     hello.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.bindingContext, 'arg'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.bindingContext, 'arg'], 'binding.calls[0]');
   });
 
   it(`connects defined property on first ancestor overrideContext`, function () {
     const s1 = createScopeForTest({ abc: 'xyz' }, { def: 'rsw' });
-    s1.parentScope.overrideContext.foo = () => 'bar';
-    s1.parentScope.overrideContext.hello = arg => arg;
-    s1.parentScope.overrideContext.arg = 'world';
+    s1.parent.overrideContext.foo = () => 'bar';
+    s1.parent.overrideContext.hello = arg => arg;
+    s1.parent.overrideContext.arg = 'world';
     const [scope] = getScopes(s1);
     const binding = new MockBinding();
     foo.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.filter(c => c[0] === 'observe').length, 0, `binding.calls.filter(c => c[0] === 'observe').length`);
     hello.evaluate(scope, dummyLocator, binding);
     assert.strictEqual(binding.calls.length, 1, 'binding.calls.length');
-    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parentScope.overrideContext, 'arg'], 'binding.calls[0]');
+    assert.deepStrictEqual(binding.calls[0], ['observe', scope.parent.overrideContext, 'arg'], 'binding.calls[0]');
   });
 });
 

--- a/packages/__tests__/2-runtime/binding-context.spec.ts
+++ b/packages/__tests__/2-runtime/binding-context.spec.ts
@@ -14,7 +14,7 @@ describe('Scope', function () {
       const actual = Scope.create(bindingContext, undefined);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.instanceOf(actual.overrideContext, Object, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope, null, `actual.parentScope`);
+      assert.strictEqual(actual.parent, null, `actual.parent`);
     });
 
     it('{}, null', function () {
@@ -22,7 +22,7 @@ describe('Scope', function () {
       const actual = Scope.create(bindingContext, null);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.instanceOf(actual.overrideContext, Object, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope, null, `actual.parentScope`);
+      assert.strictEqual(actual.parent, null, `actual.parent`);
     });
 
     it('{}, {}', function () {
@@ -31,7 +31,7 @@ describe('Scope', function () {
       const actual = Scope.create(bindingContext, overrideContext);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.strictEqual(actual.overrideContext, overrideContext, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope, null, `actual.parentScope`);
+      assert.strictEqual(actual.parent, null, `actual.parent`);
     });
 
     it('{}, { bindingContext }', function () {
@@ -40,7 +40,7 @@ describe('Scope', function () {
       const actual = Scope.create(bindingContext, overrideContext);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.strictEqual(actual.overrideContext, overrideContext, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope, null, `actual.parentScope`);
+      assert.strictEqual(actual.parent, null, `actual.parent`);
     });
   });
 
@@ -59,7 +59,7 @@ describe('Scope', function () {
       const actual = Scope.fromParent(parentScope, bindingContext);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.instanceOf(actual.overrideContext, Object, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope.overrideContext, undefined, `actual.parentScope.overrideContext`);
+      assert.strictEqual(actual.parent.overrideContext, undefined, `actual.parent.overrideContext`);
     });
 
     it('{}, { overrideContext }', function () {
@@ -69,7 +69,7 @@ describe('Scope', function () {
       const actual = Scope.fromParent(parentScope, bindingContext);
       assert.strictEqual(actual.bindingContext, bindingContext, `actual.bindingContext`);
       assert.instanceOf(actual.overrideContext, Object, `actual.overrideContext`);
-      assert.strictEqual(actual.parentScope.overrideContext, overrideContext, `actual.parentScope.overrideContext`);
+      assert.strictEqual(actual.parent.overrideContext, overrideContext, `actual.parent.overrideContext`);
     });
   });
 

--- a/packages/__tests__/2-runtime/subscriber-collection.spec.ts
+++ b/packages/__tests__/2-runtime/subscriber-collection.spec.ts
@@ -124,12 +124,11 @@ describe('2-runtime/subscriber-collection.spec.ts', function () {
 
     let removalCount = 0;
     for (let i = 4, ii = subscribers.length; ii > i; i += 5) {
-      const result = observer.subs.remove(subscribers[i]);
-      if (result) {
-        removalCount++;
-      }
+      observer.subs.remove(subscribers[i]);
+      removalCount++;
     }
-    assert.strictEqual(observer['subs']['sr'].length, subscribers.length - 3 - removalCount, `observer['subs']['_sr'].length`);
+    assert.strictEqual(removalCount, 20);
+    assert.strictEqual(observer.subs.count, subscribers.length - removalCount, `observer.subs.count`);
 
     assert.strictEqual(observer.subs.remove({} as any), false, `observer.subs.remove({} as any)`);
   });

--- a/packages/__tests__/3-runtime-html/has-multi-bindings.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/has-multi-bindings.unit.spec.ts
@@ -1,4 +1,4 @@
-import { Char } from '../util';
+import { Char } from '../util.js';
 import { assert } from '@aurelia/testing';
 
 describe('[UNIT]3-runtime-html/has-multi-bindings.unit.spec.ts', function () {

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -13,6 +13,7 @@ import {
   BindingIdentifier,
   PrimitiveLiteralExpression,
   IExpressionParser,
+  ExpressionKind,
 } from '@aurelia/runtime';
 import {
   bindable,
@@ -41,6 +42,7 @@ import {
   attributePattern,
   PropertyBindingInstruction,
   InterpolationInstruction,
+  InstructionType,
 } from '@aurelia/runtime-html';
 import {
   assert,
@@ -1070,13 +1072,15 @@ describe(`TemplateCompiler - combinations`, function () {
           ),
           instructions: [[
             {
+              "type": InstructionType.interpolation,
               "from": {
+                '$kind': ExpressionKind.Interpolation,
                 "parts": ["abc-",""],
                 "expressions": [
-                  {"name":"value","ancestor":0}
+                  {"$kind":ExpressionKind.AccessScope,"name":"value","ancestor":0}
                 ],
                 "isMulti": false,
-                "firstExpression": {"name":"value","ancestor":0}
+                "firstExpression": { "$kind": ExpressionKind.AccessScope, "name":"value","ancestor":0}
               },
               "to":"class"
             }

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -27,6 +27,8 @@ module.exports =
   if (browsers.length !== 1) {
     browsers = ['Chrome'];
   }
+  const isFirefox = /firefox/i.test(browsers.toString());
+
   const baseUrl = 'packages/__tests__/dist/esm/__tests__';
 
   const testFilePatterns = cliArgs.length > 0
@@ -93,8 +95,8 @@ module.exports =
       { type: 'module', watched: false,         included: false, nocache: false,  pattern: `packages/__tests__/${name}/**/*.ts` }, // 2.4
     ]),
     ...packageNames.flatMap(name => [
-      { type: 'module', watched: !hasSingleRun, included: false, nocache: false,  pattern: `packages/${name}/dist/esm/index.mjs` }, // 3.1
-      { type: 'module', watched: false,         included: false, nocache: false,  pattern: `packages/${name}/dist/esm/index.mjs.map` }, // 3.2
+      { type: 'module', watched: !hasSingleRun, included: false, nocache: !process.env.CI && !isFirefox,   pattern: `packages/${name}/dist/esm/index.mjs` }, // 3.1
+      { type: 'module', watched: false,         included: false, nocache: !process.env.CI && !isFirefox,   pattern: `packages/${name}/dist/esm/index.mjs.map` }, // 3.2
       { type: 'module', watched: false,         included: false, nocache: true,   pattern: `packages/${name}/src/**/*.ts` }, // 3.3
     ]),
     // for i18n tests 
@@ -114,7 +116,12 @@ module.exports =
       if (/__tests__|testing|node_modules/.test(file.pattern) || !config.coverage) {
         p[file.pattern] = ['aurelia'];
       } else {
-        p[file.pattern] = ['aurelia', 'karma-coverage-istanbul-instrumenter'];
+        p[file.pattern] = process.env.CI || isFirefox
+          ? ['aurelia', 'karma-coverage-istanbul-instrumenter']
+          : [
+            ...(/packages\/[a-z]+\/dist\/esm\/index\.mjs(\.map)?$/.test(file.pattern) ? [] : ['aurelia']),
+            'karma-coverage-istanbul-instrumenter'
+          ];
       }
     }
     return p;
@@ -212,19 +219,24 @@ module.exports =
             response.end('');
             return;
           }
-          // const cachedCode = resourceCache[requestUrl];
-          // if (cachedCode != null) {
-          //   response.setHeader('Content-Type', mimetypes.js);
-          //   response.end(cachedCode);
-          //   return;
-          // }
-          // const maybeFilePath = path.resolve(basePath, requestUrl.replace('/base/', '') + '.js');
-          // if (fs.existsSync(maybeFilePath)) {
-          //   const jsCode = resourceCache[requestUrl] = fs.readFileSync(maybeFilePath, { encoding: 'utf-8' });
-          //   response.setHeader('Content-Type', mimetypes.js);
-          //   response.end(jsCode);
-          //   return;
-          // }
+
+          if (process.env.CI || isFirefox) {
+            next();
+            return;
+          }
+          const cachedCode = resourceCache[requestUrl];
+          if (cachedCode != null) {
+            response.setHeader('Content-Type', mimetypes.js);
+            response.end(cachedCode);
+            return;
+          }
+          const maybeFilePath = path.resolve(basePath, requestUrl.replace('/base/', '').replace(/(\.js)?$/, '.js'));
+          if (fs.existsSync(maybeFilePath)) {
+            const jsCode = resourceCache[requestUrl] = fs.readFileSync(maybeFilePath, { encoding: 'utf-8' });
+            response.setHeader('Content-Type', mimetypes.js);
+            response.end(jsCode);
+            return;
+          }
 
           next();
         }

--- a/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/validation-html/validate-binding-behavior.spec.ts
@@ -5,6 +5,7 @@ import {
   IBinding,
   IObserverLocator,
   Scope,
+  Unparser,
 } from '@aurelia/runtime';
 import {
   bindable,
@@ -324,7 +325,7 @@ describe('validation-html/validate-binding-behavior.spec.ts/validate-binding-beh
 
     const binding = bindings[0];
     assert.equal(binding.target, target);
-    assert.equal(binding.ast.expression.toString(), rawExpression);
+    assert.equal(Unparser.unparse(binding.ast.expression), rawExpression);
   }
 
   async function assertEventHandler(target: HTMLElement, event: 'change' | 'blur' | 'focusout', callCount: number, platform: IPlatform, validateBindingSpy: ISpy, validateSpy: ISpy, ctx: TestContext) {
@@ -1121,7 +1122,7 @@ describe('validation-html/validate-binding-behavior.spec.ts/validate-binding-beh
       assert.equal(bindings.length, 1);
 
       const binding = bindings[0];
-      assert.equal(binding.ast.expression.toString(), 'org.employees');
+      assert.equal(Unparser.unparse(binding.ast.expression), 'org.employees');
 
       assert.equal(controller.results.filter((r) => !r.valid && r.propertyName === 'employees').length, 0, 'error1');
       await controller.validate();
@@ -1155,7 +1156,7 @@ describe('validation-html/validate-binding-behavior.spec.ts/validate-binding-beh
       assert.equal(bindings.length, 1);
 
       const binding = bindings[0];
-      assert.equal(binding.ast.expression.toString(), 'org.employees');
+      assert.equal(Unparser.unparse(binding.ast.expression), 'org.employees');
 
       assert.equal(controller.results.filter((r) => !r.valid && r.propertyName === 'employees').length, 0, 'error1');
       await controller.validate();
@@ -1188,9 +1189,9 @@ describe('validation-html/validate-binding-behavior.spec.ts/validate-binding-beh
       const bindings = Array.from((controller['bindings'] as Map<IBinding, any>).keys()) as BindingWithBehavior[];
       assert.equal(bindings.length, 2);
       assert.equal(bindings[0].target, target1);
-      assert.equal(bindings[0].ast.expression.toString(), 'obj.coll[(0)].a|toNumber');
+      assert.equal(Unparser.unparse(bindings[0].ast.expression), 'obj.coll[(0)].a|toNumber');
       assert.equal(bindings[1].target, target2);
-      assert.equal(bindings[1].ast.expression.toString(), 'obj.coll[(1)].a|toNumber');
+      assert.equal(Unparser.unparse(bindings[1].ast.expression), 'obj.coll[(1)].a|toNumber');
 
       assert.equal(controller.results.filter((r) => !r.valid && (r.propertyName === 'coll[0].a' || r.propertyName === 'coll[1].a')).length, 0, 'error1');
       await controller.validate();

--- a/packages/__tests__/validation-i18n/localization.spec.ts
+++ b/packages/__tests__/validation-i18n/localization.spec.ts
@@ -8,7 +8,7 @@ import {
   StandardValidator,
   ValidationMessageProvider,
 } from '@aurelia/validation';
-import { IBinding } from '@aurelia/runtime';
+import { IBinding, Unparser } from '@aurelia/runtime';
 import { CustomElement, INode, Aurelia, IPlatform } from '@aurelia/runtime-html';
 import {
   BindingWithBehavior,
@@ -181,7 +181,7 @@ describe('validation-i18n/localization.spec.ts/validation-i18n', function () {
 
     const binding = bindings[0];
     assert.equal(binding.target, target);
-    assert.equal(binding.ast.expression.toString(), rawExpression);
+    assert.equal(Unparser.unparse(binding.ast.expression), rawExpression);
   }
 
   async function assertEventHandler(target: HTMLElement, event: 'change' | 'focusout', callCount: number, platform: IPlatform, controllerSpy: Spy, ctx: TestContext) {

--- a/packages/__tests__/validation/rule-provider.spec.ts
+++ b/packages/__tests__/validation/rule-provider.spec.ts
@@ -13,7 +13,8 @@ import {
   PrimitiveLiteralExpression,
   IExpressionParser,
   ExpressionType,
-  Scope
+  Scope,
+  astEvaluate
 } from '@aurelia/runtime';
 import { assert, TestContext } from '@aurelia/testing';
 import {
@@ -692,7 +693,7 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
       const $rule = getRule();
       sut.setMessage($rule, message);
       const scope = Scope.create({});
-      const actual = sut.getMessage($rule).evaluate(scope, container, null);
+      const actual = astEvaluate(sut.getMessage($rule), scope, container, null);
       assert.equal(actual, message);
     });
 
@@ -700,7 +701,7 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
       const { sut, container } = setup();
       const $rule = getRule();
       const scope = Scope.create({ $displayName: 'FooBar', $rule });
-      const actual = sut.getMessage($rule).evaluate(scope, container, null);
+      const actual = astEvaluate(sut.getMessage($rule), scope, container, null);
       assert.equal(actual, messages[i]);
     });
 
@@ -709,7 +710,7 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
       const $rule = getRule();
       $rule.messageKey = 'foobar';
       const scope = Scope.create({ $displayName: 'FooBar', $rule });
-      const actual = sut.getMessage($rule).evaluate(scope, container, null);
+      const actual = astEvaluate(sut.getMessage($rule), scope, container, null);
       assert.equal(actual, 'FooBar is invalid.');
     });
   }
@@ -764,10 +765,10 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
     for (const { getRule } of rules) {
       const $rule = getRule();
       const scope = Scope.create({ $displayName: 'FooBar', $rule });
-      const actual = sut.getMessage($rule).evaluate(scope, container, null);
+      const actual = astEvaluate(sut.getMessage($rule), scope, container, null);
       const aliases = customMessages.find((item) => $rule instanceof item.rule).aliases;
       const template = aliases.length === 1 ? aliases[0].defaultMessage : aliases.find(({ name }) => name === $rule.messageKey)?.defaultMessage;
-      const expected = sut.parseMessage(template).evaluate(scope, null!, null);
+      const expected = astEvaluate(sut.parseMessage(template), scope, null!, null);
       assert.equal(actual, expected);
     }
     // reset the messages
@@ -799,8 +800,8 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
     const scope1 = Scope.create({ $displayName, $rule: $rule1 });
     const scope2 = Scope.create({ $displayName, $rule: $rule2 });
 
-    const actual1 = sut.getMessage($rule1).evaluate(scope1, container, null);
-    const actual2 = sut.getMessage($rule2).evaluate(scope2, container, null);
+    const actual1 = astEvaluate(sut.getMessage($rule1), scope1, container, null);
+    const actual2 = astEvaluate(sut.getMessage($rule2), scope2, container, null);
 
     assert.equal(actual1, 'FooBar is required.');
     assert.equal(actual2, 'FooBar foobar fizbaz');

--- a/packages/compat-v1/.eslintignore
+++ b/packages/compat-v1/.eslintignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+.eslintrc.cjs
+*.js

--- a/packages/compat-v1/.eslintrc.cjs
+++ b/packages/compat-v1/.eslintrc.cjs
@@ -1,0 +1,15 @@
+const path = require('path');
+const thisDir = path.resolve(__dirname);
+
+module.exports = {
+  extends: [
+    '../../.eslintrc.cjs',
+  ],
+  parserOptions: {
+    project: path.join(thisDir, 'tsconfig.json'),
+    tsconfigRootDir: thisDir,
+  },
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+  }
+};

--- a/packages/compat-v1/CHANGELOG.md
+++ b/packages/compat-v1/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/compat-v1/LICENSE
+++ b/packages/compat-v1/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2010 - 2020 Blue Spire Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/compat-v1/README.md
+++ b/packages/compat-v1/README.md
@@ -1,0 +1,19 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg)](http://www.typescriptlang.org/)
+[![CircleCI](https://circleci.com/gh/aurelia/aurelia.svg?style=shield)](https://circleci.com/gh/aurelia/aurelia)
+[![npm](https://img.shields.io/npm/v/@aurelia/metadata.svg?maxAge=3600)](https://www.npmjs.com/package/@aurelia/metadata)
+# @aurelia/state
+
+## Installing
+
+For the latest stable version:
+
+```bash
+npm i @aurelia/state
+```
+
+For our nightly builds:
+
+```bash
+npm i @aurelia/state@dev
+```

--- a/packages/compat-v1/package.json
+++ b/packages/compat-v1/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@aurelia/compat-v1",
+  "version": "2.0.0-alpha.41",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.mjs",
+  "exports": {
+    "require": "./dist/cjs/index.cjs",
+    "import": "./dist/esm/index.mjs"
+  },
+  "typings": "dist/types/index.d.ts",
+  "license": "MIT",
+  "homepage": "https://aurelia.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aurelia/aurelia"
+  },
+  "bugs": {
+    "url": "https://github.com/aurelia/aurelia/issues"
+  },
+  "keywords": [
+    "aurelia",
+    "v1",
+    "compat"
+  ],
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "lint": "eslint --cache --ext .js,.ts src/",
+    "lint:ci": "eslint --cache --ext .js,.ts --quiet --report-unused-disable-directives src/",
+    "build": "rollup -c",
+    "dev": "rollup -c -w",
+    "publish:dev": "npm publish --tag dev",
+    "publish:latest": "npm publish --tag latest",
+    "rollup": "rollup -c",
+    "postrollup": "tsc --emitDeclarationOnly",
+    "build:packages": "npm run rollup"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@aurelia/kernel": "2.0.0-alpha.41",
+    "@aurelia/metadata": "2.0.0-alpha.41",
+    "@aurelia/platform": "2.0.0-alpha.41",
+    "@aurelia/platform-browser": "2.0.0-alpha.41",
+    "@aurelia/runtime": "2.0.0-alpha.41",
+    "@aurelia/runtime-html": "2.0.0-alpha.41"
+  },
+  "devDependencies": {
+    "typescript": "4.7.3"
+  },
+  "engines": {
+    "node": ">=14.17.0"
+  }
+}

--- a/packages/compat-v1/rollup.config.js
+++ b/packages/compat-v1/rollup.config.js
@@ -1,0 +1,5 @@
+// @ts-check
+import pkg from './package.json';
+import { getRollupConfig } from '../rollup-utils';
+
+export default getRollupConfig(pkg);

--- a/packages/compat-v1/src/compat-ast.ts
+++ b/packages/compat-v1/src/compat-ast.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+import { Constructable } from '@aurelia/kernel';
+import { AccessKeyedExpression, AccessMemberExpression, AccessScopeExpression, AccessThisExpression, ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, AssignExpression, astAssign, astBind, astEvaluate, astUnbind, astVisit, BinaryExpression, BindingBehaviorExpression, BindingIdentifier, CallFunctionExpression, CallMemberExpression, CallScopeExpression, ConditionalExpression, DestructuringAssignmentExpression, DestructuringAssignmentRestExpression, DestructuringAssignmentSingleExpression, ForOfStatement, Interpolation, ObjectBindingPattern, ObjectLiteralExpression, PrimitiveLiteralExpression, TaggedTemplateExpression, TemplateExpression, UnaryExpression, ValueConverterExpression } from '@aurelia/runtime';
+
+let defined = false;
+export function defineAstMethods() {
+  if (defined) {
+    return;
+  }
+  defined = true;
+  const def = (Klass: Constructable, name: string, value: unknown) => Object.defineProperty(
+    Klass.prototype,
+    name,
+    { configurable: true, enumerable: false, writable: true, value }
+  );
+
+  [
+    BindingBehaviorExpression,
+    ValueConverterExpression,
+    AssignExpression,
+    ConditionalExpression,
+    AccessThisExpression,
+    AccessScopeExpression,
+    AccessMemberExpression,
+    AccessKeyedExpression,
+    CallScopeExpression,
+    CallMemberExpression,
+    CallFunctionExpression,
+    BinaryExpression,
+    UnaryExpression,
+    PrimitiveLiteralExpression,
+    ArrayLiteralExpression,
+    ObjectLiteralExpression,
+    TemplateExpression,
+    TaggedTemplateExpression,
+    ArrayBindingPattern,
+    ObjectBindingPattern,
+    BindingIdentifier,
+    ForOfStatement,
+    Interpolation,
+    DestructuringAssignmentExpression,
+    DestructuringAssignmentSingleExpression,
+    DestructuringAssignmentRestExpression,
+    ArrowFunction
+  ].forEach(ast => {
+    def(ast, 'evaluate', function (this: typeof ast, ...args: unknown[]) {
+      return (astEvaluate as any)(this, ...args);
+    });
+    def(ast, 'assign', function (this: typeof ast, ...args: unknown[]) {
+      return (astAssign as any)(this, ...args);
+    });
+    def(ast, 'accept', function (this: typeof ast, ...args: unknown[]) {
+      return (astVisit as any)(this, ...args);
+    });
+    def(ast, 'bind', function (this: typeof ast, ...args: unknown[]) {
+      return (astBind as any)(this, ...args);
+    });
+    def(ast, 'unbind', function (this: typeof ast, ...args: unknown[]) {
+      return (astUnbind as any)(this, ...args);
+    });
+  });
+}

--- a/packages/compat-v1/src/compat-form.ts
+++ b/packages/compat-v1/src/compat-form.ts
@@ -1,0 +1,12 @@
+import { AppTask, IEventTarget } from '@aurelia/runtime-html';
+
+export const PreventFormActionlessSubmit = AppTask.creating(IEventTarget, appRoot => {
+  appRoot.addEventListener('submit', (e: Event) => {
+    const target = e.target as HTMLFormElement;
+    const action = target.action;
+
+    if (target.tagName.toLowerCase() === 'form' && !action) {
+      e.preventDefault();
+    }
+  }, false);
+});

--- a/packages/compat-v1/src/index.ts
+++ b/packages/compat-v1/src/index.ts
@@ -1,0 +1,14 @@
+import { IContainer, IRegistry } from '@aurelia/kernel';
+import { PreventFormActionlessSubmit } from './compat-form';
+
+const registration: IRegistry = {
+  register(container: IContainer) {
+    container.register(PreventFormActionlessSubmit);
+  }
+};
+
+export {
+  PreventFormActionlessSubmit,
+};
+
+export default registration;

--- a/packages/compat-v1/src/index.ts
+++ b/packages/compat-v1/src/index.ts
@@ -1,8 +1,10 @@
 import { IContainer, IRegistry } from '@aurelia/kernel';
+import { defineAstMethods } from './compat-ast';
 import { PreventFormActionlessSubmit } from './compat-form';
 
 const registration: IRegistry = {
   register(container: IContainer) {
+    defineAstMethods();
     container.register(PreventFormActionlessSubmit);
   }
 };

--- a/packages/compat-v1/tsconfig.build.json
+++ b/packages/compat-v1/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "rootDir": "src",
+    "lib": ["esnext", "DOM"]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/compat-v1/tsconfig.json
+++ b/packages/compat-v1/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig-build.json",
+  "compilerOptions": {
+    "declarationDir": "dist/types",
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "lib": ["esnext", "dom"]
+  },
+  "include": ["src"]
+}

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -4,3 +4,13 @@
  * @internal
  */
 declare const __DEV__: boolean;
+
+/**
+ * A build variable to help packages mark const enum region for removing them from output bundle
+ */
+declare const _START_CONST_ENUM: () => void;
+
+/**
+ * A build variable to help packages mark const enum region for removing them from output bundle
+ */
+declare const _END_CONST_ENUM: () => void;

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -125,7 +125,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
     if (isParameterContext) {
       binding.useParameter(expr);
     } else {
-      const interpolation = expr instanceof CustomExpression ? parser.parse(expr.value, ExpressionType.Interpolation) : undefined;
+      const interpolation = expr instanceof CustomExpression ? parser.parse(expr.value as string, ExpressionType.Interpolation) : undefined;
       binding.ast = interpolation || expr;
     }
   }

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -5,6 +5,9 @@ import {
   ExpressionType,
   Interpolation,
   connectable,
+  astEvaluate,
+  astUnbind,
+  astBind,
 } from '@aurelia/runtime';
 import {
   CustomElement,
@@ -150,7 +153,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
     this.scope = scope;
     this._isInterpolation = this.ast instanceof Interpolation;
 
-    this._keyExpression = this.ast.evaluate(scope, this, this) as string;
+    this._keyExpression = astEvaluate(this.ast, scope, this, this) as string;
     this._ensureKeyExpression();
     this.parameter?.$bind(scope);
 
@@ -163,9 +166,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
       return;
     }
 
-    if (this.ast.hasUnbind) {
-      this.ast.unbind(this.scope, this);
-    }
+    astUnbind(this.ast, this.scope, this);
 
     this.parameter?.$unbind();
     this._targetAccessors.clear();
@@ -181,7 +182,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
   public handleChange(newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions): void {
     this.obs.version++;
     this._keyExpression = this._isInterpolation
-        ? this.ast.evaluate(this.scope, this, this) as string
+        ? astEvaluate(this.ast, this.scope, this, this) as string
         : newValue as string;
     this.obs.clear();
     this._ensureKeyExpression();
@@ -392,7 +393,7 @@ class ParameterBinding {
       return;
     }
     this.obs.version++;
-    this.value = this.ast.evaluate(this.scope, this, this) as i18next.TOptions;
+    this.value = astEvaluate(this.ast, this.scope, this, this) as i18next.TOptions;
     this.obs.clear();
     this.updater();
   }
@@ -403,11 +404,9 @@ class ParameterBinding {
     }
     this.scope = scope;
 
-    if (this.ast.hasBind) {
-      this.ast.bind(scope, this);
-    }
+    astBind(this.ast, scope, this);
 
-    this.value = this.ast.evaluate(scope, this, this) as i18next.TOptions;
+    this.value = astEvaluate(this.ast, scope, this, this) as i18next.TOptions;
     this.isBound = true;
   }
 
@@ -416,9 +415,7 @@ class ParameterBinding {
       return;
     }
 
-    if (this.ast.hasUnbind) {
-      this.ast.unbind(this.scope, this);
-    }
+    astUnbind(this.ast, this.scope, this);
 
     this.scope = (void 0)!;
     this.obs.clearAll();

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -715,8 +715,8 @@ function createNewInstance(key: any, handler: IContainer, requestor: IContainer)
   return handler.getFactory(key).construct(requestor);
 }
 
-/** @internal */
-export const enum ResolverStrategy {
+_START_CONST_ENUM();
+const enum ResolverStrategy {
   instance = 0,
   singleton = 1,
   transient = 2,
@@ -724,6 +724,7 @@ export const enum ResolverStrategy {
   array = 4,
   alias = 5
 }
+_END_CONST_ENUM();
 
 class Resolver implements IResolver, IRegistration {
   public constructor(

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -45,12 +45,14 @@ export function isArrayIndex(value: unknown): value is number | string {
  * Base implementation of camel and kebab cases
  */
 const baseCase = (function () {
+  _START_CONST_ENUM();
   const enum CharKind {
     none  = 0,
     digit = 1,
     upper = 2,
     lower = 3,
   }
+  _END_CONST_ENUM();
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const isDigit = Object.assign(createObject(), {

--- a/packages/rollup-utils.js
+++ b/packages/rollup-utils.js
@@ -132,6 +132,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     __DEV__: process.env.__DEV__,
     NO_MINIFIED: process.env.NO_MINIFIED
   };
+  // @ts-ignore
   const isDevMode = /^true$/.test(process.env.DEV_MODE);
   const inputFile = 'src/index.ts';
   const esmDevDist = 'dist/esm/index.dev.mjs';
@@ -148,6 +149,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
 
   const devConfig = configure({
     input: inputFile,
+    // @ts-ignore
     external: Object.keys(pkg.dependencies),
     output: [
       {
@@ -180,12 +182,14 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           rollupTypeScript({}, isDevMode),
         ]
       ),
+      stripInternalConstEnum(),
     ],
     onwarn: onWarn
   }, true, envVars);
 
   const prodConfig = configure({
     input: inputFile,
+    // @ts-ignore
     external: Object.keys(pkg.dependencies),
     output: [
       {
@@ -227,9 +231,12 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
         ]
         : [
           rollupReplace({ ...envVars, __DEV__: false }),
-          rollupTypeScript({}, isDevMode),
+          rollupTypeScript({
+            removeComments: false
+          }, isDevMode),
         ]
       ),
+      stripInternalConstEnum(),
       runPostbuildScript(...postBuildScript),
     ],
     onwarn: onWarn,
@@ -245,4 +252,52 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
  */
 function identity(a) {
   return a;
+}
+
+import { createFilter } from '@rollup/pluginutils';
+import MagicString from 'magic-string';
+
+/** @return {import('rollup').Plugin} */
+function stripInternalConstEnum (options = {}) {
+  const { include, exclude } = options
+
+  const filter = createFilter(include, exclude)
+
+  return {
+    name: 'stripCode',
+
+    transform (source, id) {
+      if (!filter(id)) return
+
+      const s = new MagicString(source);
+      const indexPairs = [];
+
+      let startIndex = 0;
+      let endIndex = 0;
+      while (true) {
+        startIndex = source.indexOf('_START_CONST_ENUM();', endIndex);
+        if (startIndex === -1) {
+          break;
+        }
+
+        endIndex = source.indexOf('_END_CONST_ENUM();', startIndex);
+        if (endIndex === -1) {
+          break;
+        }
+        indexPairs.push([startIndex, endIndex]);
+      }
+
+      if (indexPairs.length === 0) {
+        return;
+      }
+
+      indexPairs.forEach(([startIndex, endIndex]) => {
+        s.overwrite(startIndex, endIndex + '_END_CONST_ENUM();'.length, '');
+      })
+      
+      const map = s.generateMap({ hires: true })
+
+      return { code: s.toString(), map };
+    }
+  }
 }

--- a/packages/rollup-utils.js
+++ b/packages/rollup-utils.js
@@ -141,7 +141,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
   const typingsDist = 'dist/types/index.d.ts';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
-    if (warning.code === 'CIRCULAR_DEPENDENCY') return;
+    if (warning.code === 'CIRCULAR_DEPENDENCY' || warning.code === 'MIXED_EXPORTS') return;
     if (warning.message.includes('Mixing named and default exports')) return;
     warn(warning);
   };

--- a/packages/route-recognizer/src/index.ts
+++ b/packages/route-recognizer/src/index.ts
@@ -579,11 +579,13 @@ type AnySegment<T> = (
   StarSegment<T>
 );
 
+_START_CONST_ENUM();
 const enum SegmentKind {
   star    = 1,
   dynamic = 2,
   static  = 3,
 }
+_END_CONST_ENUM();
 
 class StaticSegment<T> {
   public get kind(): SegmentKind.static { return SegmentKind.static; }

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -1,8 +1,9 @@
-import { DI, InstanceProvider, onResolve, resolveAll } from '@aurelia/kernel';
+import { InstanceProvider, onResolve, resolveAll } from '@aurelia/kernel';
 import { INode } from './dom';
 import { IAppTask } from './app-task';
 import { isElementType } from './resources/custom-element';
 import { LifecycleFlags, Controller, IControllerElementHydrationInstruction } from './templating/controller';
+import { createInterface, registerResolver } from './utilities-di';
 
 import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
 import type { TaskSlot } from './app-task';
@@ -15,7 +16,7 @@ export interface ISinglePageApp {
 }
 
 export interface IAppRoot extends AppRoot {}
-export const IAppRoot = DI.createInterface<IAppRoot>('IAppRoot');
+export const IAppRoot = createInterface<IAppRoot>('IAppRoot');
 
 export class AppRoot implements IDisposable {
   public readonly host: HTMLElement;
@@ -34,11 +35,13 @@ export class AppRoot implements IDisposable {
     this.host = config.host;
     rootProvider.prepare(this);
 
-    container.registerResolver(
+    registerResolver(
+      container,
       platform.HTMLElement,
-      container.registerResolver(
+      registerResolver(
+        container,
         platform.Element,
-        container.registerResolver(INode, new InstanceProvider('ElementResolver', config.host))
+        registerResolver(container, INode, new InstanceProvider('ElementResolver', config.host))
       )
     );
 

--- a/packages/runtime-html/src/app-task.ts
+++ b/packages/runtime-html/src/app-task.ts
@@ -1,6 +1,5 @@
-import { DI } from '@aurelia/kernel';
 import { isFunction } from './utilities';
-import { instanceRegistration } from './utilities-di';
+import { createInterface, instanceRegistration } from './utilities-di';
 import type { IContainer, IRegistry, Key, Resolved } from '@aurelia/kernel';
 
 export type TaskSlot =
@@ -12,7 +11,7 @@ export type TaskSlot =
   | 'deactivating'
   | 'deactivated';
 
-export const IAppTask = DI.createInterface<IAppTask>('IAppTask');
+export const IAppTask = createInterface<IAppTask>('IAppTask');
 export interface IAppTask {
   readonly slot: TaskSlot;
   register(c: IContainer): IContainer;

--- a/packages/runtime-html/src/attribute-mapper.ts
+++ b/packages/runtime-html/src/attribute-mapper.ts
@@ -1,10 +1,9 @@
-import { DI } from '@aurelia/kernel';
 import { createLookup, isDataAttribute } from './utilities';
 import { ISVGAnalyzer } from './observation/svg-analyzer';
+import { createInterface } from './utilities-di';
 
 export interface IAttrMapper extends AttrMapper {}
-export const IAttrMapper = DI
-  .createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
+export const IAttrMapper = createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
 
 export type IsTwoWayPredicate = (element: Element, attribute: string) => boolean;
 

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -1,9 +1,9 @@
-import { DI, type Constructable, type Key } from '@aurelia/kernel';
+import { type Constructable, type Key } from '@aurelia/kernel';
 import { def, defineHiddenProp } from '../utilities';
 import { astEvaluate, BindingBehaviorInstance, type IAstEvaluator, type ISubscriber, type ValueConverterInstance } from '@aurelia/runtime';
 import { BindingBehavior } from '../resources/binding-behavior';
 import { ValueConverter } from '../resources/value-converter';
-import { resource } from '../utilities-di';
+import { createInterface, resource } from '../utilities-di';
 import { type IAstBasedBinding } from './interfaces-bindings';
 
 interface ITwoWayBindingImpl extends IAstBasedBinding {
@@ -96,7 +96,7 @@ export interface IFlushable {
   flush(): void;
 }
 
-export const IFlushQueue = DI.createInterface<IFlushQueue>('IFlushQueue', x => x.singleton(FlushQueue));
+export const IFlushQueue = createInterface<IFlushQueue>('IFlushQueue', x => x.singleton(FlushQueue));
 export interface IFlushQueue {
   get count(): number;
   add(flushable: IFlushable): void;

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -1,6 +1,6 @@
 import { DI, type Constructable, type Key } from '@aurelia/kernel';
 import { def, defineHiddenProp } from '../utilities';
-import { BindingBehaviorInstance, type IAstEvaluator, type ISubscriber, type ValueConverterInstance } from '@aurelia/runtime';
+import { astEvaluate, BindingBehaviorInstance, type IAstEvaluator, type ISubscriber, type ValueConverterInstance } from '@aurelia/runtime';
 import { BindingBehavior } from '../resources/binding-behavior';
 import { ValueConverter } from '../resources/value-converter';
 import { resource } from '../utilities-di';
@@ -44,7 +44,7 @@ export class BindingTargetSubscriber implements ISubscriber {
   // deepscan-disable-next-line
   public handleChange(value: unknown, _: unknown): void {
     const b = this.b;
-    if (value !== b.ast.evaluate(b.$scope!, b, null)) {
+    if (value !== astEvaluate(b.ast, b.$scope!, b, null)) {
       this._value = value;
       this._flushQueue.add(this);
     }

--- a/packages/runtime-html/src/binding/call-binding.ts
+++ b/packages/runtime-html/src/binding/call-binding.ts
@@ -1,5 +1,5 @@
 import type { IServiceLocator } from '@aurelia/kernel';
-import type { IAccessor, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, IAccessor, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IAstBasedBinding } from './interfaces-bindings';
 import { astEvaluator } from './binding-utils';
 
@@ -32,7 +32,7 @@ export class CallBinding implements IAstBasedBinding {
   public callSource(args: object): unknown {
     const overrideContext = this.$scope!.overrideContext;
     overrideContext.$event = args;
-    const result = this.ast.evaluate(this.$scope!, this, null);
+    const result = astEvaluate(this.ast, this.$scope!, this, null);
     Reflect.deleteProperty(overrideContext, '$event');
 
     return result;
@@ -49,9 +49,7 @@ export class CallBinding implements IAstBasedBinding {
 
     this.$scope = scope;
 
-    if (this.ast.hasBind) {
-      this.ast.bind(scope, this.interceptor);
-    }
+    astBind(this.ast, scope, this.interceptor);
 
     this.targetObserver.setValue(($args: object) => this.interceptor.callSource($args), this.target, this.targetProperty);
 
@@ -64,9 +62,7 @@ export class CallBinding implements IAstBasedBinding {
       return;
     }
 
-    if (this.ast.hasUnbind) {
-      this.ast.unbind(this.$scope!, this.interceptor);
-    }
+    astUnbind(this.ast, this.$scope!, this.interceptor);
 
     this.$scope = void 0;
     this.targetObserver.setValue(null, this.target, this.targetProperty);

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -1,4 +1,4 @@
-import { connectable } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, connectable } from '@aurelia/runtime';
 import { astEvaluator } from './binding-utils';
 
 import type { ITask } from '@aurelia/platform';
@@ -54,7 +54,7 @@ export class LetBinding implements IAstBasedBinding {
     const targetProperty = this.targetProperty;
     const previousValue: unknown = target[targetProperty];
     this.obs.version++;
-    const newValue = this.ast.evaluate(this.$scope!, this, this.interceptor);
+    const newValue = astEvaluate(this.ast, this.$scope!, this, this.interceptor);
     this.obs.clear();
     if (newValue !== previousValue) {
       target[targetProperty] = newValue;
@@ -76,12 +76,10 @@ export class LetBinding implements IAstBasedBinding {
     this.$scope = scope;
     this.target = (this._toBindingContext ? scope.bindingContext : scope.overrideContext) as IIndexable;
 
-    if (this.ast.hasBind) {
-      this.ast.bind(scope, this.interceptor);
-    }
-    // ast might have been changed during bind
+    astBind(this.ast, scope, this.interceptor);
+
     this.target[this.targetProperty]
-      = this.ast.evaluate(scope, this, this.interceptor);
+      = astEvaluate(this.ast, scope, this, this.interceptor);
 
     // add isBound flag and remove isBinding flag
     this.isBound = true;
@@ -92,9 +90,8 @@ export class LetBinding implements IAstBasedBinding {
       return;
     }
 
-    if (this.ast.hasUnbind) {
-      this.ast.unbind(this.$scope!, this.interceptor);
-    }
+    astUnbind(this.ast, this.$scope!, this.interceptor);
+
     this.$scope = void 0;
     this.obs.clearAll();
 

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -53,7 +53,7 @@ export class Listener implements IAstBasedBinding {
     this._options = options;
   }
 
-  public callSource(event: Event): ReturnType<IsBindingBehavior['evaluate']> {
+  public callSource(event: Event): unknown {
     const overrideContext = this.$scope.overrideContext;
     overrideContext.$event = event;
 

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -4,7 +4,7 @@ import { astEvaluator } from './binding-utils';
 import { DelegationStrategy } from '../renderer';
 
 import type { IDisposable, IIndexable, IServiceLocator } from '@aurelia/kernel';
-import type { IsBindingBehavior, Scope } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IEventDelegator } from '../observation/event-delegator';
 import type { IAstBasedBinding } from './interfaces-bindings';
 
@@ -57,7 +57,7 @@ export class Listener implements IAstBasedBinding {
     const overrideContext = this.$scope.overrideContext;
     overrideContext.$event = event;
 
-    let result = this.ast.evaluate(this.$scope, this, null);
+    let result = astEvaluate(this.ast, this.$scope, this, null);
 
     delete overrideContext.$event;
 
@@ -87,10 +87,7 @@ export class Listener implements IAstBasedBinding {
 
     this.$scope = scope;
 
-    const ast = this.ast;
-    if (ast.hasBind) {
-      ast.bind(scope, this.interceptor);
-    }
+    astBind(this.ast, scope, this.interceptor);
 
     if (this._options.strategy === DelegationStrategy.none) {
       this.target.addEventListener(this.targetEvent, this);
@@ -113,9 +110,7 @@ export class Listener implements IAstBasedBinding {
       return;
     }
 
-    if (this.ast.hasUnbind) {
-      this.ast.unbind(this.$scope, this.interceptor);
-    }
+    astUnbind(this.ast, this.$scope, this.interceptor);
 
     this.$scope = null!;
     if (this._options.strategy === DelegationStrategy.none) {

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -1,5 +1,5 @@
+import { astAssign, astBind, astEvaluate, astUnbind, type IsBindingBehavior, type Scope } from '@aurelia/runtime';
 import type { IIndexable, IServiceLocator } from '@aurelia/kernel';
-import type { IsBindingBehavior, Scope } from '@aurelia/runtime';
 import type { IAstBasedBinding } from './interfaces-bindings';
 
 export interface RefBinding extends IAstBasedBinding {}
@@ -26,11 +26,9 @@ export class RefBinding implements IAstBasedBinding {
 
     this.$scope = scope;
 
-    if (this.ast.hasBind) {
-      this.ast.bind(scope, this);
-    }
+    astBind(this.ast, scope, this);
 
-    this.ast.assign(this.$scope, this, this.target);
+    astAssign(this.ast, this.$scope, this, this.target);
 
     // add isBound flag and remove isBinding flag
     this.isBound = true;
@@ -41,17 +39,11 @@ export class RefBinding implements IAstBasedBinding {
       return;
     }
 
-    let ast = this.ast;
-    if (ast.evaluate(this.$scope!, this, null) === this.target) {
-      ast.assign(this.$scope!, this, null);
+    if (astEvaluate(this.ast, this.$scope!, this, null) === this.target) {
+      astAssign(this.ast, this.$scope!, this, null);
     }
 
-    // source expression might have been modified durring assign, via a BB
-    // deepscan-disable-next-line
-    ast = this.ast;
-    if (ast.hasUnbind) {
-      ast.unbind(this.$scope!, this.interceptor);
-    }
+    astUnbind(this.ast, this.$scope!, this.interceptor);
 
     this.$scope = void 0;
 

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -1,9 +1,10 @@
-import { DI, Writable } from '@aurelia/kernel';
+import { type Writable } from '@aurelia/kernel';
 import { IAppRoot } from './app-root';
 import { IPlatform } from './platform';
 import { findElementControllerFor } from './resources/custom-element';
 import { MountTarget } from './templating/controller';
 import type { IHydratedController } from './templating/controller';
+import { createInterface } from './utilities-di';
 
 export class Refs {
   [key: string]: IHydratedController | undefined;
@@ -20,17 +21,17 @@ export function setRef(node: INode, name: string, controller: IHydratedControlle
 export type INode<T extends Node = Node> = T & {
   readonly $au?: Refs;
 };
-export const INode = DI.createInterface<INode>('INode');
+export const INode = createInterface<INode>('INode');
 
 export type IEventTarget<T extends EventTarget = EventTarget> = T;
-export const IEventTarget = DI.createInterface<IEventTarget>('IEventTarget', x => x.cachedCallback(handler => {
+export const IEventTarget = createInterface<IEventTarget>('IEventTarget', x => x.cachedCallback(handler => {
   if (handler.has(IAppRoot, true)) {
     return handler.get(IAppRoot).host;
   }
   return handler.get(IPlatform).document;
 }));
 
-export const IRenderLocation = DI.createInterface<IRenderLocation>('IRenderLocation');
+export const IRenderLocation = createInterface<IRenderLocation>('IRenderLocation');
 export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
 };
@@ -81,7 +82,8 @@ export interface INodeSequence<T extends INode = INode> {
   link(next: INodeSequence<T> | IRenderLocation | undefined): void;
 }
 
-export const enum NodeType {
+_START_CONST_ENUM();
+const enum NodeType {
   Element = 1,
   Attr = 2,
   Text = 3,
@@ -95,6 +97,7 @@ export const enum NodeType {
   DocumentFragment = 11,
   Notation = 12
 }
+_END_CONST_ENUM();
 
 const effectiveParentNodeOverrides = new WeakMap<Node, Node>();
 
@@ -387,13 +390,13 @@ export class FragmentNodeSequence implements INodeSequence {
   }
 }
 
-export const IWindow = DI.createInterface<IWindow>('IWindow', x => x.callback(handler => handler.get(IPlatform).window));
+export const IWindow = createInterface<IWindow>('IWindow', x => x.callback(handler => handler.get(IPlatform).window));
 export interface IWindow extends Window { }
 
-export const ILocation = DI.createInterface<ILocation>('ILocation', x => x.callback(handler => handler.get(IWindow).location));
+export const ILocation = createInterface<ILocation>('ILocation', x => x.callback(handler => handler.get(IWindow).location));
 export interface ILocation extends Location { }
 
-export const IHistory = DI.createInterface<IHistory>('IHistory', x => x.callback(handler => handler.get(IWindow).history));
+export const IHistory = createInterface<IHistory>('IHistory', x => x.callback(handler => handler.get(IWindow).history));
 // NOTE: `IHistory` is documented
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/History

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -479,7 +479,6 @@ export {
   IEventTarget,
   IRenderLocation,
   type INodeSequence,
-  NodeType,
   FragmentNodeSequence,
   IHistory,
   IWindow,

--- a/packages/runtime-html/src/observation/event-delegator.ts
+++ b/packages/runtime-html/src/observation/event-delegator.ts
@@ -1,5 +1,5 @@
-import { DI } from '@aurelia/kernel';
 import { createLookup, isFunction } from '../utilities';
+import { createInterface } from '../utilities-di';
 import type { NodeObserverConfig } from './observer-locator';
 import type { IDisposable } from '@aurelia/kernel';
 
@@ -126,7 +126,7 @@ export class EventSubscriber {
 }
 
 export interface IEventDelegator extends EventDelegator {}
-export const IEventDelegator = DI.createInterface<IEventDelegator>('IEventDelegator', x => x.singleton(EventDelegator));
+export const IEventDelegator = createInterface<IEventDelegator>('IEventDelegator', x => x.singleton(EventDelegator));
 
 export class EventDelegator implements IDisposable {
   /** @internal */

--- a/packages/runtime-html/src/observation/svg-analyzer.ts
+++ b/packages/runtime-html/src/observation/svg-analyzer.ts
@@ -1,13 +1,12 @@
-import { DI } from '@aurelia/kernel';
 import { IPlatform } from '../platform';
 import { createLookup, isString } from '../utilities';
+import { createInterface, singletonRegistration } from '../utilities-di';
 
 import type { IContainer, IResolver } from '@aurelia/kernel';
 import type { INode } from '../dom';
-import { singletonRegistration } from '../utilities-di';
 
 export interface ISVGAnalyzer extends NoopSVGAnalyzer {}
-export const ISVGAnalyzer = DI.createInterface<ISVGAnalyzer>('ISVGAnalyzer', x => x.singleton(NoopSVGAnalyzer));
+export const ISVGAnalyzer = createInterface<ISVGAnalyzer>('ISVGAnalyzer', x => x.singleton(NoopSVGAnalyzer));
 
 const o = (keys: string | string[]): Record<string, true | undefined> => {
   const lookup = createLookup<true | undefined>();

--- a/packages/runtime-html/src/plugins/dialog/dialog-interfaces.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-interfaces.ts
@@ -1,4 +1,4 @@
-import { DI } from '@aurelia/kernel';
+import { createInterface } from '../../utilities-di';
 
 import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
 import type { ICustomElementViewModel } from '../../templating/controller';
@@ -6,7 +6,7 @@ import type { ICustomElementViewModel } from '../../templating/controller';
 /**
  * The dialog service for composing view & view model into a dialog
  */
-export const IDialogService = DI.createInterface<IDialogService>('IDialogService');
+export const IDialogService = createInterface<IDialogService>('IDialogService');
 export interface IDialogService {
   readonly controllers: IDialogController[];
   /**
@@ -28,7 +28,7 @@ export interface IDialogService {
 /**
  * The controller asscociated with every dialog view model
  */
-export const IDialogController = DI.createInterface<IDialogController>('IDialogController');
+export const IDialogController = createInterface<IDialogController>('IDialogController');
 export interface IDialogController {
   readonly settings: IDialogLoadedSettings;
   /**
@@ -44,7 +44,7 @@ export interface IDialogController {
 /**
  * An interface describing the object responsible for creating the dom structure of a dialog
  */
-export const IDialogDomRenderer = DI.createInterface<IDialogDomRenderer>('IDialogDomRenderer');
+export const IDialogDomRenderer = createInterface<IDialogDomRenderer>('IDialogDomRenderer');
 export interface IDialogDomRenderer {
   render(dialogHost: Element, settings: IDialogLoadedSettings): IDialogDom;
 }
@@ -52,7 +52,7 @@ export interface IDialogDomRenderer {
 /**
  * An interface describing the DOM structure of a dialog
  */
-export const IDialogDom = DI.createInterface<IDialogDom>('IDialogDom');
+export const IDialogDom = createInterface<IDialogDom>('IDialogDom');
 export interface IDialogDom extends IDisposable {
   readonly overlay: HTMLElement;
   readonly contentHost: HTMLElement;
@@ -160,7 +160,7 @@ export type IDialogGlobalSettings = Pick<
   IDialogSettings,
   'lock' | 'startingZIndex' | 'rejectOnCancel'
 >;
-export const IDialogGlobalSettings = DI.createInterface<IDialogGlobalSettings>('IDialogGlobalSettings');
+export const IDialogGlobalSettings = createInterface<IDialogGlobalSettings>('IDialogGlobalSettings');
 
 export interface DialogError<T> extends Error {
   wasCancelled: boolean;

--- a/packages/runtime-html/src/plugins/web-components.ts
+++ b/packages/runtime-html/src/plugins/web-components.ts
@@ -1,12 +1,13 @@
-import { Constructable, DI, IContainer, IIndexable, InstanceProvider } from '@aurelia/kernel';
+import { type Constructable, IContainer, type IIndexable, InstanceProvider } from '@aurelia/kernel';
 
 import { INode, setRef } from '../dom';
 import { IPlatform } from '../platform';
 import { CustomElement, CustomElementDefinition, PartialCustomElementDefinition } from '../resources/custom-element';
 import { LifecycleFlags, Controller, ICustomElementController } from '../templating/controller';
 import { IRendering } from '../templating/rendering';
+import { createInterface } from '../utilities-di';
 
-export const IWcElementRegistry = DI.createInterface<IAuElementRegistry>(x => x.singleton(WcCustomElementRegistry));
+export const IWcElementRegistry = createInterface<IAuElementRegistry>(x => x.singleton(WcCustomElementRegistry));
 export interface IAuElementRegistry {
   /**
    * Define a web-component custom element for a set of given parameters

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1299,7 +1299,7 @@ class SpreadBinding implements IBinding {
       return;
     }
     this.isBound = true;
-    const innerScope = this.$scope = this._hydrationContext.controller.scope.parentScope ?? void 0;
+    const innerScope = this.$scope = this._hydrationContext.controller.scope.parent ?? void 0;
     if (innerScope == null) {
       throw new Error('Invalid spreading. Context scope is null/undefined');
     }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1,4 +1,4 @@
-import { DI, emptyArray, InstanceProvider, Key } from '@aurelia/kernel';
+import { emptyArray, InstanceProvider, Key } from '@aurelia/kernel';
 import {
   ExpressionType,
   IExpressionParser,
@@ -28,7 +28,7 @@ import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
 import { AttrSyntax } from './resources/attribute-pattern';
 import { defineProp, isString } from './utilities';
-import { registerResolver, singletonRegistration } from './utilities-di';
+import { createInterface, registerResolver, singletonRegistration } from './utilities-di';
 
 import type { IServiceLocator, IContainer, Class, IRegistry, Constructable, IResolver } from '@aurelia/kernel';
 import type {
@@ -70,7 +70,7 @@ export type InstructionTypeName = string;
 export interface IInstruction {
   readonly type: InstructionTypeName;
 }
-export const IInstruction = DI.createInterface<IInstruction>('Instruction');
+export const IInstruction = createInterface<IInstruction>('Instruction');
 
 export function isInstruction(value: unknown): value is IInstruction {
   const type = (value as { type?: string }).type;
@@ -78,7 +78,7 @@ export function isInstruction(value: unknown): value is IInstruction {
 }
 
 export class InterpolationInstruction {
-  public get type(): InstructionType.interpolation { return InstructionType.interpolation; }
+  public readonly type = InstructionType.interpolation;
 
   public constructor(
     public from: string | Interpolation,
@@ -87,7 +87,7 @@ export class InterpolationInstruction {
 }
 
 export class PropertyBindingInstruction {
-  public get type(): InstructionType.propertyBinding { return InstructionType.propertyBinding; }
+  public readonly type = InstructionType.propertyBinding;
 
   public constructor(
     public from: string | IsBindingBehavior,
@@ -97,7 +97,7 @@ export class PropertyBindingInstruction {
 }
 
 export class IteratorBindingInstruction {
-  public get type(): InstructionType.iteratorBinding { return InstructionType.iteratorBinding; }
+  public readonly type = InstructionType.iteratorBinding;
 
   public constructor(
     public from: string | ForOfStatement,
@@ -106,7 +106,7 @@ export class IteratorBindingInstruction {
 }
 
 export class CallBindingInstruction {
-  public get type(): InstructionType.callBinding { return InstructionType.callBinding; }
+  public readonly type = InstructionType.callBinding;
 
   public constructor(
     public from: string | IsBindingBehavior,
@@ -115,7 +115,7 @@ export class CallBindingInstruction {
 }
 
 export class RefBindingInstruction {
-  public get type(): InstructionType.refBinding { return InstructionType.refBinding; }
+  public readonly type = InstructionType.refBinding;
 
   public constructor(
     public readonly from: string | IsBindingBehavior,
@@ -124,7 +124,7 @@ export class RefBindingInstruction {
 }
 
 export class SetPropertyInstruction {
-  public get type(): InstructionType.setProperty { return InstructionType.setProperty; }
+  public readonly type = InstructionType.setProperty;
 
   public constructor(
     public value: unknown,
@@ -133,7 +133,7 @@ export class SetPropertyInstruction {
 }
 
 export class HydrateElementInstruction {
-  public get type(): InstructionType.hydrateElement { return InstructionType.hydrateElement; }
+  public readonly type = InstructionType.hydrateElement;
 
   /**
    * A special property that can be used to store <au-slot/> usage information
@@ -169,7 +169,7 @@ export class HydrateElementInstruction {
 }
 
 export class HydrateAttributeInstruction {
-  public get type(): InstructionType.hydrateAttribute { return InstructionType.hydrateAttribute; }
+  public readonly type = InstructionType.hydrateAttribute;
 
   public constructor(
     // in theory, Constructor of resources should be accepted too
@@ -184,7 +184,7 @@ export class HydrateAttributeInstruction {
 }
 
 export class HydrateTemplateController {
-  public get type(): InstructionType.hydrateTemplateController { return InstructionType.hydrateTemplateController; }
+  public readonly type = InstructionType.hydrateTemplateController;
 
   public constructor(
     public def: PartialCustomElementDefinition,
@@ -200,7 +200,7 @@ export class HydrateTemplateController {
 }
 
 export class HydrateLetElementInstruction {
-  public get type(): InstructionType.hydrateLetElement { return InstructionType.hydrateLetElement; }
+  public readonly type = InstructionType.hydrateLetElement;
 
   public constructor(
     public instructions: LetBindingInstruction[],
@@ -209,7 +209,7 @@ export class HydrateLetElementInstruction {
 }
 
 export class LetBindingInstruction {
-  public get type(): InstructionType.letBinding { return InstructionType.letBinding; }
+  public readonly type = InstructionType.letBinding;
 
   public constructor(
     public from: string | IsBindingBehavior | Interpolation,
@@ -218,7 +218,7 @@ export class LetBindingInstruction {
 }
 
 export class TextBindingInstruction {
-  public get type(): InstructionType.textBinding { return InstructionType.textBinding; }
+  public readonly type = InstructionType.textBinding;
 
   public constructor(
     public from: string | Interpolation,
@@ -239,7 +239,7 @@ export const enum DelegationStrategy {
 }
 
 export class ListenerBindingInstruction {
-  public get type(): InstructionType.listenerBinding { return InstructionType.listenerBinding; }
+  public readonly type = InstructionType.listenerBinding;
 
   public constructor(
     public from: string | IsBindingBehavior,
@@ -249,7 +249,7 @@ export class ListenerBindingInstruction {
   ) {}
 }
 export class StylePropertyBindingInstruction {
-  public get type(): InstructionType.stylePropertyBinding { return InstructionType.stylePropertyBinding; }
+  public readonly type = InstructionType.stylePropertyBinding;
 
   public constructor(
     public from: string | IsBindingBehavior,
@@ -258,7 +258,7 @@ export class StylePropertyBindingInstruction {
 }
 
 export class SetAttributeInstruction {
-  public get type(): InstructionType.setAttribute { return InstructionType.setAttribute; }
+  public readonly type = InstructionType.setAttribute;
 
   public constructor(
     public value: string,
@@ -283,7 +283,7 @@ export class SetStyleAttributeInstruction {
 }
 
 export class AttributeBindingInstruction {
-  public get type(): InstructionType.attributeBinding { return InstructionType.attributeBinding; }
+  public readonly type = InstructionType.attributeBinding;
 
   public constructor(
     /**
@@ -299,17 +299,17 @@ export class AttributeBindingInstruction {
 }
 
 export class SpreadBindingInstruction {
-  public get type(): InstructionType.spreadBinding { return InstructionType.spreadBinding; }
+  public readonly type = InstructionType.spreadBinding;
 }
 
 export class SpreadElementPropBindingInstruction {
-  public get type(): InstructionType.spreadElementProp { return InstructionType.spreadElementProp; }
+  public readonly type = InstructionType.spreadElementProp;
   public constructor(
     public readonly instructions: IInstruction,
   ) {}
 }
 
-export const ITemplateCompiler = DI.createInterface<ITemplateCompiler>('ITemplateCompiler');
+export const ITemplateCompiler = createInterface<ITemplateCompiler>('ITemplateCompiler');
 export interface ITemplateCompiler {
   /**
    * Indicates whether this compiler should compile template in debug mode
@@ -371,7 +371,7 @@ export interface IRenderer<
   ): void;
 }
 
-export const IRenderer = DI.createInterface<IRenderer>('IRenderer');
+export const IRenderer = createInterface<IRenderer>('IRenderer');
 
 type DecoratableInstructionRenderer<TType extends string, TProto, TClass> = Class<TProto & Partial<IInstructionTypeClassifier<TType> & Pick<IRenderer, 'render'>>, TClass> & Partial<IRegistry>;
 type DecoratedInstructionRenderer<TType extends string, TProto, TClass> =  Class<TProto & IInstructionTypeClassifier<TType> & Pick<IRenderer, 'render'>, TClass> & IRegistry;

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -28,7 +28,7 @@ import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
 import { AttrSyntax } from './resources/attribute-pattern';
 import { defineProp, isString } from './utilities';
-import { singletonRegistration } from './utilities-di';
+import { registerResolver, singletonRegistration } from './utilities-di';
 
 import type { IServiceLocator, IContainer, Class, IRegistry, Constructable, IResolver } from '@aurelia/kernel';
 import type {
@@ -517,7 +517,7 @@ export class CustomElementRenderer implements IRenderer {
     );
     Ctor = def.Type;
     component = container.invoke(Ctor);
-    container.registerResolver(Ctor, new InstanceProvider<typeof Ctor>(def.key, component));
+    registerResolver(container, Ctor, new InstanceProvider<typeof Ctor>(def.key, component));
     childCtrl = Controller.$el(
       /* own container       */container,
       /* viewModel           */component,
@@ -1362,20 +1362,22 @@ function createElementContainer(
   // if there's no value associated, unlike InstanceProvider
   // reason being some custom element can have `containerless` attribute on them
   // causing the host to disappear, and replace by a location instead
-  ctn.registerResolver(
+  registerResolver(
+    ctn,
     p.HTMLElement,
-    ctn.registerResolver(
+    registerResolver(
+      ctn,
       p.Element,
-      ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+      registerResolver(ctn, INode, new InstanceProvider('ElementResolver', host))
     )
   );
-  ctn.registerResolver(IController, new InstanceProvider(controllerProviderName, renderingCtrl));
-  ctn.registerResolver(IInstruction, new InstanceProvider(instructionProviderName, instruction));
-  ctn.registerResolver(IRenderLocation, location == null
+  registerResolver(ctn, IController, new InstanceProvider(controllerProviderName, renderingCtrl));
+  registerResolver(ctn, IInstruction, new InstanceProvider(instructionProviderName, instruction));
+  registerResolver(ctn, IRenderLocation, location == null
     ? noLocationProvider
     : new RenderLocationProvider(location));
-  ctn.registerResolver(IViewFactory, noViewFactoryProvider);
-  ctn.registerResolver(IAuSlotsInfo, auSlotsInfo == null
+  registerResolver(ctn, IViewFactory, noViewFactoryProvider);
+  registerResolver(ctn, IAuSlotsInfo, auSlotsInfo == null
     ? noAuSlotProvider
     : new InstanceProvider(slotInfoProviderName, auSlotsInfo)
   );
@@ -1426,25 +1428,27 @@ function invokeAttribute(
   auSlotsInfo?: IAuSlotsInfo,
 ): { vm: ICustomAttributeViewModel; ctn: IContainer } {
   const ctn = renderingCtrl.container.createChild();
-  ctn.registerResolver(
+  registerResolver(
+    ctn,
     p.HTMLElement,
-    ctn.registerResolver(
+    registerResolver(
+      ctn,
       p.Element,
-      ctn.registerResolver(INode, new InstanceProvider('ElementResolver', host))
+      registerResolver(ctn, INode, new InstanceProvider('ElementResolver', host))
     )
   );
   renderingCtrl = renderingCtrl instanceof Controller
     ? renderingCtrl
     : (renderingCtrl as unknown as SpreadBinding).ctrl;
-  ctn.registerResolver(IController, new InstanceProvider(controllerProviderName, renderingCtrl));
-  ctn.registerResolver(IInstruction, new InstanceProvider<IInstruction>(instructionProviderName, instruction));
-  ctn.registerResolver(IRenderLocation, location == null
+  registerResolver(ctn, IController, new InstanceProvider(controllerProviderName, renderingCtrl));
+  registerResolver(ctn, IInstruction, new InstanceProvider<IInstruction>(instructionProviderName, instruction));
+  registerResolver(ctn, IRenderLocation, location == null
     ? noLocationProvider
     : new InstanceProvider(locationProviderName, location));
-  ctn.registerResolver(IViewFactory, viewFactory == null
+  registerResolver(ctn, IViewFactory, viewFactory == null
     ? noViewFactoryProvider
     : new ViewFactoryProvider(viewFactory));
-  ctn.registerResolver(IAuSlotsInfo, auSlotsInfo == null
+  registerResolver(ctn, IAuSlotsInfo, auSlotsInfo == null
     ? noAuSlotProvider
     : new InstanceProvider(slotInfoProviderName, auSlotsInfo));
 

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -1,6 +1,6 @@
-import { DI, emptyArray, Protocol, all } from '@aurelia/kernel';
+import { emptyArray, Protocol, all } from '@aurelia/kernel';
 import { appendAnnotationKey, appendResourceKey, defineMetadata, getResourceKeyFor } from '../utilities-metadata';
-import { singletonRegistration } from '../utilities-di';
+import { createInterface, singletonRegistration } from '../utilities-di';
 import type { Class, Constructable, IContainer, ResourceDefinition, ResourceType } from '@aurelia/kernel';
 
 export interface AttributePatternDefinition {
@@ -283,7 +283,7 @@ export class SegmentTypes {
 }
 
 export interface ISyntaxInterpreter extends SyntaxInterpreter {}
-export const ISyntaxInterpreter = DI.createInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
+export const ISyntaxInterpreter = createInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
 
 export class SyntaxInterpreter {
   public rootState: AttrParsingState = new AttrParsingState(null!);
@@ -437,12 +437,12 @@ export interface IAttributePattern {
   [pattern: string]: (rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax;
 }
 
-export const IAttributePattern = DI.createInterface<IAttributePattern>('IAttributePattern');
+export const IAttributePattern = createInterface<IAttributePattern>('IAttributePattern');
 
 export interface IAttributeParser {
   parse(name: string, value: string): AttrSyntax;
 }
-export const IAttributeParser = DI.createInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
+export const IAttributeParser = createInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
 
 export class AttributeParser implements IAttributeParser {
   /** @internal */

--- a/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
@@ -2,7 +2,7 @@ import { IPlatform } from '@aurelia/kernel';
 import { bindingBehavior, BindingInterceptor, IInterceptableBinding } from '../binding-behavior';
 
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
-import type { BindingBehaviorExpression, IsAssign, Scope } from '@aurelia/runtime';
+import { astEvaluate, type BindingBehaviorExpression, type IsAssign, type Scope } from '@aurelia/runtime';
 
 const defaultDelay = 200;
 
@@ -64,7 +64,7 @@ export class DebounceBindingBehavior extends BindingInterceptor {
 
   public $bind(scope: Scope): void {
     if (this._firstArg !== null) {
-      const delay = Number(this._firstArg.evaluate(scope, this, null));
+      const delay = Number(astEvaluate(this._firstArg, scope, this, null));
       this._opts.delay = isNaN(delay) ? defaultDelay : delay;
     }
     this.binding.$bind(scope);

--- a/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
@@ -1,8 +1,8 @@
 import { IPlatform } from '@aurelia/kernel';
-import { bindingBehavior, BindingInterceptor, IInterceptableBinding } from '../binding-behavior';
+import { bindingBehavior, BindingInterceptor, type IInterceptableBinding } from '../binding-behavior';
 
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
-import type { BindingBehaviorExpression, IsAssign, Scope } from '@aurelia/runtime';
+import { astEvaluate, type BindingBehaviorExpression, type IsAssign, type Scope } from '@aurelia/runtime';
 
 const defaultDelay = 200;
 
@@ -83,7 +83,7 @@ export class ThrottleBindingBehavior extends BindingInterceptor {
 
   public $bind(scope: Scope): void {
     if (this._firstArg !== null) {
-      const delay = Number(this._firstArg.evaluate(scope, this, null));
+      const delay = Number(astEvaluate(this._firstArg, scope, this, null));
       this._opts.delay = this._delay = isNaN(delay) ? defaultDelay : delay;
     }
     super.$bind(scope);

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -65,7 +65,6 @@ export type ICommandBuildInfo = IPlainAttrCommandInfo | IBindableCommandInfo;
 
 export type BindingCommandInstance<T extends {} = {}> = {
   type: CommandType;
-  name: string;
   build(info: ICommandBuildInfo, parser: IExpressionParser, mapper: IAttrMapper): IInstruction;
 } & T;
 
@@ -173,7 +172,6 @@ export const BindingCommand = Object.freeze<BindingCommandKind>({
 @bindingCommand('one-time')
 export class OneTimeBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'one-time'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     const attr = info.attr;
@@ -199,7 +197,6 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
 @bindingCommand('to-view')
 export class ToViewBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'to-view'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     const attr = info.attr;
@@ -225,7 +222,6 @@ export class ToViewBindingCommand implements BindingCommandInstance {
 @bindingCommand('from-view')
 export class FromViewBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'from-view'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     const attr = info.attr;
@@ -251,7 +247,6 @@ export class FromViewBindingCommand implements BindingCommandInstance {
 @bindingCommand('two-way')
 export class TwoWayBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'two-way'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     const attr = info.attr;
@@ -277,7 +272,6 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
 @bindingCommand('bind')
 export class DefaultBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'bind'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     type CA = CustomAttributeDefinition;
@@ -314,7 +308,6 @@ export class DefaultBindingCommand implements BindingCommandInstance {
 @bindingCommand('call')
 export class CallBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'call'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     const target = info.bindable === null
@@ -327,7 +320,6 @@ export class CallBindingCommand implements BindingCommandInstance {
 @bindingCommand('for')
 export class ForBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.None { return CommandType.None; }
-  public get name() { return 'for'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     const target = info.bindable === null
@@ -340,7 +332,6 @@ export class ForBindingCommand implements BindingCommandInstance {
 @bindingCommand('trigger')
 export class TriggerBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'trigger'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new ListenerBindingInstruction(exprParser.parse(info.attr.rawValue, ExpressionType.IsFunction), info.attr.target, true, DelegationStrategy.none);
@@ -350,7 +341,6 @@ export class TriggerBindingCommand implements BindingCommandInstance {
 @bindingCommand('delegate')
 export class DelegateBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'delegate'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new ListenerBindingInstruction(exprParser.parse(info.attr.rawValue, ExpressionType.IsFunction), info.attr.target, false, DelegationStrategy.bubbling);
@@ -360,7 +350,6 @@ export class DelegateBindingCommand implements BindingCommandInstance {
 @bindingCommand('capture')
 export class CaptureBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'capture'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new ListenerBindingInstruction(exprParser.parse(info.attr.rawValue, ExpressionType.IsFunction), info.attr.target, false, DelegationStrategy.capturing);
@@ -373,7 +362,6 @@ export class CaptureBindingCommand implements BindingCommandInstance {
 @bindingCommand('attr')
 export class AttrBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'attr'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new AttributeBindingInstruction(info.attr.target, exprParser.parse(info.attr.rawValue, ExpressionType.IsProperty), info.attr.target);
@@ -386,7 +374,6 @@ export class AttrBindingCommand implements BindingCommandInstance {
 @bindingCommand('style')
 export class StyleBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'style'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new AttributeBindingInstruction('style', exprParser.parse(info.attr.rawValue, ExpressionType.IsProperty), info.attr.target);
@@ -399,7 +386,6 @@ export class StyleBindingCommand implements BindingCommandInstance {
 @bindingCommand('class')
 export class ClassBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'class'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new AttributeBindingInstruction('class', exprParser.parse(info.attr.rawValue, ExpressionType.IsProperty), info.attr.target);
@@ -412,7 +398,6 @@ export class ClassBindingCommand implements BindingCommandInstance {
 @bindingCommand('ref')
 export class RefBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name() { return 'ref'; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     return new RefBindingInstruction(exprParser.parse(info.attr.rawValue, ExpressionType.IsProperty), info.attr.target);
@@ -422,7 +407,6 @@ export class RefBindingCommand implements BindingCommandInstance {
 @bindingCommand('...$attrs')
 export class SpreadBindingCommand implements BindingCommandInstance {
   public get type(): CommandType.IgnoreAttr { return CommandType.IgnoreAttr; }
-  public get name(): string { return '...$attrs'; }
 
   public build(_info: ICommandBuildInfo): IInstruction {
     return new SpreadBindingInstruction();

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -7,6 +7,7 @@ import { HydrateElementInstruction, IInstruction } from '../../renderer';
 import { LifecycleFlags, Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller';
 import { IRendering } from '../../templating/rendering';
 import { isFunction, isPromise } from '../../utilities';
+import { registerResolver } from '../../utilities-di';
 import { CustomElement, customElement, CustomElementDefinition } from '../custom-element';
 
 /**
@@ -298,20 +299,23 @@ export class AuCompose {
 
     const p = this._platform;
     const isLocation = isRenderLocation(host);
-    container.registerResolver(
+    registerResolver(
+      container,
       p.Element,
-      container.registerResolver(
+      registerResolver(
+        container,
         INode,
         new InstanceProvider('ElementResolver', isLocation ? null : host)
       )
     );
-    container.registerResolver(
+    registerResolver(
+      container,
       IRenderLocation,
       new InstanceProvider('IRenderLocation', isLocation ? host : null)
     );
 
     const instance = container.invoke(comp);
-    container.registerResolver(comp, new InstanceProvider('au-compose.viewModel', instance));
+    registerResolver(container, comp, new InstanceProvider('au-compose.viewModel', instance));
 
     return instance;
   }

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -233,7 +233,7 @@ export class AuCompose {
 
         return new CompositionController(
           controller,
-          (attachInitiator) => controller.activate(attachInitiator ?? controller, $controller, LifecycleFlags.fromBind, $controller.scope.parentScope!),
+          (attachInitiator) => controller.activate(attachInitiator ?? controller, $controller, LifecycleFlags.fromBind, $controller.scope.parent!),
           // todo: call deactivate on the component view model
           (deactachInitiator) => onResolve(
             controller.deactivate(deactachInitiator ?? controller, $controller, LifecycleFlags.fromUnbind),

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -50,7 +50,7 @@ export class AuSlot implements ICustomElementViewModel {
     _parent: IHydratedParentController,
     _flags: LifecycleFlags,
   ): void | Promise<void> {
-    this._parentScope = this.$controller.scope.parentScope!;
+    this._parentScope = this.$controller.scope.parent!;
     let outerScope: Scope;
     if (this._hasProjection) {
       // if there is a projection,
@@ -58,7 +58,7 @@ export class AuSlot implements ICustomElementViewModel {
       // via overlaying the outerscope with another scope that has
       // - binding context & override context pointing to the outer scope binding & override context respectively
       // - override context has the $host pointing to inner scope binding context
-      outerScope = this._hdrContext.controller.scope.parentScope!;
+      outerScope = this._hdrContext.controller.scope.parent!;
       (this._outerScope = Scope.fromParent(outerScope, outerScope.bindingContext))
         .overrideContext.$host = this.expose ?? this._parentScope.bindingContext;
     }

--- a/packages/runtime-html/src/resources/slot-injectables.ts
+++ b/packages/runtime-html/src/resources/slot-injectables.ts
@@ -1,12 +1,12 @@
 // A specific file for primitive of au slot to avoid circular dependencies
-import { DI } from '@aurelia/kernel';
+import { createInterface } from '../utilities-di';
 import { CustomElementDefinition } from './custom-element';
 
 export type IProjections = Record<string, CustomElementDefinition>;
-export const IProjections = DI.createInterface<IProjections>("IProjections");
+export const IProjections = createInterface<IProjections>("IProjections");
 
 export interface IAuSlotsInfo extends AuSlotsInfo { }
-export const IAuSlotsInfo = DI.createInterface<IAuSlotsInfo>('IAuSlotsInfo');
+export const IAuSlotsInfo = createInterface<IAuSlotsInfo>('IAuSlotsInfo');
 export class AuSlotsInfo {
   /**
    * @param {string[]} projectedSlots - Name of the slots to which content are projected.

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -15,6 +15,8 @@ import {
   Scope,
   synchronizeIndices,
   ValueConverterExpression,
+  astEvaluate,
+  astAssign,
 } from '@aurelia/runtime';
 import { IRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';
@@ -103,7 +105,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     this._refreshCollectionObserver();
     const dec = forOf.declaration;
     if(!(this._hasDestructuredLocal = dec.$kind === ExpressionKind.ArrayDestructuring || dec.$kind === ExpressionKind.ObjectDestructuring)) {
-      this.local = dec.evaluate(this.$controller.scope, binding, null) as string;
+      this.local = astEvaluate(dec, this.$controller.scope, binding, null) as string;
     }
   }
 
@@ -156,7 +158,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
         return;
       }
       this._reevaluating = true;
-      this.items = this.forOf.iterable.evaluate($controller.scope, this._forOfBinding, null) as Items<C>;
+      this.items = astEvaluate(this.forOf.iterable, $controller.scope, this._forOfBinding, null) as Items<C>;
       this._reevaluating = false;
       return;
     }
@@ -203,7 +205,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     let newObserver: CollectionObserver | undefined;
 
     if (observingInnerItems) {
-      innerItems = this._innerItems = this._innerItemsExpression!.evaluate(scope, this._forOfBinding, null) as Items<C> ?? null;
+      innerItems = this._innerItems = astEvaluate(this._innerItemsExpression!, scope, this._forOfBinding, null) as Items<C> ?? null;
       observingInnerItems = this._observingInnerItems = !Object.is(this.items, innerItems);
     }
 
@@ -254,7 +256,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
       view = views[i] = factory.create().setLocation(location);
       view.nodes.unlink();
       if(this._hasDestructuredLocal) {
-        (forOf.declaration as DestructuringAssignmentExpression)!.assign(viewScope = Scope.fromParent(parentScope, new BindingContext()), this._forOfBinding, item);
+        astAssign(forOf.declaration as DestructuringAssignmentExpression, viewScope = Scope.fromParent(parentScope, new BindingContext()), this._forOfBinding, item);
       } else {
         viewScope = Scope.fromParent(parentScope, new BindingContext(local, item));
       }
@@ -382,7 +384,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
 
       if (indexMap[i] === -2) {
         if(this._hasDestructuredLocal) {
-          (this.forOf.declaration as DestructuringAssignmentExpression)!.assign(viewScope = Scope.fromParent(parentScope, new BindingContext()), this._forOfBinding, normalizedItems![i]);
+          astAssign(this.forOf.declaration as DestructuringAssignmentExpression, viewScope = Scope.fromParent(parentScope, new BindingContext()), this._forOfBinding, normalizedItems![i]);
         } else {
           viewScope = Scope.fromParent(parentScope, new BindingContext(local, normalizedItems![i]));
         }

--- a/packages/runtime-html/src/resources/value-converters/sanitize.ts
+++ b/packages/runtime-html/src/resources/value-converters/sanitize.ts
@@ -1,4 +1,4 @@
-import { DI } from '@aurelia/kernel';
+import { createInterface } from '../../utilities-di';
 import { valueConverter } from '../value-converter';
 
 export interface ISanitizer {
@@ -10,7 +10,7 @@ export interface ISanitizer {
   sanitize(input: string): string;
 }
 
-export const ISanitizer = DI.createInterface<ISanitizer>('ISanitizer', x => x.singleton(class {
+export const ISanitizer = createInterface<ISanitizer>('ISanitizer', x => x.singleton(class {
   public sanitize(): string {
     throw new Error('"sanitize" method not implemented');
   }

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -535,27 +535,18 @@ export class TemplateCompiler implements ITemplateCompiler {
 
       bindingCommand = context._createCommand(attrSyntax);
       if (bindingCommand !== null) {
-        // supporting one time may not be as simple as it appears
-        // as the let expression could compute its value from various expressions,
-        // which means some value could be unavailable by the time it computes.
-        //
-        // Onetime means it will not have appropriate value, but it's also a good thing,
-        // since often one it's just a simple declaration
-        // todo: consider supporting one-time for <let>
-        switch (bindingCommand.name) {
-          case 'to-view':
-          case 'bind':
-            letInstructions.push(new LetBindingInstruction(
-              exprParser.parse(realAttrValue, ExpressionType.IsProperty),
-              camelCase(realAttrTarget)
-            ));
-            continue;
-          default:
-            if (__DEV__)
-              throw new Error(`AUR0704: Invalid command ${attrSyntax.command} for <let>. Only to-view/bind supported.`);
-            else
-              throw new Error(`AUR0704:${attrSyntax.command}`);
+        if (attrSyntax.command === 'bind') {
+          letInstructions.push(new LetBindingInstruction(
+            exprParser.parse(realAttrValue, ExpressionType.IsProperty),
+            camelCase(realAttrTarget)
+          ));
+        } else {
+          if (__DEV__)
+            throw new Error(`AUR0704: Invalid command ${attrSyntax.command} for <let>. Only to-view/bind supported.`);
+          else
+            throw new Error(`AUR0704:${attrSyntax.command}`);
         }
+        continue;
       }
 
       expr = exprParser.parse(realAttrValue, ExpressionType.Interpolation);

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 /* eslint-disable @typescript-eslint/prefer-optional-chain */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { DI, emptyArray, toArray, ILogger, camelCase, ResourceDefinition, ResourceType, noop, Key } from '@aurelia/kernel';
+import { emptyArray, toArray, ILogger, camelCase, ResourceDefinition, ResourceType, noop, Key } from '@aurelia/kernel';
 import { ExpressionType, IExpressionParser, PrimitiveLiteralExpression } from '@aurelia/runtime';
 import { IAttrMapper } from './attribute-mapper';
 import { ITemplateElementFactory } from './template-element-factory';
@@ -28,7 +28,7 @@ import { CustomAttribute } from './resources/custom-attribute';
 import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from './resources/custom-element';
 import { BindingCommand, CommandType } from './resources/binding-command';
 import { createLookup, isString } from './utilities';
-import { allResources, singletonRegistration } from './utilities-di';
+import { allResources, createInterface, singletonRegistration } from './utilities-di';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from './utilities-metadata';
 import { BindingMode } from './binding/interfaces-bindings';
 
@@ -1843,11 +1843,13 @@ export class BindablesInfo<T extends 0 | 1 = 0> {
   ) {}
 }
 
+_START_CONST_ENUM();
 const enum LocalTemplateBindableAttributes {
   property = "property",
   attribute = "attribute",
   mode = "mode",
 }
+_END_CONST_ENUM();
 const allowedLocalTemplateBindableAttributes: readonly string[] = Object.freeze([
   LocalTemplateBindableAttributes.property,
   LocalTemplateBindableAttributes.attribute,
@@ -1896,7 +1898,7 @@ function getBindingMode(bindable: Element): BindingMode {
  *
  * A feature available to the default template compiler.
  */
-export const ITemplateCompilerHooks = DI.createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
+export const ITemplateCompilerHooks = createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
 export interface ITemplateCompilerHooks {
   /**
    * Should be invoked immediately before a template gets compiled
@@ -1951,6 +1953,7 @@ export const templateCompilerHooks = (target?: Function) => {
 const DEFAULT_SLOT_NAME = 'default';
 const AU_SLOT = 'au-slot';
 
+_START_CONST_ENUM();
 const enum Char {
   // Null           = 0x00,
   // Backspace      = 0x08,
@@ -1990,3 +1993,4 @@ const enum Char {
   // GreaterThan    = 0x3E,
   // Question       = 0x3F,
 }
+_END_CONST_ENUM();

--- a/packages/runtime-html/src/template-element-factory.ts
+++ b/packages/runtime-html/src/template-element-factory.ts
@@ -1,6 +1,6 @@
-import { DI } from '@aurelia/kernel';
 import { IPlatform } from './platform';
 import { isString } from './utilities';
+import { createInterface } from './utilities-di';
 
 /**
  * Utility that creates a `HTMLTemplateElement` out of string markup or an existing DOM node.
@@ -9,7 +9,7 @@ import { isString } from './utilities';
  * so it is always safe to pass in a node without causing unnecessary DOM parsing or template creation.
  */
 export interface ITemplateElementFactory extends TemplateElementFactory {}
-export const ITemplateElementFactory = DI.createInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
+export const ITemplateElementFactory = createInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
 
 const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -558,7 +558,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     switch (this.vmKind) {
       case ViewModelKind.customElement:
         // Custom element scope is created and assigned during hydration
-        (this.scope as Writable<Scope>).parentScope = scope ?? null;
+        (this.scope as Writable<Scope>).parent = scope ?? null;
         break;
       case ViewModelKind.customAttribute:
         this.scope = scope ?? null;
@@ -910,7 +910,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         }
         break;
       case ViewModelKind.customElement:
-        (this.scope as Writable<Scope>).parentScope = null;
+        (this.scope as Writable<Scope>).parent = null;
         break;
     }
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -2,7 +2,6 @@
 import {
   ILogger,
   LogLevel,
-  DI,
   emptyArray,
   InstanceProvider,
   optional,
@@ -27,6 +26,8 @@ import { ComputedWatcher, ExpressionWatcher } from './watchers';
 import { LifecycleHooks, LifecycleHooksEntry } from './lifecycle-hooks';
 import { IRendering } from './rendering';
 import { isFunction, isPromise, isString } from '../utilities';
+import { isObject } from '@aurelia/metadata';
+import { createInterface, registerResolver } from '../utilities-di';
 
 import type {
   IContainer,
@@ -50,7 +51,6 @@ import type { IViewFactory } from './view';
 import type { IInstruction } from '../renderer';
 import type { IWatchDefinition, IWatcherCallback } from '../watch';
 import type { PartialCustomElementDefinition } from '../resources/custom-element';
-import { isObject } from '@aurelia/metadata';
 
 type BindingContext<C extends IViewModel> = Required<ICompileHooks> & Required<IActivationHooks<IHydratedController | null>> & C;
 
@@ -242,7 +242,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ctn.register(...definition.dependencies);
     }
     // each CE controller provides its own hydration context for its internal template
-    ctn.registerResolver(IHydrationContext, new InstanceProvider(
+    registerResolver(ctn, IHydrationContext, new InstanceProvider(
       'IHydrationContext',
       new HydrationContext(
         controller,
@@ -384,7 +384,8 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     definition.register(container);
 
     if (definition.injectable !== null) {
-      container.registerResolver(
+      registerResolver(
+        container,
         definition.injectable,
         new InstanceProvider('definition.injectable', instance as ICustomElementViewModel),
       );
@@ -1744,9 +1745,9 @@ export interface ICustomElementController<C extends ICustomElementViewModel = IC
   ): void | Promise<void>;
 }
 
-export const IController = DI.createInterface<IController>('IController');
+export const IController = createInterface<IController>('IController');
 
-export const IHydrationContext = DI.createInterface<IHydrationContext>('IHydrationContext');
+export const IHydrationContext = createInterface<IHydrationContext>('IHydrationContext');
 export interface IHydrationContext<T = unknown> extends HydrationContext<T> {
 }
 

--- a/packages/runtime-html/src/templating/lifecycle-hooks.ts
+++ b/packages/runtime-html/src/templating/lifecycle-hooks.ts
@@ -1,6 +1,5 @@
-import { DI } from '@aurelia/kernel';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata } from '../utilities-metadata';
-import { singletonRegistration } from '../utilities-di';
+import { createInterface, singletonRegistration } from '../utilities-di';
 import type { Constructable, IContainer, AnyFunction, FunctionPropNames } from '@aurelia/kernel';
 
 export type LifecycleHook<TViewModel, TKey extends keyof TViewModel> =
@@ -9,7 +8,7 @@ export type LifecycleHook<TViewModel, TKey extends keyof TViewModel> =
     : never;
 
 export type ILifecycleHooks<TViewModel = {}, TKey extends keyof TViewModel = keyof TViewModel> = { [K in TKey]-?: LifecycleHook<TViewModel, K>; };
-export const ILifecycleHooks = DI.createInterface<ILifecycleHooks<object>>('ILifecycleHooks');
+export const ILifecycleHooks = createInterface<ILifecycleHooks<object>>('ILifecycleHooks');
 
 export type LifecycleHooksLookup<TViewModel = {}> = {
   [K in FunctionPropNames<TViewModel>]?: readonly LifecycleHooksEntry<TViewModel, K>[];

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer } from '@aurelia/kernel';
+import { IContainer } from '@aurelia/kernel';
 
 import { FragmentNodeSequence, INode, INodeSequence } from '../dom';
 import { IPlatform } from '../platform';
@@ -7,8 +7,9 @@ import { CustomElementDefinition, PartialCustomElementDefinition } from '../reso
 import { createLookup, isString } from '../utilities';
 import { IViewFactory, ViewFactory } from './view';
 import type { IHydratableController } from './controller';
+import { createInterface } from '../utilities-di';
 
-export const IRendering = DI.createInterface<IRendering>('IRendering', x => x.singleton(Rendering));
+export const IRendering = createInterface<IRendering>('IRendering', x => x.singleton(Rendering));
 export interface IRendering extends Rendering { }
 
 export class Rendering {

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -1,10 +1,10 @@
-import { IContainer, DI, noop } from '@aurelia/kernel';
+import { IContainer, noop } from '@aurelia/kernel';
 import { AppTask } from '../app-task';
 import { INode } from '../dom';
 import { getClassesToAdd } from '../observation/class-attribute-accessor';
 import { IPlatform } from '../platform';
 import { defineAttribute } from '../resources/custom-attribute';
-import { instanceRegistration } from '../utilities-di';
+import { createInterface, instanceRegistration } from '../utilities-di';
 
 import type { IRegistry } from '@aurelia/kernel';
 
@@ -57,7 +57,7 @@ export interface IShadowDOMStyleFactory {
   createStyles(localStyles: (string | CSSStyleSheet)[], sharedStyles: IShadowDOMStyles | null): IShadowDOMStyles;
 }
 
-export const IShadowDOMStyleFactory = DI.createInterface<IShadowDOMStyleFactory>('IShadowDOMStyleFactory', x => x.cachedCallback(handler => {
+export const IShadowDOMStyleFactory = createInterface<IShadowDOMStyleFactory>('IShadowDOMStyleFactory', x => x.cachedCallback(handler => {
   if (AdoptedStyleSheetsStyles.supported(handler.get(IPlatform))) {
     return handler.get(AdoptedStyleSheetsStylesFactory);
   }
@@ -104,8 +104,8 @@ export interface IShadowDOMStyles {
   applyTo(shadowRoot: ShadowRoot): void;
 }
 
-export const IShadowDOMStyles = DI.createInterface<IShadowDOMStyles>('IShadowDOMStyles');
-export const IShadowDOMGlobalStyles = DI.createInterface<IShadowDOMStyles>('IShadowDOMGlobalStyles', x => x.instance({ applyTo: noop }));
+export const IShadowDOMStyles = createInterface<IShadowDOMStyles>('IShadowDOMStyles');
+export const IShadowDOMGlobalStyles = createInterface<IShadowDOMStyles>('IShadowDOMGlobalStyles', x => x.instance({ applyTo: noop }));
 
 export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
   private readonly styleSheets: CSSStyleSheet[];

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -1,9 +1,9 @@
-import { DI } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { CustomElementDefinition, defineElement, getElementDefinition } from '../resources/custom-element';
 import { Controller } from './controller';
 import { defineMetadata, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
 import { isFunction, isString } from '../utilities';
+import { createInterface } from '../utilities-di';
 
 import type { Constructable, ConstructableClass, IContainer } from '@aurelia/kernel';
 import type {
@@ -22,7 +22,7 @@ import type {
 import type { PartialCustomElementDefinition } from '../resources/custom-element';
 
 export interface IViewFactory extends ViewFactory {}
-export const IViewFactory = DI.createInterface<IViewFactory>('IViewFactory');
+export const IViewFactory = createInterface<IViewFactory>('IViewFactory');
 export class ViewFactory implements IViewFactory {
   public static maxCacheSize: number = 0xFFFF;
 
@@ -153,7 +153,7 @@ export type ViewSelector = (object: ICustomElementViewModel, views: readonly Par
 export type ComposableObjectComponentType<T extends ICustomElementViewModel>
   = ConstructableClass<{ viewModel: T } & ICustomElementViewModel>;
 
-export const IViewLocator = DI.createInterface<IViewLocator>('IViewLocator', x => x.singleton(ViewLocator));
+export const IViewLocator = createInterface<IViewLocator>('IViewLocator', x => x.singleton(ViewLocator));
 export interface IViewLocator extends ViewLocator {}
 
 export class ViewLocator {

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -1,4 +1,5 @@
 import {
+  astEvaluate,
   connectable,
   ConnectableSwitcher,
   ExpressionKind,
@@ -138,7 +139,7 @@ export class ExpressionWatcher implements IConnectableBinding {
     const canOptimize = expr.$kind === ExpressionKind.AccessScope && this.obs.count === 1;
     if (!canOptimize) {
       this.obs.version++;
-      value = expr.evaluate(this.scope, this, this);
+      value = astEvaluate(expr, this.scope, this, this);
       this.obs.clear();
     }
     if (!Object.is(value, oldValue)) {
@@ -154,7 +155,7 @@ export class ExpressionWatcher implements IConnectableBinding {
     }
     this.isBound = true;
     this.obs.version++;
-    this.value = this.expression.evaluate(this.scope, this, this);
+    this.value = astEvaluate(this.expression, this.scope, this, this);
     this.obs.clear();
   }
 

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -49,6 +49,9 @@ export const allResources = function <T extends Key>(key: T) {
 };
 
 /** @internal */
+export const createInterface = DI.createInterface;
+
+/** @internal */
 export const singletonRegistration = Registration.singleton;
 
 /** @internal */

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -63,6 +63,10 @@ export const callbackRegistration = Registration.callback;
 /** @internal */
 export const transientRegistration = Registration.transient;
 
+/** @internal */
+export const registerResolver = (ctn: IContainer, key: Key, resolver: IResolver): IResolver =>
+  ctn.registerResolver(key, resolver);
+
 export function alias(...aliases: readonly string[]) {
   return function (target: Constructable) {
     const key = getAnnotationKeyFor('aliases');

--- a/packages/runtime/src/binding/ast.eval.ts
+++ b/packages/runtime/src/binding/ast.eval.ts
@@ -1,0 +1,624 @@
+/* eslint-disable no-fallthrough */
+import { IIndexable, isArrayIndex } from '@aurelia/kernel';
+import { IConnectable, IOverrideContext, IBindingContext, IObservable } from '../observation';
+import { Scope } from '../observation/binding-context';
+import { ISignaler } from '../observation/signaler';
+import { isFunction } from '../utilities-objects';
+import { ExpressionKind, IsExpressionOrStatement, IAstEvaluator, DestructuringAssignmentExpression, DestructuringAssignmentRestExpression, DestructuringAssignmentSingleExpression, BindingBehaviorInstance } from './ast';
+import { IConnectableBinding } from './connectable';
+
+const getContext = Scope.getContext;
+// eslint-disable-next-line max-lines-per-function
+export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
+  switch (ast.$kind) {
+    case ExpressionKind.AccessThis: {
+      let oc: IOverrideContext | null = s.overrideContext;
+      let currentScope: Scope | null = s;
+      let i = ast.ancestor;
+      while (i-- && oc) {
+        currentScope = currentScope!.parent;
+        oc = currentScope?.overrideContext ?? null;
+      }
+      return i < 1 && currentScope ? currentScope.bindingContext : void 0;
+    }
+    case ExpressionKind.AccessScope: {
+      const obj = getContext(s, ast.name, ast.ancestor) as IBindingContext;
+      if (c !== null) {
+        c.observe(obj, ast.name);
+      }
+      const evaluatedValue: unknown = obj[ast.name];
+      if (evaluatedValue == null && ast.name === '$host') {
+        if (__DEV__)
+          throw new Error(`AUR0105: Unable to find $host context. Did you forget [au-slot] attribute?`);
+        else
+          throw new Error(`AUR0105`);
+      }
+      if (e?.strict) {
+        // return evaluatedValue;
+        return e?.boundFn && isFunction(evaluatedValue)
+          ? evaluatedValue.bind(obj)
+          : evaluatedValue;
+      }
+      return evaluatedValue == null
+        ? ''
+        : e?.boundFn && isFunction(evaluatedValue)
+          ? evaluatedValue.bind(obj)
+          : evaluatedValue;
+    }
+    case ExpressionKind.ArrayLiteral:
+      return ast.elements.map(expr => astEvaluate(expr, s, e, c));
+    case ExpressionKind.ObjectLiteral: {
+      const instance: Record<string, unknown> = {};
+      for (let i = 0; i < ast.keys.length; ++i) {
+        instance[ast.keys[i]] = astEvaluate(ast.values[i], s, e, c);
+      }
+      return instance;
+    }
+    case ExpressionKind.PrimitiveLiteral:
+      return ast.value;
+    case ExpressionKind.Template: {
+      let result = ast.cooked[0];
+      for (let i = 0; i < ast.expressions.length; ++i) {
+        result += String(astEvaluate(ast.expressions[i], s, e, c));
+        result += ast.cooked[i + 1];
+      }
+      return result;
+    }
+    case ExpressionKind.Unary:
+      switch (ast.operation as string) {
+        case 'void':
+          return void astEvaluate(ast.expression, s, e, c);
+        case 'typeof':
+          return typeof astEvaluate(ast.expression, s, e, c);
+        case '!':
+          return !(astEvaluate(ast.expression, s, e, c) as boolean);
+        case '-':
+          return -(astEvaluate(ast.expression, s, e, c) as number);
+        case '+':
+          return +(astEvaluate(ast.expression, s, e, c) as number);
+        default:
+          if (__DEV__)
+            throw new Error(`AUR0109: Unknown unary operator: '${ast.operation}'`);
+          else
+            throw new Error(`AUR0109:${ast.operation}`);
+      }
+    case ExpressionKind.CallScope: {
+      const args = ast.args.map(a => astEvaluate(a, s, e, c));
+      const context = getContext(s, ast.name, ast.ancestor)!;
+      // ideally, should observe property represents by ast.name as well
+      // because it could be changed
+      // todo: did it ever surprise anyone?
+      const func = getFunction(e?.strictFnCall, context, ast.name);
+      if (func) {
+        return func.apply(context, args);
+      }
+      return void 0;
+    }
+    case ExpressionKind.CallMember: {
+      const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
+
+      const args = ast.args.map(a => astEvaluate(a, s, e, c));
+      const func = getFunction(e?.strictFnCall, instance, ast.name);
+      if (func) {
+        return func.apply(instance, args);
+      }
+      return void 0;
+    }
+    case ExpressionKind.CallFunction: {
+      const func = astEvaluate(ast.func, s, e, c);
+      if (isFunction(func)) {
+        return func(...ast.args.map(a => astEvaluate(a, s, e, c)));
+      }
+      if (!e?.strictFnCall && func == null) {
+        return void 0;
+      }
+      if (__DEV__)
+        throw new Error(`AUR0107: Expression is not a function.`);
+      else
+        throw new Error(`AUR0107`);
+    }
+    case ExpressionKind.ArrowFunction: {
+      const func = (...args: unknown[]) => {
+        const params = ast.args;
+        const rest = ast.rest;
+        const lastIdx = params.length - 1;
+        const context = params.reduce<IIndexable>((map, param, i) => {
+          if (rest && i === lastIdx) {
+            map[param.name] = args.slice(i);
+          } else {
+            map[param.name] = args[i];
+          }
+          return map;
+        }, {});
+        const functionScope = Scope.fromParent(s, context);
+        return astEvaluate(ast.body, functionScope, e, c);
+      };
+      return func;
+    }
+    case ExpressionKind.AccessMember: {
+      const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
+      let ret: unknown;
+      if (e?.strict) {
+        if (instance == null) {
+          return instance;
+        }
+        if (c !== null) {
+          c.observe(instance, ast.name);
+        }
+        ret = instance[ast.name];
+        if (e?.boundFn && isFunction(ret)) {
+          return ret.bind(instance);
+        }
+        return ret;
+      }
+      if (c !== null && instance instanceof Object) {
+        c.observe(instance, ast.name);
+      }
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (instance) {
+        ret = instance[ast.name];
+        if (e?.boundFn && isFunction(ret)) {
+          return ret.bind(instance);
+        }
+        return ret;
+      }
+      return '';
+    }
+    case ExpressionKind.AccessKeyed: {
+      const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
+      if (instance instanceof Object) {
+        const key = astEvaluate(ast.key, s, e, c) as string;
+        if (c !== null) {
+          c.observe(instance, key);
+        }
+        return instance[key];
+      }
+      return void 0;
+    }
+    case ExpressionKind.TaggedTemplate: {
+      const results = ast.expressions.map(expr => astEvaluate(expr, s, e, c));
+      const func = astEvaluate(ast.func, s, e, c);
+      if (!isFunction(func)) {
+        if (__DEV__)
+          throw new Error(`AUR0110: Left-hand side of tagged template expression is not a function.`);
+        else
+          throw new Error(`AUR0110`);
+      }
+      return func(ast.cooked, ...results);
+    }
+    case ExpressionKind.Binary: {
+      const left = ast.left;
+      const right = ast.right;
+      switch (ast.operation as string) {
+        case '&&':
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+          return astEvaluate(left, s, e, c) && astEvaluate(right, s, e, c);
+        case '||':
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+          return astEvaluate(left, s, e, c) || astEvaluate(right, s, e, c);
+        case '??':
+          return astEvaluate(left, s, e, c) ?? astEvaluate(right, s, e, c);
+        case '==':
+          // eslint-disable-next-line eqeqeq
+          return astEvaluate(left, s, e, c) == astEvaluate(right, s, e, c);
+        case '===':
+          return astEvaluate(left, s, e, c) === astEvaluate(right, s, e, c);
+        case '!=':
+          // eslint-disable-next-line eqeqeq
+          return astEvaluate(left, s, e, c) != astEvaluate(right, s, e, c);
+        case '!==':
+          return astEvaluate(left, s, e, c) !== astEvaluate(right, s, e, c);
+        case 'instanceof': {
+          const $right = astEvaluate(right, s, e, c);
+          if (isFunction($right)) {
+            return astEvaluate(left, s, e, c) instanceof $right;
+          }
+          return false;
+        }
+        case 'in': {
+          const $right = astEvaluate(right, s, e, c);
+          if ($right instanceof Object) {
+            return astEvaluate(left, s, e, c) as string in $right;
+          }
+          return false;
+        }
+        // note: autoConvertAdd (and the null check) is removed because the default spec behavior is already largely similar
+        // and where it isn't, you kind of want it to behave like the spec anyway (e.g. return NaN when adding a number to undefined)
+        // ast makes bugs in user code easier to track down for end users
+        // also, skipping these checks and leaving it to the runtime is a nice little perf boost and simplifies our code
+        case '+': {
+          const $left: unknown = astEvaluate(left, s, e, c);
+          const $right: unknown = astEvaluate(right, s, e, c);
+
+          if (e?.strict) {
+            return ($left as number) + ($right as number);
+          }
+
+          // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+          if (!$left || !$right) {
+            if (isNumberOrBigInt($left) || isNumberOrBigInt($right)) {
+              return ($left as number || 0) + ($right as number || 0);
+            }
+            if (isStringOrDate($left) || isStringOrDate($right)) {
+              return ($left as string || '') + ($right as string || '');
+            }
+          }
+          return ($left as number) + ($right as number);
+        }
+        case '-':
+          return (astEvaluate(left, s, e, c) as number) - (astEvaluate(right, s, e, c) as number);
+        case '*':
+          return (astEvaluate(left, s, e, c) as number) * (astEvaluate(right, s, e, c) as number);
+        case '/':
+          return (astEvaluate(left, s, e, c) as number) / (astEvaluate(right, s, e, c) as number);
+        case '%':
+          return (astEvaluate(left, s, e, c) as number) % (astEvaluate(right, s, e, c) as number);
+        case '<':
+          return (astEvaluate(left, s, e, c) as number) < (astEvaluate(right, s, e, c) as number);
+        case '>':
+          return (astEvaluate(left, s, e, c) as number) > (astEvaluate(right, s, e, c) as number);
+        case '<=':
+          return (astEvaluate(left, s, e, c) as number) <= (astEvaluate(right, s, e, c) as number);
+        case '>=':
+          return (astEvaluate(left, s, e, c) as number) >= (astEvaluate(right, s, e, c) as number);
+        default:
+          if (__DEV__)
+            throw new Error(`AUR0108: Unknown binary operator: '${ast.operation}'`);
+          else
+            throw new Error(`AUR0108:${ast.operation}`);
+      }
+    }
+    case ExpressionKind.Conditional:
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      return astEvaluate(ast.condition, s, e, c) ? astEvaluate(ast.yes, s, e, c) : astEvaluate(ast.no, s, e, c);
+    case ExpressionKind.Assign:
+      return astAssign(ast.target, s, e, astEvaluate(ast.value, s, e, c));
+    case ExpressionKind.ValueConverter: {
+      const vc = e?.getConverter?.(ast.name);
+      if (vc == null) {
+        if (__DEV__)
+          throw new Error(`AUR0103: ValueConverter named '${ast.name}' could not be found. Did you forget to register it as a dependency?`);
+        else
+          throw new Error(`AUR0103:${ast.name}`);
+      }
+      if ('toView' in vc) {
+        return vc.toView(astEvaluate(ast.expression, s, e, c), ...ast.args.map(a => astEvaluate(a, s, e, c)));
+      }
+      return astEvaluate(ast.expression, s, e, c);
+    }
+    case ExpressionKind.BindingBehavior:
+      return astEvaluate(ast.expression, s, e, c);
+    case ExpressionKind.BindingIdentifier:
+      return ast.name;
+    case ExpressionKind.ForOfStatement:
+      return astEvaluate(ast.iterable, s, e, c);
+    case ExpressionKind.Interpolation:
+      if (ast.isMulti) {
+        let result = ast.parts[0];
+        for (let i = 0; i < ast.expressions.length; ++i) {
+          result += String(astEvaluate(ast.expressions[i], s, e, c));
+          result += ast.parts[i + 1];
+        }
+        return result;
+      } else {
+        return `${ast.parts[0]}${astEvaluate(ast.firstExpression, s, e, c)}${ast.parts[1]}`;
+      }
+    // TODO: this should come after batch
+    // as a destructuring expression like [x, y] = value
+    //
+    // should only trigger change only once:
+    // batch(() => {
+    //   object.x = value[0]
+    //   object.y = value[1]
+    // })
+    //
+    // instead of twice:
+    // object.x = value[0]
+    // object.y = value[1]
+    case ExpressionKind.ArrayBindingPattern:
+    // TODO
+    // similar to array binding ast, this should only come after batch
+    // for a single notification per destructing,
+    // regardless number of property assignments on the scope binding context
+    case ExpressionKind.ObjectBindingPattern:
+    case ExpressionKind.ArrayDestructuring:
+    case ExpressionKind.ObjectDestructuring:
+    case ExpressionKind.DestructuringAssignmentLeaf:
+    default:
+      return void 0;
+    case ExpressionKind.Custom:
+      return ast.evaluate(s, e, c);
+  }
+}
+
+export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
+  switch (ast.$kind) {
+    case ExpressionKind.AccessScope: {
+      if (ast.name === '$host') {
+        if (__DEV__)
+          throw new Error(`AUR0106: Invalid assignment. $host is a reserved keyword.`);
+        else
+          throw new Error(`AUR0106`);
+      }
+      const obj = getContext(s, ast.name, ast.ancestor) as IObservable;
+      if (obj instanceof Object) {
+        if (obj.$observers?.[ast.name] !== void 0) {
+          obj.$observers[ast.name].setValue(val);
+          return val;
+        } else {
+          return obj[ast.name] = val;
+        }
+      }
+      return void 0;
+    }
+    case ExpressionKind.AccessMember: {
+      const obj = astEvaluate(ast.object, s, e, null) as IObservable;
+      if (obj instanceof Object) {
+        if (obj.$observers !== void 0 && obj.$observers[ast.name] !== void 0) {
+          obj.$observers[ast.name].setValue(val);
+        } else {
+          obj[ast.name] = val;
+        }
+      } else {
+        astAssign(ast.object, s, e, { [ast.name]: val });
+      }
+      return val;
+    }
+    case ExpressionKind.AccessKeyed: {
+      const instance = astEvaluate(ast.object, s, e, null) as IIndexable;
+      const key = astEvaluate(ast.key, s, e, null) as string;
+      return instance[key] = val;
+    }
+    case ExpressionKind.Assign:
+      astAssign(ast.value, s, e, val);
+      return astAssign(ast.target, s, e, val);
+    case ExpressionKind.ValueConverter: {
+      const vc = e?.getConverter?.(ast.name);
+      if (vc == null) {
+        throw converterNotFoundError(ast.name);
+      }
+      if ('fromView' in vc) {
+        val = vc.fromView!(val, ...ast.args.map(a => astEvaluate(a, s, e, null)));
+      }
+      return astAssign(ast.expression, s, e, val);
+    }
+    case ExpressionKind.BindingBehavior:
+      return astAssign(ast.expression, s, e, val);
+    case ExpressionKind.ArrayDestructuring:
+    case ExpressionKind.ObjectDestructuring: {
+      const list = ast.list;
+      const len = list.length;
+      let i: number;
+      let item: DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
+      for (i = 0; i < len; i++) {
+        item = list[i];
+        switch (item.$kind) {
+          case ExpressionKind.DestructuringAssignmentLeaf:
+            astAssign(item, s, e, val);
+            break;
+          case ExpressionKind.ArrayDestructuring:
+          case ExpressionKind.ObjectDestructuring: {
+            if (typeof val !== 'object' || val === null) {
+              if (__DEV__) {
+                throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+              } else {
+                throw new Error(`AUR0112`);
+              }
+            }
+            let source = astEvaluate(item.source!, Scope.create(val), e, null);
+            if (source === void 0 && item.initializer) {
+              source = astEvaluate(item.initializer, s, e, null);
+            }
+            astAssign(item, s, e, source);
+            break;
+          }
+        }
+      }
+      break;
+    }
+    case ExpressionKind.DestructuringAssignmentLeaf: {
+      if (ast instanceof DestructuringAssignmentSingleExpression) {
+        if (val == null) { return; }
+        if (typeof val !== 'object') {
+          if (__DEV__) {
+            throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+          } else {
+            throw new Error(`AUR0112`);
+          }
+        }
+        let source = astEvaluate(ast.source, Scope.create(val), e, null);
+        if (source === void 0 && ast.initializer) {
+          source = astEvaluate(ast.initializer, s, e, null);
+        }
+        astAssign(ast.target, s, e, source);
+      } else {
+        if (val == null) { return; }
+        if (typeof val !== 'object') {
+          if (__DEV__) {
+            throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+          } else {
+            throw new Error(`AUR0112`);
+          }
+        }
+
+        const indexOrProperties = ast.indexOrProperties;
+
+        let restValue: Record<string, unknown> | unknown[];
+        if (isArrayIndex(indexOrProperties)) {
+          if (!Array.isArray(val)) {
+            if (__DEV__) {
+              throw new Error(`AUR0112: Cannot use non-array value for array-destructuring assignment.`);
+            } else {
+              throw new Error(`AUR0112`);
+            }
+          }
+          restValue = val.slice(indexOrProperties);
+        } else {
+          restValue = Object
+            .entries(val)
+            .reduce((acc, [k, v]) => {
+              if (!indexOrProperties.includes(k)) { acc[k] = v; }
+              return acc;
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            }, {} as Record<string, unknown>);
+        }
+        astAssign(ast.target, s, e, restValue);
+      }
+      break;
+    }
+    case ExpressionKind.Custom:
+      return ast.assign(s, e, val);
+    default:
+      return void 0;
+  }
+}
+
+type BindingWithBehavior = IConnectableBinding & { [key: string]: BindingBehaviorInstance | undefined };
+
+export function astBind(ast: IsExpressionOrStatement, s: Scope, b: IAstEvaluator & IConnectableBinding) {
+  switch (ast.$kind) {
+    case ExpressionKind.BindingBehavior: {
+      const name = ast.name;
+      const key = ast.key;
+      const behavior = b.getBehavior?.<BindingBehaviorInstance>(name);
+      if (behavior == null) {
+        throw behaviorNotFoundError(name);
+      }
+      if ((b as BindingWithBehavior)[key] === void 0) {
+        (b as BindingWithBehavior)[key] = behavior;
+        behavior.bind?.(s, b, ...ast.args.map(a => astEvaluate(a, s, b, null) as {}[]));
+      } else {
+        throw duplicateBehaviorAppliedError(name);
+      }
+      astBind(ast.expression, s, b);
+      return;
+    }
+    case ExpressionKind.ValueConverter: {
+      const name = ast.name;
+      const vc = b.getConverter?.(name);
+      if (vc == null) {
+        throw converterNotFoundError(name);
+      }
+      // note: the cast is expected. To connect, it just needs to be a IConnectable
+      // though to work with signal, it needs to have `handleChange`
+      // so having `handleChange` as a guard in the connectable as a safe measure is needed
+      // to make sure signaler works
+      const signals = vc.signals;
+      if (signals != null) {
+        const signaler = b.get?.(ISignaler);
+        const ii = signals.length;
+        let i = 0;
+        for (; i < ii; ++i) {
+          // todo: signaler api
+          signaler?.addSignalListener(signals[i], b);
+        }
+      }
+      astBind(ast.expression, s, b);
+      return;
+    }
+    case ExpressionKind.ForOfStatement: {
+      astBind(ast.iterable, s, b);
+      break;
+    }
+    case ExpressionKind.Custom: {
+      ast.unbind(s, b);
+    }
+  }
+}
+
+export function astUnbind(ast: IsExpressionOrStatement, s: Scope, b: IAstEvaluator & IConnectableBinding) {
+  switch (ast.$kind) {
+    case ExpressionKind.BindingBehavior: {
+      const key = ast.key;
+      const $b = b as BindingWithBehavior;
+      if ($b[key] !== void 0) {
+        $b[key]!.unbind?.(s, b);
+        $b[key] = void 0;
+      }
+      astUnbind(ast.expression, s, b);
+      break;
+    }
+    case ExpressionKind.ValueConverter: {
+      const vc = b.getConverter?.(ast.name);
+      if (vc?.signals === void 0) {
+        return;
+      }
+      const signaler = b.get(ISignaler);
+      let i = 0;
+      for (; i < vc.signals.length; ++i) {
+        // the cast is correct, as the value converter expression would only add
+        // a IConnectable that also implements `ISubscriber` interface to the signaler
+        signaler.removeSignalListener(vc.signals[i], b);
+      }
+      astUnbind(ast.expression, s, b);
+      break;
+    }
+    case ExpressionKind.ForOfStatement: {
+      astUnbind(ast.iterable, s, b);
+      break;
+    }
+    case ExpressionKind.Custom: {
+      ast.unbind(s, b);
+    }
+  }
+}
+
+const behaviorNotFoundError = (name: string) =>
+  __DEV__
+    ? new Error(`AUR0101: BindingBehavior '${name}' could not be found. Did you forget to register it as a dependency?`)
+    : new Error(`AUR0101:${name}`);
+const duplicateBehaviorAppliedError = (name: string) =>
+  __DEV__
+    ? new Error(`AUR0102: BindingBehavior '${name}' already applied.`)
+    : new Error(`AUR0102:${name}`);
+const converterNotFoundError = (name: string) => {
+  if (__DEV__)
+    return new Error(`AUR0103: ValueConverter '${name}' could not be found. Did you forget to register it as a dependency?`);
+  else
+    return new Error(`AUR0103:${name}`);
+};
+
+function getFunction(mustEvaluate: boolean | undefined, obj: object, name: string): ((...args: unknown[]) => unknown) | null {
+  const func = obj == null ? null : (obj as IIndexable)[name];
+  if (isFunction(func)) {
+    return func as (...args: unknown[]) => unknown;
+  }
+  if (!mustEvaluate && func == null) {
+    return null;
+  }
+  if (__DEV__)
+    throw new Error(`AUR0111: Expected '${name}' to be a function`);
+  else
+    throw new Error(`AUR0111:${name}`);
+}
+
+/**
+ * Determines if the value passed is a number or bigint for parsing purposes
+ *
+ * @param value - Value to evaluate
+ */
+function isNumberOrBigInt(value: unknown): value is number | bigint {
+  switch (typeof value) {
+    case 'number':
+    case 'bigint':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Determines if the value passed is a string or Date for parsing purposes
+ *
+ * @param value - Value to evaluate
+ */
+function isStringOrDate(value: unknown): value is string | Date {
+  switch (typeof value) {
+    case 'string':
+      return true;
+    case 'object':
+      return value instanceof Date;
+    default:
+      return false;
+  }
+}

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -17,7 +17,7 @@ import { IVisitor } from './ast.visitor';
 export {
   IVisitor,
   Unparser,
-  visitAst,
+  astVisit,
 } from './ast.visitor';
 
 export const enum ExpressionKind {
@@ -74,24 +74,6 @@ export type AnyBindingExpression = CustomExpression | Interpolation | ForOfState
 export interface IExpressionHydrator {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hydrate(jsonExpr: any): any;
-}
-
-/**
- * An interface describing the object that can evaluate Aurelia AST
- */
-export interface IAstEvaluator {
-  /** describe whether the evaluator wants to evaluate in strict mode */
-  strict?: boolean;
-  /** describe whether the evaluator wants a bound function to be returned, in case the returned value is a function */
-  boundFn?: boolean;
-  /** describe whether the evaluator wants to evaluate the function call in strict mode */
-  strictFnCall?: boolean;
-  /** Allow an AST to retrieve a service that it needs */
-  get?: IServiceLocator['get'];
-  /** Allow an AST to retrieve a value converter that it needs */
-  getConverter?<T>(name: string): ValueConverterInstance<T> | undefined;
-  /** Allow an AST to retrieve a binding behavior that it needs */
-  getBehavior?<T>(name: string): BindingBehaviorInstance<T> | undefined;
 }
 
 type BindingWithBehavior = IConnectableBinding & { [key: string]: BindingBehaviorInstance | undefined };
@@ -1204,4 +1186,25 @@ function isStringOrDate(value: unknown): value is string | Date {
     default:
       return false;
   }
+}
+
+// -----------------------------------
+// this interface causes issues to sourcemap mapping in devtool
+// chuck it at the bottom to avoid such issue
+/**
+ * An interface describing the object that can evaluate Aurelia AST
+ */
+ export interface IAstEvaluator {
+  /** describe whether the evaluator wants to evaluate in strict mode */
+  strict?: boolean;
+  /** describe whether the evaluator wants a bound function to be returned, in case the returned value is a function */
+  boundFn?: boolean;
+  /** describe whether the evaluator wants to evaluate the function call in strict mode */
+  strictFnCall?: boolean;
+  /** Allow an AST to retrieve a service that it needs */
+  get?: IServiceLocator['get'];
+  /** Allow an AST to retrieve a value converter that it needs */
+  getConverter?<T>(name: string): ValueConverterInstance<T> | undefined;
+  /** Allow an AST to retrieve a binding behavior that it needs */
+  getBehavior?<T>(name: string): BindingBehaviorInstance<T> | undefined;
 }

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -321,7 +321,7 @@ export class AccessThisExpression {
     let currentScope: Scope | null = s;
     let i = this.ancestor;
     while (i-- && currentScope) {
-      currentScope = currentScope.parentScope;
+      currentScope = currentScope.parent;
     }
     return i < 1 && currentScope ? currentScope.bindingContext : void 0;
   }

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -58,19 +58,16 @@ export type IsUnary = IsLeftHandSide | UnaryExpression;
 export type IsBinary = IsUnary | BinaryExpression;
 export type IsConditional = IsBinary | ConditionalExpression;
 export type IsAssign = IsConditional | AssignExpression | ArrowFunction;
-export type IsValueConverter = IsAssign | ValueConverterExpression;
+export type IsValueConverter = CustomExpression | IsAssign | ValueConverterExpression;
 export type IsBindingBehavior = IsValueConverter | BindingBehaviorExpression;
 export type IsAssignable = AccessScopeExpression | AccessKeyedExpression | AccessMemberExpression | AssignExpression;
 export type IsExpression = IsBindingBehavior | Interpolation;
 export type BindingIdentifierOrPattern = BindingIdentifier | ArrayBindingPattern | ObjectBindingPattern;
-export type IsExpressionOrStatement =  CustomExpression | IsExpression | ForOfStatement | BindingIdentifierOrPattern | DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
-export type AnyBindingExpression = CustomExpression | Interpolation | ForOfStatement | IsBindingBehavior;
+export type IsExpressionOrStatement = IsExpression | ForOfStatement | BindingIdentifierOrPattern | DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
+export type AnyBindingExpression = Interpolation | ForOfStatement | IsBindingBehavior;
 
 export class CustomExpression {
-  public get $kind(): ExpressionKind.Custom { return ExpressionKind.Custom; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
+  public readonly $kind = ExpressionKind.Custom;
   public constructor(
     public readonly value: unknown,
   ) {}
@@ -105,7 +102,7 @@ export type BindingBehaviorInstance<T extends {} = {}> = {
 } & T;
 
 export class BindingBehaviorExpression {
-  public get $kind(): ExpressionKind.BindingBehavior { return ExpressionKind.BindingBehavior; }
+  public readonly $kind = ExpressionKind.BindingBehavior;
   /**
    * The name of the property to store a binding behavior on the binding when binding
    */
@@ -127,7 +124,7 @@ export type ValueConverterInstance<T extends {} = {}> = {
 } & T;
 
 export class ValueConverterExpression {
-  public get $kind(): ExpressionKind.ValueConverter { return ExpressionKind.ValueConverter; }
+  public readonly $kind = ExpressionKind.ValueConverter;
   public constructor(
     public readonly expression: IsValueConverter,
     public readonly name: string,
@@ -137,7 +134,7 @@ export class ValueConverterExpression {
 }
 
 export class AssignExpression {
-  public get $kind(): ExpressionKind.Assign { return ExpressionKind.Assign; }
+  public readonly $kind = ExpressionKind.Assign;
 
   public constructor(
     public readonly target: IsAssignable,
@@ -146,7 +143,7 @@ export class AssignExpression {
 }
 
 export class ConditionalExpression {
-  public get $kind(): ExpressionKind.Conditional { return ExpressionKind.Conditional; }
+  public readonly $kind = ExpressionKind.Conditional;
   public constructor(
     public readonly condition: IsBinary,
     public readonly yes: IsAssign,
@@ -157,7 +154,7 @@ export class ConditionalExpression {
 export class AccessThisExpression {
   public static readonly $this: AccessThisExpression = new AccessThisExpression(0);
   public static readonly $parent: AccessThisExpression = new AccessThisExpression(1);
-  public get $kind(): ExpressionKind.AccessThis { return ExpressionKind.AccessThis; }
+  public readonly $kind: ExpressionKind.AccessThis = ExpressionKind.AccessThis;
 
   public constructor(
     public readonly ancestor: number = 0,
@@ -165,7 +162,7 @@ export class AccessThisExpression {
 }
 
 export class AccessScopeExpression {
-  public get $kind(): ExpressionKind.AccessScope { return ExpressionKind.AccessScope; }
+  public readonly $kind = ExpressionKind.AccessScope;
   public constructor(
     public readonly name: string,
     public readonly ancestor: number = 0,
@@ -173,7 +170,7 @@ export class AccessScopeExpression {
 }
 
 export class AccessMemberExpression {
-  public get $kind(): ExpressionKind.AccessMember { return ExpressionKind.AccessMember; }
+  public readonly $kind: ExpressionKind.AccessMember = ExpressionKind.AccessMember;
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly name: string,
@@ -182,7 +179,7 @@ export class AccessMemberExpression {
 }
 
 export class AccessKeyedExpression {
-  public get $kind(): ExpressionKind.AccessKeyed { return ExpressionKind.AccessKeyed; }
+  public readonly $kind = ExpressionKind.AccessKeyed;
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly key: IsAssign,
@@ -191,7 +188,7 @@ export class AccessKeyedExpression {
 }
 
 export class CallScopeExpression {
-  public get $kind(): ExpressionKind.CallScope { return ExpressionKind.CallScope; }
+  public readonly $kind = ExpressionKind.CallScope;
   public constructor(
     public readonly name: string,
     public readonly args: readonly IsAssign[],
@@ -201,7 +198,7 @@ export class CallScopeExpression {
 }
 
 export class CallMemberExpression {
-  public get $kind(): ExpressionKind.CallMember { return ExpressionKind.CallMember; }
+  public readonly $kind = ExpressionKind.CallMember;
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly name: string,
@@ -212,7 +209,7 @@ export class CallMemberExpression {
 }
 
 export class CallFunctionExpression {
-  public get $kind(): ExpressionKind.CallFunction { return ExpressionKind.CallFunction; }
+  public readonly $kind = ExpressionKind.CallFunction;
   public constructor(
     public readonly func: IsLeftHandSide,
     public readonly args: readonly IsAssign[],
@@ -221,7 +218,7 @@ export class CallFunctionExpression {
 }
 
 export class BinaryExpression {
-  public get $kind(): ExpressionKind.Binary { return ExpressionKind.Binary; }
+  public readonly $kind: ExpressionKind.Binary = ExpressionKind.Binary;
   public constructor(
     public readonly operation: BinaryOperator,
     public readonly left: IsBinary,
@@ -230,7 +227,7 @@ export class BinaryExpression {
 }
 
 export class UnaryExpression {
-  public get $kind(): ExpressionKind.Unary { return ExpressionKind.Unary; }
+  public readonly $kind = ExpressionKind.Unary;
   public constructor(
     public readonly operation: UnaryOperator,
     public readonly expression: IsLeftHandSide,
@@ -242,7 +239,7 @@ export class PrimitiveLiteralExpression<TValue extends null | undefined | number
   public static readonly $true: PrimitiveLiteralExpression<true> = new PrimitiveLiteralExpression<true>(true);
   public static readonly $false: PrimitiveLiteralExpression<false> = new PrimitiveLiteralExpression<false>(false);
   public static readonly $empty: PrimitiveLiteralExpression<string> = new PrimitiveLiteralExpression<''>('');
-  public get $kind(): ExpressionKind.PrimitiveLiteral { return ExpressionKind.PrimitiveLiteral; }
+  public readonly $kind = ExpressionKind.PrimitiveLiteral;
 
   public constructor(
     public readonly value: TValue,
@@ -251,7 +248,7 @@ export class PrimitiveLiteralExpression<TValue extends null | undefined | number
 
 export class ArrayLiteralExpression {
   public static readonly $empty: ArrayLiteralExpression = new ArrayLiteralExpression(emptyArray);
-  public get $kind(): ExpressionKind.ArrayLiteral { return ExpressionKind.ArrayLiteral; }
+  public readonly $kind = ExpressionKind.ArrayLiteral;
   public constructor(
     public readonly elements: readonly IsAssign[],
   ) {}
@@ -259,7 +256,7 @@ export class ArrayLiteralExpression {
 
 export class ObjectLiteralExpression {
   public static readonly $empty: ObjectLiteralExpression = new ObjectLiteralExpression(emptyArray, emptyArray);
-  public get $kind(): ExpressionKind.ObjectLiteral { return ExpressionKind.ObjectLiteral; }
+  public readonly $kind = ExpressionKind.ObjectLiteral;
   public constructor(
     public readonly keys: readonly (number | string)[],
     public readonly values: readonly IsAssign[],
@@ -268,7 +265,7 @@ export class ObjectLiteralExpression {
 
 export class TemplateExpression {
   public static readonly $empty: TemplateExpression = new TemplateExpression(['']);
-  public get $kind(): ExpressionKind.Template { return ExpressionKind.Template; }
+  public readonly $kind = ExpressionKind.Template;
   public constructor(
     public readonly cooked: readonly string[],
     public readonly expressions: readonly IsAssign[] = emptyArray,
@@ -276,7 +273,7 @@ export class TemplateExpression {
 }
 
 export class TaggedTemplateExpression {
-  public get $kind(): ExpressionKind.TaggedTemplate { return ExpressionKind.TaggedTemplate; }
+  public readonly $kind = ExpressionKind.TaggedTemplate;
   public constructor(
     public readonly cooked: readonly string[] & { raw?: readonly string[] },
     raw: readonly string[],
@@ -288,9 +285,7 @@ export class TaggedTemplateExpression {
 }
 
 export class ArrayBindingPattern {
-  public get $kind(): ExpressionKind.ArrayBindingPattern { return ExpressionKind.ArrayBindingPattern; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
+  public readonly $kind = ExpressionKind.ArrayBindingPattern;
   // We'll either have elements, or keys+values, but never all 3
   public constructor(
     public readonly elements: readonly IsAssign[],
@@ -298,7 +293,7 @@ export class ArrayBindingPattern {
 }
 
 export class ObjectBindingPattern {
-  public get $kind(): ExpressionKind.ObjectBindingPattern { return ExpressionKind.ObjectBindingPattern; }
+  public readonly $kind = ExpressionKind.ObjectBindingPattern;
   // We'll either have elements, or keys+values, but never all 3
   public constructor(
     public readonly keys: readonly (string | number)[],
@@ -307,7 +302,7 @@ export class ObjectBindingPattern {
 }
 
 export class BindingIdentifier {
-  public get $kind(): ExpressionKind.BindingIdentifier { return ExpressionKind.BindingIdentifier; }
+  public readonly $kind = ExpressionKind.BindingIdentifier;
   public constructor(
     public readonly name: string,
   ) {}
@@ -316,7 +311,7 @@ export class BindingIdentifier {
 // https://tc39.github.io/ecma262/#sec-iteration-statements
 // https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements
 export class ForOfStatement {
-  public get $kind(): ExpressionKind.ForOfStatement { return ExpressionKind.ForOfStatement; }
+  public readonly $kind = ExpressionKind.ForOfStatement;
   public constructor(
     public readonly declaration: BindingIdentifierOrPattern | DestructuringAssignmentExpression,
     public readonly iterable: IsBindingBehavior,
@@ -329,7 +324,7 @@ export class ForOfStatement {
 * but this class might be a candidate for removal if it turns out it does provide all we need
 */
 export class Interpolation {
-  public get $kind(): ExpressionKind.Interpolation { return ExpressionKind.Interpolation; }
+  public readonly $kind = ExpressionKind.Interpolation;
   public readonly isMulti: boolean;
   public readonly firstExpression: IsBindingBehavior;
   public constructor(
@@ -354,7 +349,7 @@ export class DestructuringAssignmentExpression {
 
 /** This is an internal API */
 export class DestructuringAssignmentSingleExpression {
-  public get $kind(): ExpressionKind.DestructuringAssignmentLeaf { return ExpressionKind.DestructuringAssignmentLeaf; }
+  public readonly $kind = ExpressionKind.DestructuringAssignmentLeaf;
   public constructor(
     public readonly target: AccessMemberExpression,
     public readonly source: AccessMemberExpression | AccessKeyedExpression,
@@ -364,7 +359,7 @@ export class DestructuringAssignmentSingleExpression {
 
 /** This is an internal API */
 export class DestructuringAssignmentRestExpression {
-  public get $kind(): ExpressionKind.DestructuringAssignmentLeaf { return ExpressionKind.DestructuringAssignmentLeaf; }
+  public readonly $kind = ExpressionKind.DestructuringAssignmentLeaf;
   public constructor(
     public readonly target: AccessMemberExpression,
     public readonly indexOrProperties: string[] | number,
@@ -372,10 +367,7 @@ export class DestructuringAssignmentRestExpression {
 }
 
 export class ArrowFunction {
-  public get $kind(): ExpressionKind.ArrowFunction { return ExpressionKind.ArrowFunction; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
+  public readonly $kind = ExpressionKind.ArrowFunction;
   public constructor(
     public args: BindingIdentifier[],
     public body: IsAssign,

--- a/packages/runtime/src/binding/ast.ts
+++ b/packages/runtime/src/binding/ast.ts
@@ -1,23 +1,18 @@
-import { emptyArray, isArrayIndex } from '@aurelia/kernel';
+import { emptyArray } from '@aurelia/kernel';
 import { type IBinding } from '../observation';
-import { Scope } from '../observation/binding-context';
-import { ISignaler } from '../observation/signaler';
+import { type Scope } from '../observation/binding-context';
 import { type IConnectableBinding } from './connectable';
-import { safeString, isArray, isFunction } from '../utilities-objects';
 
-import type { IIndexable, IServiceLocator } from '@aurelia/kernel';
+import type { IServiceLocator } from '@aurelia/kernel';
 import type {
-  IBindingContext,
-  IObservable,
-  IConnectable,
-  ISubscriber,
+  IConnectable
 } from '../observation';
 import { IVisitor } from './ast.visitor';
 
 export {
-  IVisitor,
-  Unparser,
   astVisit,
+  IVisitor,
+  Unparser
 } from './ast.visitor';
 
 export const enum ExpressionKind {
@@ -71,13 +66,6 @@ export type BindingIdentifierOrPattern = BindingIdentifier | ArrayBindingPattern
 export type IsExpressionOrStatement =  CustomExpression | IsExpression | ForOfStatement | BindingIdentifierOrPattern | DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
 export type AnyBindingExpression = CustomExpression | Interpolation | ForOfStatement | IsBindingBehavior;
 
-export interface IExpressionHydrator {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  hydrate(jsonExpr: any): any;
-}
-
-type BindingWithBehavior = IConnectableBinding & { [key: string]: BindingBehaviorInstance | undefined };
-
 export class CustomExpression {
   public get $kind(): ExpressionKind.Custom { return ExpressionKind.Custom; }
   public get hasBind(): false { return false; }
@@ -118,8 +106,6 @@ export type BindingBehaviorInstance<T extends {} = {}> = {
 
 export class BindingBehaviorExpression {
   public get $kind(): ExpressionKind.BindingBehavior { return ExpressionKind.BindingBehavior; }
-  public get hasBind(): true { return true; }
-  public get hasUnbind(): true { return true; }
   /**
    * The name of the property to store a binding behavior on the binding when binding
    */
@@ -132,54 +118,7 @@ export class BindingBehaviorExpression {
   ) {
     this.key = `_bb_${name}`;
   }
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    return this.expression.evaluate(s, e, c);
-  }
-
-  public assign(s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
-    return this.expression.assign(s, e, val);
-  }
-
-  public bind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
-    const name = this.name;
-    const key = this.key;
-    const behavior = b.getBehavior?.<BindingBehaviorInstance>(name);
-    if (behavior == null) {
-      throw behaviorNotFoundError(name);
-    }
-    if ((b as BindingWithBehavior)[key] === void 0) {
-      (b as BindingWithBehavior)[key] = behavior;
-      behavior.bind?.(s, b, ...this.args.map(a => a.evaluate(s, b, null) as {}[]));
-    } else {
-      throw duplicateBehaviorAppliedError(name);
-    }
-    if (this.expression.hasBind) {
-      this.expression.bind(s, b);
-    }
-  }
-
-  public unbind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
-    const internalKey = this.key;
-    const $b = b as BindingWithBehavior;
-    if ($b[internalKey] !== void 0) {
-      $b[internalKey]!.unbind?.(s, b);
-      $b[internalKey] = void 0;
-    }
-    if (this.expression.hasUnbind) {
-      this.expression.unbind(s, b);
-    }
-  }
 }
-
-const behaviorNotFoundError = (name: string) =>
-  __DEV__
-    ? new Error(`AUR0101: BindingBehavior '${name}' could not be found. Did you forget to register it as a dependency?`)
-    : new Error(`AUR0101:${name}`);
-const duplicateBehaviorAppliedError = (name: string) =>
-  __DEV__
-    ? new Error(`AUR0102: BindingBehavior '${name}' already applied.`)
-    : new Error(`AUR0102:${name}`);
 
 export type ValueConverterInstance<T extends {} = {}> = {
   signals?: string[];
@@ -189,343 +128,80 @@ export type ValueConverterInstance<T extends {} = {}> = {
 
 export class ValueConverterExpression {
   public get $kind(): ExpressionKind.ValueConverter { return ExpressionKind.ValueConverter; }
-  public get hasBind(): true { return true; }
-  public get hasUnbind(): true { return true; }
-
   public constructor(
     public readonly expression: IsValueConverter,
     public readonly name: string,
     public readonly args: readonly IsAssign[],
   ) {
   }
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const name = this.name;
-    const vc = e?.getConverter?.(name);
-    if (vc == null) {
-      throw converterNotFoundError(name);
-    }
-    if ('toView' in vc) {
-      return vc.toView(this.expression.evaluate(s, e, c), ...this.args.map(a => a.evaluate(s, e, c)));
-    }
-    return this.expression.evaluate(s, e, c);
-  }
-
-  public assign(s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
-    const name = this.name;
-    const vc = e?.getConverter?.<ValueConverterExpression & ValueConverterInstance>(name);
-    if (vc == null) {
-      throw converterNotFoundError(name);
-    }
-    if ('fromView' in vc) {
-      val = vc.fromView!(val, ...this.args.map(a => a.evaluate(s, e, null)));
-    }
-    return this.expression.assign(s, e, val);
-  }
-
-  public bind(s: Scope, b: IAstEvaluator & IConnectableBinding): void {
-    const name = this.name;
-    const vc = b.getConverter?.(name);
-    if (vc == null) {
-      throw converterNotFoundError(name);
-    }
-    // note: the cast is expected. To connect, it just needs to be a IConnectable
-    // though to work with signal, it needs to have `handleChange`
-    // so having `handleChange` as a guard in the connectable as a safe measure is needed
-    // to make sure signaler works
-    const signals = vc.signals;
-    if (signals != null) {
-      const signaler = b.get?.(ISignaler);
-      const ii = signals.length;
-      let i = 0;
-      for (; i < ii; ++i) {
-        // todo: signaler api
-        signaler?.addSignalListener(signals[i], b);
-      }
-    }
-    if (this.expression.hasBind) {
-      this.expression.bind(s, b);
-    }
-  }
-
-  public unbind(_s: Scope, b: IAstEvaluator & IConnectableBinding): void {
-    const vc = b.getConverter?.(this.name);
-    if (vc?.signals === void 0) {
-      return;
-    }
-    const signaler = b.get(ISignaler);
-    let i = 0;
-    for (; i < vc.signals.length; ++i) {
-      // the cast is correct, as the value converter expression would only add
-      // a IConnectable that also implements `ISubscriber` interface to the signaler
-      signaler.removeSignalListener(vc.signals[i], b as unknown as ISubscriber);
-    }
-  }
 }
-
-const converterNotFoundError = (name: string) => {
-  if (__DEV__)
-    return new Error(`AUR0103: ValueConverter '${name}' could not be found. Did you forget to register it as a dependency?`);
-  else
-    return new Error(`AUR0103:${name}`);
-};
 
 export class AssignExpression {
   public get $kind(): ExpressionKind.Assign { return ExpressionKind.Assign; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
 
   public constructor(
     public readonly target: IsAssignable,
     public readonly value: IsAssign,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    return this.target.assign(s, e, this.value.evaluate(s, e, c));
-  }
-
-  public assign(s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
-    this.value.assign(s, e, val);
-    return this.target.assign(s, e, val);
-  }
 }
 
 export class ConditionalExpression {
   public get $kind(): ExpressionKind.Conditional { return ExpressionKind.Conditional; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly condition: IsBinary,
     public readonly yes: IsAssign,
     public readonly no: IsAssign,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    return this.condition.evaluate(s, e, c) ? this.yes.evaluate(s, e, c) : this.no.evaluate(s, e, c);
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class AccessThisExpression {
   public static readonly $this: AccessThisExpression = new AccessThisExpression(0);
   public static readonly $parent: AccessThisExpression = new AccessThisExpression(1);
   public get $kind(): ExpressionKind.AccessThis { return ExpressionKind.AccessThis; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
 
   public constructor(
     public readonly ancestor: number = 0,
   ) {}
-
-  public evaluate(s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): IBindingContext | undefined {
-    let currentScope: Scope | null = s;
-    let i = this.ancestor;
-    while (i-- && currentScope) {
-      currentScope = currentScope.parent;
-    }
-    return i < 1 && currentScope ? currentScope.bindingContext : void 0;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class AccessScopeExpression {
   public get $kind(): ExpressionKind.AccessScope { return ExpressionKind.AccessScope; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly name: string,
     public readonly ancestor: number = 0,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const obj = Scope.getContext(s, this.name, this.ancestor) as IBindingContext;
-    if (c !== null) {
-      c.observe(obj, this.name);
-    }
-    const evaluatedValue = obj[this.name] as ReturnType<AccessScopeExpression['evaluate']>;
-    if (evaluatedValue == null && this.name === '$host') {
-      if (__DEV__)
-        throw new Error(`AUR0105: Unable to find $host context. Did you forget [au-slot] attribute?`);
-      else
-        throw new Error(`AUR0105`);
-    }
-    if (e?.strict) {
-      // return evaluatedValue;
-      return e?.boundFn && isFunction(evaluatedValue)
-        ? evaluatedValue.bind(obj)
-        : evaluatedValue;
-    }
-    return evaluatedValue == null
-      ? ''
-      : e?.boundFn && isFunction(evaluatedValue)
-        ? evaluatedValue.bind(obj)
-        : evaluatedValue;
-  }
-
-  public assign(s: Scope, _e: IAstEvaluator | null, val: unknown): unknown {
-    if (this.name === '$host') {
-      if (__DEV__)
-        throw new Error(`AUR0106: Invalid assignment. $host is a reserved keyword.`);
-      else
-        throw new Error(`AUR0106`);
-    }
-    const obj = Scope.getContext(s, this.name, this.ancestor) as IObservable;
-    if (obj instanceof Object) {
-      if (obj.$observers?.[this.name] !== void 0) {
-        obj.$observers[this.name].setValue(val);
-        return val;
-      } else {
-        return obj[this.name] = val;
-      }
-    }
-  }
 }
 
 export class AccessMemberExpression {
   public get $kind(): ExpressionKind.AccessMember { return ExpressionKind.AccessMember; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly name: string,
     public readonly optional: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const instance = this.object.evaluate(s, e, c) as IIndexable;
-    let ret: unknown;
-    if (e?.strict) {
-      if (instance == null) {
-        return instance;
-      }
-      if (c !== null) {
-        c.observe(instance, this.name);
-      }
-      ret = instance[this.name];
-      if (e?.boundFn && isFunction(ret)) {
-        return ret.bind(instance);
-      }
-      return ret;
-    }
-    if (c !== null && instance instanceof Object) {
-      c.observe(instance, this.name);
-    }
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (instance) {
-      ret = instance[this.name];
-      if (e?.boundFn && isFunction(ret)) {
-        return ret.bind(instance);
-      }
-      return ret;
-    }
-    return '';
-  }
-
-  public assign(s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
-    const obj = this.object.evaluate(s, e, null) as IObservable;
-    if (obj instanceof Object) {
-      if (obj.$observers !== void 0 && obj.$observers[this.name] !== void 0) {
-        obj.$observers[this.name].setValue(val);
-      } else {
-        obj[this.name] = val;
-      }
-    } else {
-      this.object.assign(s, e, { [this.name]: val });
-    }
-    return val;
-  }
 }
 
 export class AccessKeyedExpression {
   public get $kind(): ExpressionKind.AccessKeyed { return ExpressionKind.AccessKeyed; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly key: IsAssign,
     public readonly optional: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const instance = this.object.evaluate(s, e, c) as IIndexable;
-    if (instance instanceof Object) {
-      const key = this.key.evaluate(s, e, c) as string;
-      if (c !== null) {
-        c.observe(instance, key);
-      }
-      return instance[key];
-    }
-    return void 0;
-  }
-
-  public assign(s: Scope, e: IAstEvaluator | null, val: unknown): unknown {
-    const instance = this.object.evaluate(s, e, null) as IIndexable;
-    const key = this.key.evaluate(s, e, null) as string;
-    return instance[key] = val;
-  }
 }
 
 export class CallScopeExpression {
   public get $kind(): ExpressionKind.CallScope { return ExpressionKind.CallScope; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly name: string,
     public readonly args: readonly IsAssign[],
     public readonly ancestor: number = 0,
     public readonly optional: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const args = this.args.map(a => a.evaluate(s, e, c));
-    const context = Scope.getContext(s, this.name, this.ancestor)!;
-    // ideally, should observe property represents by this.name as well
-    // because it could be changed
-    // todo: did it ever surprise anyone?
-    const func = getFunction(e?.strictFnCall, context, this.name);
-    if (func) {
-      return func.apply(context, args);
-    }
-    return void 0;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
-
-const autoObserveArrayMethods =
-  'at map filter includes indexOf lastIndexOf findIndex find flat flatMap join reduce reduceRight slice every some sort'.split(' ');
-// sort,      // bad supported, self mutation + unclear dependency
-
-// push,      // not supported, self mutation + unclear dependency
-// pop,       // not supported, self mutation + unclear dependency
-// shift,     // not supported, self mutation + unclear dependency
-// splice,    // not supported, self mutation + unclear dependency
-// unshift,   // not supported, self mutation + unclear dependency
-// reverse,   // not supported, self mutation + unclear dependency
-
-// keys,    // not meaningful in template
-// values,  // not meaningful in template
-// entries, // not meaningful in template
 
 export class CallMemberExpression {
   public get $kind(): ExpressionKind.CallMember { return ExpressionKind.CallMember; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly object: IsLeftHandSide,
     public readonly name: string,
@@ -533,189 +209,32 @@ export class CallMemberExpression {
     public readonly optionalMember: boolean = false,
     public readonly optionalCall: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const instance = this.object.evaluate(s, e, c) as IIndexable;
-
-    const args = this.args.map(a => a.evaluate(s, e, c));
-    const func = getFunction(e?.strictFnCall, instance, this.name);
-    if (func) {
-      const ret = func.apply(instance, args);
-      // todo(doc): investigate & document in engineering doc the difference
-      //            between observing before/after func.apply
-      if (isArray(instance) && autoObserveArrayMethods.includes(this.name)) {
-        c?.observeCollection(instance);
-      }
-      return ret;
-    }
-    return void 0;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class CallFunctionExpression {
   public get $kind(): ExpressionKind.CallFunction { return ExpressionKind.CallFunction; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly func: IsLeftHandSide,
     public readonly args: readonly IsAssign[],
     public readonly optional: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const func = this.func.evaluate(s, e, c);
-    if (isFunction(func)) {
-      return func(...this.args.map(a => a.evaluate(s, e, c)));
-    }
-    if (!e?.strictFnCall && func == null) {
-      return void 0;
-    }
-    if (__DEV__)
-      throw new Error(`AUR0107: Expression is not a function.`);
-    else
-      throw new Error(`AUR0107`);
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class BinaryExpression {
   public get $kind(): ExpressionKind.Binary { return ExpressionKind.Binary; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly operation: BinaryOperator,
     public readonly left: IsBinary,
     public readonly right: IsBinary,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    switch (this.operation) {
-      case '&&':
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        return this.left.evaluate(s, e, c) && this.right.evaluate(s, e, c);
-      case '||':
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        return this.left.evaluate(s, e, c) || this.right.evaluate(s, e, c);
-      case '??':
-        return this.left.evaluate(s, e, c) ?? this.right.evaluate(s, e, c);
-      case '==':
-        // eslint-disable-next-line eqeqeq
-        return this.left.evaluate(s, e, c) == this.right.evaluate(s, e, c);
-      case '===':
-        return this.left.evaluate(s, e, c) === this.right.evaluate(s, e, c);
-      case '!=':
-        // eslint-disable-next-line eqeqeq
-        return this.left.evaluate(s, e, c) != this.right.evaluate(s, e, c);
-      case '!==':
-        return this.left.evaluate(s, e, c) !== this.right.evaluate(s, e, c);
-      case 'instanceof': {
-        const right = this.right.evaluate(s, e, c);
-        if (isFunction(right)) {
-          return this.left.evaluate(s, e, c) instanceof right;
-        }
-        return false;
-      }
-      case 'in': {
-        const right = this.right.evaluate(s, e, c);
-        if (right instanceof Object) {
-          return this.left.evaluate(s, e, c) as string in right;
-        }
-        return false;
-      }
-      // note: autoConvertAdd (and the null check) is removed because the default spec behavior is already largely similar
-      // and where it isn't, you kind of want it to behave like the spec anyway (e.g. return NaN when adding a number to undefined)
-      // this makes bugs in user code easier to track down for end users
-      // also, skipping these checks and leaving it to the runtime is a nice little perf boost and simplifies our code
-      case '+': {
-        const left: unknown = this.left.evaluate(s, e, c);
-        const right: unknown = this.right.evaluate(s, e, c);
-
-        if (e?.strict) {
-          return (left as number) + (right as number);
-        }
-
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!left || !right) {
-          if (isNumberOrBigInt(left) || isNumberOrBigInt(right)) {
-            return (left as number || 0) + (right as number || 0);
-          }
-          if (isStringOrDate(left) || isStringOrDate(right)) {
-            return (left as string || '') + (right as string || '');
-          }
-        }
-        return (left as number) + (right as number);
-      }
-      case '-':
-        return (this.left.evaluate(s, e, c) as number) - (this.right.evaluate(s, e, c) as number);
-      case '*':
-        return (this.left.evaluate(s, e, c) as number) * (this.right.evaluate(s, e, c) as number);
-      case '/':
-        return (this.left.evaluate(s, e, c) as number) / (this.right.evaluate(s, e, c) as number);
-      case '%':
-        return (this.left.evaluate(s, e, c) as number) % (this.right.evaluate(s, e, c) as number);
-      case '<':
-        return (this.left.evaluate(s, e, c) as number) < (this.right.evaluate(s, e, c) as number);
-      case '>':
-        return (this.left.evaluate(s, e, c) as number) > (this.right.evaluate(s, e, c) as number);
-      case '<=':
-        return (this.left.evaluate(s, e, c) as number) <= (this.right.evaluate(s, e, c) as number);
-      case '>=':
-        return (this.left.evaluate(s, e, c) as number) >= (this.right.evaluate(s, e, c) as number);
-      default:
-        if (__DEV__)
-          throw new Error(`AUR0108: Unknown binary operator: '${this.operation}'`);
-        else
-          throw new Error(`AUR0108:${this.operation}`);
-    }
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class UnaryExpression {
   public get $kind(): ExpressionKind.Unary { return ExpressionKind.Unary; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly operation: UnaryOperator,
     public readonly expression: IsLeftHandSide,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    switch (this.operation) {
-      case 'void':
-        return void this.expression.evaluate(s, e, c);
-      case 'typeof':
-        return typeof this.expression.evaluate(s, e, c);
-      case '!':
-        return !(this.expression.evaluate(s, e, c) as boolean);
-      case '-':
-        return -(this.expression.evaluate(s, e, c) as number);
-      case '+':
-        return +(this.expression.evaluate(s, e, c) as number);
-      default:
-        if (__DEV__)
-          throw new Error(`AUR0109: Unknown unary operator: '${this.operation}'`);
-        else
-          throw new Error(`AUR0109:${this.operation}`);
-    }
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 export class PrimitiveLiteralExpression<TValue extends null | undefined | number | boolean | string = null | undefined | number | boolean | string> {
   public static readonly $undefined: PrimitiveLiteralExpression<undefined> = new PrimitiveLiteralExpression<undefined>(void 0);
@@ -724,95 +243,40 @@ export class PrimitiveLiteralExpression<TValue extends null | undefined | number
   public static readonly $false: PrimitiveLiteralExpression<false> = new PrimitiveLiteralExpression<false>(false);
   public static readonly $empty: PrimitiveLiteralExpression<string> = new PrimitiveLiteralExpression<''>('');
   public get $kind(): ExpressionKind.PrimitiveLiteral { return ExpressionKind.PrimitiveLiteral; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
 
   public constructor(
     public readonly value: TValue,
   ) {}
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): TValue {
-    return this.value;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class ArrayLiteralExpression {
   public static readonly $empty: ArrayLiteralExpression = new ArrayLiteralExpression(emptyArray);
   public get $kind(): ExpressionKind.ArrayLiteral { return ExpressionKind.ArrayLiteral; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly elements: readonly IsAssign[],
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): readonly unknown[] {
-    return this.elements.map(el => el.evaluate(s, e, c));
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class ObjectLiteralExpression {
   public static readonly $empty: ObjectLiteralExpression = new ObjectLiteralExpression(emptyArray, emptyArray);
   public get $kind(): ExpressionKind.ObjectLiteral { return ExpressionKind.ObjectLiteral; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly keys: readonly (number | string)[],
     public readonly values: readonly IsAssign[],
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): Record<string, unknown> {
-    const instance: Record<string, unknown> = {};
-    for (let i = 0; i < this.keys.length; ++i) {
-      instance[this.keys[i]] = this.values[i].evaluate(s, e, c);
-    }
-    return instance;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class TemplateExpression {
   public static readonly $empty: TemplateExpression = new TemplateExpression(['']);
   public get $kind(): ExpressionKind.Template { return ExpressionKind.Template; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly cooked: readonly string[],
     public readonly expressions: readonly IsAssign[] = emptyArray,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): string {
-    let result = this.cooked[0];
-    for (let i = 0; i < this.expressions.length; ++i) {
-      result += safeString(this.expressions[i].evaluate(s, e, c));
-      result += this.cooked[i + 1];
-    }
-    return result;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class TaggedTemplateExpression {
   public get $kind(): ExpressionKind.TaggedTemplate { return ExpressionKind.TaggedTemplate; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly cooked: readonly string[] & { raw?: readonly string[] },
     raw: readonly string[],
@@ -821,126 +285,42 @@ export class TaggedTemplateExpression {
   ) {
     cooked.raw = raw;
   }
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): string {
-    const results = this.expressions.map(el => el.evaluate(s, e, c));
-    const func = this.func.evaluate(s, e, c);
-    if (!isFunction(func)) {
-      if (__DEV__)
-        throw new Error(`AUR0110: Left-hand side of tagged template expression is not a function.`);
-      else
-        throw new Error(`AUR0110`);
-    }
-    return func(this.cooked, ...results);
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 export class ArrayBindingPattern {
   public get $kind(): ExpressionKind.ArrayBindingPattern { return ExpressionKind.ArrayBindingPattern; }
   public get hasBind(): false { return false; }
   public get hasUnbind(): false { return false; }
-
   // We'll either have elements, or keys+values, but never all 3
   public constructor(
     public readonly elements: readonly IsAssign[],
   ) {}
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): unknown {
-    // TODO: this should come after batch
-    // as a destructuring expression like [x, y] = value
-    //
-    // should only trigger change only once:
-    // batch(() => {
-    //   object.x = value[0]
-    //   object.y = value[1]
-    // })
-    //
-    // instead of twice:
-    // object.x = value[0]
-    // object.y = value[1]
-    return void 0;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    // TODO
-    return void 0;
-  }
 }
 
 export class ObjectBindingPattern {
   public get $kind(): ExpressionKind.ObjectBindingPattern { return ExpressionKind.ObjectBindingPattern; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   // We'll either have elements, or keys+values, but never all 3
   public constructor(
     public readonly keys: readonly (string | number)[],
     public readonly values: readonly IsAssign[],
   ) {}
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): unknown {
-    // TODO
-    // similar to array binding ast, this should only come after batch
-    // for a single notification per destructing,
-    // regardless number of property assignments on the scope binding context
-    return void 0;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    // TODO
-    return void 0;
-  }
 }
 
 export class BindingIdentifier {
   public get $kind(): ExpressionKind.BindingIdentifier { return ExpressionKind.BindingIdentifier; }
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly name: string,
   ) {}
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): string {
-    return this.name;
-  }
 }
 
 // https://tc39.github.io/ecma262/#sec-iteration-statements
 // https://tc39.github.io/ecma262/#sec-for-in-and-for-of-statements
 export class ForOfStatement {
   public get $kind(): ExpressionKind.ForOfStatement { return ExpressionKind.ForOfStatement; }
-  public get hasBind(): true { return true; }
-  public get hasUnbind(): true { return true; }
-
   public constructor(
     public readonly declaration: BindingIdentifierOrPattern | DestructuringAssignmentExpression,
     public readonly iterable: IsBindingBehavior,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    return this.iterable.evaluate(s, e, c);
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
-
-  public bind(s: Scope, b: IConnectableBinding): void {
-    if (this.iterable.hasBind) {
-      this.iterable.bind(s, b);
-    }
-  }
-
-  public unbind(s: Scope, b: IConnectableBinding): void {
-    if (this.iterable.hasUnbind) {
-      this.iterable.unbind(s, b);
-    }
-  }
 }
 
 /*
@@ -952,9 +332,6 @@ export class Interpolation {
   public get $kind(): ExpressionKind.Interpolation { return ExpressionKind.Interpolation; }
   public readonly isMulti: boolean;
   public readonly firstExpression: IsBindingBehavior;
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
-
   public constructor(
     public readonly parts: readonly string[],
     public readonly expressions: readonly IsBindingBehavior[] = emptyArray,
@@ -962,73 +339,17 @@ export class Interpolation {
     this.isMulti = expressions.length > 1;
     this.firstExpression = expressions[0];
   }
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): string {
-    if (this.isMulti) {
-      let result = this.parts[0];
-      let i = 0;
-      for (; i < this.expressions.length; ++i) {
-        result += safeString(this.expressions[i].evaluate(s, e, c));
-        result += this.parts[i + 1];
-      }
-      return result;
-    } else {
-      return `${this.parts[0]}${this.firstExpression.evaluate(s, e, c)}${this.parts[1]}`;
-    }
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _obj: unknown): unknown {
-    return void 0;
-  }
 }
 
 // spec: https://tc39.es/ecma262/#sec-destructuring-assignment
 /** This is an internal API */
 export class DestructuringAssignmentExpression {
-  public get hasBind(): false { return false; }
-  public get hasUnbind(): false { return false; }
   public constructor(
     public readonly $kind: ExpressionKind.ArrayDestructuring | ExpressionKind.ObjectDestructuring,
     public readonly list: readonly (DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression)[],
     public readonly source: AccessMemberExpression | AccessKeyedExpression | undefined,
     public readonly initializer: IsBindingBehavior | undefined,
   ) { }
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): undefined {
-    return void 0;
-  }
-
-  public assign(s: Scope, l: IAstEvaluator, value: unknown): void {
-    const list = this.list;
-    const len = list.length;
-    let i: number;
-    let item: DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
-    for (i = 0; i < len; i++) {
-      item = list[i];
-      switch(item.$kind) {
-        case ExpressionKind.DestructuringAssignmentLeaf:
-        // case ExpressionKind.DestructuringAssignmentRestLeaf:
-          item.assign(s, l, value);
-          break;
-        case ExpressionKind.ArrayDestructuring:
-        case ExpressionKind.ObjectDestructuring: {
-          if (typeof value !== 'object' || value === null) {
-            if (__DEV__) {
-              throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
-            } else {
-              throw new Error(`AUR0112`);
-            }
-          }
-          let source = item.source!.evaluate(Scope.create(value), l, null);
-          if(source === void 0) {
-            source = item.initializer?.evaluate(s, l, null);
-          }
-          item.assign(s, l, source);
-          break;
-        }
-      }
-    }
-  }
 }
 
 /** This is an internal API */
@@ -1039,26 +360,6 @@ export class DestructuringAssignmentSingleExpression {
     public readonly source: AccessMemberExpression | AccessKeyedExpression,
     public readonly initializer: IsBindingBehavior | undefined,
   ) { }
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): undefined {
-    return void 0;
-  }
-
-  public assign(s: Scope, l: IAstEvaluator, value: unknown): void {
-    if(value == null) { return; }
-    if (typeof value !== 'object') {
-      if (__DEV__) {
-        throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
-      } else {
-        throw new Error(`AUR0112`);
-      }
-    }
-    let source = this.source.evaluate(Scope.create(value), l, null);
-    if(source === void 0) {
-      source = this.initializer?.evaluate(s, l, null);
-    }
-    this.target.assign(s, l, source);
-  }
 }
 
 /** This is an internal API */
@@ -1068,44 +369,6 @@ export class DestructuringAssignmentRestExpression {
     public readonly target: AccessMemberExpression,
     public readonly indexOrProperties: string[] | number,
   ) { }
-
-  public evaluate(_s: Scope, _e: IAstEvaluator | null, _c: IConnectable | null): undefined {
-    return void 0;
-  }
-
-  public assign(s: Scope, l: IAstEvaluator, value: unknown): void {
-    if(value == null) { return; }
-    if (typeof value !== 'object') {
-      if (__DEV__) {
-        throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
-      } else {
-        throw new Error(`AUR0112`);
-      }
-    }
-
-    const indexOrProperties = this.indexOrProperties;
-
-    let restValue: Record<string, unknown> | unknown[];
-    if (isArrayIndex(indexOrProperties)) {
-      if (!Array.isArray(value)) {
-        if (__DEV__) {
-          throw new Error(`AUR0112: Cannot use non-array value for array-destructuring assignment.`);
-        } else {
-          throw new Error(`AUR0112`);
-        }
-      }
-      restValue = value.slice(indexOrProperties);
-    } else {
-      restValue = Object
-          .entries(value)
-          .reduce((acc, [k, v]) => {
-            if (!indexOrProperties.includes(k)) { acc[k] = v; }
-            return acc;
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          }, {} as Record<string, unknown>);
-    }
-    this.target.assign(s, l, restValue);
-  }
 }
 
 export class ArrowFunction {
@@ -1118,74 +381,6 @@ export class ArrowFunction {
     public body: IsAssign,
     public rest: boolean = false,
   ) {}
-
-  public evaluate(s: Scope, e: IAstEvaluator | null, c: IConnectable | null): unknown {
-    const func = (...args: unknown[]) => {
-      const params = this.args;
-      const rest = this.rest;
-      const lastIdx = params.length - 1;
-      const context = params.reduce<IIndexable>((map, param, i) => {
-        if (rest && i === lastIdx) {
-          map[param.name] = args.slice(i);
-        } else {
-          map[param.name] = args[i];
-        }
-        return map;
-      }, {});
-      const functionScope = Scope.fromParent(s, context);
-      return this.body.evaluate(functionScope, e, c);
-    };
-    return func;
-  }
-
-  public assign(_s: Scope, _e: IAstEvaluator | null, _value: unknown): void {
-    return void 0;
-  }
-}
-
-function getFunction(mustEvaluate: boolean | undefined, obj: object, name: string): ((...args: unknown[]) => unknown) | null {
-  const func = obj == null ? null : (obj as IIndexable)[name];
-  if (isFunction(func)) {
-    return func as (...args: unknown[]) => unknown;
-  }
-  if (!mustEvaluate && func == null) {
-    return null;
-  }
-  if (__DEV__)
-    throw new Error(`AUR0111: Expected '${name}' to be a function`);
-  else
-    throw new Error(`AUR0111:${name}`);
-}
-
-/**
- * Determines if the value passed is a number or bigint for parsing purposes
- *
- * @param value - Value to evaluate
- */
-function isNumberOrBigInt(value: unknown): value is number | bigint {
-  switch (typeof value) {
-    case 'number':
-    case 'bigint':
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
- * Determines if the value passed is a string or Date for parsing purposes
- *
- * @param value - Value to evaluate
- */
-function isStringOrDate(value: unknown): value is string | Date {
-  switch (typeof value) {
-    case 'string':
-      return true;
-    case 'object':
-      return value instanceof Date;
-    default:
-      return false;
-  }
 }
 
 // -----------------------------------

--- a/packages/runtime/src/binding/ast.visitor.ts
+++ b/packages/runtime/src/binding/ast.visitor.ts
@@ -34,7 +34,7 @@ export interface IVisitor<T = unknown> {
   visitCustom(expr: CustomExpression): T;
 }
 
-export const visitAst = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) => {
+export const astVisit = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) => {
   switch (ast.$kind) {
     case ExpressionKind.AccessKeyed: return visitor.visitAccessKeyed(ast);
     case ExpressionKind.AccessMember: return visitor.visitAccessMember(ast);
@@ -75,19 +75,19 @@ export class Unparser implements IVisitor<void> {
 
   public static unparse(expr: IsExpressionOrStatement): string {
     const visitor = new Unparser();
-    visitAst(expr, visitor);
+    astVisit(expr, visitor);
     return visitor.text;
   }
 
   public visitAccessMember(expr: AccessMemberExpression): void {
-    visitAst(expr.object, this);
+    astVisit(expr.object, this);
     this.text += `${expr.optional ? '?' : ''}.${expr.name}`;
   }
 
   public visitAccessKeyed(expr: AccessKeyedExpression): void {
-    visitAst(expr.object, this);
+    astVisit(expr.object, this);
     this.text += `${expr.optional ? '?.' : ''}[`;
-    visitAst(expr.key, this);
+    astVisit(expr.key, this);
     this.text += ']';
   }
 
@@ -118,7 +118,7 @@ export class Unparser implements IVisitor<void> {
       if (i !== 0) {
         this.text += ',';
       }
-      visitAst(elements[i], this);
+      astVisit(elements[i], this);
     }
     this.text += ']';
   }
@@ -141,7 +141,7 @@ export class Unparser implements IVisitor<void> {
       }
     }
     this.text += `${text}) => `;
-    visitAst(expr.body, this);
+    astVisit(expr.body, this);
   }
 
   public visitObjectLiteral(expr: ObjectLiteralExpression): void {
@@ -153,7 +153,7 @@ export class Unparser implements IVisitor<void> {
         this.text += ',';
       }
       this.text += `'${keys[i]}':`;
-      visitAst(values[i], this);
+      astVisit(values[i], this);
     }
     this.text += '}';
   }
@@ -171,7 +171,7 @@ export class Unparser implements IVisitor<void> {
 
   public visitCallFunction(expr: CallFunctionExpression): void {
     this.text += '(';
-    visitAst(expr.func, this);
+    astVisit(expr.func, this);
     this.text += expr.optional ? '?.' : '';
     this.writeArgs(expr.args);
     this.text += ')';
@@ -179,7 +179,7 @@ export class Unparser implements IVisitor<void> {
 
   public visitCallMember(expr: CallMemberExpression): void {
     this.text += '(';
-    visitAst(expr.object, this);
+    astVisit(expr.object, this);
     this.text += `${expr.optionalMember ? '?.' : ''}.${expr.name}${expr.optionalCall ? '?.' : ''}`;
     this.writeArgs(expr.args);
     this.text += ')';
@@ -202,7 +202,7 @@ export class Unparser implements IVisitor<void> {
     this.text += '`';
     this.text += cooked[0];
     for (let i = 0; i < length; i++) {
-      visitAst(expressions[i], this);
+      astVisit(expressions[i], this);
       this.text += cooked[i + 1];
     }
     this.text += '`';
@@ -211,11 +211,11 @@ export class Unparser implements IVisitor<void> {
   public visitTaggedTemplate(expr: TaggedTemplateExpression): void {
     const { cooked, expressions } = expr;
     const length = expressions.length;
-    visitAst(expr.func, this);
+    astVisit(expr.func, this);
     this.text += '`';
     this.text += cooked[0];
     for (let i = 0; i < length; i++) {
-      visitAst(expressions[i], this);
+      astVisit(expressions[i], this);
       this.text += cooked[i + 1];
     }
     this.text += '`';
@@ -226,57 +226,57 @@ export class Unparser implements IVisitor<void> {
     if (expr.operation.charCodeAt(0) >= /* a */97) {
       this.text += ' ';
     }
-    visitAst(expr.expression, this);
+    astVisit(expr.expression, this);
     this.text += ')';
   }
 
   public visitBinary(expr: BinaryExpression): void {
     this.text += '(';
-    visitAst(expr.left, this);
+    astVisit(expr.left, this);
     if (expr.operation.charCodeAt(0) === /* i */105) {
       this.text += ` ${expr.operation} `;
     } else {
       this.text += expr.operation;
     }
-    visitAst(expr.right, this);
+    astVisit(expr.right, this);
     this.text += ')';
   }
 
   public visitConditional(expr: ConditionalExpression): void {
     this.text += '(';
-    visitAst(expr.condition, this);
+    astVisit(expr.condition, this);
     this.text += '?';
-    visitAst(expr.yes, this);
+    astVisit(expr.yes, this);
     this.text += ':';
-    visitAst(expr.no, this);
+    astVisit(expr.no, this);
     this.text += ')';
   }
 
   public visitAssign(expr: AssignExpression): void {
     this.text += '(';
-    visitAst(expr.target, this);
+    astVisit(expr.target, this);
     this.text += '=';
-    visitAst(expr.value, this);
+    astVisit(expr.value, this);
     this.text += ')';
   }
 
   public visitValueConverter(expr: ValueConverterExpression): void {
     const args = expr.args;
-    visitAst(expr.expression, this);
+    astVisit(expr.expression, this);
     this.text += `|${expr.name}`;
     for (let i = 0, length = args.length; i < length; ++i) {
       this.text += ':';
-      visitAst(args[i], this);
+      astVisit(args[i], this);
     }
   }
 
   public visitBindingBehavior(expr: BindingBehaviorExpression): void {
     const args = expr.args;
-    visitAst(expr.expression, this);
+    astVisit(expr.expression, this);
     this.text += `&${expr.name}`;
     for (let i = 0, length = args.length; i < length; ++i) {
       this.text += ':';
-      visitAst(args[i], this);
+      astVisit(args[i], this);
     }
   }
 
@@ -287,7 +287,7 @@ export class Unparser implements IVisitor<void> {
       if (i !== 0) {
         this.text += ',';
       }
-      visitAst(elements[i], this);
+      astVisit(elements[i], this);
     }
     this.text += ']';
   }
@@ -301,7 +301,7 @@ export class Unparser implements IVisitor<void> {
         this.text += ',';
       }
       this.text += `'${keys[i]}':`;
-      visitAst(values[i], this);
+      astVisit(values[i], this);
     }
     this.text += '}';
   }
@@ -311,9 +311,9 @@ export class Unparser implements IVisitor<void> {
   }
 
   public visitForOfStatement(expr: ForOfStatement): void {
-    visitAst(expr.declaration, this);
+    astVisit(expr.declaration, this);
     this.text += ' of ';
-    visitAst(expr.iterable, this);
+    astVisit(expr.iterable, this);
   }
 
   public visitInterpolation(expr: Interpolation): void {
@@ -322,7 +322,7 @@ export class Unparser implements IVisitor<void> {
     this.text += '${';
     this.text += parts[0];
     for (let i = 0; i < length; i++) {
-      visitAst(expressions[i], this);
+      astVisit(expressions[i], this);
       this.text += parts[i + 1];
     }
     this.text += '}';
@@ -340,16 +340,16 @@ export class Unparser implements IVisitor<void> {
       item = list[i];
       switch(item.$kind) {
         case ExpressionKind.DestructuringAssignmentLeaf:
-          visitAst(item, this);
+          astVisit(item, this);
           break;
         case ExpressionKind.ArrayDestructuring:
         case ExpressionKind.ObjectDestructuring: {
           const source = item.source;
           if(source) {
-            visitAst(source, this);
+            astVisit(source, this);
             this.text += ':';
           }
-          visitAst(item, this);
+          astVisit(item, this);
           break;
         }
       }
@@ -358,19 +358,19 @@ export class Unparser implements IVisitor<void> {
   }
 
   public visitDestructuringAssignmentSingleExpression(expr: DestructuringAssignmentSingleExpression): void {
-    visitAst(expr.source, this);
+    astVisit(expr.source, this);
     this.text += ':';
-    visitAst(expr.target, this);
+    astVisit(expr.target, this);
     const initializer = expr.initializer;
     if(initializer !== void 0) {
       this.text +='=';
-      visitAst(initializer, this);
+      astVisit(initializer, this);
     }
   }
 
   public visitDestructuringAssignmentRestExpression(expr: DestructuringAssignmentRestExpression): void {
     this.text += '...';
-    visitAst(expr.target, this);
+    astVisit(expr.target, this);
   }
 
   public visitCustom(expr: CustomExpression): void {
@@ -383,7 +383,7 @@ export class Unparser implements IVisitor<void> {
       if (i !== 0) {
         this.text += ',';
       }
-      visitAst(args[i], this);
+      astVisit(args[i], this);
     }
     this.text += ')';
   }

--- a/packages/runtime/src/binding/ast.visitor.ts
+++ b/packages/runtime/src/binding/ast.visitor.ts
@@ -1,0 +1,384 @@
+import { isString } from '../utilities-objects';
+import { ExpressionKind } from './ast';
+
+import type { AccessKeyedExpression, AccessMemberExpression, AccessScopeExpression, AccessThisExpression, ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, AssignExpression, BinaryExpression, BindingBehaviorExpression, BindingIdentifier, CallFunctionExpression, CallMemberExpression, CallScopeExpression, ConditionalExpression, ForOfStatement, Interpolation, ObjectBindingPattern, ObjectLiteralExpression, PrimitiveLiteralExpression, TaggedTemplateExpression, TemplateExpression, UnaryExpression, ValueConverterExpression, DestructuringAssignmentExpression, DestructuringAssignmentSingleExpression, DestructuringAssignmentRestExpression, IsExpressionOrStatement, IsBindingBehavior } from './ast';
+
+export interface IVisitor<T = unknown> {
+  visitAccessKeyed(expr: AccessKeyedExpression): T;
+  visitAccessMember(expr: AccessMemberExpression): T;
+  visitAccessScope(expr: AccessScopeExpression): T;
+  visitAccessThis(expr: AccessThisExpression): T;
+  visitArrayBindingPattern(expr: ArrayBindingPattern): T;
+  visitArrayLiteral(expr: ArrayLiteralExpression): T;
+  visitArrowFunction(expr: ArrowFunction): T;
+  visitAssign(expr: AssignExpression): T;
+  visitBinary(expr: BinaryExpression): T;
+  visitBindingBehavior(expr: BindingBehaviorExpression): T;
+  visitBindingIdentifier(expr: BindingIdentifier): T;
+  visitCallFunction(expr: CallFunctionExpression): T;
+  visitCallMember(expr: CallMemberExpression): T;
+  visitCallScope(expr: CallScopeExpression): T;
+  visitConditional(expr: ConditionalExpression): T;
+  visitForOfStatement(expr: ForOfStatement): T;
+  visitInterpolation(expr: Interpolation): T;
+  visitObjectBindingPattern(expr: ObjectBindingPattern): T;
+  visitObjectLiteral(expr: ObjectLiteralExpression): T;
+  visitPrimitiveLiteral(expr: PrimitiveLiteralExpression): T;
+  visitTaggedTemplate(expr: TaggedTemplateExpression): T;
+  visitTemplate(expr: TemplateExpression): T;
+  visitUnary(expr: UnaryExpression): T;
+  visitValueConverter(expr: ValueConverterExpression): T;
+  visitDestructuringAssignmentExpression(expr: DestructuringAssignmentExpression): T;
+  visitDestructuringAssignmentSingleExpression(expr: DestructuringAssignmentSingleExpression): T;
+  visitDestructuringAssignmentRestExpression(expr: DestructuringAssignmentRestExpression): T;
+}
+
+export const visitAst = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) => {
+  switch (ast.$kind) {
+    case ExpressionKind.AccessKeyed: return visitor.visitAccessKeyed(ast);
+    case ExpressionKind.AccessMember: return visitor.visitAccessMember(ast);
+    case ExpressionKind.AccessScope: return visitor.visitAccessScope(ast);
+    case ExpressionKind.AccessThis: return visitor.visitAccessThis(ast);
+    case ExpressionKind.ArrayBindingPattern: return visitor.visitArrayBindingPattern(ast);
+    case ExpressionKind.ArrayDestructuring: return visitor.visitDestructuringAssignmentExpression(ast);
+    case ExpressionKind.ArrayLiteral: return visitor.visitArrayLiteral(ast);
+    case ExpressionKind.ArrowFunction: return visitor.visitArrowFunction(ast);
+    case ExpressionKind.Assign: return visitor.visitAssign(ast);
+    case ExpressionKind.Binary: return visitor.visitBinary(ast);
+    case ExpressionKind.BindingBehavior: return visitor.visitBindingBehavior(ast);
+    case ExpressionKind.BindingIdentifier: return visitor.visitBindingIdentifier(ast);
+    case ExpressionKind.CallFunction: return visitor.visitCallFunction(ast);
+    case ExpressionKind.CallMember: return visitor.visitCallMember(ast);
+    case ExpressionKind.CallScope: return visitor.visitCallScope(ast);
+    case ExpressionKind.Conditional: return visitor.visitConditional(ast);
+    case ExpressionKind.DestructuringAssignmentLeaf: return visitor.visitDestructuringAssignmentSingleExpression(ast as DestructuringAssignmentSingleExpression);
+    case ExpressionKind.ForOfStatement: return visitor.visitForOfStatement(ast);
+    case ExpressionKind.Interpolation: return visitor.visitInterpolation(ast);
+    case ExpressionKind.ObjectBindingPattern: return visitor.visitObjectBindingPattern(ast);
+    case ExpressionKind.ObjectDestructuring: return visitor.visitDestructuringAssignmentExpression(ast);
+    case ExpressionKind.ObjectLiteral: return visitor.visitObjectLiteral(ast);
+    case ExpressionKind.PrimitiveLiteral: return visitor.visitPrimitiveLiteral(ast);
+    case ExpressionKind.TaggedTemplate: return visitor.visitTaggedTemplate(ast);
+    case ExpressionKind.Template: return visitor.visitTemplate(ast);
+    case ExpressionKind.Unary: return visitor.visitUnary(ast);
+    case ExpressionKind.ValueConverter: return visitor.visitValueConverter(ast);
+    default: {
+      throw new Error(`Unknown ast node ${JSON.stringify(ast)}`);
+    }
+  }
+};
+
+export class Unparser implements IVisitor<void> {
+  public text: string = '';
+
+  public static unparse(expr: IsExpressionOrStatement): string {
+    const visitor = new Unparser();
+    visitAst(expr, visitor);
+    return visitor.text;
+  }
+
+  public visitAccessMember(expr: AccessMemberExpression): void {
+    visitAst(expr.object, this);
+    this.text += `${expr.optional ? '?' : ''}.${expr.name}`;
+  }
+
+  public visitAccessKeyed(expr: AccessKeyedExpression): void {
+    visitAst(expr.object, this);
+    this.text += `${expr.optional ? '?.' : ''}[`;
+    visitAst(expr.key, this);
+    this.text += ']';
+  }
+
+  public visitAccessThis(expr: AccessThisExpression): void {
+    if (expr.ancestor === 0) {
+      this.text += '$this';
+      return;
+    }
+    this.text += '$parent';
+    let i = expr.ancestor - 1;
+    while (i--) {
+      this.text += '.$parent';
+    }
+  }
+
+  public visitAccessScope(expr: AccessScopeExpression): void {
+    let i = expr.ancestor;
+    while (i--) {
+      this.text += '$parent.';
+    }
+    this.text += expr.name;
+  }
+
+  public visitArrayLiteral(expr: ArrayLiteralExpression): void {
+    const elements = expr.elements;
+    this.text += '[';
+    for (let i = 0, length = elements.length; i < length; ++i) {
+      if (i !== 0) {
+        this.text += ',';
+      }
+      visitAst(elements[i], this);
+    }
+    this.text += ']';
+  }
+
+  public visitArrowFunction(expr: ArrowFunction): void {
+    const args = expr.args;
+    const ii = args.length;
+    let i = 0;
+    let text = '(';
+    let name: string;
+    for (; i < ii; ++i) {
+      name = args[i].name;
+      if (i > 0) {
+        text += ', ';
+      }
+      if (i < ii - 1) {
+        text += name;
+      } else {
+        text += expr.rest ? `...${name}` : name;
+      }
+    }
+    this.text += `${text}) => `;
+    visitAst(expr.body, this);
+  }
+
+  public visitObjectLiteral(expr: ObjectLiteralExpression): void {
+    const keys = expr.keys;
+    const values = expr.values;
+    this.text += '{';
+    for (let i = 0, length = keys.length; i < length; ++i) {
+      if (i !== 0) {
+        this.text += ',';
+      }
+      this.text += `'${keys[i]}':`;
+      visitAst(values[i], this);
+    }
+    this.text += '}';
+  }
+
+  public visitPrimitiveLiteral(expr: PrimitiveLiteralExpression): void {
+    this.text += '(';
+    if (isString(expr.value)) {
+      const escaped = expr.value.replace(/'/g, '\\\'');
+      this.text += `'${escaped}'`;
+    } else {
+      this.text += `${expr.value}`;
+    }
+    this.text += ')';
+  }
+
+  public visitCallFunction(expr: CallFunctionExpression): void {
+    this.text += '(';
+    visitAst(expr.func, this);
+    this.text += expr.optional ? '?.' : '';
+    this.writeArgs(expr.args);
+    this.text += ')';
+  }
+
+  public visitCallMember(expr: CallMemberExpression): void {
+    this.text += '(';
+    visitAst(expr.object, this);
+    this.text += `${expr.optionalMember ? '?.' : ''}.${expr.name}${expr.optionalCall ? '?.' : ''}`;
+    this.writeArgs(expr.args);
+    this.text += ')';
+  }
+
+  public visitCallScope(expr: CallScopeExpression): void {
+    this.text += '(';
+    let i = expr.ancestor;
+    while (i--) {
+      this.text += '$parent.';
+    }
+    this.text += `${expr.name}${expr.optional ? '?.' : ''}`;
+    this.writeArgs(expr.args);
+    this.text += ')';
+  }
+
+  public visitTemplate(expr: TemplateExpression): void {
+    const { cooked, expressions } = expr;
+    const length = expressions.length;
+    this.text += '`';
+    this.text += cooked[0];
+    for (let i = 0; i < length; i++) {
+      visitAst(expressions[i], this);
+      this.text += cooked[i + 1];
+    }
+    this.text += '`';
+  }
+
+  public visitTaggedTemplate(expr: TaggedTemplateExpression): void {
+    const { cooked, expressions } = expr;
+    const length = expressions.length;
+    visitAst(expr.func, this);
+    this.text += '`';
+    this.text += cooked[0];
+    for (let i = 0; i < length; i++) {
+      visitAst(expressions[i], this);
+      this.text += cooked[i + 1];
+    }
+    this.text += '`';
+  }
+
+  public visitUnary(expr: UnaryExpression): void {
+    this.text += `(${expr.operation}`;
+    if (expr.operation.charCodeAt(0) >= /* a */97) {
+      this.text += ' ';
+    }
+    visitAst(expr.expression, this);
+    this.text += ')';
+  }
+
+  public visitBinary(expr: BinaryExpression): void {
+    this.text += '(';
+    visitAst(expr.left, this);
+    if (expr.operation.charCodeAt(0) === /* i */105) {
+      this.text += ` ${expr.operation} `;
+    } else {
+      this.text += expr.operation;
+    }
+    visitAst(expr.right, this);
+    this.text += ')';
+  }
+
+  public visitConditional(expr: ConditionalExpression): void {
+    this.text += '(';
+    visitAst(expr.condition, this);
+    this.text += '?';
+    visitAst(expr.yes, this);
+    this.text += ':';
+    visitAst(expr.no, this);
+    this.text += ')';
+  }
+
+  public visitAssign(expr: AssignExpression): void {
+    this.text += '(';
+    visitAst(expr.target, this);
+    this.text += '=';
+    visitAst(expr.value, this);
+    this.text += ')';
+  }
+
+  public visitValueConverter(expr: ValueConverterExpression): void {
+    const args = expr.args;
+    visitAst(expr.expression, this);
+    this.text += `|${expr.name}`;
+    for (let i = 0, length = args.length; i < length; ++i) {
+      this.text += ':';
+      visitAst(args[i], this);
+    }
+  }
+
+  public visitBindingBehavior(expr: BindingBehaviorExpression): void {
+    const args = expr.args;
+    visitAst(expr.expression, this);
+    this.text += `&${expr.name}`;
+    for (let i = 0, length = args.length; i < length; ++i) {
+      this.text += ':';
+      visitAst(args[i], this);
+    }
+  }
+
+  public visitArrayBindingPattern(expr: ArrayBindingPattern): void {
+    const elements = expr.elements;
+    this.text += '[';
+    for (let i = 0, length = elements.length; i < length; ++i) {
+      if (i !== 0) {
+        this.text += ',';
+      }
+      visitAst(elements[i], this);
+    }
+    this.text += ']';
+  }
+
+  public visitObjectBindingPattern(expr: ObjectBindingPattern): void {
+    const keys = expr.keys;
+    const values = expr.values;
+    this.text += '{';
+    for (let i = 0, length = keys.length; i < length; ++i) {
+      if (i !== 0) {
+        this.text += ',';
+      }
+      this.text += `'${keys[i]}':`;
+      visitAst(values[i], this);
+    }
+    this.text += '}';
+  }
+
+  public visitBindingIdentifier(expr: BindingIdentifier): void {
+    this.text += expr.name;
+  }
+
+  public visitForOfStatement(expr: ForOfStatement): void {
+    visitAst(expr.declaration, this);
+    this.text += ' of ';
+    visitAst(expr.iterable, this);
+  }
+
+  public visitInterpolation(expr: Interpolation): void {
+    const { parts, expressions } = expr;
+    const length = expressions.length;
+    this.text += '${';
+    this.text += parts[0];
+    for (let i = 0; i < length; i++) {
+      visitAst(expressions[i], this);
+      this.text += parts[i + 1];
+    }
+    this.text += '}';
+  }
+
+  public visitDestructuringAssignmentExpression(expr: DestructuringAssignmentExpression): void {
+    const $kind = expr.$kind;
+    const isObjDes = $kind === ExpressionKind.ObjectDestructuring;
+    this.text += isObjDes ? '{' : '[';
+    const list = expr.list;
+    const len = list.length;
+    let i: number;
+    let item: DestructuringAssignmentExpression | DestructuringAssignmentSingleExpression | DestructuringAssignmentRestExpression;
+    for(i = 0; i< len; i++) {
+      item = list[i];
+      switch(item.$kind) {
+        case ExpressionKind.DestructuringAssignmentLeaf:
+          visitAst(item, this);
+          break;
+        case ExpressionKind.ArrayDestructuring:
+        case ExpressionKind.ObjectDestructuring: {
+          const source = item.source;
+          if(source) {
+            visitAst(source, this);
+            this.text += ':';
+          }
+          visitAst(item, this);
+          break;
+        }
+      }
+    }
+    this.text += isObjDes ? '}' : ']';
+  }
+
+  public visitDestructuringAssignmentSingleExpression(expr: DestructuringAssignmentSingleExpression): void {
+    visitAst(expr.source, this);
+    this.text += ':';
+    visitAst(expr.target, this);
+    const initializer = expr.initializer;
+    if(initializer !== void 0) {
+      this.text +='=';
+      visitAst(initializer, this);
+    }
+  }
+
+  public visitDestructuringAssignmentRestExpression(expr: DestructuringAssignmentRestExpression): void {
+    this.text += '...';
+    visitAst(expr.target, this);
+  }
+
+  private writeArgs(args: readonly IsBindingBehavior[]): void {
+    this.text += '(';
+    for (let i = 0, length = args.length; i < length; ++i) {
+      if (i !== 0) {
+        this.text += ',';
+      }
+      visitAst(args[i], this);
+    }
+    this.text += ')';
+  }
+}

--- a/packages/runtime/src/binding/ast.visitor.ts
+++ b/packages/runtime/src/binding/ast.visitor.ts
@@ -1,5 +1,5 @@
-import { isString } from '../utilities-objects';
-import { ExpressionKind } from './ast';
+import { isString, safeString } from '../utilities-objects';
+import { CustomExpression, ExpressionKind } from './ast';
 
 import type { AccessKeyedExpression, AccessMemberExpression, AccessScopeExpression, AccessThisExpression, ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, AssignExpression, BinaryExpression, BindingBehaviorExpression, BindingIdentifier, CallFunctionExpression, CallMemberExpression, CallScopeExpression, ConditionalExpression, ForOfStatement, Interpolation, ObjectBindingPattern, ObjectLiteralExpression, PrimitiveLiteralExpression, TaggedTemplateExpression, TemplateExpression, UnaryExpression, ValueConverterExpression, DestructuringAssignmentExpression, DestructuringAssignmentSingleExpression, DestructuringAssignmentRestExpression, IsExpressionOrStatement, IsBindingBehavior } from './ast';
 
@@ -31,6 +31,7 @@ export interface IVisitor<T = unknown> {
   visitDestructuringAssignmentExpression(expr: DestructuringAssignmentExpression): T;
   visitDestructuringAssignmentSingleExpression(expr: DestructuringAssignmentSingleExpression): T;
   visitDestructuringAssignmentRestExpression(expr: DestructuringAssignmentRestExpression): T;
+  visitCustom(expr: CustomExpression): T;
 }
 
 export const visitAst = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) => {
@@ -62,6 +63,7 @@ export const visitAst = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) 
     case ExpressionKind.Template: return visitor.visitTemplate(ast);
     case ExpressionKind.Unary: return visitor.visitUnary(ast);
     case ExpressionKind.ValueConverter: return visitor.visitValueConverter(ast);
+    case ExpressionKind.Custom: return visitor.visitCustom(ast);
     default: {
       throw new Error(`Unknown ast node ${JSON.stringify(ast)}`);
     }
@@ -369,6 +371,10 @@ export class Unparser implements IVisitor<void> {
   public visitDestructuringAssignmentRestExpression(expr: DestructuringAssignmentRestExpression): void {
     this.text += '...';
     visitAst(expr.target, this);
+  }
+
+  public visitCustom(expr: CustomExpression): void {
+    this.text += safeString(expr.value);
   }
 
   private writeArgs(args: readonly IsBindingBehavior[]): void {

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -1,8 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import {
-  DI,
-} from '@aurelia/kernel';
-import {
   AccessKeyedExpression,
   AccessMemberExpression,
   AccessScopeExpression,
@@ -43,10 +40,10 @@ import {
   DestructuringAssignmentExpression as DAE,
   ArrowFunction,
 } from './ast';
-import { createLookup } from '../utilities-objects';
+import { createInterface, createLookup } from '../utilities-objects';
 
 export interface IExpressionParser extends ExpressionParser {}
-export const IExpressionParser = DI.createInterface<IExpressionParser>('IExpressionParser', x => x.singleton(ExpressionParser));
+export const IExpressionParser = createInterface<IExpressionParser>('IExpressionParser', x => x.singleton(ExpressionParser));
 
 export class ExpressionParser {
   /** @internal */ private readonly _expressionLookup: Record<string, IsBindingBehavior> = createLookup();
@@ -113,6 +110,7 @@ export class ExpressionParser {
   }
 }
 
+_START_CONST_ENUM();
 const enum Char {
   Null           = 0x00,
   Backspace      = 0x08,
@@ -217,6 +215,7 @@ const enum Char {
   LowerY  = 0x79,
   LowerZ  = 0x7A
 }
+_END_CONST_ENUM();
 
 function unescapeCode(code: number): number {
   switch (code) {
@@ -233,7 +232,8 @@ function unescapeCode(code: number): number {
   }
 }
 
-export const enum Precedence {
+_START_CONST_ENUM();
+const enum Precedence {
   Variadic                = 0b0000_111101,
   Assign                  = 0b0000_111110,
   Conditional             = 0b0000_111111,
@@ -249,6 +249,9 @@ export const enum Precedence {
   Primary                 = 0b1000_000011,
   Unary                   = 0b1000_000100,
 }
+_END_CONST_ENUM();
+
+_START_CONST_ENUM();
 const enum Token {
   EOF                     = 0b1100000000000_0000_000000,
   ExpressionTerminal      = 0b1000000000000_0000_000000,
@@ -317,6 +320,7 @@ const enum Token {
   OfKeyword               = 0b1000000001010_0000_110000,
   Arrow                   = 0b0000000000000_0000_110001,
 }
+_END_CONST_ENUM();
 
 const $false = PrimitiveLiteralExpression.$false;
 const $true = PrimitiveLiteralExpression.$true;
@@ -997,12 +1001,14 @@ function parseMemberExpressionLHS(lhs: IsLeftHandSide, optional: boolean) {
   }
 }
 
+_START_CONST_ENUM();
 const enum ArrowFnParams {
   Valid         = 1,
   Invalid       = 2,
   Default       = 3,
   Destructuring = 4,
 }
+_END_CONST_ENUM();
 
 /**
  * https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -52,7 +52,6 @@ export {
   type BinaryOperator,
   type BindingIdentifierOrPattern,
   type UnaryOperator,
-  type IExpressionHydrator,
   type IAstEvaluator,
   type ValueConverterInstance,
 } from './binding/ast';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -30,7 +30,7 @@ export {
   DestructuringAssignmentRestExpression,
   ArrowFunction,
 
-  visitAst,
+  astVisit,
   Unparser,
 
   // ast typing helpers

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -30,6 +30,9 @@ export {
   DestructuringAssignmentRestExpression,
   ArrowFunction,
 
+  visitAst,
+  Unparser,
+
   // ast typing helpers
   type AnyBindingExpression,
   type BindingBehaviorInstance,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -57,6 +57,12 @@ export {
   type ValueConverterInstance,
 } from './binding/ast';
 export {
+  astAssign,
+  astBind,
+  astEvaluate,
+  astUnbind,
+} from './binding/ast.eval';
+export {
   type IObserverLocatorBasedConnectable,
   type IConnectableBinding,
   connectable,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -55,9 +55,7 @@ export interface ICollectionSubscribable {
 export interface ISubscriberRecord<T extends ISubscriber | ICollectionSubscriber> {
   readonly count: number;
   add(subscriber: T): boolean;
-  has(subscriber: T): boolean;
   remove(subscriber: T): boolean;
-  any(): boolean;
   notify(value: unknown, oldValue: unknown): void;
   notifyCollection(collection: Collection, indexMap: IndexMap): void;
 }

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -17,7 +17,7 @@ export class BindingContext implements IBindingContext {
 
 export class Scope {
   private constructor(
-    public parentScope: Scope | null,
+    public parent: Scope | null,
     public bindingContext: IBindingContext,
     public overrideContext: IOverrideContext,
     public readonly isBoundary: boolean,
@@ -34,7 +34,7 @@ export class Scope {
       // jump up the required number of ancestor contexts (eg $parent.$parent requires two jumps)
       while (ancestor > 0) {
         ancestor--;
-        currentScope = currentScope.parentScope;
+        currentScope = currentScope.parent;
         if (currentScope == null) {
           return void 0;
         }
@@ -60,7 +60,7 @@ export class Scope {
       && !(name in currentScope.overrideContext)
       && !(name in currentScope.bindingContext)
     ) {
-      currentScope = currentScope.parentScope;
+      currentScope = currentScope.parent;
     }
 
     if (currentScope == null) {

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -1,14 +1,14 @@
-import { DI, IPlatform } from '@aurelia/kernel';
+import { IPlatform } from '@aurelia/kernel';
 import { AccessorType, type IObserver, type ISubscriberCollection } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
-import { safeString } from '../utilities-objects';
+import { createInterface, safeString } from '../utilities-objects';
 
 import type { ITask, QueueTaskOptions } from '@aurelia/platform';
 import type { IIndexable } from '@aurelia/kernel';
 import type { IObservable, ISubscriber } from '../observation';
 
 export interface IDirtyChecker extends DirtyChecker {}
-export const IDirtyChecker = DI.createInterface<IDirtyChecker>('IDirtyChecker', x => x.singleton(DirtyChecker));
+export const IDirtyChecker = createInterface<IDirtyChecker>('IDirtyChecker', x => x.singleton(DirtyChecker));
 
 export const DirtyCheckSettings = {
   /**

--- a/packages/runtime/src/observation/observation.ts
+++ b/packages/runtime/src/observation/observation.ts
@@ -1,13 +1,13 @@
-import { DI } from '@aurelia/kernel';
 import { connectable } from '../binding/connectable';
 import { enterConnectable, exitConnectable } from './connectable-switcher';
 import { IObserverLocator } from './observer-locator';
 
 import type { ICollectionSubscriber, IConnectable, ISubscriber } from '../observation';
 import type { BindingObserverRecord } from '../binding/connectable';
+import { createInterface } from '../utilities-objects';
 
 export interface IObservation extends Observation {}
-export const IObservation = DI.createInterface<IObservation>('IObservation', x => x.singleton(Observation));
+export const IObservation = createInterface<IObservation>('IObservation', x => x.singleton(Observation));
 
 export class Observation implements IObservation {
 

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -1,4 +1,4 @@
-import { DI, Primitive, isArrayIndex, ILogger } from '@aurelia/kernel';
+import { Primitive, isArrayIndex, ILogger } from '@aurelia/kernel';
 import { getArrayObserver } from './array-observer';
 import { ComputedObserver } from './computed-observer';
 import { IDirtyChecker } from './dirty-checker';
@@ -7,7 +7,7 @@ import { PrimitiveObserver } from './primitive-observer';
 import { PropertyAccessor } from './property-accessor';
 import { getSetObserver } from './set-observer';
 import { SetterObserver } from './setter-observer';
-import { safeString, createLookup, def, hasOwnProp, isArray } from '../utilities-objects';
+import { safeString, createLookup, def, hasOwnProp, isArray, createInterface } from '../utilities-objects';
 
 import type {
   Collection,
@@ -27,22 +27,21 @@ export interface IObjectObservationAdapter {
 }
 
 export interface IObserverLocator extends ObserverLocator {}
-export const IObserverLocator = DI.createInterface<IObserverLocator>('IObserverLocator', x => x.singleton(ObserverLocator));
+export const IObserverLocator = createInterface<IObserverLocator>('IObserverLocator', x => x.singleton(ObserverLocator));
 
 export interface INodeObserverLocator {
   handles(obj: unknown, key: PropertyKey, requestor: IObserverLocator): boolean;
   getObserver(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
   getAccessor(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
 }
-export const INodeObserverLocator = DI
-  .createInterface<INodeObserverLocator>('INodeObserverLocator', x => x.cachedCallback(handler => {
-    if (__DEV__) {
-      handler.getAll(ILogger).forEach(logger => {
-        logger.error('Using default INodeObserverLocator implementation. Will not be able to observe nodes (HTML etc...).');
-      });
-    }
-    return new DefaultNodeObserverLocator();
-  }));
+export const INodeObserverLocator = createInterface<INodeObserverLocator>('INodeObserverLocator', x => x.cachedCallback(handler => {
+  if (__DEV__) {
+    handler.getAll(ILogger).forEach(logger => {
+      logger.error('Using default INodeObserverLocator implementation. Will not be able to observe nodes (HTML etc...).');
+    });
+  }
+  return new DefaultNodeObserverLocator();
+}));
 
 class DefaultNodeObserverLocator implements INodeObserverLocator {
   public handles(): boolean {

--- a/packages/runtime/src/observation/signaler.ts
+++ b/packages/runtime/src/observation/signaler.ts
@@ -1,9 +1,8 @@
-import { DI } from '@aurelia/kernel';
-import { createLookup } from '../utilities-objects';
+import { createInterface, createLookup } from '../utilities-objects';
 import type { ISubscriber } from '../observation';
 
 export interface ISignaler extends Signaler {}
-export const ISignaler = DI.createInterface<ISignaler>('ISignaler', x => x.singleton(Signaler));
+export const ISignaler = createInterface<ISignaler>('ISignaler', x => x.singleton(Signaler));
 
 export class Signaler {
   public signals: Record<string, Set<ISubscriber> | undefined> = createLookup();

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -223,14 +223,6 @@ export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRe
     return true;
   }
 
-  public has(subscriber: T): boolean {
-    return this._subs.includes(subscriber);
-  }
-
-  public any(): boolean {
-    return this.count > 0;
-  }
-
   public remove(subscriber: T): boolean {
     const idx = this._subs.indexOf(subscriber);
     if (idx !== -1) {

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -30,107 +30,213 @@ function subscriberCollectionDeco(target: Function): void { // ClassDecorator ex
 }
 /* eslint-enable @typescript-eslint/ban-types */
 
-export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
-  /**
-   * subscriber flags: bits indicating the existence status of the subscribers of this record
-   */
-  private sf: SubFlags = SubFlags.None;
-  private s0?: T;
-  private s1?: T;
-  private s2?: T;
-  /**
-   * subscriber rest: When there's more than 3 subscribers, use an array to store the subscriber references
-   */
-  private sr?: T[];
+// export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
+//   /**
+//    * subscriber flags: bits indicating the existence status of the subscribers of this record
+//    */
+//   private sf: SubFlags = SubFlags.None;
+//   private s0?: T;
+//   private s1?: T;
+//   private s2?: T;
+//   /**
+//    * subscriber rest: When there's more than 3 subscribers, use an array to store the subscriber references
+//    */
+//   private sr?: T[];
 
+//   public count: number = 0;
+
+//   public add(subscriber: T): boolean {
+//     if (this.has(subscriber)) {
+//       return false;
+//     }
+//     const subscriberFlags = this.sf;
+//     if ((subscriberFlags & SubFlags.Sub0) === 0) {
+//       this.s0 = subscriber;
+//       this.sf |= SubFlags.Sub0;
+//     } else if ((subscriberFlags & SubFlags.Sub1) === 0) {
+//       this.s1 = subscriber;
+//       this.sf |= SubFlags.Sub1;
+//     } else if ((subscriberFlags & SubFlags.Sub2) === 0) {
+//       this.s2 = subscriber;
+//       this.sf |= SubFlags.Sub2;
+//     } else if ((subscriberFlags & SubFlags.SubRest) === 0) {
+//       this.sr = [subscriber];
+//       this.sf |= SubFlags.SubRest;
+//     } else {
+//       this.sr!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
+//     }
+//     ++this.count;
+//     return true;
+//   }
+
+//   public has(subscriber: T): boolean {
+//     // Flags here is just a perf tweak
+//     // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
+//     // and minor slow-down when it does, and the former is more common than the latter.
+//     const subscriberFlags = this.sf;
+//     if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
+//       return true;
+//     }
+//     if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
+//       return true;
+//     }
+//     if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
+//       return true;
+//     }
+//     if ((subscriberFlags & SubFlags.SubRest) > 0) {
+//       const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
+//       const ii = subscribers.length;
+//       let i = 0;
+//       for (; i < ii; ++i) {
+//         if (subscribers[i] === subscriber) {
+//           return true;
+//         }
+//       }
+//     }
+//     return false;
+//   }
+
+//   public any(): boolean {
+//     return this.sf !== SubFlags.None;
+//   }
+
+//   public remove(subscriber: T): boolean {
+//     const subscriberFlags = this.sf;
+//     if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
+//       this.s0 = void 0;
+//       this.sf = (this.sf | SubFlags.Sub0) ^ SubFlags.Sub0;
+//       --this.count;
+//       return true;
+//     } else if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
+//       this.s1 = void 0;
+//       this.sf = (this.sf | SubFlags.Sub1) ^ SubFlags.Sub1;
+//       --this.count;
+//       return true;
+//     } else if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
+//       this.s2 = void 0;
+//       this.sf = (this.sf | SubFlags.Sub2) ^ SubFlags.Sub2;
+//       --this.count;
+//       return true;
+//     } else if ((subscriberFlags & SubFlags.SubRest) > 0) {
+//       const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
+//       const ii = subscribers.length;
+//       let i = 0;
+//       for (; i < ii; ++i) {
+//         if (subscribers[i] === subscriber) {
+//           subscribers.splice(i, 1);
+//           if (ii === 1) {
+//             this.sf = (this.sf | SubFlags.SubRest) ^ SubFlags.SubRest;
+//           }
+//           --this.count;
+//           return true;
+//         }
+//       }
+//     }
+//     return false;
+//   }
+
+//   public notify(val: unknown, oldVal: unknown): void {
+//     if (batching) {
+//       addValueBatch(this, val, oldVal);
+//       return;
+//     }
+//     /**
+//      * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
+//      * callSubscribers invocation, so we're caching them all before invoking any.
+//      * Subscribers added during this invocation are not invoked (and they shouldn't be).
+//      * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
+//      * however this is accounted for via $isBound and similar flags on the subscriber objects)
+//      */
+//     const sub0 = this.s0 as ISubscriber;
+//     const sub1 = this.s1 as ISubscriber;
+//     const sub2 = this.s2 as ISubscriber;
+//     let subs = this.sr as ISubscriber[];
+//     if (subs !== void 0) {
+//       subs = subs.slice();
+//     }
+
+//     if (sub0 !== void 0) {
+//       sub0.handleChange(val, oldVal);
+//     }
+//     if (sub1 !== void 0) {
+//       sub1.handleChange(val, oldVal);
+//     }
+//     if (sub2 !== void 0) {
+//       sub2.handleChange(val, oldVal);
+//     }
+//     if (subs !== void 0) {
+//       const ii = subs.length;
+//       let sub: ISubscriber | undefined;
+//       let i = 0;
+//       for (; i < ii; ++i) {
+//         sub = subs[i];
+//         if (sub !== void 0) {
+//           sub.handleChange(val, oldVal);
+//         }
+//       }
+//     }
+//   }
+
+//   public notifyCollection(collection: Collection, indexMap: IndexMap): void {
+//     const sub0 = this.s0 as ICollectionSubscriber;
+//     const sub1 = this.s1 as ICollectionSubscriber;
+//     const sub2 = this.s2 as ICollectionSubscriber;
+//     let subs = this.sr as ICollectionSubscriber[];
+//     if (subs !== void 0) {
+//       subs = subs.slice();
+//     }
+
+//     if (sub0 !== void 0) {
+//       sub0.handleCollectionChange(collection, indexMap);
+//     }
+//     if (sub1 !== void 0) {
+//       sub1.handleCollectionChange(collection, indexMap);
+//     }
+//     if (sub2 !== void 0) {
+//       sub2.handleCollectionChange(collection, indexMap);
+//     }
+//     if (subs !== void 0) {
+//       const ii = subs.length;
+//       let sub: ICollectionSubscriber | undefined;
+//       let i = 0;
+//       for (; i < ii; ++i) {
+//         sub = subs[i];
+//         if (sub !== void 0) {
+//           sub.handleCollectionChange(collection, indexMap);
+//         }
+//       }
+//     }
+//   }
+// }
+
+export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
   public count: number = 0;
+  /** @internal */
+  private readonly _subs: T[] = [];
 
   public add(subscriber: T): boolean {
-    if (this.has(subscriber)) {
+    if (this._subs.includes(subscriber)) {
       return false;
     }
-    const subscriberFlags = this.sf;
-    if ((subscriberFlags & SubFlags.Sub0) === 0) {
-      this.s0 = subscriber;
-      this.sf |= SubFlags.Sub0;
-    } else if ((subscriberFlags & SubFlags.Sub1) === 0) {
-      this.s1 = subscriber;
-      this.sf |= SubFlags.Sub1;
-    } else if ((subscriberFlags & SubFlags.Sub2) === 0) {
-      this.s2 = subscriber;
-      this.sf |= SubFlags.Sub2;
-    } else if ((subscriberFlags & SubFlags.SubRest) === 0) {
-      this.sr = [subscriber];
-      this.sf |= SubFlags.SubRest;
-    } else {
-      this.sr!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
-    }
+    this._subs[this._subs.length] = subscriber;
     ++this.count;
     return true;
   }
 
   public has(subscriber: T): boolean {
-    // Flags here is just a perf tweak
-    // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
-    // and minor slow-down when it does, and the former is more common than the latter.
-    const subscriberFlags = this.sf;
-    if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
-      return true;
-    }
-    if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
-      return true;
-    }
-    if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
-      return true;
-    }
-    if ((subscriberFlags & SubFlags.SubRest) > 0) {
-      const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-      const ii = subscribers.length;
-      let i = 0;
-      for (; i < ii; ++i) {
-        if (subscribers[i] === subscriber) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return this._subs.includes(subscriber);
   }
 
   public any(): boolean {
-    return this.sf !== SubFlags.None;
+    return this.count > 0;
   }
 
   public remove(subscriber: T): boolean {
-    const subscriberFlags = this.sf;
-    if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
-      this.s0 = void 0;
-      this.sf = (this.sf | SubFlags.Sub0) ^ SubFlags.Sub0;
+    const idx = this._subs.indexOf(subscriber);
+    if (idx !== -1) {
+      this._subs.splice(idx, 1);
       --this.count;
       return true;
-    } else if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
-      this.s1 = void 0;
-      this.sf = (this.sf | SubFlags.Sub1) ^ SubFlags.Sub1;
-      --this.count;
-      return true;
-    } else if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
-      this.s2 = void 0;
-      this.sf = (this.sf | SubFlags.Sub2) ^ SubFlags.Sub2;
-      --this.count;
-      return true;
-    } else if ((subscriberFlags & SubFlags.SubRest) > 0) {
-      const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-      const ii = subscribers.length;
-      let i = 0;
-      for (; i < ii; ++i) {
-        if (subscribers[i] === subscriber) {
-          subscribers.splice(i, 1);
-          if (ii === 1) {
-            this.sf = (this.sf | SubFlags.SubRest) ^ SubFlags.SubRest;
-          }
-          --this.count;
-          return true;
-        }
-      }
     }
     return false;
   }
@@ -147,65 +253,23 @@ export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRe
      * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
      * however this is accounted for via $isBound and similar flags on the subscriber objects)
      */
-    const sub0 = this.s0 as ISubscriber;
-    const sub1 = this.s1 as ISubscriber;
-    const sub2 = this.s2 as ISubscriber;
-    let subs = this.sr as ISubscriber[];
-    if (subs !== void 0) {
-      subs = subs.slice();
+    const _subs = this._subs.slice(0) as ISubscriber[];
+    const len = _subs.length;
+    let i = 0;
+    for (; i < len; ++i) {
+      _subs[i].handleChange(val, oldVal);
     }
-
-    if (sub0 !== void 0) {
-      sub0.handleChange(val, oldVal);
-    }
-    if (sub1 !== void 0) {
-      sub1.handleChange(val, oldVal);
-    }
-    if (sub2 !== void 0) {
-      sub2.handleChange(val, oldVal);
-    }
-    if (subs !== void 0) {
-      const ii = subs.length;
-      let sub: ISubscriber | undefined;
-      let i = 0;
-      for (; i < ii; ++i) {
-        sub = subs[i];
-        if (sub !== void 0) {
-          sub.handleChange(val, oldVal);
-        }
-      }
-    }
+    return;
   }
 
   public notifyCollection(collection: Collection, indexMap: IndexMap): void {
-    const sub0 = this.s0 as ICollectionSubscriber;
-    const sub1 = this.s1 as ICollectionSubscriber;
-    const sub2 = this.s2 as ICollectionSubscriber;
-    let subs = this.sr as ICollectionSubscriber[];
-    if (subs !== void 0) {
-      subs = subs.slice();
+    const _subs = this._subs.slice(0) as ICollectionSubscriber[];
+    const len = _subs.length;
+    let i = 0;
+    for (; i < len; ++i) {
+      _subs[i].handleCollectionChange(collection, indexMap);
     }
-
-    if (sub0 !== void 0) {
-      sub0.handleCollectionChange(collection, indexMap);
-    }
-    if (sub1 !== void 0) {
-      sub1.handleCollectionChange(collection, indexMap);
-    }
-    if (sub2 !== void 0) {
-      sub2.handleCollectionChange(collection, indexMap);
-    }
-    if (subs !== void 0) {
-      const ii = subs.length;
-      let sub: ICollectionSubscriber | undefined;
-      let i = 0;
-      for (; i < ii; ++i) {
-        sub = subs[i];
-        if (sub !== void 0) {
-          sub.handleCollectionChange(collection, indexMap);
-        }
-      }
-    }
+    return;
   }
 }
 
@@ -221,14 +285,15 @@ function removeSubscriber(this: ISubscriberCollection, subscriber: IAnySubscribe
   return this.subs.remove(subscriber as ISubscriber & ICollectionSubscriber);
 }
 
-/**
- * Subscriber flags to indicate subcription on a record
- */
-const enum SubFlags {
-  None      = 0,
-  Sub0      = 0b0001,
-  Sub1      = 0b0010,
-  Sub2      = 0b0100,
-  SubRest   = 0b1000,
-  Any       = 0b1111,
-}
+// /**
+//  * Subscriber flags to indicate subcription on a record
+//  */
+// const enum SubFlags {
+//   None      = 0,
+//   Sub0      = 0b0001,
+//   Sub1      = 0b0010,
+//   Sub2      = 0b0100,
+//   SubRest   = 0b1000,
+//   Any       = 0b1111,
+// }
+

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -1,5 +1,5 @@
 import { Metadata } from '@aurelia/metadata';
-import { Protocol } from '@aurelia/kernel';
+import { DI, Protocol } from '@aurelia/kernel';
 
 /**
  * A shortcut to Object.prototype.hasOwnProperty
@@ -46,6 +46,7 @@ export function ensureProto<T extends object, K extends keyof T>(
 
 // this is used inside template literal, since TS errs without String(...value)
 /** @internal */ export const safeString = String;
+/** @internal */ export const createInterface = DI.createInterface;
 
 /** @internal */ export const createLookup = <T>(): Record<string, T> => Object.create(null) as Record<string, T>;
 

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -3,6 +3,7 @@ import { IDisposable, type IServiceLocator, type Writable } from '@aurelia/kerne
 import { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import {
   AccessorType,
+  astEvaluate,
   connectable,
   Scope,
   type IAccessor,
@@ -101,7 +102,8 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     this.targetObserver = this.oL.getAccessor(this.target, this.targetProperty);
     this.$scope = createStateBindingScope(this._store.getState(), scope);
     this._store.subscribe(this);
-    this.updateTarget(this._value = this.ast.evaluate(
+    this.updateTarget(this._value = astEvaluate(
+      this.ast,
       this.$scope,
       this,
       this.mode > BindingMode.oneTime ? this : null),
@@ -134,7 +136,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     const shouldQueueFlush = this._controller.state !== State.activating && (this.targetObserver.type & AccessorType.Layout) > 0;
     const obsRecord = this.obs;
     obsRecord.version++;
-    newValue = this.ast.evaluate(this.$scope!, this, this.interceptor);
+    newValue = astEvaluate(this.ast, this.$scope!, this, this.interceptor);
     obsRecord.clear();
 
     let task: ITask | null;
@@ -160,7 +162,8 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     const $scope = this.$scope!;
     const overrideContext = $scope.overrideContext as Writable<IOverrideContext>;
     $scope.bindingContext = overrideContext.bindingContext = overrideContext.$state = state;
-    const value = this.ast.evaluate(
+    const value = astEvaluate(
+      this.ast,
       $scope,
       this,
       this.mode > BindingMode.oneTime ? this : null

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -4,7 +4,8 @@ import {
   type IOverrideContext,
   Scope,
   type IsBindingBehavior,
-  connectable
+  connectable,
+  astEvaluate
 } from '@aurelia/runtime';
 import { astEvaluator, type IAstBasedBinding } from '@aurelia/runtime-html';
 import {
@@ -48,7 +49,7 @@ export class StateDispatchBinding implements IAstBasedBinding {
   public callSource(e: Event) {
     const $scope = this.$scope!;
     $scope.overrideContext.$event = e;
-    const value = this.ast.evaluate($scope, this, null);
+    const value = astEvaluate(this.ast, $scope, this, null);
     delete $scope.overrideContext.$event;
     if (!this.isAction(value)) {
       throw new Error(`Invalid dispatch value from expression on ${this.target} on event: "${e.type}"`);

--- a/packages/state/src/state-utilities.ts
+++ b/packages/state/src/state-utilities.ts
@@ -5,7 +5,7 @@ import { type SubscribableValue } from './interfaces';
 export function createStateBindingScope(state: object, scope: Scope) {
   const overrideContext = { bindingContext: state };
   const stateScope = Scope.create(state, overrideContext, true);
-  stateScope.parentScope = scope;
+  stateScope.parent = scope;
   return stateScope;
 }
 

--- a/packages/testing/src/inspect.ts
+++ b/packages/testing/src/inspect.ts
@@ -100,6 +100,7 @@ import {
 } from './util';
 import { PLATFORM } from './test-context';
 
+_START_CONST_ENUM();
 const enum Char {
   Null           = 0x00,
   Backspace      = 0x08,
@@ -204,6 +205,7 @@ const enum Char {
   LowerY  = 0x79,
   LowerZ  = 0x7A
 }
+_END_CONST_ENUM();
 
 /* eslint-disable max-lines-per-function, @typescript-eslint/ban-types */
 

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -2,6 +2,10 @@ import {
   Key,
 } from '@aurelia/kernel';
 import {
+  astAssign,
+  astBind,
+  astEvaluate,
+  astUnbind,
   ExpressionKind,
 } from '@aurelia/runtime';
 import {
@@ -165,31 +169,22 @@ export class MockTracingExpression {
 
   public evaluate(...args: any[]): any {
     this.trace('evaluate', ...args);
-    return this.inner.evaluate(...args);
+    return (astEvaluate as any)(this.inner, ...args);
   }
 
   public assign(...args: any[]): any {
     this.trace('assign', ...args);
-    return this.inner.assign(...args);
-  }
-
-  public connect(...args: any[]): any {
-    this.trace('connect', ...args);
-    this.inner.connect(...args);
+    return (astAssign as any)(this.inner, ...args);
   }
 
   public bind(...args: any[]): any {
     this.trace('bind', ...args);
-    if (this.inner.bind) {
-      this.inner.bind(...args);
-    }
+    (astBind as any)(this.inner, ...args);
   }
 
   public unbind(...args: any[]): any {
     this.trace('unbind', ...args);
-    if (this.inner.unbind) {
-      this.inner.unbind(...args);
-    }
+    (astUnbind as any)(this.inner, ...args);
   }
 
   public accept(...args: any[]): any {

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -156,7 +156,7 @@ export class MockPropertySubscriber {
 }
 
 export class MockTracingExpression {
-  public $kind: ExpressionKind = ExpressionKind.BindingBehavior;
+  public $kind: ExpressionKind.Custom = ExpressionKind.Custom;
   public hasBind: true = true;
   public hasUnbind: true = true;
   public calls: [keyof MockTracingExpression, ...any[]][] = [];

--- a/packages/testing/src/specialized-assertions.ts
+++ b/packages/testing/src/specialized-assertions.ts
@@ -1,4 +1,4 @@
-import { InstructionType, NodeType, CustomElement } from '@aurelia/runtime-html';
+import { InstructionType, CustomElement } from '@aurelia/runtime-html';
 import { assert } from './assert';
 
 // Disabling this as it this is nowhere used. And also the ast-serialization infra is moved to validation package.
@@ -187,3 +187,20 @@ export function verifyBindingInstructionsEqual(actual: any, expected: any, error
     throw new Error(`Failed assertion: binding instruction mismatch\n  - ${errors.join('\n  - ')}`);
   }
 }
+
+_START_CONST_ENUM();
+const enum NodeType {
+  Element = 1,
+  Attr = 2,
+  Text = 3,
+  CDATASection = 4,
+  EntityReference = 5,
+  Entity = 6,
+  ProcessingInstruction = 7,
+  Comment = 8,
+  Document = 9,
+  DocumentType = 10,
+  DocumentFragment = 11,
+  Notation = 12
+}
+_END_CONST_ENUM();

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -10,6 +10,7 @@ import {
   IndexMap,
   BindingContext,
   type IOverrideContext,
+  astEvaluate,
 } from '@aurelia/runtime';
 import {
   customAttribute,
@@ -479,7 +480,7 @@ export class VirtualRepeat implements IScrollerSubscriber, IVirtualRepeater {
    * @internal
    */
   public handleInnerCollectionChange(): void {
-    const newItems = this.iterable.evaluate(this.parent.scope, this._container, null) as Collection;
+    const newItems = astEvaluate(this.iterable, this.parent.scope, this._container, null) as Collection;
     const oldItems = this.items;
     this.items = newItems;
     if (newItems === oldItems) {

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -1,6 +1,7 @@
 import { DI, IServiceLocator } from '@aurelia/kernel';
 import { ITask } from '@aurelia/platform';
 import {
+  astEvaluate,
   BindingBehaviorExpression,
   connectable,
   IBinding,
@@ -179,16 +180,16 @@ export class ValidateBindingBehavior extends BindingInterceptor implements Valid
       const arg = args[i];
       switch (i) {
         case 0:
-          trigger = this._ensureTrigger(arg.evaluate(scope, this, this.triggerMediator));
+          trigger = this._ensureTrigger(astEvaluate(arg, scope, this, this.triggerMediator));
           break;
         case 1:
-          controller = this._ensureController(arg.evaluate(scope, this, this.controllerMediator));
+          controller = this._ensureController(astEvaluate(arg, scope, this, this.controllerMediator));
           break;
         case 2:
-          rules = this._ensureRules(arg.evaluate(scope, this, this.rulesMediator));
+          rules = this._ensureRules(astEvaluate(arg, scope, this, this.rulesMediator));
           break;
         default:
-          throw new Error(`Unconsumed argument#${i + 1} for validate binding behavior: ${arg.evaluate(scope, this, null)}`);
+          throw new Error(`Unconsumed argument#${i + 1} for validate binding behavior: ${astEvaluate(arg, scope, this, null)}`);
       }
     }
 

--- a/packages/validation-html/src/validation-controller.ts
+++ b/packages/validation-html/src/validation-controller.ts
@@ -11,6 +11,7 @@ import {
   BindingBehaviorExpression,
   IExpressionParser,
   ExpressionKind,
+  astEvaluate,
   // IsBindingBehavior
 } from '@aurelia/runtime';
 import {
@@ -147,7 +148,7 @@ export function getPropertyInfo(binding: BindingWithBehavior, info: BindingInfo,
           toCachePropertyName = keyExpr.$kind === ExpressionKind.PrimitiveLiteral;
         }
         // eslint-disable-next-line
-        memberName = `[${(keyExpr.evaluate(scope, binding, null) as any).toString()}]`;
+        memberName = `[${(astEvaluate(keyExpr, scope, binding, null) as any).toString()}]`;
         break;
       }
       default:
@@ -166,7 +167,7 @@ export function getPropertyInfo(binding: BindingWithBehavior, info: BindingInfo,
     propertyName = expression.name;
     object = scope.bindingContext;
   } else {
-    object = expression.evaluate(scope, binding, null);
+    object = astEvaluate(expression, scope, binding, null);
   }
   if (object === null || object === void 0) {
     return (void 0);

--- a/packages/validation/src/ast-serialization.ts
+++ b/packages/validation/src/ast-serialization.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { IExpressionHydrator } from '@aurelia/runtime';
 import * as AST from '@aurelia/runtime';
 
 const astVisit = AST.astVisit;
@@ -34,6 +33,10 @@ enum ASTExpressionTypes {
   DestructuringRestAssignment = 'DestructuringRestAssignment',
   ArrowFunction = 'ArrowFunction',
   Custom = 'Custom',
+}
+
+export interface IExpressionHydrator {
+  hydrate(jsonExpr: any): any;
 }
 
 export class Deserializer implements IExpressionHydrator {

--- a/packages/validation/src/ast-serialization.ts
+++ b/packages/validation/src/ast-serialization.ts
@@ -3,7 +3,7 @@
 import { IExpressionHydrator } from '@aurelia/runtime';
 import * as AST from '@aurelia/runtime';
 
-const { visitAst } = AST;
+const astVisit = AST.astVisit;
 
 enum ASTExpressionTypes {
   BindingBehaviorExpression = 'BindingBehaviorExpression',
@@ -33,6 +33,7 @@ enum ASTExpressionTypes {
   DestructuringSingleAssignment = 'DestructuringSingleAssignment',
   DestructuringRestAssignment = 'DestructuringRestAssignment',
   ArrowFunction = 'ArrowFunction',
+  Custom = 'Custom',
 }
 
 export class Deserializer implements IExpressionHydrator {
@@ -179,13 +180,13 @@ export class Serializer implements AST.IVisitor<string> {
     if (expr == null) {
       return `${expr}`;
     }
-    return visitAst(expr, visitor);
+    return astVisit(expr, visitor);
   }
   public visitAccessMember(expr: AST.AccessMemberExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AccessMemberExpression}","name":"${expr.name}","object":${visitAst(expr.object, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AccessMemberExpression}","name":"${expr.name}","object":${astVisit(expr.object, this)}}`;
   }
   public visitAccessKeyed(expr: AST.AccessKeyedExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AccessKeyedExpression}","object":${visitAst(expr.object, this)},"key":${visitAst(expr.key, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AccessKeyedExpression}","object":${astVisit(expr.object, this)},"key":${astVisit(expr.key, this)}}`;
   }
   public visitAccessThis(expr: AST.AccessThisExpression): string {
     return `{"$TYPE":"${ASTExpressionTypes.AccessThisExpression}","ancestor":${expr.ancestor}}`;
@@ -203,10 +204,10 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.PrimitiveLiteralExpression}","value":${serializePrimitive(expr.value)}}`;
   }
   public visitCallFunction(expr: AST.CallFunctionExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.CallFunctionExpression}","func":${visitAst(expr.func, this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.CallFunctionExpression}","func":${astVisit(expr.func, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitCallMember(expr: AST.CallMemberExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.CallMemberExpression}","name":"${expr.name}","object":${visitAst(expr.object, this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.CallMemberExpression}","name":"${expr.name}","object":${astVisit(expr.object, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitCallScope(expr: AST.CallScopeExpression): string {
     return `{"$TYPE":"${ASTExpressionTypes.CallScopeExpression}","name":"${expr.name}","ancestor":${expr.ancestor},"args":${this.serializeExpressions(expr.args)}}`;
@@ -215,25 +216,25 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.TemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitTaggedTemplate(expr: AST.TaggedTemplateExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.TaggedTemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"raw":${serializePrimitives(expr.cooked.raw as readonly unknown[])},"func":${visitAst(expr.func, this)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.TaggedTemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"raw":${serializePrimitives(expr.cooked.raw as readonly unknown[])},"func":${astVisit(expr.func, this)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitUnary(expr: AST.UnaryExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.UnaryExpression}","operation":"${expr.operation}","expression":${visitAst(expr.expression, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.UnaryExpression}","operation":"${expr.operation}","expression":${astVisit(expr.expression, this)}}`;
   }
   public visitBinary(expr: AST.BinaryExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.BinaryExpression}","operation":"${expr.operation}","left":${visitAst(expr.left, this)},"right":${visitAst(expr.right, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.BinaryExpression}","operation":"${expr.operation}","left":${astVisit(expr.left, this)},"right":${astVisit(expr.right, this)}}`;
   }
   public visitConditional(expr: AST.ConditionalExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ConditionalExpression}","condition":${visitAst(expr.condition, this)},"yes":${visitAst(expr.yes, this)},"no":${visitAst(expr.no, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ConditionalExpression}","condition":${astVisit(expr.condition, this)},"yes":${astVisit(expr.yes, this)},"no":${astVisit(expr.no, this)}}`;
   }
   public visitAssign(expr: AST.AssignExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AssignExpression}","target":${visitAst(expr.target, this)},"value":${visitAst(expr.value, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AssignExpression}","target":${astVisit(expr.target, this)},"value":${astVisit(expr.value, this)}}`;
   }
   public visitValueConverter(expr: AST.ValueConverterExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ValueConverterExpression}","name":"${expr.name}","expression":${visitAst(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ValueConverterExpression}","name":"${expr.name}","expression":${astVisit(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitBindingBehavior(expr: AST.BindingBehaviorExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.BindingBehaviorExpression}","name":"${expr.name}","expression":${visitAst(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.BindingBehaviorExpression}","name":"${expr.name}","expression":${astVisit(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitArrayBindingPattern(expr: AST.ArrayBindingPattern): string {
     return `{"$TYPE":"${ASTExpressionTypes.ArrayBindingPattern}","elements":${this.serializeExpressions(expr.elements)}}`;
@@ -245,22 +246,25 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.BindingIdentifier}","name":"${expr.name}"}`;
   }
   public visitForOfStatement(expr: AST.ForOfStatement): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ForOfStatement}","declaration":${visitAst(expr.declaration, this)},"iterable":${visitAst(expr.iterable, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ForOfStatement}","declaration":${astVisit(expr.declaration, this)},"iterable":${astVisit(expr.iterable, this)}}`;
   }
   public visitInterpolation(expr: AST.Interpolation): string {
     return `{"$TYPE":"${ASTExpressionTypes.Interpolation}","cooked":${serializePrimitives(expr.parts)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitDestructuringAssignmentExpression(expr: AST.DestructuringAssignmentExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringAssignment}","$kind":${serializePrimitive(expr.$kind)},"list":${this.serializeExpressions(expr.list)},"source":${expr.source === void 0 ? serializePrimitive(expr.source) : visitAst(expr.source, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : visitAst(expr.initializer, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringAssignment}","$kind":${serializePrimitive(expr.$kind)},"list":${this.serializeExpressions(expr.list)},"source":${expr.source === void 0 ? serializePrimitive(expr.source) : astVisit(expr.source, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : astVisit(expr.initializer, this)}}`;
   }
   public visitDestructuringAssignmentSingleExpression(expr: AST.DestructuringAssignmentSingleExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringSingleAssignment}","source":${visitAst(expr.source, this)},"target":${visitAst(expr.target, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : visitAst(expr.initializer, this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringSingleAssignment}","source":${astVisit(expr.source, this)},"target":${astVisit(expr.target, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : astVisit(expr.initializer, this)}}`;
   }
   public visitDestructuringAssignmentRestExpression(expr: AST.DestructuringAssignmentRestExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${visitAst(expr.target, this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${astVisit(expr.target, this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
   }
   public visitArrowFunction(expr: AST.ArrowFunction): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.args)},"body":${visitAst(expr.body, this)},"rest":${serializePrimitive(expr.rest)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.args)},"body":${astVisit(expr.body, this)},"rest":${serializePrimitive(expr.rest)}}`;
+  }
+  public visitCustom(expr: AST.CustomExpression): string {
+    return `{"$TYPE":"${ASTExpressionTypes.Custom}","body":${expr.value}}`;
   }
   private serializeExpressions(args: readonly AST.IsExpressionOrStatement[]): string {
     let text = '[';
@@ -268,7 +272,7 @@ export class Serializer implements AST.IVisitor<string> {
       if (i !== 0) {
         text += ',';
       }
-      text += visitAst(args[i], this);
+      text += astVisit(args[i], this);
     }
     text += ']';
     return text;

--- a/packages/validation/src/ast-serialization.ts
+++ b/packages/validation/src/ast-serialization.ts
@@ -1,5 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { IExpressionHydrator } from '@aurelia/runtime';
 import * as AST from '@aurelia/runtime';
+
+const { visitAst } = AST;
 
 enum ASTExpressionTypes {
   BindingBehaviorExpression = 'BindingBehaviorExpression',
@@ -172,16 +176,16 @@ export class Deserializer implements IExpressionHydrator {
 export class Serializer implements AST.IVisitor<string> {
   public static serialize(expr: AST.IsExpressionOrStatement): string {
     const visitor = new Serializer();
-    if (expr == null || typeof expr.accept !== 'function') {
+    if (expr == null) {
       return `${expr}`;
     }
-    return expr.accept(visitor);
+    return visitAst(expr, visitor);
   }
   public visitAccessMember(expr: AST.AccessMemberExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AccessMemberExpression}","name":"${expr.name}","object":${expr.object.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AccessMemberExpression}","name":"${expr.name}","object":${visitAst(expr.object, this)}}`;
   }
   public visitAccessKeyed(expr: AST.AccessKeyedExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AccessKeyedExpression}","object":${expr.object.accept(this)},"key":${expr.key.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AccessKeyedExpression}","object":${visitAst(expr.object, this)},"key":${visitAst(expr.key, this)}}`;
   }
   public visitAccessThis(expr: AST.AccessThisExpression): string {
     return `{"$TYPE":"${ASTExpressionTypes.AccessThisExpression}","ancestor":${expr.ancestor}}`;
@@ -199,10 +203,10 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.PrimitiveLiteralExpression}","value":${serializePrimitive(expr.value)}}`;
   }
   public visitCallFunction(expr: AST.CallFunctionExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.CallFunctionExpression}","func":${expr.func.accept(this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.CallFunctionExpression}","func":${visitAst(expr.func, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitCallMember(expr: AST.CallMemberExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.CallMemberExpression}","name":"${expr.name}","object":${expr.object.accept(this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.CallMemberExpression}","name":"${expr.name}","object":${visitAst(expr.object, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitCallScope(expr: AST.CallScopeExpression): string {
     return `{"$TYPE":"${ASTExpressionTypes.CallScopeExpression}","name":"${expr.name}","ancestor":${expr.ancestor},"args":${this.serializeExpressions(expr.args)}}`;
@@ -211,25 +215,25 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.TemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitTaggedTemplate(expr: AST.TaggedTemplateExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.TaggedTemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"raw":${serializePrimitives(expr.cooked.raw as readonly unknown[])},"func":${expr.func.accept(this)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.TaggedTemplateExpression}","cooked":${serializePrimitives(expr.cooked)},"raw":${serializePrimitives(expr.cooked.raw as readonly unknown[])},"func":${visitAst(expr.func, this)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitUnary(expr: AST.UnaryExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.UnaryExpression}","operation":"${expr.operation}","expression":${expr.expression.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.UnaryExpression}","operation":"${expr.operation}","expression":${visitAst(expr.expression, this)}}`;
   }
   public visitBinary(expr: AST.BinaryExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.BinaryExpression}","operation":"${expr.operation}","left":${expr.left.accept(this)},"right":${expr.right.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.BinaryExpression}","operation":"${expr.operation}","left":${visitAst(expr.left, this)},"right":${visitAst(expr.right, this)}}`;
   }
   public visitConditional(expr: AST.ConditionalExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ConditionalExpression}","condition":${expr.condition.accept(this)},"yes":${expr.yes.accept(this)},"no":${expr.no.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ConditionalExpression}","condition":${visitAst(expr.condition, this)},"yes":${visitAst(expr.yes, this)},"no":${visitAst(expr.no, this)}}`;
   }
   public visitAssign(expr: AST.AssignExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.AssignExpression}","target":${expr.target.accept(this)},"value":${expr.value.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.AssignExpression}","target":${visitAst(expr.target, this)},"value":${visitAst(expr.value, this)}}`;
   }
   public visitValueConverter(expr: AST.ValueConverterExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ValueConverterExpression}","name":"${expr.name}","expression":${expr.expression.accept(this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ValueConverterExpression}","name":"${expr.name}","expression":${visitAst(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitBindingBehavior(expr: AST.BindingBehaviorExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.BindingBehaviorExpression}","name":"${expr.name}","expression":${expr.expression.accept(this)},"args":${this.serializeExpressions(expr.args)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.BindingBehaviorExpression}","name":"${expr.name}","expression":${visitAst(expr.expression, this)},"args":${this.serializeExpressions(expr.args)}}`;
   }
   public visitArrayBindingPattern(expr: AST.ArrayBindingPattern): string {
     return `{"$TYPE":"${ASTExpressionTypes.ArrayBindingPattern}","elements":${this.serializeExpressions(expr.elements)}}`;
@@ -241,22 +245,22 @@ export class Serializer implements AST.IVisitor<string> {
     return `{"$TYPE":"${ASTExpressionTypes.BindingIdentifier}","name":"${expr.name}"}`;
   }
   public visitForOfStatement(expr: AST.ForOfStatement): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ForOfStatement}","declaration":${expr.declaration.accept(this)},"iterable":${expr.iterable.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ForOfStatement}","declaration":${visitAst(expr.declaration, this)},"iterable":${visitAst(expr.iterable, this)}}`;
   }
   public visitInterpolation(expr: AST.Interpolation): string {
     return `{"$TYPE":"${ASTExpressionTypes.Interpolation}","cooked":${serializePrimitives(expr.parts)},"expressions":${this.serializeExpressions(expr.expressions)}}`;
   }
   public visitDestructuringAssignmentExpression(expr: AST.DestructuringAssignmentExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringAssignment}","$kind":${serializePrimitive(expr.$kind)},"list":${this.serializeExpressions(expr.list)},"source":${expr.source === void 0 ? serializePrimitive(expr.source) : expr.source.accept(this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : expr.initializer.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringAssignment}","$kind":${serializePrimitive(expr.$kind)},"list":${this.serializeExpressions(expr.list)},"source":${expr.source === void 0 ? serializePrimitive(expr.source) : visitAst(expr.source, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : visitAst(expr.initializer, this)}}`;
   }
   public visitDestructuringAssignmentSingleExpression(expr: AST.DestructuringAssignmentSingleExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringSingleAssignment}","source":${expr.source.accept(this)},"target":${expr.target.accept(this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : expr.initializer.accept(this)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringSingleAssignment}","source":${visitAst(expr.source, this)},"target":${visitAst(expr.target, this)},"initializer":${expr.initializer === void 0 ? serializePrimitive(expr.initializer) : visitAst(expr.initializer, this)}}`;
   }
   public visitDestructuringAssignmentRestExpression(expr: AST.DestructuringAssignmentRestExpression): string {
-    return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${expr.target.accept(this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.DestructuringRestAssignment}","target":${visitAst(expr.target, this)},"indexOrProperties":${Array.isArray(expr.indexOrProperties) ? serializePrimitives(expr.indexOrProperties) : serializePrimitive(expr.indexOrProperties)}}`;
   }
   public visitArrowFunction(expr: AST.ArrowFunction): string {
-    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.args)},"body":${expr.body.accept(this)},"rest":${serializePrimitive(expr.rest)}}`;
+    return `{"$TYPE":"${ASTExpressionTypes.ArrowFunction}","parameters":${this.serializeExpressions(expr.args)},"body":${visitAst(expr.body, this)},"rest":${serializePrimitive(expr.rest)}}`;
   }
   private serializeExpressions(args: readonly AST.IsExpressionOrStatement[]): string {
     let text = '[';
@@ -264,7 +268,7 @@ export class Serializer implements AST.IVisitor<string> {
       if (i !== 0) {
         text += ',';
       }
-      text += args[i].accept(this);
+      text += visitAst(args[i], this);
     }
     text += ']';
     return text;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -10,6 +10,7 @@ import {
   Scope,
   ExpressionKind,
   IAstEvaluator,
+  astEvaluate,
 } from '@aurelia/runtime';
 import {
   astEvaluator,
@@ -153,7 +154,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
     if (expression === void 0) {
       value = object;
     } else {
-      value = expression.evaluate(scope, this, null);
+      value = astEvaluate(expression, scope, this, null);
     }
 
     let isValid = true;
@@ -176,7 +177,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
               rule,
               object,
             ));
-          message = this.messageProvider.getMessage(rule).evaluate(messageEvaluationScope, this, null) as string;
+          message = astEvaluate(this.messageProvider.getMessage(rule), messageEvaluationScope, this, null) as string;
         }
         return new ValidationResult(isValidOrPromise, message, name, object, rule, this);
       };

--- a/packages/validation/src/serialization.ts
+++ b/packages/validation/src/serialization.ts
@@ -1,5 +1,5 @@
 import { IContainer, IServiceLocator } from '@aurelia/kernel';
-import { IExpressionParser, ExpressionType, Scope, IAstEvaluator } from '@aurelia/runtime';
+import { IExpressionParser, ExpressionType, Scope, IAstEvaluator, astEvaluate } from '@aurelia/runtime';
 import { astEvaluator } from '@aurelia/runtime-html';
 import { Deserializer, serializePrimitive, Serializer } from './ast-serialization';
 import {
@@ -257,7 +257,7 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
         const parsed = this.parser.parse(when, ExpressionType.None);
         rule.canExecute = (object: IValidateable) => {
           // const flags = LifecycleFlags.none; // TODO? need to get the flags propagated here?
-          return parsed.evaluate(Scope.create({ $object: object }), this, null) as boolean;
+          return astEvaluate(parsed, Scope.create({ $object: object }), this, null) as boolean;
         };
       } else if (typeof when === 'function') {
         rule.canExecute = when;


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Extract all ast methods into separate fn for better perf and size, keep the ability to extend via `CustomExpression` ast
  - Unparser is now not included by default with the AST
- fix karma config so that it'll always yield correct sourcemap in continuous long running debugging session
- Add a `compat-v1` package to make it easier to add compat features as we go, & prepare for migration doc
- tweak package building scripts so that it'll drop all private const enum (~20 KB saved in runtime bundle)
- rename property `Scope.parentScope`  -> `Scope.parent`