### PR TITLE
fix(observation): array length observation should notify owning array subscribers

### DIFF
--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -291,8 +291,8 @@ Such cases can be summarized.
 | binding   | Fetch data (working with API services & Ajax calls), initialize data/subscriptions.               |
 | bound     | Any work that relies on fromView/twoWay binding data coming from children, Defining router hooks. |
 | attached  | Use anything (like third-party libraries) that touches the DOM.                                   |
-| unbinding | Persisting data.                                                                                  |
-| dispose   | Cleanup data/subscriptions.                                                                       |
+| unbinding | Cleanup data/subscriptions, maybe persist some data for the next activation.                      |
+| dispose   | One way cleanup all the references/resources. This is invoked only once and is irreversible       |
 
 ## Dependency injection
 

--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -100,7 +100,6 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
         controller.viewModel = controller.container.invoke(currentClassType);
         controller.definition = newDefinition;
         Object.assign(controller.viewModel, values);
-        controller.hooks = new controller.hooks.constructor(controller.viewModel);
         if (controller._hydrateCustomElement) {
           controller._hydrateCustomElement(hydrationInst, hydrationContext);
         } else {

--- a/packages/__e2e__/hmr-webpack/playwright/app.spec.ts
+++ b/packages/__e2e__/hmr-webpack/playwright/app.spec.ts
@@ -55,5 +55,12 @@ test.describe.serial('examples/hmr-webpack-e2e/app.spec.ts', function () {
     await expect(page.locator('app p')).toHaveText('Hello 2!');
     await expect(page.locator('textarea')).toHaveValue('Hello 2!');
   });
+
+  test.skip('invokes binding lifecycle', function () {/* empty */});
+  test.skip('invokes bound lifecycle', function () {/* empty */});
+  test.skip('invokes attaching lifecycle', function () {/* empty */});
+  test.skip('invokes attached lifecycle', function () {/* empty */});
+  test.skip('invokes detaching lifecycle', function () {/* empty */});
+  test.skip('invokes unbinding lifecycle', function () {/* empty */});
 });
 

--- a/packages/__tests__/1-kernel/logger.spec.ts
+++ b/packages/__tests__/1-kernel/logger.spec.ts
@@ -207,7 +207,7 @@ describe('Logger', function () {
   it('additional sink registration works', function () {
     const { sut } = createFixture(LogLevel.error, ColorOptions.noColors, []);
 
-    const sinks = (sut as DefaultLogger)['errorSinks'] as ISink[];
+    const sinks = (sut as DefaultLogger).sinks;
     const eventLog = sinks.find((s) => s instanceof EventLog) as EventLog;
     assert.notStrictEqual(eventLog, void 0);
 
@@ -222,7 +222,7 @@ describe('Logger', function () {
   it('respects the handling capabilities of sinks', function () {
     const { sut } = createFixture(LogLevel.trace, ColorOptions.noColors, []);
 
-    const sinks = (sut as DefaultLogger)['errorSinks'] as ISink[];
+    const sinks = (sut as DefaultLogger).sinks;
     const eventLog = sinks.find((s) => s instanceof EventLog) as EventLog;
     assert.strictEqual(eventLog !== void 0, true);
 
@@ -240,7 +240,7 @@ describe('Logger', function () {
   it('console logging can be deactivated', function () {
     const { sut, mock } = createFixture(LogLevel.trace, ColorOptions.noColors, [], true);
 
-    const sinks = (sut as DefaultLogger)['errorSinks'] as ISink[];
+    const sinks = (sut as DefaultLogger).sinks;
     const eventLog = sinks.find((s) => s instanceof EventLog) as EventLog;
 
     sut.error('foo');

--- a/packages/__tests__/3-runtime-html/array-length-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/array-length-observer.spec.ts
@@ -1,114 +1,77 @@
 import {
-  assert,
-  createFixture,
-  eachCartesianJoin,
-  TestContext,
-} from '@aurelia/testing';
-import {
-  Constructable,
-} from '@aurelia/kernel';
-import {
   ValueConverter,
 } from '@aurelia/runtime-html';
+import {
+  assert,
+  createFixture,
+} from '@aurelia/testing';
 
 describe('3-runtime-html/array-length-observer.spec.ts', function () {
-
-  interface IArrayLengthTestCase<T extends IApp = IApp> {
-    title: string;
-    template: string;
-    only?: boolean;
-    vm?: Constructable<T>;
-    assertFn: AssertionFn;
-    afterAssertFn?: AssertionFn;
-  }
-
-  interface AssertionFn<T extends IApp = IApp> {
-    // eslint-disable-next-line @typescript-eslint/prefer-function-type
-    (ctx: TestContext, testHost: HTMLElement, component: T): void | Promise<void>;
-  }
-
-  interface IApp {
-    [key: string]: any;
-    items: IAppItem[];
-    logs: string[];
-  }
-
-  interface IAppItem {
-    name: string;
-    value: number;
-    isDone?: boolean;
-  }
-
-  class TestClass implements IApp {
-    public items: IAppItem[] = Array.from({ length: 10 }, (_, idx) => {
-      return { name: `i-${idx}`, value: idx + 1 };
-    });
-
-    public logs: string[] = [];
-
-    public logChange(e: InputEvent) {
-      this.logs.push((e.target as HTMLInputElement).value);
+  const NumberVc = ValueConverter.define('number', class NumberVc {
+    public fromView(v: unknown) {
+      return Number(v);
     }
-  }
+  });
 
-  const collectionLengthBindingTestCases: IArrayLengthTestCase[] = [
-    {
-      title: 'works in basic scenario',
-      template: `<input value.bind="items.length | number" input.trigger="logChange($event)" />`,
-      vm: TestClass,
-      assertFn: (ctx, host, component) => {
-        const inputEl = host.querySelector('input');
-        assert.strictEqual(inputEl.value, '10');
+  it('works when bound with input number', function () {
+    const { getBy, component, type, flush } = createFixture(
+      `<input value.bind="items.length | number" input.trigger="logChange($event)" />`,
+      class TestClass {
+        items = Array.from({ length: 10 }, (_, idx) => {
+          return { name: `i-${idx}`, value: idx + 1 };
+        });
 
-        inputEl.value = '00';
-        inputEl.dispatchEvent(new ctx.CustomEvent('input'));
+        logs: string[] = [];
 
-        assert.strictEqual(component.items.length, 0);
-        assert.deepStrictEqual(component.logs, ['00']);
-        assert.strictEqual(inputEl.value, '00');
-        ctx.platform.domWriteQueue.flush();
-        assert.strictEqual(inputEl.value, '0');
-
-        component.items.push({ name: 'i-0', value: 1 });
-        assert.strictEqual(inputEl.value, '0');
-        ctx.platform.domWriteQueue.flush();
-        assert.strictEqual(inputEl.value, '1');
-
-        inputEl.value = 'aa';
-        inputEl.dispatchEvent(new ctx.CustomEvent('input'));
-        assert.strictEqual(component.items.length, 1);
-        assert.deepStrictEqual(component.logs, ['00', 'aa']);
-        assert.strictEqual(inputEl.value, 'aa');
-        ctx.platform.domWriteQueue.flush();
-        assert.strictEqual(inputEl.value, 'aa');
+        logChange(e: InputEvent) {
+          this.logs.push((e.target as HTMLInputElement).value);
+        }
       },
-    },
-  ];
+      [NumberVc]
+    );
 
-  eachCartesianJoin(
-    [collectionLengthBindingTestCases],
-    ({ only, title, template, vm, assertFn }: IArrayLengthTestCase) => {
-      // eslint-disable-next-line mocha/no-exclusive-tests
-      const $it = (title_: string, fn: Mocha.Func) => only ? it.only(title_, fn) : it(title_, fn);
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      $it(title, async function () {
-        const { ctx, component, appHost, startPromise, tearDown } = createFixture<any>(
-          template,
-          vm,
-          [
-            ValueConverter.define('number', class NumberVc {
-              public fromView(v: unknown) {
-                return Number(v);
-              }
-            }),
-          ],
-        );
-        await startPromise;
-        await assertFn(ctx, appHost, component);
-        // test cases could be sharing the same context document
-        // so wait a bit before running the next test
-        await tearDown();
-      });
-    }
-  );
+    const inputEl = getBy('input');
+    assert.strictEqual(inputEl.value, '10');
+
+    type('input', '00');
+
+    assert.strictEqual(component.items.length, 0);
+    assert.deepStrictEqual(component.logs, ['00']);
+    assert.strictEqual(inputEl.value, '00');
+    flush();
+    assert.strictEqual(inputEl.value, '0');
+
+    component.items.push({ name: 'i-0', value: 1 });
+    assert.strictEqual(inputEl.value, '0');
+    flush();
+    assert.strictEqual(inputEl.value, '1');
+
+    type('input', 'aa');
+    assert.strictEqual(component.items.length, 1);
+    assert.deepStrictEqual(component.logs, ['00', 'aa']);
+    assert.strictEqual(inputEl.value, 'aa');
+    flush();
+    assert.strictEqual(inputEl.value, 'aa');
+  });
+
+  it('notifies subscribers of the owning array', function () {
+    const { assertText, type } = createFixture(
+      '<input value.bind="items.length | number"><div repeat.for="i of items">${i}',
+      class {
+        items = [1, 2, 3];
+      },
+      [NumberVc]
+    );
+
+    assertText('123');
+
+    type('input', '2');
+    assertText('12');
+
+    type('input', '3');
+    assertText('12');
+
+    type('input', '1');
+    assertText('1');
+  });
 });

--- a/packages/__tests__/3-runtime-html/platform.spec.ts
+++ b/packages/__tests__/3-runtime-html/platform.spec.ts
@@ -1,0 +1,17 @@
+import { assert, TestContext } from '@aurelia/testing';
+import { isNode } from '../util.js';
+
+describe('IPlatform', function () {
+  it('setups platform', function () {
+    const ctx = TestContext.create();
+
+    assert.strictEqual(typeof ctx.platform.setInterval, 'function');
+    assert.strictEqual(typeof ctx.platform.clearInterval, 'function');
+    assert.strictEqual(typeof ctx.platform.setTimeout, 'function');
+    assert.strictEqual(typeof ctx.platform.clearTimeout, 'function');
+    assert.strictEqual(ctx.platform.Date, Date);
+    if (!isNode()) {
+      assert.strictEqual(ctx.platform.console, console);
+    }
+  });
+});

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -179,7 +179,7 @@ describe('promise template-controller', function () {
       public controller: Controller,
       public error: Error | null,
     ) {
-      this._log = (container.get(ILogger)['debugSinks'] as ISink[]).find((s) => s instanceof DebugLog) as DebugLog;
+      this._log = container.get(ILogger).sinks.find((s) => s instanceof DebugLog) as DebugLog;
     }
     public get platform(): IPlatform { return this._scheduler ?? (this._scheduler = this.container.get(IPlatform)); }
     public get log() {

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -188,7 +188,7 @@ describe('3-runtime-html/switch.spec.ts', function () {
       public controller: Controller,
       public error: Error | null,
     ) {
-      this._log = (container.get(ILogger)['debugSinks'] as ISink[]).find((s) => s instanceof DebugLog) as DebugLog;
+      this._log = container.get(ILogger).sinks.find((s) => s instanceof DebugLog) as DebugLog;
     }
     public get platform(): IPlatform { return this._scheduler ?? (this._scheduler = this.container.get(IPlatform)); }
     public get log() {

--- a/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
@@ -436,7 +436,7 @@ describe('[UNIT] 3-runtime-html/template-compiler.local-templates.spec.ts', func
 
     sut.compile({ name: 'lorem-ipsum', template }, container, null);
     if (__DEV__) {
-      const sinks = container.get(DefaultLogger)['warnSinks'] as ISink[];
+      const sinks = container.get(DefaultLogger).sinks;
       const eventLog = sinks.find((s) => s instanceof EventLog) as EventLog;
       assert.strictEqual(eventLog.log.length, 1, `eventLog.log.length`);
       const event = eventLog.log[0];

--- a/packages/__tests__/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/router-lite/lifecycle-hooks.spec.ts
@@ -10,7 +10,7 @@
  * However, that misses the `@lifeCycleHooks`. Hence, this spec focuses on that.
  */
 
-import { DefaultLogEvent, DefaultLogger, DI, IContainer, ILogger, ISink, LogLevel, Registration } from '@aurelia/kernel';
+import { DefaultLogEvent, DI, IContainer, ILogger, ISink, LogLevel, Registration } from '@aurelia/kernel';
 import { IRouter, IRouteViewModel, IViewportInstruction, NavigationInstruction, Params, route, RouteNode, RouterConfiguration } from '@aurelia/router-lite';
 import { Aurelia, customElement, ILifecycleHooks, lifecycleHooks, StandardConfiguration } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
@@ -52,8 +52,7 @@ describe('lifecycle hooks', function () {
     }
 
     public static getInstance(container: IContainer): EventLog {
-      const logger = container.get<DefaultLogger>(ILogger);
-      const eventLog = (logger['traceSinks'] as ISink[]).find(x => x instanceof this);
+      const eventLog = container.getAll(ISink).find(x => x instanceof this);
       if (eventLog === undefined) throw new Error('Event log is not found');
       return eventLog as EventLog;
     }

--- a/packages/compat-v1/src/compat-ast.ts
+++ b/packages/compat-v1/src/compat-ast.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import { Constructable } from '@aurelia/kernel';
 import { AccessKeyedExpression, AccessMemberExpression, AccessScopeExpression, AccessThisExpression, ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, AssignExpression, astAssign, astBind, astEvaluate, astUnbind, astVisit, BinaryExpression, BindingBehaviorExpression, BindingIdentifier, CallFunctionExpression, CallMemberExpression, CallScopeExpression, ConditionalExpression, DestructuringAssignmentExpression, DestructuringAssignmentRestExpression, DestructuringAssignmentSingleExpression, ForOfStatement, Interpolation, ObjectBindingPattern, ObjectLiteralExpression, PrimitiveLiteralExpression, TaggedTemplateExpression, TemplateExpression, UnaryExpression, ValueConverterExpression } from '@aurelia/runtime';
@@ -41,7 +42,7 @@ export function defineAstMethods() {
     DestructuringAssignmentExpression,
     DestructuringAssignmentSingleExpression,
     DestructuringAssignmentRestExpression,
-    ArrowFunction
+    ArrowFunction,
   ].forEach(ast => {
     def(ast, 'evaluate', function (this: typeof ast, ...args: unknown[]) {
       return (astEvaluate as any)(this, ...args);
@@ -58,5 +59,8 @@ export function defineAstMethods() {
     def(ast, 'unbind', function (this: typeof ast, ...args: unknown[]) {
       return (astUnbind as any)(this, ...args);
     });
+    console.warn('"evaluate"/"assign"/"accept"/"visit"/"bind"/"unbind" are only valid on AST with $kind Custom.'
+      + ' Or import and use astEvaluate/astAssign/astVisit/astBind/astUnbind accordingly.'
+    );
   });
 }

--- a/packages/compat-v1/src/compat-binding.ts
+++ b/packages/compat-v1/src/compat-binding.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+import { Unparser } from '@aurelia/runtime';
+import { AttributeBinding, CallBinding, InterpolationPartBinding, LetBinding, Listener, PropertyBinding, RefBinding } from '@aurelia/runtime-html';
+import { ContentBinding } from '@aurelia/runtime-html/dist/types/binding/interpolation-binding';
+
+let defined = false;
+export const defineBindingMethods = () => {
+  if (defined) return;
+  defined = true;
+
+  ([
+    [PropertyBinding, 'Property binding'],
+    [AttributeBinding, 'Attribute binding'],
+    [Listener, 'Listener binding'],
+    [CallBinding, 'Call binding'],
+    [LetBinding, 'Let binding'],
+    [InterpolationPartBinding, 'Interpolation binding'],
+    [ContentBinding, 'Text binding'],
+    [RefBinding, 'Ref binding']
+  ] as const).forEach(([b, name]) => {
+    Object.defineProperty(
+      b.prototype,
+      'sourceExpression',
+      {
+        configurable: true, enumerable: false, writable: true, get(this: InstanceType<typeof b>) {
+          console.warn(`@deprecated "sourceExpression" property for expression on ${name}. It has been renamed to "ast". expression: "${Unparser.unparse(this.ast)}"`);
+          return this.ast;
+        }
+      }
+    );
+  });
+};

--- a/packages/compat-v1/src/index.ts
+++ b/packages/compat-v1/src/index.ts
@@ -1,10 +1,12 @@
 import { IContainer, IRegistry } from '@aurelia/kernel';
 import { defineAstMethods } from './compat-ast';
+import { defineBindingMethods } from './compat-binding';
 import { PreventFormActionlessSubmit } from './compat-form';
 
 const registration: IRegistry = {
   register(container: IContainer) {
     defineAstMethods();
+    defineBindingMethods();
     container.register(PreventFormActionlessSubmit);
   }
 };

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -11,7 +11,7 @@ import { isArrayIndex, isNativeFunction } from './functions';
 import { Class, Constructable, IDisposable } from './interfaces';
 import { emptyArray } from './platform';
 import { appendAnnotation, getAnnotationKeyFor, IResourceKind, Protocol, ResourceDefinition, ResourceType } from './resource';
-import { createObject, defineMetadata, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { createError, createObject, defineMetadata, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
 
 export type ResolveCallback<T = any> = (handler: IContainer, requestor: IContainer, resolver: IResolver<T>) => T;
 
@@ -172,8 +172,8 @@ export const DefaultResolver = {
 
 const noResolverForKeyError = (key: Key) =>
   __DEV__
-    ? new Error(`AUR0002: ${toStringSafe(key)} not registered, did you forget to add @singleton()?`)
-    : new Error(`AUR0002:${toStringSafe(key)}`);
+    ? createError(`AUR0002: ${toStringSafe(key)} not registered, did you forget to add @singleton()?`)
+    : createError(`AUR0002:${toStringSafe(key)}`);
 
 export class ContainerConfiguration implements IContainerConfiguration {
   public static readonly DEFAULT: ContainerConfiguration = ContainerConfiguration.from({});
@@ -258,9 +258,9 @@ export const DI = {
     const Interface = function (target: Injectable<K>, property: string, index: number): void {
       if (target == null || new.target !== undefined) {
         if (__DEV__) {
-          throw new Error(`AUR0001: No registration for interface: '${Interface.friendlyName}'`);
+          throw createError(`AUR0001: No registration for interface: '${Interface.friendlyName}'`);
         } else {
-          throw new Error(`AUR0001:${Interface.friendlyName}`);
+          throw createError(`AUR0001:${Interface.friendlyName}`);
         }
       }
       const annotationParamtypes = getOrCreateAnnotationParamTypes(target);
@@ -788,16 +788,16 @@ class Resolver implements IResolver, IRegistration {
 }
 const cyclicDependencyError = (name: string) =>
   __DEV__
-    ? new Error(`AUR0003: Cyclic dependency found: ${name}`)
-    : new Error(`AUR0003:${name}`);
+    ? createError(`AUR0003: Cyclic dependency found: ${name}`)
+    : createError(`AUR0003:${name}`);
 const nullFactoryError = (key: Key) =>
   __DEV__
-    ? new Error(`AUR0004: Resolver for ${toStringSafe(key)} returned a null factory`)
-    : new Error(`AUR0004:${toStringSafe(key)}`);
+    ? createError(`AUR0004: Resolver for ${toStringSafe(key)} returned a null factory`)
+    : createError(`AUR0004:${toStringSafe(key)}`);
 const invalidResolverStrategyError = (strategy: ResolverStrategy) =>
   __DEV__
-    ? new Error(`AUR0005: Invalid resolver strategy specified: ${strategy}.`)
-    : new Error(`AUR0005:${strategy}`);
+    ? createError(`AUR0005: Invalid resolver strategy specified: ${strategy}.`)
+    : createError(`AUR0005:${strategy}`);
 
 /** @internal */
 export interface IInvoker<T extends Constructable = any> {
@@ -873,40 +873,7 @@ function isResourceKey(key: Key): key is string {
   return isString(key) && key.indexOf(':') > 0;
 }
 
-const InstrinsicTypeNames = new Set<string>([
-  'Array',
-  'ArrayBuffer',
-  'Boolean',
-  'DataView',
-  'Date',
-  'Error',
-  'EvalError',
-  'Float32Array',
-  'Float64Array',
-  'Function',
-  'Int8Array',
-  'Int16Array',
-  'Int32Array',
-  'Map',
-  'Number',
-  'Object',
-  'Promise',
-  'RangeError',
-  'ReferenceError',
-  'RegExp',
-  'Set',
-  'SharedArrayBuffer',
-  'String',
-  'SyntaxError',
-  'TypeError',
-  'Uint8Array',
-  'Uint8ClampedArray',
-  'Uint16Array',
-  'Uint32Array',
-  'URIError',
-  'WeakMap',
-  'WeakSet',
-]);
+const InstrinsicTypeNames = new Set<string>('Array ArrayBuffer Boolean DataView Date Error EvalError Float32Array Float64Array Function Int8Array Int16Array Int32Array Map Number Object Promise RangeError ReferenceError RegExp Set SharedArrayBuffer String SyntaxError TypeError Uint8Array Uint8ClampedArray Uint16Array Uint32Array URIError WeakMap WeakSet'.split(' '));
 
 // const factoryKey = 'di:factory';
 // const factoryAnnotationKey = Protocol.annotation.keyFor(factoryKey);
@@ -1080,7 +1047,7 @@ export class Container implements IContainer {
 
   //   if (resolver == null) { return; }
   //   if (resolver instanceof Resolver && resolver.strategy === ResolverStrategy.array) {
-  //     throw new Error('Cannot deregister a resolver with array strategy');
+  //     throw createError('Cannot deregister a resolver with array strategy');
   //   }
   //   if (this._disposableResolvers.has(resolver as IDisposableResolver<K>)) {
   //     (resolver as IDisposableResolver<K>).dispose();
@@ -1380,32 +1347,32 @@ const registrationError = (deps: Key[]) =>
   // Most likely cause is trying to register a plain object that does not have a
   // register method and is not a class constructor
   __DEV__
-    ? new Error(`AUR0006: Unable to autoregister dependency: [${deps.map(toStringSafe)}]`)
-    : new Error(`AUR0006:${deps.map(toStringSafe)}`);
+    ? createError(`AUR0006: Unable to autoregister dependency: [${deps.map(toStringSafe)}]`)
+    : createError(`AUR0006:${deps.map(toStringSafe)}`);
 const resourceExistError = (key: Key) =>
   __DEV__
-    ? new Error(`AUR0007: Resource key "${toStringSafe(key)}" already registered`)
-    : new Error(`AUR0007:${toStringSafe(key)}`);
+    ? createError(`AUR0007: Resource key "${toStringSafe(key)}" already registered`)
+    : createError(`AUR0007:${toStringSafe(key)}`);
 const cantResolveKeyError = (key: Key) =>
   __DEV__
-    ? new Error(`AUR0008: Unable to resolve key: ${toStringSafe(key)}`)
-    : new Error(`AUR0008:${toStringSafe(key)}`);
+    ? createError(`AUR0008: Unable to resolve key: ${toStringSafe(key)}`)
+    : createError(`AUR0008:${toStringSafe(key)}`);
 const jitRegisterNonFunctionError = (keyAsValue: Key) =>
   __DEV__
-    ? new Error(`AUR0009: Attempted to jitRegister something that is not a constructor: '${toStringSafe(keyAsValue)}'. Did you forget to register this resource?`)
-    : new Error(`AUR0009:${toStringSafe(keyAsValue)}`);
+    ? createError(`AUR0009: Attempted to jitRegister something that is not a constructor: '${toStringSafe(keyAsValue)}'. Did you forget to register this resource?`)
+    : createError(`AUR0009:${toStringSafe(keyAsValue)}`);
 const jitInstrinsicTypeError = (keyAsValue: any) =>
   __DEV__
-    ? new Error(`AUR0010: Attempted to jitRegister an intrinsic type: ${keyAsValue.name}. Did you forget to add @inject(Key)`)
-    : new Error(`AUR0010:${keyAsValue.name}`);
+    ? createError(`AUR0010: Attempted to jitRegister an intrinsic type: ${keyAsValue.name}. Did you forget to add @inject(Key)`)
+    : createError(`AUR0010:${keyAsValue.name}`);
 const invalidResolverFromRegisterError = () =>
   __DEV__
-    ? new Error(`AUR0011: Invalid resolver returned from the static register method`)
-    : new Error(`AUR0011`);
+    ? createError(`AUR0011: Invalid resolver returned from the static register method`)
+    : createError(`AUR0011`);
 const jitInterfaceError = (name: string) =>
   __DEV__
-    ? new Error(`AUR0012: Attempted to jitRegister an interface: ${name}`)
-    : new Error(`AUR0012:${name}`);
+    ? createError(`AUR0012: Attempted to jitRegister an interface: ${name}`)
+    : createError(`AUR0012:${name}`);
 /**
  * An implementation of IRegistry that delegates registration to a
  * separately registered class. The ParameterizedRegistry facilitates the
@@ -1595,9 +1562,9 @@ export class InstanceProvider<K extends Key> implements IDisposableResolver<K | 
 function validateKey(key: any): void {
   if (key === null || key === void 0) {
     if (__DEV__) {
-      throw new Error(`AUR0014: key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?`);
+      throw createError(`AUR0014: key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?`);
     } else {
-      throw new Error(`AUR0014`);
+      throw createError(`AUR0014`);
     }
   }
 }
@@ -1618,17 +1585,17 @@ function buildAllResponse(resolver: IResolver, handler: IContainer, requestor: I
   return [resolver.resolve(handler, requestor)];
 }
 
-function noInstanceError(name?: string) {
+const noInstanceError = (name?: string) => {
   if (__DEV__) {
-    return new Error(`AUR0013: Cannot call resolve ${name} before calling prepare or after calling dispose.`);
+    return createError(`AUR0013: Cannot call resolve ${name} before calling prepare or after calling dispose.`);
   } else {
-    return new Error(`AUR0013:${name}`);
+    return createError(`AUR0013:${name}`);
   }
-}
+};
 
-function createNativeInvocationError(Type: Constructable): Error {
+const createNativeInvocationError = (Type: Constructable): Error => {
   if (__DEV__) {
-    return new Error(`AUR0015: ${Type.name} is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`);
+    return createError(`AUR0015: ${Type.name} is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`);
   }
-  return new Error(`AUR0015:${Type.name}`);
-}
+  return createError(`AUR0015:${Type.name}`);
+};

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -1,6 +1,6 @@
 import { DI } from './di';
 import { Constructable, IDisposable } from './interfaces';
-import { isString } from './utilities';
+import { createError, isString } from './utilities';
 
 /**
  * Represents a handler for an EventAggregator event.
@@ -54,7 +54,7 @@ export class EventAggregator {
   ): void {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!channelOrInstance) {
-      throw new Error(`Invalid channel name or instance: ${channelOrInstance}.`);
+      throw createError(`Invalid channel name or instance: ${channelOrInstance}.`);
     }
 
     if (isString(channelOrInstance)) {
@@ -103,7 +103,7 @@ export class EventAggregator {
   ): IDisposable {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!channelOrType) {
-      throw new Error(`Invalid channel name or type: ${channelOrType}.`);
+      throw createError(`Invalid channel name or type: ${channelOrType}.`);
     }
 
     let handler: unknown;

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -1,5 +1,5 @@
 import { Constructable, Overwrite } from './interfaces';
-import { createObject } from './utilities';
+import { createError, createObject } from './utilities';
 
 const isNumericLookup: Record<string, boolean> = {};
 
@@ -13,7 +13,7 @@ const isNumericLookup: Record<string, boolean> = {};
  *
  * Results are cached.
  */
-export function isArrayIndex(value: unknown): value is number | string {
+export const isArrayIndex = (value: unknown): value is number | string => {
   switch (typeof value) {
     case 'number':
       return value >= 0 && (value | 0) === value;
@@ -29,7 +29,7 @@ export function isArrayIndex(value: unknown): value is number | string {
       let ch = 0;
       let i = 0;
       for (; i < length; ++i) {
-        ch = value.charCodeAt(i);
+        ch = charCodeAt(value, i);
         if (i === 0 && ch === 0x30 && length > 1 /* must not start with 0 */ || ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
           return isNumericLookup[value] = false;
         }
@@ -39,7 +39,7 @@ export function isArrayIndex(value: unknown): value is number | string {
     default:
       return false;
   }
-}
+};
 
 /**
  * Base implementation of camel and kebab cases
@@ -68,7 +68,7 @@ const baseCase = (function () {
     '9': true,
   } as Record<string, true | undefined>);
 
-  function charToKind(char: string): CharKind {
+  const charToKind = (char: string): CharKind => {
     if (char === '') {
       // We get this if we do charAt() with an index out of range
       return CharKind.none;
@@ -87,9 +87,9 @@ const baseCase = (function () {
     }
 
     return CharKind.none;
-  }
+  };
 
-  return function (input: string, cb: (char: string, sep: boolean) => string): string {
+  return (input: string, cb: (char: string, sep: boolean) => string): string => {
     const len = input.length;
     if (len === 0) {
       return input;
@@ -149,11 +149,11 @@ const baseCase = (function () {
 export const camelCase = (function () {
   const cache: Record<string, string | undefined> = createObject();
 
-  function callback(char: string, sep: boolean): string {
+  const callback = (char: string, sep: boolean): string => {
     return sep ? char.toUpperCase() : char.toLowerCase();
-  }
+  };
 
-  return function (input: string): string {
+  return (input: string): string => {
     let output = cache[input];
     if (output === void 0) {
       output = cache[input] = baseCase(input, callback);
@@ -175,7 +175,7 @@ export const camelCase = (function () {
 export const pascalCase = (function () {
   const cache: Record<string, string | undefined> = createObject();
 
-  return function (input: string): string {
+  return (input: string): string => {
     let output = cache[input];
     if (output === void 0) {
       output = camelCase(input);
@@ -201,11 +201,11 @@ export const pascalCase = (function () {
 export const kebabCase = (function () {
   const cache: Record<string, string | undefined> = createObject();
 
-  function callback(char: string, sep: boolean): string {
+  const callback = (char: string, sep: boolean): string => {
     return sep ? `-${char.toLowerCase()}` : char.toLowerCase();
-  }
+  };
 
-  return function (input: string): string {
+  return (input: string): string => {
     let output = cache[input];
     if (output === void 0) {
       output = cache[input] = baseCase(input, callback);
@@ -220,7 +220,7 @@ export const kebabCase = (function () {
  *
  * Primarily used by Aurelia to convert DOM node lists to arrays.
  */
-export function toArray<T = unknown>(input: ArrayLike<T>): T[] {
+export const toArray = <T = unknown>(input: ArrayLike<T>): T[] => {
   // benchmark: http://jsben.ch/xjsyF
   const length = input.length;
   const arr = Array(length) as T[];
@@ -229,13 +229,13 @@ export function toArray<T = unknown>(input: ArrayLike<T>): T[] {
     arr[i] = input[i];
   }
   return arr;
-}
+};
 
 /**
  * Decorator. (lazily) bind the method to the class instance on first call.
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function bound<T extends Function>(target: Object, key: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> {
+export const bound = <T extends Function>(target: Object, key: string | symbol, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T> => {
   return {
     configurable: true,
     enumerable: descriptor.enumerable,
@@ -250,9 +250,9 @@ export function bound<T extends Function>(target: Object, key: string | symbol, 
       return boundFn as T;
     },
   };
-}
+};
 
-export function mergeArrays<T>(...arrays: (readonly T[] | undefined)[]): T[] {
+export const mergeArrays = <T>(...arrays: (readonly T[] | undefined)[]): T[] => {
   const result: T[] = [];
   let k = 0;
   const arraysLen = arrays.length;
@@ -270,9 +270,9 @@ export function mergeArrays<T>(...arrays: (readonly T[] | undefined)[]): T[] {
     }
   }
   return result;
-}
+};
 
-export function firstDefined<T>(...values: readonly (T | undefined)[]): T {
+export const firstDefined = <T>(...values: readonly (T | undefined)[]): T => {
   const len = values.length;
   let value: T | undefined;
   let i = 0;
@@ -282,8 +282,8 @@ export function firstDefined<T>(...values: readonly (T | undefined)[]): T {
       return value;
     }
   }
-  throw new Error(`No default value found`);
-}
+  throw createError(`No default value found`);
+};
 
 export const getPrototypeChain = (function () {
   const functionPrototype = Function.prototype;
@@ -365,7 +365,6 @@ export function toLookup(...objs: {}[]): Readonly<{}> {
 export const isNativeFunction = (function () {
   // eslint-disable-next-line @typescript-eslint/ban-types
   const lookup: WeakMap<Function, boolean> = new WeakMap();
-
   let isNative = false as boolean | undefined;
   let sourceText = '';
   let i = 0;
@@ -384,22 +383,22 @@ export const isNativeFunction = (function () {
         // 100 seems to be a safe upper bound of the max length of a native function. In Chrome and FF it's 56, in Edge it's 61.
         i <= 100 &&
         // This whole heuristic *could* be tricked by a comment. Do we need to care about that?
-        sourceText.charCodeAt(i -  1) === 0x7D && // }
+        charCodeAt(sourceText, i -  1) === 0x7D && // }
         // TODO: the spec is a little vague about the precise constraints, so we do need to test this across various browsers to make sure just one whitespace is a safe assumption.
-        sourceText.charCodeAt(i -  2)  <= 0x20 && // whitespace
-        sourceText.charCodeAt(i -  3) === 0x5D && // ]
-        sourceText.charCodeAt(i -  4) === 0x65 && // e
-        sourceText.charCodeAt(i -  5) === 0x64 && // d
-        sourceText.charCodeAt(i -  6) === 0x6F && // o
-        sourceText.charCodeAt(i -  7) === 0x63 && // c
-        sourceText.charCodeAt(i -  8) === 0x20 && //
-        sourceText.charCodeAt(i -  9) === 0x65 && // e
-        sourceText.charCodeAt(i - 10) === 0x76 && // v
-        sourceText.charCodeAt(i - 11) === 0x69 && // i
-        sourceText.charCodeAt(i - 12) === 0x74 && // t
-        sourceText.charCodeAt(i - 13) === 0x61 && // a
-        sourceText.charCodeAt(i - 14) === 0x6E && // n
-        sourceText.charCodeAt(i - 15) === 0x58    // [
+        charCodeAt(sourceText, i -  2)  <= 0x20 && // whitespace
+        charCodeAt(sourceText, i -  3) === 0x5D && // ]
+        charCodeAt(sourceText, i -  4) === 0x65 && // e
+        charCodeAt(sourceText, i -  5) === 0x64 && // d
+        charCodeAt(sourceText, i -  6) === 0x6F && // o
+        charCodeAt(sourceText, i -  7) === 0x63 && // c
+        charCodeAt(sourceText, i -  8) === 0x20 && //
+        charCodeAt(sourceText, i -  9) === 0x65 && // e
+        charCodeAt(sourceText, i - 10) === 0x76 && // v
+        charCodeAt(sourceText, i - 11) === 0x69 && // i
+        charCodeAt(sourceText, i - 12) === 0x74 && // t
+        charCodeAt(sourceText, i - 13) === 0x61 && // a
+        charCodeAt(sourceText, i - 14) === 0x6E && // n
+        charCodeAt(sourceText, i - 15) === 0x58    // [
       );
 
       lookup.set(fn, isNative);
@@ -416,15 +415,15 @@ type MaybePromise<T> = T extends Promise<infer R> ? (T | R) : (T | Promise<T>);
  *
  * If the value is a promise, it is `then`ed before the callback is invoked. Otherwise the callback is invoked synchronously.
  */
-export function onResolve<TValue, TRet>(
+export const onResolve = <TValue, TRet>(
   maybePromise: TValue,
   resolveCallback: (value: UnwrapPromise<TValue>) => TRet,
-): MaybePromise<TRet> {
+): MaybePromise<TRet> => {
   if (maybePromise instanceof Promise) {
     return maybePromise.then(resolveCallback) as MaybePromise<TRet>;
   }
   return resolveCallback(maybePromise as UnwrapPromise<TValue>) as MaybePromise<TRet>;
-}
+};
 
 /**
  * Normalize an array of potential promises, to ensure things stay synchronous when they can.
@@ -435,9 +434,9 @@ export function onResolve<TValue, TRet>(
  *
  * If none of the values is a promise, nothing is returned, to indicate that things can stay synchronous.
  */
-export function resolveAll(
+export const resolveAll = (
   ...maybePromises: (void | Promise<void>)[]
-): void | Promise<void> {
+): void | Promise<void> => {
   let maybePromise: Promise<void> | void = void 0;
   let firstPromise: Promise<void> | void = void 0;
   let promises: Promise<void>[] | undefined = void 0;
@@ -461,4 +460,6 @@ export function resolveAll(
     return firstPromise;
   }
   return Promise.all(promises) as unknown as Promise<void>;
-}
+};
+
+const charCodeAt = (str: string, index: number) => str.charCodeAt(index);

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -12,6 +12,7 @@ import { Metadata } from '@aurelia/metadata';
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
 /** @internal */ export const createObject = <T extends object>() => Object.create(null) as T;
+/** @internal */ export const createError = (message: string) => new Error(message);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyFunction = (...args: any) => any;

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1008,7 +1008,9 @@ function def(
     configurable,
     value,
   })) {
-    throw new Error(`Unable to apply metadata polyfill: could not add property '${key}' to the global Reflect object`);
+    throw __DEV__
+      ? createError(`AUR1000: Unable to apply metadata polyfill: could not add property '${key}' to the global Reflect object`)
+      : createError(`AUR1000`);
   }
 }
 
@@ -1053,7 +1055,9 @@ export function applyMetadataPolyfill(
       // todo: log something
       return;
     }
-    throw new Error(`Conflicting @aurelia/metadata module import detected. Please make sure you have the same version of all Aurelia packages in your dependency tree.`);
+    throw __DEV__
+      ? createError(`AUR1001: Conflicting @aurelia/metadata module import detected. Please make sure you have the same version of all Aurelia packages in your dependency tree.`)
+      : createError(`AUR1001`);
   }
 
   const presentProps = [
@@ -1077,7 +1081,9 @@ export function applyMetadataPolyfill(
         const impl = `${(Reflect as { [k: string]: Function })[p].toString().slice(0, 100)}...`;
         return `${p}:\n${impl}`;
       }).join('\n\n');
-      throw new Error(`Conflicting reflect.metadata polyfill found. If you have 'reflect-metadata' or any other reflect polyfill imported, please remove it, if not (or if you must use a specific polyfill) please file an issue at https://github.com/aurelia/aurelia/issues so that we can look into compatibility options for this scenario. Implementation summary:\n\n${implementationSummary}`);
+      throw __DEV__
+        ? createError(`AUR1002: Conflicting reflect.metadata polyfill found. If you have 'reflect-metadata' or any other reflect polyfill imported, please remove it, if not (or if you must use a specific polyfill) please file an issue at https://github.com/aurelia/aurelia/issues so that we can look into compatibility options for this scenario. Implementation summary:\n\n${implementationSummary}`)
+        : createError(`AUR1002:${implementationSummary}`);
     } else if (forceOverwrite) {
       $applyMetadataPolyfill(reflect, writable, configurable);
     }
@@ -1085,3 +1091,5 @@ export function applyMetadataPolyfill(
     $applyMetadataPolyfill(reflect, writable, configurable);
   }
 }
+
+const createError = (message: string) => new Error(message);

--- a/packages/platform-browser/src/index.ts
+++ b/packages/platform-browser/src/index.ts
@@ -2,13 +2,6 @@ import { Platform, TaskQueue } from '@aurelia/platform';
 
 const lookup = new Map<object, BrowserPlatform>();
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function notImplemented(name: string): (...args: any[]) => any {
-  return function notImplemented() {
-    throw new Error(`The PLATFORM did not receive a valid reference to the global function '${name}'.`); // TODO: link to docs describing how to fix this issue
-  };
-}
-
 export class BrowserPlatform<TGlobal extends typeof globalThis = typeof globalThis> extends Platform<TGlobal> {
   public readonly Node!: TGlobal['Node'];
   public readonly Element!: TGlobal['Element'];
@@ -42,16 +35,16 @@ export class BrowserPlatform<TGlobal extends typeof globalThis = typeof globalTh
   public constructor(g: TGlobal, overrides: Partial<Exclude<BrowserPlatform, 'globalThis'>> = {}) {
     super(g, overrides);
 
-    ('Node,Element,HTMLElement,CustomEvent,CSSStyleSheet,ShadowRoot,MutationObserver,'
-    + 'window,document,location,history,navigator,customElements')
-      .split(',')
-      .forEach(prop => {
-        (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : (g as any)[prop];
-      });
+    ('Node Element HTMLElement CustomEvent CSSStyleSheet ShadowRoot MutationObserver '
+    + 'window document location history navigator customElements')
+      .split(' ')
+      // eslint-disable-next-line
+      .forEach(prop => (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : (g as any)[prop]);
 
-    'fetch,requestAnimationFrame,cancelAnimationFrame'.split(',').forEach(prop => {
-      (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : ((g as any)[prop]?.bind(g) ?? notImplemented(prop));
-    });
+    'fetch requestAnimationFrame cancelAnimationFrame'.split(' ').forEach(prop =>
+      // eslint-disable-next-line
+      (this as any)[prop] = prop in overrides ? (overrides as any)[prop] : ((g as any)[prop]?.bind(g) ?? notImplemented(prop))
+    );
 
     this.flushDomRead = this.flushDomRead.bind(this);
     this.flushDomWrite = this.flushDomWrite.bind(this);
@@ -136,3 +129,10 @@ export class BrowserPlatform<TGlobal extends typeof globalThis = typeof globalTh
     }
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const notImplemented = (name: string): (...args: any[]) => any => {
+  return () => {
+    throw new Error(`The PLATFORM did not receive a valid reference to the global function '${name}'.`); // TODO: link to docs describing how to fix this issue
+  };
+};

--- a/packages/rollup-utils.js
+++ b/packages/rollup-utils.js
@@ -232,7 +232,6 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
         : [
           rollupReplace({ ...envVars, __DEV__: false }),
           rollupTypeScript({
-            removeComments: false
           }, isDevMode),
         ]
       ),

--- a/packages/route-recognizer/src/index.ts
+++ b/packages/route-recognizer/src/index.ts
@@ -77,11 +77,11 @@ class Candidate<T> {
 
       if (state.segment === null && nextState.isOptional && nextState.nextStates !== null) {
         if (nextState.nextStates.length > 1) {
-          throw new Error(`${nextState.nextStates.length} nextStates`);
+          throw createError(`${nextState.nextStates.length} nextStates`);
         }
         const separator = nextState.nextStates[0];
         if (!separator.isSeparator) {
-          throw new Error(`Not a separator`);
+          throw createError(`Not a separator`);
         }
         if (separator.nextStates !== null) {
           for (const $nextState of separator.nextStates) {
@@ -156,6 +156,7 @@ class Candidate<T> {
         if (params[name] === void 0) {
           params[name] = chars[i];
         } else {
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
           params[name] += chars[i];
         }
       }
@@ -334,7 +335,7 @@ export class RouteRecognizer<T> {
         this.$add(route);
       }
     } else {
-      this.$add(routeOrRoutes as IConfigurableRoute<T>);
+      this.$add(routeOrRoutes);
     }
 
     // Clear the cache whenever there are state changes, because the recognizeResults could be arbitrarily different as a result
@@ -344,7 +345,7 @@ export class RouteRecognizer<T> {
   private $add(route: IConfigurableRoute<T>): void {
     const path = route.path;
     const lookup = this.endpointLookup;
-    if(lookup.has(path)) throw new Error(`Cannot add duplicate path '${path}'.`);
+    if(lookup.has(path)) throw createError(`Cannot add duplicate path '${path}'.`);
     const $route = new ConfigurableRoute(path, route.caseSensitive === true, route.handler);
 
     // Normalize leading, trailing and double slashes by ignoring empty segments
@@ -531,7 +532,7 @@ class State<T> {
     } else if (segment === null) {
       state = nextStates.find(s => s.value === value);
     } else {
-      state = nextStates.find(s => s.segment?.equals(segment!));
+      state = nextStates.find(s => s.segment?.equals(segment));
     }
 
     if (state === void 0) {
@@ -543,7 +544,7 @@ class State<T> {
 
   public setEndpoint(this: AnyState<T>, endpoint: Endpoint<T>): void {
     if (this.endpoint !== null) {
-      throw new Error(`Cannot add ambiguous route. The pattern '${endpoint.route.path}' clashes with '${this.endpoint.route.path}'`);
+      throw createError(`Cannot add ambiguous route. The pattern '${endpoint.route.path}' clashes with '${this.endpoint.route.path}'`);
     }
     this.endpoint = endpoint;
     if (this.isOptional) {
@@ -676,3 +677,5 @@ class StarSegment<T> {
     );
   }
 }
+
+const createError = (msg: string) => new Error(msg);

--- a/packages/runtime-html/src/attribute-mapper.ts
+++ b/packages/runtime-html/src/attribute-mapper.ts
@@ -1,4 +1,4 @@
-import { createLookup, isDataAttribute } from './utilities';
+import { createError, createLookup, isDataAttribute } from './utilities';
 import { ISVGAnalyzer } from './observation/svg-analyzer';
 import { createInterface } from './utilities-di';
 
@@ -142,5 +142,5 @@ function shouldDefaultToTwoWay(element: Element, attr: string): boolean {
 }
 
 function createMappedError(attr: string, tagName: string) {
-  return new Error(`Attribute ${attr} has been already registered for ${tagName === '*' ? 'all elements' : `<${tagName}/>`}`);
+  return createError(`Attribute ${attr} has been already registered for ${tagName === '*' ? 'all elements' : `<${tagName}/>`}`);
 }

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -5,7 +5,7 @@ import { IEventTarget, INode } from './dom';
 import { IPlatform } from './platform';
 import { CustomElementDefinition, generateElementName } from './resources/custom-element';
 import { LifecycleFlags, Controller, ICustomElementController, ICustomElementViewModel, IHydratedParentController } from './templating/controller';
-import { isFunction, isPromise } from './utilities';
+import { createError, isFunction, isPromise } from './utilities';
 import { createInterface, instanceRegistration, registerResolver } from './utilities-di';
 
 import type {
@@ -39,9 +39,9 @@ export class Aurelia implements IDisposable {
     if (this._root == null) {
       if (this.next == null) {
         if (__DEV__)
-          throw new Error(`AUR0767: root is not defined`);
+          throw createError(`AUR0767: root is not defined`);
         else
-          throw new Error(`AUR0767`);
+          throw createError(`AUR0767`);
       }
       return this.next;
     }
@@ -58,9 +58,9 @@ export class Aurelia implements IDisposable {
   ) {
     if (container.has(IAurelia, true)) {
       if (__DEV__)
-        throw new Error(`AUR0768: An instance of Aurelia is already registered with the container or an ancestor of it.`);
+        throw createError(`AUR0768: An instance of Aurelia is already registered with the container or an ancestor of it.`);
       else
-        throw new Error(`AUR0768`);
+        throw createError(`AUR0768`);
     }
 
     registerResolver(container, IAurelia, new InstanceProvider<IAurelia>('IAurelia', this));
@@ -129,9 +129,9 @@ export class Aurelia implements IDisposable {
     if (!this.container.has(IPlatform, false)) {
       if (host.ownerDocument.defaultView === null) {
         if (__DEV__)
-          throw new Error(`AUR0769: Failed to initialize the platform object. The host element's ownerDocument does not have a defaultView`);
+          throw createError(`AUR0769: Failed to initialize the platform object. The host element's ownerDocument does not have a defaultView`);
         else
-          throw new Error(`AUR0769`);
+          throw createError(`AUR0769`);
       }
       p = new BrowserPlatform(host.ownerDocument.defaultView);
       this.container.register(instanceRegistration(IPlatform, p));
@@ -146,9 +146,9 @@ export class Aurelia implements IDisposable {
   public start(root: IAppRoot | undefined = this.next): void | Promise<void> {
     if (root == null) {
       if (__DEV__)
-        throw new Error(`AUR0770: There is no composition root`);
+        throw createError(`AUR0770: There is no composition root`);
       else
-        throw new Error(`AUR0770`);
+        throw createError(`AUR0770`);
     }
 
     if (isPromise(this._startPromise)) {
@@ -197,9 +197,9 @@ export class Aurelia implements IDisposable {
   public dispose(): void {
     if (this._isRunning || this._isStopping) {
       if (__DEV__)
-        throw new Error(`AUR0771: The aurelia instance must be fully stopped before it can be disposed`);
+        throw createError(`AUR0771: The aurelia instance must be fully stopped before it can be disposed`);
       else
-        throw new Error(`AUR0771`);
+        throw createError(`AUR0771`);
     }
     this.container.dispose();
   }

--- a/packages/runtime-html/src/create-element.ts
+++ b/packages/runtime-html/src/create-element.ts
@@ -10,7 +10,7 @@ import { IPlatform } from './platform';
 import { CustomElementDefinition, CustomElementType, generateElementName, getElementDefinition, isElementType } from './resources/custom-element';
 import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
-import { isString } from './utilities';
+import { createError, isString } from './utilities';
 
 import type { ISyntheticView } from './templating/controller';
 
@@ -26,7 +26,7 @@ export function createElement<C extends Constructable = Constructable>(
   if (isElementType(tagOrType)) {
     return createElementForType(p, tagOrType, props, children);
   }
-  throw new Error(`Invalid Tag or Type.`);
+  throw createError(`Invalid Tag or Type.`);
 }
 
 /**

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,5 +1,5 @@
 import { subscriberCollection, AccessorType } from '@aurelia/runtime';
-import { isString } from '../utilities';
+import { createError, isString } from '../utilities';
 
 import type {
   IObserver,
@@ -127,9 +127,9 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
           break;
         default:
           if (__DEV__)
-            throw new Error(`AUR0651: Unsupported observation of attribute: ${this._attr}`);
+            throw createError(`AUR0651: Unsupported observation of attribute: ${this._attr}`);
           else
-            throw new Error(`AUR0651:${this._attr}`);
+            throw createError(`AUR0651:${this._attr}`);
       }
 
       if (newValue !== this._value) {

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -17,7 +17,7 @@ import { SelectValueObserver } from './select-value-observer';
 import { StyleAttributeAccessor } from './style-attribute-accessor';
 import { ISVGAnalyzer } from './svg-analyzer';
 import { ValueAttributeObserver } from './value-attribute-observer';
-import { createLookup, isDataAttribute, isString } from '../utilities';
+import { createError, createLookup, isDataAttribute, isString } from '../utilities';
 import { aliasRegistration, singletonRegistration } from '../utilities-di';
 
 import type { IIndexable, IContainer } from '@aurelia/kernel';
@@ -309,9 +309,9 @@ export class NodeObserverLocator implements INodeObserverLocator {
       // consider:
       // - maybe add a adapter API to handle unknown obj/key combo
       if (__DEV__)
-        throw new Error(`AUR0652: Unable to observe property ${String(key)}. Register observation mapping with .useConfig().`);
+        throw createError(`AUR0652: Unable to observe property ${String(key)}. Register observation mapping with .useConfig().`);
       else
-        throw new Error(`AUR0652:${String(key)}`);
+        throw createError(`AUR0652:${String(key)}`);
     } else {
       // todo: probably still needs to get the property descriptor via getOwnPropertyDescriptor
       // but let's start with simplest scenario
@@ -334,7 +334,7 @@ export function getCollectionObserver(collection: unknown, observerLocator: IObs
 
 function throwMappingExisted(nodeName: string, key: PropertyKey): never {
   if (__DEV__)
-    throw new Error(`AUR0653: Mapping for property ${String(key)} of <${nodeName} /> already exists`);
+    throw createError(`AUR0653: Mapping for property ${String(key)} of <${nodeName} /> already exists`);
   else
-    throw new Error(`AUR0653:${String(key)}@${nodeName}`);
+    throw createError(`AUR0653:${String(key)}@${nodeName}`);
 }

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -13,7 +13,7 @@ import type {
   ISubscriber,
   ISubscriberCollection,
 } from '@aurelia/runtime';
-import { hasOwnProperty, isArray } from '../utilities';
+import { createError, hasOwnProperty, isArray } from '../utilities';
 
 const childObserverOptions = {
   childList: true,
@@ -247,9 +247,9 @@ export class SelectValueObserver implements IObserver {
     if (array != null) {
       if (!this._obj.multiple) {
         if (__DEV__)
-          throw new Error(`AUR0654: Only null or Array instances can be bound to a multi-select.`);
+          throw createError(`AUR0654: Only null or Array instances can be bound to a multi-select.`);
         else
-          throw new Error(`AUR0654`);
+          throw createError(`AUR0654`);
       }
       (this._arrayObserver = this._observerLocator.getArrayObserver(array)).subscribe(this);
     }

--- a/packages/runtime-html/src/plugins/dialog/dialog-configuration.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-configuration.ts
@@ -5,6 +5,7 @@ import { DefaultDialogGlobalSettings, DefaultDialogDomRenderer } from './dialog-
 import { AppTask } from '../../app-task';
 import { DialogService } from './dialog-service';
 import { singletonRegistration } from '../../utilities-di';
+import { createError } from '../../utilities';
 
 export type DialogConfigurationProvider = (settings: IDialogGlobalSettings) => void | Promise<unknown>;
 
@@ -37,13 +38,13 @@ DialogConfiguration.customize(settings => {
  */
 export const DialogConfiguration = createDialogConfiguration(() => {
   if (__DEV__)
-    throw new Error(`AUR0904: Invalid dialog configuration. ` +
+    throw createError(`AUR0904: Invalid dialog configuration. ` +
       'Specify the implementations for ' +
       '<IDialogService>, <IDialogGlobalSettings> and <IDialogDomRenderer>, ' +
       'or use the DialogDefaultConfiguration export.'
     );
   else
-    throw new Error(`AUR0904`);
+    throw createError(`AUR0904`);
 }, [class NoopDialogGlobalSettings {
   public static register(container: IContainer): void {
     container.register(singletonRegistration(IDialogGlobalSettings, this));

--- a/packages/runtime-html/src/plugins/dialog/dialog-controller.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-controller.ts
@@ -13,7 +13,7 @@ import {
 import { IEventTarget, INode } from '../../dom';
 import { IPlatform } from '../../platform';
 import { CustomElement, CustomElementDefinition } from '../../resources/custom-element';
-import { isFunction } from '../../utilities';
+import { createError, isFunction } from '../../utilities';
 import { instanceRegistration } from '../../utilities-di';
 
 import type {
@@ -272,14 +272,14 @@ export class DialogController implements IDialogController {
 class EmptyComponent {}
 
 function createDialogCancelError<T>(output: T | undefined, msg: string): DialogCancelError<T> {
-  const error = new Error(msg) as DialogCancelError<T>;
+  const error = createError(msg) as DialogCancelError<T>;
   error.wasCancelled = true;
   error.value = output;
   return error;
 }
 
 function createDialogCloseError<T = unknown>(output: T): DialogCloseError<T> {
-  const error = new Error() as DialogCloseError<T>;
+  const error = createError('') as DialogCloseError<T>;
   error.wasCancelled = false;
   error.value = output;
   return error;

--- a/packages/runtime-html/src/plugins/dialog/dialog-service.ts
+++ b/packages/runtime-html/src/plugins/dialog/dialog-service.ts
@@ -13,7 +13,7 @@ import {
 import { DialogController } from './dialog-controller';
 import { AppTask } from '../../app-task';
 import { IPlatform } from '../../platform';
-import { isFunction, isPromise } from '../../utilities';
+import { createError, isFunction, isPromise } from '../../utilities';
 import { callbackRegistration, instanceRegistration, singletonRegistration } from '../../utilities-di';
 
 import type {
@@ -58,9 +58,9 @@ export class DialogService implements IDialogService {
           if (openDialogController.length > 0) {
             // todo: what to do?
             if (__DEV__)
-              throw new Error(`AUR0901: There are still ${openDialogController.length} open dialog(s).`);
+              throw createError(`AUR0901: There are still ${openDialogController.length} open dialog(s).`);
             else
-              throw new Error(`AUR0901:${openDialogController.length}`);
+              throw createError(`AUR0901:${openDialogController.length}`);
           }
         }
       ))
@@ -96,9 +96,9 @@ export class DialogService implements IDialogService {
           container.register(instanceRegistration(IDialogController, dialogController));
           container.register(callbackRegistration(DialogController, () => {
             if (__DEV__)
-              throw new Error(`AUR0902: Invalid injection of DialogController. Use IDialogController instead.`);
+              throw createError(`AUR0902: Invalid injection of DialogController. Use IDialogController instead.`);
             else
-              throw new Error(`AUR0902`);
+              throw createError(`AUR0902`);
           }));
 
           return onResolve(
@@ -208,9 +208,9 @@ class DialogSettings<T extends object = object> implements IDialogSettings<T> {
   private _validate(): this {
     if (this.component == null && this.template == null) {
       if (__DEV__)
-        throw new Error(`AUR0903: Invalid Dialog Settings. You must provide "component", "template" or both.`);
+        throw createError(`AUR0903: Invalid Dialog Settings. You must provide "component", "template" or both.`);
       else
-        throw new Error(`AUR0903`);
+        throw createError(`AUR0903`);
     }
     return this;
   }

--- a/packages/runtime-html/src/plugins/web-components.ts
+++ b/packages/runtime-html/src/plugins/web-components.ts
@@ -5,6 +5,7 @@ import { IPlatform } from '../platform';
 import { CustomElement, CustomElementDefinition, PartialCustomElementDefinition } from '../resources/custom-element';
 import { LifecycleFlags, Controller, ICustomElementController } from '../templating/controller';
 import { IRendering } from '../templating/rendering';
+import { createError } from '../utilities';
 import { createInterface } from '../utilities-di';
 
 export const IWcElementRegistry = createInterface<IAuElementRegistry>(x => x.singleton(WcCustomElementRegistry));
@@ -56,11 +57,11 @@ export class WcCustomElementRegistry implements IAuElementRegistry {
 
   public define(name: string, def: Constructable | Omit<PartialCustomElementDefinition, 'name'>, options?: ElementDefinitionOptions): Constructable<HTMLElement> {
     if (!name.includes('-')) {
-      throw new Error('Invalid web-components custom element name. It must include a "-"');
+      throw createError('Invalid web-components custom element name. It must include a "-"');
     }
     let elDef: CustomElementDefinition;
     if (def == null) {
-      throw new Error('Invalid custom element definition');
+      throw createError('Invalid custom element definition');
     }
     switch (typeof def) {
       case 'function':
@@ -73,7 +74,7 @@ export class WcCustomElementRegistry implements IAuElementRegistry {
         break;
     }
     if (elDef.containerless) {
-      throw new Error('Containerless custom element is not supported. Consider using buitl-in extends instead');
+      throw createError('Containerless custom element is not supported. Consider using buitl-in extends instead');
     }
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const BaseClass = !options?.extends ? HTMLElement : this.p.document.createElement(options.extends).constructor as unknown as Constructable<HTMLElement>;

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -27,7 +27,7 @@ import { IPlatform } from './platform';
 import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
 import { AttrSyntax } from './resources/attribute-pattern';
-import { defineProp, isString } from './utilities';
+import { createError, defineProp, isString } from './utilities';
 import { createInterface, registerResolver, singletonRegistration } from './utilities-di';
 
 import type { IServiceLocator, IContainer, Class, IRegistry, Constructable, IResolver } from '@aurelia/kernel';
@@ -416,9 +416,9 @@ function getRefTarget(refHost: INode, refTargetName: string): object {
     case 'view':
       // todo: returns node sequences for fun?
       if (__DEV__)
-        throw new Error(`AUR0750: Not supported API`);
+        throw createError(`AUR0750: Not supported API`);
       else
-        throw new Error(`AUR0750`);
+        throw createError(`AUR0750`);
     case 'view-model':
       // this means it supports returning undefined
       return findElementControllerFor(refHost)!.viewModel;
@@ -430,9 +430,9 @@ function getRefTarget(refHost: INode, refTargetName: string): object {
       const ceController = findElementControllerFor(refHost, { name: refTargetName });
       if (ceController === void 0) {
         if (__DEV__)
-          throw new Error(`AUR0751: Attempted to reference "${refTargetName}", but it was not found amongst the target's API.`);
+          throw createError(`AUR0751: Attempted to reference "${refTargetName}", but it was not found amongst the target's API.`);
         else
-          throw new Error(`AUR0751:${refTargetName}`);
+          throw createError(`AUR0751:${refTargetName}`);
       }
       return ceController.viewModel;
     }
@@ -490,9 +490,9 @@ export class CustomElementRenderer implements IRenderer {
         def = ctxContainer.find(CustomElement, res);
         if (def == null) {
           if (__DEV__)
-            throw new Error(`AUR0752: Element ${res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
+            throw createError(`AUR0752: Element ${res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
           else
-            throw new Error(`AUR0752:${res}@${(renderingCtrl as Controller)['name']}`);
+            throw createError(`AUR0752:${res}@${(renderingCtrl as Controller)['name']}`);
         }
         break;
       // constructor based instruction
@@ -575,9 +575,9 @@ export class CustomAttributeRenderer implements IRenderer {
         def = ctxContainer.find(CustomAttribute, instruction.res);
         if (def == null) {
           if (__DEV__)
-            throw new Error(`AUR0753: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
+            throw createError(`AUR0753: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
           else
-            throw new Error(`AUR0753:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
+            throw createError(`AUR0753:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
         }
         break;
       // constructor based instruction
@@ -650,9 +650,9 @@ export class TemplateControllerRenderer implements IRenderer {
         def = ctxContainer.find(CustomAttribute, instruction.res);
         if (def == null) {
           if (__DEV__)
-            throw new Error(`AUR0754: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
+            throw createError(`AUR0754: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
           else
-            throw new Error(`AUR0754:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
+            throw createError(`AUR0754:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
         }
         break;
       // constructor based instruction
@@ -1222,7 +1222,7 @@ export class SpreadRenderer implements IRenderer {
         --currentLevel;
       }
       if (currentContext == null) {
-        throw new Error('No scope context for spread binding.');
+        throw createError('No scope context for spread binding.');
       }
       return currentContext as IHydrationContext<object>;
     };
@@ -1301,7 +1301,7 @@ class SpreadBinding implements IBinding {
     this.isBound = true;
     const innerScope = this.$scope = this._hydrationContext.controller.scope.parent ?? void 0;
     if (innerScope == null) {
-      throw new Error('Invalid spreading. Context scope is null/undefined');
+      throw createError('Invalid spreading. Context scope is null/undefined');
     }
 
     this._innerBindings.forEach(b => b.$bind(innerScope));
@@ -1318,7 +1318,7 @@ class SpreadBinding implements IBinding {
 
   public addChild(controller: IController) {
     if (controller.vmKind !== ViewModelKind.customAttribute) {
-      throw new Error('Spread binding does not support spreading custom attributes/template controllers');
+      throw createError('Spread binding does not support spreading custom attributes/template controllers');
     }
     this.ctrl.addChild(controller);
   }
@@ -1403,15 +1403,15 @@ class ViewFactoryProvider implements IResolver {
     const f = this.f;
     if (f === null) {
       if (__DEV__)
-        throw new Error(`AUR7055: Cannot resolve ViewFactory before the provider was prepared.`);
+        throw createError(`AUR7055: Cannot resolve ViewFactory before the provider was prepared.`);
       else
-        throw new Error(`AUR7055`);
+        throw createError(`AUR7055`);
     }
     if (!isString(f.name) || f.name.length === 0) {
       if (__DEV__)
-        throw new Error(`AUR0756: Cannot resolve ViewFactory without a (valid) name.`);
+        throw createError(`AUR0756: Cannot resolve ViewFactory without a (valid) name.`);
       else
-        throw new Error(`AUR0756`);
+        throw createError(`AUR0756`);
     }
     return f;
   }

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -1,7 +1,7 @@
 import { DI, firstDefined, fromAnnotationOrDefinitionOrTypeOrDefault, mergeArrays, Registration, Resolved, ResourceType } from '@aurelia/kernel';
 import { BindingBehaviorInstance, Collection, IAstEvaluator, IndexMap, ValueConverterInstance } from '@aurelia/runtime';
 import { BindingMode } from '../binding/interfaces-bindings';
-import { def, isFunction, isString } from '../utilities';
+import { createError, def, isFunction, isString } from '../utilities';
 import { registerAliases } from '../utilities-di';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
 
@@ -233,9 +233,9 @@ export const BindingBehavior = Object.freeze<BindingBehaviorKind>({
     const def = getOwnMetadata(bbBaseName, Type) as BindingBehaviorDefinition<T>;
     if (def === void 0) {
       if (__DEV__)
-        throw new Error(`AUR0151: No definition found for type ${Type.name}`);
+        throw createError(`AUR0151: No definition found for type ${Type.name}`);
       else
-        throw new Error(`AUR0151:${Type.name}`);
+        throw createError(`AUR0151:${Type.name}`);
     }
 
     return def;

--- a/packages/runtime-html/src/resources/binding-behaviors/self.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/self.ts
@@ -3,6 +3,7 @@ import { Listener } from '../../binding/listener';
 import { bindingBehavior } from '../binding-behavior';
 
 import type { Scope } from '@aurelia/runtime';
+import { createError } from '../../utilities';
 
 /** @internal */
 export function handleSelfEvent(this: SelfableBinding, event: Event): ReturnType<Listener['callSource']> {
@@ -24,9 +25,9 @@ export class SelfBindingBehavior implements BindingBehaviorInstance {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!binding.callSource || !binding.targetEvent) {
       if (__DEV__)
-        throw new Error(`AUR0801: Self binding behavior only supports events.`);
+        throw createError(`AUR0801: Self binding behavior only supports events.`);
       else
-        throw new Error(`AUR0801`);
+        throw createError(`AUR0801`);
     }
 
     binding.selfEventCallSource = binding.callSource;

--- a/packages/runtime-html/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/signals.ts
@@ -1,6 +1,7 @@
 import { ISignaler } from '@aurelia/runtime';
 import { bindingBehavior } from '../binding-behavior';
 import type { BindingBehaviorInstance, IBinding, IConnectableBinding, Scope } from '@aurelia/runtime';
+import { createError } from '../../utilities';
 
 export class SignalBindingBehavior implements BindingBehaviorInstance {
   /** @internal */
@@ -17,15 +18,15 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
   public bind(scope: Scope, binding: IConnectableBinding, ...names: string[]): void {
     if (!('handleChange' in binding)) {
       if (__DEV__)
-        throw new Error(`AUR0817: The signal behavior can only be used with bindings that have a "handleChange" method`);
+        throw createError(`AUR0817: The signal behavior can only be used with bindings that have a "handleChange" method`);
       else
-        throw new Error(`AUR0817`);
+        throw createError(`AUR0817`);
     }
     if (names.length === 0) {
       if (__DEV__)
-        throw new Error(`AUR0818: At least one signal name must be passed to the signal behavior, e.g. "expr & signal:'my-signal'"`);
+        throw createError(`AUR0818: At least one signal name must be passed to the signal behavior, e.g. "expr & signal:'my-signal'"`);
       else
-        throw new Error(`AUR0818`);
+        throw createError(`AUR0818`);
     }
 
     this._lookup.set(binding, names);

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -10,6 +10,7 @@ import type { PropertyBinding } from '../../binding/property-binding';
 import type { CheckedObserver } from '../../observation/checked-observer';
 import type { SelectValueObserver } from '../../observation/select-value-observer';
 import type { ValueAttributeObserver } from '../../observation/value-attribute-observer';
+import { createError } from '../../utilities';
 
 export type UpdateTriggerableObserver = (
   (ValueAttributeObserver & Required<ValueAttributeObserver>) |
@@ -35,16 +36,16 @@ export class UpdateTriggerBindingBehavior implements BindingBehaviorInstance {
   public bind(_scope: Scope, binding: UpdateTriggerableBinding, ...events: string[]): void {
     if (events.length === 0) {
       if (__DEV__)
-        throw new Error(`AUR0802: The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`);
+        throw createError(`AUR0802: The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`);
       else
-        throw new Error(`AUR0802`);
+        throw createError(`AUR0802`);
     }
 
     if (binding.mode !== BindingMode.twoWay && binding.mode !== BindingMode.fromView) {
       if (__DEV__)
-        throw new Error(`AUR0803: The updateTrigger binding behavior can only be applied to two-way/ from-view bindings.`);
+        throw createError(`AUR0803: The updateTrigger binding behavior can only be applied to two-way/ from-view bindings.`);
       else
-        throw new Error(`AUR0803`);
+        throw createError(`AUR0803`);
     }
 
     // ensure the binding's target observer has been set.
@@ -52,9 +53,9 @@ export class UpdateTriggerBindingBehavior implements BindingBehaviorInstance {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!targetObserver.handler) {
       if (__DEV__)
-        throw new Error(`AUR0804: The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.`);
+        throw createError(`AUR0804: The updateTrigger binding behavior can only be applied to two-way/ from-view bindings on input/select elements.`);
       else
-        throw new Error(`AUR0804`);
+        throw createError(`AUR0804`);
     }
 
     binding.targetObserver = targetObserver;

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -156,9 +156,9 @@ export const BindingCommand = Object.freeze<BindingCommandKind>({
   //   const def = getOwnMetadata(cmdBaseName, Type);
   //   if (def === void 0) {
   //     if (__DEV__)
-  //       throw new Error(`AUR0758: No definition found for type ${Type.name}`);
+  //       throw createError(`AUR0758: No definition found for type ${Type.name}`);
   //     else
-  //       throw new Error(`AUR0758:${Type.name}`);
+  //       throw createError(`AUR0758:${Type.name}`);
   //   }
 
   //   return def;

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -4,7 +4,7 @@ import { Watch } from '../watch';
 import { getRef } from '../dom';
 import { DefinitionType } from './resources-shared';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
-import { isFunction, isString } from '../utilities';
+import { createError, isFunction, isString } from '../utilities';
 import { aliasRegistration, registerAliases, transientRegistration } from '../utilities-di';
 import { BindingMode } from '../binding/interfaces-bindings';
 
@@ -185,9 +185,9 @@ export const getAttributeDefinition = <T extends Constructable>(Type: T | Functi
   const def = getOwnMetadata(caBaseName, Type) as CustomAttributeDefinition<T>;
   if (def === void 0) {
     if (__DEV__)
-      throw new Error(`No definition found for type ${Type.name}`);
+      throw createError(`No definition found for type ${Type.name}`);
     else
-      throw new Error(`AUR0759:${Type.name}`);
+      throw createError(`AUR0759:${Type.name}`);
   }
 
   return def;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -13,7 +13,7 @@ import { Children } from '../templating/children';
 import { Watch } from '../watch';
 import { DefinitionType } from './resources-shared';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
-import { isFunction, isString } from '../utilities';
+import { createError, isFunction, isString } from '../utilities';
 import { aliasRegistration, registerAliases, transientRegistration } from '../utilities-di';
 
 import type {
@@ -266,9 +266,9 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       const def = nameOrDef;
       if (isString(def)) {
         if (__DEV__)
-          throw new Error(`AUR0761: Cannot create a custom element definition with only a name and no type: ${nameOrDef}`);
+          throw createError(`AUR0761: Cannot create a custom element definition with only a name and no type: ${nameOrDef}`);
         else
-          throw new Error(`AUR0761:${nameOrDef}`);
+          throw createError(`AUR0761:${nameOrDef}`);
       }
 
       const name = fromDefinitionOrDefault('name', def, generateElementName);
@@ -477,9 +477,9 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
         return null!;
       }
       if (__DEV__)
-        throw new Error(`AUR0762: The provided node is not a custom element or containerless host.`);
+        throw createError(`AUR0762: The provided node is not a custom element or containerless host.`);
       else
-        throw new Error(`AUR0762`);
+        throw createError(`AUR0762`);
     }
     return controller as unknown as ICustomElementController<C>;
   }
@@ -488,9 +488,9 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
       const controller = getRef(node, elementBaseName) as Controller<C> | null;
       if (controller === null) {
         if (__DEV__)
-          throw new Error(`AUR0763: The provided node is not a custom element or containerless host.`);
+          throw createError(`AUR0763: The provided node is not a custom element or containerless host.`);
         else
-          throw new Error(`AUR0763`);
+          throw createError(`AUR0763`);
       }
 
       if (controller.is(opts.name)) {
@@ -519,9 +519,9 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
     }
 
     if (__DEV__)
-      throw new Error(`AUR0764: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
+      throw createError(`AUR0764: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
     else
-      throw new Error(`AUR0764`);
+      throw createError(`AUR0764`);
   }
 
   let cur = node as INode | null;
@@ -535,9 +535,9 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
   }
 
   if (__DEV__)
-    throw new Error(`AUR0765: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
+    throw createError(`AUR0765: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
   else
-    throw new Error(`AUR0765`);
+    throw createError(`AUR0765`);
 };
 
 const getElementAnnotation = <K extends keyof PartialCustomElementDefinition>(
@@ -551,9 +551,9 @@ export const getElementDefinition = <C extends Constructable>(Type: C | Function
   const def = getOwnMetadata(elementBaseName, Type) as CustomElementDefinition<C>;
   if (def === void 0) {
     if (__DEV__)
-      throw new Error(`AUR0760: No definition found for type ${Type.name}`);
+      throw createError(`AUR0760: No definition found for type ${Type.name}`);
     else
-      throw new Error(`AUR0760:${Type.name}`);
+      throw createError(`AUR0760:${Type.name}`);
   }
 
   return def;
@@ -663,9 +663,9 @@ function ensureHook<TClass>(target: Constructable<TClass>, hook: string | Proces
 
   if (!isFunction(hook)) {
     if (__DEV__)
-      throw new Error(`AUR0766: Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${typeof hook}.`);
+      throw createError(`AUR0766: Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${typeof hook}.`);
     else
-      throw new Error(`AUR0766:${typeof hook}`);
+      throw createError(`AUR0766:${typeof hook}`);
   }
   return hook;
 }

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -6,7 +6,7 @@ import { IPlatform } from '../../platform';
 import { HydrateElementInstruction, IInstruction } from '../../renderer';
 import { LifecycleFlags, Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller';
 import { IRendering } from '../../templating/rendering';
-import { isFunction, isPromise } from '../../utilities';
+import { createError, isFunction, isPromise } from '../../utilities';
 import { registerResolver } from '../../utilities-di';
 import { CustomElement, customElement, CustomElementDefinition } from '../custom-element';
 
@@ -53,9 +53,9 @@ export class AuCompose {
         return v;
       }
       if (__DEV__)
-        throw new Error(`AUR0805: Invalid scope behavior config. Only "scoped" or "auto" allowed.`);
+        throw createError(`AUR0805: Invalid scope behavior config. Only "scoped" or "auto" allowed.`);
       else
-        throw new Error(`AUR0805`);
+        throw createError(`AUR0805`);
     }
   })
   public scopeBehavior: 'auto' | 'scoped' = 'auto';
@@ -197,9 +197,9 @@ export class AuCompose {
     if (vmDef !== null) {
       if (vmDef.containerless) {
         if (__DEV__)
-          throw new Error(`AUR0806: Containerless custom element is not supported by <au-compose/>`);
+          throw createError(`AUR0806: Containerless custom element is not supported by <au-compose/>`);
         else
-          throw new Error(`AUR0806`);
+          throw createError(`AUR0806`);
       }
       if (loc == null) {
         compositionHost = host;
@@ -418,9 +418,9 @@ class CompositionController implements ICompositionController {
   public activate(initiator?: IHydratedController) {
     if (this.state !== 0) {
       if (__DEV__)
-        throw new Error(`AUR0807: Composition has already been activated/deactivated. Id: ${this.controller.name}`);
+        throw createError(`AUR0807: Composition has already been activated/deactivated. Id: ${this.controller.name}`);
       else
-        throw new Error(`AUR0807:${this.controller.name}`);
+        throw createError(`AUR0807:${this.controller.name}`);
     }
     this.state = 1;
     return this.start(initiator);
@@ -433,9 +433,9 @@ class CompositionController implements ICompositionController {
         return this.stop(detachInitator);
       case -1:
         if (__DEV__)
-          throw new Error(`AUR0808: Composition has already been deactivated.`);
+          throw createError(`AUR0808: Composition has already been deactivated.`);
         else
-          throw new Error(`AUR0808`);
+          throw createError(`AUR0808`);
       default:
         this.state = -1;
     }

--- a/packages/runtime-html/src/resources/custom-elements/au-render.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-render.ts
@@ -7,7 +7,7 @@ import { CustomElement, customElement, CustomElementDefinition } from '../custom
 import { bindable } from '../../bindable';
 import { LifecycleFlags, ControllerVisitor, ICustomElementController, ICustomElementViewModel, IHydratedController, IHydratedParentController, IHydrationContext, ISyntheticView } from '../../templating/controller';
 import { IRendering } from '../../templating/rendering';
-import { isPromise, isString } from '../../utilities';
+import { createError, isPromise, isString } from '../../utilities';
 import { BindingMode } from '../../binding/interfaces-bindings';
 
 export type Subject = string | IViewFactory | ISyntheticView | RenderPlan | Constructable | CustomElementDefinition;
@@ -182,9 +182,9 @@ export class AuRender implements ICustomElementViewModel {
       const def = ctxContainer.find(CustomElement, comp);
       if (def == null) {
         if (__DEV__)
-          throw new Error(`AUR0809: Unable to find custom element ${comp} for <au-render>.`);
+          throw createError(`AUR0809: Unable to find custom element ${comp} for <au-render>.`);
         else
-          throw new Error(`AUR0809:${comp}`);
+          throw createError(`AUR0809:${comp}`);
       }
       comp = def.Type;
     }

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -8,6 +8,7 @@ import { bindable } from '../../bindable';
 import type { LifecycleFlags, ISyntheticView, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor, IHydratableController } from '../../templating/controller';
 import type { IInstruction } from '../../renderer';
 import type { INode } from '../../dom';
+import { createError } from '../../utilities';
 
 export class If implements ICustomAttributeViewModel {
   /** @internal */ protected static inject = [IViewFactory, IRenderLocation];
@@ -200,9 +201,9 @@ export class Else implements ICustomAttributeViewModel {
       ifBehavior.viewModel.elseFactory = this._factory;
     } else {
       if (__DEV__)
-        throw new Error(`AUR0810: Unsupported If behavior`);
+        throw createError(`AUR0810: Unsupported If behavior`);
       else
-        throw new Error(`AUR0810`);
+        throw createError(`AUR0810`);
     }
   }
 }

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -4,7 +4,7 @@ import { IPlatform } from '../../platform';
 import { IViewFactory } from '../../templating/view';
 import { templateController } from '../custom-attribute';
 import { bindable } from '../../bindable';
-import { isPromise, isString } from '../../utilities';
+import { createError, isPromise, isString } from '../../utilities';
 import type { LifecycleFlags, ControllerVisitor, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ISyntheticView } from '../../templating/controller';
 
 export type PortalTarget<T extends Node & ParentNode = Node & ParentNode> = string | T | null | undefined;
@@ -213,9 +213,9 @@ export class Portal<T extends Node & ParentNode = Node & ParentNode> implements 
     if (target === '') {
       if (this.strict) {
         if (__DEV__)
-          throw new Error(`AUR0811: Empty querySelector`);
+          throw createError(`AUR0811: Empty querySelector`);
         else
-          throw new Error(`AUR0811`);
+          throw createError(`AUR0811`);
       }
       return $document.body as unknown as T;
     }
@@ -238,9 +238,9 @@ export class Portal<T extends Node & ParentNode = Node & ParentNode> implements 
     if (target == null) {
       if (this.strict) {
         if (__DEV__)
-          throw new Error(`AUR0812: Portal target not found`);
+          throw createError(`AUR0812: Portal target not found`);
         else
-          throw new Error(`AUR0812`);
+          throw createError(`AUR0812`);
       }
       return $document.body as unknown as T;
     }

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -19,7 +19,7 @@ import {
 import { IViewFactory } from '../../templating/view';
 import { attributePattern, AttrSyntax } from '../attribute-pattern';
 import { templateController } from '../custom-attribute';
-import { isPromise } from '../../utilities';
+import { createError, isPromise } from '../../utilities';
 
 @templateController('promise')
 export class PromiseTemplateController implements ICustomAttributeViewModel {
@@ -313,9 +313,9 @@ function getPromiseController(controller: IHydratableController) {
     return $promise;
   }
   if (__DEV__)
-    throw new Error(`AUR0813: The parent promise.resolve not found; only "*[promise.resolve] > *[pending|then|catch]" relation is supported.`);
+    throw createError(`AUR0813: The parent promise.resolve not found; only "*[promise.resolve] > *[pending|then|catch]" relation is supported.`);
   else
-    throw new Error(`AUR0813`);
+    throw createError(`AUR0813`);
 }
 
 @attributePattern({ pattern: 'promise.resolve', symbols: '' })

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -23,7 +23,7 @@ import { IViewFactory } from '../../templating/view';
 import { templateController } from '../custom-attribute';
 import { IController } from '../../templating/controller';
 import { bindable } from '../../bindable';
-import { isArray, isPromise, rethrow } from '../../utilities';
+import { createError, isArray, isPromise, rethrow } from '../../utilities';
 
 import type { PropertyBinding } from '../../binding/property-binding';
 import type { LifecycleFlags, ISyntheticView, ICustomAttributeController, IHydratableController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor } from '../../templating/controller';
@@ -515,8 +515,8 @@ interface IRepeatOverrideContext extends IOverrideContext {
 
 const mismatchedLengthError = (viewCount: number, itemCount: number) =>
   __DEV__
-    ? new Error(`AUR0814: viewsLen=${viewCount}, mapLen=${itemCount}`)
-    : new Error(`AUR0814:${viewCount}!=${itemCount}`);
+    ? createError(`AUR0814: viewsLen=${viewCount}, mapLen=${itemCount}`)
+    : createError(`AUR0814:${viewCount}!=${itemCount}`);
 const setContextualProperties = (oc: IRepeatOverrideContext, index: number, length: number): void => {
   const isFirst = index === 0;
   const isLast = index === length - 1;
@@ -543,7 +543,7 @@ const getCount = (result: AcceptableCollection): number => {
     case '[object Null]': return 0;
     case '[object Undefined]': return 0;
     // todo: remove this count method
-    default: throw new Error(`Cannot count ${toStringTag.call(result) as string}`);
+    default: throw createError(`Cannot count ${toStringTag.call(result) as string}`);
   }
 };
 
@@ -556,7 +556,7 @@ const iterate = (result: AcceptableCollection, func: (item: unknown, index: numb
     case '[object Null]': return;
     case '[object Undefined]': return;
     // todo: remove this count method
-    default: throw new Error(`Cannot iterate over ${toStringTag.call(result) as string}`);
+    default: throw createError(`Cannot iterate over ${toStringTag.call(result) as string}`);
   }
 };
 

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -16,7 +16,7 @@ import { templateController } from '../custom-attribute';
 import { IViewFactory } from '../../templating/view';
 import { bindable } from '../../bindable';
 import { BindingMode } from '../../binding/interfaces-bindings';
-import { isArray } from '../../utilities';
+import { createError, isArray } from '../../utilities';
 
 import type { LifecycleFlags, Controller, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, IHydratableController, ISyntheticView, ControllerVisitor } from '../../templating/controller';
 import type { INode } from '../../dom';
@@ -285,9 +285,9 @@ export class Case implements ICustomAttributeViewModel {
       this.linkToSwitch($switch);
     } else {
       if (__DEV__)
-        throw new Error(`AUR0815: The parent switch not found; only "*[switch] > *[case|default-case]" relation is supported.`);
+        throw createError(`AUR0815: The parent switch not found; only "*[switch] > *[case|default-case]" relation is supported.`);
       else
-        throw new Error(`AUR0815`);
+        throw createError(`AUR0815`);
     }
   }
 
@@ -367,9 +367,9 @@ export class DefaultCase extends Case {
   protected linkToSwitch($switch: Switch): void {
     if ($switch.defaultCase !== void 0) {
       if (__DEV__)
-        throw new Error(`AUR0816: Multiple 'default-case's are not allowed.`);
+        throw createError(`AUR0816: Multiple 'default-case's are not allowed.`);
       else
-        throw new Error(`AUR0816`);
+        throw createError(`AUR0816`);
     }
     $switch.defaultCase = this;
   }

--- a/packages/runtime-html/src/resources/value-converter.ts
+++ b/packages/runtime-html/src/resources/value-converter.ts
@@ -4,7 +4,7 @@ import {
   firstDefined,
 } from '@aurelia/kernel';
 import { registerAliases } from '../utilities-di';
-import { isFunction, isString } from '../utilities';
+import { createError, isFunction, isString } from '../utilities';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
 
 import type {
@@ -104,9 +104,9 @@ export const ValueConverter = Object.freeze<ValueConverterKind>({
     const def = getOwnMetadata(vcBaseName, Type);
     if (def === void 0) {
       if (__DEV__)
-        throw new Error(`AUR0152: No definition found for type ${Type.name}`);
+        throw createError(`AUR0152: No definition found for type ${Type.name}`);
       else
-        throw new Error(`AUR0152:${Type.name}`);
+        throw createError(`AUR0152:${Type.name}`);
     }
 
     return def;

--- a/packages/runtime-html/src/resources/value-converters/sanitize.ts
+++ b/packages/runtime-html/src/resources/value-converters/sanitize.ts
@@ -1,3 +1,4 @@
+import { createError } from '../../utilities';
 import { createInterface } from '../../utilities-di';
 import { valueConverter } from '../value-converter';
 
@@ -12,7 +13,7 @@ export interface ISanitizer {
 
 export const ISanitizer = createInterface<ISanitizer>('ISanitizer', x => x.singleton(class {
   public sanitize(): string {
-    throw new Error('"sanitize" method not implemented');
+    throw createError('"sanitize" method not implemented');
   }
 }));
 

--- a/packages/runtime-html/src/template-compiler.ts
+++ b/packages/runtime-html/src/template-compiler.ts
@@ -27,7 +27,7 @@ import { AttrSyntax, IAttributeParser } from './resources/attribute-pattern';
 import { CustomAttribute } from './resources/custom-attribute';
 import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from './resources/custom-element';
 import { BindingCommand, CommandType } from './resources/binding-command';
-import { createLookup, isString } from './utilities';
+import { createError, createLookup, isString } from './utilities';
 import { allResources, createInterface, singletonRegistration } from './utilities-di';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from './utilities-metadata';
 import { BindingMode } from './binding/interfaces-bindings';
@@ -85,9 +85,9 @@ export class TemplateCompiler implements ITemplateCompiler {
 
     if (template.hasAttribute(localTemplateIdentifier)) {
       if (__DEV__)
-        throw new Error(`AUR0701: The root cannot be a local template itself.`);
+        throw createError(`AUR0701: The root cannot be a local template itself.`);
       else
-        throw new Error(`AUR0701`);
+        throw createError(`AUR0701`);
     }
     this._compileLocalElement(content, context);
     this._compileNode(content, context);
@@ -161,9 +161,9 @@ export class TemplateCompiler implements ITemplateCompiler {
       if (attrDef !== null) {
         if (attrDef.isTemplateController) {
           if (__DEV__)
-            throw new Error(`AUR0703: Spreading template controller ${attrTarget} is not supported.`);
+            throw createError(`AUR0703: Spreading template controller ${attrTarget} is not supported.`);
           else
-            throw new Error(`AUR0703:${attrTarget}`);
+            throw createError(`AUR0703:${attrTarget}`);
         }
         bindablesInfo = BindablesInfo.from(attrDef, true);
         // Custom attributes are always in multiple binding mode,
@@ -334,9 +334,9 @@ export class TemplateCompiler implements ITemplateCompiler {
 
       if (invalidSurrogateAttribute[realAttrTarget]) {
         if (__DEV__)
-          throw new Error(`AUR0702: Attribute ${attrName} is invalid on surrogate.`);
+          throw createError(`AUR0702: Attribute ${attrName} is invalid on surrogate.`);
         else
-          throw new Error(`AUR0702:${attrName}`);
+          throw createError(`AUR0702:${attrName}`);
       }
 
       bindingCommand = context._createCommand(attrSyntax);
@@ -361,9 +361,9 @@ export class TemplateCompiler implements ITemplateCompiler {
       if (attrDef !== null) {
         if (attrDef.isTemplateController) {
           if (__DEV__)
-            throw new Error(`AUR0703: Template controller ${realAttrTarget} is invalid on surrogate.`);
+            throw createError(`AUR0703: Template controller ${realAttrTarget} is invalid on surrogate.`);
           else
-            throw new Error(`AUR0703:${realAttrTarget}`);
+            throw createError(`AUR0703:${realAttrTarget}`);
         }
         bindableInfo = BindablesInfo.from(attrDef, true);
         // Custom attributes are always in multiple binding mode,
@@ -542,9 +542,9 @@ export class TemplateCompiler implements ITemplateCompiler {
           ));
         } else {
           if (__DEV__)
-            throw new Error(`AUR0704: Invalid command ${attrSyntax.command} for <let>. Only to-view/bind supported.`);
+            throw createError(`AUR0704: Invalid command ${attrSyntax.command} for <let>. Only to-view/bind supported.`);
           else
-            throw new Error(`AUR0704:${attrSyntax.command}`);
+            throw createError(`AUR0704:${attrSyntax.command}`);
         }
         continue;
       }
@@ -668,9 +668,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     if (elName === 'slot') {
       if (context.root.def.shadowOptions == null) {
         if (__DEV__)
-          throw new Error(`AUR0717: detect a usage of "<slot>" element without specifying shadow DOM options in element: ${context.root.def.name}`);
+          throw createError(`AUR0717: detect a usage of "<slot>" element without specifying shadow DOM options in element: ${context.root.def.name}`);
         else
-          throw new Error(`AUR0717:${context.root.def.name}`);
+          throw createError(`AUR0717:${context.root.def.name}`);
       }
       context.root.hasSlot = true;
     }
@@ -685,13 +685,13 @@ export class TemplateCompiler implements ITemplateCompiler {
 
     if (context.root.def.enhance && el.classList.contains('au')) {
       if (__DEV__)
-        throw new Error(`AUR0705: `
+        throw createError(`AUR0705: `
           + 'Trying to enhance with a template that was probably compiled before. '
           + 'This is likely going to cause issues. '
           + 'Consider enhancing only untouched elements or first remove all "au" classes.'
         );
       else
-        throw new Error(`AUR0705`);
+        throw createError(`AUR0705`);
     }
 
     // 1. walk and compile through all attributes
@@ -1061,9 +1061,9 @@ export class TemplateCompiler implements ITemplateCompiler {
             if (targetSlot !== null) {
               targetSlot = targetSlot || DEFAULT_SLOT_NAME;
               if (__DEV__)
-                throw new Error(`AUR0706: Projection with [au-slot="${targetSlot}"] is attempted on a non custom element ${el.nodeName}.`);
+                throw createError(`AUR0706: Projection with [au-slot="${targetSlot}"] is attempted on a non custom element ${el.nodeName}.`);
               else
-                throw new Error(`AUR0706:${elName}[${targetSlot}]`);
+                throw createError(`AUR0706:${elName}[${targetSlot}]`);
             }
             child = child.nextSibling;
           }
@@ -1249,9 +1249,9 @@ export class TemplateCompiler implements ITemplateCompiler {
             if (targetSlot !== null) {
               targetSlot = targetSlot || DEFAULT_SLOT_NAME;
               if (__DEV__)
-                throw new Error(`AUR0706: Projection with [au-slot="${targetSlot}"] is attempted on a non custom element ${el.nodeName}.`);
+                throw createError(`AUR0706: Projection with [au-slot="${targetSlot}"] is attempted on a non custom element ${el.nodeName}.`);
               else
-                throw new Error(`AUR0706:${elName}[${targetSlot}]`);
+                throw createError(`AUR0706:${elName}[${targetSlot}]`);
             }
             child = child.nextSibling;
           }
@@ -1417,9 +1417,9 @@ export class TemplateCompiler implements ITemplateCompiler {
         bindable = bindableAttrsInfo.attrs[attrSyntax.target];
         if (bindable == null) {
           if (__DEV__)
-            throw new Error(`AUR0707: Bindable ${attrSyntax.target} not found on ${attrDef.name}.`);
+            throw createError(`AUR0707: Bindable ${attrSyntax.target} not found on ${attrDef.name}.`);
           else
-            throw new Error(`AUR0707:${attrDef.name}.${attrSyntax.target}`);
+            throw createError(`AUR0707:${attrDef.name}.${attrSyntax.target}`);
         }
         if (command === null) {
           expr = context._exprParser.parse(attrValue, ExpressionType.Interpolation);
@@ -1458,9 +1458,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     if (numLocalTemplates === 0) { return; }
     if (numLocalTemplates === root.childElementCount) {
       if (__DEV__)
-        throw new Error(`AUR0708: The custom element does not have any content other than local template(s).`);
+        throw createError(`AUR0708: The custom element does not have any content other than local template(s).`);
       else
-        throw new Error(`AUR0708`);
+        throw createError(`AUR0708`);
     }
     const localTemplateNames: Set<string> = new Set();
     const localElTypes: CustomElementType[] = [];
@@ -1468,9 +1468,9 @@ export class TemplateCompiler implements ITemplateCompiler {
     for (const localTemplate of localTemplates) {
       if (localTemplate.parentNode !== root) {
         if (__DEV__)
-          throw new Error(`AUR0709: Local templates needs to be defined directly under root.`);
+          throw createError(`AUR0709: Local templates needs to be defined directly under root.`);
         else
-          throw new Error(`AUR0709`);
+          throw createError(`AUR0709`);
       }
       const name = processTemplateName(localTemplate, localTemplateNames);
 
@@ -1483,16 +1483,16 @@ export class TemplateCompiler implements ITemplateCompiler {
       for (const bindableEl of bindableEls) {
         if (bindableEl.parentNode !== content) {
           if (__DEV__)
-            throw new Error(`AUR0710: Bindable properties of local templates needs to be defined directly under root.`);
+            throw createError(`AUR0710: Bindable properties of local templates needs to be defined directly under root.`);
           else
-            throw new Error(`AUR0710`);
+            throw createError(`AUR0710`);
         }
         const property = bindableEl.getAttribute(LocalTemplateBindableAttributes.property);
         if (property === null) {
           if (__DEV__)
-            throw new Error(`AUR0711: The attribute 'property' is missing in ${bindableEl.outerHTML}`);
+            throw createError(`AUR0711: The attribute 'property' is missing in ${bindableEl.outerHTML}`);
           else
-            throw new Error(`AUR0711`);
+            throw createError(`AUR0711`);
         }
         const attribute = bindableEl.getAttribute(LocalTemplateBindableAttributes.attribute);
         if (attribute !== null
@@ -1500,9 +1500,9 @@ export class TemplateCompiler implements ITemplateCompiler {
           || properties.has(property)
         ) {
           if (__DEV__)
-            throw new Error(`Bindable property and attribute needs to be unique; found property: ${property}, attribute: ${attribute}`);
+            throw createError(`Bindable property and attribute needs to be unique; found property: ${property}, attribute: ${attribute}`);
           else
-            throw new Error(`AUR0712:${property}+${attribute}`);
+            throw createError(`AUR0712:${property}+${attribute}`);
         } else {
           if (attribute !== null) {
             attributes.add(attribute);
@@ -1726,9 +1726,9 @@ class CompilationContext {
       result = this.c.create(BindingCommand, name) as BindingCommandInstance;
       if (result === null) {
         if (__DEV__)
-          throw new Error(`AUR0713: Unknown binding command: ${name}`);
+          throw createError(`AUR0713: Unknown binding command: ${name}`);
         else
-          throw new Error(`AUR0713:${name}`);
+          throw createError(`AUR0713:${name}`);
       }
       this._commands[name] = result;
     }
@@ -1814,9 +1814,9 @@ export class BindablesInfo<T extends 0 | 1 = 0> {
         if (bindable.primary === true) {
           if (hasPrimary) {
             if (__DEV__)
-              throw new Error(`AUR0714: Primary already exists on ${def.name}`);
+              throw createError(`AUR0714: Primary already exists on ${def.name}`);
             else
-              throw new Error(`AUR0714:${def.name}`);
+              throw createError(`AUR0714:${def.name}`);
           }
           hasPrimary = true;
           primary = bindable;
@@ -1861,15 +1861,15 @@ function processTemplateName(localTemplate: HTMLTemplateElement, localTemplateNa
   const name = localTemplate.getAttribute(localTemplateIdentifier);
   if (name === null || name === '') {
     if (__DEV__)
-      throw new Error(`AUR0715: The value of "as-custom-element" attribute cannot be empty for local template`);
+      throw createError(`AUR0715: The value of "as-custom-element" attribute cannot be empty for local template`);
     else
-      throw new Error(`AUR0715`);
+      throw createError(`AUR0715`);
   }
   if (localTemplateNames.has(name)) {
     if (__DEV__)
-      throw new Error(`AUR0716: Duplicate definition of the local template named ${name}`);
+      throw createError(`AUR0716: Duplicate definition of the local template named ${name}`);
     else
-      throw new Error(`AUR0716:${name}`);
+      throw createError(`AUR0716:${name}`);
   } else {
     localTemplateNames.add(name);
     localTemplate.removeAttribute(localTemplateIdentifier);

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -4,7 +4,7 @@ import { FragmentNodeSequence, INode, INodeSequence } from '../dom';
 import { IPlatform } from '../platform';
 import { ICompliationInstruction, IInstruction, IRenderer, ITemplateCompiler } from '../renderer';
 import { CustomElementDefinition, PartialCustomElementDefinition } from '../resources/custom-element';
-import { createLookup, isString } from '../utilities';
+import { createError, createLookup, isString } from '../utilities';
 import { IViewFactory, ViewFactory } from './view';
 import type { IHydratableController } from './controller';
 import { createInterface } from '../utilities-di';
@@ -115,9 +115,9 @@ export class Rendering {
     const ii = targets.length;
     if (targets.length !== rows.length) {
       if (__DEV__)
-        throw new Error(`AUR0757: The compiled template is not aligned with the render instructions. There are ${ii} targets and ${rows.length} instructions.`);
+        throw createError(`AUR0757: The compiled template is not aligned with the render instructions. There are ${ii} targets and ${rows.length} instructions.`);
       else
-        throw new Error(`AUR0757:${ii}<>${rows.length}`);
+        throw createError(`AUR0757:${ii}<>${rows.length}`);
     }
 
     let i = 0;

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -2,7 +2,7 @@ import { Scope } from '@aurelia/runtime';
 import { CustomElementDefinition, defineElement, getElementDefinition } from '../resources/custom-element';
 import { Controller } from './controller';
 import { defineMetadata, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
-import { isFunction, isString } from '../utilities';
+import { createError, isFunction, isString } from '../utilities';
 import { createInterface } from '../utilities-di';
 
 import type { Constructable, ConstructableClass, IContainer } from '@aurelia/kernel';
@@ -367,7 +367,7 @@ export class ViewLocator {
     const v = views.find(x => x.name === name);
 
     if (v === void 0) {
-      throw new Error(`Could not find view: ${name}`);
+      throw createError(`Could not find view: ${name}`);
     }
 
     return v;

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -2,6 +2,8 @@ import type { ISVGAnalyzer } from './observation/svg-analyzer';
 
 /** @internal */ export const createLookup = <T = unknown>() => Object.create(null) as Record<string, T>;
 
+/** @internal */ export const createError = (message: string) => new Error(message);
+
 /** @internal */ export const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const IsDataAttribute: Record<string, boolean> = createLookup();

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -3,7 +3,7 @@ import { emptyArray } from '@aurelia/kernel';
 import { getAttributeDefinition, isAttributeType } from './resources/custom-attribute';
 import { getElementDefinition, isElementType } from './resources/custom-element';
 import { defineMetadata, getAnnotationKeyFor, getOwnMetadata } from './utilities-metadata';
-import { isFunction } from './utilities';
+import { createError, isFunction } from './utilities';
 
 import type { Constructable } from '@aurelia/kernel';
 import type { IConnectable } from '@aurelia/runtime';
@@ -61,9 +61,9 @@ export function watch<T extends object = object>(
 ): WatchClassDecorator<T> | WatchMethodDecorator<T> {
   if (expressionOrPropertyAccessFn == null) {
     if (__DEV__)
-      throw new Error(`AUR0772: Invalid watch config. Expected an expression or a fn`);
+      throw createError(`AUR0772: Invalid watch config. Expected an expression or a fn`);
     else
-      throw new Error(`AUR0772`);
+      throw createError(`AUR0772`);
   }
 
   return function decorator(
@@ -84,15 +84,15 @@ export function watch<T extends object = object>(
         && (changeHandlerOrCallback == null || !(changeHandlerOrCallback in Type.prototype))
       ) {
         if (__DEV__)
-          throw new Error(`AUR0773: Invalid change handler config. Method "${String(changeHandlerOrCallback)}" not found in class ${Type.name}`);
+          throw createError(`AUR0773: Invalid change handler config. Method "${String(changeHandlerOrCallback)}" not found in class ${Type.name}`);
         else
-          throw new Error(`AUR0773:${String(changeHandlerOrCallback)}@${Type.name}}`);
+          throw createError(`AUR0773:${String(changeHandlerOrCallback)}@${Type.name}}`);
       }
     } else if (!isFunction(descriptor?.value)) {
       if (__DEV__)
-        throw new Error(`AUR0774: decorated target ${String(key)} is not a class method.`);
+        throw createError(`AUR0774: decorated target ${String(key)} is not a class method.`);
       else
-        throw new Error(`AUR0774:${String(key)}`);
+        throw createError(`AUR0774:${String(key)}`);
     }
 
     Watch.add(Type, watchDef as IWatchDefinition);

--- a/packages/runtime/src/binding/ast.eval.ts
+++ b/packages/runtime/src/binding/ast.eval.ts
@@ -3,7 +3,7 @@ import { IIndexable, isArrayIndex } from '@aurelia/kernel';
 import { IConnectable, IOverrideContext, IBindingContext, IObservable } from '../observation';
 import { Scope } from '../observation/binding-context';
 import { ISignaler } from '../observation/signaler';
-import { isArray, isFunction, safeString } from '../utilities-objects';
+import { createError, isArray, isFunction, safeString } from '../utilities-objects';
 import { ExpressionKind, IsExpressionOrStatement, IAstEvaluator, DestructuringAssignmentExpression, DestructuringAssignmentRestExpression, DestructuringAssignmentSingleExpression, BindingBehaviorInstance } from './ast';
 import { IConnectableBinding } from './connectable';
 
@@ -29,9 +29,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
       const evaluatedValue: unknown = obj[ast.name];
       if (evaluatedValue == null && ast.name === '$host') {
         if (__DEV__)
-          throw new Error(`AUR0105: Unable to find $host context. Did you forget [au-slot] attribute?`);
+          throw createError(`AUR0105: Unable to find $host context. Did you forget [au-slot] attribute?`);
         else
-          throw new Error(`AUR0105`);
+          throw createError(`AUR0105`);
       }
       if (e?.strict) {
         // return evaluatedValue;
@@ -78,9 +78,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
           return +(astEvaluate(ast.expression, s, e, c) as number);
         default:
           if (__DEV__)
-            throw new Error(`AUR0109: Unknown unary operator: '${ast.operation}'`);
+            throw createError(`AUR0109: Unknown unary operator: '${ast.operation}'`);
           else
-            throw new Error(`AUR0109:${ast.operation}`);
+            throw createError(`AUR0109:${ast.operation}`);
       }
     case ExpressionKind.CallScope: {
       const args = ast.args.map(a => astEvaluate(a, s, e, c));
@@ -119,9 +119,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
         return void 0;
       }
       if (__DEV__)
-        throw new Error(`AUR0107: Expression is not a function.`);
+        throw createError(`AUR0107: Expression is not a function.`);
       else
-        throw new Error(`AUR0107`);
+        throw createError(`AUR0107`);
     }
     case ExpressionKind.ArrowFunction: {
       const func = (...args: unknown[]) => {
@@ -186,9 +186,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
       const func = astEvaluate(ast.func, s, e, c);
       if (!isFunction(func)) {
         if (__DEV__)
-          throw new Error(`AUR0110: Left-hand side of tagged template expression is not a function.`);
+          throw createError(`AUR0110: Left-hand side of tagged template expression is not a function.`);
         else
-          throw new Error(`AUR0110`);
+          throw createError(`AUR0110`);
       }
       return func(ast.cooked, ...results);
     }
@@ -269,9 +269,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
           return (astEvaluate(left, s, e, c) as number) >= (astEvaluate(right, s, e, c) as number);
         default:
           if (__DEV__)
-            throw new Error(`AUR0108: Unknown binary operator: '${ast.operation}'`);
+            throw createError(`AUR0108: Unknown binary operator: '${ast.operation}'`);
           else
-            throw new Error(`AUR0108:${ast.operation}`);
+            throw createError(`AUR0108:${ast.operation}`);
       }
     }
     case ExpressionKind.Conditional:
@@ -283,9 +283,9 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
       const vc = e?.getConverter?.(ast.name);
       if (vc == null) {
         if (__DEV__)
-          throw new Error(`AUR0103: ValueConverter named '${ast.name}' could not be found. Did you forget to register it as a dependency?`);
+          throw createError(`AUR0103: ValueConverter named '${ast.name}' could not be found. Did you forget to register it as a dependency?`);
         else
-          throw new Error(`AUR0103:${ast.name}`);
+          throw createError(`AUR0103:${ast.name}`);
       }
       if ('toView' in vc) {
         return vc.toView(astEvaluate(ast.expression, s, e, c), ...ast.args.map(a => astEvaluate(a, s, e, c)));
@@ -343,9 +343,9 @@ export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluat
     case ExpressionKind.AccessScope: {
       if (ast.name === '$host') {
         if (__DEV__)
-          throw new Error(`AUR0106: Invalid assignment. $host is a reserved keyword.`);
+          throw createError(`AUR0106: Invalid assignment. $host is a reserved keyword.`);
         else
-          throw new Error(`AUR0106`);
+          throw createError(`AUR0106`);
       }
       const obj = getContext(s, ast.name, ast.ancestor) as IObservable;
       if (obj instanceof Object) {
@@ -407,9 +407,9 @@ export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluat
           case ExpressionKind.ObjectDestructuring: {
             if (typeof val !== 'object' || val === null) {
               if (__DEV__) {
-                throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+                throw createError(`AUR0112: Cannot use non-object value for destructuring assignment.`);
               } else {
-                throw new Error(`AUR0112`);
+                throw createError(`AUR0112`);
               }
             }
             let source = astEvaluate(item.source!, Scope.create(val), e, null);
@@ -428,9 +428,9 @@ export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluat
         if (val == null) { return; }
         if (typeof val !== 'object') {
           if (__DEV__) {
-            throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+            throw createError(`AUR0112: Cannot use non-object value for destructuring assignment.`);
           } else {
-            throw new Error(`AUR0112`);
+            throw createError(`AUR0112`);
           }
         }
         let source = astEvaluate(ast.source, Scope.create(val), e, null);
@@ -442,9 +442,9 @@ export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluat
         if (val == null) { return; }
         if (typeof val !== 'object') {
           if (__DEV__) {
-            throw new Error(`AUR0112: Cannot use non-object value for destructuring assignment.`);
+            throw createError(`AUR0112: Cannot use non-object value for destructuring assignment.`);
           } else {
-            throw new Error(`AUR0112`);
+            throw createError(`AUR0112`);
           }
         }
 
@@ -454,9 +454,9 @@ export function astAssign(ast: IsExpressionOrStatement, s: Scope, e: IAstEvaluat
         if (isArrayIndex(indexOrProperties)) {
           if (!Array.isArray(val)) {
             if (__DEV__) {
-              throw new Error(`AUR0112: Cannot use non-array value for array-destructuring assignment.`);
+              throw createError(`AUR0112: Cannot use non-array value for array-destructuring assignment.`);
             } else {
-              throw new Error(`AUR0112`);
+              throw createError(`AUR0112`);
             }
           }
           restValue = val.slice(indexOrProperties);
@@ -572,17 +572,17 @@ export function astUnbind(ast: IsExpressionOrStatement, s: Scope, b: IAstEvaluat
 
 const behaviorNotFoundError = (name: string) =>
   __DEV__
-    ? new Error(`AUR0101: BindingBehavior '${name}' could not be found. Did you forget to register it as a dependency?`)
-    : new Error(`AUR0101:${name}`);
+    ? createError(`AUR0101: BindingBehavior '${name}' could not be found. Did you forget to register it as a dependency?`)
+    : createError(`AUR0101:${name}`);
 const duplicateBehaviorAppliedError = (name: string) =>
   __DEV__
-    ? new Error(`AUR0102: BindingBehavior '${name}' already applied.`)
-    : new Error(`AUR0102:${name}`);
+    ? createError(`AUR0102: BindingBehavior '${name}' already applied.`)
+    : createError(`AUR0102:${name}`);
 const converterNotFoundError = (name: string) => {
   if (__DEV__)
-    return new Error(`AUR0103: ValueConverter '${name}' could not be found. Did you forget to register it as a dependency?`);
+    return createError(`AUR0103: ValueConverter '${name}' could not be found. Did you forget to register it as a dependency?`);
   else
-    return new Error(`AUR0103:${name}`);
+    return createError(`AUR0103:${name}`);
 };
 
 const getFunction = (mustEvaluate: boolean | undefined, obj: object, name: string): ((...args: unknown[]) => unknown) | null => {
@@ -594,9 +594,9 @@ const getFunction = (mustEvaluate: boolean | undefined, obj: object, name: strin
     return null;
   }
   if (__DEV__)
-    throw new Error(`AUR0111: Expected '${name}' to be a function`);
+    throw createError(`AUR0111: Expected '${name}' to be a function`);
   else
-    throw new Error(`AUR0111:${name}`);
+    throw createError(`AUR0111:${name}`);
 };
 
 /**

--- a/packages/runtime/src/binding/ast.visitor.ts
+++ b/packages/runtime/src/binding/ast.visitor.ts
@@ -1,4 +1,4 @@
-import { isString, safeString } from '../utilities-objects';
+import { createError, isString, safeString } from '../utilities-objects';
 import { CustomExpression, ExpressionKind } from './ast';
 
 import type { AccessKeyedExpression, AccessMemberExpression, AccessScopeExpression, AccessThisExpression, ArrayBindingPattern, ArrayLiteralExpression, ArrowFunction, AssignExpression, BinaryExpression, BindingBehaviorExpression, BindingIdentifier, CallFunctionExpression, CallMemberExpression, CallScopeExpression, ConditionalExpression, ForOfStatement, Interpolation, ObjectBindingPattern, ObjectLiteralExpression, PrimitiveLiteralExpression, TaggedTemplateExpression, TemplateExpression, UnaryExpression, ValueConverterExpression, DestructuringAssignmentExpression, DestructuringAssignmentSingleExpression, DestructuringAssignmentRestExpression, IsExpressionOrStatement, IsBindingBehavior } from './ast';
@@ -65,7 +65,7 @@ export const astVisit = <T>(ast: IsExpressionOrStatement, visitor: IVisitor<T>) 
     case ExpressionKind.ValueConverter: return visitor.visitValueConverter(ast);
     case ExpressionKind.Custom: return visitor.visitCustom(ast);
     default: {
-      throw new Error(`Unknown ast node ${JSON.stringify(ast)}`);
+      throw createError(`Unknown ast node ${JSON.stringify(ast)}`);
     }
   }
 };

--- a/packages/runtime/src/binding/connectable.ts
+++ b/packages/runtime/src/binding/connectable.ts
@@ -1,4 +1,4 @@
-import { def, defineHiddenProp, ensureProto, isArray } from '../utilities-objects';
+import { createError, def, defineHiddenProp, ensureProto, isArray } from '../utilities-objects';
 import { getArrayObserver } from '../observation/array-observer';
 import { getSetObserver } from '../observation/set-observer';
 import { getMapObserver } from '../observation/map-observer';
@@ -53,9 +53,9 @@ function observeCollection(this: IConnectableBinding, collection: Collection): v
     obs = getMapObserver(collection);
   } else {
     if (__DEV__)
-      throw new Error(`AUR0210: Unrecognised collection type.`);
+      throw createError(`AUR0210: Unrecognised collection type.`);
     else
-      throw new Error(`AUR0210`);
+      throw createError(`AUR0210`);
   }
   this.obs.add(obs);
 }
@@ -66,16 +66,16 @@ function subscribeTo(this: IConnectableBinding, subscribable: ISubscribable | IC
 
 function noopHandleChange() {
   if (__DEV__)
-    throw new Error(`AUR2011: method "handleChange" not implemented`);
+    throw createError(`AUR2011: method "handleChange" not implemented`);
   else
-    throw new Error(`AUR2011:handleChange`);
+    throw createError(`AUR2011:handleChange`);
 }
 
 function noopHandleCollectionChange() {
   if (__DEV__)
-    throw new Error(`AUR2011: method "handleCollectionChange" not implemented`);
+    throw createError(`AUR2011: method "handleCollectionChange" not implemented`);
   else
-    throw new Error(`AUR2011:handleCollectionChange`);
+    throw createError(`AUR2011:handleCollectionChange`);
 }
 
 type ObservationRecordImplType = {

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -40,7 +40,7 @@ import {
   DestructuringAssignmentExpression as DAE,
   ArrowFunction,
 } from './ast';
-import { createInterface, createLookup } from '../utilities-objects';
+import { createError, createInterface, createLookup } from '../utilities-objects';
 
 export interface IExpressionParser extends ExpressionParser {}
 export const IExpressionParser = createInterface<IExpressionParser>('IExpressionParser', x => x.singleton(ExpressionParser));
@@ -103,7 +103,7 @@ export class ExpressionParser {
     $startIndex = 0;
     $currentToken = Token.EOF;
     $tokenValue = '';
-    $currentChar = expression.charCodeAt(0);
+    $currentChar = $charCodeAt(0);
     $assignable = true;
     $optional = false;
     return parse(Precedence.Variadic, expressionType === void 0 ? ExpressionType.IsProperty : expressionType);
@@ -349,9 +349,11 @@ let $tokenValue: string | number = '';
 let $currentChar: number;
 let $assignable: boolean = true;
 let $optional: boolean = false;
-function $tokenRaw(): string {
-  return $input.slice($startIndex, $index);
-}
+
+const stringFromCharCode = String.fromCharCode;
+const $charCodeAt = (index: number) => $input.charCodeAt(index);
+
+const $tokenRaw = (): string => $input.slice($startIndex, $index);
 
 export function parseExpression(input: string, expressionType?: ExpressionType): AnyBindingExpression {
   $input = input;
@@ -361,7 +363,7 @@ export function parseExpression(input: string, expressionType?: ExpressionType):
   $startIndex = 0;
   $currentToken = Token.EOF;
   $tokenValue = '';
-  $currentChar = input.charCodeAt(0);
+  $currentChar = $charCodeAt(0);
   $assignable = true;
   $optional = false;
   return parse(Precedence.Variadic, expressionType === void 0 ? ExpressionType.IsProperty : expressionType);
@@ -1343,12 +1345,12 @@ function parseInterpolation(): Interpolation {
   while ($index < length) {
     switch ($currentChar) {
       case Char.Dollar:
-        if ($input.charCodeAt($index + 1) === Char.OpenBrace) {
+        if ($charCodeAt($index + 1) === Char.OpenBrace) {
           parts.push(result);
           result = '';
 
           $index += 2;
-          $currentChar = $input.charCodeAt($index);
+          $currentChar = $charCodeAt($index);
           nextToken();
           const expression = parse(Precedence.Variadic, ExpressionType.Interpolation) as IsBindingBehavior | Interpolation;
           expressions.push(expression);
@@ -1358,10 +1360,10 @@ function parseInterpolation(): Interpolation {
         }
         break;
       case Char.Backslash:
-        result += String.fromCharCode(unescapeCode(nextChar()));
+        result += stringFromCharCode(unescapeCode(nextChar()));
         break;
       default:
-        result += String.fromCharCode($currentChar);
+        result += stringFromCharCode($currentChar);
     }
     nextChar();
   }
@@ -1447,7 +1449,7 @@ function nextToken(): void {
 }
 
 function nextChar(): number {
-  return $currentChar = $input.charCodeAt(++$index);
+  return $currentChar = $charCodeAt(++$index);
 }
 
 function scanIdentifier(): Token {
@@ -1484,7 +1486,7 @@ function scanNumber(isFloat: boolean): Token {
       char = nextChar();
     } while (char <= Char.Nine && char >= Char.Zero);
   } else {
-    $currentChar = $input.charCodeAt(--$index);
+    $currentChar = $charCodeAt(--$index);
   }
 
   $tokenValue = parseFloat($tokenRaw());
@@ -1505,7 +1507,7 @@ function scanString(): Token {
       nextChar();
       unescaped = unescapeCode($currentChar);
       nextChar();
-      buffer.push(String.fromCharCode(unescaped));
+      buffer.push(stringFromCharCode(unescaped));
       marker = $index;
     } else if ($index >= $length) {
       throw unterminatedStringLiteral();
@@ -1531,7 +1533,7 @@ function scanTemplate(): Token {
 
   while (nextChar() !== Char.Backtick) {
     if ($currentChar === Char.Dollar) {
-      if (($index + 1) < $length && $input.charCodeAt($index + 1) === Char.OpenBrace) {
+      if (($index + 1) < $length && $charCodeAt($index + 1) === Char.OpenBrace) {
         $index++;
         tail = false;
         break;
@@ -1539,12 +1541,12 @@ function scanTemplate(): Token {
         result += '$';
       }
     } else if ($currentChar === Char.Backslash) {
-      result += String.fromCharCode(unescapeCode(nextChar()));
+      result += stringFromCharCode(unescapeCode(nextChar()));
     } else {
       if ($index >= $length) {
         throw unterminatedTemplateLiteral();
       }
-      result += String.fromCharCode($currentChar);
+      result += stringFromCharCode($currentChar);
     }
   }
 
@@ -1556,241 +1558,241 @@ function scanTemplate(): Token {
   return Token.TemplateContinuation;
 }
 
-function scanTemplateTail(): Token {
+const scanTemplateTail = (): Token => {
   if ($index >= $length) {
     throw unterminatedTemplateLiteral();
   }
   $index--;
   return scanTemplate();
-}
+};
 
-function consumeOpt(token: Token): boolean {
+const consumeOpt = (token: Token): boolean => {
   if ($currentToken === token) {
     nextToken();
     return true;
   }
 
   return false;
-}
+};
 
-function consume(token: Token): void {
+const consume = (token: Token): void => {
   if ($currentToken === token) {
     nextToken();
   } else {
     throw missingExpectedToken(token);
   }
-}
+};
 
 // #region errors
 
-function invalidStartOfExpression() {
+const invalidStartOfExpression = () => {
   if (__DEV__) {
-    return new Error(`AUR0151: Invalid start of expression: '${$input}'`);
+    return createError(`AUR0151: Invalid start of expression: '${$input}'`);
   } else {
-    return new Error(`AUR0151:${$input}`);
+    return createError(`AUR0151:${$input}`);
   }
-}
+};
 
-function invalidSpreadOp() {
+const invalidSpreadOp = () => {
   if (__DEV__) {
-    return new Error(`AUR0152: Spread operator is not supported: '${$input}'`);
+    return createError(`AUR0152: Spread operator is not supported: '${$input}'`);
   } else {
-    return new Error(`AUR0152:${$input}`);
+    return createError(`AUR0152:${$input}`);
   }
-}
+};
 
-function expectedIdentifier() {
+const expectedIdentifier = () => {
   if (__DEV__) {
-    return new Error(`AUR0153: Expected identifier: '${$input}'`);
+    return createError(`AUR0153: Expected identifier: '${$input}'`);
   } else {
-    return new Error(`AUR0153:${$input}`);
+    return createError(`AUR0153:${$input}`);
   }
-}
+};
 
-function invalidMemberExpression() {
+const invalidMemberExpression = () => {
   if (__DEV__) {
-    return new Error(`AUR0154: Invalid member expression: '${$input}'`);
+    return createError(`AUR0154: Invalid member expression: '${$input}'`);
   } else {
-    return new Error(`AUR0154:${$input}`);
+    return createError(`AUR0154:${$input}`);
   }
-}
+};
 
-function unexpectedEndOfExpression() {
+const unexpectedEndOfExpression = () => {
   if (__DEV__) {
-    return new Error(`AUR0155: Unexpected end of expression: '${$input}'`);
+    return createError(`AUR0155: Unexpected end of expression: '${$input}'`);
   } else {
-    return new Error(`AUR0155:${$input}`);
+    return createError(`AUR0155:${$input}`);
   }
-}
+};
 
-function unconsumedToken() {
+const unconsumedToken = () => {
   if (__DEV__) {
-    return new Error(`AUR0156: Unconsumed token: '${$tokenRaw()}' at position ${$index} of '${$input}'`);
+    return createError(`AUR0156: Unconsumed token: '${$tokenRaw()}' at position ${$index} of '${$input}'`);
   } else {
-    return new Error(`AUR0156:${$input}`);
+    return createError(`AUR0156:${$input}`);
   }
-}
+};
 
-function invalidEmptyExpression() {
+const invalidEmptyExpression = () => {
   if (__DEV__) {
-    return new Error(`AUR0157: Invalid expression. Empty expression is only valid in event bindings (trigger, delegate, capture etc...)`);
+    return createError(`AUR0157: Invalid expression. Empty expression is only valid in event bindings (trigger, delegate, capture etc...)`);
   } else {
-    return new Error(`AUR0157`);
+    return createError(`AUR0157`);
   }
-}
+};
 
-function lhsNotAssignable() {
+const lhsNotAssignable = () => {
   if (__DEV__) {
-    return new Error(`AUR0158: Left hand side of expression is not assignable: '${$input}'`);
+    return createError(`AUR0158: Left hand side of expression is not assignable: '${$input}'`);
   } else {
-    return new Error(`AUR0158:${$input}`);
+    return createError(`AUR0158:${$input}`);
   }
-}
+};
 
-function expectedValueConverterIdentifier() {
+const expectedValueConverterIdentifier = () => {
   if (__DEV__) {
-    return new Error(`AUR0159: Expected identifier to come after ValueConverter operator: '${$input}'`);
+    return createError(`AUR0159: Expected identifier to come after ValueConverter operator: '${$input}'`);
   } else {
-    return new Error(`AUR0159:${$input}`);
+    return createError(`AUR0159:${$input}`);
   }
-}
+};
 
-function expectedBindingBehaviorIdentifier() {
+const expectedBindingBehaviorIdentifier = () => {
   if (__DEV__) {
-    return new Error(`AUR0160: Expected identifier to come after BindingBehavior operator: '${$input}'`);
+    return createError(`AUR0160: Expected identifier to come after BindingBehavior operator: '${$input}'`);
   } else {
-    return new Error(`AUR0160:${$input}`);
+    return createError(`AUR0160:${$input}`);
   }
-}
+};
 
-function unexpectedOfKeyword() {
+const unexpectedOfKeyword = () => {
   if (__DEV__) {
-    return new Error(`AUR0161: Unexpected keyword "of": '${$input}'`);
+    return createError(`AUR0161: Unexpected keyword "of": '${$input}'`);
   } else {
-    return new Error(`AUR0161:${$input}`);
+    return createError(`AUR0161:${$input}`);
   }
-}
+};
 
-function invalidLHSBindingIdentifierInForOf() {
+const invalidLHSBindingIdentifierInForOf = () => {
   if (__DEV__) {
-    return new Error(`AUR0163: Invalid BindingIdentifier at left hand side of "of": '${$input}'`);
+    return createError(`AUR0163: Invalid BindingIdentifier at left hand side of "of": '${$input}'`);
   } else {
-    return new Error(`AUR0163:${$input}`);
+    return createError(`AUR0163:${$input}`);
   }
-}
+};
 
-function invalidPropDefInObjLiteral() {
+const invalidPropDefInObjLiteral = () => {
   if (__DEV__) {
-    return new Error(`AUR0164: Invalid or unsupported property definition in object literal: '${$input}'`);
+    return createError(`AUR0164: Invalid or unsupported property definition in object literal: '${$input}'`);
   } else {
-    return new Error(`AUR0164:${$input}`);
+    return createError(`AUR0164:${$input}`);
   }
-}
+};
 
-function unterminatedStringLiteral() {
+const unterminatedStringLiteral = () => {
   if (__DEV__) {
-    return new Error(`AUR0165: Unterminated quote in string literal: '${$input}'`);
+    return createError(`AUR0165: Unterminated quote in string literal: '${$input}'`);
   } else {
-    return new Error(`AUR0165:${$input}`);
+    return createError(`AUR0165:${$input}`);
   }
-}
+};
 
-function unterminatedTemplateLiteral() {
+const unterminatedTemplateLiteral = () => {
   if (__DEV__) {
-    return new Error(`AUR0166: Unterminated template string: '${$input}'`);
+    return createError(`AUR0166: Unterminated template string: '${$input}'`);
   } else {
-    return new Error(`AUR0166:${$input}`);
+    return createError(`AUR0166:${$input}`);
   }
-}
+};
 
-function missingExpectedToken(token: Token) {
+const missingExpectedToken = (token: Token) => {
   if (__DEV__) {
-    return new Error(`AUR0167: Missing expected token '${TokenValues[token & Token.Type]}' in '${$input}' `);
+    return createError(`AUR0167: Missing expected token '${TokenValues[token & Token.Type]}' in '${$input}' `);
   } else {
-    return new Error(`AUR0167:${$input}<${TokenValues[token & Token.Type]}`);
+    return createError(`AUR0167:${$input}<${TokenValues[token & Token.Type]}`);
   }
-}
+};
 
 const unexpectedCharacter: CharScanner = () => {
   if (__DEV__) {
-    throw new Error(`AUR0168: Unexpected character: '${$input}'`);
+    throw createError(`AUR0168: Unexpected character: '${$input}'`);
   } else {
-    throw new Error(`AUR0168:${$input}`);
+    throw createError(`AUR0168:${$input}`);
   }
 };
 unexpectedCharacter.notMapped = true;
 
-function unexpectedTokenInDestructuring() {
+const unexpectedTokenInDestructuring = () => {
   if (__DEV__) {
-    return new Error(`AUR0170: Unexpected '${$tokenRaw()}' at position ${$index - 1} for destructuring assignment in ${$input}`);
+    return createError(`AUR0170: Unexpected '${$tokenRaw()}' at position ${$index - 1} for destructuring assignment in ${$input}`);
   } else {
-    return new Error(`AUR0170:${$input}`);
+    return createError(`AUR0170:${$input}`);
   }
-}
+};
 
-function unexpectedTokenInOptionalChain() {
+const unexpectedTokenInOptionalChain = () => {
   if (__DEV__) {
-    return new Error(`AUR0171: Unexpected '${$tokenRaw()}' at position ${$index - 1} for optional chain in ${$input}`);
+    return createError(`AUR0171: Unexpected '${$tokenRaw()}' at position ${$index - 1} for optional chain in ${$input}`);
   } else {
-    return new Error(`AUR0171:${$input}`);
+    return createError(`AUR0171:${$input}`);
   }
-}
+};
 
-function invalidTaggedTemplateOnOptionalChain() {
+const invalidTaggedTemplateOnOptionalChain = () => {
   if (__DEV__) {
-    return new Error(`AUR0172: Invalid tagged template on optional chain in ${$input}`);
+    return createError(`AUR0172: Invalid tagged template on optional chain in ${$input}`);
   } else {
-    return new Error(`AUR0172:${$input}`);
+    return createError(`AUR0172:${$input}`);
   }
-}
+};
 
-function invalidArrowParameterList() {
+const invalidArrowParameterList = () => {
   if (__DEV__) {
-    return new Error(`AUR0173: Invalid arrow parameter list in ${$input}`);
+    return createError(`AUR0173: Invalid arrow parameter list in ${$input}`);
   } else {
-    return new Error(`AUR0173:${$input}`);
+    return createError(`AUR0173:${$input}`);
   }
-}
+};
 
-function defaultParamsInArrowFn() {
+const defaultParamsInArrowFn = () => {
   if (__DEV__) {
-    return new Error(`AUR0174: Arrow function with default parameters is not supported: ${$input}`);
+    return createError(`AUR0174: Arrow function with default parameters is not supported: ${$input}`);
   } else {
-    return new Error(`AUR0174:${$input}`);
+    return createError(`AUR0174:${$input}`);
   }
-}
+};
 
-function destructuringParamsInArrowFn() {
+const destructuringParamsInArrowFn = () => {
   if (__DEV__) {
-    return new Error(`AUR0175: Arrow function with destructuring parameters is not supported: ${$input}`);
+    return createError(`AUR0175: Arrow function with destructuring parameters is not supported: ${$input}`);
   } else {
-    return new Error(`AUR0175:${$input}`);
+    return createError(`AUR0175:${$input}`);
   }
-}
+};
 
-function restParamsMustBeLastParam() {
+const restParamsMustBeLastParam = () => {
   if (__DEV__) {
-    return new Error(`AUR0176: Rest parameter must be last formal parameter in arrow function: ${$input}`);
+    return createError(`AUR0176: Rest parameter must be last formal parameter in arrow function: ${$input}`);
   } else {
-    return new Error(`AUR0176:${$input}`);
+    return createError(`AUR0176:${$input}`);
   }
-}
+};
 
-function functionBodyInArrowFN() {
+const functionBodyInArrowFN = () => {
   if (__DEV__) {
-    return new Error(`AUR0178: Arrow function with function body is not supported: ${$input}`);
+    return createError(`AUR0178: Arrow function with function body is not supported: ${$input}`);
   } else {
-    return new Error(`AUR0178:${$input}`);
+    return createError(`AUR0178:${$input}`);
   }
-}
+};
 
-function unexpectedDoubleDot() {
+const unexpectedDoubleDot = () => {
   if (__DEV__) {
-    return new Error(`AUR0179: Unexpected token '.' at position ${$index - 1} in ${$input}`);
+    return createError(`AUR0179: Unexpected token '.' at position ${$index - 1} in ${$input}`);
   } else {
-    return new Error(`AUR0179:${$input}`);
+    return createError(`AUR0179:${$input}`);
   }
-}
+};
 
 // #endregion
 
@@ -1846,7 +1848,7 @@ const codes = {
  * Decompress the ranges into an array of numbers so that the char code
  * can be used as an index to the lookup
  */
-function decompress(lookup: (CharScanner | number)[] | null, $set: Set<number> | null, compressed: number[], value: CharScanner | number | boolean): void {
+const decompress = (lookup: (CharScanner | number)[] | null, $set: Set<number> | null, compressed: number[], value: CharScanner | number | boolean): void => {
   const rangeCount = compressed.length;
   for (let i = 0; i < rangeCount; i += 2) {
     const start = compressed[i];
@@ -1861,15 +1863,14 @@ function decompress(lookup: (CharScanner | number)[] | null, $set: Set<number> |
       }
     }
   }
-}
+};
 
 // CharFuncLookup functions
-function returnToken(token: Token): () => Token {
-  return () => {
+const returnToken = (token: Token): () => Token =>
+  () => {
     nextChar();
     return token;
   };
-}
 
 // ASCII IdentifierPart lookup
 const AsciiIdParts = new Set<number>();
@@ -1952,7 +1953,7 @@ CharScanners[Char.Bar] = () => {
 // ?, ??, ?.
 CharScanners[Char.Question] = () => {
   if (nextChar() === Char.Dot) {
-    const peek = $input.charCodeAt($index + 1);
+    const peek = $charCodeAt($index + 1);
     if (peek <= Char.Zero || peek >= Char.Nine) {
       nextChar();
       return Token.QuestionDot;

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -265,8 +265,8 @@ const observe = {
     const indexMap = o.indexMap;
     const argCount = args.length;
     const actualDeleteCount = argCount === 0 ? 0 : argCount === 1 ? len - actualStart : deleteCount;
+    let i = actualStart;
     if (actualDeleteCount > 0) {
-      let i = actualStart;
       const to = i + actualDeleteCount;
       while (i < to) {
         // only mark indices as deleted if they actually existed in the original array
@@ -277,10 +277,10 @@ const observe = {
         i++;
       }
     }
+    i = 0;
     if (argCount > 2) {
       const itemCount = argCount - 2;
       const inserts = new Array(itemCount);
-      let i = 0;
       while (i < itemCount) {
         inserts[i++] = - 2;
       }
@@ -289,7 +289,10 @@ const observe = {
       $splice.apply(indexMap, args);
     }
     const deleted = $splice.apply(this, args);
-    o.notify();
+    // only notify when there's deletion, or addition
+    if (actualDeleteCount > 0 || i > 0) {
+      o.notify();
+    }
     return deleted;
   },
   // https://tc39.github.io/ecma262/#sec-array.prototype.reverse

--- a/packages/runtime/src/observation/binding-context.ts
+++ b/packages/runtime/src/observation/binding-context.ts
@@ -1,4 +1,5 @@
 import type { IBinding, IBindingContext, IOverrideContext } from '../observation';
+import { createError } from '../utilities-objects';
 
 /**
  * A class for creating context in synthetic scope to keep the number of classes of context in scope small
@@ -117,13 +118,13 @@ export class Scope {
 
 const nullScopeError = () => {
   return __DEV__
-    ? new Error(`AUR0203: scope is null/undefined.`)
-    : new Error(`AUR0203`);
+    ? createError(`AUR0203: scope is null/undefined.`)
+    : createError(`AUR0203`);
 };
 const nullContextError = () => {
   return __DEV__
-    ? new Error('AUR0204: binding context is null/undefined')
-    : new Error('AUR0204');
+    ? createError('AUR0204: binding context is null/undefined')
+    : createError('AUR0204');
 };
 
 class OverrideContext implements IOverrideContext {

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -1,6 +1,6 @@
 import { AccessorType, Collection, CollectionKind, IObserver } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
-import { ensureProto } from '../utilities-objects';
+import { createError, ensureProto } from '../utilities-objects';
 
 import type { Constructable } from '@aurelia/kernel';
 import type {
@@ -39,6 +39,7 @@ export class CollectionLengthObserver implements IObserver, ICollectionSubscribe
     if (newValue !== this._value) {
       if (!Number.isNaN(newValue)) {
         this._obj.splice(newValue);
+        this._value = this._obj.length;
         // todo: maybe use splice so that it'll notify everything properly
         // this._obj.length = newValue;
         // this.subs.notify(newValue, currentValue);
@@ -82,9 +83,9 @@ export class CollectionSizeObserver implements ICollectionSubscriber {
 
   public setValue(): void {
     if (__DEV__)
-      throw new Error(`AUR02: Map/Set "size" is a readonly property`);
+      throw createError(`AUR02: Map/Set "size" is a readonly property`);
     else
-      throw new Error(`AUR02`);
+      throw createError(`AUR02`);
   }
 
   public handleCollectionChange(_collection: Collection,  _: IndexMap): void {

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -1,4 +1,3 @@
-import { isArrayIndex } from '@aurelia/kernel';
 import { AccessorType, Collection, CollectionKind, IObserver } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
 import { ensureProto } from '../utilities-objects';
@@ -34,15 +33,19 @@ export class CollectionLengthObserver implements IObserver, ICollectionSubscribe
   }
 
   public setValue(newValue: number): void {
-    const currentValue = this._value;
     // if in the template, length is two-way bound directly
     // then there's a chance that the new value is invalid
     // add a guard so that we don't accidentally broadcast invalid values
-    if (newValue !== currentValue && isArrayIndex(newValue)) {
-      // todo: maybe use splice so that it'll notify everything properly
-      this._obj.length = newValue;
-      this._value = newValue;
-      this.subs.notify(newValue, currentValue);
+    if (newValue !== this._value) {
+      if (!Number.isNaN(newValue)) {
+        this._obj.splice(newValue);
+        // todo: maybe use splice so that it'll notify everything properly
+        // this._obj.length = newValue;
+        // this.subs.notify(newValue, currentValue);
+      } else if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.warn(`Invalid value "${newValue}" for array length`);
+      }
     }
   }
 

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -6,7 +6,7 @@ import { subscriberCollection } from './subscriber-collection';
 import { enterConnectable, exitConnectable } from './connectable-switcher';
 import { connectable } from '../binding/connectable';
 import { wrap, unwrap } from './proxy-observation';
-import { def, isFunction } from '../utilities-objects';
+import { createError, def, isFunction } from '../utilities-objects';
 
 import type {
   ISubscriber,
@@ -125,9 +125,9 @@ export class ComputedObserver implements
       }
     } else {
       if (__DEV__)
-        throw new Error(`AUR0221: Property is readonly`);
+        throw createError(`AUR0221: Property is readonly`);
       else
-        throw new Error(`AUR0221`);
+        throw createError(`AUR0221`);
     }
   }
 

--- a/packages/runtime/src/observation/connectable-switcher.ts
+++ b/packages/runtime/src/observation/connectable-switcher.ts
@@ -1,9 +1,11 @@
 import type { IConnectable } from '../observation';
+import { createError } from '../utilities-objects';
 
 /**
  * Current subscription collector
  */
-let _connectable: IConnectable | null = null;
+// eslint-disable-next-line import/no-mutable-exports
+export let _connectable: IConnectable | null = null;
 const connectables: IConnectable[] = [];
 // eslint-disable-next-line
 export let connecting = false;
@@ -24,9 +26,9 @@ export function currentConnectable(): IConnectable | null {
 export function enterConnectable(connectable: IConnectable): void {
   if (connectable == null) {
     if (__DEV__)
-      throw new Error(`AUR0206: Connectable cannot be null/undefined`);
+      throw createError(`AUR0206: Connectable cannot be null/undefined`);
     else
-      throw new Error(`AUR0206`);
+      throw createError(`AUR0206`);
   }
   if (_connectable == null) {
     _connectable = connectable;
@@ -36,9 +38,9 @@ export function enterConnectable(connectable: IConnectable): void {
   }
   if (_connectable === connectable) {
     if (__DEV__)
-      throw new Error(`AUR0207: Trying to enter an active connectable`);
+      throw createError(`AUR0207: Trying to enter an active connectable`);
     else
-      throw new Error(`AUR0207`);
+      throw createError(`AUR0207`);
   }
   connectables.push(connectable);
   _connectable = connectable;
@@ -48,15 +50,15 @@ export function enterConnectable(connectable: IConnectable): void {
 export function exitConnectable(connectable: IConnectable): void {
   if (connectable == null) {
     if (__DEV__)
-      throw new Error(`AUR0208: Connectable cannot be null/undefined`);
+      throw createError(`AUR0208: Connectable cannot be null/undefined`);
     else
-      throw new Error(`AUR0208`);
+      throw createError(`AUR0208`);
   }
   if (_connectable !== connectable) {
     if (__DEV__)
-      throw new Error(`AUR0209: Trying to exit an unactive connectable`);
+      throw createError(`AUR0209: Trying to exit an unactive connectable`);
     else
-      throw new Error(`AUR0209`);
+      throw createError(`AUR0209`);
   }
 
   connectables.pop();

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -1,7 +1,7 @@
 import { IPlatform } from '@aurelia/kernel';
 import { AccessorType, type IObserver, type ISubscriberCollection } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
-import { createInterface, safeString } from '../utilities-objects';
+import { createError, createInterface, safeString } from '../utilities-objects';
 
 import type { ITask, QueueTaskOptions } from '@aurelia/platform';
 import type { IIndexable } from '@aurelia/kernel';
@@ -64,9 +64,9 @@ export class DirtyChecker {
   public createProperty(obj: object, key: PropertyKey): DirtyCheckProperty {
     if (DirtyCheckSettings.throw) {
       if (__DEV__)
-        throw new Error(`AUR0222: Property '${safeString(key)}' is being dirty-checked.`);
+        throw createError(`AUR0222: Property '${safeString(key)}' is being dirty-checked.`);
       else
-        throw new Error(`AUR0222:${safeString(key)}`);
+        throw createError(`AUR0222:${safeString(key)}`);
     }
     return new DirtyCheckProperty(this, obj as IIndexable, key as string);
   }
@@ -133,7 +133,7 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
   public setValue(_v: unknown) {
     // todo: this should be allowed, probably
     // but the construction of dirty checker should throw instead
-    throw new Error(`Trying to set value for property ${safeString(this.key)} in dirty checker`);
+    throw createError(`Trying to set value for property ${safeString(this.key)} in dirty checker`);
   }
 
   public isDirty(): boolean {

--- a/packages/runtime/src/observation/observable.ts
+++ b/packages/runtime/src/observation/observable.ts
@@ -1,6 +1,6 @@
 import { IObserver } from '../observation';
 import { SetterNotifier } from './setter-observer';
-import { safeString, def } from '../utilities-objects';
+import { safeString, def, createError } from '../utilities-objects';
 import { currentConnectable } from './connectable-switcher';
 
 import type { Constructable, IIndexable } from '@aurelia/kernel';
@@ -96,9 +96,9 @@ export function observable(
 
     if (key == null || key === '') {
       if (__DEV__)
-        throw new Error(`AUR0224: Invalid usage, cannot determine property name for @observable`);
+        throw createError(`AUR0224: Invalid usage, cannot determine property name for @observable`);
       else
-        throw new Error(`AUR0224`);
+        throw createError(`AUR0224`);
     }
 
     // determine callback name based on config or convention.

--- a/packages/runtime/src/observation/observation.ts
+++ b/packages/runtime/src/observation/observation.ts
@@ -4,7 +4,7 @@ import { IObserverLocator } from './observer-locator';
 
 import type { ICollectionSubscriber, IConnectable, ISubscriber } from '../observation';
 import type { BindingObserverRecord } from '../binding/connectable';
-import { createInterface } from '../utilities-objects';
+import { createError, createInterface } from '../utilities-objects';
 
 export interface IObservation extends Observation {}
 export const IObservation = createInterface<IObservation>('IObservation', x => x.singleton(Observation));
@@ -66,9 +66,9 @@ class Effect implements IEffect, ISubscriber, ICollectionSubscriber {
   public run(): void {
     if (this.stopped) {
       if (__DEV__)
-        throw new Error(`AUR0225: Effect has already been stopped`);
+        throw createError(`AUR0225: Effect has already been stopped`);
       else
-        throw new Error(`AUR0225`);
+        throw createError(`AUR0225`);
     }
     if (this.running) {
       return;
@@ -93,9 +93,9 @@ class Effect implements IEffect, ISubscriber, ICollectionSubscriber {
       if (this.runCount > this.maxRunCount) {
         this.runCount = 0;
         if (__DEV__)
-          throw new Error(`AUR0226: Maximum number of recursive effect run reached. Consider handle effect dependencies differently.`);
+          throw createError(`AUR0226: Maximum number of recursive effect run reached. Consider handle effect dependencies differently.`);
         else
-          throw new Error(`AUR0226`);
+          throw createError(`AUR0226`);
       }
       this.run();
     } else {

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -7,7 +7,7 @@ import { PrimitiveObserver } from './primitive-observer';
 import { PropertyAccessor } from './property-accessor';
 import { getSetObserver } from './set-observer';
 import { SetterObserver } from './setter-observer';
-import { safeString, createLookup, def, hasOwnProp, isArray, createInterface } from '../utilities-objects';
+import { safeString, createLookup, def, hasOwnProp, isArray, createInterface, createError } from '../utilities-objects';
 
 import type {
   Collection,
@@ -228,5 +228,5 @@ export const getObserverLookup = <T extends IObserver>(instance: object): Record
 
 const nullObjectError = (key: PropertyKey) =>
   __DEV__
-    ? new Error(`AUR0199: trying to observe property ${safeString(key)} on null/undefined`)
-    : new Error(`AUR0199:${safeString(key)}`);
+    ? createError(`AUR0199: trying to observe property ${safeString(key)} on null/undefined`)
+    : createError(`AUR0199:${safeString(key)}`);

--- a/packages/runtime/src/observation/proxy-observation.ts
+++ b/packages/runtime/src/observation/proxy-observation.ts
@@ -1,6 +1,7 @@
 import { IIndexable } from '@aurelia/kernel';
+import { Collection, IConnectable } from '../observation';
 import { isArray } from '../utilities-objects';
-import { connecting, currentConnectable } from './connectable-switcher';
+import { connecting, currentConnectable, _connectable } from './connectable-switcher';
 
 const R$get = Reflect.get;
 const toStringTag = Object.prototype.toString;
@@ -90,15 +91,13 @@ const arrayHandler: ProxyHandler<unknown[]> = {
       return target;
     }
 
-    const connectable = currentConnectable();
-
-    if (!connecting || doNotCollect(key) || connectable == null) {
+    if (!connecting || doNotCollect(key) || _connectable == null) {
       return R$get(target, key, receiver);
     }
 
     switch (key) {
       case 'length':
-        connectable.observe(target, 'length');
+        _connectable.observe(target, 'length');
         return target.length;
       case 'map':
         return wrappedArrayMap;
@@ -153,7 +152,7 @@ const arrayHandler: ProxyHandler<unknown[]> = {
         return wrappedEntries;
     }
 
-    connectable.observe(target, key);
+    _connectable.observe(target, key);
 
     return wrap(R$get(target, key, receiver));
   },
@@ -170,14 +169,14 @@ function wrappedArrayMap(this: unknown[], cb: (v: unknown, i: number, arr: unkno
     // do we wrap `thisArg`?
     unwrap(cb.call(thisArg, wrap(v), i, this))
   );
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedArrayEvery(this: unknown[], cb: (v: unknown, i: number, arr: unknown[]) => unknown, thisArg?: unknown): boolean {
   const raw = getRaw(this);
   const res = raw.every((v, i) => cb.call(thisArg, wrap(v), i, this));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 
@@ -187,58 +186,58 @@ function wrappedArrayFilter(this: unknown[], cb: (v: unknown, i: number, arr: un
     // do we wrap `thisArg`?
     unwrap(cb.call(thisArg, wrap(v), i, this))
   );
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedArrayIncludes(this: unknown[], v: unknown): boolean {
   const raw = getRaw(this);
   const res = raw.includes(unwrap(v));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 
 function wrappedArrayIndexOf(this: unknown[], v: unknown): number {
   const raw = getRaw(this);
   const res = raw.indexOf(unwrap(v));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 function wrappedArrayLastIndexOf(this: unknown[], v: unknown): number {
   const raw = getRaw(this);
   const res = raw.lastIndexOf(unwrap(v));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 function wrappedArrayFindIndex(this: unknown[], cb: (v: unknown, i: number, arr: unknown[]) => boolean, thisArg?: unknown): number {
   const raw = getRaw(this);
   const res = raw.findIndex((v, i) => unwrap(cb.call(thisArg, wrap(v), i, this)));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 
 function wrappedArrayFind(this: unknown[], cb: (v: unknown, i: number, arr: unknown[]) => boolean, thisArg?: unknown): unknown {
   const raw = getRaw(this);
   const res = raw.find((v, i) => cb(wrap(v), i, this), thisArg);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedArrayFlat(this: unknown[]): unknown[] {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(raw.flat());
 }
 function wrappedArrayFlatMap(this: unknown[], cb: (v: unknown, i: number, arr: unknown[]) => unknown, thisArg?: unknown): unknown[] {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return getProxy(raw.flatMap((v, i) =>
     wrap(cb.call(thisArg, wrap(v), i, this)))
   );
 }
 function wrappedArrayJoin(this: unknown[], separator?: string): string {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return raw.join(separator);
 }
 
@@ -260,41 +259,41 @@ function wrappedArraySplice(this: unknown[], ...args: [number, number, ...unknow
 function wrappedArrayReverse(this: unknown[], ..._args: unknown[]): unknown[] {
   const raw = getRaw(this);
   const res = raw.reverse();
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedArraySome(this: unknown[], cb: (v: unknown, i: number, arr: unknown[]) => boolean, thisArg?: unknown): boolean {
   const raw = getRaw(this);
   const res = raw.some((v, i) => unwrap(cb.call(thisArg, wrap(v), i, this)));
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return res;
 }
 
 function wrappedArraySort(this: unknown[], cb?: (a: unknown, b: unknown) => number): unknown[] {
   const raw = getRaw(this);
   const res = raw.sort(cb);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedArraySlice(this: unknown[], start?: number, end?: number): unknown[] {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return getProxy(raw.slice(start, end));
 }
 
 function wrappedReduce(this: unknown[], cb: (curr: unknown, v: unknown, i: number, arr: unknown[]) => unknown, initValue: unknown): unknown {
   const raw = getRaw(this);
   const res = raw.reduce((curr, v, i) => cb(curr, wrap(v), i, this), initValue);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
 function wrappedReduceRight(this: unknown[], cb: (curr: unknown, v: unknown, i: number, arr: unknown[]) => unknown, initValue: unknown): unknown {
   const raw = getRaw(this);
   const res = raw.reduceRight((curr, v, i) => cb(curr, wrap(v), i, this), initValue);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(res);
 }
 
@@ -359,7 +358,7 @@ type CollectionMethod = (this: unknown, ...args: unknown[]) => unknown;
 
 function wrappedForEach(this: $MapOrSet, cb: CollectionMethod, thisArg?: unknown): void {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return raw.forEach((v: unknown, key: unknown) => {
     cb.call(/* should wrap or not?? */thisArg, wrap(v), wrap(key), this);
   });
@@ -367,13 +366,13 @@ function wrappedForEach(this: $MapOrSet, cb: CollectionMethod, thisArg?: unknown
 
 function wrappedHas(this: $MapOrSet, v: unknown): boolean {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return raw.has(unwrap(v));
 }
 
 function wrappedGet(this: Map<unknown, unknown>, k: unknown): unknown {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   return wrap(raw.get(unwrap(k)));
 }
 function wrappedSet(this: Map<unknown, unknown>, k: unknown, v: unknown): Map<unknown, unknown> {
@@ -394,7 +393,7 @@ function wrappedDelete(this: $MapOrSet, k: unknown): boolean {
 
 function wrappedKeys(this: $MapOrSet | unknown[]): IterableIterator<unknown> {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   const iterator = raw.keys();
 
   return {
@@ -415,7 +414,7 @@ function wrappedKeys(this: $MapOrSet | unknown[]): IterableIterator<unknown> {
 
 function wrappedValues(this: $MapOrSet | unknown[]): IterableIterator<unknown> {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   const iterator = raw.values();
 
   return {
@@ -436,7 +435,7 @@ function wrappedValues(this: $MapOrSet | unknown[]): IterableIterator<unknown> {
 
 function wrappedEntries(this: $MapOrSet | unknown[]): IterableIterator<unknown> {
   const raw = getRaw(this);
-  currentConnectable()?.observeCollection(raw);
+  observeCollection(_connectable, raw);
   const iterator = raw.entries();
 
   // return a wrapped iterator which returns observed versions of the
@@ -458,6 +457,7 @@ function wrappedEntries(this: $MapOrSet | unknown[]): IterableIterator<unknown> 
   };
 }
 
+const observeCollection = (connectable: IConnectable | null, collection: Collection) => connectable?.observeCollection(collection);
 export const ProxyObservable = Object.freeze({
   getProxy,
   getRaw,

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -13,6 +13,9 @@ export const hasOwnProp = Object.prototype.hasOwnProperty;
 export const def = Reflect.defineProperty;
 
 /** @internal */
+export const createError = (message: string) => new Error(message);
+
+/** @internal */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const isFunction = <K extends Function>(v: unknown): v is K => typeof v === 'function';
 

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -177,6 +177,14 @@ export function createFixture<T extends object>(
       el.dispatchEvent(new ctx.CustomEvent(event, init));
     } });
   });
+  function type(selector: string, value: string): void {
+    const el = queryBy(selector);
+    if (el === null || !/input|textarea/i.test(el.nodeName)) {
+      throw new Error(`No <input>/<textarea> element found for selector "${selector}" to emulate input for "${value}"`);
+    }
+    (el as HTMLInputElement).value = value;
+    el.dispatchEvent(new platform.window.Event('input'));
+  }
 
   const scrollBy = (selector: string, init: number | ScrollToOptions) => {
     const el = queryBy(selector);
@@ -184,7 +192,7 @@ export function createFixture<T extends object>(
       throw new Error(`No element found for selector "${selector}" to scroll by "${JSON.stringify(init)}"`);
     }
     el.scrollBy(typeof init === 'number' ? { top: init } : init);
-    el.dispatchEvent(new Event('scroll'));
+    el.dispatchEvent(new platform.window.Event('scroll'));
   };
 
   const flush = (time?: number) => {
@@ -247,7 +255,9 @@ export function createFixture<T extends object>(
     public assertAttr = assertAttr;
     public assertAttrNS = assertAttrNS;
     public assertValue = assertValue;
+    public createEvent = (name: string, init?: CustomEventInit) => new platform.CustomEvent(name, init);
     public trigger = trigger as ITrigger;
+    public type = type;
     public scrollBy = scrollBy;
     public flush = flush;
   }();
@@ -332,6 +342,15 @@ export interface IFixture<T> {
    * Will throw if there' more than one elements with matching selector
    */
   assertValue(selector: string, value: unknown): void;
+  /**
+   * Create a custom event by the given name and init for the current platform
+   */
+  createEvent<T>(name: string, init?: CustomEventInit<T>): CustomEvent;
+
+  /**
+   * Find an input or text area by the selector and emulate a keyboard event with the given value
+   */
+  type(selector: string, value: string): void;
 
   hJsx(name: string, attrs: Record<string, string> | null, ...children: (Node | string | (Node | string)[])[]): HTMLElement;
 

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -25,6 +25,7 @@ export class TestContext {
   public get Comment() { return this.platform.globalThis.Comment; }
   public get DOMParser() { return this.platform.globalThis.DOMParser; }
 
+  /** @internal */
   private _container: IContainer | undefined = void 0;
   public get container(): IContainer {
     if (this._container === void 0) {
@@ -39,6 +40,7 @@ export class TestContext {
     }
     return this._container;
   }
+  /** @internal */
   private _platform: IPlatform | undefined = void 0;
   public get platform(): IPlatform {
     if (this._platform === void 0) {
@@ -46,6 +48,7 @@ export class TestContext {
     }
     return this._platform;
   }
+  /** @internal */
   private _templateCompiler: ITemplateCompiler | undefined = void 0;
   public get templateCompiler(): ITemplateCompiler {
     if (this._templateCompiler === void 0) {
@@ -60,6 +63,7 @@ export class TestContext {
     }
     return this.oL;
   }
+  /** @internal */
   private _domParser: HTMLDivElement | undefined = void 0;
   public get domParser(): HTMLDivElement {
     if (this._domParser === void 0) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Updating length from binding also updates array subscribers.
  At the moment, for a template like this
  ```html
  <input value.bind="items.length | number">
  <div repeat.for="i of items">${i}</div>
  ```
  typing a number into the input will only set the length of the `items` array to that value, without notifying the repeat. This PR fixes this.

- cleanup & optimize packages internal to have ~10KB more saving on bundle size.
- fix some doc