### PR TITLE
fix(router-lite): handling hash in load, href CAs

### DIFF
--- a/docs/engineering-notes/router-architecture-notes.md
+++ b/docs/engineering-notes/router-architecture-notes.md
@@ -138,10 +138,9 @@ This process of updating a given route node with a given viewport instruction tr
 ## Compiling viewport instruction and appending to node
 
 This process starts with a route node and a viewport instruction.
-Quite evidently, in this step the viewport instruction is compiled to a route node, and later down the line the new route node is added as a children to the given route node.
+In this step the viewport instruction is compiled to a route node, and later down the line the new route node is added as a children to the given route node.
 
-Once the child node is created, the process of **appending** the node is very straight-forward.
-It involves appending the child node as one of the children of the given route node, and scheduling update for the viewport-agent associated to the routing context of the child node.
+Once the child node is created, the node (child-node) is appended as one of the children of the given route node, and scheduling update for the viewport-agent associated to the routing context of the child node.
 
 Depending on the type of the viewport instruction, the route node can be **compiled** differently.
 In this phase the viewport instruction can be categorized broadly into string instruction and routed view-model or custom element definition instruction.
@@ -152,7 +151,7 @@ It involves
 - generating the viewport instruction using the routing context, from the route definition; [details](#generating-viewport-instruction)
 - creating a configured node from the viewport instruction; the details can be found [here](#creating-configured-route-node).
 
-Compiling **from the sting instruction** is inherently bit more involved.
+Compiling **from the string instruction** is inherently bit more involved.
 When dealing with string instructions, there are couple special case that needs to be handled, namely the `../` prefix in the route that handles navigating to the ancestor/parent routing context.
 Whenever, `../` prefix is encountered, the parent node is selected and [this process](#compiling-viewport-instruction-and-appending-to-node) is restarted with the child viewport instruction coming from the given view port instruction.
 The default/non-special case is to create a node by using the [create node](#create-a-node-from-viewport-instruction) routine.

--- a/packages/__tests__/router-lite/_shared/create-fixture.ts
+++ b/packages/__tests__/router-lite/_shared/create-fixture.ts
@@ -93,13 +93,13 @@ export async function createFixture<T extends Constructable>(
 /**
  * Simpler fixture creation.
  */
-export async function start<TAppRoot>(appRoot: Class<TAppRoot>, ...registrations: any[]) {
+export async function start<TAppRoot>(appRoot: Class<TAppRoot>, useHash: boolean = false, ...registrations: any[]) {
   const ctx = TestContext.create();
   const { container } = ctx;
 
   container.register(
     TestRouterConfiguration.for(LogLevel.warn),
-    RouterConfiguration,
+    RouterConfiguration.customize({ useUrlFragmentHash: useHash }),
     ...registrations,
   );
 

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -34,7 +34,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, Foo);
+    const { au, host, container } = await start(Root, false, Foo);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -72,7 +72,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, Foo);
+    const { au, host, container } = await start(Root, false, Foo);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -96,7 +96,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, Foo);
+    const { au, host, container } = await start(Root, false, Foo);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -135,7 +135,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, Products, Product);
+    const { au, host, container } = await start(Root, false, Products, Product);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -197,7 +197,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, Products, Product);
+    const { au, host, container } = await start(Root, false, Products, Product);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -260,7 +260,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const { au, host, container } = await start(Root, false, L11, L12, L21, L22);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21');
@@ -319,7 +319,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, L11, L12, L21, L22);
+    const { au, host, container } = await start(Root, false, L11, L12, L21, L22);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21');
@@ -396,7 +396,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, L11, L12, L21, L22, L23, L24);
+    const { au, host, container } = await start(Root, false, L11, L12, L21, L22, L23, L24);
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21', 'init');
@@ -420,6 +420,58 @@ describe('load custom-attribute', function () {
     host.querySelector('a').click();
     await queue.yield();
     assert.html.textContent(host, 'l11 l21', '#5 l24 -> l11');
+
+    await au.stop();
+  });
+
+  it('adds hash correctly to the href when useUrlFragmentHash is set', async function () {
+    @customElement({ name: 'ce-one', template: `ce1` })
+    class CeOne { }
+
+    @customElement({ name: 'ce-two', template: `ce2` })
+    class CeTwo { }
+
+    @customElement({
+      name: 'ro-ot',
+      template: `
+      <a load="#ce-one"></a>
+      <a load="#ce-two"></a>
+      <a load="ce-two"></a>
+      <au-viewport></au-viewport>
+      `
+    })
+    @route({
+      routes: [
+        {
+          path: 'ce-one',
+          component: CeOne,
+        },
+        {
+          path: 'ce-two',
+          component: CeTwo,
+        },
+      ]
+    })
+    class Root { }
+
+    const { au, host, container } = await start(Root, true, CeOne, CeTwo);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+
+    const anchors = Array.from(host.querySelectorAll('a'));
+    assert.deepStrictEqual(anchors.map(a => a.getAttribute('href')), ['#ce-one', '#ce-two', '#ce-two']);
+
+    anchors[1].click();
+    await queue.yield();
+    assert.html.textContent(host, 'ce2');
+
+    anchors[0].click();
+    await queue.yield();
+    assert.html.textContent(host, 'ce1');
+
+    anchors[2].click();
+    await queue.yield();
+    assert.html.textContent(host, 'ce2');
 
     await au.stop();
   });

--- a/packages/router-lite/src/configuration.ts
+++ b/packages/router-lite/src/configuration.ts
@@ -41,19 +41,12 @@ export const DefaultResources: IRegistry[] = [
   HrefCustomAttribute as unknown as IRegistry,
 ];
 
-export type RouterConfig = IRouterOptions | ((router: IRouter) => ReturnType<IRouter['start']>);
-function configure(container: IContainer, config?: RouterConfig): IContainer {
-  let activation: AppTaskCallback<InterfaceSymbol<IRouter>>;
+function configure(container: IContainer, options?: IRouterOptions): IContainer {
   let basePath: string | null = null;
-  if (isObject(config)) {
-    if (typeof config === 'function') {
-      activation = router => config(router) as void | Promise<void>;
-    } else {
-      basePath = (config as IRouterOptions).basePath ?? null;
-      activation = router => router.start(config, true) as void | Promise<void>;
-    }
+  if (isObject(options)) {
+    basePath = (options as IRouterOptions).basePath ?? null;
   } else {
-    activation = router => router.start({}, true) as void | Promise<void>;
+    options = {};
   }
   return container.register(
     Registration.cachedCallback(IBaseHref, (handler, _, __) => {
@@ -62,8 +55,9 @@ function configure(container: IContainer, config?: RouterConfig): IContainer {
       url.pathname = normalizePath(basePath ?? url.pathname);
       return url;
     }),
+    AppTask.hydrated(IRouter, router => router._setOptions(options!)),
     AppTask.hydrated(IContainer, RouteContext.setRoot),
-    AppTask.activated(IRouter, activation),
+    AppTask.activated(IRouter, router => router.start(true)),
     AppTask.deactivated(IRouter, router => {
       router.stop();
     }),
@@ -81,10 +75,10 @@ export const RouterConfiguration = {
    * Parameter is either a config object that's passed to Router's activate
    * or a config function that's called instead of Router's activate.
    */
-  customize(config?: RouterConfig): IRegistry {
+  customize(options?: IRouterOptions): IRegistry {
     return {
       register(container: IContainer): IContainer {
-        return configure(container, config);
+        return configure(container, options);
       },
     };
   },

--- a/packages/router-lite/src/configuration.ts
+++ b/packages/router-lite/src/configuration.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@aurelia/metadata';
-import { IContainer, InterfaceSymbol, IRegistry, Registration } from '@aurelia/kernel';
-import { AppTask, AppTaskCallback, IWindow } from '@aurelia/runtime-html';
+import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
+import { AppTask, IWindow } from '@aurelia/runtime-html';
 
 import { RouteContext } from './route-context';
 import { IRouterOptions, IRouter } from './router';

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -358,13 +358,11 @@ export class ViewportInstructionTree {
     let search = this.queryParams.toString();
     search = search === '' ? '' : `?${search}`;
 
-    const url = `${pathname}${hash}${search}`;
-    return url;
+    return `${pathname}${hash}${search}`;
   }
 
   public toPath(): string {
-    const path = this.children.map(x => x.toUrlComponent()).join('+');
-    return path;
+    return this.children.map(x => x.toUrlComponent()).join('+');
   }
 
   public toString(): string {

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -78,7 +78,10 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
     if (newValue == null) {
       this.el.removeAttribute('href');
     } else {
-      if (this.router.options.useUrlFragmentHash && !(newValue as string).startsWith('#')) {
+      if (this.router.options.useUrlFragmentHash
+        && this.ctx.isRoot
+        && !/^[.#]/.test(newValue as string)
+      ) {
         newValue = `#${newValue}`;
       }
       this.el.setAttribute('href', newValue as string);

--- a/packages/router-lite/src/resources/href.ts
+++ b/packages/router-lite/src/resources/href.ts
@@ -67,11 +67,7 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
       this.isInitialized = true;
       this.isEnabled = this.isEnabled && getRef(this.el, CustomAttribute.getDefinition(LoadCustomAttribute).key) === null;
     }
-    if (this.value == null) {
-      this.el.removeAttribute('href');
-    } else {
-      this.el.setAttribute('href', this.value as string);
-    }
+    this.valueChanged(this.value);
     this.eventListener = this.delegator.addEventListener(this.target, this.el, 'click', this);
   }
   public unbinding(): void {
@@ -82,6 +78,9 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
     if (newValue == null) {
       this.el.removeAttribute('href');
     } else {
+      if (this.router.options.useUrlFragmentHash && !(newValue as string).startsWith('#')) {
+        newValue = `#${newValue}`;
+      }
       this.el.setAttribute('href', newValue as string);
     }
   }

--- a/packages/router-lite/src/route-expression.ts
+++ b/packages/router-lite/src/route-expression.ts
@@ -135,7 +135,7 @@ export class RouteExpression {
 
   private static $parse(path: string, fragmentIsRoute: boolean): RouteExpression {
     // First strip off the fragment (and if fragment should be used as route, set it as the path)
-    let fragment: string | null;
+    let fragment: string | null = null;
     const fragmentStart = path.indexOf('#');
     if (fragmentStart >= 0) {
       const rawFragment = path.slice(fragmentStart + 1);
@@ -145,11 +145,6 @@ export class RouteExpression {
       } else {
         path = path.slice(0, fragmentStart);
       }
-    } else {
-      if (fragmentIsRoute) {
-        path = '';
-      }
-      fragment = null;
     }
 
     // Strip off and parse the query string using built-in URLSearchParams.

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -198,6 +198,7 @@ export class NavigationOptions extends RouterOptions {
 export class UnknownRouteError extends Error { }
 
 export class Transition {
+  /** @internal */
   private _erredWithUnknownRoute: boolean = false;
   public get erredWithUnknownRoute(): boolean { return this._erredWithUnknownRoute; }
 

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -382,8 +382,17 @@ export class Router {
     return RouteContext.resolve(this.ctx, context);
   }
 
-  public start(routerOptions: IRouterOptions, performInitialNavigation: boolean): void | Promise<boolean> {
+  /**
+   * Only for internal usage as the options are supposed to be set only once at the beginning.
+   * At present no use-case for dynamic routing configuration can be imagined; hence it is limited to as a bootstrapping activity.
+   *
+   * @internal
+   */
+  public _setOptions(routerOptions: IRouterOptions) {
     this.options = RouterOptions.create(routerOptions);
+  }
+
+  public start(performInitialNavigation: boolean): void | Promise<boolean> {
     (this as Writable<Router>)._hasTitleBuilder = typeof this.options.buildTitle === 'function';
 
     this.locationMgr.startListening();

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -47,7 +47,7 @@ export class ViewportAgent {
   private nextNode: RouteNode | null = null;
 
   private currTransition: Transition | null = null;
-  private prevTransition: Transition | null = null;
+  /** @internal */
   private _cancellationPromise: Promise<void> | void | null = null;
 
   public constructor(
@@ -690,7 +690,6 @@ export class ViewportAgent {
           this.nextState = State.nextIsEmpty;
           this.nextCA = null;
           this.nextNode = null;
-          this.prevTransition = null;
           this.currTransition = null;
           this._cancellationPromise = null;
         });
@@ -759,7 +758,6 @@ export class ViewportAgent {
       this.nextState = State.nextIsEmpty;
       this.nextNode = null;
       this.nextCA = null;
-      this.prevTransition = this.currTransition;
       this.currTransition = null;
     }
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

The configuration options supported was supported to be a function
that starts the Router. This was undocumented, also probably contrived.
This is removed, and the options are initialized in the `hydrated` phase
rather than the `activated` phase which was the case previously.
This hindered the availability of the customization of options to the
CAs at the right time.

Note that this is a BREAKING CHANGE, although it might be relatively
low-impacting, as the "feature" was undocumented in the first place.

Additionally, it contains some residual cleanups from the PR #1569 as pointed out by @bigopon.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
