### PR TITLE
refactor(runtime): cleanup & size opt, rename binding methods

### DIFF
--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -1,14 +1,4 @@
 /**
- * This is the minimum required runtime modules for HMR
- */
-export const hmrRuntimeModules = ['CustomElement', 'LifecycleFlags', 'IHydrationContext', 'Controller'];
-
-/**
- * This is the minimum required metadata modules for HMR
- */
-export const hmrMetadataModules = ['Metadata'];
-
-/**
  * This gets the generated HMR code for the specified class
  *
  * @param className - The name of the class to generate HMR code for
@@ -19,7 +9,9 @@ export const hmrMetadataModules = ['Metadata'];
 export const getHmrCode = (className: string, moduleText: string = 'module'): string => {
 
   const code = `
+    import { Metadata as $$M } from '@aurelia/metadata';
     import { ExpressionKind as $$EK } from '@aurelia/runtime';
+    import { Controller as $$C, CustomElement as $$CE, IHydrationContext as $$IHC } from '@aurelia/runtime-html';
 
     // @ts-ignore
     const controllers = [];
@@ -62,10 +54,10 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
     });
 
     if (hot.data?.aurelia) {
-      const newDefinition = CustomElement.getDefinition(currentClassType);
-      Metadata.define(newDefinition.name, newDefinition, currentClassType);
-      Metadata.define(newDefinition.name, newDefinition, newDefinition);
-      hot.data.aurelia.container.res[CustomElement.keyFrom(newDefinition.name)] = newDefinition;
+      const newDefinition = $$CE.getDefinition(currentClassType);
+      $$M.define(newDefinition.name, newDefinition, currentClassType);
+      $$M.define(newDefinition.name, newDefinition, newDefinition);
+      hot.data.aurelia.container.res[$$CE.keyFrom(newDefinition.name)] = newDefinition;
 
       const previousControllers = hot.data.controllers;
       if(previousControllers == null || previousControllers.length === 0) {
@@ -76,7 +68,7 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
       // @ts-ignore
       previousControllers.forEach(controller => {
         const values = { ...controller.viewModel };
-        const hydrationContext = controller.container.get(IHydrationContext)
+        const hydrationContext = controller.container.get($$IHC)
         const hydrationInst = hydrationContext.instruction;
 
         const bindableNames = Object.keys(controller.definition.bindables);
@@ -107,8 +99,8 @@ export const getHmrCode = (className: string, moduleText: string = 'module'): st
         }
         h.parentNode.replaceChild(controller.host, h);
         controller.hostController = null;
-        controller.deactivate(controller, controller.parent ?? null, LifecycleFlags.none);
-        controller.activate(controller, controller.parent ?? null, LifecycleFlags.none);
+        controller.deactivate(controller, controller.parent ?? null, 0);
+        controller.activate(controller, controller.parent ?? null, 0);
       });
     }
   }`;

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -1,4 +1,4 @@
-import { getHmrCode, hmrMetadataModules, hmrRuntimeModules } from './hmr';
+import { getHmrCode } from './hmr';
 import * as path from 'path';
 import modifyCode, { ModifyCodeResult } from 'modify-code';
 import { IFileUnit, IPreprocessOptions } from './options';
@@ -78,12 +78,7 @@ export function preprocessHtmlTemplate(unit: IFileUnit, options: IPreprocessOpti
 
   const m = modifyCode('', unit.path);
   const hmrEnabled = !hasViewModel && options.hmr && process.env.NODE_ENV !== 'production';
-  if (hmrEnabled) {
-    m.append(`import { ${hmrRuntimeModules.join(', ')} } from '@aurelia/runtime-html';\n`);
-    m.append(`import { ${hmrMetadataModules.join(', ')} } from '@aurelia/metadata';\n`);
-  } else {
-    m.append(`import { CustomElement } from '@aurelia/runtime-html';\n`);
-  }
+  m.append(`import { CustomElement } from '@aurelia/runtime-html';\n`);
   if (cssDeps.length > 0) {
     if (shadowMode !== null) {
       m.append(`import { shadowCSS } from '@aurelia/runtime-html';\n`);

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -1,6 +1,6 @@
 import modifyCode, { ModifyCodeResult } from 'modify-code';
 import * as ts from 'typescript';
-import { getHmrCode, hmrMetadataModules, hmrRuntimeModules } from './hmr';
+import { getHmrCode } from './hmr';
 import { nameConvention } from './name-convention';
 import { IFileUnit, IPreprocessOptions, ResourceType } from './options';
 import { resourceName } from './resource-name';
@@ -104,16 +104,6 @@ export function preprocessResource(unit: IFileUnit, options: IPreprocessOptions)
     }
     if (className && options.hmr && process.env.NODE_ENV !== 'production') {
       exportedClassName = className;
-      hmrRuntimeModules.forEach(m => {
-        if (!auImport.names.includes(m)) {
-          ensureTypeIsExported(runtimeImport.names, m);
-        }
-      });
-      hmrMetadataModules.forEach(m => {
-        if (!auImport.names.includes(m)) {
-          ensureTypeIsExported(metadataImport.names, m);
-        }
-      });
     }
     if (customName) customElementName = customName;
   });

--- a/packages/__tests__/1-kernel/eventaggregator.spec.ts
+++ b/packages/__tests__/1-kernel/eventaggregator.spec.ts
@@ -124,8 +124,8 @@ describe('event aggregator', function () {
         ea.subscribe(DinnerEvent, callback);
 
         assert.strictEqual(ea.messageHandlers.length, 1, `ea.messageHandlers.length`);
-        assert.strictEqual(ea.messageHandlers[0].messageType, DinnerEvent, `ea.messageHandlers[0].messageType`);
-        assert.strictEqual(ea.messageHandlers[0].callback, callback, `ea.messageHandlers[0].callback`);
+        assert.strictEqual(ea.messageHandlers[0].type, DinnerEvent, `ea.messageHandlers[0].type`);
+        assert.strictEqual(ea.messageHandlers[0].cb, callback, `ea.messageHandlers[0].cb`);
       });
 
       it('removes the handler after execution', function () {
@@ -254,9 +254,9 @@ describe('event aggregator', function () {
         ea.subscribeOnce(DinnerEvent, callback);
 
         assert.strictEqual(ea.messageHandlers.length, 1, `ea.messageHandlers.length`);
-        assert.strictEqual(ea.messageHandlers[0].messageType, DinnerEvent, `ea.messageHandlers[0].messageType`);
-        assert.strictEqual(ea.messageHandlers[0].callback === callback, false, `ea.messageHandlers[0].callback === callback`);
-        assert.strictEqual(typeof ea.messageHandlers[0].callback === 'function', true, `typeof ea.messageHandlers[0].callback === 'function'`);
+        assert.strictEqual(ea.messageHandlers[0].type, DinnerEvent, `ea.messageHandlers[0].type`);
+        assert.strictEqual(ea.messageHandlers[0].cb === callback, false, `ea.messageHandlers[0].cb === callback`);
+        assert.strictEqual(typeof ea.messageHandlers[0].cb === 'function', true, `typeof ea.messageHandlers[0].cb === 'function'`);
 
       });
 

--- a/packages/__tests__/2-runtime/ast.integration.spec.ts
+++ b/packages/__tests__/2-runtime/ast.integration.spec.ts
@@ -36,7 +36,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           BindingMode.toView,
         );
 
-        binding.$bind(createScopeForTest(source));
+        binding.bind(createScopeForTest(source));
 
         assert.strictEqual(target.name, 'hello');
 
@@ -76,7 +76,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
             return handleChange.apply(this, args);
           };
         })(binding.handleChange);
-        binding.$bind(scope);
+        binding.bind(scope);
 
         assert.strictEqual(target.value, 'no');
 
@@ -129,7 +129,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           true
         );
 
-        binding.$bind(scope);
+        binding.bind(scope);
 
         assert.strictEqual(source.value, 'hello');
 
@@ -166,7 +166,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
             return handleChange.apply(this, args);
           };
         })(binding.handleChange);
-        binding.$bind(scope);
+        binding.bind(scope);
 
         assert.strictEqual(source.value, 'no');
         assert.strictEqual(handleChangeCallCount, 0);

--- a/packages/__tests__/2-runtime/call.spec.ts
+++ b/packages/__tests__/2-runtime/call.spec.ts
@@ -33,7 +33,7 @@ describe.skip('CallBinding', function () {
     return { sut, container, observerLocator };
   }
 
-  describe('$bind -> $bind', function () {
+  describe('bind -> bind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -63,7 +63,7 @@ describe.skip('CallBinding', function () {
        = [targetVariations, propVariations, exprVariations, scopeVariations, renewScopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4], [renewScope, $5]) => {
-      it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function () {
+      it(`bind() target=${$1} prop=${$2} expr=${$3} scope=${$4} renewScope=${$5}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
         const targetObserver = observerLocator.getObserver(target, prop);
@@ -76,7 +76,7 @@ describe.skip('CallBinding', function () {
         // expr['unbind'] = spy();
 
         // - Act -
-        sut.$bind(scope);
+        sut.bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -106,13 +106,13 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$bind(scope);
+        sut.bind(scope);
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
         assert.strictEqual(sut.targetObserver, targetObserver, `sut.targetObserver`);
         if (renewScope) {
-          // called during $bind, then during $unbind, then during $bind again
+          // called during bind, then during unbind, then during bind again
           // expect(targetObserver.setValue).to.have.been.calledThrice;
 
           // expect(expr.unbind).to.have.been.calledOnce;
@@ -132,7 +132,7 @@ describe.skip('CallBinding', function () {
     );
   });
 
-  describe('$bind -> $unbind -> $unbind', function () {
+  describe('bind -> unbind -> unbind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -157,7 +157,7 @@ describe.skip('CallBinding', function () {
        = [targetVariations, propVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [expr, $3], [scope, $4]) => {
-      it(`$bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function () {
+      it(`bind() target=${$1} prop=${$2} expr=${$3} scope=${$4}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
         const targetObserver = observerLocator.getObserver(target, prop);
@@ -170,7 +170,7 @@ describe.skip('CallBinding', function () {
         // expr['unbind'] = spy();
 
         // - Act -
-        sut.$bind(scope);
+        sut.bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -196,7 +196,7 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$unbind();
+        sut.unbind();
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
@@ -214,7 +214,7 @@ describe.skip('CallBinding', function () {
         // massReset(expr);
 
         // - Act -
-        sut.$unbind();
+        sut.unbind();
 
         // - Assert -
         assert.instanceOf(sut.targetObserver, SetterObserver, `sut.targetObserver`);
@@ -227,7 +227,7 @@ describe.skip('CallBinding', function () {
     );
   });
 
-  describe('$bind -> call -> $unbind', function () {
+  describe('bind -> call -> unbind', function () {
 
     const targetVariations: (() => [{foo?: string}, string])[] = [
       () => [({}), `{}`],
@@ -259,7 +259,7 @@ describe.skip('CallBinding', function () {
        = [targetVariations, propVariations, argsVariations, exprVariations, scopeVariations];
 
     eachCartesianJoinFactory(inputs, ([target, $1], [prop, $2], [args, $3], [expr, $4], [scope, $5]) => {
-      it(`$bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function () {
+      it(`bind() target=${$1} prop=${$2} args=${$3} expr=${$4} scope=${$5}`, function () {
         // - Arrange -
         const { sut, observerLocator } = createFixture(expr, target, prop);
         const targetObserver = observerLocator.getObserver(target, prop);
@@ -270,7 +270,7 @@ describe.skip('CallBinding', function () {
         // massSpy(expr, 'evaluate', 'assign', 'connect');
 
         // - Act -
-        sut.$bind(scope);
+        sut.bind(scope);
 
         // - Assert -
         // double check we have the correct target observer
@@ -307,7 +307,7 @@ describe.skip('CallBinding', function () {
         // massRestore(expr);
 
         // - Act -
-        sut.$unbind();
+        sut.unbind();
 
         // - Assert -
         assert.strictEqual(target[prop], null, `target[prop]`);

--- a/packages/__tests__/3-runtime-html/decorator-watch.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/decorator-watch.unit.spec.ts
@@ -24,7 +24,7 @@ describe('3-runtime-html/decorator-watch.unit.spec.ts', function () {
         true,
       );
 
-      watcher.$bind();
+      watcher.bind();
       assert.strictEqual(watcher['value'], undefined);
       assert.strictEqual(getCallCount, 1);
       assert.deepStrictEqual(callbackValues, []);
@@ -105,7 +105,7 @@ describe('3-runtime-html/decorator-watch.unit.spec.ts', function () {
         false,
       );
 
-      watcher.$bind();
+      watcher.bind();
       assert.strictEqual(watcher['value'], undefined);
       assert.strictEqual(getCallCount, 1);
       assert.deepStrictEqual(callbackValues, []);
@@ -165,7 +165,7 @@ describe('3-runtime-html/decorator-watch.unit.spec.ts', function () {
       assert.strictEqual(watcher['value'], void 0);
       assert.deepStrictEqual(callbackValues, []);
 
-      watcher.$bind();
+      watcher.bind();
       assert.strictEqual(evaluateCallCount, 1);
       assert.strictEqual(watcher['value'], 1);
       assert.deepStrictEqual(callbackValues, []);
@@ -175,7 +175,7 @@ describe('3-runtime-html/decorator-watch.unit.spec.ts', function () {
       assert.strictEqual(watcher['value'], 2);
       assert.deepStrictEqual(callbackValues, [2]);
 
-      watcher.$unbind();
+      watcher.unbind();
       assert.strictEqual(evaluateCallCount, 2);
       assert.strictEqual(watcher['value'], void 0);
       assert.deepStrictEqual(callbackValues, [2]);

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -318,7 +318,7 @@ describe('3-runtime/interpolation.spec.ts -- [UNIT]interpolation', function () {
           return handleChange.apply(this, args);
         };
       })(binding.partBindings[0].handleChange);
-      binding.$bind(createScopeForTest(source));
+      binding.bind(createScopeForTest(source));
 
       assert.strictEqual(target.value, 'no');
       assert.deepStrictEqual(
@@ -416,7 +416,7 @@ describe('3-runtime/interpolation.spec.ts -- [UNIT]interpolation', function () {
           return handleChange.apply(this, args);
         };
       })(binding.partBindings[1].handleChange);
-      binding.$bind(createScopeForTest(source));
+      binding.bind(createScopeForTest(source));
 
       assert.strictEqual(target.value, 'no1--no2');
       assert.deepStrictEqual(

--- a/packages/__tests__/3-runtime-html/template-compiler.ref.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.ref.spec.ts
@@ -358,7 +358,7 @@ describe('3-runtime-html/templating-compiler.ref.spec.ts', function () {
         comp: { div: HTMLDivElement; divSetterCount: number; divGetterCount: number }
       ) => {
         assert.strictEqual(comp.divGetterCount, 10, 'shoulda called getter 10 times');
-        assert.strictEqual(comp.divSetterCount, 11, 'shoulda called setter 11 times' /* 1 comes from $unbind */);
+        assert.strictEqual(comp.divSetterCount, 11, 'shoulda called setter 11 times' /* 1 comes from unbind */);
       }
     },
     {
@@ -385,7 +385,7 @@ describe('3-runtime-html/templating-compiler.ref.spec.ts', function () {
         host,
         comp: { div: HTMLDivElement; divSetterCount: number; divGetterCount: number }
       ) => {
-        assert.strictEqual(comp.divSetterCount, 11, 'shoulda called setter 11 times' /* 1 comes from $unbind */);
+        assert.strictEqual(comp.divSetterCount, 11, 'shoulda called setter 11 times' /* 1 comes from unbind */);
       }
     },
     // #endregion ref-binding order

--- a/packages/__tests__/validation/rule-provider.spec.ts
+++ b/packages/__tests__/validation/rule-provider.spec.ts
@@ -38,7 +38,7 @@ import {
 } from '@aurelia/validation';
 import { Person } from './_test-resources.js';
 
-describe('validation/validation.spec.ts/ValidationRules', function () {
+describe('validation/rule-provider.spec.ts/ValidationRules', function () {
 
   function setup() {
     const container = DI.createContainer();
@@ -545,7 +545,7 @@ describe('validation/validation.spec.ts/ValidationRules', function () {
   });
 });
 
-describe('validation/validation.spec.ts/ValidationMessageProvider', function () {
+describe('validation/rule-provider.spec.ts/ValidationMessageProvider', function () {
   class EventLog implements ISink {
     public log: ILogEvent[] = [];
     public handleEvent(event: ILogEvent): void {
@@ -830,7 +830,7 @@ describe('validation/validation.spec.ts/ValidationMessageProvider', function () 
   }
 });
 
-describe('validation/validation.spec.ts/parsePropertyName', function () {
+describe('validation/rule-provider.spec.ts/parsePropertyName', function () {
 
   function setup() {
     const container = TestContext.create().container;
@@ -976,7 +976,7 @@ describe('validation/validation.spec.ts/parsePropertyName', function () {
   }
 });
 
-describe('validation/validation.spec.ts/PropertyRule', function () {
+describe('validation/rule-provider.spec.ts/PropertyRule', function () {
 
   function setup() {
     const container = TestContext.create().container;

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -706,7 +706,6 @@ export {
   // SelfBindingBehavior,
 
   // UpdateTriggerBindingBehavior,
-  // UpdateTriggerableBinding,
   // UpdateTriggerableObserver,
 
   // Focus,

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -15,7 +15,7 @@ import {
   type IAstBasedBinding,
   type IBindingController,
   State,
-  implementAstEvaluator,
+  mixinAstEvaluator,
   mixingBindingLimited,
 } from '@aurelia/runtime-html';
 import i18next from 'i18next';
@@ -344,7 +344,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
   }
 }
 connectable(TranslationBinding);
-implementAstEvaluator(true)(TranslationBinding);
+mixinAstEvaluator(true)(TranslationBinding);
 mixingBindingLimited(TranslationBinding, () => 'updateTranslations');
 
 class AccessorUpdateTask {
@@ -424,4 +424,4 @@ class ParameterBinding {
 }
 
 connectable(ParameterBinding);
-implementAstEvaluator(true)(ParameterBinding);
+mixinAstEvaluator(true)(ParameterBinding);

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -80,6 +80,9 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
   private readonly platform: IPlatform;
   private readonly taskQueue: TaskQueue;
   private parameter: ParameterBinding | null = null;
+
+  /** @internal */
+  public readonly l: IServiceLocator;
   /**
    * A semi-private property used by connectable mixin
    */
@@ -93,14 +96,15 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
 
   public constructor(
     controller: IBindingController,
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     platform: IPlatform,
     target: INode,
   ) {
+    this.l = locator;
     this._controller = controller;
     this.target = target as HTMLElement;
-    this.i18n = this.locator.get(I18N);
+    this.i18n = locator.get(I18N);
     this.platform = platform;
     this._targetAccessors = new Set<IAccessor>();
     this.oL = observerLocator;
@@ -370,7 +374,7 @@ class ParameterBinding {
    * @internal
    */
   public readonly oL: IObserverLocator;
-  public readonly locator: IServiceLocator;
+  public readonly l: IServiceLocator;
   public isBound: boolean = false;
 
   public scope!: Scope;
@@ -384,7 +388,7 @@ class ParameterBinding {
     public readonly updater: () => void,
   ) {
     this.oL = owner.oL;
-    this.locator = owner.locator;
+    this.l = owner.l;
   }
 
   public handleChange(_newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions): void {

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -150,7 +150,7 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
     return binding;
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -161,20 +161,20 @@ export class TranslationBinding implements IObserverLocatorBasedConnectable {
 
     this._keyExpression = astEvaluate(this.ast, scope, this, this) as string;
     this._ensureKeyExpression();
-    this.parameter?.$bind(scope);
+    this.parameter?.bind(scope);
 
     this.updateTranslations();
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }
 
     astUnbind(this.ast, this.scope, this);
 
-    this.parameter?.$unbind();
+    this.parameter?.unbind();
     this._targetAccessors.clear();
     if (this.task !== null) {
       this.task.cancel();
@@ -403,7 +403,7 @@ class ParameterBinding {
     this.updater();
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -415,7 +415,7 @@ class ParameterBinding {
     this.isBound = true;
   }
 
-  public $unbind() {
+  public unbind() {
     if (!this.isBound) {
       return;
     }

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -1,0 +1,556 @@
+/* eslint-disable @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+import { isObject } from '@aurelia/metadata';
+import { isNativeFunction } from './functions';
+import { Class, Constructable, IDisposable } from './interfaces';
+import { emptyArray } from './platform';
+import { IResourceKind, Protocol, ResourceDefinition, ResourceType } from './resource';
+import { createError, createObject, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { IContainer, type Key, type IResolver, type IDisposableResolver, Factory, ContainerConfiguration, type IRegistry, Registration, Resolver, ResolverStrategy, Transformer, type RegisterSelf, type Resolved, getDependencies, containerGetKey, IFactory, IContainerConfiguration } from './di';
+
+const InstrinsicTypeNames = new Set<string>('Array ArrayBuffer Boolean DataView Date Error EvalError Float32Array Float64Array Function Int8Array Int16Array Int32Array Map Number Object Promise RangeError ReferenceError RegExp Set SharedArrayBuffer String SyntaxError TypeError Uint8Array Uint8ClampedArray Uint16Array Uint32Array URIError WeakMap WeakSet'.split(' '));
+// const factoryKey = 'di:factory';
+// const factoryAnnotationKey = Protocol.annotation.keyFor(factoryKey);
+let containerId = 0;
+/** @internal */
+export class Container implements IContainer {
+  public readonly id: number = ++containerId;
+  /** @internal */
+  private _registerDepth: number = 0;
+
+  public get depth(): number {
+    return this.parent === null ? 0 : this.parent.depth + 1;
+  }
+  public readonly root: Container;
+
+  /**
+   * All own resolvers of this container
+   *
+   * @internal
+   */
+  private readonly _resolvers: Map<Key, IResolver | IDisposableResolver>;
+  /**
+   * A map of Factory per Constructor (Type) of this container tree.
+   *
+   * Factories are "global" per container tree
+   *
+   * @internal
+   */
+  private readonly _factories: Map<Constructable, Factory>;
+
+  /**
+   * A map of all resources resolver by their key
+   */
+  private res: Record<string, IResolver | IDisposableResolver | undefined>;
+
+  /** @internal */
+  private readonly _disposableResolvers: Map<Key, IDisposableResolver> = new Map<Key, IDisposableResolver>();
+
+  public constructor(
+    private readonly parent: Container | null,
+    private readonly config: ContainerConfiguration
+  ) {
+    if (parent === null) {
+      this.root = this;
+
+      this._resolvers = new Map();
+      this._factories = new Map<Constructable, Factory>();
+
+      this.res = createObject();
+    } else {
+      this.root = parent.root;
+
+      this._resolvers = new Map();
+      this._factories = parent._factories;
+
+      if (config.inheritParentResources) {
+        this.res = Object.assign(
+          createObject(),
+          parent.res,
+          this.root.res
+        );
+      } else {
+        this.res = createObject();
+      }
+    }
+
+    this._resolvers.set(IContainer, containerResolver);
+  }
+
+  public register(...params: any[]): IContainer {
+    if (++this._registerDepth === 100) {
+      throw registrationError(params);
+    }
+    let current: IRegistry | Record<string, IRegistry>;
+    let keys: string[];
+    let value: IRegistry;
+    let j: number;
+    let jj: number;
+    let i = 0;
+    // eslint-disable-next-line
+    let ii = params.length;
+    for (; i < ii; ++i) {
+      current = params[i];
+      if (!isObject(current)) {
+        continue;
+      }
+      if (isRegistry(current)) {
+        current.register(this);
+      } else if (Protocol.resource.has(current)) {
+        const defs = Protocol.resource.getAll(current);
+        if (defs.length === 1) {
+          // Fast path for the very common case
+          defs[0].register(this);
+        } else {
+          j = 0;
+          jj = defs.length;
+          while (jj > j) {
+            defs[j].register(this);
+            ++j;
+          }
+        }
+      } else if (isClass(current)) {
+        Registration.singleton(current, current as Constructable).register(this);
+      } else {
+        keys = Object.keys(current);
+        j = 0;
+        jj = keys.length;
+        for (; j < jj; ++j) {
+          value = current[keys[j]];
+          if (!isObject(value)) {
+            continue;
+          }
+          // note: we could remove this if-branch and call this.register directly
+          // - the extra check is just a perf tweak to create fewer unnecessary arrays by the spread operator
+          if (isRegistry(value)) {
+            value.register(this);
+          } else {
+            this.register(value);
+          }
+        }
+      }
+    }
+    --this._registerDepth;
+    return this;
+  }
+
+  public registerResolver<K extends Key, T = K>(key: K, resolver: IResolver<T>, isDisposable: boolean = false): IResolver<T> {
+    validateKey(key);
+
+    const resolvers = this._resolvers;
+    const result = resolvers.get(key);
+
+    if (result == null) {
+      resolvers.set(key, resolver);
+      if (isResourceKey(key)) {
+        if (this.res[key] !== void 0) {
+          throw resourceExistError(key);
+        }
+        this.res[key] = resolver;
+      }
+    } else if (result instanceof Resolver && result._strategy === ResolverStrategy.array) {
+      (result._state as IResolver[]).push(resolver);
+    } else {
+      resolvers.set(key, new Resolver(key, ResolverStrategy.array, [result, resolver]));
+    }
+
+    if (isDisposable) {
+      this._disposableResolvers.set(key, resolver as IDisposableResolver<T>);
+    }
+
+    return resolver;
+  }
+
+  // public deregisterResolverFor<K extends Key>(key: K, searchAncestors: boolean): void {
+  //   validateKey(key);
+  //   // eslint-disable-next-line @typescript-eslint/no-this-alias
+  //   let current: Container | null = this;
+  //   let resolver: IResolver | undefined;
+  //   while (current != null) {
+  //     resolver = current._resolvers.get(key);
+  //     if (resolver != null) {
+  //       current._resolvers.delete(key);
+  //       break;
+  //     }
+  //     if (current.parent == null) { return; }
+  //     current = searchAncestors ? current.parent : null;
+  //   }
+  //   if (resolver == null) { return; }
+  //   if (resolver instanceof Resolver && resolver.strategy === ResolverStrategy.array) {
+  //     throw createError('Cannot deregister a resolver with array strategy');
+  //   }
+  //   if (this._disposableResolvers.has(resolver as IDisposableResolver<K>)) {
+  //     (resolver as IDisposableResolver<K>).dispose();
+  //   }
+  //   if (isResourceKey(key)) {
+  //     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  //     delete this.res[key];
+  //   }
+  // }
+  public registerTransformer<K extends Key, T = K>(key: K, transformer: Transformer<T>): boolean {
+    const resolver = this.getResolver(key);
+
+    if (resolver == null) {
+      return false;
+    }
+
+    if (resolver.getFactory) {
+      const factory = resolver.getFactory(this);
+
+      if (factory == null) {
+        return false;
+      }
+
+      // This type cast is a bit of a hacky one, necessary due to the duplicity of IResolverLike.
+      // Problem is that that interface's type arg can be of type Key, but the getFactory method only works on
+      // type Constructable. So the return type of that optional method has this additional constraint, which
+      // seems to confuse the type checker.
+      factory.registerTransformer(transformer as unknown as Transformer<Constructable>);
+      return true;
+    }
+
+    return false;
+  }
+
+  public getResolver<K extends Key, T = K>(key: K | Key, autoRegister: boolean = true): IResolver<T> | null {
+    validateKey(key);
+
+    if ((key as unknown as IResolver).resolve !== void 0) {
+      return key as unknown as IResolver;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let current: Container = this;
+    let resolver: IResolver | undefined;
+    let handler: Container;
+
+    while (current != null) {
+      resolver = current._resolvers.get(key);
+
+      if (resolver == null) {
+        if (current.parent == null) {
+          handler = (isRegisterInRequester(key as unknown as RegisterSelf<Constructable>)) ? this : current;
+          return autoRegister ? this._jitRegister(key, handler) : null;
+        }
+
+        current = current.parent;
+      } else {
+        return resolver;
+      }
+    }
+
+    return null;
+  }
+
+  public has<K extends Key>(key: K, searchAncestors: boolean = false): boolean {
+    return this._resolvers.has(key)
+      ? true
+      : searchAncestors && this.parent != null
+        ? this.parent.has(key, true)
+        : false;
+  }
+
+  public get<K extends Key>(key: K): Resolved<K> {
+    validateKey(key);
+
+    if ((key as IResolver).$isResolver) {
+      return (key as IResolver).resolve(this, this);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let current: Container = this;
+    let resolver: IResolver | undefined;
+    let handler: Container;
+
+    while (current != null) {
+      resolver = current._resolvers.get(key);
+
+      if (resolver == null) {
+        if (current.parent == null) {
+          handler = (isRegisterInRequester(key as unknown as RegisterSelf<Constructable>)) ? this : current;
+          resolver = this._jitRegister(key, handler);
+          return resolver.resolve(current, this);
+        }
+
+        current = current.parent;
+      } else {
+        return resolver.resolve(current, this);
+      }
+    }
+
+    throw cantResolveKeyError(key);
+  }
+
+  public getAll<K extends Key>(key: K, searchAncestors: boolean = false): readonly Resolved<K>[] {
+    validateKey(key);
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const requestor = this;
+    let current: Container | null = requestor;
+    let resolver: IResolver | undefined;
+
+    if (searchAncestors) {
+      let resolutions: Resolved<K>[] = emptyArray;
+      while (current != null) {
+        resolver = current._resolvers.get(key);
+        if (resolver != null) {
+          resolutions = resolutions.concat(buildAllResponse(resolver, current, requestor));
+        }
+        current = current.parent;
+      }
+      return resolutions;
+    } else {
+      while (current != null) {
+        resolver = current._resolvers.get(key);
+
+        if (resolver == null) {
+          current = current.parent;
+
+          if (current == null) {
+            return emptyArray;
+          }
+        } else {
+          return buildAllResponse(resolver, current, requestor);
+        }
+      }
+    }
+
+    return emptyArray;
+  }
+
+  public invoke<T, TDeps extends unknown[] = unknown[]>(Type: Constructable<T>, dynamicDependencies?: TDeps): T {
+    if (isNativeFunction(Type)) {
+      throw createNativeInvocationError(Type);
+    }
+    if (dynamicDependencies === void 0) {
+      return new Type(...getDependencies(Type).map(containerGetKey, this));
+    } else {
+      return new Type(...getDependencies(Type).map(containerGetKey, this), ...dynamicDependencies);
+    }
+  }
+
+  public getFactory<K extends Constructable>(Type: K): IFactory<K> {
+    let factory = this._factories.get(Type);
+    if (factory === void 0) {
+      if (isNativeFunction(Type)) {
+        throw createNativeInvocationError(Type);
+      }
+      this._factories.set(Type, factory = new Factory<K>(Type, getDependencies(Type)));
+    }
+    return factory;
+  }
+
+  public registerFactory<K extends Constructable>(key: K, factory: IFactory<K>): void {
+    this._factories.set(key, factory as Factory);
+  }
+
+  public createChild(config?: Partial<IContainerConfiguration>): IContainer {
+    if (config === void 0 && this.config.inheritParentResources) {
+      if (this.config === ContainerConfiguration.DEFAULT) {
+        return new Container(this, this.config);
+      }
+      return new Container(
+        this,
+        ContainerConfiguration.from({
+          ...this.config,
+          inheritParentResources: false,
+        })
+      );
+    }
+    return new Container(this, ContainerConfiguration.from(config ?? this.config));
+  }
+
+  public disposeResolvers(): void {
+    const resolvers = this._resolvers;
+    const disposableResolvers = this._disposableResolvers;
+
+    let disposable: IDisposable;
+    let key: Key;
+
+    for ([key, disposable] of disposableResolvers.entries()) {
+      disposable.dispose();
+      resolvers.delete(key);
+    }
+    disposableResolvers.clear();
+  }
+
+  public find<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): TDef | null {
+    const key = kind.keyFrom(name);
+    let resolver = this.res[key];
+    if (resolver === void 0) {
+      resolver = this.root.res[key];
+      if (resolver === void 0) {
+        return null;
+      }
+    }
+
+    if (resolver === null) {
+      return null;
+    }
+
+    if (isFunction(resolver.getFactory)) {
+      const factory = resolver.getFactory(this);
+      if (factory === null || factory === void 0) {
+        return null;
+      }
+
+      const definition = getOwnMetadata(kind.name, factory.Type);
+      if (definition === void 0) {
+        // TODO: we may want to log a warning here, or even throw. This would happen if a dependency is registered with a resource-like key
+        // but does not actually have a definition associated via the type's metadata. That *should* generally not happen.
+        return null;
+      }
+
+      return definition;
+    }
+
+    return null;
+  }
+
+  public create<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): InstanceType<TType> | null {
+    const key = kind.keyFrom(name);
+    let resolver = this.res[key];
+    if (resolver === void 0) {
+      resolver = this.root.res[key];
+      if (resolver === void 0) {
+        return null;
+      }
+      return resolver.resolve(this.root, this) ?? null;
+    }
+    return resolver.resolve(this, this) ?? null;
+  }
+
+  public dispose(): void {
+    if (this._disposableResolvers.size > 0) {
+      this.disposeResolvers();
+    }
+    this._resolvers.clear();
+  }
+
+  /** @internal */
+  private _jitRegister(keyAsValue: any, handler: Container): IResolver {
+    if (!isFunction(keyAsValue)) {
+      throw jitRegisterNonFunctionError(keyAsValue);
+    }
+    if (InstrinsicTypeNames.has(keyAsValue.name)) {
+      throw jitInstrinsicTypeError(keyAsValue);
+    }
+
+    if (isRegistry(keyAsValue)) {
+      const registrationResolver = keyAsValue.register(handler, keyAsValue);
+      if (!(registrationResolver instanceof Object) || (registrationResolver as IResolver).resolve == null) {
+        const newResolver = handler._resolvers.get(keyAsValue);
+        if (newResolver != null) {
+          return newResolver;
+        }
+        throw invalidResolverFromRegisterError();
+      }
+      return registrationResolver as IResolver;
+    } else if (Protocol.resource.has(keyAsValue)) {
+      const defs = Protocol.resource.getAll(keyAsValue);
+      if (defs.length === 1) {
+        // Fast path for the very common case
+        defs[0].register(handler);
+      } else {
+        const len = defs.length;
+        for (let d = 0; d < len; ++d) {
+          defs[d].register(handler);
+        }
+      }
+      const newResolver = handler._resolvers.get(keyAsValue);
+      if (newResolver != null) {
+        return newResolver;
+      }
+      throw invalidResolverFromRegisterError();
+    } else if (keyAsValue.$isInterface) {
+      throw jitInterfaceError(keyAsValue.friendlyName);
+    } else {
+      const resolver = this.config.defaultResolver(keyAsValue, handler);
+      handler._resolvers.set(keyAsValue, resolver);
+      return resolver;
+    }
+  }
+}
+
+function validateKey(key: any): void {
+  if (key === null || key === void 0) {
+    if (__DEV__) {
+      throw createError(`AUR0014: key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?`);
+    } else {
+      throw createError(`AUR0014`);
+    }
+  }
+}
+
+const buildAllResponse = (resolver: IResolver, handler: IContainer, requestor: IContainer): any[] => {
+  if (resolver instanceof Resolver && resolver._strategy === ResolverStrategy.array) {
+    const state = resolver._state as IResolver[];
+    let i = state.length;
+    const results = new Array(i);
+
+    while (i--) {
+      results[i] = state[i].resolve(handler, requestor);
+    }
+
+    return results;
+  }
+
+  return [resolver.resolve(handler, requestor)];
+};
+
+const containerResolver: IResolver = {
+  $isResolver: true,
+  resolve(handler: IContainer, requestor: IContainer): IContainer {
+    return requestor;
+  }
+};
+
+const isRegistry = (obj: IRegistry | Record<string, IRegistry>): obj is IRegistry =>
+  isFunction(obj.register);
+
+const isSelfRegistry = <T extends Constructable>(obj: RegisterSelf<T>): obj is RegisterSelf<T> =>
+  isRegistry(obj) && typeof obj.registerInRequestor === 'boolean';
+
+const isRegisterInRequester = <T extends Constructable>(obj: RegisterSelf<T>): obj is RegisterSelf<T> =>
+  isSelfRegistry(obj) && obj.registerInRequestor;
+
+const isClass = <T extends { prototype?: any }>(obj: T): obj is Class<any, T> =>
+  obj.prototype !== void 0;
+
+const isResourceKey = (key: Key): key is string =>
+  isString(key) && key.indexOf(':') > 0;
+
+const registrationError = (deps: Key[]) =>
+  // TODO: change to reporter.error and add various possible causes in description.
+  // Most likely cause is trying to register a plain object that does not have a
+  // register method and is not a class constructor
+  __DEV__
+    ? createError(`AUR0006: Unable to autoregister dependency: [${deps.map(toStringSafe)}]`)
+    : createError(`AUR0006:${deps.map(toStringSafe)}`);
+const resourceExistError = (key: Key) =>
+  __DEV__
+    ? createError(`AUR0007: Resource key "${toStringSafe(key)}" already registered`)
+    : createError(`AUR0007:${toStringSafe(key)}`);
+const cantResolveKeyError = (key: Key) =>
+  __DEV__
+    ? createError(`AUR0008: Unable to resolve key: ${toStringSafe(key)}`)
+    : createError(`AUR0008:${toStringSafe(key)}`);
+const jitRegisterNonFunctionError = (keyAsValue: Key) =>
+  __DEV__
+    ? createError(`AUR0009: Attempted to jitRegister something that is not a constructor: '${toStringSafe(keyAsValue)}'. Did you forget to register this resource?`)
+    : createError(`AUR0009:${toStringSafe(keyAsValue)}`);
+const jitInstrinsicTypeError = (keyAsValue: any) =>
+  __DEV__
+    ? createError(`AUR0010: Attempted to jitRegister an intrinsic type: ${keyAsValue.name}. Did you forget to add @inject(Key)`)
+    : createError(`AUR0010:${keyAsValue.name}`);
+const invalidResolverFromRegisterError = () =>
+  __DEV__
+    ? createError(`AUR0011: Invalid resolver returned from the static register method`)
+    : createError(`AUR0011`);
+const jitInterfaceError = (name: string) =>
+  __DEV__
+    ? createError(`AUR0012: Attempted to jitRegister an interface: ${name}`)
+    : createError(`AUR0012:${name}`);
+const createNativeInvocationError = (Type: Constructable): Error =>
+  __DEV__
+    ? createError(`AUR0015: ${Type.name} is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`)
+    : createError(`AUR0015:${Type.name}`);

--- a/packages/kernel/src/di.registration.ts
+++ b/packages/kernel/src/di.registration.ts
@@ -1,0 +1,59 @@
+import {
+  type Key,
+  IRegistration,
+  Resolver,
+  ResolverStrategy,
+  type ResolveCallback,
+  type Resolved,
+  type IRegistry,
+  ParameterizedRegistry,
+  type IContainer,
+  IResolver
+} from './di';
+import { Constructable } from './interfaces';
+
+/** @internal */
+export const instanceRegistration = <T>(key: Key, value: T): IRegistration<T> =>
+  new Resolver(key, ResolverStrategy.instance, value);
+
+/** @internal */
+export const singletonRegistration = <T extends Constructable>(key: Key, value: T): IRegistration<InstanceType<T>> =>
+  new Resolver(key, ResolverStrategy.singleton, value);
+
+/** @internal */
+export const transientRegistation = <T extends Constructable>(key: Key, value: T): IRegistration<InstanceType<T>> =>
+  new Resolver(key, ResolverStrategy.transient, value);
+
+/** @internal */
+export const callbackRegistration = <T>(key: Key, callback: ResolveCallback<T>): IRegistration<Resolved<T>> =>
+  new Resolver(key, ResolverStrategy.callback, callback);
+
+/** @internal */
+export const cachedCallbackRegistration = <T>(key: Key, callback: ResolveCallback<T>): IRegistration<Resolved<T>> =>
+  new Resolver(key, ResolverStrategy.callback, cacheCallbackResult(callback));
+
+/** @internal */
+export const aliasToRegistration = <T>(originalKey: T, aliasKey: Key): IRegistration<Resolved<T>> =>
+  new Resolver(aliasKey, ResolverStrategy.alias, originalKey);
+
+/** @internal */
+export const deferRegistration = (key: Key, ...params: unknown[]): IRegistry =>
+  new ParameterizedRegistry(key, params);
+
+type ResolverLookup = WeakMap<IResolver, unknown>;
+const containerLookup = new WeakMap<IContainer, ResolverLookup>();
+
+export const cacheCallbackResult = <T>(fun: ResolveCallback<T>): ResolveCallback<T> => {
+  return (handler: IContainer, requestor: IContainer, resolver: IResolver): T => {
+    let resolverLookup = containerLookup.get(handler);
+    if (resolverLookup === void 0) {
+      containerLookup.set(handler, resolverLookup = new WeakMap());
+    }
+    if (resolverLookup.has(resolver)) {
+      return resolverLookup.get(resolver) as T;
+    }
+    const t = fun(handler, requestor, resolver);
+    resolverLookup.set(resolver, t);
+    return t;
+  };
+};

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -236,7 +236,7 @@ export const getDependencies = (Type: Constructable | Injectable): Key[] => {
     const inject = (Type as Injectable).inject;
     if (inject === void 0) {
       // design:paramtypes is set by tsc when emitDecoratorMetadata is enabled.
-      const designParamtypes = getDesignParamtypes(Type);
+      const designParamtypes = DI.getDesignParamtypes(Type);
       // au:annotation:di:paramtypes is set by the parameter decorator from DI.createInterface or by @inject
       const annotationParamtypes = getAnnotationParamtypes(Type);
       if (designParamtypes === void 0) {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -3,15 +3,16 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { isObject, applyMetadataPolyfill } from '@aurelia/metadata';
+import { applyMetadataPolyfill } from '@aurelia/metadata';
 
 applyMetadataPolyfill(Reflect, false, false);
 
-import { isArrayIndex, isNativeFunction } from './functions';
-import { Class, Constructable, IDisposable } from './interfaces';
-import { emptyArray } from './platform';
-import { appendAnnotation, getAnnotationKeyFor, IResourceKind, Protocol, ResourceDefinition, ResourceType } from './resource';
-import { createError, createObject, defineMetadata, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { isArrayIndex } from './functions';
+import { Container } from './di.container';
+import { Constructable, IDisposable, Writable } from './interfaces';
+import { appendAnnotation, getAnnotationKeyFor, IResourceKind, ResourceDefinition, ResourceType } from './resource';
+import { createError, defineMetadata, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { instanceRegistration, singletonRegistration, transientRegistation, callbackRegistration, cachedCallbackRegistration, aliasToRegistration, deferRegistration, cacheCallbackResult } from './di.registration';
 
 export type ResolveCallback<T = any> = (handler: IContainer, requestor: IContainer, resolver: IResolver<T>) => T;
 
@@ -136,7 +137,7 @@ export type Resolved<K> = (
 
 export type Injectable<T = {}> = Constructable<T> & { inject?: Key[] };
 
-function cloneArrayWithPossibleProps<T>(source: readonly T[]): T[] {
+const cloneArrayWithPossibleProps = <T>(source: readonly T[]): T[] => {
   const clone = source.slice();
   const keys = Object.keys(source);
   const len = keys.length;
@@ -148,7 +149,7 @@ function cloneArrayWithPossibleProps<T>(source: readonly T[]): T[] {
     }
   }
   return clone;
-}
+};
 
 export interface IContainerConfiguration {
   /**
@@ -166,8 +167,8 @@ export const DefaultResolver = {
   none(key: Key): IResolver {
     throw noResolverForKeyError(key);
   },
-  singleton(key: Key): IResolver {return new Resolver(key, ResolverStrategy.singleton, key);},
-  transient(key: Key): IResolver {return new Resolver(key, ResolverStrategy.transient, key);},
+  singleton: (key: Key): IResolver => new Resolver(key, ResolverStrategy.singleton, key),
+  transient: (key: Key): IResolver => new Resolver(key, ResolverStrategy.transient, key),
 };
 
 const noResolverForKeyError = (key: Key) =>
@@ -197,18 +198,138 @@ export class ContainerConfiguration implements IContainerConfiguration {
   }
 }
 
+/** @internal */
+export const createContainer = (config?: Partial<IContainerConfiguration>): IContainer => new Container(null, ContainerConfiguration.from(config));
+
+const getAnnotationParamtypes = (Type: Constructable | Injectable): readonly Key[] | undefined => {
+  const key = getAnnotationKeyFor('di:paramtypes');
+  return getOwnMetadata(key, Type);
+};
+
+const getDesignParamtypes = (Type: Constructable | Injectable): readonly Key[] | undefined =>
+  getOwnMetadata('design:paramtypes', Type);
+
+const getOrCreateAnnotationParamTypes = (Type: Constructable | Injectable): Key[] => {
+  const key = getAnnotationKeyFor('di:paramtypes');
+  let annotationParamtypes = getOwnMetadata(key, Type);
+  if (annotationParamtypes === void 0) {
+    defineMetadata(key, annotationParamtypes = [], Type);
+    appendAnnotation(Type, key);
+  }
+  return annotationParamtypes;
+};
+
+export const getDependencies = (Type: Constructable | Injectable): Key[] => {
+  // Note: Every detail of this getDependencies method is pretty deliberate at the moment, and probably not yet 100% tested from every possible angle,
+  // so be careful with making changes here as it can have a huge impact on complex end user apps.
+  // Preferably, only make changes to the dependency resolution process via a RFC.
+
+  const key = getAnnotationKeyFor('di:dependencies');
+  let dependencies = getOwnMetadata(key, Type) as Key[] | undefined;
+  if (dependencies === void 0) {
+    // Type.length is the number of constructor parameters. If this is 0, it could mean the class has an empty constructor
+    // but it could also mean the class has no constructor at all (in which case it inherits the constructor from the prototype).
+
+    // Non-zero constructor length + no paramtypes means emitDecoratorMetadata is off, or the class has no decorator.
+    // We're not doing anything with the above right now, but it's good to keep in mind for any future issues.
+
+    const inject = (Type as Injectable).inject;
+    if (inject === void 0) {
+      // design:paramtypes is set by tsc when emitDecoratorMetadata is enabled.
+      const designParamtypes = getDesignParamtypes(Type);
+      // au:annotation:di:paramtypes is set by the parameter decorator from DI.createInterface or by @inject
+      const annotationParamtypes = getAnnotationParamtypes(Type);
+      if (designParamtypes === void 0) {
+        if (annotationParamtypes === void 0) {
+          // Only go up the prototype if neither static inject nor any of the paramtypes is defined, as
+          // there is no sound way to merge a type's deps with its prototype's deps
+          const Proto = Object.getPrototypeOf(Type);
+          if (isFunction(Proto) && Proto !== Function.prototype) {
+            dependencies = cloneArrayWithPossibleProps(getDependencies(Proto));
+          } else {
+            dependencies = [];
+          }
+        } else {
+          // No design:paramtypes so just use the au:annotation:di:paramtypes
+          dependencies = cloneArrayWithPossibleProps(annotationParamtypes);
+        }
+      } else if (annotationParamtypes === void 0) {
+        // No au:annotation:di:paramtypes so just use the design:paramtypes
+        dependencies = cloneArrayWithPossibleProps(designParamtypes);
+      } else {
+        // We've got both, so merge them (in case of conflict on same index, au:annotation:di:paramtypes take precedence)
+        dependencies = cloneArrayWithPossibleProps(designParamtypes);
+        let len = annotationParamtypes.length;
+        let auAnnotationParamtype: Key;
+        let i = 0;
+        for (; i < len; ++i) {
+          auAnnotationParamtype = annotationParamtypes[i];
+          if (auAnnotationParamtype !== void 0) {
+            dependencies[i] = auAnnotationParamtype;
+          }
+        }
+
+        const keys = Object.keys(annotationParamtypes);
+        let key: string;
+        i = 0;
+        len = keys.length;
+        for (i = 0; i < len; ++i) {
+          key = keys[i];
+          if (!isArrayIndex(key)) {
+            dependencies[key] = annotationParamtypes[key];
+          }
+        }
+      }
+    } else {
+      // Ignore paramtypes if we have static inject
+      dependencies = cloneArrayWithPossibleProps(inject);
+    }
+
+    defineMetadata(key, dependencies, Type);
+    appendAnnotation(Type, key);
+  }
+
+  return dependencies;
+};
+
+/**
+ * @internal
+ *
+ * @param configureOrName - Use for improving error messaging
+ */
+export const createInterface = <K extends Key>(configureOrName?: string | ((builder: ResolverBuilder<K>) => IResolver<K>), configuror?: (builder: ResolverBuilder<K>) => IResolver<K>): InterfaceSymbol<K> => {
+ const configure = isFunction(configureOrName) ? configureOrName : configuror;
+ const friendlyName = isString(configureOrName) ? configureOrName : undefined;
+
+ const Interface = function (target: Injectable<K>, property: string, index: number): void {
+   if (target == null || new.target !== undefined) {
+    throw createNoRegistrationError(Interface.friendlyName);
+   }
+   const annotationParamtypes = getOrCreateAnnotationParamTypes(target);
+   annotationParamtypes[index] = Interface;
+ };
+ Interface.$isInterface = true;
+ Interface.friendlyName = friendlyName == null ? '(anonymous)' : friendlyName;
+
+ if (configure != null) {
+   Interface.register = (container: IContainer, key?: Key): IResolver<K> =>
+     configure(new ResolverBuilder(container, key ?? Interface));
+ }
+
+ Interface.toString = (): string => `InterfaceSymbol<${Interface.friendlyName}>`;
+
+ return Interface;
+};
+const createNoRegistrationError = (name: string) =>
+  __DEV__
+    ? createError(`AUR0001: No registration for interface: '${name}'`)
+    : createError(`AUR0001:${name}`);
+
 export const DI = {
-  createContainer(config?: Partial<IContainerConfiguration>): IContainer {
-    return new Container(null, ContainerConfiguration.from(config));
-  },
-  getDesignParamtypes(Type: Constructable | Injectable): readonly Key[] | undefined {
-    return getOwnMetadata('design:paramtypes', Type);
-  },
-  getAnnotationParamtypes(Type: Constructable | Injectable): readonly Key[] | undefined {
-    const key = getAnnotationKeyFor('di:paramtypes');
-    return getOwnMetadata(key, Type);
-  },
-  getOrCreateAnnotationParamTypes: getOrCreateAnnotationParamTypes,
+  createContainer,
+  getDesignParamtypes,
+  getAnnotationParamtypes,
+  getOrCreateAnnotationParamTypes,
   getDependencies: getDependencies,
   /**
    * creates a decorator that also matches an interface and can be used as a {@linkcode Key}.
@@ -249,37 +370,11 @@ export const DI = {
    * container.get(Foo).str; // returns 'somestring'
    * ```
    *
-   * - @param friendlyName used to improve error messaging
+   * - @param configureOrName - supply a string to improve error messaging
    */
-  createInterface<K extends Key>(configureOrName?: string | ((builder: ResolverBuilder<K>) => IResolver<K>), configuror?: (builder: ResolverBuilder<K>) => IResolver<K>): InterfaceSymbol<K> {
-    const configure = isFunction(configureOrName) ? configureOrName : configuror;
-    const friendlyName = isString(configureOrName) ? configureOrName : undefined;
-
-    const Interface = function (target: Injectable<K>, property: string, index: number): void {
-      if (target == null || new.target !== undefined) {
-        if (__DEV__) {
-          throw createError(`AUR0001: No registration for interface: '${Interface.friendlyName}'`);
-        } else {
-          throw createError(`AUR0001:${Interface.friendlyName}`);
-        }
-      }
-      const annotationParamtypes = getOrCreateAnnotationParamTypes(target);
-      annotationParamtypes[index] = Interface;
-    };
-    Interface.$isInterface = true;
-    Interface.friendlyName = friendlyName == null ? '(anonymous)' : friendlyName;
-
-    if (configure != null) {
-      Interface.register = (container: IContainer, key?: Key): IResolver<K> =>
-        configure(new ResolverBuilder(container, key ?? Interface));
-    }
-
-    Interface.toString = (): string => `InterfaceSymbol<${Interface.friendlyName}>`;
-
-    return Interface;
-  },
+  createInterface,
   inject(...dependencies: Key[]): (target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number) => void {
-    return function (target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number): void {
+    return (target: Injectable, key?: string | number, descriptor?: PropertyDescriptor | number): void => {
       if (typeof descriptor === 'number') { // It's a parameter decorator.
         const annotationParamtypes = getOrCreateAnnotationParamTypes(target);
         const dep = dependencies[0];
@@ -370,96 +465,13 @@ export const DI = {
   },
 };
 
-function getDependencies(Type: Constructable | Injectable): Key[] {
-  // Note: Every detail of this getDependencies method is pretty deliberate at the moment, and probably not yet 100% tested from every possible angle,
-  // so be careful with making changes here as it can have a huge impact on complex end user apps.
-  // Preferably, only make changes to the dependency resolution process via a RFC.
-
-  const key = getAnnotationKeyFor('di:dependencies');
-  let dependencies = getOwnMetadata(key, Type) as Key[] | undefined;
-  if (dependencies === void 0) {
-    // Type.length is the number of constructor parameters. If this is 0, it could mean the class has an empty constructor
-    // but it could also mean the class has no constructor at all (in which case it inherits the constructor from the prototype).
-
-    // Non-zero constructor length + no paramtypes means emitDecoratorMetadata is off, or the class has no decorator.
-    // We're not doing anything with the above right now, but it's good to keep in mind for any future issues.
-
-    const inject = (Type as Injectable).inject;
-    if (inject === void 0) {
-      // design:paramtypes is set by tsc when emitDecoratorMetadata is enabled.
-      const designParamtypes = DI.getDesignParamtypes(Type);
-      // au:annotation:di:paramtypes is set by the parameter decorator from DI.createInterface or by @inject
-      const annotationParamtypes = DI.getAnnotationParamtypes(Type);
-      if (designParamtypes === void 0) {
-        if (annotationParamtypes === void 0) {
-          // Only go up the prototype if neither static inject nor any of the paramtypes is defined, as
-          // there is no sound way to merge a type's deps with its prototype's deps
-          const Proto = Object.getPrototypeOf(Type);
-          if (isFunction(Proto) && Proto !== Function.prototype) {
-            dependencies = cloneArrayWithPossibleProps(getDependencies(Proto));
-          } else {
-            dependencies = [];
-          }
-        } else {
-          // No design:paramtypes so just use the au:annotation:di:paramtypes
-          dependencies = cloneArrayWithPossibleProps(annotationParamtypes);
-        }
-      } else if (annotationParamtypes === void 0) {
-        // No au:annotation:di:paramtypes so just use the design:paramtypes
-        dependencies = cloneArrayWithPossibleProps(designParamtypes);
-      } else {
-        // We've got both, so merge them (in case of conflict on same index, au:annotation:di:paramtypes take precedence)
-        dependencies = cloneArrayWithPossibleProps(designParamtypes);
-        let len = annotationParamtypes.length;
-        let auAnnotationParamtype: Key;
-        let i = 0;
-        for (; i < len; ++i) {
-          auAnnotationParamtype = annotationParamtypes[i];
-          if (auAnnotationParamtype !== void 0) {
-            dependencies[i] = auAnnotationParamtype;
-          }
-        }
-
-        const keys = Object.keys(annotationParamtypes);
-        let key: string;
-        i = 0;
-        len = keys.length;
-        for (i = 0; i < len; ++i) {
-          key = keys[i];
-          if (!isArrayIndex(key)) {
-            dependencies[key] = annotationParamtypes[key];
-          }
-        }
-      }
-    } else {
-      // Ignore paramtypes if we have static inject
-      dependencies = cloneArrayWithPossibleProps(inject);
-    }
-
-    defineMetadata(key, dependencies, Type);
-    appendAnnotation(Type, key);
-  }
-
-  return dependencies;
-}
-
-function getOrCreateAnnotationParamTypes(Type: Constructable | Injectable): Key[] {
-  const key = getAnnotationKeyFor('di:paramtypes');
-  let annotationParamtypes = getOwnMetadata(key, Type);
-  if (annotationParamtypes === void 0) {
-    defineMetadata(key, annotationParamtypes = [], Type);
-    appendAnnotation(Type, key);
-  }
-  return annotationParamtypes;
-}
-
-export const IContainer = DI.createInterface<IContainer>('IContainer');
+export const IContainer = createInterface<IContainer>('IContainer');
 export const IServiceLocator = IContainer as unknown as InterfaceSymbol<IServiceLocator>;
 
 function createResolver(getter: (key: any, handler: IContainer, requestor: IContainer) => any): (key: any) => any {
   return function (key: any): ReturnType<typeof DI.inject> {
     const resolver: ReturnType<typeof DI.inject> & Partial<Pick<IResolver, 'resolve'>> & { $isResolver: true} = function (target: Injectable, property?: string | number, descriptor?: PropertyDescriptor | number): void {
-      DI.inject(resolver)(target, property, descriptor);
+      inject(resolver)(target, property, descriptor);
     };
 
     resolver.$isResolver = true;
@@ -505,10 +517,11 @@ export function transient<T extends Constructable>(target?: T & Partial<Register
 
 type SingletonOptions = { scoped: boolean };
 const defaultSingletonOptions = { scoped: false };
+const decorateSingleton = DI.singleton;
 
-function singletonDecorator<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> {
-  return DI.singleton(target);
-}
+const singletonDecorator = <T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T> => {
+  return decorateSingleton(target);
+};
 /**
  * Registers the decorated class as a singleton dependency; the class will only be created once. Each
  * consecutive time the dependency is resolved, the same instance will be returned.
@@ -534,17 +547,17 @@ export function singleton<T extends Constructable>(options?: SingletonOptions): 
 export function singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
 export function singleton<T extends Constructable>(targetOrOptions?: (T & Partial<RegisterSelf<T>>) | SingletonOptions): T & RegisterSelf<T> | typeof singletonDecorator {
   if (isFunction(targetOrOptions)) {
-    return DI.singleton(targetOrOptions);
+    return decorateSingleton(targetOrOptions);
   }
   return function <T extends Constructable>($target: T) {
-    return DI.singleton($target, targetOrOptions);
+    return decorateSingleton($target, targetOrOptions);
   };
 }
 
-function createAllResolver(
+const createAllResolver = (
   getter: (key: any, handler: IContainer, requestor: IContainer, searchAncestors: boolean) => readonly any[]
-): (key: any, searchAncestors?: boolean) => ReturnType<typeof DI.inject> {
-  return function (key: any, searchAncestors?: boolean): ReturnType<typeof DI.inject> {
+): (key: any, searchAncestors?: boolean) => ReturnType<typeof DI.inject> => {
+  return (key: any, searchAncestors?: boolean): ReturnType<typeof DI.inject> => {
     searchAncestors = !!searchAncestors;
     const resolver: ReturnType<typeof DI.inject>
       & Required<Pick<IResolver, 'resolve'>>
@@ -554,7 +567,7 @@ function createAllResolver(
           property?: string | number,
           descriptor?: PropertyDescriptor | number
         ): void {
-          DI.inject(resolver)(target, property, descriptor);
+          inject(resolver)(target, property, descriptor);
         };
 
     resolver.$isResolver = true;
@@ -564,7 +577,7 @@ function createAllResolver(
 
     return resolver;
   };
-}
+};
 
 export const all = createAllResolver(
   (key: any,
@@ -643,9 +656,9 @@ export const optional = createResolver((key: Key, handler: IContainer, requestor
 /**
  * ignore tells the container not to try to inject a dependency
  */
-export function ignore(target: Injectable, property?: string | number, descriptor?: PropertyDescriptor | number): void {
-  DI.inject(ignore)(target, property, descriptor);
-}
+export const ignore = (target: Injectable, property?: string | number, descriptor?: PropertyDescriptor | number): void => {
+  inject(ignore)(target, property, descriptor);
+};
 ignore.$isResolver = true;
 ignore.resolve = () => undefined;
 
@@ -711,12 +724,12 @@ export type INewInstanceResolver<T> = {
   (...args: unknown[]): any;
 };
 
-function createNewInstance(key: any, handler: IContainer, requestor: IContainer) {
+const createNewInstance = (key: any, handler: IContainer, requestor: IContainer) => {
   return handler.getFactory(key).construct(requestor);
-}
+};
 
 _START_CONST_ENUM();
-const enum ResolverStrategy {
+export const enum ResolverStrategy {
   instance = 0,
   singleton = 1,
   transient = 2,
@@ -726,7 +739,7 @@ const enum ResolverStrategy {
 }
 _END_CONST_ENUM();
 
-class Resolver implements IResolver, IRegistration {
+export class Resolver implements IResolver, IRegistration {
   public constructor(
     public _key: Key,
     public _strategy: ResolverStrategy,
@@ -810,7 +823,7 @@ export interface IInvoker<T extends Constructable = any> {
   ): Resolved<T>;
 }
 
-function containerGetKey(this: IContainer, d: Key) {
+export function containerGetKey(this: IContainer, d: Key) {
   return this.get(d);
 }
 
@@ -846,533 +859,6 @@ export class Factory<T extends Constructable = any> implements IFactory<T> {
   }
 }
 
-const containerResolver: IResolver = {
-  $isResolver: true,
-  resolve(handler: IContainer, requestor: IContainer): IContainer {
-    return requestor;
-  }
-};
-
-function isRegistry(obj: IRegistry | Record<string, IRegistry>): obj is IRegistry {
-  return isFunction(obj.register);
-}
-
-function isSelfRegistry<T extends Constructable>(obj: RegisterSelf<T>): obj is RegisterSelf<T> {
-  return isRegistry(obj) && typeof obj.registerInRequestor === 'boolean';
-}
-
-function isRegisterInRequester<T extends Constructable>(obj: RegisterSelf<T>): obj is RegisterSelf<T> {
-  return isSelfRegistry(obj) && obj.registerInRequestor;
-}
-
-function isClass<T extends { prototype?: any }>(obj: T): obj is Class<any, T> {
-  return obj.prototype !== void 0;
-}
-
-function isResourceKey(key: Key): key is string {
-  return isString(key) && key.indexOf(':') > 0;
-}
-
-const InstrinsicTypeNames = new Set<string>('Array ArrayBuffer Boolean DataView Date Error EvalError Float32Array Float64Array Function Int8Array Int16Array Int32Array Map Number Object Promise RangeError ReferenceError RegExp Set SharedArrayBuffer String SyntaxError TypeError Uint8Array Uint8ClampedArray Uint16Array Uint32Array URIError WeakMap WeakSet'.split(' '));
-
-// const factoryKey = 'di:factory';
-// const factoryAnnotationKey = Protocol.annotation.keyFor(factoryKey);
-let containerId = 0;
-/** @internal */
-export class Container implements IContainer {
-  public readonly id: number = ++containerId;
-  /** @internal */
-  private _registerDepth: number = 0;
-
-  public get depth(): number {
-    return this.parent === null ? 0 : this.parent.depth + 1;
-  }
-  public readonly root: Container;
-
-  /**
-   * All own resolvers of this container
-   *
-   * @internal
-   */
-  private readonly _resolvers: Map<Key, IResolver | IDisposableResolver>;
-  /**
-   * A map of Factory per Constructor (Type) of this container tree.
-   *
-   * Factories are "global" per container tree
-   *
-   * @internal
-   */
-  private readonly _factories: Map<Constructable, Factory>;
-
-  /**
-   * A map of all resources resolver by their key
-   */
-  private res: Record<string, IResolver | IDisposableResolver | undefined>;
-
-  /** @internal */
-  private readonly _disposableResolvers: Map<Key, IDisposableResolver> = new Map<Key, IDisposableResolver>();
-
-  public constructor(
-    private readonly parent: Container | null,
-    private readonly config: ContainerConfiguration,
-  ) {
-    if (parent === null) {
-      this.root = this;
-
-      this._resolvers = new Map();
-      this._factories = new Map<Constructable, Factory>();
-
-      this.res = createObject();
-    } else {
-      this.root = parent.root;
-
-      this._resolvers = new Map();
-      this._factories = parent._factories;
-
-      if (config.inheritParentResources) {
-        this.res = Object.assign(
-          createObject(),
-          parent.res,
-          this.root.res,
-        );
-      } else {
-        this.res = createObject();
-      }
-    }
-
-    this._resolvers.set(IContainer, containerResolver);
-  }
-
-  public register(...params: any[]): IContainer {
-    if (++this._registerDepth === 100) {
-      throw registrationError(params);
-    }
-    let current: IRegistry | Record<string, IRegistry>;
-    let keys: string[];
-    let value: IRegistry;
-    let j: number;
-    let jj: number;
-    let i = 0;
-    // eslint-disable-next-line
-    let ii = params.length;
-    for (; i < ii; ++i) {
-      current = params[i];
-      if (!isObject(current)) {
-        continue;
-      }
-      if (isRegistry(current)) {
-        current.register(this);
-      } else if (Protocol.resource.has(current)) {
-        const defs = Protocol.resource.getAll(current);
-        if (defs.length === 1) {
-          // Fast path for the very common case
-          defs[0].register(this);
-        } else {
-          j = 0;
-          jj = defs.length;
-          while (jj > j) {
-            defs[j].register(this);
-            ++j;
-          }
-        }
-      } else if (isClass(current)) {
-        Registration.singleton(current, current as Constructable).register(this);
-      } else {
-        keys = Object.keys(current);
-        j = 0;
-        jj = keys.length;
-        for (; j < jj; ++j) {
-          value = current[keys[j]];
-          if (!isObject(value)) {
-            continue;
-          }
-          // note: we could remove this if-branch and call this.register directly
-          // - the extra check is just a perf tweak to create fewer unnecessary arrays by the spread operator
-          if (isRegistry(value)) {
-            value.register(this);
-          } else {
-            this.register(value);
-          }
-        }
-      }
-    }
-    --this._registerDepth;
-    return this;
-  }
-
-  public registerResolver<K extends Key, T = K>(key: K, resolver: IResolver<T>, isDisposable: boolean = false): IResolver<T> {
-    validateKey(key);
-
-    const resolvers = this._resolvers;
-    const result = resolvers.get(key);
-
-    if (result == null) {
-      resolvers.set(key, resolver);
-      if (isResourceKey(key)) {
-        if (this.res[key] !== void 0) {
-          throw resourceExistError(key);
-        }
-        this.res[key] = resolver;
-      }
-    } else if (result instanceof Resolver && result._strategy === ResolverStrategy.array) {
-      (result._state as IResolver[]).push(resolver);
-    } else {
-      resolvers.set(key, new Resolver(key, ResolverStrategy.array, [result, resolver]));
-    }
-
-    if (isDisposable) {
-      this._disposableResolvers.set(key, resolver as IDisposableResolver<T>);
-    }
-
-    return resolver;
-  }
-
-  // public deregisterResolverFor<K extends Key>(key: K, searchAncestors: boolean): void {
-  //   validateKey(key);
-
-  //   // eslint-disable-next-line @typescript-eslint/no-this-alias
-  //   let current: Container | null = this;
-  //   let resolver: IResolver | undefined;
-
-  //   while (current != null) {
-  //     resolver = current._resolvers.get(key);
-
-  //     if (resolver != null) {
-  //       current._resolvers.delete(key);
-  //       break;
-  //     }
-  //     if (current.parent == null) { return; }
-  //     current = searchAncestors ? current.parent : null;
-  //   }
-
-  //   if (resolver == null) { return; }
-  //   if (resolver instanceof Resolver && resolver.strategy === ResolverStrategy.array) {
-  //     throw createError('Cannot deregister a resolver with array strategy');
-  //   }
-  //   if (this._disposableResolvers.has(resolver as IDisposableResolver<K>)) {
-  //     (resolver as IDisposableResolver<K>).dispose();
-  //   }
-  //   if (isResourceKey(key)) {
-  //     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-  //     delete this.res[key];
-  //   }
-  // }
-
-  public registerTransformer<K extends Key, T = K>(key: K, transformer: Transformer<T>): boolean {
-    const resolver = this.getResolver(key);
-
-    if (resolver == null) {
-      return false;
-    }
-
-    if (resolver.getFactory) {
-      const factory = resolver.getFactory(this);
-
-      if (factory == null) {
-        return false;
-      }
-
-      // This type cast is a bit of a hacky one, necessary due to the duplicity of IResolverLike.
-      // Problem is that that interface's type arg can be of type Key, but the getFactory method only works on
-      // type Constructable. So the return type of that optional method has this additional constraint, which
-      // seems to confuse the type checker.
-      factory.registerTransformer(transformer as unknown as Transformer<Constructable>);
-      return true;
-    }
-
-    return false;
-  }
-
-  public getResolver<K extends Key, T = K>(key: K | Key, autoRegister: boolean = true): IResolver<T> | null {
-    validateKey(key);
-
-    if ((key as unknown as IResolver).resolve !== void 0) {
-      return key as unknown as IResolver;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let current: Container = this;
-    let resolver: IResolver | undefined;
-    let handler: Container;
-
-    while (current != null) {
-      resolver = current._resolvers.get(key);
-
-      if (resolver == null) {
-        if (current.parent == null) {
-          handler = (isRegisterInRequester(key as unknown as RegisterSelf<Constructable>)) ? this : current;
-          return autoRegister ? this._jitRegister(key, handler) : null;
-        }
-
-        current = current.parent;
-      } else {
-        return resolver;
-      }
-    }
-
-    return null;
-  }
-
-  public has<K extends Key>(key: K, searchAncestors: boolean = false): boolean {
-    return this._resolvers.has(key)
-      ? true
-      : searchAncestors && this.parent != null
-        ? this.parent.has(key, true)
-        : false;
-  }
-
-  public get<K extends Key>(key: K): Resolved<K> {
-    validateKey(key);
-
-    if ((key as IResolver).$isResolver) {
-      return (key as IResolver).resolve(this, this);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let current: Container = this;
-    let resolver: IResolver | undefined;
-    let handler: Container;
-
-    while (current != null) {
-      resolver = current._resolvers.get(key);
-
-      if (resolver == null) {
-        if (current.parent == null) {
-          handler = (isRegisterInRequester(key as unknown as RegisterSelf<Constructable>)) ? this : current;
-          resolver = this._jitRegister(key, handler);
-          return resolver.resolve(current, this);
-        }
-
-        current = current.parent;
-      } else {
-        return resolver.resolve(current, this);
-      }
-    }
-
-    throw cantResolveKeyError(key);
-  }
-
-  public getAll<K extends Key>(key: K, searchAncestors: boolean = false): readonly Resolved<K>[] {
-    validateKey(key);
-
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const requestor = this;
-    let current: Container | null = requestor;
-    let resolver: IResolver | undefined;
-
-    if (searchAncestors) {
-      let resolutions: any[] = emptyArray;
-      while (current != null) {
-        resolver = current._resolvers.get(key);
-        if (resolver != null) {
-          resolutions = resolutions.concat(buildAllResponse(resolver, current, requestor));
-        }
-        current = current.parent;
-      }
-      return resolutions;
-    } else {
-      while (current != null) {
-        resolver = current._resolvers.get(key);
-
-        if (resolver == null) {
-          current = current.parent;
-
-          if (current == null) {
-            return emptyArray;
-          }
-        } else {
-          return buildAllResponse(resolver, current, requestor);
-        }
-      }
-    }
-
-    return emptyArray;
-  }
-
-  public invoke<T, TDeps extends unknown[] = unknown[]>(Type: Constructable<T>, dynamicDependencies?: TDeps): T {
-    if (isNativeFunction(Type)) {
-      throw createNativeInvocationError(Type);
-    }
-    if (dynamicDependencies === void 0) {
-      return new Type(...getDependencies(Type).map(containerGetKey, this));
-    } else {
-      return new Type(...getDependencies(Type).map(containerGetKey, this), ...dynamicDependencies);
-    }
-  }
-
-  public getFactory<K extends Constructable>(Type: K): IFactory<K> {
-    let factory = this._factories.get(Type);
-    if (factory === void 0) {
-      if (isNativeFunction(Type)) {
-        throw createNativeInvocationError(Type);
-      }
-      this._factories.set(Type, factory = new Factory<K>(Type, getDependencies(Type)));
-    }
-    return factory;
-  }
-
-  public registerFactory<K extends Constructable>(key: K, factory: IFactory<K>): void {
-    this._factories.set(key, factory as Factory);
-  }
-
-  public createChild(config?: Partial<IContainerConfiguration>): IContainer {
-    if (config === void 0 && this.config.inheritParentResources) {
-      if (this.config === ContainerConfiguration.DEFAULT) {
-        return new Container(this, this.config);
-      }
-      return new Container(
-        this,
-        ContainerConfiguration.from({
-          ...this.config,
-          inheritParentResources: false,
-        }),
-      );
-    }
-    return new Container(this, ContainerConfiguration.from(config ?? this.config));
-  }
-
-  public disposeResolvers(): void {
-    const resolvers = this._resolvers;
-    const disposableResolvers = this._disposableResolvers;
-
-    let disposable: IDisposable;
-    let key: Key;
-
-    for ([key, disposable] of disposableResolvers.entries()) {
-      disposable.dispose();
-      resolvers.delete(key);
-    }
-    disposableResolvers.clear();
-  }
-
-  public find<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): TDef | null {
-    const key = kind.keyFrom(name);
-    let resolver = this.res[key];
-    if (resolver === void 0) {
-      resolver = this.root.res[key];
-      if (resolver === void 0) {
-        return null;
-      }
-    }
-
-    if (resolver === null) {
-      return null;
-    }
-
-    if (isFunction(resolver.getFactory)) {
-      const factory = resolver.getFactory(this);
-      if (factory === null || factory === void 0) {
-        return null;
-      }
-
-      const definition = getOwnMetadata(kind.name, factory.Type);
-      if (definition === void 0) {
-        // TODO: we may want to log a warning here, or even throw. This would happen if a dependency is registered with a resource-like key
-        // but does not actually have a definition associated via the type's metadata. That *should* generally not happen.
-        return null;
-      }
-
-      return definition;
-    }
-
-    return null;
-  }
-
-  public create<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): InstanceType<TType> | null {
-    const key = kind.keyFrom(name);
-    let resolver = this.res[key];
-    if (resolver === void 0) {
-      resolver = this.root.res[key];
-      if (resolver === void 0) {
-        return null;
-      }
-      return resolver.resolve(this.root, this) ?? null;
-    }
-    return resolver.resolve(this, this) ?? null;
-  }
-
-  public dispose(): void {
-    if (this._disposableResolvers.size > 0) {
-      this.disposeResolvers();
-    }
-    this._resolvers.clear();
-  }
-
-  /** @internal */
-  private _jitRegister(keyAsValue: any, handler: Container): IResolver {
-    if (!isFunction(keyAsValue)) {
-      throw jitRegisterNonFunctionError(keyAsValue);
-    }
-    if (InstrinsicTypeNames.has(keyAsValue.name)) {
-      throw jitInstrinsicTypeError(keyAsValue);
-    }
-
-    if (isRegistry(keyAsValue)) {
-      const registrationResolver = keyAsValue.register(handler, keyAsValue);
-      if (!(registrationResolver instanceof Object) || (registrationResolver as IResolver).resolve == null) {
-        const newResolver = handler._resolvers.get(keyAsValue);
-        if (newResolver != null) {
-          return newResolver;
-        }
-        throw invalidResolverFromRegisterError();
-      }
-      return registrationResolver as IResolver;
-    } else if (Protocol.resource.has(keyAsValue)) {
-      const defs = Protocol.resource.getAll(keyAsValue);
-      if (defs.length === 1) {
-        // Fast path for the very common case
-        defs[0].register(handler);
-      } else {
-        const len = defs.length;
-        for (let d = 0; d < len; ++d) {
-          defs[d].register(handler);
-        }
-      }
-      const newResolver = handler._resolvers.get(keyAsValue);
-      if (newResolver != null) {
-        return newResolver;
-      }
-      throw invalidResolverFromRegisterError();
-    } else if (keyAsValue.$isInterface) {
-      throw jitInterfaceError(keyAsValue.friendlyName);
-    } else {
-      const resolver = this.config.defaultResolver(keyAsValue, handler);
-      handler._resolvers.set(keyAsValue, resolver);
-      return resolver;
-    }
-  }
-}
-const registrationError = (deps: Key[]) =>
-  // TODO: change to reporter.error and add various possible causes in description.
-  // Most likely cause is trying to register a plain object that does not have a
-  // register method and is not a class constructor
-  __DEV__
-    ? createError(`AUR0006: Unable to autoregister dependency: [${deps.map(toStringSafe)}]`)
-    : createError(`AUR0006:${deps.map(toStringSafe)}`);
-const resourceExistError = (key: Key) =>
-  __DEV__
-    ? createError(`AUR0007: Resource key "${toStringSafe(key)}" already registered`)
-    : createError(`AUR0007:${toStringSafe(key)}`);
-const cantResolveKeyError = (key: Key) =>
-  __DEV__
-    ? createError(`AUR0008: Unable to resolve key: ${toStringSafe(key)}`)
-    : createError(`AUR0008:${toStringSafe(key)}`);
-const jitRegisterNonFunctionError = (keyAsValue: Key) =>
-  __DEV__
-    ? createError(`AUR0009: Attempted to jitRegister something that is not a constructor: '${toStringSafe(keyAsValue)}'. Did you forget to register this resource?`)
-    : createError(`AUR0009:${toStringSafe(keyAsValue)}`);
-const jitInstrinsicTypeError = (keyAsValue: any) =>
-  __DEV__
-    ? createError(`AUR0010: Attempted to jitRegister an intrinsic type: ${keyAsValue.name}. Did you forget to add @inject(Key)`)
-    : createError(`AUR0010:${keyAsValue.name}`);
-const invalidResolverFromRegisterError = () =>
-  __DEV__
-    ? createError(`AUR0011: Invalid resolver returned from the static register method`)
-    : createError(`AUR0011`);
-const jitInterfaceError = (name: string) =>
-  __DEV__
-    ? createError(`AUR0012: Attempted to jitRegister an interface: ${name}`)
-    : createError(`AUR0012:${name}`);
 /**
  * An implementation of IRegistry that delegates registration to a
  * separately registered class. The ParameterizedRegistry facilitates the
@@ -1394,24 +880,6 @@ export class ParameterizedRegistry implements IRegistry {
   }
 }
 
-type ResolverLookup = WeakMap<IResolver, unknown>;
-const containerLookup = new WeakMap<IContainer, ResolverLookup>();
-
-function cacheCallbackResult<T>(fun: ResolveCallback<T>): ResolveCallback<T> {
-  return function (handler: IContainer, requestor: IContainer, resolver: IResolver): T {
-    let resolverLookup = containerLookup.get(handler);
-    if (resolverLookup === void 0) {
-      containerLookup.set(handler, resolverLookup = new WeakMap());
-    }
-    if (resolverLookup.has(resolver)) {
-      return resolverLookup.get(resolver) as T;
-    }
-    const t = fun(handler, requestor, resolver);
-    resolverLookup.set(resolver, t);
-    return t;
-  };
-}
-
 /**
  * you can use the resulting {@linkcode IRegistration} of any of the factory methods
  * to register with the container, e.g.
@@ -1422,7 +890,7 @@ function cacheCallbackResult<T>(fun: ResolveCallback<T>): ResolveCallback<T> {
  * container.get(Foo);
  * ```
  */
-export const Registration = {
+ export const Registration = {
   /**
    * allows you to pass an instance.
    * Every time you request this {@linkcode Key} you will get this instance back.
@@ -1433,9 +901,7 @@ export const Registration = {
    * @param key - key to register the instance with
    * @param value - the instance associated with the key
    */
-  instance<T>(key: Key, value: T): IRegistration<T> {
-    return new Resolver(key, ResolverStrategy.instance, value);
-  },
+  instance: instanceRegistration,
   /**
    * Creates an instance from the class.
    * Every time you request this {@linkcode Key} you will get the same one back.
@@ -1446,9 +912,7 @@ export const Registration = {
    * @param key - key to register the singleton class with
    * @param value - the singleton class to instantiate when a container resolves the associated key
    */
-  singleton<T extends Constructable>(key: Key, value: T): IRegistration<InstanceType<T>> {
-    return new Resolver(key, ResolverStrategy.singleton, value);
-  },
+  singleton: singletonRegistration,
   /**
    * Creates an instance from a class.
    * Every time you request this {@linkcode Key} you will get a new instance.
@@ -1459,9 +923,7 @@ export const Registration = {
    * @param key - key to register the transient class with
    * @param value - the class to instantiate when a container resolves the associated key
    */
-  transient<T extends Constructable>(key: Key, value: T): IRegistration<InstanceType<T>> {
-    return new Resolver(key, ResolverStrategy.transient, value);
-  },
+  transient: transientRegistation,
   /**
    * Creates an instance from the method passed.
    * Every time you request this {@linkcode Key} you will get a new instance.
@@ -1473,9 +935,7 @@ export const Registration = {
    * @param key - key to register the callback with
    * @param callback - the callback to invoke when a container resolves the associated key
    */
-  callback<T>(key: Key, callback: ResolveCallback<T>): IRegistration<Resolved<T>> {
-    return new Resolver(key, ResolverStrategy.callback, callback);
-  },
+  callback: callbackRegistration,
   /**
    * Creates an instance from the method passed.
    * On the first request for the {@linkcode Key} your callback is called and returns an instance.
@@ -1490,9 +950,7 @@ export const Registration = {
    * @param key - key to register the cached callback with
    * @param callback - the cache callback to invoke when a container resolves the associated key
    */
-  cachedCallback<T>(key: Key, callback: ResolveCallback<T>): IRegistration<Resolved<T>> {
-    return new Resolver(key, ResolverStrategy.callback, cacheCallbackResult(callback));
-  },
+  cachedCallback: cachedCallbackRegistration,
   /**
    * creates an alternate {@linkcode Key} to retrieve an instance by.
    * Returns the same scope as the original {@linkcode Key}.
@@ -1506,17 +964,13 @@ export const Registration = {
    * @param originalKey - the real key to resolve the get call from a container
    * @param aliasKey - the key that a container allows to resolve the real key associated
    */
-  aliasTo<T>(originalKey: T, aliasKey: Key): IRegistration<Resolved<T>> {
-    return new Resolver(aliasKey, ResolverStrategy.alias, originalKey);
-  },
+  aliasTo: aliasToRegistration,
   /**
    * @internal
    * @param key - the key to register a defer registration
    * @param params - the parameters that should be passed to the resolution of the key
    */
-  defer(key: Key, ...params: unknown[]): IRegistry {
-    return new ParameterizedRegistry(key, params);
-  }
+  defer: deferRegistration,
 };
 
 export class InstanceProvider<K extends Key> implements IDisposableResolver<K | null> {
@@ -1559,43 +1013,10 @@ export class InstanceProvider<K extends Key> implements IDisposableResolver<K | 
   }
 }
 
-function validateKey(key: any): void {
-  if (key === null || key === void 0) {
-    if (__DEV__) {
-      throw createError(`AUR0014: key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?`);
-    } else {
-      throw createError(`AUR0014`);
-    }
-  }
-}
-
-function buildAllResponse(resolver: IResolver, handler: IContainer, requestor: IContainer): any[] {
-  if (resolver instanceof Resolver && resolver._strategy === ResolverStrategy.array) {
-    const state = resolver._state as IResolver[];
-    let i = state.length;
-    const results = new Array(i);
-
-    while (i--) {
-      results[i] = state[i].resolve(handler, requestor);
-    }
-
-    return results;
-  }
-
-  return [resolver.resolve(handler, requestor)];
-}
-
 const noInstanceError = (name?: string) => {
   if (__DEV__) {
     return createError(`AUR0013: Cannot call resolve ${name} before calling prepare or after calling dispose.`);
   } else {
     return createError(`AUR0013:${name}`);
   }
-};
-
-const createNativeInvocationError = (Type: Constructable): Error => {
-  if (__DEV__) {
-    return createError(`AUR0015: ${Type.name} is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`);
-  }
-  return createError(`AUR0015:${Type.name}`);
 };

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -1,4 +1,4 @@
-import { DI } from './di';
+import { createInterface } from './di';
 import { Constructable, IDisposable } from './interfaces';
 import { createError, isString } from './utilities';
 
@@ -7,18 +7,18 @@ import { createError, isString } from './utilities';
  */
 class Handler<T extends Constructable> {
   public constructor(
-    public readonly messageType: T,
-    public readonly callback: (message: InstanceType<T>) => void,
+    private readonly _messageType: T,
+    private readonly _callback: (message: InstanceType<T>) => void,
   ) {}
 
   public handle(message: InstanceType<T>): void {
-    if (message instanceof this.messageType) {
-      this.callback.call(null, message);
+    if (message instanceof this._messageType) {
+      this._callback.call(null, message);
     }
   }
 }
 
-export const IEventAggregator = DI.createInterface<IEventAggregator>('IEventAggregator', x => x.singleton(EventAggregator));
+export const IEventAggregator = createInterface<IEventAggregator>('IEventAggregator', x => x.singleton(EventAggregator));
 export interface IEventAggregator extends EventAggregator {}
 
 /**
@@ -157,7 +157,7 @@ export class EventAggregator {
     channelOrType: string | Constructable,
     callback: (...args: unknown[]) => void,
   ): IDisposable {
-    const sub = this.subscribe(channelOrType as string, function (message, event) {
+    const sub = this.subscribe(channelOrType as string, (message, event) => {
       sub.dispose();
       callback(message, event);
     });

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -7,13 +7,13 @@ import { createError, isString } from './utilities';
  */
 class Handler<T extends Constructable> {
   public constructor(
-    private readonly _messageType: T,
-    private readonly _callback: (message: InstanceType<T>) => void,
+    private readonly type: T,
+    private readonly cb: (message: InstanceType<T>) => void,
   ) {}
 
   public handle(message: InstanceType<T>): void {
-    if (message instanceof this._messageType) {
-      this._callback.call(null, message);
+    if (message instanceof this.type) {
+      this.cb.call(null, message);
     }
   }
 }

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -370,7 +370,7 @@ export const isNativeFunction = (function () {
   let i = 0;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  return function (fn: Function) {
+  return (fn: Function) => {
     isNative = lookup.get(fn);
     if (isNative === void 0) {
       sourceText = fn.toString();

--- a/packages/kernel/src/logger.ts
+++ b/packages/kernel/src/logger.ts
@@ -1,9 +1,10 @@
-import { all, DI, IContainer, ignore, IRegistry, optional, Registration } from './di';
+import { Metadata } from '@aurelia/metadata';
+import { all, createInterface, IContainer, ignore, IRegistry, optional } from './di';
+import { instanceRegistration, singletonRegistration } from './di.registration';
 import { bound, toLookup } from './functions';
 import { Class, Constructable } from './interfaces';
-import { getAnnotationKeyFor } from './resource';
-import { Metadata } from '@aurelia/metadata';
 import { IPlatform } from './platform';
+import { getAnnotationKeyFor } from './resource';
 import { createObject, defineMetadata, isFunction } from './utilities';
 
 export const enum LogLevel {
@@ -159,11 +160,11 @@ export interface ISink {
  */
 export interface ILogger extends DefaultLogger {}
 
-export const ILogConfig = DI.createInterface<ILogConfig>('ILogConfig', x => x.instance(new LogConfig(ColorOptions.noColors, LogLevel.warn)));
-export const ISink = DI.createInterface<ISink>('ISink');
-export const ILogEventFactory = DI.createInterface<ILogEventFactory>('ILogEventFactory', x => x.singleton(DefaultLogEventFactory));
-export const ILogger = DI.createInterface<ILogger>('ILogger', x => x.singleton(DefaultLogger));
-export const ILogScopes = DI.createInterface<string[]>('ILogScope');
+export const ILogConfig = createInterface<ILogConfig>('ILogConfig', x => x.instance(new LogConfig(ColorOptions.noColors, LogLevel.warn)));
+export const ISink = createInterface<ISink>('ISink');
+export const ILogEventFactory = createInterface<ILogEventFactory>('ILogEventFactory', x => x.singleton(DefaultLogEventFactory));
+export const ILogger = createInterface<ILogger>('ILogger', x => x.singleton(DefaultLogger));
+export const ILogScopes = createInterface<string[]>('ILogScope');
 
 interface SinkDefinition {
   handles: Exclude<LogLevel, LogLevel.none>[];
@@ -179,11 +180,11 @@ export const LoggerSink = Object.freeze({
     return Metadata.get(this.key, target) as LogLevel[] | undefined;
   },
 });
-export function sink(definition: SinkDefinition) {
-  return function <TSink extends ISink>(target: Constructable<TSink>): Constructable<TSink> {
-    return LoggerSink.define(target, definition);
-  };
-}
+
+export const sink = (definition: SinkDefinition) => {
+  return <TSink extends ISink>(target: Constructable<TSink>): Constructable<TSink> =>
+    LoggerSink.define(target, definition);
+};
 
 export interface IConsoleLike {
   debug(message: string, ...optionalParams: unknown[]): void;
@@ -255,7 +256,7 @@ const getLogLevelString = (function () {
     } as const),
   ] as const;
 
-  return function (level: LogLevel, colorOptions: ColorOptions): string {
+  return (level: LogLevel, colorOptions: ColorOptions): string => {
     if (level <= LogLevel.trace) {
       return logLevelString[colorOptions].TRC;
     }
@@ -324,7 +325,7 @@ export class DefaultLogEventFactory implements ILogEventFactory {
 
 export class ConsoleSink implements ISink {
   public static register(container: IContainer) {
-    Registration.singleton(ISink, ConsoleSink).register(container);
+    singletonRegistration(ISink, ConsoleSink).register(container);
   }
 
   public readonly handleEvent: (event: ILogEvent) => void;
@@ -718,11 +719,11 @@ export const LoggerConfiguration = toLookup({
     return toLookup({
       register(container: IContainer): IContainer {
         container.register(
-          Registration.instance(ILogConfig, new LogConfig(colorOptions, level)),
+          instanceRegistration(ILogConfig, new LogConfig(colorOptions, level)),
         );
         for (const $sink of sinks) {
           if (isFunction($sink)) {
-            container.register(Registration.singleton(ISink, $sink));
+            container.register(singletonRegistration(ISink, $sink));
           } else {
             container.register($sink);
           }

--- a/packages/kernel/src/module-loader.ts
+++ b/packages/kernel/src/module-loader.ts
@@ -1,4 +1,4 @@
-import { DI } from './di';
+import { createInterface } from './di';
 import { emptyArray } from './platform';
 import { Protocol } from './resource';
 import { createError, isFunction } from './utilities';
@@ -13,7 +13,7 @@ export interface IModule {
 }
 
 export interface IModuleLoader extends ModuleLoader {}
-export const IModuleLoader = DI.createInterface<IModuleLoader>(x => x.singleton(ModuleLoader));
+export const IModuleLoader = createInterface<IModuleLoader>(x => x.singleton(ModuleLoader));
 
 const noTransform = <TRet = AnalyzedModule>(m: AnalyzedModule): TRet => m as unknown as TRet;
 

--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -1,5 +1,5 @@
 import { Platform } from '@aurelia/platform';
-import { DI } from './di';
+import { createInterface } from './di';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const emptyArray: any[] = Object.freeze<any>([]) as any;
@@ -9,4 +9,4 @@ export const emptyObject: any = Object.freeze({}) as any;
 export function noop(): void {}
 
 export interface IPlatform extends Platform {}
-export const IPlatform = DI.createInterface<IPlatform>('IPlatform');
+export const IPlatform = createInterface<IPlatform>('IPlatform');

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-returns-check */
 /**
  * Determine whether a value is an object.
  *

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -1,6 +1,6 @@
 import { IServiceLocator } from '@aurelia/kernel';
 import {
-  AccessorType, astBind, astEvaluate, astUnbind, connectable, IObserver
+  AccessorType, astBind, astEvaluate, astUnbind, connectable, IBinding, IObserver
 } from '@aurelia/runtime';
 
 import { AttributeObserver } from '../observation/element-attribute-observer';
@@ -32,7 +32,7 @@ export interface AttributeBinding extends IAstBasedBinding {}
 /**
  * Attribute binding. Handle attribute binding betwen view/view model. Understand Html special attributes
  */
-export class AttributeBinding implements IAstBasedBinding {
+export class AttributeBinding implements IBinding {
   public isBound: boolean = false;
   public scope?: Scope = void 0;
   public task: ITask | null = null;
@@ -133,12 +133,12 @@ export class AttributeBinding implements IAstBasedBinding {
     this.handleChange();
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -159,7 +159,7 @@ export class AttributeBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -5,7 +5,7 @@ import {
 
 import { AttributeObserver } from '../observation/element-attribute-observer';
 import { State } from '../templating/controller';
-import { implementAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
+import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 import { BindingMode } from './interfaces-bindings';
 
 import type {
@@ -48,8 +48,10 @@ export class AttributeBinding implements IAstBasedBinding {
 
   /**
    * A semi-private property used by connectable mixin
+   *
+   * @internal
    */
-  public oL: IObserverLocator;
+  public readonly oL: IObserverLocator;
 
   /** @internal */
   private readonly _controller: IBindingController;
@@ -57,16 +59,21 @@ export class AttributeBinding implements IAstBasedBinding {
   /** @internal */
   private readonly _taskQueue: TaskQueue;
 
+  /** @internal */
+  public readonly l: IServiceLocator;
+
   // see Listener binding for explanation
   /** @internal */
   public readonly boundFn = false;
 
+  public ast: IsBindingBehavior | ForOfStatement;
+
   public constructor(
     controller: IBindingController,
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     taskQueue: TaskQueue,
-    public ast: IsBindingBehavior | ForOfStatement,
+    ast: IsBindingBehavior | ForOfStatement,
     target: INode,
     // some attributes may have inner structure
     // such as class -> collection of class names
@@ -77,6 +84,8 @@ export class AttributeBinding implements IAstBasedBinding {
     public targetProperty: string,
     public mode: BindingMode,
   ) {
+    this.l = locator;
+    this.ast = ast;
     this._controller = controller;
     this.target = target as Element;
     this.oL = observerLocator;
@@ -170,4 +179,4 @@ export class AttributeBinding implements IAstBasedBinding {
 mixinBindingUseScope(AttributeBinding);
 mixingBindingLimited(AttributeBinding, () => 'updateTarget');
 connectable(AttributeBinding);
-implementAstEvaluator(true)(AttributeBinding);
+mixinAstEvaluator(true)(AttributeBinding);

--- a/packages/runtime-html/src/binding/call-binding.ts
+++ b/packages/runtime-html/src/binding/call-binding.ts
@@ -1,5 +1,5 @@
 import type { IServiceLocator } from '@aurelia/kernel';
-import { astBind, astEvaluate, astUnbind, IAccessor, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, IAccessor, IBinding, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
 import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 import type { IAstBasedBinding } from './interfaces-bindings';
 
@@ -7,7 +7,7 @@ import type { IAstBasedBinding } from './interfaces-bindings';
  * A binding for handling .call syntax
  */
 export interface CallBinding extends IAstBasedBinding { }
-export class CallBinding implements IAstBasedBinding {
+export class CallBinding implements IBinding {
   public isBound: boolean = false;
   public scope?: Scope;
 
@@ -40,13 +40,13 @@ export class CallBinding implements IAstBasedBinding {
     return result;
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
 
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -56,7 +56,7 @@ export class CallBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/call-binding.ts
+++ b/packages/runtime-html/src/binding/call-binding.ts
@@ -1,6 +1,6 @@
 import type { IServiceLocator } from '@aurelia/kernel';
 import { astBind, astEvaluate, astUnbind, IAccessor, IObserverLocator, IsBindingBehavior, Scope } from '@aurelia/runtime';
-import { implementAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
+import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 import type { IAstBasedBinding } from './interfaces-bindings';
 
 /**
@@ -13,17 +13,21 @@ export class CallBinding implements IAstBasedBinding {
 
   public targetObserver: IAccessor;
 
+  /** @internal */
+  public l: IServiceLocator;
+
   // see Listener binding for explanation
   /** @internal */
   public readonly boundFn = false;
 
   public constructor(
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     public ast: IsBindingBehavior,
     public readonly target: object,
     public readonly targetProperty: string,
   ) {
+    this.l = locator;
     this.targetObserver = observerLocator.getAccessor(target, targetProperty);
   }
 
@@ -67,4 +71,4 @@ export class CallBinding implements IAstBasedBinding {
 
 mixinBindingUseScope(CallBinding);
 mixingBindingLimited(CallBinding, () => 'callSource');
-implementAstEvaluator(true)(CallBinding);
+mixinAstEvaluator(true)(CallBinding);

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -117,12 +117,12 @@ export class InterpolationBinding implements IBinding {
     }
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -130,13 +130,13 @@ export class InterpolationBinding implements IBinding {
     const ii = partBindings.length;
     let i = 0;
     for (; ii > i; ++i) {
-      partBindings[i].$bind(scope);
+      partBindings[i].bind(scope);
     }
     this.updateTarget();
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }
@@ -146,7 +146,7 @@ export class InterpolationBinding implements IBinding {
     const ii = partBindings.length;
     let i = 0;
     for (; ii > i; ++i) {
-      partBindings[i].$unbind();
+      partBindings[i].unbind();
     }
     this.task?.cancel();
     this.task = null;
@@ -157,7 +157,7 @@ export class InterpolationBinding implements IBinding {
 // employed to support full expression per expression part of an interpolation
 export interface InterpolationPartBinding extends IAstBasedBinding {}
 
-export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSubscriber {
+export class InterpolationPartBinding implements IBinding, ICollectionSubscriber {
 
   // at runtime, mode may be overriden by binding behavior
   // but it wouldn't matter here, just start with something for later check
@@ -226,12 +226,12 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
     this.handleChange();
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -250,7 +250,7 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }
@@ -273,7 +273,7 @@ export interface ContentBinding extends IAstBasedBinding {}
 /**
  * A binding for handling the element content interpolation
  */
-export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
+export class ContentBinding implements IBinding, ICollectionSubscriber {
   // at runtime, mode may be overriden by binding behavior
   // but it wouldn't matter here, just start with something for later check
   public readonly mode: BindingMode = BindingMode.toView;
@@ -381,12 +381,12 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
     }
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -406,7 +406,7 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -7,7 +7,7 @@ import {
   connectable
 } from '@aurelia/runtime';
 import { State } from '../templating/controller';
-import { implementAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
+import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 import { BindingMode } from './interfaces-bindings';
 
 import type { IServiceLocator } from '@aurelia/kernel';
@@ -48,12 +48,13 @@ export class InterpolationBinding implements IBinding {
    * A semi-private property used by connectable mixin
    */
   public readonly oL: IObserverLocator;
+
   /** @internal */
   private readonly _controller: IBindingController;
 
   public constructor(
     controller: IBindingController,
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     private readonly taskQueue: TaskQueue,
     public ast: Interpolation,
@@ -151,7 +152,6 @@ export class InterpolationBinding implements IBinding {
     this.task = null;
   }
 }
-implementAstEvaluator(true)(InterpolationBinding);
 
 // a pseudo binding, part of a larger interpolation binding
 // employed to support full expression per expression part of an interpolation
@@ -170,8 +170,13 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
   public _value: unknown = '';
   /**
    * A semi-private property used by connectable mixin
+   *
+   * @internal
    */
   public readonly oL: IObserverLocator;
+
+  /** @internal */
+  public readonly l: IServiceLocator;
   // see Listener binding for explanation
   /** @internal */
   public readonly boundFn = false;
@@ -180,10 +185,11 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
     public readonly ast: IsExpression,
     public readonly target: object,
     public readonly targetProperty: string,
-    public readonly locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     public readonly owner: InterpolationBinding,
   ) {
+    this.l = locator;
     this.oL = observerLocator;
   }
 
@@ -260,7 +266,7 @@ export class InterpolationPartBinding implements IAstBasedBinding, ICollectionSu
 mixinBindingUseScope(InterpolationPartBinding);
 mixingBindingLimited(InterpolationPartBinding, () => 'updateTarget');
 connectable(InterpolationPartBinding);
-implementAstEvaluator(true)(InterpolationPartBinding);
+mixinAstEvaluator(true)(InterpolationPartBinding);
 
 export interface ContentBinding extends IAstBasedBinding {}
 
@@ -277,8 +283,13 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
 
   /**
    * A semi-private property used by connectable mixin
+   *
+   * @internal
    */
   public readonly oL: IObserverLocator;
+
+  /** @internal */
+  public readonly l: IServiceLocator;
 
   /** @internal */
   private _value: unknown = '';
@@ -290,7 +301,7 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
 
   public constructor(
     controller: IBindingController,
-    public readonly locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     private readonly taskQueue: TaskQueue,
     private readonly p: IPlatform,
@@ -298,6 +309,7 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
     public readonly target: Text,
     public readonly strict: boolean,
   ) {
+    this.l = locator;
     this._controller = controller;
     this.oL = observerLocator;
   }
@@ -426,4 +438,4 @@ export class ContentBinding implements IAstBasedBinding, ICollectionSubscriber {
 mixinBindingUseScope(ContentBinding);
 mixingBindingLimited(ContentBinding, () => 'updateTarget');
 connectable()(ContentBinding);
-implementAstEvaluator(void 0, false)(ContentBinding);
+mixinAstEvaluator(void 0, false)(ContentBinding);

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -1,4 +1,4 @@
-import { astBind, astEvaluate, astUnbind, connectable } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, connectable, IBinding } from '@aurelia/runtime';
 import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 
 import type { IIndexable, IServiceLocator } from '@aurelia/kernel';
@@ -11,7 +11,7 @@ import type {
 import type { IAstBasedBinding } from './interfaces-bindings';
 export interface LetBinding extends IAstBasedBinding {}
 
-export class LetBinding implements IAstBasedBinding {
+export class LetBinding implements IBinding {
   public isBound: boolean = false;
   public scope?: Scope = void 0;
 
@@ -68,12 +68,12 @@ export class LetBinding implements IAstBasedBinding {
     this.handleChange();
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
     this.target = (this._toBindingContext ? scope.bindingContext : scope.overrideContext) as IIndexable;
@@ -86,7 +86,7 @@ export class LetBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -1,5 +1,5 @@
 import { astBind, astEvaluate, astUnbind, connectable } from '@aurelia/runtime';
-import { implementAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
+import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 
 import type { IIndexable, IServiceLocator } from '@aurelia/kernel';
 import type {
@@ -27,6 +27,9 @@ export class LetBinding implements IAstBasedBinding {
   public readonly oL: IObserverLocator;
 
   /** @internal */
+  public l: IServiceLocator;
+
+  /** @internal */
   private _value: unknown;
 
   // see Listener binding for explanation
@@ -34,12 +37,13 @@ export class LetBinding implements IAstBasedBinding {
   public readonly boundFn = false;
 
   public constructor(
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     public ast: IsExpression,
     public targetProperty: string,
     toBindingContext: boolean = false,
   ) {
+    this.l = locator;
     this.oL = observerLocator;
     this._toBindingContext = toBindingContext;
   }
@@ -98,6 +102,6 @@ export class LetBinding implements IAstBasedBinding {
 mixinBindingUseScope(LetBinding);
 mixingBindingLimited(LetBinding, () => 'updateTarget');
 connectable(LetBinding);
-implementAstEvaluator(true)(LetBinding);
+mixinAstEvaluator(true)(LetBinding);
 
 let nV: unknown;

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -4,7 +4,7 @@ import { isFunction } from '../utilities';
 import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 
 import type { IDisposable, IServiceLocator } from '@aurelia/kernel';
-import { astBind, astEvaluate, astUnbind, Scope, type IsBindingBehavior } from '@aurelia/runtime';
+import { astBind, astEvaluate, astUnbind, IBinding, Scope, type IsBindingBehavior } from '@aurelia/runtime';
 import { type IEventDelegator } from '../observation/event-delegator';
 import { type IAstBasedBinding } from './interfaces-bindings';
 
@@ -24,7 +24,7 @@ export interface Listener extends IAstBasedBinding {}
 /**
  * Listener binding. Handle event binding between view and view model
  */
-export class Listener implements IAstBasedBinding {
+export class Listener implements IBinding {
   public isBound: boolean = false;
   public scope?: Scope;
 
@@ -78,12 +78,12 @@ export class Listener implements IAstBasedBinding {
     this.callSource(event);
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -104,7 +104,7 @@ export class Listener implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/listener.ts
+++ b/packages/runtime-html/src/binding/listener.ts
@@ -1,7 +1,7 @@
 import { IEventTarget } from '../dom';
 import { DelegationStrategy } from '../renderer';
 import { isFunction } from '../utilities';
-import { implementAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
+import { mixinAstEvaluator, mixinBindingUseScope, mixingBindingLimited } from './binding-utils';
 
 import type { IDisposable, IServiceLocator } from '@aurelia/kernel';
 import { astBind, astEvaluate, astUnbind, Scope, type IsBindingBehavior } from '@aurelia/runtime';
@@ -32,6 +32,9 @@ export class Listener implements IAstBasedBinding {
   /** @internal */
   private readonly _options: ListenerOptions;
 
+  /** @internal */
+  public l: IServiceLocator;
+
   /**
    * Indicates if this binding evaluates an ast and get a function, that function should be bound
    * to the instance it is on
@@ -41,13 +44,14 @@ export class Listener implements IAstBasedBinding {
   public readonly boundFn = true;
 
   public constructor(
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     public ast: IsBindingBehavior,
     public target: Node,
     public targetEvent: string,
     public eventDelegator: IEventDelegator,
     options: ListenerOptions,
   ) {
+    this.l = locator;
     this._options = options;
   }
 
@@ -89,7 +93,7 @@ export class Listener implements IAstBasedBinding {
       this.target.addEventListener(this.targetEvent, this);
     } else {
       this.handler = this.eventDelegator.addEventListener(
-        this.locator.get(IEventTarget),
+        this.l.get(IEventTarget),
         this.target,
         this.targetEvent,
         this,
@@ -120,4 +124,4 @@ export class Listener implements IAstBasedBinding {
 
 mixinBindingUseScope(Listener);
 mixingBindingLimited(Listener, () => 'callSource');
-implementAstEvaluator(true, true)(Listener);
+mixinAstEvaluator(true, true)(Listener);

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -1,4 +1,4 @@
-import { AccessorType, astAssign, astBind, astEvaluate, astUnbind, connectable, ISubscriber } from '@aurelia/runtime';
+import { AccessorType, astAssign, astBind, astEvaluate, astUnbind, connectable, IBinding, ISubscriber } from '@aurelia/runtime';
 import { State } from '../templating/controller';
 import { mixinAstEvaluator, BindingTargetSubscriber, IFlushQueue, mixingBindingLimited, mixinBindingUseScope } from './binding-utils';
 import { BindingMode } from './interfaces-bindings';
@@ -23,7 +23,7 @@ const updateTaskOpts: QueueTaskOptions = {
 
 export interface PropertyBinding extends IAstBasedBinding {}
 
-export class PropertyBinding implements IAstBasedBinding {
+export class PropertyBinding implements IBinding {
   public isBound: boolean = false;
   public scope?: Scope = void 0;
 
@@ -112,12 +112,12 @@ export class PropertyBinding implements IAstBasedBinding {
     this.handleChange();
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -153,7 +153,7 @@ export class PropertyBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -1,6 +1,6 @@
 import { AccessorType, astAssign, astBind, astEvaluate, astUnbind, connectable, ISubscriber } from '@aurelia/runtime';
 import { State } from '../templating/controller';
-import { implementAstEvaluator, BindingTargetSubscriber, IFlushQueue, mixingBindingLimited, mixinBindingUseScope } from './binding-utils';
+import { mixinAstEvaluator, BindingTargetSubscriber, IFlushQueue, mixingBindingLimited, mixinBindingUseScope } from './binding-utils';
 import { BindingMode } from './interfaces-bindings';
 
 import type { IServiceLocator } from '@aurelia/kernel';
@@ -42,6 +42,9 @@ export class PropertyBinding implements IAstBasedBinding {
   public readonly oL: IObserverLocator;
 
   /** @internal */
+  public l: IServiceLocator;
+
+  /** @internal */
   private readonly _controller: IBindingController;
 
   /** @internal */
@@ -53,7 +56,7 @@ export class PropertyBinding implements IAstBasedBinding {
 
   public constructor(
     controller: IBindingController,
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     observerLocator: IObserverLocator,
     taskQueue: TaskQueue,
     public ast: IsBindingBehavior | ForOfStatement,
@@ -61,6 +64,7 @@ export class PropertyBinding implements IAstBasedBinding {
     public targetProperty: string,
     public mode: BindingMode,
   ) {
+    this.l = locator;
     this._controller = controller;
     this._taskQueue = taskQueue;
     this.oL = observerLocator;
@@ -187,6 +191,6 @@ export class PropertyBinding implements IAstBasedBinding {
 mixinBindingUseScope(PropertyBinding);
 mixingBindingLimited(PropertyBinding, (propBinding: PropertyBinding) => (propBinding.mode & BindingMode.fromView) ? 'updateSource' : 'updateTarget');
 connectable(PropertyBinding);
-implementAstEvaluator(true, false)(PropertyBinding);
+mixinAstEvaluator(true, false)(PropertyBinding);
 
 let task: ITask | null = null;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -144,7 +144,7 @@ export class PropertyBinding implements IAstBasedBinding {
     }
 
     if ($mode & BindingMode.fromView) {
-      (targetObserver as IObserver).subscribe(this._targetSubscriber ??= new BindingTargetSubscriber(this, this.locator.get(IFlushQueue)));
+      (targetObserver as IObserver).subscribe(this._targetSubscriber ??= new BindingTargetSubscriber(this, this.l.get(IFlushQueue)));
       if (!shouldConnect) {
         this.updateSource(targetObserver.getValue(this.target, this.targetProperty));
       }

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -1,17 +1,22 @@
 import { astAssign, astBind, astEvaluate, astUnbind, type IsBindingBehavior, type Scope } from '@aurelia/runtime';
 import type { IServiceLocator } from '@aurelia/kernel';
 import type { IAstBasedBinding } from './interfaces-bindings';
+import { mixinAstEvaluator } from './binding-utils';
 
 export interface RefBinding extends IAstBasedBinding {}
 export class RefBinding implements IAstBasedBinding {
+  /** @internal */
+  public l: IServiceLocator;
   public isBound: boolean = false;
   public scope?: Scope = void 0;
 
   public constructor(
-    public locator: IServiceLocator,
+    locator: IServiceLocator,
     public ast: IsBindingBehavior,
     public target: object,
-  ) {}
+  ) {
+    this.l = locator;
+  }
 
   public $bind(scope: Scope): void {
     if (this.isBound) {
@@ -46,3 +51,5 @@ export class RefBinding implements IAstBasedBinding {
     this.scope = void 0;
   }
 }
+
+mixinAstEvaluator(false)(RefBinding);

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -1,10 +1,10 @@
-import { astAssign, astBind, astEvaluate, astUnbind, type IsBindingBehavior, type Scope } from '@aurelia/runtime';
+import { astAssign, astBind, astEvaluate, astUnbind, IBinding, type IsBindingBehavior, type Scope } from '@aurelia/runtime';
 import type { IServiceLocator } from '@aurelia/kernel';
 import type { IAstBasedBinding } from './interfaces-bindings';
 import { mixinAstEvaluator } from './binding-utils';
 
 export interface RefBinding extends IAstBasedBinding {}
-export class RefBinding implements IAstBasedBinding {
+export class RefBinding implements IBinding {
   /** @internal */
   public l: IServiceLocator;
   public isBound: boolean = false;
@@ -18,13 +18,13 @@ export class RefBinding implements IAstBasedBinding {
     this.l = locator;
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       if (this.scope === scope) {
         return;
       }
 
-      this.$unbind();
+      this.unbind();
     }
     this.scope = scope;
 
@@ -36,7 +36,7 @@ export class RefBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -115,7 +115,7 @@ export {
   FlushQueue,
   IFlushable,
   BindingTargetSubscriber,
-  implementAstEvaluator,
+  mixinAstEvaluator,
   mixingBindingLimited,
   mixinBindingUseScope as mixinUseScope,
 } from './binding/binding-utils';
@@ -223,7 +223,6 @@ export {
 } from './resources/binding-behaviors/self';
 export {
   UpdateTriggerBindingBehavior,
-  type UpdateTriggerableBinding,
   type UpdateTriggerableObserver,
 } from './resources/binding-behaviors/update-trigger';
 

--- a/packages/runtime-html/src/observation/bindable-observer.ts
+++ b/packages/runtime-html/src/observation/bindable-observer.ts
@@ -1,6 +1,6 @@
 import { noop } from '@aurelia/kernel';
 import { subscriberCollection, AccessorType, ICoercionConfiguration } from '@aurelia/runtime';
-import { isFunction } from '../utilities';
+import { areEqual, isFunction } from '../utilities';
 
 import type { IIndexable } from '@aurelia/kernel';
 import type {
@@ -71,8 +71,8 @@ export class BindableObserver {
 
     this._obj = obj;
     this._key = key;
-    this.cb = hasCb ? cb : noop;
     this._cbAll = hasCbAll ? cbAll : noop;
+    this.cb = hasCb ? cb : noop;
     // when user declare @bindable({ set })
     // it's expected to work from the start,
     // regardless where the assignment comes from: either direct view model assignment or from binding during render
@@ -99,7 +99,7 @@ export class BindableObserver {
 
     const currentValue = this._value;
     if (this._observing) {
-      if (Object.is(newValue, currentValue)) {
+      if (areEqual(newValue, currentValue)) {
         return;
       }
       this._value = newValue;

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1212,7 +1212,7 @@ class SpreadBinding implements IBinding {
     return this.locator.get(key);
   }
 
-  public $bind(_scope: Scope): void {
+  public bind(_scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -1222,11 +1222,11 @@ class SpreadBinding implements IBinding {
       throw createError('Invalid spreading. Context scope is null/undefined');
     }
 
-    this._innerBindings.forEach(b => b.$bind(innerScope));
+    this._innerBindings.forEach(b => b.bind(innerScope));
   }
 
-  public $unbind(): void {
-    this._innerBindings.forEach(b => b.$unbind());
+  public unbind(): void {
+    this._innerBindings.forEach(b => b.unbind());
     this.isBound = false;
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/with.ts
+++ b/packages/runtime-html/src/resources/template-controllers/with.ts
@@ -33,7 +33,7 @@ export class With implements ICustomAttributeViewModel {
     if ($controller.isActive && bindings != null) {
       scope = Scope.fromParent($controller.scope, newValue === void 0 ? {} : newValue as object);
       for (ii = bindings.length; ii > i; ++i) {
-        bindings[i].$bind(scope);
+        bindings[i].bind(scope);
       }
     }
   }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -56,8 +56,8 @@ type BindingContext<C extends IViewModel> = Required<ICompileHooks> & Required<I
 
 export const enum LifecycleFlags {
   none                          = 0b0_00_00,
-  // Bitmask for flags that need to be stored on a binding during $bind for mutation
-  // callbacks outside of $bind
+  // Bitmask for flags that need to be stored on a binding during bind for mutation
+  // callbacks outside of bind
   fromBind                      = 0b0_00_01,
   fromUnbind                    = 0b0_00_10,
   dispose                       = 0b0_01_00,
@@ -634,7 +634,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     let ii = this._childrenObs.length;
     let ret: void | Promise<void>;
     // timing: after binding, before bound
-    // reason: needs to start observing before all the bindings finish their $bind phase,
+    // reason: needs to start observing before all the bindings finish their bind phase,
     //         so that changes in one binding can be reflected into the other, regardless the index of the binding
     //
     // todo: is this timing appropriate?
@@ -649,7 +649,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       i = 0;
       ii = this.bindings.length;
       while (ii > i) {
-        this.bindings[i].$bind(this.scope!);
+        this.bindings[i].bind(this.scope!);
         ++i;
       }
     }
@@ -898,7 +898,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     if (this.bindings !== null) {
       for (; i < this.bindings.length; ++i) {
-        this.bindings[i].$unbind();
+        this.bindings[i].unbind();
       }
     }
 

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -60,7 +60,7 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
     this.run();
   }
 
-  public $bind(): void {
+  public bind(): void {
     if (this.isBound) {
       return;
     }
@@ -68,7 +68,7 @@ export class ComputedWatcher implements IConnectableBinding, ISubscriber, IColle
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }
@@ -146,7 +146,7 @@ export class ExpressionWatcher implements IConnectableBinding {
     }
   }
 
-  public $bind(): void {
+  public bind(): void {
     if (this.isBound) {
       return;
     }
@@ -156,7 +156,7 @@ export class ExpressionWatcher implements IConnectableBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -5,7 +5,7 @@ import {
   ExpressionKind,
   ProxyObservable,
 } from '@aurelia/runtime';
-import { implementAstEvaluator } from '../binding/binding-utils';
+import { mixinAstEvaluator } from '../binding/binding-utils';
 
 import type { IServiceLocator } from '@aurelia/kernel';
 import type {
@@ -121,7 +121,7 @@ export class ExpressionWatcher implements IConnectableBinding {
 
   public constructor(
     public scope: Scope,
-    public locator: IServiceLocator,
+    public l: IServiceLocator,
     public oL: IObserverLocator,
     private readonly expression: IsBindingBehavior,
     private readonly callback: IWatcherCallback<object>,
@@ -167,7 +167,6 @@ export class ExpressionWatcher implements IConnectableBinding {
 }
 
 connectable(ComputedWatcher);
-implementAstEvaluator(true)(ComputedWatcher);
 
 connectable(ExpressionWatcher);
-implementAstEvaluator(true)(ExpressionWatcher);
+mixinAstEvaluator(true)(ExpressionWatcher);

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -33,6 +33,7 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
 /** @internal */ export const defineProp = Object.defineProperty;
 /** @internal */ export const rethrow = (err: unknown) => { throw err; };
+/** @internal */ export const areEqual = Object.is;
 
 /** @internal */
 export const def = Reflect.defineProperty;

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -6,7 +6,6 @@ import type { CollectionLengthObserver, CollectionSizeObserver } from './observa
 import { TaskQueue } from '@aurelia/platform';
 
 export interface IBinding {
-  readonly locator: IServiceLocator;
   readonly scope?: Scope;
   readonly isBound: boolean;
   $bind(scope: Scope): void;

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -8,8 +8,8 @@ import { TaskQueue } from '@aurelia/platform';
 export interface IBinding {
   readonly scope?: Scope;
   readonly isBound: boolean;
-  $bind(scope: Scope): void;
-  $unbind(): void;
+  bind(scope: Scope): void;
+  unbind(): void;
   get: IServiceLocator['get'];
   useScope(scope: Scope): void;
   limit(opts: IRateLimitOptions): IDisposable;

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -6,7 +6,7 @@ import { subscriberCollection } from './subscriber-collection';
 import { enterConnectable, exitConnectable } from './connectable-switcher';
 import { connectable } from '../binding/connectable';
 import { wrap, unwrap } from './proxy-observation';
-import { createError, def, isFunction } from '../utilities-objects';
+import { areEqual, createError, def, isFunction } from '../utilities-objects';
 
 import type {
   ISubscriber,
@@ -169,7 +169,7 @@ export class ComputedObserver implements
 
     this._isDirty = false;
 
-    if (!Object.is(newValue, oldValue)) {
+    if (!areEqual(newValue, oldValue)) {
       this._oldValue = oldValue;
       oV = this._oldValue;
       this._oldValue = this._value;

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -1,6 +1,6 @@
 import { AccessorType } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
-import { def, isFunction } from '../utilities-objects';
+import { areEqual, def, isFunction } from '../utilities-objects';
 
 import type { IIndexable } from '@aurelia/kernel';
 import type {
@@ -42,7 +42,7 @@ export class SetterObserver implements IAccessor, ISubscriberCollection {
 
   public setValue(newValue: unknown): void {
     if (this._observing) {
-      if (Object.is(newValue, this._value)) {
+      if (areEqual(newValue, this._value)) {
         return;
       }
       oV = this._value;
@@ -144,7 +144,7 @@ export class SetterNotifier implements IAccessor {
     if (this._hasSetter) {
       value = this._setter!(value, null);
     }
-    if (!Object.is(value, this._value)) {
+    if (!areEqual(value, this._value)) {
       this._oldValue = this._value;
       this._value = value;
       this.cb?.call(this._obj, this._value, this._oldValue);

--- a/packages/runtime/src/observation/setter-observer.ts
+++ b/packages/runtime/src/observation/setter-observer.ts
@@ -53,8 +53,8 @@ export class SetterObserver implements IAccessor, ISubscriberCollection {
       // so calling obj[propertyKey] will actually return this.value.
       // However, if subscribe() was not yet called (indicated by !this.observing), the target descriptor
       // is unmodified and we need to explicitly set the property value.
-      // This will happen in one-time, to-view and two-way bindings during $bind, meaning that the $bind will not actually update the target value.
-      // This wasn't visible in vCurrent due to connect-queue always doing a delayed update, so in many cases it didn't matter whether $bind updated the target or not.
+      // This will happen in one-time, to-view and two-way bindings during bind, meaning that the bind will not actually update the target value.
+      // This wasn't visible in vCurrent due to connect-queue always doing a delayed update, so in many cases it didn't matter whether bind updated the target or not.
       this._obj[this._key] = newValue;
     }
   }

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -26,6 +26,9 @@ export const isString = (v: unknown): v is string => typeof v === 'string';
 export const isArray = <T>(v: unknown): v is T[] => v instanceof Array;
 
 /** @internal */
+export const areEqual = Object.is;
+
+/** @internal */
 export function defineHiddenProp<T>(obj: object, key: PropertyKey, value: T): T {
   def(obj, key, {
     enumerable: false,

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -9,7 +9,7 @@ import {
   type IAccessor,
   type IObserverLocator, type IOverrideContext, type IsBindingBehavior
 } from '@aurelia/runtime';
-import { BindingMode, type IBindingController, type IAstBasedBinding, State, implementAstEvaluator, mixingBindingLimited } from '@aurelia/runtime-html';
+import { BindingMode, type IBindingController, type IAstBasedBinding, State, mixinAstEvaluator, mixingBindingLimited } from '@aurelia/runtime-html';
 import {
   IStore,
   type IStoreSubscriber
@@ -21,8 +21,11 @@ import { createStateBindingScope } from './state-utilities';
  */
 export interface StateBinding extends IAstBasedBinding { }
 export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> {
+  /** @internal */
   public readonly oL: IObserverLocator;
-  public locator: IServiceLocator;
+  /** @internal */
+  public l: IServiceLocator;
+
   public scope?: Scope | undefined;
   public isBound: boolean = false;
   public ast: IsBindingBehavior;
@@ -55,7 +58,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     store: IStore<object>,
   ) {
     this._controller = controller;
-    this.locator = locator;
+    this.l = locator;
     this._taskQueue = taskQueue;
     this._store = store;
     this.oL = observerLocator;
@@ -216,5 +219,5 @@ const updateTaskOpts: QueueTaskOptions = {
 };
 
 connectable(StateBinding);
-implementAstEvaluator(true)(StateBinding);
+mixinAstEvaluator(true)(StateBinding);
 mixingBindingLimited(StateBinding, () => 'updateTarget');

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -5,6 +5,7 @@ import {
   AccessorType,
   astEvaluate,
   connectable,
+  IBinding,
   Scope,
   type IAccessor,
   type IObserverLocator, type IOverrideContext, type IsBindingBehavior
@@ -20,7 +21,7 @@ import { createStateBindingScope } from './state-utilities';
  * A binding that handles the connection of the global state to a property of a target object
  */
 export interface StateBinding extends IAstBasedBinding { }
-export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> {
+export class StateBinding implements IBinding, IStoreSubscriber<object> {
   /** @internal */
   public readonly oL: IObserverLocator;
   /** @internal */
@@ -96,7 +97,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     targetAccessor.setValue(value, target, prop);
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -111,7 +112,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -29,7 +29,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
   private readonly target: object;
   private readonly targetProperty: PropertyKey;
   private task: ITask | null = null;
-  private readonly taskQueue: TaskQueue;
+  /** @internal */ private readonly _taskQueue: TaskQueue;
 
   /** @internal */ private readonly _store: IStore<object>;
   /** @internal */ private targetObserver!: IAccessor;
@@ -56,7 +56,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
   ) {
     this._controller = controller;
     this.locator = locator;
-    this.taskQueue = taskQueue;
+    this._taskQueue = taskQueue;
     this._store = store;
     this.oL = observerLocator;
     this.ast = ast;
@@ -141,7 +141,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     if (shouldQueueFlush) {
       // Queue the new one before canceling the old one, to prevent early yield
       task = this.task;
-      this.task = this.taskQueue.queueTask(() => {
+      this.task = this._taskQueue.queueTask(() => {
         this.updateTarget(newValue);
         this.task = null;
       }, updateTaskOpts);
@@ -176,7 +176,7 @@ export class StateBinding implements IAstBasedBinding, IStoreSubscriber<object> 
     if (shouldQueueFlush) {
       // Queue the new one before canceling the old one, to prevent early yield
       task = this.task;
-      this.task = this.taskQueue.queueTask(() => {
+      this.task = this._taskQueue.queueTask(() => {
         this.updateTarget(value);
         this.task = null;
       }, updateTaskOpts);

--- a/packages/state/src/state-decorator.ts
+++ b/packages/state/src/state-decorator.ts
@@ -60,7 +60,6 @@ class HydratingLifecycleHooks {
   public hydrating(vm: object, controller: IHydratedComponentController) {
     const container = controller.container;
     controller.addBinding(new StateGetterBinding(
-      container,
       vm,
       this.key,
       container.get(IStore),
@@ -83,7 +82,6 @@ class CreatedLifecycleHooks {
   public created(vm: object, controller: IHydratedComponentController) {
     const container = controller.container;
     controller.addBinding(new StateGetterBinding(
-      container,
       vm,
       this.key,
       container.get(IStore),

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -9,7 +9,7 @@ import {
   astBind,
   astUnbind
 } from '@aurelia/runtime';
-import { implementAstEvaluator, mixingBindingLimited, type IAstBasedBinding } from '@aurelia/runtime-html';
+import { mixinAstEvaluator, mixingBindingLimited, type IAstBasedBinding } from '@aurelia/runtime-html';
 import {
   IAction,
   type IStore
@@ -21,10 +21,13 @@ import { createStateBindingScope } from './state-utilities';
  */
 export interface StateDispatchBinding extends IAstBasedBinding { }
 export class StateDispatchBinding implements IAstBasedBinding {
-  public locator: IServiceLocator;
+  /** @internal */
+  public readonly l: IServiceLocator;
+
   public scope?: Scope | undefined;
   public isBound: boolean = false;
   public ast: IsBindingBehavior;
+
   private readonly target: HTMLElement;
   private readonly targetProperty: string;
 
@@ -40,7 +43,7 @@ export class StateDispatchBinding implements IAstBasedBinding {
     prop: string,
     store: IStore<object>,
   ) {
-    this.locator = locator;
+    this.l = locator;
     this._store = store;
     this.ast = expr;
     this.target = target;
@@ -100,5 +103,5 @@ export class StateDispatchBinding implements IAstBasedBinding {
 }
 
 connectable(StateDispatchBinding);
-implementAstEvaluator(true)(StateDispatchBinding);
+mixinAstEvaluator(true)(StateDispatchBinding);
 mixingBindingLimited(StateDispatchBinding, () => 'callSource');

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -7,7 +7,8 @@ import {
   connectable,
   astEvaluate,
   astBind,
-  astUnbind
+  astUnbind,
+  IBinding
 } from '@aurelia/runtime';
 import { mixinAstEvaluator, mixingBindingLimited, type IAstBasedBinding } from '@aurelia/runtime-html';
 import {
@@ -20,7 +21,7 @@ import { createStateBindingScope } from './state-utilities';
  * A binding that handles the connection of the global state to a property of a target object
  */
 export interface StateDispatchBinding extends IAstBasedBinding { }
-export class StateDispatchBinding implements IAstBasedBinding {
+export class StateDispatchBinding implements IBinding {
   /** @internal */
   public readonly l: IServiceLocator;
 
@@ -65,7 +66,7 @@ export class StateDispatchBinding implements IAstBasedBinding {
     this.callSource(e);
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -76,7 +77,7 @@ export class StateDispatchBinding implements IAstBasedBinding {
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -70,7 +70,7 @@ export class StateGetterBinding implements IConnectableBinding, IStoreSubscriber
     target[prop] = value;
   }
 
-  public $bind(scope: Scope): void {
+  public bind(scope: Scope): void {
     if (this.isBound) {
       return;
     }
@@ -81,7 +81,7 @@ export class StateGetterBinding implements IConnectableBinding, IStoreSubscriber
     this.isBound = true;
   }
 
-  public $unbind(): void {
+  public unbind(): void {
     if (!this.isBound) {
       return;
     }

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -1,5 +1,5 @@
 
-import { IDisposable, IIndexable, type IServiceLocator, type Writable } from '@aurelia/kernel';
+import { IDisposable, IIndexable, type Writable } from '@aurelia/kernel';
 import {
   connectable,
   Scope,
@@ -19,7 +19,6 @@ import { createStateBindingScope, isSubscribable } from './state-utilities';
 export interface StateGetterBinding extends IConnectableBinding { }
 @connectable()
 export class StateGetterBinding implements IConnectableBinding, IStoreSubscriber<object> {
-  public locator: IServiceLocator;
   public scope?: Scope | undefined;
   public isBound: boolean = false;
   private readonly $get: (s: unknown) => unknown;
@@ -32,13 +31,11 @@ export class StateGetterBinding implements IConnectableBinding, IStoreSubscriber
   /** @internal */ private _updateCount = 0;
 
   public constructor(
-    locator: IServiceLocator,
     target: object,
     prop: PropertyKey,
     store: IStore<object>,
     getValue: (s: unknown) => unknown,
   ) {
-    this.locator = locator;
     this._store = store;
     this.$get = getValue;
     this.target = target as IIndexable;

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -108,7 +108,7 @@ export class StateBindingInstructionRenderer implements IRenderer {
     target: object,
     instruction: StateBindingInstruction,
   ): void {
-    const binding = new StateBinding(
+    renderingCtrl.addBinding(new StateBinding(
       renderingCtrl,
       renderingCtrl.container,
       this._observerLocator,
@@ -117,8 +117,7 @@ export class StateBindingInstructionRenderer implements IRenderer {
       target,
       instruction.to,
       this._stateContainer,
-    );
-    renderingCtrl.addBinding(binding);
+    ));
   }
 }
 

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -77,12 +77,12 @@ export class MockBinding implements IConnectableBinding {
     this.trace('subscribeTo', subscribable);
   }
 
-  public $bind(scope: Scope): void {
-    this.trace('$bind', scope);
+  public bind(scope: Scope): void {
+    this.trace('bind', scope);
   }
 
-  public $unbind(): void {
-    this.trace('$unbind');
+  public unbind(): void {
+    this.trace('unbind');
   }
 
   public trace(fnName: keyof MockBinding, ...args: any[]): void {

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -36,7 +36,7 @@ export class MockBinding implements IConnectableBinding {
   public observerSlots!: number;
   public version!: number;
   public oL!: IObserverLocator;
-  public locator!: IServiceLocator;
+  public l!: IServiceLocator;
   public scope?: Scope | undefined;
   public isBound!: boolean;
   public value: unknown;

--- a/packages/testing/src/test-builder.ts
+++ b/packages/testing/src/test-builder.ts
@@ -376,7 +376,7 @@ import { createContainer } from './test-context';
 
 //   public bind(flags?: LF): void {
 //     flags = arguments.length === 1 ? flags : LF.fromAppTask | LF.fromBind;
-//     this.component.$bind(flags!);
+//     this.component.bind(flags!);
 //   }
 
 //   public attach(flags?: LF): void {
@@ -391,7 +391,7 @@ import { createContainer } from './test-context';
 
 //   public unbind(flags?: LF): void {
 //     flags = arguments.length === 1 ? flags : LF.fromStopTask | LF.fromUnbind;
-//     this.component.$unbind(flags!);
+//     this.component.unbind(flags!);
 //   }
 
 //   public start(): void {

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer, IServiceLocator, Writable } from '@aurelia/kernel';
+import { DI, IContainer, IServiceLocator } from '@aurelia/kernel';
 import { ITask } from '@aurelia/platform';
 import {
   astEvaluate,
@@ -10,8 +10,9 @@ import {
   IConnectable, IObserverLocator, Scope
 } from '@aurelia/runtime';
 import {
-  bindingBehavior, IAstBasedBinding,
-  IFlushQueue, mixinAstEvaluator, IPlatform, PropertyBinding, type ICustomElementViewModel, BindingTargetSubscriber } from '@aurelia/runtime-html';
+  bindingBehavior, BindingTargetSubscriber, IAstBasedBinding,
+  IFlushQueue, IPlatform, mixinAstEvaluator, PropertyBinding, type ICustomElementViewModel
+} from '@aurelia/runtime-html';
 import { PropertyRule } from '@aurelia/validation';
 import { BindingInfo, BindingWithBehavior, IValidationController, ValidationController, ValidationEvent, ValidationResultsSubscriber } from './validation-controller';
 
@@ -128,6 +129,7 @@ class ValidatitionConnector implements ValidationResultsSubscriber {
   private validatedOnce: boolean = false;
   private triggerEvent: 'blur' | 'focusout' | null = null;
   private bindingInfo!: BindingInfo;
+  /** @internal */ public readonly l: IServiceLocator;
   /** @internal */ private readonly _platform: IPlatform;
   /** @internal */ private readonly _triggerMediator: BindingMediator<'handleTriggerChange'>;
   /** @internal */ private readonly _controllerMediator: BindingMediator<'handleControllerChange'>;
@@ -145,7 +147,7 @@ class ValidatitionConnector implements ValidationResultsSubscriber {
     this.defaultTrigger = defaultTrigger;
     this._platform = platform;
     this.oL = observerLocator;
-    (this as Writable<typeof this>).locator = locator;
+    this.l = locator;
     this._triggerMediator = new BindingMediator('handleTriggerChange', this, observerLocator, locator);
     this._controllerMediator = new BindingMediator('handleControllerChange', this, observerLocator, locator);
     this._rulesMediator = new BindingMediator('handleRulesChange', this, observerLocator, locator);
@@ -393,7 +395,7 @@ export class BindingMediator<K extends string> {
     public readonly key: K,
     public readonly binding: MediatedBinding<K>,
     public oL: IObserverLocator,
-    public locator: IServiceLocator,
+    public readonly l: IServiceLocator,
   ) {
   }
 

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -11,7 +11,7 @@ import {
 } from '@aurelia/runtime';
 import {
   bindingBehavior, IAstBasedBinding,
-  IFlushQueue, implementAstEvaluator, IPlatform, PropertyBinding, type ICustomElementViewModel, BindingTargetSubscriber } from '@aurelia/runtime-html';
+  IFlushQueue, mixinAstEvaluator, IPlatform, PropertyBinding, type ICustomElementViewModel, BindingTargetSubscriber } from '@aurelia/runtime-html';
 import { PropertyRule } from '@aurelia/validation';
 import { BindingInfo, BindingWithBehavior, IValidationController, ValidationController, ValidationEvent, ValidationResultsSubscriber } from './validation-controller';
 
@@ -357,7 +357,7 @@ class ValidatitionConnector implements ValidationResultsSubscriber {
 }
 
 connectable()(ValidatitionConnector);
-implementAstEvaluator(true)(ValidatitionConnector);
+mixinAstEvaluator(true)(ValidatitionConnector);
 
 class WithValidationTargetSubscriber extends BindingTargetSubscriber {
   public constructor(
@@ -403,4 +403,4 @@ export class BindingMediator<K extends string> {
 }
 
 connectable()(BindingMediator);
-implementAstEvaluator(true)(BindingMediator);
+mixinAstEvaluator(true)(BindingMediator);

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -116,14 +116,19 @@ export interface PropertyRule extends IAstEvaluator {}
 export class PropertyRule<TObject extends IValidateable = IValidateable, TValue = unknown> implements IPropertyRule {
   public static readonly $TYPE: string = 'PropertyRule';
   private latestRule?: IValidationRule;
+  /** @internal */
+  public readonly l: IServiceLocator;
 
   public constructor(
-    private readonly locator: IServiceLocator,
+    locator: IServiceLocator,
     public readonly validationRules: IValidationRules,
     public readonly messageProvider: IValidationMessageProvider,
     public property: RuleProperty,
     public $rules: IValidationRule[][] = [[]],
-  ) { }
+  ) {
+    this.l = locator;
+  }
+
   public accept(visitor: IValidationVisitor): string {
     return visitor.visitPropertyRule(this);
   }

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -13,7 +13,7 @@ import {
   astEvaluate,
 } from '@aurelia/runtime';
 import {
-  implementAstEvaluator,
+  mixinAstEvaluator,
   LifecycleFlags,
 } from '@aurelia/runtime-html';
 import {
@@ -423,7 +423,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
   }
   // #endregion
 }
-implementAstEvaluator()(PropertyRule);
+mixinAstEvaluator()(PropertyRule);
 
 export class ModelBasedRule {
   public constructor(

--- a/packages/validation/src/serialization.ts
+++ b/packages/validation/src/serialization.ts
@@ -1,6 +1,6 @@
 import { IContainer, IServiceLocator } from '@aurelia/kernel';
 import { IExpressionParser, ExpressionType, Scope, IAstEvaluator, astEvaluate } from '@aurelia/runtime';
-import { implementAstEvaluator } from '@aurelia/runtime-html';
+import { mixinAstEvaluator } from '@aurelia/runtime-html';
 import { Deserializer, serializePrimitive, Serializer } from './ast-serialization';
 import {
   IPropertyRule,
@@ -316,4 +316,4 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
   }
 }
 
-implementAstEvaluator()(ModelValidationExpressionHydrator);
+mixinAstEvaluator()(ModelValidationExpressionHydrator);

--- a/packages/validation/src/serialization.ts
+++ b/packages/validation/src/serialization.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { IContainer, IServiceLocator } from '@aurelia/kernel';
 import { IExpressionParser, ExpressionType, Scope, IAstEvaluator, astEvaluate } from '@aurelia/runtime';
 import { mixinAstEvaluator } from '@aurelia/runtime-html';
@@ -98,6 +99,7 @@ export class ValidationDeserializer implements IValidationExpressionHydrator {
   ) { }
 
   public hydrate(raw: any, validationRules: IValidationRules): any {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     switch (raw.$TYPE) {
       case RequiredRule.$TYPE: {
         const $raw: Pick<RequiredRule, 'messageKey' | 'tag'> = raw;
@@ -192,7 +194,8 @@ export interface ModelValidationExpressionHydrator extends IAstEvaluator {}
 export class ModelValidationExpressionHydrator implements IValidationExpressionHydrator {
   public readonly astDeserializer: Deserializer = new Deserializer();
   public constructor(
-    @IServiceLocator private readonly locator: IServiceLocator,
+    /** @internal */
+    @IServiceLocator public readonly l: IServiceLocator,
     @IValidationMessageProvider public readonly messageProvider: IValidationMessageProvider,
     @IExpressionParser public readonly parser: IExpressionParser
   ) { }
@@ -210,7 +213,7 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
           const rules: IValidationRule[][] = value.rules.map((rule) => Object.entries(rule).map(([ruleName, ruleConfig]) => this.hydrateRule(ruleName, ruleConfig)));
           const propertyPrefix = propertyPath.join('.');
           const property = this.hydrateRuleProperty({ name: propertyPrefix !== '' ? `${propertyPrefix}.${key}` : key, displayName: value.displayName });
-          accRules.push(new PropertyRule(this.locator, validationRules, this.messageProvider, property, rules));
+          accRules.push(new PropertyRule(this.l, validationRules, this.messageProvider, property, rules));
         } else {
           iterate(Object.entries(value), [...propertyPath, key]);
         }
@@ -252,6 +255,7 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
     }
     rule.tag = raw.tag;
     const when = raw.when;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (when) {
       if (typeof when === 'string') {
         const parsed = this.parser.parse(when, ExpressionType.None);
@@ -308,6 +312,7 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
 
   private hydrateRuleProperty(raw: Pick<RuleProperty, 'expression' | 'name' | 'displayName'>) {
     const rawName = raw.name;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!rawName || typeof rawName !== 'string') {
       throw new Error('The property name needs to be a non-empty string'); // TODO: use reporter
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

- binding methods `$bind` and `$unbind` renamed -> `bind` + `unbind`.
- hmr code to be cleaner & self contained.
- more size optimization with semi private properties on bindings
