### PR TITLE
refactor(router-lite): same URL handling

### DIFF
--- a/packages/router-lite/src/index.ts
+++ b/packages/router-lite/src/index.ts
@@ -84,7 +84,6 @@ export {
   Transition,
   type ResolutionMode,
   type HistoryStrategy,
-  type SameUrlStrategy,
 } from './router';
 
 export {

--- a/packages/router-lite/src/route.ts
+++ b/packages/router-lite/src/route.ts
@@ -206,6 +206,11 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
       config.nav ?? this.nav,
     );
   }
+
+  public getTransitionPlan(cur: RouteNode, next: RouteNode) {
+    const plan = this.transitionPlan;
+    return typeof plan === 'function' ? plan(cur, next) : plan;
+  }
 }
 
 export const Route = {

--- a/packages/router-lite/src/route.ts
+++ b/packages/router-lite/src/route.ts
@@ -91,7 +91,7 @@ export interface IRedirectRouteConfig extends Pick<IRouteConfig, 'caseSensitive'
 
 export type TransitionPlan = 'none' | 'replace' | 'invoke-lifecycles';
 export type TransitionPlanOrFunc = TransitionPlan | ((current: RouteNode, next: RouteNode) => TransitionPlan);
-export function defaultReentryBehavior(current: RouteNode, next: RouteNode): TransitionPlan {
+function defaultReentryBehavior(current: RouteNode, next: RouteNode): TransitionPlan {
   if (!shallowEquals(current.params, next.params)) {
     return 'replace';
   }

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -291,7 +291,7 @@ export class Router {
   }
 
   private _currentTr: Transition | null = null;
-  private get currentTr(): Transition {
+  public get currentTr(): Transition {
     let currentTr = this._currentTr;
     if (currentTr === null) {
       currentTr = this._currentTr = Transition.create({

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -682,7 +682,8 @@ export class Router {
       || trChildren.length !== nodeChildren.length
       || trChildren.some((x, i) => !(nodeChildren[i]?.originalInstruction!.equals(x) ?? false));
 
-    if (!routeChanged) {
+    const shouldProcess = routeChanged || this.ctx.definition.config.getTransitionPlan(tr.previousRouteTree.root, tr.routeTree.root) === 'replace';
+    if (!shouldProcess) {
       this.logger.trace(`run(tr:%s) - NOT processing route`, tr);
 
       this.navigated = true;

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -633,12 +633,7 @@ export class ViewportAgent {
       this.$plan = 'replace';
     } else {
       // Component is the same, so determine plan based on config and/or convention
-      const plan = next.context.definition.config.transitionPlan;
-      if (typeof plan === 'function') {
-        this.$plan = plan(cur, next);
-      } else {
-        this.$plan = plan;
-      }
+      this.$plan = next.context.definition.config.getTransitionPlan(cur, next);
     }
 
     this.logger.trace(`scheduleUpdate(next:%s) - plan set to '%s'`, next, this.$plan);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR drops the `sameUrlStrategy` router-configuration option in favour of consolidating the behaviour to the `transitionPlan` route-configuration option. This also enables the inheritance of the `transitionPlan` from the parent configuration. See the tests for example usage.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
