### PR TITLE
perf: render location creation to compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,13 +860,13 @@ workflows:
       - tacho_benchmark:
           <<: *filter_ignore_develop_release
           name: benchmark_startup
-          command: npm run bench:startup1k
+          command: npm run bench:startup10k
           requires:
             - tacho_benchmark_prep
       - tacho_benchmark:
           <<: *filter_ignore_develop_release
           name: benchmark_rerender
-          command: npm run bench:rerender1k
+          command: npm run bench:rerender10k
           requires:
             - tacho_benchmark_prep
       - tacho_benchmark:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,72 +29,70 @@ jobs:
         with:
           initialize: true
 
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - name: Cache node modules
-  #       id: cache-npm
-  #       uses: actions/cache@v3
-  #       with:
-  #         # npm cache files are stored in `~/.npm` on Linux/macOS
-  #         path: node_modules
-  #         key: ${{ runner.os }}-build-deps-${{ hashFiles('**/package-lock.json') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-build-deps-
+      - name: Cache node modules
+        id: cache_npm
+        uses: actions/cache@v3
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: node_modules
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
 
-  #     - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-  #       name: Missing deps, reinstalling the state of node modules
-  #       run: npm install
+      - if: ${{ steps.cache_npm.outputs.cache-hit != 'true' }}
+        name: installing deps
+        run: npm install
 
-  #     - name: Build
-  #       run: npm build
-
-  #     - name: Cache build output
-  #       id: cache-build
-  #       uses: actions/cache@v3
-  #       with:
-  #         key: ${{ runner.os }}-build-dist-${{ github.sha }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-build-dist-
-  #         path: |
-  #           packages/__tests__/dist
-  #           packages/aurelia/dist
-  #           packages/compat-v1/dist
-  #           packages/addons/dist
-  #           packages/fetch-client/dist
-  #           packages/i18n/dist
-  #           packages/kernel/dist
-  #           packages/metadata/dist
-  #           packages/platform/dist
-  #           packages/platform-browser/dist
-  #           packages/route-recognizer/dist
-  #           packages/router/dist
-  #           packages/router-lite/dist
-  #           packages/runtime/dist
-  #           packages/runtime-html/dist
-  #           packages/state/dist
-  #           packages/store-v1/dist
-  #           packages/testing/dist
-  #           packages/ui-virtualization/dist
-  #           packages/validation/dist
-  #           packages/validation-html/dist
-  #           packages/validation-i18n/dist
-  #           packages-tooling/__tests__/dist
-  #           packages-tooling/aot/dist
-  #           packages-tooling/au/dist
-  #           packages-tooling/babel-jest/dist
-  #           packages-tooling/http-server/dist
-  #           packages-tooling/parcel-transformer/dist
-  #           packages-tooling/plugin-conventions/dist
-  #           packages-tooling/plugin-gulp/dist
-  #           packages-tooling/ts-jest/dist
-  #           packages-tooling/webpack-loader/dist
+      - name: Cache build output
+        id: cache_build
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-build-dist-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-build-dist-
+          path: |
+            packages/__tests__/dist
+            packages/addons/dist
+            packages/aurelia/dist
+            packages/compat-v1/dist
+            packages/dialog/dist
+            packages/fetch-client/dist
+            packages/i18n/dist
+            packages/kernel/dist
+            packages/metadata/dist
+            packages/platform/dist
+            packages/platform-browser/dist
+            packages/route-recognizer/dist
+            packages/router/dist
+            packages/router-lite/dist
+            packages/runtime/dist
+            packages/runtime-html/dist
+            packages/state/dist
+            packages/store-v1/dist
+            packages/testing/dist
+            packages/ui-virtualization/dist
+            packages/validation/dist
+            packages/validation-html/dist
+            packages/validation-i18n/dist
+            packages/web-components/dist
+            packages-tooling/__tests__/dist
+            packages-tooling/aot/dist
+            packages-tooling/au/dist
+            packages-tooling/babel-jest/dist
+            packages-tooling/http-server/dist
+            packages-tooling/parcel-transformer/dist
+            packages-tooling/plugin-conventions/dist
+            packages-tooling/plugin-gulp/dist
+            packages-tooling/ts-jest/dist
+            packages-tooling/webpack-loader/dist
 
   bench_startup:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/benchmarks/app.js
+++ b/benchmarks/app.js
@@ -5,7 +5,7 @@ let $count = 0;
 
 const App = CustomElement.define({
     name: 'app',
-    template: '<div repeat.for="i of items">${i.message}</div>'
+    template: '<div repeat.for="i of items">hello ${i.message} item</div>'
 }, class {
     constructor() {
         this.newItems($count);

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -8,8 +8,8 @@
     "build:runtime-html": "cd ../packages/runtime-html && npm run build",
     "build:all": "concurrently \"npm run build:kernel\" \"npm run build:runtime\" \"npm run build:runtime-html\"",
     "bench": "npm run bench rerender1k && npm run bench:startup1k && npm run bench:update1k",
-    "bench:rerender1k": "tach --config rerender-1k.json --json-file results/rerender-1k.json",
-    "bench:startup1k": "tach --config startup-1k.json --json-file results/startup-1k.json",
+    "bench:rerender10k": "tach --config rerender-10k.json --json-file results/rerender-10k.json",
+    "bench:startup10k": "tach --config startup-10k.json --json-file results/startup-10k.json",
     "bench:update1k": "tach --config update-1k.json --json-file results/update-1k.json"
   },
   "dependencies": {

--- a/benchmarks/rerender-10k.json
+++ b/benchmarks/rerender-10k.json
@@ -10,17 +10,17 @@
         "addArguments": ["--js-flags=--expose-gc", "--enable-precise-memory-info"]
       },
       "measurement": [
-        { "name": "perf", "mode": "performance", "entryName": "startup-1k" },
+        { "name": "perf", "mode": "performance", "entryName": "rerender-10k" },
         { "name": "memory", "mode": "expression", "expression": "jsHeapSize" }
       ],
       "expand": [
         {
-          "name": "startup 1k latest",
-          "url": "startup1k-latest.html"
+          "name": "rerender 10k latest",
+          "url": "rerender10k-latest.html"
         },
         {
-          "name": "startup 1k local",
-          "url": "startup1k-local.html"
+          "name": "rerender 10k local",
+          "url": "rerender10k-local.html"
         }
       ]
     }

--- a/benchmarks/rerender10k-latest.html
+++ b/benchmarks/rerender10k-latest.html
@@ -1,16 +1,17 @@
 <script type="module">
-import { start } from './local/dist/app.local.js';
+import { start } from './latest/dist/app.latest.js';
 
 const host = document.body.appendChild(document.createElement('div'));
 const au = start(host);
-performance.mark('1k-start');
+performance.mark('10k-start');
 
 au.root.controller.viewModel.newItems(10000);
 
-performance.mark('1k-end');
+performance.mark('10k-end');
 
 // measure memory in MBs
 window.jsHeapSize = performance.memory.usedJSHeapSize / 1e6;
 
-performance.measure('rerender-1k', '1k-start', '1k-end');
+performance.measure('rerender-10k', '10k-start', '10k-end');
+
 </script>

--- a/benchmarks/rerender10k-local.html
+++ b/benchmarks/rerender10k-local.html
@@ -1,17 +1,16 @@
 <script type="module">
-import { start } from './latest/dist/app.latest.js';
+import { start } from './local/dist/app.local.js';
 
 const host = document.body.appendChild(document.createElement('div'));
 const au = start(host);
-performance.mark('1k-start');
+performance.mark('10k-start');
 
 au.root.controller.viewModel.newItems(10000);
 
-performance.mark('1k-end');
+performance.mark('10k-end');
 
 // measure memory in MBs
 window.jsHeapSize = performance.memory.usedJSHeapSize / 1e6;
 
-performance.measure('rerender-1k', '1k-start', '1k-end');
-
+performance.measure('rerender-10k', '10k-start', '10k-end');
 </script>

--- a/benchmarks/startup-10k.json
+++ b/benchmarks/startup-10k.json
@@ -10,17 +10,17 @@
         "addArguments": ["--js-flags=--expose-gc", "--enable-precise-memory-info"]
       },
       "measurement": [
-        { "name": "perf", "mode": "performance", "entryName": "rerender-1k" },
+        { "name": "perf", "mode": "performance", "entryName": "startup-10k" },
         { "name": "memory", "mode": "expression", "expression": "jsHeapSize" }
       ],
       "expand": [
         {
-          "name": "rerender 1k latest",
-          "url": "rerender1k-latest.html"
+          "name": "startup 10k latest",
+          "url": "startup10k-latest.html"
         },
         {
-          "name": "rerender 1k local",
-          "url": "rerender1k-local.html"
+          "name": "startup 10k local",
+          "url": "startup10k-local.html"
         }
       ]
     }

--- a/benchmarks/startup10k-latest.html
+++ b/benchmarks/startup10k-latest.html
@@ -2,13 +2,13 @@
 import { start } from './latest/dist/app.latest.js';
 
 const host = document.body.appendChild(document.createElement('div'));
-performance.mark('1k-start');
-const au = start(host, 1000);
+performance.mark('10k-start');
+const au = start(host, 10000);
 
-performance.mark('1k-end');
+performance.mark('10k-end');
 
 // measure memory in MBs
 window.jsHeapSize = performance.memory.usedJSHeapSize / 1e6;
 
-performance.measure('startup-1k', '1k-start', '1k-end');
+performance.measure('startup-10k', '10k-start', '10k-end');
 </script>

--- a/benchmarks/startup10k-local.html
+++ b/benchmarks/startup10k-local.html
@@ -2,13 +2,13 @@
 import { start } from './local/dist/app.local.js';
 
 const host = document.body.appendChild(document.createElement('div'));
-performance.mark('1k-start');
-const au = start(host, 1000);
+performance.mark('10k-start');
+const au = start(host, 10000);
 
-performance.mark('1k-end');
+performance.mark('10k-end');
 
 // measure memory in MBs
 window.jsHeapSize = performance.memory.usedJSHeapSize / 1e6;
 
-performance.measure('startup-1k', '1k-start', '1k-end');
+performance.measure('startup-10k', '10k-start', '10k-end');
 </script>

--- a/benchmarks/update1k-latest.html
+++ b/benchmarks/update1k-latest.html
@@ -2,7 +2,7 @@
 import { start } from './latest/dist/app.latest.js';
 
 const host = document.body.appendChild(document.createElement('div'));
-const au = start(host);
+const au = start(host, 1000);
 performance.mark('1k-start');
 
 au.root.controller.viewModel.updateItems();

--- a/benchmarks/update1k-local.html
+++ b/benchmarks/update1k-local.html
@@ -2,7 +2,7 @@
 import { start } from './local/dist/app.local.js';
 
 const host = document.body.appendChild(document.createElement('div'));
-const au = start(host);
+const au = start(host, 1000);
 performance.mark('1k-start');
 
 au.root.controller.viewModel.updateItems();

--- a/docs/user-docs/developer-guides/cheat-sheet.md
+++ b/docs/user-docs/developer-guides/cheat-sheet.md
@@ -136,13 +136,13 @@ import {
   ForBindingCommandRegistration,
   TriggerBindingCommandRegistration,
 
-  PropertyBindingRendererRegistration,
-  IteratorBindingRendererRegistration,
-  RefBindingRendererRegistration,
-  CustomElementRendererRegistration,
-  TemplateControllerRendererRegistration,
-  ListenerBindingRendererRegistration,
-  TextBindingRendererRegistration,
+  PropertyBindingRenderer,
+  IteratorBindingRenderer,
+  RefBindingRenderer,
+  CustomElementRenderer,
+  TemplateControllerRenderer,
+  ListenerBindingRenderer,
+  TextBindingRenderer,
 } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import { AppRoot } from './app-root';
@@ -176,13 +176,13 @@ container.register(
   TriggerBindingCommandRegistration, // .trigger
 
   // Commonly used Aurelia renderers (only a small selection)
-  PropertyBindingRendererRegistration, // .bind, .one-time, .to-view, .from-view, .two-way bindings
-  IteratorBindingRendererRegistration, // .for bindings
-  RefBindingRendererRegistration, // ref bindings
-  CustomElementRendererRegistration, // custom element hydration
-  TemplateControllerRendererRegistration, // template controller hydration (if, repeat)
-  ListenerBindingRendererRegistration, // .trigger, .capture, .delegate bindings
-  TextBindingRendererRegistration, // ${} text bindings
+  PropertyBindingRenderer, // .bind, .one-time, .to-view, .from-view, .two-way bindings
+  IteratorBindingRenderer, // .for bindings
+  RefBindingRenderer, // ref bindings
+  CustomElementRenderer, // custom element hydration
+  TemplateControllerRenderer, // template controller hydration (if, repeat)
+  ListenerBindingRenderer, // .trigger, .capture bindings
+  TextBindingRenderer, // ${} text bindings
 );
 
 await new Aurelia(container).app({

--- a/examples/helloworld/app.js
+++ b/examples/helloworld/app.js
@@ -1,4 +1,5 @@
 import { Aurelia, CustomElement, StandardConfiguration } from '@aurelia/runtime-html';
+import { TemplateCompiler, TextBindingRenderer } from '@aurelia/runtime-html';
 
 const App = CustomElement.define(
   {
@@ -12,7 +13,10 @@ const App = CustomElement.define(
   }
 );
 
-void new Aurelia().register(StandardConfiguration).app(
+void new Aurelia().register(
+  TemplateCompiler,
+  TextBindingRenderer,
+).app(
   {
     host: document.getElementById('app'),
     component: App,

--- a/examples/helloworld/app.js
+++ b/examples/helloworld/app.js
@@ -1,4 +1,4 @@
-import { Aurelia, CustomElement, StandardConfiguration } from '@aurelia/runtime-html';
+import { Aurelia, CustomElement, /* StandardConfiguration */ } from '@aurelia/runtime-html';
 import { TemplateCompiler, TextBindingRenderer } from '@aurelia/runtime-html';
 
 const App = CustomElement.define(

--- a/examples/rainbow-spiral/package.json
+++ b/examples/rainbow-spiral/package.json
@@ -9,7 +9,12 @@
   "version": "0.8.0",
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "serve": "node ../../node_modules/@aurelia/http-server/dist/esm/cli.js au.conf.js"
+    "serve": "node ../../node_modules/@aurelia/http-server/dist/esm/cli.js au.conf.js",
+    "build:kernel": "cd ../../packages/kernel && npm run build",
+    "build:runtime": "cd ../../packages/runtime && npm run build",
+    "build:runtime-html": "cd ../../packages/runtime-html && npm run build",
+    "build:all": "concurrently \"npm run build:kernel\" \"npm run build:runtime\" \"npm run build:runtime-html\"",
+    "postbuild:all": "rollup -c"
   },
   "dependencies": {
     "@aurelia/kernel": "2.0.0-alpha.41",

--- a/examples/rainbow-spiral/rollup.config.js
+++ b/examples/rainbow-spiral/rollup.config.js
@@ -1,0 +1,12 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+    input: './app',
+    output: {
+        file: 'dist/bundle.js',
+        sourcemap: true
+    },
+    plugins: [nodeResolve(), terser()]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2676,13 +2676,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.24.1.tgz",
-      "integrity": "sha512-VJ9qekMis7Oze2Q/Vb+w1g2aPaJFRdl5vhTS6h82kG89Jb8trlU2WHY7oYzNRjvFPoVUMcWXiblH2bWcbEax/A==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.24.1"
+        "playwright-core": "1.27.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14950,9 +14950,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.1.tgz",
-      "integrity": "sha512-1RoSDe/oTQS1Ct7Pb8i+vcFKbKYpmVIBXk0IUiD8RvCUMnNl7EJF1OSQ9E8TZ5RYamWkW2Psir9e8Doyz1FnhQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -19386,7 +19386,7 @@
       },
       "devDependencies": {
         "@aurelia/webpack-loader": "2.0.0-alpha.41",
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "html-webpack-plugin": "^5.5.0",
         "playwright-watch": "1.3.23",
@@ -19420,7 +19420,7 @@
         "aurelia": "2.0.0-alpha.41"
       },
       "devDependencies": {
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "playwright-watch": "1.3.23",
         "webpack": "^5.72.0",
@@ -19448,7 +19448,7 @@
         "perf-monitor": "latest"
       },
       "devDependencies": {
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "playwright-watch": "1.3.23",
         "webpack": "^5.72.0",
@@ -20190,7 +20190,7 @@
         "@aurelia/runtime": "2.0.0-alpha.41",
         "@aurelia/runtime-html": "2.0.0-alpha.41",
         "@aurelia/webpack-loader": "2.0.0-alpha.41",
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "aurelia": "2.0.0-alpha.41",
         "html-webpack-plugin": "^5.5.0",
@@ -20218,7 +20218,7 @@
         "@aurelia/router": "2.0.0-alpha.41",
         "@aurelia/runtime": "2.0.0-alpha.41",
         "@aurelia/runtime-html": "2.0.0-alpha.41",
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "aurelia": "2.0.0-alpha.41",
         "playwright-watch": "1.3.23",
@@ -20245,7 +20245,7 @@
         "@aurelia/router-lite": "2.0.0-alpha.41",
         "@aurelia/runtime": "2.0.0-alpha.41",
         "@aurelia/runtime-html": "2.0.0-alpha.41",
-        "@playwright/test": "^1.24.1",
+        "@playwright/test": "1.27.1",
         "@types/node": "^14.18.14",
         "aurelia": "2.0.0-alpha.41",
         "perf-monitor": "latest",
@@ -22688,13 +22688,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.24.1.tgz",
-      "integrity": "sha512-VJ9qekMis7Oze2Q/Vb+w1g2aPaJFRdl5vhTS6h82kG89Jb8trlU2WHY7oYzNRjvFPoVUMcWXiblH2bWcbEax/A==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+      "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.24.1"
+        "playwright-core": "1.27.1"
       }
     },
     "@polka/url": {
@@ -32068,9 +32068,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.1.tgz",
-      "integrity": "sha512-1RoSDe/oTQS1Ct7Pb8i+vcFKbKYpmVIBXk0IUiD8RvCUMnNl7EJF1OSQ9E8TZ5RYamWkW2Psir9e8Doyz1FnhQ==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+      "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
       "dev": true
     },
     "playwright-watch": {

--- a/packages/__e2e__/hmr-webpack/package.json
+++ b/packages/__e2e__/hmr-webpack/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@aurelia/webpack-loader": "2.0.0-alpha.41",
-    "@playwright/test": "^1.24.1",
+    "@playwright/test": "1.27.1",
     "@types/node": "^14.18.14",
     "playwright-watch": "1.3.23",
     "webpack": "^5.72.0",

--- a/packages/__e2e__/router-lite/package.json
+++ b/packages/__e2e__/router-lite/package.json
@@ -29,7 +29,7 @@
     "perf-monitor": "latest"
   },
   "devDependencies": {
-    "@playwright/test": "^1.24.1",
+    "@playwright/test": "1.27.1",
     "playwright-watch": "1.3.23",
     "@types/node": "^14.18.14",
     "webpack": "^5.72.0",

--- a/packages/__e2e__/router/package.json
+++ b/packages/__e2e__/router/package.json
@@ -28,7 +28,7 @@
     "@aurelia/router": "2.0.0-alpha.41"
   },
   "devDependencies": {
-    "@playwright/test": "^1.24.1",
+    "@playwright/test": "1.27.1",
     "playwright-watch": "1.3.23",
     "@types/node": "^14.18.14",
     "webpack": "^5.72.0",

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -56,6 +56,7 @@ module.exports = {
     '@typescript-eslint/require-array-sort-compare': 'off',
     '@typescript-eslint/restrict-plus-operands': 'off',
     '@typescript-eslint/no-this-alias': 'off',
+    '@typescript-eslint/prefer-nullish-coalescing': 'off',
   },
   overrides: [{ // Specific overrides for JS files as some TS rules don't make sense there.
     files: ['3-runtime-html/generated/**'],

--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -5,7 +5,7 @@ import { BindingMode, Aurelia, AuSlotsInfo, bindable, customElement, CustomEleme
 import { assert, createFixture, hJsx, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../util.js';
 
-describe('3-runtime-html/au-slot.spec.ts', function () {
+describe('3-runtime-html/au-slot.spec.tsx', function () {
   interface TestSetupContext {
     template: string;
     registrations: any[];
@@ -1038,7 +1038,8 @@ describe('3-runtime-html/au-slot.spec.ts', function () {
         [
           createMyElement(`<au-slot with.bind="{item: people[0]}">\${item.firstName}</au-slot><au-slot with.bind="{item: people[1]}">\${item.firstName}</au-slot>`),
         ],
-        { 'my-element': [`<div>Doe</div><div>Mustermann</div>`, new AuSlotsInfo(['default'])] }
+        { 'my-element': [`<div>Doe</div><div>Mustermann</div>`, new AuSlotsInfo(['default'])] },
+        void 0,
       );
     }
     // #endregion

--- a/packages/__tests__/3-runtime-html/if.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/if.integration.spec.ts
@@ -1,227 +1,11 @@
-import { Scope, Interpolation, AccessScopeExpression, BindingContext } from '@aurelia/runtime';
 import {
-  LifecycleFlags,
-  Else,
-  If,
-  Controller,
-  CustomElementDefinition,
-  IHydratableController,
-  IRenderLocation,
-  PropertyBindingRendererRegistration,
-  TextBindingRendererRegistration,
-  TextBindingInstruction,
-  INodeObserverLocatorRegistration,
-  CustomAttribute,
-  IRendering,
+  CustomAttribute
 } from '@aurelia/runtime-html';
 import {
-  eachCartesianJoin,
-  assert,
-  PLATFORM,
-  createContainer,
-  createFixture,
+  assert, createFixture
 } from '@aurelia/testing';
-import { Writable } from '@aurelia/kernel';
 
 describe(`3-runtime-html/if.integration.spec.ts`, function () {
-  function runActivateLifecycle(sut: If, flags: LifecycleFlags, scope: Scope): void {
-    void sut.$controller.activate(sut.$controller, null, flags, scope);
-  }
-  function runDeactivateLifecycle(sut: If, flags: LifecycleFlags): void {
-    void sut.$controller.deactivate(sut.$controller, null, flags);
-  }
-
-  interface Spec {
-    t: string;
-  }
-  interface DuplicateOperationSpec extends Spec {
-    activateTwice: boolean;
-    deactivateTwice: boolean;
-  }
-  interface BindSpec extends Spec {
-    ifPropName: string;
-    elsePropName: string;
-    ifText: string;
-    elseText: string;
-
-    value1: any;
-    value2: any;
-  }
-  interface MutationSpec extends Spec {
-    newValue1: any;
-    newValue2: any;
-  }
-  interface FlagsSpec extends Spec {
-    activateFlags1: LifecycleFlags;
-    deactivateFlags1: LifecycleFlags;
-
-    activateFlags2: LifecycleFlags;
-    deactivateFlags2: LifecycleFlags;
-  }
-
-  const duplicateOperationSpecs: DuplicateOperationSpec[] = [
-    { t: '1', activateTwice: false, deactivateTwice: false },
-    { t: '2', activateTwice: true,  deactivateTwice: false },
-    { t: '3', activateTwice: true,  deactivateTwice: true  },
-    { t: '4', activateTwice: false, deactivateTwice: true  },
-  ];
-
-  const bindSpecs: BindSpec[] = [
-    { t: '1', ifPropName: 'ifValue', elsePropName: 'elseValue', ifText: 'foo', elseText: 'bar', value1: true,  value2: true  },
-    { t: '2', ifPropName: 'ifValue', elsePropName: 'elseValue', ifText: 'foo', elseText: 'bar', value1: true,  value2: false },
-    { t: '3', ifPropName: 'ifValue', elsePropName: 'elseValue', ifText: 'foo', elseText: 'bar', value1: false, value2: true  },
-    { t: '4', ifPropName: 'ifValue', elsePropName: 'elseValue', ifText: 'foo', elseText: 'bar', value1: false, value2: false },
-  ];
-
-  const none = LifecycleFlags.none;
-  const bind = LifecycleFlags.fromBind;
-  const unbind = LifecycleFlags.fromUnbind;
-
-  const mutationSpecs: MutationSpec[] = [
-    { t: '01', newValue1: false, newValue2: false, },
-    { t: '02', newValue1: false, newValue2: true,  },
-    { t: '03', newValue1: true,  newValue2: false, },
-    { t: '04', newValue1: true,  newValue2: true,  },
-  ];
-
-  const flagsSpecs: FlagsSpec[] = [
-    { t: '1', activateFlags1: none,            deactivateFlags1: none,              activateFlags2: none,            deactivateFlags2: none,              },
-    { t: '2', activateFlags1: bind,            deactivateFlags1: unbind,            activateFlags2: bind,            deactivateFlags2: unbind,            },
-  ];
-
-  const container = createContainer().register(
-    INodeObserverLocatorRegistration,
-    PropertyBindingRendererRegistration,
-    TextBindingRendererRegistration,
-  );
-
-  const marker = PLATFORM.document.createElement('au-m');
-  marker.className = 'au';
-  const text = PLATFORM.document.createTextNode('');
-  const textTemplate = PLATFORM.document.createElement('template');
-  textTemplate.content.append(marker, text);
-
-  eachCartesianJoin(
-    [duplicateOperationSpecs, bindSpecs, mutationSpecs, flagsSpecs],
-    (duplicateOperationSpec, bindSpec, mutationSpec, flagsSpec) => {
-      it(`verify if/else behavior - duplicateOperationSpec ${duplicateOperationSpec.t}, bindSpec ${bindSpec.t}, mutationSpec ${mutationSpec.t}, flagsSpec ${flagsSpec.t}, `, function () {
-        const { activateTwice, deactivateTwice } = duplicateOperationSpec;
-        const { ifPropName, elsePropName, ifText, elseText, value1, value2 } = bindSpec;
-        const { newValue1, newValue2 } = mutationSpec;
-        const { activateFlags1, deactivateFlags1, activateFlags2, deactivateFlags2 } = flagsSpec;
-
-        // common stuff
-        const baseFlags: LifecycleFlags = LifecycleFlags.none;
-
-        const host = PLATFORM.document.createElement('div');
-        const ifLoc = PLATFORM.document.createComment('au-end') as IRenderLocation;
-        const elseLoc = PLATFORM.document.createComment('au-end') as IRenderLocation;
-        ifLoc.$start = PLATFORM.document.createComment('au-start');
-        elseLoc.$start = PLATFORM.document.createComment('au-start');
-        host.append(ifLoc.$start, ifLoc, elseLoc.$start, elseLoc);
-
-        const ifDef = CustomElementDefinition.create({
-          name: 'if-view',
-          template: textTemplate.content.cloneNode(true),
-          instructions: [
-            [
-              new TextBindingInstruction(new Interpolation(['', ''], [new AccessScopeExpression(ifPropName)]), false),
-            ],
-          ],
-          needsCompile: false,
-        });
-        const elseDef = CustomElementDefinition.create({
-          name: 'else-view',
-          template: textTemplate.content.cloneNode(true),
-          instructions: [
-            [
-              new TextBindingInstruction(new Interpolation(['', ''], [new AccessScopeExpression(elsePropName)]), false),
-            ],
-          ],
-          needsCompile: false,
-        });
-
-        const rendering = container.get(IRendering);
-        const ifFactory = rendering.getViewFactory(ifDef, container);
-        const elseFactory = rendering.getViewFactory(elseDef, container);
-        const sut = new If(ifFactory, ifLoc);
-        const elseSut = new Else(elseFactory);
-        const ifController = (sut as Writable<If>).$controller = Controller.$attr(container, sut, (void 0)!);
-        elseSut.link({ children: [ifController] } as unknown as IHydratableController, void 0!, void 0!, void 0!);
-
-        const firstBindInitialNodesText: string = value1 ? ifText : elseText;
-        const firstBindFinalNodesText = firstBindInitialNodesText;
-        const firstAttachInitialHostText = value1 ? ifText : elseText;
-        const firstAttachFinalHostText: string = newValue1 ? ifText : elseText;
-
-        const secondBindInitialNodesText: string = value2 ? ifText : elseText;
-        const secondBindFinalNodesText = secondBindInitialNodesText;
-        const secondAttachInitialHostText = value2 ? ifText : elseText;
-        const secondAttachFinalHostText: string = newValue2 ? ifText : elseText;
-
-        // -- Round 1 --
-
-        const ctx = Object.assign(new BindingContext(), {
-          [ifPropName]: ifText,
-          [elsePropName]: elseText
-        });
-        const scope = Scope.create(ctx);
-
-        sut.value = value1;
-
-        runActivateLifecycle(sut, baseFlags | activateFlags1, scope);
-
-        assert.strictEqual(sut.view.nodes.lastChild.previousSibling['textContent'], firstBindInitialNodesText, '$nodes.textContent #1');
-
-        if (activateTwice) {
-          runActivateLifecycle(sut, baseFlags | activateFlags1, scope);
-        }
-
-        assert.strictEqual(sut.view.nodes.lastChild.previousSibling['textContent'], firstBindFinalNodesText, '$nodes.textContent #2');
-
-        assert.strictEqual(host.textContent, firstAttachInitialHostText, 'host.textContent #1');
-
-        sut.value = newValue1;
-
-        assert.strictEqual(host.textContent, firstAttachFinalHostText, 'host.textContent #2');
-
-        runDeactivateLifecycle(sut, baseFlags | deactivateFlags1);
-        if (deactivateTwice) {
-          runDeactivateLifecycle(sut, baseFlags | deactivateFlags1);
-        }
-
-        assert.strictEqual(host.textContent, '', 'host.textContent #3');
-
-        // unbind should not affect existing values but stops them from updating afterwards
-
-        // -- Round 2 --
-
-        sut.value = value2;
-
-        runActivateLifecycle(sut, baseFlags | activateFlags2, scope);
-
-        assert.strictEqual(sut.view.nodes.lastChild.previousSibling['textContent'], secondBindInitialNodesText, '$nodes.textContent #3');
-        if (activateTwice) {
-          runActivateLifecycle(sut, baseFlags | activateFlags2, scope);
-        }
-
-        assert.strictEqual(sut.view.nodes.lastChild.previousSibling['textContent'], secondBindFinalNodesText, '$nodes.textContent #4');
-
-        assert.strictEqual(host.textContent, secondAttachInitialHostText, 'host.textContent #4');
-
-        sut.value = newValue2;
-
-        assert.strictEqual(host.textContent, secondAttachFinalHostText, 'host.textContent #5');
-
-        runDeactivateLifecycle(sut, baseFlags | deactivateFlags2);
-        if (deactivateTwice) {
-          runDeactivateLifecycle(sut, baseFlags | deactivateFlags2);
-        }
-
-        assert.strictEqual(host.textContent, '', 'host.textContent #6');
-      });
-    });
-
   describe('with caching', function () {
     it('disables cache with "false" string', async function () {
       let callCount = 0;
@@ -398,6 +182,57 @@ describe(`3-runtime-html/if.integration.spec.ts`, function () {
       await tearDown();
 
       assert.visibleTextEqual(appHost, '');
+    });
+
+    it('works with interpolation as only child of <template>', function () {
+      const { assertText, component, flush, tearDown } = createFixture(
+        '<div><template if.bind="on">${name}</template>',
+        { on: false, name: 'a' }
+      );
+
+      assertText('');
+
+      component.on = true;
+      flush();
+      assertText('a');
+
+      void tearDown();
+
+      assertText('');
+    });
+
+    it('works with interpolation + leading + trailing text inside template', function () {
+      const { assertText, component, flush, tearDown } = createFixture(
+        '<div><template if.bind="on">hey ${name}</template>',
+        { on: false, name: 'a' }
+      );
+
+      assertText('');
+
+      component.on = true;
+      flush();
+      assertText('hey a');
+
+      void tearDown();
+
+      assertText('');
+    });
+
+    it('works with interpolation as only child of <template> + else', function () {
+      const { assertText, component, flush, tearDown } = createFixture(
+        '<template if.bind="on">${name}</template><template else>${name + 1}</template>',
+        { on: false, name: 'a' }
+      );
+
+      assertText('a1');
+
+      component.on = true;
+      flush();
+      assertText('a');
+
+      void tearDown();
+
+      assertText('');
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -466,6 +466,22 @@ describe('3-runtime/interpolation.spec.ts -- [UNIT]interpolation', function () {
 });
 
 describe('3-runtime/interpolation.spec.ts', function () {
+  it('works with strict mode', function () {
+    const { assertText, component, flush } = createFixture(
+      'hey ${id}',
+      CustomElement.define({ name: 'app', isStrictBinding: true }, class { id = undefined; })
+    );
+    assertText('hey undefined');
+
+    component.id = '1';
+    flush();
+    assertText('hey 1');
+
+    component.id = null;
+    flush();
+    assertText('hey null');
+  });
+
   it('observes and updates when bound with array', async function () {
     const { tearDown, appHost, ctx, startPromise } = createFixture(
       `<label repeat.for="product of products">

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -1,4 +1,5 @@
 import {
+  reportTaskQueue,
   Task,
   TaskStatus,
 } from '@aurelia/platform';
@@ -2549,7 +2550,8 @@ describe('promise template-controller', function () {
 
               const tc = (ctx.app as ICustomElementViewModel).$controller.children.find((c) => c.viewModel instanceof PromiseTemplateController).viewModel as PromiseTemplateController;
               const postSettleTask = tc['postSettledTask'];
-              const taskNums = [q['pending'].length, q['processing'].length, q['delayed'].length];
+              let { pending, processing, delayed } = reportTaskQueue(q);
+              const taskNums = [pending.length, processing.length, delayed.length];
 
               try {
                 if ($resolve) {
@@ -2563,7 +2565,8 @@ describe('promise template-controller', function () {
               }
               await q.yield();
               assert.strictEqual(tc['postSettledTask'], postSettleTask);
-              assert.deepStrictEqual([q['pending'].length, q['processing'].length, q['delayed'].length], taskNums);
+              ({ pending, processing, delayed } = reportTaskQueue(q));
+              assert.deepStrictEqual([pending.length, processing.length, delayed.length], taskNums);
             },
           );
         }

--- a/packages/__tests__/3-runtime-html/repeater-custom-element.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater-custom-element.spec.ts
@@ -20,9 +20,7 @@ import {
   TestFunction,
 } from '../util.js';
 
-const spec = 'repeater-custom-element';
-
-describe(spec, function () {
+describe('3-runtime-html/repeater-custom-element.spec.ts', function () {
 
   interface TestSetupContext<TApp> {
     template: string;

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -518,11 +518,13 @@ describe(`Repeat`, function () {
     TextBindingRendererRegistration,
   );
 
+  const createStartLocation = () => PLATFORM.document.createComment('au-start');
+  const createEndLocation = () => PLATFORM.document.createComment('au-end');
   const marker = PLATFORM.document.createElement('au-m');
   marker.className = 'au';
   const text = PLATFORM.document.createTextNode('');
   const textTemplate = PLATFORM.document.createElement('template');
-  textTemplate.content.append(marker, text);
+  textTemplate.content.append(createStartLocation(), createEndLocation(), marker, text);
 
   eachCartesianJoin(
     [duplicateOperationSpecs, bindSpecs, flagsSpecs],

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -1,4 +1,4 @@
-import { Scope, Interpolation, AccessScopeExpression, ForOfStatement, BindingIdentifier, BindingContext } from '@aurelia/runtime';
+import { Scope, AccessScopeExpression, ForOfStatement, BindingIdentifier, BindingContext } from '@aurelia/runtime';
 import {
   LifecycleFlags,
   Repeat,
@@ -6,8 +6,8 @@ import {
   CustomElementDefinition,
   IHydratableController,
   IRenderLocation,
-  PropertyBindingRendererRegistration,
-  TextBindingRendererRegistration,
+  PropertyBindingRenderer,
+  TextBindingRenderer,
   TextBindingInstruction,
   INodeObserverLocatorRegistration,
   IRendering,
@@ -514,8 +514,8 @@ describe(`Repeat`, function () {
 
   const container = createContainer().register(
     INodeObserverLocatorRegistration,
-    PropertyBindingRendererRegistration,
-    TextBindingRendererRegistration,
+    PropertyBindingRenderer,
+    TextBindingRenderer,
   );
 
   const createStartLocation = () => PLATFORM.document.createComment('au-start');
@@ -535,7 +535,6 @@ describe(`Repeat`, function () {
         const { activateFlags1, deactivateFlags1, activateFlags2, deactivateFlags2 } = flagsSpec;
 
         const items = $items.slice();
-        // common stuff
         const baseFlags: LifecycleFlags = LifecycleFlags.none;
 
         const host = PLATFORM.document.createElement('div');
@@ -548,7 +547,7 @@ describe(`Repeat`, function () {
           template: textTemplate.content.cloneNode(true),
           instructions: [
             [
-              new TextBindingInstruction(new Interpolation(['', ''], [new AccessScopeExpression('item')]), false),
+              new TextBindingInstruction(new AccessScopeExpression('item'), false),
             ],
           ],
           needsCompile: false,

--- a/packages/__tests__/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -34,6 +34,7 @@ describe('[UNIT] 3-runtime-html/template-compiler.au-slot.spec.ts', function () 
       public readonly customElements: CustomElementType[],
       public readonly allExpectedProjections: [string, Record<string, string>][] | null,
       public readonly expectedSlotInfos: ExpectedSlotFallbackInfo[],
+      public readonly only = false,
     ) {
     }
   }
@@ -61,7 +62,7 @@ describe('[UNIT] 3-runtime-html/template-compiler.au-slot.spec.ts', function () 
     yield new TestData(
       `<my-element><au-slot au-slot><div au-slot="s1">p1</div><div au-slot="s1">p2</div></au-slot></my-element>`,
       [$createCustomElement('', 'my-element')],
-      [['my-element', { 'default': '<au-m class="au"></au-m>' }]],
+      [['my-element', { 'default': '<!--au-start--><!--au-end--><au-m class="au"></au-m>' }]],
       [],
     );
 
@@ -102,8 +103,8 @@ describe('[UNIT] 3-runtime-html/template-compiler.au-slot.spec.ts', function () 
       ],
     );
   }
-  for (const { customElements, template, expectedSlotInfos, allExpectedProjections } of getTestData()) {
-    it(`compiles - ${template}`, function () {
+  for (const { only, customElements, template, expectedSlotInfos, allExpectedProjections } of getTestData()) {
+    (only ? it.only : it)(`compiles - ${template}`, function () {
       const { sut, container } = createFixture();
       container.register(AuSlot, ...customElements);
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -554,16 +554,7 @@ export {
   // ThrottleBindingBehaviorRegistration,
   // TwoWayBindingBehaviorRegistration,
 
-  // RefBindingRendererRegistration,
   // CallBindingRendererRegistration,
-  // CustomAttributeRendererRegistration,
-  // CustomElementRendererRegistration,
-  // InterpolationBindingRendererRegistration,
-  // IteratorBindingRendererRegistration,
-  // LetElementRendererRegistration,
-  // PropertyBindingRendererRegistration,
-  // SetPropertyRendererRegistration,
-  // TemplateControllerRendererRegistration,
 
   // DefaultResources as RuntimeDefaultResources,
   // IObserverLocatorRegistration,
@@ -791,20 +782,11 @@ export {
   // ToViewBindingCommandRegistration,
   // TwoWayBindingCommandRegistration,
 
-  // AttrBindingBehaviorRegistration,
   // SelfBindingBehaviorRegistration,
   // UpdateTriggerBindingBehaviorRegistration,
   // ComposeRegistration,
 
   // DefaultResources as RuntimeHtmlDefaultResources,
-
-  // AttributeBindingRendererRegistration,
-  // ListenerBindingRendererRegistration,
-  // SetAttributeRendererRegistration,
-  // SetClassAttributeRendererRegistration,
-  // SetStyleAttributeRendererRegistration,
-  // StylePropertyBindingRendererRegistration,
-  // TextBindingRendererRegistration,
 
   // DefaultRenderers,
 
@@ -819,7 +801,6 @@ export {
   // ISetAttributeInstruction,
   // isInstruction,
   // IStylePropertyBindingInstruction,
-  // ITextBindingInstruction,
 
   // NodeSequenceFactory,
   // FragmentNodeSequence,
@@ -829,7 +810,6 @@ export {
   // SetClassAttributeInstruction,
   // SetStyleAttributeInstruction,
   // StylePropertyBindingInstruction,
-  // TextBindingInstruction,
 
   // ContainerlessProjector,
   // HostProjector,

--- a/packages/runtime-html/src/compiler/attribute-mapper.ts
+++ b/packages/runtime-html/src/compiler/attribute-mapper.ts
@@ -1,6 +1,6 @@
-import { createError, createLookup, isDataAttribute } from './utilities';
-import { ISVGAnalyzer } from './observation/svg-analyzer';
-import { createInterface } from './utilities-di';
+import { createError, createLookup, isDataAttribute } from '../utilities';
+import { ISVGAnalyzer } from '../observation/svg-analyzer';
+import { createInterface } from '../utilities-di';
 
 export interface IAttrMapper extends AttrMapper {}
 export const IAttrMapper = createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -20,17 +20,17 @@ import {
   ITemplateCompiler,
   PropertyBindingInstruction,
   SpreadElementPropBindingInstruction,
-} from './renderer';
-import { IPlatform } from './platform';
-import { Bindable, BindableDefinition } from './bindable';
-import { AttrSyntax, IAttributeParser } from './resources/attribute-pattern';
-import { CustomAttribute } from './resources/custom-attribute';
-import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from './resources/custom-element';
-import { BindingCommand, CommandType } from './resources/binding-command';
-import { createError, createLookup, isString, objectAssign, objectFreeze } from './utilities';
-import { allResources, createInterface, singletonRegistration } from './utilities-di';
-import { appendResourceKey, defineMetadata, getResourceKeyFor } from './utilities-metadata';
-import { BindingMode } from './binding/interfaces-bindings';
+} from '../renderer';
+import { IPlatform } from '../platform';
+import { Bindable, BindableDefinition } from '../bindable';
+import { AttrSyntax, IAttributeParser } from '../resources/attribute-pattern';
+import { CustomAttribute } from '../resources/custom-attribute';
+import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from '../resources/custom-element';
+import { BindingCommand, CommandType } from '../resources/binding-command';
+import { createError, createLookup, isString, objectAssign, objectFreeze } from '../utilities';
+import { allResources, createInterface, singletonRegistration } from '../utilities-di';
+import { appendResourceKey, defineMetadata, getResourceKeyFor } from '../utilities-metadata';
+import { BindingMode } from '../binding/interfaces-bindings';
 
 import type {
   IContainer,
@@ -39,11 +39,11 @@ import type {
   Writable,
 } from '@aurelia/kernel';
 import type { AnyBindingExpression } from '@aurelia/runtime';
-import type { CustomAttributeDefinition } from './resources/custom-attribute';
-import type { PartialCustomElementDefinition } from './resources/custom-element';
-import type { IProjections } from './resources/slot-injectables';
-import type { BindingCommandInstance, ICommandBuildInfo } from './resources/binding-command';
-import type { ICompliationInstruction, IInstruction, } from './renderer';
+import type { CustomAttributeDefinition } from '../resources/custom-attribute';
+import type { PartialCustomElementDefinition } from '../resources/custom-element';
+import type { IProjections } from '../resources/slot-injectables';
+import type { BindingCommandInstance, ICommandBuildInfo } from '../resources/binding-command';
+import type { ICompliationInstruction, IInstruction, } from '../renderer';
 
 export class TemplateCompiler implements ITemplateCompiler {
   public static register(container: IContainer): IResolver<ITemplateCompiler> {
@@ -1737,7 +1737,7 @@ class CompilationContext {
   }
 }
 
-function hasInlineBindings(rawValue: string): boolean {
+const hasInlineBindings = (rawValue: string): boolean => {
   const len = rawValue.length;
   let ch = 0;
   let i = 0;
@@ -1754,14 +1754,14 @@ function hasInlineBindings(rawValue: string): boolean {
     ++i;
   }
   return false;
-}
+};
 
-function resetCommandBuildInfo(): void {
+const resetCommandBuildInfo = (): void => {
   commandBuildInfo.node
     = commandBuildInfo.attr
     = commandBuildInfo.bindable
     = commandBuildInfo.def = null!;
-}
+};
 
 const emptyCompilationInstructions: ICompliationInstruction = { projections: null };
 // eslint-disable-next-line
@@ -1858,7 +1858,7 @@ const allowedLocalTemplateBindableAttributes: readonly string[] = objectFreeze([
 ]);
 const localTemplateIdentifier = 'as-custom-element';
 
-function processTemplateName(localTemplate: HTMLTemplateElement, localTemplateNames: Set<string>): string {
+const processTemplateName = (localTemplate: HTMLTemplateElement, localTemplateNames: Set<string>): string => {
   const name = localTemplate.getAttribute(localTemplateIdentifier);
   if (name === null || name === '') {
     if (__DEV__)
@@ -1876,9 +1876,9 @@ function processTemplateName(localTemplate: HTMLTemplateElement, localTemplateNa
     localTemplate.removeAttribute(localTemplateIdentifier);
   }
   return name;
-}
+};
 
-function getBindingMode(bindable: Element): BindingMode {
+const getBindingMode = (bindable: Element): BindingMode => {
   switch (bindable.getAttribute(LocalTemplateBindableAttributes.mode)) {
     case 'oneTime':
       return BindingMode.oneTime;
@@ -1892,7 +1892,7 @@ function getBindingMode(bindable: Element): BindingMode {
     default:
       return BindingMode.default;
   }
-}
+};
 
 /**
  * An interface describing the hooks a compilation process should invoke.

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -14,13 +14,17 @@ export const ITemplateElementFactory = createInterface<ITemplateElementFactory>(
 const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 
 export class TemplateElementFactory {
+  /** @internal */
   public static inject = [IPlatform];
-  /** @internal */ private _template: HTMLTemplateElement;
 
-  public constructor(
-    private readonly p: IPlatform,
-  ) {
-    this._template = p.document.createElement('template');
+  /** @internal */
+  private _template: HTMLTemplateElement;
+  /** @internal */
+  private readonly p: IPlatform;
+
+  public constructor(p: IPlatform) {
+    this.p = p;
+    this._template = createTemplate(this.p);
   }
 
   public createTemplate(markup: string): HTMLTemplateElement;
@@ -36,7 +40,7 @@ export class TemplateElementFactory {
         // if the input is either not wrapped in a template or there is more than one node,
         // return the whole template that wraps it/them (and create a new one for the next input)
         if (node == null || node.nodeName !== 'TEMPLATE' || node.nextElementSibling != null) {
-          this._template = this.p.document.createElement('template');
+          this._template = createTemplate(this.p);
           result = template;
         } else {
           // the node to return is both a template and the only node, so return just the node
@@ -52,7 +56,7 @@ export class TemplateElementFactory {
     }
     if (input.nodeName !== 'TEMPLATE') {
       // if we get one node that is not a template, wrap it in one
-      const template = this.p.document.createElement('template');
+      const template = createTemplate(this.p);
       template.content.appendChild(input);
       return template;
     }
@@ -62,3 +66,5 @@ export class TemplateElementFactory {
     return input.cloneNode(true) as HTMLTemplateElement;
   }
 }
+
+const createTemplate = (p: IPlatform) => p.document.createElement('template');

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -1,6 +1,6 @@
-import { IPlatform } from './platform';
-import { isString } from './utilities';
-import { createInterface } from './utilities-di';
+import { IPlatform } from '../platform';
+import { isString } from '../utilities';
+import { createInterface } from '../utilities-di';
 
 /**
  * Utility that creates a `HTMLTemplateElement` out of string markup or an existing DOM node.

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -21,7 +21,7 @@ import {
   TriggerBindingCommand,
   SpreadBindingCommand,
 } from './resources/binding-command';
-import { TemplateCompiler } from './template-compiler';
+import { TemplateCompiler } from './compiler/template-compiler';
 import {
   CustomAttributeRenderer,
   CustomElementRenderer,

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -40,6 +40,7 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
   SpreadRenderer,
+  ContentBindingRenderer,
 } from './renderer';
 import {
   FromViewBindingBehavior,
@@ -284,6 +285,7 @@ export const DefaultRenderers = [
   SetStyleAttributeRendererRegistration,
   StylePropertyBindingRendererRegistration,
   TextBindingRendererRegistration,
+  ContentBindingRenderer,
   SpreadRendererRegistration,
 ];
 

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -40,7 +40,6 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
   SpreadRenderer,
-  ContentBindingRenderer,
 } from './renderer';
 import {
   FromViewBindingBehavior,
@@ -183,7 +182,6 @@ export const RejectedTemplateControllerRegistration = RejectedTemplateController
 export const PromiseAttributePatternRegistration = PromiseAttributePattern as unknown as IRegistry;
 export const FulfilledAttributePatternRegistration = FulfilledAttributePattern as unknown as IRegistry;
 export const RejectedAttributePatternRegistration = RejectedAttributePattern as unknown as IRegistry;
-export const AttrBindingBehaviorRegistration = AttrBindingBehavior as unknown as IRegistry;
 export const SelfBindingBehaviorRegistration = SelfBindingBehavior as unknown as IRegistry;
 export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as unknown as IRegistry;
 export const AuComposeRegistration = AuCompose as unknown as IRegistry;
@@ -223,7 +221,7 @@ export const DefaultResources = [
   PromiseAttributePatternRegistration,
   FulfilledAttributePatternRegistration,
   RejectedAttributePatternRegistration,
-  AttrBindingBehaviorRegistration,
+  AttrBindingBehavior,
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
   AuComposeRegistration,
@@ -232,24 +230,6 @@ export const DefaultResources = [
   ShowRegistration,
   AuSlot,
 ];
-
-export const CustomAttributeRendererRegistration = CustomAttributeRenderer as unknown as IRegistry;
-export const CustomElementRendererRegistration = CustomElementRenderer as unknown as IRegistry;
-export const InterpolationBindingRendererRegistration = InterpolationBindingRenderer as unknown as IRegistry;
-export const IteratorBindingRendererRegistration = IteratorBindingRenderer as unknown as IRegistry;
-export const LetElementRendererRegistration = LetElementRenderer as unknown as IRegistry;
-export const PropertyBindingRendererRegistration = PropertyBindingRenderer as unknown as IRegistry;
-export const RefBindingRendererRegistration = RefBindingRenderer as unknown as IRegistry;
-export const SetPropertyRendererRegistration = SetPropertyRenderer as unknown as IRegistry;
-export const TemplateControllerRendererRegistration = TemplateControllerRenderer as unknown as IRegistry;
-export const ListenerBindingRendererRegistration = ListenerBindingRenderer as unknown as IRegistry;
-export const AttributeBindingRendererRegistration = AttributeBindingRenderer as unknown as IRegistry;
-export const SetAttributeRendererRegistration = SetAttributeRenderer as unknown as IRegistry;
-export const SetClassAttributeRendererRegistration = SetClassAttributeRenderer as unknown as IRegistry;
-export const SetStyleAttributeRendererRegistration = SetStyleAttributeRenderer as unknown as IRegistry;
-export const StylePropertyBindingRendererRegistration = StylePropertyBindingRenderer as unknown as IRegistry;
-export const TextBindingRendererRegistration = TextBindingRenderer as unknown as IRegistry;
-export const SpreadRendererRegistration = SpreadRenderer as unknown as IRegistry;
 
 /**
  * Default renderers for:
@@ -269,24 +249,23 @@ export const SpreadRendererRegistration = SpreadRenderer as unknown as IRegistry
  * - TextBinding: `${}`
  */
 export const DefaultRenderers = [
-  PropertyBindingRendererRegistration,
-  IteratorBindingRendererRegistration,
-  RefBindingRendererRegistration,
-  InterpolationBindingRendererRegistration,
-  SetPropertyRendererRegistration,
-  CustomElementRendererRegistration,
-  CustomAttributeRendererRegistration,
-  TemplateControllerRendererRegistration,
-  LetElementRendererRegistration,
-  ListenerBindingRendererRegistration,
-  AttributeBindingRendererRegistration,
-  SetAttributeRendererRegistration,
-  SetClassAttributeRendererRegistration,
-  SetStyleAttributeRendererRegistration,
-  StylePropertyBindingRendererRegistration,
-  TextBindingRendererRegistration,
-  ContentBindingRenderer,
-  SpreadRendererRegistration,
+  PropertyBindingRenderer,
+  IteratorBindingRenderer,
+  RefBindingRenderer,
+  InterpolationBindingRenderer,
+  SetPropertyRenderer,
+  CustomElementRenderer,
+  CustomAttributeRenderer,
+  TemplateControllerRenderer,
+  LetElementRenderer,
+  ListenerBindingRenderer,
+  AttributeBindingRenderer,
+  SetAttributeRenderer,
+  SetClassAttributeRenderer,
+  SetStyleAttributeRenderer,
+  StylePropertyBindingRenderer,
+  TextBindingRenderer,
+  SpreadRenderer,
 ];
 
 export const StandardConfiguration = createConfiguration(noop);

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -192,26 +192,14 @@ export function convertToRenderLocation(node: Node): IRenderLocation {
     return node; // it's already a IRenderLocation (converted by FragmentNodeSequence)
   }
 
-  const previousSibling = node.previousSibling;
-  let locationEnd: IRenderLocation;
-  let locationStart: Comment;
+  const locationEnd = node.ownerDocument!.createComment('au-end') as IRenderLocation;
+  const locationStart = locationEnd.$start = node.ownerDocument!.createComment('au-start') as IRenderLocation;
+  const parentNode = node.parentNode;
 
-  if (previousSibling?.nodeType === NodeType.Comment && previousSibling.textContent === 'au-end') {
-    locationEnd = previousSibling as IRenderLocation;
-    locationEnd.$start = locationStart = locationEnd.previousSibling! as Comment;
-    node.parentNode?.removeChild(node);
-    return locationEnd;
+  if (parentNode !== null) {
+    parentNode.replaceChild(locationEnd, node);
+    parentNode.insertBefore(locationStart, locationEnd);
   }
-
-  locationEnd = node.ownerDocument!.createComment('au-end');
-  locationStart = node.ownerDocument!.createComment('au-start');
-
-  if (node.parentNode !== null) {
-    node.parentNode.replaceChild(locationEnd, node);
-    locationEnd.parentNode!.insertBefore(locationStart, locationEnd);
-  }
-
-  (locationEnd).$start = locationStart;
 
   return locationEnd;
 }

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -193,17 +193,28 @@ export function convertToRenderLocation(node: Node): IRenderLocation {
     return node; // it's already a IRenderLocation (converted by FragmentNodeSequence)
   }
 
-  const locationEnd = node.ownerDocument!.createComment('au-end');
-  const locationStart = node.ownerDocument!.createComment('au-start');
+  const previousSibling = node.previousSibling;
+  let locationEnd: IRenderLocation;
+  let locationStart: Comment;
+
+  if (previousSibling?.nodeType === NodeType.Comment && previousSibling.textContent === 'au-end') {
+    locationEnd = previousSibling as IRenderLocation;
+    locationEnd.$start = locationStart = locationEnd.previousSibling! as Comment;
+    node.parentNode?.removeChild(node);
+    return locationEnd;
+  }
+
+  locationEnd = node.ownerDocument!.createComment('au-end');
+  locationStart = node.ownerDocument!.createComment('au-start');
 
   if (node.parentNode !== null) {
     node.parentNode.replaceChild(locationEnd, node);
     locationEnd.parentNode!.insertBefore(locationStart, locationEnd);
   }
 
-  (locationEnd as IRenderLocation).$start = locationStart as IRenderLocation;
+  (locationEnd).$start = locationStart;
 
-  return locationEnd as IRenderLocation;
+  return locationEnd;
 }
 
 export function isRenderLocation(node: INode | INodeSequence): node is IRenderLocation {

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -5,6 +5,7 @@ import { findElementControllerFor } from './resources/custom-element';
 import { MountTarget } from './templating/controller';
 import type { IHydratedController } from './templating/controller';
 import { createInterface } from './utilities-di';
+import { markerToLocation } from './utilities-dom';
 
 export class Refs {
   [key: string]: IHydratedController | undefined;
@@ -41,8 +42,6 @@ export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
  */
 export interface INodeSequence<T extends INode = INode> {
   readonly platform: IPlatform;
-  readonly isMounted: boolean;
-  readonly isLinked: boolean;
 
   readonly next?: INodeSequence<T>;
 
@@ -51,9 +50,9 @@ export interface INodeSequence<T extends INode = INode> {
    */
   readonly childNodes: ArrayLike<T>;
 
-  readonly firstChild: T;
+  readonly firstChild: T | null;
 
-  readonly lastChild: T;
+  readonly lastChild: T | null;
 
   /**
    * Find all instruction targets in this sequence.
@@ -222,29 +221,48 @@ export function isRenderLocation(node: INode | INodeSequence): node is IRenderLo
 }
 
 export class FragmentNodeSequence implements INodeSequence {
-  public isMounted: boolean = false;
-  public isLinked: boolean = false;
+  /** @internal */
+  private readonly _firstChild: Node | null;
+  public get firstChild(): Node | null {
+    return this._firstChild;
+  }
 
-  public firstChild: Node;
-  public lastChild: Node;
+  /** @internal */
+  private readonly _lastChild: Node | null;
+  public get lastChild(): Node | null {
+    return this._lastChild;
+  }
+
   public childNodes: Node[];
 
   public next?: INodeSequence = void 0;
 
-  private refNode?: Node = void 0;
+  /** @internal */
+  private _isMounted: boolean = false;
 
-  private readonly targets: ArrayLike<Node>;
+  /** @internal */
+  private _isLinked: boolean = false;
+
+  /** @internal */
+  private ref?: Node | null = null;
+
+  /** @internal */
+  private readonly t: ArrayLike<Node>;
+
+  /** @internal */
+  private readonly f: DocumentFragment;
 
   public constructor(
     public readonly platform: IPlatform,
-    private readonly fragment: DocumentFragment,
+    fragment: DocumentFragment,
   ) {
+    this.f = fragment;
     const targetNodeList = fragment.querySelectorAll('.au');
     let i = 0;
     let ii = targetNodeList.length;
     let target: Element;
     // eslint-disable-next-line
-    let targets = this.targets = Array(ii);
+    let targets = this.t = Array(ii);
 
     while (ii > i) {
       // eagerly convert all markers to RenderLocations (otherwise the renderer
@@ -255,7 +273,7 @@ export class FragmentNodeSequence implements INodeSequence {
       if (target.nodeName === 'AU-M') {
         // note the renderer will still call this method, but it will just return the
         // location if it sees it's already a location
-        targets[i] = convertToRenderLocation(target);
+        targets[i] = markerToLocation(target);
       } else {
         // also store non-markers for consistent ordering
         targets[i] = target;
@@ -271,23 +289,23 @@ export class FragmentNodeSequence implements INodeSequence {
       ++i;
     }
 
-    this.firstChild = fragment.firstChild!;
-    this.lastChild = fragment.lastChild!;
+    this._firstChild = fragment.firstChild;
+    this._lastChild = fragment.lastChild;
   }
 
   public findTargets(): ArrayLike<Node> {
-    return this.targets;
+    return this.t;
   }
 
   public insertBefore(refNode: IRenderLocation & Comment): void {
-    if (this.isLinked && !!this.refNode) {
+    if (this._isLinked && !!this.ref) {
       this.addToLinked();
     } else {
       const parent = refNode.parentNode!;
-      if (this.isMounted) {
-        let current = this.firstChild;
+      if (this._isMounted) {
+        let current = this._firstChild;
         let next: Node;
-        const end = this.lastChild;
+        const end = this._lastChild;
 
         while (current != null) {
           next = current.nextSibling!;
@@ -300,17 +318,17 @@ export class FragmentNodeSequence implements INodeSequence {
           current = next;
         }
       } else {
-        this.isMounted = true;
-        refNode.parentNode!.insertBefore(this.fragment, refNode);
+        this._isMounted = true;
+        refNode.parentNode!.insertBefore(this.f, refNode);
       }
     }
   }
 
   public appendTo(parent: Node, enhance: boolean = false): void {
-    if (this.isMounted) {
-      let current = this.firstChild;
+    if (this._isMounted) {
+      let current = this._firstChild;
       let next: Node;
-      const end = this.lastChild;
+      const end = this._lastChild;
 
       while (current != null) {
         next = current.nextSibling!;
@@ -323,22 +341,22 @@ export class FragmentNodeSequence implements INodeSequence {
         current = next;
       }
     } else {
-      this.isMounted = true;
+      this._isMounted = true;
       if (!enhance) {
-        parent.appendChild(this.fragment);
+        parent.appendChild(this.f);
       }
     }
   }
 
   public remove(): void {
-    if (this.isMounted) {
-      this.isMounted = false;
+    if (this._isMounted) {
+      this._isMounted = false;
 
-      const fragment = this.fragment;
-      const end = this.lastChild;
+      const fragment = this.f;
+      const end = this._lastChild;
       let next: Node;
 
-      let current = this.firstChild;
+      let current = this._firstChild;
       while (current !== null) {
         next = current.nextSibling!;
         fragment.appendChild(current);
@@ -353,12 +371,12 @@ export class FragmentNodeSequence implements INodeSequence {
   }
 
   public addToLinked(): void {
-    const refNode = this.refNode!;
+    const refNode = this.ref!;
     const parent = refNode.parentNode!;
-    if (this.isMounted) {
-      let current = this.firstChild;
+    if (this._isMounted) {
+      let current = this._firstChild;
       let next: Node;
-      const end = this.lastChild;
+      const end = this._lastChild;
 
       while (current != null) {
         next = current.nextSibling!;
@@ -371,32 +389,33 @@ export class FragmentNodeSequence implements INodeSequence {
         current = next;
       }
     } else {
-      this.isMounted = true;
-      parent.insertBefore(this.fragment, refNode);
+      this._isMounted = true;
+      parent.insertBefore(this.f, refNode);
     }
   }
 
   public unlink(): void {
-    this.isLinked = false;
+    this._isLinked = false;
     this.next = void 0;
-    this.refNode = void 0;
+    this.ref = void 0;
   }
 
   public link(next: INodeSequence | IRenderLocation & Comment | undefined): void {
-    this.isLinked = true;
+    this._isLinked = true;
     if (isRenderLocation(next!)) {
-      this.refNode = next;
+      this.ref = next;
     } else {
       this.next = next;
-      this.obtainRefNode();
+      this._obtainRefNode();
     }
   }
 
-  private obtainRefNode(): void {
+  /** @internal */
+  private _obtainRefNode(): void {
     if (this.next !== void 0) {
-      this.refNode = this.next.firstChild;
+      this.ref = this.next.firstChild;
     } else {
-      this.refNode = void 0;
+      this.ref = void 0;
     }
   }
 }

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -161,10 +161,32 @@ export {
   SetStyleAttributeInstruction,
   StylePropertyBindingInstruction,
   TextBindingInstruction,
+  SpreadBindingInstruction,
+  SpreadElementPropBindingInstruction,
+
   isInstruction,
   type InstructionTypeName,
   IInstruction,
   InstructionType,
+
+  PropertyBindingRenderer,
+  TextBindingRenderer,
+  ListenerBindingRenderer,
+  LetElementRenderer,
+  TemplateControllerRenderer,
+  AttributeBindingRenderer,
+  CustomAttributeRenderer,
+  CustomElementRenderer,
+  InterpolationBindingRenderer,
+  IteratorBindingRenderer,
+  MultiAttrInstruction,
+  RefBindingRenderer,
+  SetAttributeRenderer,
+  SetClassAttributeRenderer,
+  SetPropertyRenderer,
+  SetStyleAttributeRenderer,
+  SpreadRenderer,
+  StylePropertyBindingRenderer,
 } from './renderer';
 
 export {
@@ -339,29 +361,10 @@ export {
   ElseRegistration,
   RepeatRegistration,
   WithRegistration,
-  AttrBindingBehaviorRegistration,
   SelfBindingBehaviorRegistration,
   UpdateTriggerBindingBehaviorRegistration,
 
   DefaultResources,
-
-  AttributeBindingRendererRegistration,
-  ListenerBindingRendererRegistration,
-  SetAttributeRendererRegistration,
-  SetClassAttributeRendererRegistration,
-  SetStyleAttributeRendererRegistration,
-  StylePropertyBindingRendererRegistration,
-  TextBindingRendererRegistration,
-
-  RefBindingRendererRegistration,
-  CustomAttributeRendererRegistration,
-  CustomElementRendererRegistration,
-  InterpolationBindingRendererRegistration,
-  IteratorBindingRendererRegistration,
-  LetElementRendererRegistration,
-  PropertyBindingRendererRegistration,
-  SetPropertyRendererRegistration,
-  TemplateControllerRendererRegistration,
 
   DefaultRenderers,
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -102,7 +102,7 @@ export {
 export {
   IAttrMapper,
   type IsTwoWayPredicate,
-} from './attribute-mapper';
+} from './compiler/attribute-mapper';
 export {
   BindingMode,
   type IBindingController,
@@ -369,14 +369,14 @@ export {
 } from './configuration';
 export {
   ITemplateElementFactory
-} from './template-element-factory';
+} from './compiler/template-element-factory';
 export {
   BindablesInfo,
   TemplateCompiler,
   ITemplateCompilerHooks,
   TemplateCompilerHooks,
   templateCompilerHooks,
-} from './template-compiler';
+} from './compiler/template-compiler';
 
 export {
   allResources,

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -1,7 +1,7 @@
 import { camelCase, mergeArrays, firstDefined, emptyArray } from '@aurelia/kernel';
 import { ExpressionType, IExpressionParser } from '@aurelia/runtime';
 import { BindingMode } from '../binding/interfaces-bindings';
-import { IAttrMapper } from '../attribute-mapper';
+import { IAttrMapper } from '../compiler/attribute-mapper';
 import {
   AttributeBindingInstruction,
   PropertyBindingInstruction,

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -11,6 +11,11 @@ import type { LifecycleFlags, ControllerVisitor, ICustomElementController, ICust
 import type { IViewFactory } from '../../templating/view';
 import type { HydrateElementInstruction } from '../../renderer';
 
+@customElement({
+  name: 'au-slot',
+  template: null,
+  containerless: true
+})
 export class AuSlot implements ICustomElementViewModel {
   /** @internal */ public static get inject() { return [IRenderLocation, IInstruction, IHydrationContext, IRendering]; }
 
@@ -103,4 +108,3 @@ export class AuSlot implements ICustomElementViewModel {
   }
 }
 
-customElement({ name: 'au-slot', template: null, containerless: true })(AuSlot);

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -51,13 +51,14 @@ export const appendManyToTemplate = (parent: HTMLTemplateElement, children: Arra
   }
 };
 
+/** @internal */
 export const markerToLocation = (el: Element) => {
   const previousSibling = el.previousSibling;
   let locationEnd: IRenderLocation;
 
   if (previousSibling?.nodeType === /* Comment */8 && previousSibling.textContent === 'au-end') {
     locationEnd = previousSibling as IRenderLocation;
-    if ((locationEnd.$start = locationEnd.previousSibling! as Comment) == null) {
+    if ((locationEnd.$start = locationEnd.previousSibling! as IRenderLocation) == null) {
       throw markerMalformedError();
     }
     el.parentNode?.removeChild(el);

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -1,34 +1,47 @@
+import { IRenderLocation } from './dom';
 import { IPlatform } from './platform';
+import { createError } from './utilities';
 
+/** @internal */
 export const createElement
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   = <K extends string>(p: IPlatform, name: K): K extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[K] : HTMLElement => p.document.createElement(name) as any;
 
+/** @internal */
 export const createComment = (p: IPlatform, text: string) => p.document.createComment(text);
 
+/** @internal */
 export const createText = (p: IPlatform, text: string) => p.document.createTextNode(text);
 
-export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, target: Node) => {
+/** @internal */
+export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, target: Node | null) => {
   return parent.insertBefore(newChildNode, target);
 };
 
-export const insertManyBefore = (parent: Node, target: Node, nodes: ArrayLike<Node>) => {
-  const ii = nodes.length;
+/** @internal */
+export const insertManyBefore = (parent: Node, target: Node, newChildNodes: ArrayLike<Node>) => {
+  const ii = newChildNodes.length;
   let i = 0;
   while (ii > i) {
-    parent.insertBefore(nodes[i], target);
+    parent.insertBefore(newChildNodes[i], target);
     ++i;
   }
 };
 
+/** @internal */
+export const getPreviousSibling = (node: Node) => node.previousSibling;
+
+/** @internal */
 export const appendChild = <T extends Node>(parent: Node, child: T) => {
   return parent.appendChild(child);
 };
 
+/** @internal */
 export const appendToTemplate = <T extends Node>(parent: HTMLTemplateElement, child: T) => {
   return parent.content.appendChild(child);
 };
 
+/** @internal */
 export const appendManyToTemplate = (parent: HTMLTemplateElement, children: ArrayLike<Node>) => {
   const ii = children.length;
   let i = 0;
@@ -37,3 +50,24 @@ export const appendManyToTemplate = (parent: HTMLTemplateElement, children: Arra
     ++i;
   }
 };
+
+export const markerToLocation = (el: Element) => {
+  const previousSibling = el.previousSibling;
+  let locationEnd: IRenderLocation;
+
+  if (previousSibling?.nodeType === /* Comment */8 && previousSibling.textContent === 'au-end') {
+    locationEnd = previousSibling as IRenderLocation;
+    if ((locationEnd.$start = locationEnd.previousSibling! as Comment) == null) {
+      throw markerMalformedError();
+    }
+    el.parentNode?.removeChild(el);
+    return locationEnd;
+  } else {
+    throw markerMalformedError();
+  }
+};
+
+const markerMalformedError = () =>
+  __DEV__
+    ? createError(`AURxxxx: marker is malformed.`)
+    : createError(`AURxxxx`);

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -1,0 +1,39 @@
+import { IPlatform } from './platform';
+
+export const createElement
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  = <K extends string>(p: IPlatform, name: K): K extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[K] : HTMLElement => p.document.createElement(name) as any;
+
+export const createComment = (p: IPlatform, text: string) => p.document.createComment(text);
+
+export const createText = (p: IPlatform, text: string) => p.document.createTextNode(text);
+
+export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, target: Node) => {
+  return parent.insertBefore(newChildNode, target);
+};
+
+export const insertManyBefore = (parent: Node, target: Node, nodes: ArrayLike<Node>) => {
+  const ii = nodes.length;
+  let i = 0;
+  while (ii > i) {
+    parent.insertBefore(nodes[i], target);
+    ++i;
+  }
+};
+
+export const appendChild = <T extends Node>(parent: Node, child: T) => {
+  return parent.appendChild(child);
+};
+
+export const appendToTemplate = <T extends Node>(parent: HTMLTemplateElement, child: T) => {
+  return parent.content.appendChild(child);
+};
+
+export const appendManyToTemplate = (parent: HTMLTemplateElement, children: ArrayLike<Node>) => {
+  const ii = children.length;
+  let i = 0;
+  while (ii > i) {
+    parent.content.appendChild(children[i]);
+    ++i;
+  }
+};

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -23,7 +23,7 @@
  * IN THE SOFTWARE.
  */
 
-import { Task, TaskQueue, TaskQueuePriority } from '@aurelia/platform';
+import { Task, TaskQueue, TaskQueuePriority, reportTaskQueue } from '@aurelia/platform';
 import { IIndexable } from '@aurelia/kernel';
 import {
   isDeepEqual,
@@ -798,11 +798,8 @@ const areTaskQueuesEmpty = (function () {
       + `    task callback="${task.callback?.toString()}"`;
   }
 
-  function reportTaskQueue(name: string, taskQueue: TaskQueue) {
-    const processing = taskQueue['processing'] as any[];
-    const pending = taskQueue['pending'] as any[];
-    const delayed = taskQueue['delayed'] as any[];
-    const flushReq = taskQueue['flushRequested'];
+  function $reportTaskQueue(name: string, taskQueue: TaskQueue) {
+    const { processing, pending, delayed, flushRequested: flushReq } = reportTaskQueue(taskQueue);
 
     let info = `${name} has processing=${processing.length} pending=${pending.length} delayed=${delayed.length} flushRequested=${flushReq}\n\n`;
     if (processing.length > 0) {
@@ -828,15 +825,15 @@ const areTaskQueuesEmpty = (function () {
     let isEmpty = true;
     let message = '';
     if (!domWriteQueue.isEmpty) {
-      message += `\n${reportTaskQueue('domWriteQueue', domWriteQueue)}\n\n`;
+      message += `\n${$reportTaskQueue('domWriteQueue', domWriteQueue)}\n\n`;
       isEmpty = false;
     }
     if (!taskQueue.isEmpty) {
-      message += `\n${reportTaskQueue('taskQueue', taskQueue)}\n\n`;
+      message += `\n${$reportTaskQueue('taskQueue', taskQueue)}\n\n`;
       isEmpty = false;
     }
     if (!domReadQueue.isEmpty) {
-      message += `\n${reportTaskQueue('domReadQueue', domReadQueue)}\n\n`;
+      message += `\n${$reportTaskQueue('domReadQueue', domReadQueue)}\n\n`;
       isEmpty = false;
     }
 

--- a/packages/testing/src/scheduler.ts
+++ b/packages/testing/src/scheduler.ts
@@ -1,4 +1,4 @@
-import { ITask } from '@aurelia/platform';
+import { ensureEmpty } from '@aurelia/platform';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import { IPlatform } from '@aurelia/runtime-html';
 
@@ -8,13 +8,7 @@ export function ensureTaskQueuesEmpty(platform?: IPlatform): void {
   }
 
   // canceling pending heading to remove the sticky tasks
-
-  platform.taskQueue.flush();
-  platform.taskQueue['pending'].forEach((x: ITask) => x.cancel());
-
-  platform.domWriteQueue.flush();
-  platform.domWriteQueue['pending'].forEach((x: ITask) => x.cancel());
-
-  platform.domReadQueue.flush();
-  platform.domReadQueue['pending'].forEach((x: ITask) => x.cancel());
+  ensureEmpty(platform.taskQueue);
+  ensureEmpty(platform.domWriteQueue);
+  ensureEmpty(platform.domReadQueue);
 }

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -256,7 +256,7 @@ export class VirtualRepeat implements IScrollerSubscriber, IVirtualRepeater {
         scope.overrideContext.$index = idx;
         scope.overrideContext.$length = itemCount;
       } else {
-        view.nodes.insertBefore(prevView.nodes.firstChild.nextSibling!);
+        view.nodes.insertBefore(prevView.nodes.firstChild!.nextSibling!);
         scope = Scope.fromParent(
           controller.scope,
           new BindingContext(local, collectionStrategy.item(idx))
@@ -407,7 +407,7 @@ export class VirtualRepeat implements IScrollerSubscriber, IVirtualRepeater {
         scope.bindingContext[local] = collectionStrategy.item(idx);
         scope.overrideContext.$index = idx;
         scope.overrideContext.$length = collectionSize;
-        view.nodes.insertBefore(views[0].nodes.firstChild);
+        view.nodes.insertBefore(views[0].nodes.firstChild!);
         views.unshift(view);
         ++idxIncrement;
         --viewsToMoveCount;


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Optimize the rendering part by moving render location creation to the compiler, for both text and template controller. it requires the compiler to juggle more when it encounters a template controller/containerless/au-slot, but the perf gain is quite worth it.
- add some shakable helpers for task queue to be used in testing
- cleanup tests
- cleanup private/public props of default node sequence

## Next step

The compiler unit tests can use some refactoring so that's it's quicker to understand what is failing when a refactor happens.