### PR TITLE
fix(router-lite): history state change timing

### DIFF
--- a/packages/__tests__/router-lite/_shared/create-fixture.ts
+++ b/packages/__tests__/router-lite/_shared/create-fixture.ts
@@ -1,6 +1,6 @@
 import { Constructable, LogLevel, Registration, ILogConfig, DI, LoggerConfiguration, ConsoleSink, IContainer, Resolved, IPlatform, Class } from '@aurelia/kernel';
 import { Aurelia } from '@aurelia/runtime-html';
-import { IRouterOptions, RouterConfiguration, IRouter } from '@aurelia/router-lite';
+import { IRouterOptions, RouterConfiguration, IRouter, HistoryStrategy } from '@aurelia/router-lite';
 import { TestContext } from '@aurelia/testing';
 
 import { IHIAConfig, IHookInvocationAggregator } from './hook-invocation-tracker.js';
@@ -90,16 +90,23 @@ export async function createFixture<T extends Constructable>(
   };
 }
 
+type RouterTestStartOptions<TAppRoot> = {
+  appRoot: Class<TAppRoot>;
+  useHash?: boolean;
+  registrations?: any[];
+  historyStrategy?: HistoryStrategy;
+};
+
 /**
  * Simpler fixture creation.
  */
-export async function start<TAppRoot>(appRoot: Class<TAppRoot>, useHash: boolean = false, ...registrations: any[]) {
+export async function start<TAppRoot>({ appRoot, useHash = false, registrations = [], historyStrategy = 'replace' }: RouterTestStartOptions<TAppRoot>) {
   const ctx = TestContext.create();
   const { container } = ctx;
 
   container.register(
     TestRouterConfiguration.for(LogLevel.warn),
-    RouterConfiguration.customize({ useUrlFragmentHash: useHash }),
+    RouterConfiguration.customize({ useUrlFragmentHash: useHash, historyStrategy }),
     ...registrations,
   );
 

--- a/packages/__tests__/router-lite/resources/href.spec.ts
+++ b/packages/__tests__/router-lite/resources/href.spec.ts
@@ -27,7 +27,7 @@ describe('href custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false,  Products, Product);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Products, Product] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -90,7 +90,7 @@ describe('href custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, L11, L12, L21, L22);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [L11, L12, L21, L22] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21');
@@ -168,7 +168,7 @@ describe('href custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, L11, L12, L21, L22, L23, L24);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [L11, L12, L21, L22, L23, L24] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21', 'init');
@@ -245,7 +245,7 @@ describe('href custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, true, CeOne, CeTwo, CeThree);
+    const { au, host, container } = await start({ appRoot: Root, useHash: true, registrations: [CeOne, CeTwo, CeThree] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -34,7 +34,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, Foo);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Foo] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -72,7 +72,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, Foo);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Foo] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -96,7 +96,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, Foo);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Foo] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -135,7 +135,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, Products, Product);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Products, Product] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -197,7 +197,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, Products, Product);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [Products, Product] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 
@@ -260,7 +260,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, L11, L12, L21, L22);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [L11, L12, L21, L22] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21');
@@ -319,7 +319,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, L11, L12, L21, L22);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [L11, L12, L21, L22] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21');
@@ -396,7 +396,7 @@ describe('load custom-attribute', function () {
     @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
     class Root { }
 
-    const { au, host, container } = await start(Root, false, L11, L12, L21, L22, L23, L24);
+    const { au, host, container } = await start({ appRoot: Root, registrations: [L11, L12, L21, L22, L23, L24] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
     assert.html.textContent(host, 'l11 l21', 'init');
@@ -454,7 +454,7 @@ describe('load custom-attribute', function () {
     })
     class Root { }
 
-    const { au, host, container } = await start(Root, true, CeOne, CeTwo);
+    const { au, host, container } = await start({ appRoot: Root, useHash: true, registrations: [CeOne, CeTwo] });
     const queue = container.get(IPlatform).domWriteQueue;
     await queue.yield();
 

--- a/packages/__tests__/router-lite/router-containerless.spec.ts
+++ b/packages/__tests__/router-lite/router-containerless.spec.ts
@@ -24,7 +24,7 @@ describe('router-lite/router-containerless.spec.ts', function () {
     })
     class App {}
 
-    const { host } = await start(App);
+    const { host } = await start({ appRoot: App });
 
     assert.strictEqual(null, host.querySelector('foo'));
   });
@@ -49,7 +49,7 @@ describe('router-lite/router-containerless.spec.ts', function () {
     })
     class App {}
 
-    const { host, container } = await start(App);
+    const { host, container } = await start({ appRoot: App });
 
     assert.strictEqual(null, host.querySelector('foo'));
     assert.html.textContent(host.querySelector('au-viewport'), 'foo');

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -1,6 +1,6 @@
 import { LogLevel, Constructable, kebabCase, ILogConfig, Registration, noop, IModule } from '@aurelia/kernel';
 import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
-import { RouterConfiguration, IRouter, NavigationInstruction, IRouteContext, RouteNode, Params, route, INavigationModel, IRouterOptions, IRouteViewModel, IRouteConfig, RouteDefinition, Router } from '@aurelia/router-lite';
+import { RouterConfiguration, IRouter, NavigationInstruction, IRouteContext, RouteNode, Params, route, INavigationModel, IRouterOptions, IRouteViewModel, IRouteConfig, RouteDefinition, Router, HistoryStrategy, IRouterEvents } from '@aurelia/router-lite';
 import { LifecycleFlags, Aurelia, valueConverter, customElement, CustomElement, ICustomElementViewModel, IHistory, IHydratedController, ILocation, INode, IPlatform, IWindow, StandardConfiguration, watch } from '@aurelia/runtime-html';
 
 import { TestRouterConfiguration } from './_shared/configuration.js';
@@ -2458,7 +2458,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
 
       host.querySelector('a').click();
@@ -2515,7 +2515,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
 
       host.querySelector('a').click();
@@ -2557,7 +2557,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
       const router = container.get<Router>(IRouter);
 
@@ -2620,7 +2620,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
       const router = container.get<Router>(IRouter);
 
@@ -2687,7 +2687,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
       const router = container.get<Router>(IRouter);
 
@@ -2754,7 +2754,7 @@ describe('router (smoke tests)', function () {
       @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
       class Root { }
 
-      const { au, container, host } = await start(Root, false, CeOne);
+      const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
       const queue = container.get(IPlatform).domWriteQueue;
       const router = container.get<Router>(IRouter);
 
@@ -2770,5 +2770,93 @@ describe('router (smoke tests)', function () {
 
       await au.stop();
     });
+  });
+
+  describe('history strategy', function () {
+    class TestData {
+      public constructor(
+        public readonly strategy: HistoryStrategy,
+        public readonly expectations: string[]
+      ) { }
+    }
+
+    function* getTestData(): Generator<TestData> {
+      yield new TestData('push', [
+        '#1 - len: 1 - state: {"au-nav-id":1}',
+        '#2 - len: 2 - state: {"au-nav-id":2}',
+        '#3 - len: 3 - state: {"au-nav-id":3}',
+        '#4 - len: 4 - state: {"au-nav-id":4}',
+      ]);
+      yield new TestData('replace', [
+        '#1 - len: 1 - state: {"au-nav-id":1}',
+        '#2 - len: 1 - state: {"au-nav-id":2}',
+        '#3 - len: 1 - state: {"au-nav-id":3}',
+        '#4 - len: 1 - state: {"au-nav-id":4}',
+      ]);
+      yield new TestData('none', [
+        '#1 - len: 1 - state: {"au-nav-id":1}', // initial state replace
+        '#2 - len: 1 - state: {"au-nav-id":1}',
+        '#3 - len: 1 - state: {"au-nav-id":1}',
+        '#4 - len: 1 - state: {"au-nav-id":1}',
+      ]);
+    }
+
+    for (const data of getTestData()) {
+      it(data.strategy, async function () {
+
+        @customElement({ name: 'ce-two', template: 'ce2' })
+        class CeTwo implements IRouteViewModel { }
+
+        @customElement({ name: 'ce-one', template: 'ce1' })
+        class CeOne implements IRouteViewModel { }
+
+        @route({
+          routes: [
+            {
+              id: 'ce1',
+              path: ['', 'ce1'],
+              component: CeOne,
+            },
+            {
+              id: 'ce2',
+              path: ['ce2'],
+              component: CeTwo,
+            },
+          ]
+        })
+        @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><a load="ce2"></a><span id="history">${history}</span><au-viewport></au-viewport>' })
+        class Root {
+          private history: string;
+          public constructor(
+            @IHistory history: IHistory,
+            @IRouterEvents events: IRouterEvents
+          ) {
+            let i = 0;
+            events.subscribe('au:router:navigation-end', () => {
+              this.history = `#${++i} - len: ${history.length} - state: ${JSON.stringify(history.state)}`;
+            });
+          }
+        }
+
+        const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne, CeTwo], historyStrategy: data.strategy });
+        const queue = container.get(IPlatform).domWriteQueue;
+        const router = container.get<Router>(IRouter);
+
+        const expectations = data.expectations;
+        const len = expectations.length;
+        await queue.yield();
+        const history = host.querySelector<HTMLSpanElement>('#history');
+        assert.html.textContent(history, expectations[0], 'start');
+        const anchors = Array.from(host.querySelectorAll('a'));
+        for (let i = 1; i < len; i++) {
+          anchors[i % 2].click();
+          await router.currentTr.promise;
+          await queue.yield();
+          assert.html.textContent(history, expectations[i], `round#${i}`);
+        }
+
+        await au.stop();
+      });
+    }
   });
 });

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -802,9 +802,9 @@ export class Router {
 
         this.instructions = tr.finalInstructions = tr.routeTree.finalizeInstructions();
         this._isNavigating = false;
+        this.applyHistoryState(tr);
         this.events.publish(new NavigationEndEvent(tr.id, tr.instructions, this.instructions));
 
-        this.applyHistoryState(tr);
         tr.resolve!(true);
 
         this.runNextTransition();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
Previously, the history state was changed after the navigation end event is raised. Any subscriber listening to the navigation-end event might end up with wrong history state. This PR makes the history adjustment before the navigation-end event is raised.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
