### PR TITLE
feat(portal): ability to specify insert position

### DIFF
--- a/examples/fractals-tree/package.json
+++ b/examples/fractals-tree/package.json
@@ -8,8 +8,13 @@
   },
   "version": "0.8.0",
   "scripts": {
-    "build": "webpack --config webpack.config.js",
-    "serve": "node ../../node_modules/@aurelia/http-server/dist/esm/cli.js au.conf.js"
+    "build": "rollup -c",
+    "serve": "node ../../node_modules/@aurelia/http-server/dist/esm/cli.js au.conf.js",
+    "build:kernel": "cd ../../packages/kernel && npm run build",
+    "build:runtime": "cd ../../packages/runtime && npm run build",
+    "build:runtime-html": "cd ../../packages/runtime-html && npm run build",
+    "build:all": "concurrently \"npm run build:kernel\" \"npm run build:runtime\" \"npm run build:runtime-html\"",
+    "postbuild:all": "rollup -c"
   },
   "dependencies": {
     "@aurelia/kernel": "2.0.0-alpha.41",

--- a/examples/fractals-tree/rollup.config.js
+++ b/examples/fractals-tree/rollup.config.js
@@ -1,0 +1,12 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+
+/** @type {import('rollup').RollupOptions} */
+export default {
+    input: './app',
+    output: {
+        file: 'dist/bundle.js',
+        sourcemap: true
+    },
+    plugins: [nodeResolve(), terser()]
+}

--- a/packages/__e2e__/playwright-util.js
+++ b/packages/__e2e__/playwright-util.js
@@ -11,7 +11,7 @@ module.exports = function getPlaywrightConfig(port) {
     //   port: port,
     // }
     use: {
-      baseURL: 'http://localhost:' + port
+      baseURL: 'http://localhost:' + port,
     }
   }
 };

--- a/packages/__tests__/3-runtime-html/portal.spec.tsx
+++ b/packages/__tests__/3-runtime-html/portal.spec.tsx
@@ -4,11 +4,77 @@ import { CustomElement, Aurelia } from '@aurelia/runtime-html';
 import {
   assert,
   eachCartesianJoin,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hJsx, // deepscan-disable-line UNUSED_IMPORT
   TestContext,
+  createFixture,
 } from '@aurelia/testing';
 
 describe('portal.spec.tsx 🚪-🔁-🚪', function () {
+
+  it('portals to "beforebegin" position', function () {
+    const { assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position: beforebegin">click me</button>
+      </>
+    );
+    assertHtml('<!--au-start--><button>click me</button><!--au-end--><div id="d1">hello</div><!--au-start--><!--au-end-->');
+  });
+
+  it('portals to "afterbegin" position', function () {
+    const { assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position: afterbegin">click me</button>
+      </>
+    );
+    assertHtml('<div id="d1"><!--au-start--><button>click me</button><!--au-end-->hello</div><!--au-start--><!--au-end-->');
+  });
+
+  it('portals to "beforeend" position', function () {
+    const { assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position: beforeend">click me</button>
+      </>
+    );
+    assertHtml('<div id="d1">hello<!--au-start--><button>click me</button><!--au-end--></div><!--au-start--><!--au-end-->');
+  });
+
+  it('portals to "afterend" position', function () {
+    const { assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position: afterend">click me</button>
+      </>
+    );
+    assertHtml('<div id="d1">hello</div><!--au-start--><button>click me</button><!--au-end--><!--au-start--><!--au-end-->');
+  });
+
+  it('moves view when position change beforeend -> afterend', function () {
+    const { component, assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position.bind: position">click me</button>
+      </>,
+      { position: 'beforeend' }
+    );
+    component.position = 'afterend';
+    assertHtml('<div id="d1">hello</div><!--au-start--><button>click me</button><!--au-end--><!--au-start--><!--au-end-->');
+  });
+
+  it('moves view when position change afterend -> beforebegin', function () {
+    const { component, assertHtml } = createFixture(
+      <>
+        <div id="d1">hello</div>
+        <button portal="target: #d1; position.bind: position">click me</button>
+      </>,
+      { position: 'beforeend' }
+    );
+    component.position = 'beforebegin';
+    assertHtml('<!--au-start--><button>click me</button><!--au-end--><div id="d1">hello</div><!--au-start--><!--au-end-->');
+  });
 
   describe('basic', function () {
 
@@ -229,10 +295,10 @@ describe('portal.spec.tsx 🚪-🔁-🚪', function () {
         rootVm: CustomElement.define(
           {
             name: 'app',
-            template: <template>
+            template: <>
               <div ref='divdiv' portal='target.bind: target' class='divdiv'>{'${message}'}</div>
               <div ref='localDiv'></div>
-            </template>
+            </>
           },
           class App {
             public localDiv: HTMLElement;

--- a/packages/mangle-namecache.js
+++ b/packages/mangle-namecache.js
@@ -1,87 +1,50 @@
-// a cache for mangling private properties across modules into a consistent property name
-export const terserNameCache = (() => {
-  const cache = {
-    props: {
-      props: {
-        $_attrMapper: 'm',
-        $_callback: 'cb',
-        $_container: 'c',
-        $_exprParser: 'ep',
-        $_factory: 'f',
-        $_flags: 'fs',
-        $_getter: 'g',
-        $_hasSetter: 'hs',
-        $_hydrateCustomElement: 'hE',
-        $_hydrate: 'hS',
-        $_hydrateChildren: 'hC',
-        $_isDirty: 'D',
-        $_isRunning: 'ir',
-        $_key: 'k',
-        $_location: 'l',
-        $_obj: 'o',
-        $_observerLocator: 'oL',
-        $_observing: 'iO',
-        $_oldValue: 'ov',
-        $_platform: 'p',
-        $_rendering: 'r',
-        $_scope: 's',
-        $_setter: 'S',
-        $_useProxy: 'up',
-        $_value: 'v',
-      },
-    }
-  };
+const mapping = {
+  _attrMapper: 'm',
+  _callback: 'cb',
+  _config: 'cf',
+  _container: 'c',
+  _exprParser: 'ep',
+  _factory: 'f',
+  _flags: 'fs',
+  _getter: 'g',
+  _hasSetter: 'hs',
+  _hydrateCustomElement: 'hE',
+  _hydrate: 'hS',
+  _hydrateChildren: 'hC',
+  _isDirty: 'D',
+  _isRunning: 'ir',
+  _key: 'k',
+  _location: 'l',
+  _obj: 'o',
+  _observerLocator: 'oL',
+  _observing: 'iO',
+  _oldValue: 'ov',
+  _platform: 'p',
+  _rendering: 'r',
+  _scope: 's',
+  _setter: 'S',
+  _useProxy: 'up',
+  _value: 'v',
+};
 
+(function () {
   const mangledPropToPropMap = new Map();
-  for (const prop in cache.props.props) {
-    const value = cache.props.props[prop];
+  for (const prop in mapping) {
+    const value = mapping[prop];
     if (mangledPropToPropMap.has(value)) {
       throw new Error(`Invalid mangled name ${value}, already used for ${mangledPropToPropMap.get(value)}`);
     }
     mangledPropToPropMap.set(value, prop);
   }
-
-  return cache;
 })();
 
-// a cache for mangling private properties across modules into a consistent property name
-export const esbuildNameCache = (() => {
-  const cache = {
-    _attrMapper: 'm',
-    _callback: 'cb',
-    _container: 'c',
-    _exprParser: 'ep',
-    _factory: 'f',
-    _flags: 'fs',
-    _getter: 'g',
-    _hasSetter: 'hs',
-    _hydrateCustomElement: 'hE',
-    _hydrate: 'hS',
-    _hydrateChildren: 'hC',
-    _isDirty: 'D',
-    _isRunning: 'ir',
-    _key: 'k',
-    _location: 'l',
-    _obj: 'o',
-    _observerLocator: 'oL',
-    _observing: 'iO',
-    _oldValue: 'ov',
-    _platform: 'p',
-    _rendering: 'r',
-    _scope: 's',
-    _setter: 'S',
-    _useProxy: 'up',
-    _value: 'v',
-  };
-
-  const mangledPropToPropMap = new Map();
-  for (const prop in cache) {
-    const value = cache[prop];
-    if (mangledPropToPropMap.has(value)) {
-      throw new Error(`Invalid mangled name ${value}, already used for ${mangledPropToPropMap.get(value)}`);
-    }
-    mangledPropToPropMap.set(value, prop);
+export const terserNameCache = {
+  props: {
+    props: Object.keys(mapping).reduce((map, key) => {
+      map[`$${key}`] = mapping[key];
+      return map;
+    }, {}),
   }
+};
 
-  return cache;
-})();
+export const esbuildNameCache = { ...mapping };

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -3,12 +3,25 @@ import { IPlatform } from './platform';
 import { createError } from './utilities';
 
 /** @internal */
+export const auLocationStart = 'au-start';
+/** @internal */
+export const auLocationEnd = 'au-end';
+
+/** @internal */
 export const createElement
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   = <K extends string>(p: IPlatform, name: K): K extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[K] : HTMLElement => p.document.createElement(name) as any;
 
 /** @internal */
 export const createComment = (p: IPlatform, text: string) => p.document.createComment(text);
+
+/** @internal */
+export const createLocation = (p: IPlatform) => {
+  const locationEnd = createComment(p, auLocationEnd) as IRenderLocation;
+  locationEnd.$start = createComment(p, auLocationStart) as IRenderLocation;
+
+  return locationEnd;
+};
 
 /** @internal */
 export const createText = (p: IPlatform, text: string) => p.document.createTextNode(text);
@@ -19,7 +32,10 @@ export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, targ
 };
 
 /** @internal */
-export const insertManyBefore = (parent: Node, target: Node, newChildNodes: ArrayLike<Node>) => {
+export const insertManyBefore = (parent: Node | null, target: Node | null, newChildNodes: ArrayLike<Node>) => {
+  if (parent === null) {
+    return;
+  }
   const ii = newChildNodes.length;
   let i = 0;
   while (ii > i) {

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -129,15 +129,26 @@ export function createFixture<T extends object>(
       assert.strictEqual(host.textContent, selector);
     }
   }
-  function assertHtml(selector: string, html?: string) {
-    if (arguments.length === 2) {
-      const el = queryBy(selector);
+  function getInnerHtml(el: Element, compact?: boolean) {
+    let actual = el.innerHTML;
+    if (compact) {
+      actual = actual
+        .replace(/<!--au-start-->/g, '')
+        .replace(/<!--au-end-->/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+    return actual;
+  }
+  function assertHtml(selectorOrHtml: string, html: string = selectorOrHtml, { compact }: { compact?: boolean } = { compact: false }) {
+    if (arguments.length > 1) {
+      const el = queryBy(selectorOrHtml);
       if (el === null) {
-        throw new Error(`No element found for selector "${selector}" to compare innerHTML against "${html}"`);
+        throw new Error(`No element found for selector "${selectorOrHtml}" to compare innerHTML against "${html}"`);
       }
-      assert.strictEqual(el.innerHTML, html);
+      assert.strictEqual(getInnerHtml(el, compact) , html);
     } else {
-      assert.strictEqual(host.innerHTML, selector);
+      assert.strictEqual(getInnerHtml(host, compact), selectorOrHtml);
     }
   }
   function assertAttr(selector: string, name: string, value: string | null) {

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -61,6 +61,8 @@ const validPackages = [
   'kernel',
   'runtime',
   'runtime-html',
+  'dialog',
+  'web-components',
   'i18n',
   'fetch-client',
   'route-recognizer',


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add `position` bindable so that apps can specify where view can be moved to, similar to `insertAdjacentElement` API. There are 4 positions:
- beforebegin
- afterbegin
- beforeend
- afterend

illustrated:
```html
// beforebegin
<div>
  // afterbegin
  ...
  // beforeend
</div>
// afterend
```

Usage:

```html
<div portal="target: meta[content=charset]; position: beforebegin"></div>
```

Resolves #1527 