### PR TITLE
fix(route-recognizer): residue handling

### DIFF
--- a/packages/__tests__/router-lite/route-recognizer.spec.ts
+++ b/packages/__tests__/router-lite/route-recognizer.spec.ts
@@ -6,7 +6,6 @@ describe(RouteRecognizer.name, function () {
   interface RecognizeSpec {
     routes: [string, Parameter[]][];
     tests: [string, string | null, Record<string, string> | null][];
-    addResidue?: boolean;
   }
 
   const recognizeSpecs: RecognizeSpec[] = [
@@ -2759,29 +2758,12 @@ describe(RouteRecognizer.name, function () {
       ],
     },
     // #endregion
-    // #region
-    {
-      routes: [
-        ['', []],
-        ['a', []],
-        ['b/:1', [new Parameter('1', false, false)]],
-        ['b/:1/*2', [new Parameter('1', false, false), new Parameter('2', true, true)]],
-      ],
-      tests: [
-        ['b/1', 'b/:1', { 1: '1' }],
-        ['b/1/2', 'b/:1/*2', { 1: '1', 2: '2' }],
-        ['b/1/2/3', 'b/:1/*2', { 1: '1', 2: '2/3' }],
-        ['a/1/2/3', `a/*${RESIDUE}`, { [RESIDUE]: '1/2/3' }],
-      ],
-      addResidue: true,
-    }
-    // #endregion
   ];
 
   for (const hasLeadingSlash of [true, false]) {
     for (const hasTrailingSlash of [true, false]) {
       for (const reverseAdd of [true, false]) {
-        for (const { tests, routes: $routes, addResidue = false } of recognizeSpecs) {
+        for (const { tests, routes: $routes } of recognizeSpecs) {
           const routes = reverseAdd ? $routes.slice().reverse() : $routes;
           for (const [path, match, $params] of tests) {
             const leading = hasLeadingSlash ? '/' : '';
@@ -2795,7 +2777,7 @@ describe(RouteRecognizer.name, function () {
                 // Arrange
                 const sut = new RouteRecognizer();
                 for (const [route] of routes) {
-                  sut.add({ path: route, handler: null }, addResidue);
+                  sut.add({ path: route, handler: null }, false);
                 }
 
                 // Act
@@ -2812,22 +2794,12 @@ describe(RouteRecognizer.name, function () {
                 // Arrange
                 const sut = new RouteRecognizer();
                 for (const [route] of routes) {
-                  sut.add({ path: route, handler: null }, addResidue);
+                  sut.add({ path: route, handler: null }, false);
                 }
 
                 const params = { ...$params };
                 const configurableRoute = new ConfigurableRoute(match, false, null);
-                let parameters: Parameter[];
-                if(match.endsWith(`/*${RESIDUE}`)) {
-                  const $match = match.substring(0, match.length - (RESIDUE.length + 2));
-                  parameters = [
-                    ...routes.find(([route]) => route === $match)[1],
-                    new Parameter(RESIDUE, true, true),
-                  ];
-                } else {
-                  parameters = routes.find(([route]) => route === match)[1];
-                }
-                const endpoint = new Endpoint(configurableRoute, parameters);
+                const endpoint = new Endpoint(configurableRoute, routes.find(([route]) => route === match)[1]);
                 const expected = new RecognizedRoute(endpoint, params);
 
                 // Act
@@ -2840,6 +2812,78 @@ describe(RouteRecognizer.name, function () {
               });
             }
           }
+        }
+      }
+    }
+  }
+
+  for (const hasLeadingSlash of [true, false]) {
+    for (const hasTrailingSlash of [true, false]) {
+      for (const reverseAdd of [true, false]) {
+        const $routes: [string, Parameter[], boolean][] = [
+          ['', [], true],
+          ['a', [], true],
+          ['b/:1', [new Parameter('1', false, false)], true],
+          ['b/:1/*2', [new Parameter('1', false, false), new Parameter('2', true, true)], false],
+        ];
+        const tests: [string, string | null, Record<string, string> | null][] = [
+          ['b/1', 'b/:1', { 1: '1' }],
+          ['b/1/2', 'b/:1/*2', { 1: '1', 2: '2' }],
+          ['b/1/2/3', 'b/:1/*2', { 1: '1', 2: '2/3' }],
+          ['a/1/2/3', `a/*${RESIDUE}`, { [RESIDUE]: '1/2/3' }],
+        ];
+
+        const routes = reverseAdd ? $routes.slice().reverse() : $routes;
+        for (const [path, match, $params] of tests) {
+          const leading = hasLeadingSlash ? '/' : '';
+          const trailing = hasTrailingSlash ? '/' : '';
+
+          let title = `should`;
+          const input = `${leading}${path}${trailing}`;
+          title = `${title} recognize '${input}' as '${match}' out of routes: [${routes.map(x => `'${x[0]}'`).join(',')}]`;
+
+          it(title, function () {
+            // Arrange
+            const sut = new RouteRecognizer();
+            for (const [route] of routes) {
+              sut.add({ path: route, handler: null }, true);
+            }
+
+            for (const [route, parameters, residueAdded] of routes) {
+              const endpoint = sut.getEndpoint(route);
+              assert.notEqual(endpoint, null);
+              assert.deepStrictEqual(endpoint.params, parameters);
+              const residueEndpoint = sut.getEndpoint(`${route}/*${RESIDUE}`);
+              if(residueAdded) {
+                assert.notEqual(residueEndpoint, null);
+              } else {
+                assert.equal(residueEndpoint, null);
+              }
+            }
+
+            const params = { ...$params };
+            const configurableRoute = new ConfigurableRoute(match, false, null);
+            let parameters: Parameter[];
+            if(match.endsWith(`/*${RESIDUE}`)) {
+              const $match = match.substring(0, match.length - (RESIDUE.length + 2));
+              parameters = [
+                ...routes.find(([route]) => route === $match)[1],
+                new Parameter(RESIDUE, true, true),
+              ];
+            } else {
+              parameters = routes.find(([route]) => route === match)[1];
+            }
+            const endpoint = new Endpoint(configurableRoute, parameters);
+            const expected = new RecognizedRoute(endpoint, params);
+
+            // Act
+            const actual1 = sut.recognize(path);
+            const actual2 = sut.recognize(path);
+
+            // Assert
+            assert.deepStrictEqual(actual1, actual2, `consecutive calls should return the same result`);
+            assert.deepStrictEqual(actual1, expected);
+          });
         }
       }
     }

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -1,5 +1,5 @@
 import { Constructable, DI, IContainer, ILogger, IModule, IModuleLoader, InstanceProvider, noop, onResolve, Protocol, Registration, ResourceDefinition } from '@aurelia/kernel';
-import { Endpoint, RecognizedRoute, RouteRecognizer } from '@aurelia/route-recognizer';
+import { Endpoint, RecognizedRoute, RESIDUE, RouteRecognizer } from '@aurelia/route-recognizer';
 import { CustomElement, CustomElementDefinition, IAppRoot, IController, ICustomElementController, IPlatform, isCustomElementController, isCustomElementViewModel, PartialCustomElementDefinition } from '@aurelia/runtime-html';
 
 import { ComponentAgent, IRouteViewModel } from './component-agent';
@@ -16,8 +16,6 @@ import { ViewportAgent, ViewportRequest } from './viewport-agent';
 
 export interface IRouteContext extends RouteContext { }
 export const IRouteContext = DI.createInterface<IRouteContext>('IRouteContext');
-
-export const RESIDUE = 'au$residue' as const;
 
 type PathGenerationResult = { vi: ViewportInstruction; query: Params | null };
 
@@ -426,12 +424,7 @@ export class RouteContext {
       path,
       caseSensitive,
       handler,
-    });
-    this.recognizer.add({
-      path: `${path}/*${RESIDUE}`,
-      caseSensitive,
-      handler,
-    });
+    }, true);
   }
 
   public resolveLazy(promise: Promise<IModule>): Promise<CustomElementDefinition> | CustomElementDefinition {

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -9,6 +9,7 @@ import {
   ConfigurableRoute,
   Endpoint,
   RecognizedRoute,
+  RESIDUE,
 } from '@aurelia/route-recognizer';
 import {
   CustomElementDefinition,
@@ -25,7 +26,6 @@ import {
 import {
   $RecognizedRoute,
   IRouteContext,
-  RESIDUE,
 } from './route-context';
 import {
   defaultViewportName,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR corrects the registration of residue routes. 

Till now, for every route `ro/ute`, an additional route `ro/ute/*RESIDUE` is added to the recognizer. The registration of this additional route is required to facilitate hierarchical (parent-child) route recognition.

However, it poses a problem when a route itself ends with a *-segment. In that case, there is technically no need for the additional route registration with a `*RESIDUE` segment at the end.  The assumption here is that a route ending with a *-segment has no child routes configured. Also, due to this extra registration, the recognition of routes was also unexpected. For example, when the following 2 routes are registered, `b/:1`, `b/:1/*2`, an attempt to recognize the path `b/1/2` resulted in the selection of the endpoint `b/:1/*RESIDUE`, although it is expected in this case that `b/:1/*2` endpoint is selected instead.

This PR corrects the situation by introducing a new segment kind for residue, and associating a lower priority to it so that endpoints with residue are sorted down in the list of candidates, while recognizing a route. Additionally, it avoids registering a route with residue if the segment of the route contains a *-segment.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

Take a look at the tests added.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
