### PR TITLE
Fix `MutationObserver` from platform (#1618)

### DIFF
--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -156,6 +156,7 @@ export class AttributeBinding implements IBinding {
       this.target as HTMLElement,
       this.targetProperty,
       this.targetAttribute,
+      this.l,
     );
 
     if (this.mode & (BindingMode.toView | BindingMode.oneTime)) {

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,11 +1,14 @@
 import { subscriberCollection, AccessorType } from '@aurelia/runtime';
 import { createError, isString } from '../utilities';
+import { IPlatform } from '../platform';
 
 import type {
   IObserver,
   ISubscriber,
   ISubscriberCollection,
 } from '@aurelia/runtime';
+import type { IServiceLocator } from '@aurelia/kernel';
+import type { BrowserPlatform } from '@aurelia/platform-browser';
 
 export interface AttributeObserver extends
   IObserver,
@@ -41,15 +44,20 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   /** @internal */
   private readonly _attr: string;
 
+  /** @internal */
+  private readonly _platform: IPlatform;
+
   public constructor(
     obj: HTMLElement,
     // todo: rename to attr and sub-attr
     prop: string,
     attr: string,
+    locator: IServiceLocator,
   ) {
     this._obj = obj;
     this._prop = prop;
     this._attr = attr;
+    this._platform = locator.get(IPlatform);
   }
 
   public getValue(): unknown {
@@ -145,7 +153,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
   public subscribe(subscriber: ISubscriber): void {
     if (this.subs.add(subscriber) && this.subs.count === 1) {
       this._value = this._oldValue = this._obj.getAttribute(this._prop);
-      startObservation(this._obj.ownerDocument.defaultView!.MutationObserver, this._obj as IHtmlElement, this);
+      startObservation((this._platform as BrowserPlatform).MutationObserver, this._obj as IHtmlElement, this);
     }
   }
 

--- a/packages/runtime-html/src/observation/select-value-observer.ts
+++ b/packages/runtime-html/src/observation/select-value-observer.ts
@@ -3,6 +3,10 @@ import {
   subscriberCollection,
   AccessorType,
 } from '@aurelia/runtime';
+import { createError, hasOwnProperty, isArray } from '../utilities';
+import { INodeObserver, INodeObserverConfigBase } from './observer-locator';
+import { mixinNodeObserverUseConfig } from './observation-utils';
+import { IPlatform } from '../platform';
 
 import type { INode } from '../dom';
 import type {
@@ -10,9 +14,8 @@ import type {
   IObserverLocator,
   ISubscriberCollection,
 } from '@aurelia/runtime';
-import { createError, hasOwnProperty, isArray } from '../utilities';
-import { INodeObserver, INodeObserverConfigBase } from './observer-locator';
-import { mixinNodeObserverUseConfig } from './observation-utils';
+import type { IServiceLocator } from '@aurelia/kernel';
+import type { BrowserPlatform } from '@aurelia/platform-browser';
 
 const childObserverOptions = {
   childList: true,
@@ -62,6 +65,9 @@ export class SelectValueObserver implements INodeObserver {
   /** @internal */
   private readonly _observerLocator: IObserverLocator;
 
+  /** @internal */
+  private readonly _platform: IPlatform;
+
   /**
    * Used by mixing defined methods subscribe/unsubscribe
    *
@@ -83,10 +89,12 @@ export class SelectValueObserver implements INodeObserver {
     _key: PropertyKey,
     config: INodeObserverConfigBase,
     observerLocator: IObserverLocator,
+    locator: IServiceLocator,
   ) {
     this._el = obj as ISelectElement;
     this._observerLocator = observerLocator;
     this._config = config;
+    this._platform = locator.get(IPlatform);
   }
 
   public getValue(): unknown {
@@ -239,7 +247,7 @@ export class SelectValueObserver implements INodeObserver {
    * @internal
    */
   public _start(): void {
-    (this._nodeObserver = new this._el.ownerDocument.defaultView!.MutationObserver(this._handleNodeChange.bind(this)))
+    (this._nodeObserver = new (this._platform as BrowserPlatform).MutationObserver(this._handleNodeChange.bind(this)))
       .observe(this._el, childObserverOptions);
     this._observeArray(this._value instanceof Array ? this._value : null);
     this._observing = true;

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -3,11 +3,13 @@ import { subscriberCollection } from '@aurelia/runtime';
 import { findElementControllerFor } from '../resources/custom-element';
 import { appendAnnotationKey, defineMetadata, getAllAnnotations, getAnnotationKeyFor, getOwnMetadata } from '../utilities-metadata';
 import { isArray, isString, objectFreeze, objectKeys } from '../utilities';
+import { IPlatform } from '../platform';
 
 import type { IIndexable, Constructable } from '@aurelia/kernel';
 import type { ISubscriberCollection, IAccessor, ISubscribable, IObserver } from '@aurelia/runtime';
 import type { INode } from '../dom';
 import type { ICustomElementViewModel, ICustomElementController } from './controller';
+import type { BrowserPlatform } from '@aurelia/platform-browser';
 
 export type PartialChildrenDefinition = {
   callback?: string;
@@ -175,6 +177,9 @@ export class ChildrenObserver {
   private children: unknown[] = (void 0)!;
   private observer: MutationObserver | undefined = void 0;
 
+  /** @internal */
+  private readonly _platform: IPlatform;
+
   public constructor(
     private readonly controller: ICustomElementController,
     public readonly obj: IIndexable,
@@ -185,6 +190,7 @@ export class ChildrenObserver {
     private readonly map = defaultChildMap,
     private readonly options?: MutationObserverInit
   ) {
+    this._platform = this.controller.container.get(IPlatform);
     this.callback = obj[cbName] as typeof ChildrenObserver.prototype.callback;
     Reflect.defineProperty(
       this.obj,
@@ -208,7 +214,7 @@ export class ChildrenObserver {
     if (!this.observing) {
       this.observing = true;
       this.children = this.get();
-      (this.observer ??= new this.controller.host.ownerDocument.defaultView!.MutationObserver(() => { this._onChildrenChanged(); }))
+      (this.observer ??= new (this._platform as BrowserPlatform).MutationObserver(() => { this._onChildrenChanged(); }))
         .observe(this.controller.host, this.options);
     }
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixed **Safari 16.1** issue on `select` and others components.

Due to recent webkit breaking changes, `adoptNode` does not fill `ownerDocument` field correctly and therefore `defaultView` is `undefined`.

In our case, `MutationObserver` is used in `runtime-html` through `ownerDocument.defaultView`.
This PR change this behavior, we get the `MutationObserver` from `platform`.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

* #1618

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->
I'm not familiar with the code base, so I browsed through the history to figure out the "why": why we get the MutationObserver from `ownerDocument.defaultView.MutationObserver`.

The reason seems to be:

> "make runtime-html fully work in jsdom/nodejs"

At first MutationObserver was retrieved by `dom.createNodeObserver`, then `dom.window.MutationObserver`, then `platform.MutationObserver` and finally `obj.ownerDocument.defaultView!.MutationObserver`.

So going back to `platform` seems correct (with my limited view of the project).

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
