### PR TITLE
fix(router-lite/viewport): null default binding

### DIFF
--- a/packages/__tests__/router-lite/resources/viewport.spec.ts
+++ b/packages/__tests__/router-lite/resources/viewport.spec.ts
@@ -1,0 +1,217 @@
+import { IRouter, IRouteViewModel, route, Router, ViewportCustomElement } from '@aurelia/router-lite';
+import { CustomElement, customElement, IPlatform } from '@aurelia/runtime-html';
+import { assert } from '@aurelia/testing';
+import { start } from '../_shared/create-fixture.js';
+
+describe('viewport', function () {
+  it('sibling viewports with non-default routes are supported by binding the default property to null', async function () {
+
+    @customElement({ name: 'ce-one', template: 'ce1' })
+    class CeOne implements IRouteViewModel { }
+
+    @customElement({ name: 'ce-two', template: 'ce2' })
+    class CeTwo implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-one'],
+          component: CeOne,
+        },
+        {
+          path: 'ce-two',
+          component: CeTwo,
+        },
+      ]
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `
+                <au-viewport name="$1"></au-viewport>
+                <au-viewport name="$2" default.bind="null"></au-viewport>
+            `
+    })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
+    const queue = container.get(IPlatform).domWriteQueue;
+    const router = container.get<Router>(IRouter);
+
+    await queue.yield();
+    const [vp1, vp2] = Array.from(host.querySelectorAll('au-viewport'));
+    const vm1 = CustomElement.for<ViewportCustomElement>(vp1).viewModel;
+    const vm2 = CustomElement.for<ViewportCustomElement>(vp2).viewModel;
+    assert.strictEqual(vm1.name, '$1');
+    assert.strictEqual(vm2.name, '$2');
+    assert.html.textContent(vp1, 'ce1');
+    assert.html.textContent(vp2, '');
+
+    await router.load('ce-two');
+    await queue.yield();
+    assert.html.textContent(vp1, 'ce2');
+    assert.html.textContent(vp2, '');
+
+    await router.load('ce-one');
+    await queue.yield();
+    assert.html.textContent(vp1, 'ce1');
+    assert.html.textContent(vp2, '');
+
+    await router.load('ce-two@$1+ce-one@$2');
+    await queue.yield();
+    assert.html.textContent(vp1, 'ce2');
+    assert.html.textContent(vp2, 'ce1');
+
+    await au.stop();
+  });
+
+  it('sibling viewports in children with non-default routes are supported by binding the default property to null', async function () {
+
+    @customElement({ name: 'ce-11', template: `ce11` })
+    class CeOneOne implements IRouteViewModel { }
+
+    @customElement({ name: 'ce-21', template: `ce21` })
+    class CeTwoOne implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-11'],
+          component: CeOneOne,
+        }
+      ]
+    })
+    @customElement({
+      name: 'ce-one', template: `ce1
+        <au-viewport name="$1"></au-viewport>
+        <au-viewport name="$2" default.bind="null"></au-viewport>` })
+    class CeOne implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-21'],
+          component: CeTwoOne,
+        }
+      ]
+    })
+    @customElement({
+      name: 'ce-two', template: `ce2
+    <au-viewport name="$1"></au-viewport>
+    <au-viewport name="$2" default.bind="null"></au-viewport>` })
+    class CeTwo implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-one'],
+          component: CeOne,
+        },
+        {
+          path: 'ce-two',
+          component: CeTwo,
+        },
+      ]
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `
+                <au-viewport name="$1"></au-viewport>
+                <au-viewport name="$2" default.bind="null"></au-viewport>
+            `
+    })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
+    const queue = container.get(IPlatform).domWriteQueue;
+    const router = container.get<Router>(IRouter);
+
+    await queue.yield();
+    assert.html.textContent(host, 'ce1 ce11');
+
+    await router.load('ce-two');
+    await queue.yield();
+    assert.html.textContent(host, 'ce2 ce21');
+
+    await router.load('ce-one/ce-11');
+    await queue.yield();
+    assert.html.textContent(host, 'ce1 ce11');
+
+    await router.load('ce-two@$1+ce-one@$2');
+    await queue.yield();
+    assert.html.textContent(host, 'ce2 ce21 ce1 ce11');
+
+    await au.stop();
+  });
+
+  it('sibling viewports in children with non-default routes are supported by binding the default property to null - transition plan: invoke-lifecycle', async function () {
+
+    @customElement({ name: 'ce-21', template: `ce21` })
+    class CeTwoOne implements IRouteViewModel { }
+
+    @customElement({
+      name: 'ce-one', template: `ce1`
+    })
+    class CeOne implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-21'],
+          component: CeTwoOne,
+        }
+      ]
+    })
+    @customElement({
+      name: 'ce-two', template: `ce2
+    <au-viewport name="$1"></au-viewport>
+    <au-viewport name="$2" default.bind="null"></au-viewport>` })
+    class CeTwo implements IRouteViewModel { }
+
+    @route({
+      routes: [
+        {
+          path: ['', 'ce-one'],
+          component: CeOne,
+        },
+        {
+          path: 'ce-two',
+          component: CeTwo,
+        },
+      ],
+      transitionPlan() { return 'invoke-lifecycles'; }
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `
+                <au-viewport name="$1"></au-viewport>
+                <au-viewport name="$2" default.bind="null"></au-viewport>
+            `
+    })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
+    const queue = container.get(IPlatform).domWriteQueue;
+    const router = container.get<Router>(IRouter);
+
+    await queue.yield();
+    const [vp1, vp2] = Array.from(host.querySelectorAll('au-viewport'));
+    const vm1 = CustomElement.for<ViewportCustomElement>(vp1).viewModel;
+    const vm2 = CustomElement.for<ViewportCustomElement>(vp2).viewModel;
+    assert.strictEqual(vm1.name, '$1');
+    assert.strictEqual(vm2.name, '$2');
+    assert.html.textContent(vp1, 'ce1');
+    assert.html.textContent(vp2, '');
+
+    await router.load('ce-two/ce-21');
+    await queue.yield();
+    assert.html.textContent(vp1, 'ce2 ce21');
+    assert.html.textContent(vp2, '');
+
+    await router.load('ce-two@$2+ce-one@$1');
+    await queue.yield();
+    assert.html.textContent(vp1, 'ce1');
+    assert.html.textContent(vp2, 'ce2 ce21');
+
+    await au.stop();
+  });
+});

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -43,7 +43,7 @@ async function createFixture<T extends Constructable>(
   const { container, platform } = ctx;
 
   container.register(TestRouterConfiguration.for(level));
-  container.register(RouterConfiguration.customize({ resolutionMode: 'dynamic' }));
+  container.register(RouterConfiguration);
   container.register(...deps);
 
   const component = container.get(Component);
@@ -600,391 +600,205 @@ describe('router (smoke tests)', function () {
     }
   }
 
-  for (const mode of ['static', 'dynamic'] as const) {
-    it(`can load single anonymous default at the root with mode: ${mode}`, async function () {
-      @customElement({ name: 'a', template: 'a' })
-      class A { }
-      @customElement({ name: 'b', template: 'b' })
-      class B { }
-      @route({
-        routes: [
-          { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
-        ]
-      })
-      @customElement({
-        name: 'root',
-        template: `root<au-viewport default="a"></au-viewport>`,
-        dependencies: [A, B],
-      })
-      class Root { }
+  it('can load single anonymous default at the root', async function () {
+    @customElement({ name: 'a', template: 'a' })
+    class A { }
+    @customElement({ name: 'b', template: 'b' })
+    class B { }
+    @route({
+      routes: [
+        { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+        { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
+      ]
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport default="a"></au-viewport>`,
+      dependencies: [A, B],
+    })
+    class Root { }
 
-      const ctx = TestContext.create();
-      const { container } = ctx;
+    const ctx = TestContext.create();
+    const { container } = ctx;
 
-      container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
 
-      const component = container.get(Root);
-      const router = container.get(IRouter);
+    const component = container.get(Root);
+    const router = container.get(IRouter);
 
-      const au = new Aurelia(container);
-      const host = ctx.createElement('div');
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
 
-      au.app({ component, host });
+    au.app({ component, host });
 
-      await au.start();
+    await au.start();
 
-      assertComponentsVisible(host, [Root, [A]]);
+    assertComponentsVisible(host, [Root, [A]]);
 
-      await router.load('b');
-
-      assertComponentsVisible(host, [Root, [B]]);
-
-      await router.load('');
-
-      assertComponentsVisible(host, [Root, [A]]);
-
-      await au.stop(true);
-      assert.areTaskQueuesEmpty();
-    });
+    await router.load('b');
+
+    assertComponentsVisible(host, [Root, [B]]);
+
+    await router.load('');
+
+    assertComponentsVisible(host, [Root, [A]]);
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
 
-    it(`can load a named default with one sibling at the root with mode: ${mode}`, async function () {
-      @customElement({ name: 'a', template: 'a' })
-      class A { }
-      @customElement({ name: 'b', template: 'b' })
-      class B { }
-      @route({
-        routes: [
-          { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
-        ]
-      })
-      @customElement({
-        name: 'root',
-        template: `root<au-viewport name="a" default="a"></au-viewport><au-viewport name="b"></au-viewport>`,
-        dependencies: [A, B],
-      })
-      class Root { }
+  it('can load a named default with one sibling at the root', async function () {
+    @customElement({ name: 'a', template: 'a' })
+    class A { }
+    @customElement({ name: 'b', template: 'b' })
+    class B { }
+    @route({
+      routes: [
+        { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+        { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
+      ]
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport name="a" default="a"></au-viewport><au-viewport name="b"></au-viewport>`,
+      dependencies: [A, B],
+    })
+    class Root { }
 
-      const ctx = TestContext.create();
-      const { container } = ctx;
+    const ctx = TestContext.create();
+    const { container } = ctx;
 
-      container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
 
-      const component = container.get(Root);
-      const router = container.get(IRouter);
+    const component = container.get(Root);
+    const router = container.get(IRouter);
 
-      const au = new Aurelia(container);
-      const host = ctx.createElement('div');
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
 
-      au.app({ component, host });
+    au.app({ component, host });
 
-      await au.start();
+    await au.start();
 
-      assertComponentsVisible(host, [Root, [A]], '1');
+    assertComponentsVisible(host, [Root, [A]], '1');
 
-      await router.load('b@b');
+    await router.load('b@b');
 
-      assertComponentsVisible(host, [Root, [A, B]], '2');
+    assertComponentsVisible(host, [Root, [A, B]], '2');
 
-      await router.load('');
+    await router.load('');
 
-      assertComponentsVisible(host, [Root, [A]], '3');
+    assertComponentsVisible(host, [Root, [A]], '3');
 
-      await router.load('a@a+b@b');
+    await router.load('a@a+b@b');
 
-      assertComponentsVisible(host, [Root, [A, B]], '4');
+    assertComponentsVisible(host, [Root, [A, B]], '4');
 
-      await router.load('b@a');
+    await router.load('b@a');
 
-      assertComponentsVisible(host, [Root, [B]], '5');
+    assertComponentsVisible(host, [Root, [B]], '5');
 
-      await router.load('');
+    await router.load('');
 
-      assertComponentsVisible(host, [Root, [A]], '6');
+    assertComponentsVisible(host, [Root, [A]], '6');
 
-      await router.load('b@a+a@b');
+    await router.load('b@a+a@b');
 
-      assertComponentsVisible(host, [Root, [B, A]], '7');
+    assertComponentsVisible(host, [Root, [B, A]], '7');
 
-      await au.stop(true);
-      assert.areTaskQueuesEmpty();
-    });
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
 
-    it(`can load a named default with one sibling at a child with mode: ${mode}`, async function () {
-      @customElement({ name: 'b', template: 'b' })
-      class B { }
-      @customElement({ name: 'c', template: 'c' })
-      class C { }
-      @route({
-        routes: [
-          { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
-          { path: 'c', component: C, transitionPlan: 'invoke-lifecycles' },
-        ]
-      })
-      @customElement({
-        name: 'a',
-        template: 'a<au-viewport name="b" default="b"></au-viewport><au-viewport name="c"></au-viewport>',
-        dependencies: [B, C],
-      })
-      class A { }
-      @route({
-        routes: [
-          { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-        ]
-      })
-      @customElement({
-        name: 'root',
-        template: `root<au-viewport default="a">`,
-        dependencies: [A],
-      })
-      class Root { }
+  it('can load a named default with one sibling at a child', async function () {
+    @customElement({ name: 'b', template: 'b' })
+    class B { }
+    @customElement({ name: 'c', template: 'c' })
+    class C { }
+    @route({
+      routes: [
+        { path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
+        { path: 'c', component: C, transitionPlan: 'invoke-lifecycles' },
+      ]
+    })
+    @customElement({
+      name: 'a',
+      template: 'a<au-viewport name="b" default="b"></au-viewport><au-viewport name="c"></au-viewport>',
+      dependencies: [B, C],
+    })
+    class A { }
+    @route({
+      routes: [
+        { path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+      ]
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport default="a">`,
+      dependencies: [A],
+    })
+    class Root { }
 
-      const ctx = TestContext.create();
-      const { container } = ctx;
+    const ctx = TestContext.create();
+    const { container } = ctx;
 
-      container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
 
-      const component = container.get(Root);
-      const router = container.get(IRouter);
+    const component = container.get(Root);
+    const router = container.get(IRouter);
 
-      const au = new Aurelia(container);
-      const host = ctx.createElement('div');
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
 
-      au.app({ component, host });
+    au.app({ component, host });
 
-      await au.start();
+    await au.start();
 
-      assertComponentsVisible(host, [Root, [A, [B]]], '1');
+    assertComponentsVisible(host, [Root, [A, [B]]], '1');
 
-      await router.load('a/c@c');
+    await router.load('a/c@c');
 
-      assertComponentsVisible(host, [Root, [A, [B, C]]], '2');
+    assertComponentsVisible(host, [Root, [A, [B, C]]], '2');
 
-      await router.load('');
+    await router.load('');
 
-      assertComponentsVisible(host, [Root, [A, [B]]], '3');
+    assertComponentsVisible(host, [Root, [A, [B]]], '3');
 
-      await router.load('a/(b@b+c@c)');
+    await router.load('a/(b@b+c@c)');
 
-      assertComponentsVisible(host, [Root, [A, [B, C]]], '4');
+    assertComponentsVisible(host, [Root, [A, [B, C]]], '4');
 
-      await router.load('a/c@b');
+    await router.load('a/c@b');
 
-      assertComponentsVisible(host, [Root, [A, [C]]], '5');
+    assertComponentsVisible(host, [Root, [A, [C]]], '5');
 
-      await router.load('');
+    await router.load('');
 
-      assertComponentsVisible(host, [Root, [A, [B]]], '6');
+    assertComponentsVisible(host, [Root, [A, [B]]], '6');
 
-      await router.load('a/(c@b+b@c)');
+    await router.load('a/(c@b+b@c)');
 
-      assertComponentsVisible(host, [Root, [A, [C, B]]], '7');
+    assertComponentsVisible(host, [Root, [A, [C, B]]], '7');
 
-      await au.stop(true);
-      assert.areTaskQueuesEmpty();
-    });
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
 
-    for (const [name, fallback] of [['ce name', 'ce-a'], ['route', 'a'], ['route-id', 'r1']]) {
-      it(`will load the fallback when navigating to a non-existing route - with ${name} - with mode: ${mode} - viewport`, async function () {
-        @customElement({ name: 'ce-a', template: 'a' })
-        class A { }
-        @route({
-          routes: [
-            { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          ]
-        })
-        @customElement({
-          name: 'root',
-          template: `root<au-viewport fallback="${fallback}">`,
-          dependencies: [A],
-        })
-        class Root { }
-
-        const ctx = TestContext.create();
-        const { container } = ctx;
-
-        container.register(TestRouterConfiguration.for(LogLevel.warn));
-        container.register(RouterConfiguration.customize({ resolutionMode: mode }));
-
-        const component = container.get(Root);
-        const router = container.get(IRouter);
-
-        const au = new Aurelia(container);
-        const host = ctx.createElement('div');
-
-        au.app({ component, host });
-
-        await au.start();
-
-        assertComponentsVisible(host, [Root]);
-
-        await router.load('b');
-
-        assertComponentsVisible(host, [Root, [A]]);
-
-        await au.stop(true);
-        assert.areTaskQueuesEmpty();
-      });
-
-      it(`will load the global-fallback when navigating to a non-existing route - with ${name} - with mode: ${mode}`, async function () {
-        @customElement({ name: 'ce-a', template: 'a' })
-        class A { }
-        @route({
-          routes: [
-            { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          ],
-          fallback,
-        })
-        @customElement({
-          name: 'root',
-          template: `root<au-viewport>`,
-          dependencies: [A],
-        })
-        class Root { }
-
-        const ctx = TestContext.create();
-        const { container } = ctx;
-
-        container.register(TestRouterConfiguration.for(LogLevel.warn));
-        container.register(RouterConfiguration.customize({ resolutionMode: mode }));
-
-        const component = container.get(Root);
-        const router = container.get(IRouter);
-
-        const au = new Aurelia(container);
-        const host = ctx.createElement('div');
-
-        au.app({ component, host });
-
-        await au.start();
-
-        assertComponentsVisible(host, [Root]);
-
-        await router.load('b');
-
-        assertComponentsVisible(host, [Root, [A]]);
-
-        await au.stop(true);
-        assert.areTaskQueuesEmpty();
-      });
-
-      it(`will load the global-fallback when navigating to a non-existing route - sibling - with ${name} - with mode: ${mode}`, async function () {
-        @customElement({ name: 'ce-a', template: 'a' })
-        class A { }
-        @route({
-          routes: [
-            { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          ],
-          fallback,
-        })
-        @customElement({
-          name: 'root',
-          template: `root<au-viewport></au-viewport><au-viewport></au-viewport>`,
-          dependencies: [A],
-        })
-        class Root { }
-
-        const ctx = TestContext.create();
-        const { container } = ctx;
-
-        container.register(TestRouterConfiguration.for(LogLevel.warn));
-        container.register(RouterConfiguration.customize({ resolutionMode: mode }));
-
-        const component = container.get(Root);
-        const router = container.get(IRouter);
-
-        const au = new Aurelia(container);
-        const host = ctx.createElement('div');
-
-        au.app({ component, host });
-
-        await au.start();
-
-        assertComponentsVisible(host, [Root]);
-
-        await router.load('b+c');
-
-        assertComponentsVisible(host, [Root, [A, A]]);
-
-        await au.stop(true);
-        assert.areTaskQueuesEmpty();
-      });
-    }
-
-    it(`will load the global-fallback when navigating to a non-existing route - with ce-name - with mode: ${mode} - with empty route`, async function () {
+  for (const [name, fallback] of [['ce name', 'ce-a'], ['route', 'a'], ['route-id', 'r1']]) {
+    it('will load the fallback when navigating to a non-existing route - with ${name} - viewport', async function () {
       @customElement({ name: 'ce-a', template: 'a' })
       class A { }
-      @customElement({ name: 'n-f', template: 'nf' })
-      class NF { }
-      @route({
-        routes: [
-          { id: 'r1', path: ['', 'a'], component: A, transitionPlan: 'invoke-lifecycles' },
-          { id: 'r2', path: ['nf'], component: NF, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'n-f',
-      })
-      @customElement({
-        name: 'root',
-        template: `root<au-viewport>`,
-        dependencies: [A, NF],
-      })
-      class Root { }
-
-      const ctx = TestContext.create();
-      const { container } = ctx;
-
-      container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
-
-      const component = container.get(Root);
-      const router = container.get(IRouter);
-
-      const au = new Aurelia(container);
-      const host = ctx.createElement('div');
-
-      au.app({ component, host });
-
-      await au.start();
-
-      assertComponentsVisible(host, [Root, [A]]);
-
-      await router.load('b');
-
-      assertComponentsVisible(host, [Root, [NF]]);
-
-      await au.stop(true);
-      assert.areTaskQueuesEmpty();
-    });
-
-    it(`will load the global-fallback when navigating to a non-existing route - parent-child - with mode: ${mode}`, async function () {
-      @customElement({ name: 'ce-a01', template: 'ac01' })
-      class Ac01 { }
-      @customElement({ name: 'ce-a02', template: 'ac02' })
-      class Ac02 { }
-
-      @route({
-        routes: [
-          { id: 'rc1', path: 'ac01', component: Ac01, transitionPlan: 'invoke-lifecycles' },
-          { id: 'rc2', path: 'ac02', component: Ac02, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'rc1',
-      })
-      @customElement({ name: 'ce-a', template: 'a<au-viewport>', dependencies: [Ac01, Ac02] })
-      class A { }
-
       @route({
         routes: [
           { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'r1',
+        ]
       })
       @customElement({
         name: 'root',
-        template: `root<au-viewport>`,
+        template: `root<au-viewport fallback="${fallback}">`,
         dependencies: [A],
       })
       class Root { }
@@ -993,7 +807,7 @@ describe('router (smoke tests)', function () {
       const { container } = ctx;
 
       container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
+      container.register(RouterConfiguration);
 
       const component = container.get(Root);
       const router = container.get(IRouter);
@@ -1007,55 +821,69 @@ describe('router (smoke tests)', function () {
 
       assertComponentsVisible(host, [Root]);
 
-      await router.load('a/b');
+      await router.load('b');
 
-      assertComponentsVisible(host, [Root, [A, [Ac01]]]);
+      assertComponentsVisible(host, [Root, [A]]);
 
       await au.stop(true);
       assert.areTaskQueuesEmpty();
     });
 
-    it(`will load the global-fallback when navigating to a non-existing route - sibling + parent-child - with mode: ${mode}`, async function () {
-      @customElement({ name: 'ce-a01', template: 'ac01' })
-      class Ac01 { }
-      @customElement({ name: 'ce-a02', template: 'ac02' })
-      class Ac02 { }
-
-      @route({
-        routes: [
-          { id: 'rc1', path: 'ac01', component: Ac01, transitionPlan: 'invoke-lifecycles' },
-          { id: 'rc2', path: 'ac02', component: Ac02, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'rc1',
-      })
-      @customElement({ name: 'ce-a', template: 'a<au-viewport>', dependencies: [Ac01, Ac02] })
+    it('will load the global-fallback when navigating to a non-existing route - with ${name}', async function () {
+      @customElement({ name: 'ce-a', template: 'a' })
       class A { }
-      @customElement({ name: 'ce-b01', template: 'bc01' })
-      class Bc01 { }
-      @customElement({ name: 'ce-b02', template: 'bc02' })
-      class Bc02 { }
-
-      @route({
-        routes: [
-          { id: 'rc1', path: 'bc01', component: Bc01, transitionPlan: 'invoke-lifecycles' },
-          { id: 'rc2', path: 'bc02', component: Bc02, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'rc2',
-      })
-      @customElement({ name: 'ce-b', template: 'b<au-viewport>', dependencies: [Bc01, Bc02] })
-      class B { }
-
       @route({
         routes: [
           { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          { id: 'r2', path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
         ],
-        fallback: 'r1',
+        fallback,
+      })
+      @customElement({
+        name: 'root',
+        template: `root<au-viewport>`,
+        dependencies: [A],
+      })
+      class Root { }
+
+      const ctx = TestContext.create();
+      const { container } = ctx;
+
+      container.register(TestRouterConfiguration.for(LogLevel.warn));
+      container.register(RouterConfiguration);
+
+      const component = container.get(Root);
+      const router = container.get(IRouter);
+
+      const au = new Aurelia(container);
+      const host = ctx.createElement('div');
+
+      au.app({ component, host });
+
+      await au.start();
+
+      assertComponentsVisible(host, [Root]);
+
+      await router.load('b');
+
+      assertComponentsVisible(host, [Root, [A]]);
+
+      await au.stop(true);
+      assert.areTaskQueuesEmpty();
+    });
+
+    it(`will load the global-fallback when navigating to a non-existing route - sibling - with ${name}`, async function () {
+      @customElement({ name: 'ce-a', template: 'a' })
+      class A { }
+      @route({
+        routes: [
+          { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+        ],
+        fallback,
       })
       @customElement({
         name: 'root',
         template: `root<au-viewport></au-viewport><au-viewport></au-viewport>`,
-        dependencies: [A, B],
+        dependencies: [A],
       })
       class Root { }
 
@@ -1063,7 +891,7 @@ describe('router (smoke tests)', function () {
       const { container } = ctx;
 
       container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
+      container.register(RouterConfiguration);
 
       const component = container.get(Root);
       const router = container.get(IRouter);
@@ -1077,67 +905,237 @@ describe('router (smoke tests)', function () {
 
       assertComponentsVisible(host, [Root]);
 
-      await router.load('a/ac02+b/u');
+      await router.load('b+c');
 
-      assertComponentsVisible(host, [Root, [A, [Ac02]], [B, [Bc02]]]);
-
-      await router.load('a/u+b/bc01');
-
-      assertComponentsVisible(host, [Root, [A, [Ac01]], [B, [Bc01]]]);
-
-      await router.load('a/u+b/u');
-
-      assertComponentsVisible(host, [Root, [A, [Ac01]], [B, [Bc02]]]);
-
-      await au.stop(true);
-      assert.areTaskQueuesEmpty();
-    });
-
-    it(`au-viewport#fallback precedes global fallback - with mode: ${mode}`, async function () {
-      @customElement({ name: 'ce-a', template: 'a' })
-      class A { }
-      @customElement({ name: 'ce-b', template: 'b' })
-      class B { }
-      @route({
-        routes: [
-          { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
-          { id: 'r2', path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
-        ],
-        fallback: 'r1',
-      })
-      @customElement({
-        name: 'root',
-        template: `root<au-viewport name="1"></au-viewport><au-viewport name="2" fallback="r2"></au-viewport>`,
-        dependencies: [A, B],
-      })
-      class Root { }
-
-      const ctx = TestContext.create();
-      const { container } = ctx;
-
-      container.register(TestRouterConfiguration.for(LogLevel.warn));
-      container.register(RouterConfiguration.customize({ resolutionMode: mode }));
-
-      const component = container.get(Root);
-      const router = container.get(IRouter);
-
-      const au = new Aurelia(container);
-      const host = ctx.createElement('div');
-
-      au.app({ component, host });
-
-      await au.start();
-
-      assertComponentsVisible(host, [Root]);
-
-      await router.load('u1@1+u2@2');
-
-      assertComponentsVisible(host, [Root, [A, B]]);
+      assertComponentsVisible(host, [Root, [A, A]]);
 
       await au.stop(true);
       assert.areTaskQueuesEmpty();
     });
   }
+
+  it('will load the global-fallback when navigating to a non-existing route - with ce-name - with empty route', async function () {
+    @customElement({ name: 'ce-a', template: 'a' })
+    class A { }
+    @customElement({ name: 'n-f', template: 'nf' })
+    class NF { }
+    @route({
+      routes: [
+        { id: 'r1', path: ['', 'a'], component: A, transitionPlan: 'invoke-lifecycles' },
+        { id: 'r2', path: ['nf'], component: NF, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'n-f',
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport>`,
+      dependencies: [A, NF],
+    })
+    class Root { }
+
+    const ctx = TestContext.create();
+    const { container } = ctx;
+
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
+
+    const component = container.get(Root);
+    const router = container.get(IRouter);
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+
+    au.app({ component, host });
+
+    await au.start();
+
+    assertComponentsVisible(host, [Root, [A]]);
+
+    await router.load('b');
+
+    assertComponentsVisible(host, [Root, [NF]]);
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
+
+  it('will load the global-fallback when navigating to a non-existing route - parent-child', async function () {
+    @customElement({ name: 'ce-a01', template: 'ac01' })
+    class Ac01 { }
+    @customElement({ name: 'ce-a02', template: 'ac02' })
+    class Ac02 { }
+
+    @route({
+      routes: [
+        { id: 'rc1', path: 'ac01', component: Ac01, transitionPlan: 'invoke-lifecycles' },
+        { id: 'rc2', path: 'ac02', component: Ac02, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'rc1',
+    })
+    @customElement({ name: 'ce-a', template: 'a<au-viewport>', dependencies: [Ac01, Ac02] })
+    class A { }
+
+    @route({
+      routes: [
+        { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'r1',
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport>`,
+      dependencies: [A],
+    })
+    class Root { }
+
+    const ctx = TestContext.create();
+    const { container } = ctx;
+
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
+
+    const component = container.get(Root);
+    const router = container.get(IRouter);
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+
+    au.app({ component, host });
+
+    await au.start();
+
+    assertComponentsVisible(host, [Root]);
+
+    await router.load('a/b');
+
+    assertComponentsVisible(host, [Root, [A, [Ac01]]]);
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
+
+  it('will load the global-fallback when navigating to a non-existing route - sibling + parent-child', async function () {
+    @customElement({ name: 'ce-a01', template: 'ac01' })
+    class Ac01 { }
+    @customElement({ name: 'ce-a02', template: 'ac02' })
+    class Ac02 { }
+
+    @route({
+      routes: [
+        { id: 'rc1', path: 'ac01', component: Ac01, transitionPlan: 'invoke-lifecycles' },
+        { id: 'rc2', path: 'ac02', component: Ac02, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'rc1',
+    })
+    @customElement({ name: 'ce-a', template: 'a<au-viewport>', dependencies: [Ac01, Ac02] })
+    class A { }
+    @customElement({ name: 'ce-b01', template: 'bc01' })
+    class Bc01 { }
+    @customElement({ name: 'ce-b02', template: 'bc02' })
+    class Bc02 { }
+
+    @route({
+      routes: [
+        { id: 'rc1', path: 'bc01', component: Bc01, transitionPlan: 'invoke-lifecycles' },
+        { id: 'rc2', path: 'bc02', component: Bc02, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'rc2',
+    })
+    @customElement({ name: 'ce-b', template: 'b<au-viewport>', dependencies: [Bc01, Bc02] })
+    class B { }
+
+    @route({
+      routes: [
+        { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+        { id: 'r2', path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'r1',
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport></au-viewport><au-viewport></au-viewport>`,
+      dependencies: [A, B],
+    })
+    class Root { }
+
+    const ctx = TestContext.create();
+    const { container } = ctx;
+
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
+
+    const component = container.get(Root);
+    const router = container.get(IRouter);
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+
+    au.app({ component, host });
+
+    await au.start();
+
+    assertComponentsVisible(host, [Root]);
+
+    await router.load('a/ac02+b/u');
+
+    assertComponentsVisible(host, [Root, [A, [Ac02]], [B, [Bc02]]]);
+
+    await router.load('a/u+b/bc01');
+
+    assertComponentsVisible(host, [Root, [A, [Ac01]], [B, [Bc01]]]);
+
+    await router.load('a/u+b/u');
+
+    assertComponentsVisible(host, [Root, [A, [Ac01]], [B, [Bc02]]]);
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
+
+  it('au-viewport#fallback precedes global fallback', async function () {
+    @customElement({ name: 'ce-a', template: 'a' })
+    class A { }
+    @customElement({ name: 'ce-b', template: 'b' })
+    class B { }
+    @route({
+      routes: [
+        { id: 'r1', path: 'a', component: A, transitionPlan: 'invoke-lifecycles' },
+        { id: 'r2', path: 'b', component: B, transitionPlan: 'invoke-lifecycles' },
+      ],
+      fallback: 'r1',
+    })
+    @customElement({
+      name: 'root',
+      template: `root<au-viewport name="1"></au-viewport><au-viewport name="2" fallback="r2"></au-viewport>`,
+      dependencies: [A, B],
+    })
+    class Root { }
+
+    const ctx = TestContext.create();
+    const { container } = ctx;
+
+    container.register(TestRouterConfiguration.for(LogLevel.warn));
+    container.register(RouterConfiguration);
+
+    const component = container.get(Root);
+    const router = container.get(IRouter);
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+
+    au.app({ component, host });
+
+    await au.start();
+
+    assertComponentsVisible(host, [Root]);
+
+    await router.load('u1@1+u2@2');
+
+    assertComponentsVisible(host, [Root, [A, B]]);
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
 
   it(`correctly parses parameters`, async function () {
     const a1Params: Params[] = [];

--- a/packages/router-lite/src/index.ts
+++ b/packages/router-lite/src/index.ts
@@ -82,7 +82,6 @@ export {
   RouterOptions,
   NavigationOptions,
   Transition,
-  type ResolutionMode,
   type HistoryStrategy,
 } from './router';
 

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -8,7 +8,7 @@ import { IViewport } from './resources/viewport';
 import { IChildRouteConfig, Routeable, RouteType } from './route';
 import { RouteDefinition } from './route-definition';
 import { RouteNode } from './route-tree';
-import { IRouter, ResolutionMode } from './router';
+import { IRouter } from './router';
 import { IRouterEvents } from './router-events';
 import { ensureArrayOfStrings } from './util';
 import { isPartialChildRouteConfig } from './validation';
@@ -325,12 +325,12 @@ export class RouteContext {
     return agent;
   }
 
-  public getAvailableViewportAgents(resolution: ResolutionMode): readonly ViewportAgent[] {
-    return this.childViewportAgents.filter(x => x.isAvailable(resolution));
+  public getAvailableViewportAgents(): readonly ViewportAgent[] {
+    return this.childViewportAgents.filter(x => x.isAvailable());
   }
 
-  public getFallbackViewportAgent(resolution: ResolutionMode, name: string): ViewportAgent | null {
-    return this.childViewportAgents.find(x => x.isAvailable(resolution) && x.viewport.name === name && x.viewport.fallback.length > 0) ?? null;
+  public getFallbackViewportAgent(name: string): ViewportAgent | null {
+    return this.childViewportAgents.find(x => x.isAvailable() && x.viewport.name === name && x.viewport.fallback.length > 0) ?? null;
   }
 
   /**

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -328,95 +328,7 @@ export class RouteTree {
   }
 }
 
-export function updateNode(
-  log: ILogger,
-  vit: ViewportInstructionTree,
-  ctx: IRouteContext,
-  node: RouteNode,
-): Promise<void> | void {
-  log.trace(`updateNode(ctx:%s,node:%s)`, ctx, node);
-
-  node.queryParams = vit.queryParams;
-  node.fragment = vit.fragment;
-
-  if (!node.context.isRoot) {
-    node.context.vpa.scheduleUpdate(node.tree.options, node);
-  }
-  if (node.context === ctx) {
-    // Do an in-place update (remove children and re-add them by compiling the instructions into nodes)
-    node.clearChildren();
-    // - first append the nodes as children, compiling the viewport instructions.
-    // - if afterward, any viewports are still available
-    //   - look at the default value of those viewports
-    //   - create instructions, and
-    //   - add the compiled nodes from those to children of the node.
-    return onResolve(
-      resolveAll(...vit.children.map(vi => createAndAppendNodes(log, node, vi))),
-      () => resolveAll(...ctx.getAvailableViewportAgents('dynamic').map(vpa => {
-        const vp = vpa.viewport;
-        return createAndAppendNodes(log, node, ViewportInstruction.create({ component: vp.default, viewport: vp.name, }));
-      }))
-    );
-  }
-
-  // Drill down until we're at the node whose context matches the provided navigation context
-  return resolveAll(...node.children.map(child => {
-    return updateNode(log, vit, ctx, child);
-  }));
-}
-
-export function processResidue(node: RouteNode): Promise<void> | void {
-  const ctx = node.context;
-  const log = ctx.container.get(ILogger).scopeTo('RouteTree');
-
-  const suffix = ctx.resolved instanceof Promise ? ' - awaiting promise' : '';
-  log.trace(`processResidue(node:%s)${suffix}`, node);
-  return onResolve(ctx.resolved, () => {
-    return resolveAll(
-      ...node.residue.splice(0).map(vi => {
-        return createAndAppendNodes(log, node, vi);
-      }),
-      ...ctx.getAvailableViewportAgents('static').map(vpa => {
-        const defaultInstruction = ViewportInstruction.create({
-          component: vpa.viewport.default,
-          viewport: vpa.viewport.name,
-        });
-        return createAndAppendNodes(log, node, defaultInstruction);
-      }),
-    );
-  });
-}
-
-export function getDynamicChildren(node: RouteNode): Promise<readonly RouteNode[]> | readonly RouteNode[] {
-  const ctx = node.context;
-  const log = ctx.container.get(ILogger).scopeTo('RouteTree');
-
-  const suffix = ctx.resolved instanceof Promise ? ' - awaiting promise' : '';
-  log.trace(`getDynamicChildren(node:%s)${suffix}`, node);
-  return onResolve(ctx.resolved, () => {
-    const existingChildren = node.children.slice();
-    return onResolve(
-      resolveAll(...node
-        .residue
-        .splice(0)
-        .map(vi => createAndAppendNodes(log, node, vi))),
-      () => onResolve(
-        resolveAll(...ctx
-          .getAvailableViewportAgents('dynamic')
-          .map(vpa => {
-            const defaultInstruction = ViewportInstruction.create({
-              component: vpa.viewport.default,
-              viewport: vpa.viewport.name,
-            });
-            return createAndAppendNodes(log, node, defaultInstruction);
-          })),
-        () => node.children.filter(x => !existingChildren.includes(x))
-      ),
-    );
-  });
-}
-
-function createAndAppendNodes(
+export function createAndAppendNodes(
   log: ILogger,
   node: RouteNode,
   vi: ViewportInstruction,
@@ -491,7 +403,7 @@ function createAndAppendNodes(
             if (name === '') return;
             let vp = vi.viewport;
             if (vp === null || vp.length === 0) vp = defaultViewportName;
-            const vpa = ctx.getFallbackViewportAgent('dynamic', vp);
+            const vpa = ctx.getFallbackViewportAgent(vp);
             const fallback = vpa !== null ? vpa.viewport.fallback : ctx.definition.fallback;
             if (fallback === null) throw new UnknownRouteError(`Neither the route '${name}' matched any configured route at '${ctx.friendlyPath}' nor a fallback is configured for the viewport '${vp}' - did you forget to add '${name}' to the routes list of the route decorator of '${ctx.component.name}'?`);
 
@@ -564,7 +476,6 @@ function createConfiguredNode(
       const vpa = ctx.resolveViewportAgent(new ViewportRequest(
         vpName,
         ced.name,
-        rt.options.resolutionMode,
       ));
 
       const router = ctx.container.get(IRouter);

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -1,26 +1,26 @@
 // No-fallthrough disabled due to large numbers of false positives
 /* eslint-disable no-fallthrough */
-import { ILogger, onResolve } from '@aurelia/kernel';
+import { ILogger, onResolve, resolveAll } from '@aurelia/kernel';
 import { LifecycleFlags, IHydratedController, ICustomElementController, Controller } from '@aurelia/runtime-html';
 
 import { IViewport } from './resources/viewport';
 import { ComponentAgent } from './component-agent';
-import { processResidue, getDynamicChildren, RouteNode } from './route-tree';
+import { RouteNode, createAndAppendNodes } from './route-tree';
 import { IRouteContext } from './route-context';
-import { Transition, ResolutionMode, NavigationOptions } from './router';
+import { Transition, NavigationOptions } from './router';
 import { TransitionPlan } from './route';
 import { Batch, mergeDistinct } from './util';
 import { defaultViewportName } from './route-definition';
+import { ViewportInstruction } from './instructions';
 
 export class ViewportRequest {
   public constructor(
     public readonly viewportName: string,
     public readonly componentName: string,
-    public readonly resolution: ResolutionMode,
   ) { }
 
   public toString(): string {
-    return `VR(viewport:'${this.viewportName}',component:'${this.componentName}',resolution:'${this.resolution}')`;
+    return `VR(viewport:'${this.viewportName}',component:'${this.componentName}')`;
   }
 }
 
@@ -41,7 +41,6 @@ export class ViewportAgent {
   private get nextState(): NextState { return this.state & State.next; }
   private set nextState(state: NextState) { this.state = (this.state & State.curr) | state; }
 
-  private $resolution: ResolutionMode = 'dynamic';
   private $plan: TransitionPlan = 'replace';
   private currNode: RouteNode | null = null;
   private nextNode: RouteNode | null = null;
@@ -94,9 +93,6 @@ export class ViewportAgent {
         if (this.currTransition === null) {
           throw new Error(`Unexpected viewport activation outside of a transition context at ${this}`);
         }
-        if (this.$resolution !== 'static') {
-          throw new Error(`Unexpected viewport activation at ${this}`);
-        }
         this.logger.trace(`activateFromViewport() - running ordinary activate at %s`, this);
         const b = Batch.start(b1 => { this.activate(initiator, this.currTransition!, b1); });
         const p = new Promise<void>(resolve => { b.continueWith(() => { resolve(); }); });
@@ -138,7 +134,7 @@ export class ViewportAgent {
   }
 
   public handles(req: ViewportRequest): boolean {
-    if (!this.isAvailable(req.resolution)) {
+    if (!this.isAvailable()) {
       return false;
     }
 
@@ -160,14 +156,14 @@ export class ViewportAgent {
     return true;
   }
 
-  public isAvailable(resolution: ResolutionMode): boolean {
-    if (resolution === 'dynamic' && !this.isActive) {
-      this.logger.trace(`isAvailable(resolution:%s) -> false (viewport is not active and we're in dynamic resolution resolution)`, resolution);
+  public isAvailable(): boolean {
+    if (!this.isActive) {
+      this.logger.trace(`isAvailable -> false (viewport is not active)`);
       return false;
     }
 
     if (this.nextState !== State.nextIsEmpty) {
-      this.logger.trace(`isAvailable(resolution:%s) -> false (update already scheduled for %s)`, resolution, this.nextNode);
+      this.logger.trace(`isAvailable -> false (update already scheduled for %s)`, this.nextNode);
       return false;
     }
 
@@ -254,7 +250,7 @@ export class ViewportAgent {
       const next = this.nextNode!;
       switch (this.$plan) {
         case 'none':
-        case 'invoke-lifecycles':
+        case 'invoke-lifecycles': {
           this.logger.trace(`canLoad(next:%s) - plan set to '%s', compiling residue`, next, this.$plan);
 
           // These plans can only occur if there is already a current component active in this viewport,
@@ -265,25 +261,30 @@ export class ViewportAgent {
           // By calling `compileResidue` here on the current context, we're ensuring that such nodes are created and
           // their target viewports have the appropriate updates scheduled.
           b1.push();
-          void onResolve(processResidue(next), () => {
-            b1.pop();
-          });
+          const ctx = next.context;
+          void onResolve(
+            ctx.resolved,
+            () => onResolve(
+              resolveAll(
+                ...next.residue.splice(0).map(vi => {
+                  return createAndAppendNodes(this.logger, next, vi);
+                }),
+                ...ctx.getAvailableViewportAgents().reduce((acc, vpa) => {
+                  const vp = vpa.viewport;
+                  const component = vp.default;
+                  if (component === null) return acc;
+                  acc.push(createAndAppendNodes(this.logger, next, ViewportInstruction.create({ component, viewport: vp.name, })));
+                  return acc;
+                }, ([] as (void | Promise<void>)[])),
+              ),
+              () => { b1.pop(); }
+            )
+          );
           return;
+        }
         case 'replace':
-          // In the case of 'replace', always process this node and its subtree as if it's a new one
-          switch (this.$resolution) {
-            case 'dynamic':
-              // Residue compilation will happen at `ViewportAgent#processResidue`
-              this.logger.trace(`canLoad(next:%s) - (resolution: 'dynamic'), delaying residue compilation until activate`, next, this.$plan);
-              return;
-            case 'static':
-              this.logger.trace(`canLoad(next:%s) - (resolution: '${this.$resolution}'), creating nextCA and compiling residue`, next, this.$plan);
-              b1.push();
-              void onResolve(processResidue(next), () => {
-                b1.pop();
-              });
-              return;
-          }
+          this.logger.trace(`canLoad(next:%s), delaying residue compilation until activate`, next, this.$plan);
+          return;
       }
     }).continueWith(b1 => {
       switch (this.nextState) {
@@ -445,10 +446,7 @@ export class ViewportAgent {
 
     b.push();
 
-    if (
-      this.nextState === State.nextIsScheduled &&
-      this.$resolution === 'dynamic'
-    ) {
+    if (this.nextState === State.nextIsScheduled) {
       this.logger.trace(`activate() - invoking canLoad(), loading() and activate() on new component due to resolution 'dynamic' at %s`, this);
       // This is the default v2 mode "lazy loading" situation
       Batch.start(b1 => {
@@ -572,7 +570,29 @@ export class ViewportAgent {
 
     tr.run(() => {
       b.push();
-      return getDynamicChildren(next);
+      const ctx = next.context;
+      return onResolve(ctx.resolved, () => {
+        const existingChildren = next.children.slice();
+        return onResolve(
+          resolveAll(...next
+            .residue
+            .splice(0)
+            .map(vi => createAndAppendNodes(this.logger, next, vi))),
+          () => onResolve(
+            resolveAll(...ctx
+              .getAvailableViewportAgents()
+              .reduce((acc, vpa) => {
+                const vp = vpa.viewport;
+                const component = vp.default;
+                if (component === null) return acc;
+                acc.push(createAndAppendNodes(this.logger, next, ViewportInstruction.create({ component, viewport: vp.name, })));
+                return acc;
+              }, ([] as (void | Promise<void>)[]))
+            ),
+            () => next.children.filter(x => !existingChildren.includes(x))
+          ),
+        );
+      });
     }, newChildren => {
       Batch.start(b1 => {
         for (const node of newChildren) {
@@ -612,7 +632,6 @@ export class ViewportAgent {
       case State.nextIsEmpty:
         this.nextNode = next;
         this.nextState = State.nextIsScheduled;
-        this.$resolution = options.resolutionMode;
         break;
       default:
         this.unexpectedState('scheduleUpdate 1');
@@ -758,7 +777,7 @@ export class ViewportAgent {
   }
 
   public toString(): string {
-    return `VPA(state:${this.$state},plan:'${this.$plan}',resolution:'${this.$resolution}',n:${this.nextNode},c:${this.currNode},viewport:${this.viewport})`;
+    return `VPA(state:${this.$state},plan:'${this.$plan}',n:${this.nextNode},c:${this.currNode},viewport:${this.viewport})`;
   }
 
   public dispose(): void {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Because the default value for the `default` bindable in the au-viewport is '', it allows loading the empty route by default. However, this results in a bit weird behavior, when there are sibling viewports with default value for the `default` property. In this case both the viewports load the empty route (assuming the empty route is configured). This commit allows binding null to the `default` property which indicates that the viewport must be ignored when free and no component should be loaded by default.

This commit additionally removes the resolution mode. This option only changes the lifecycle hook timings. In my opinion that is a very niche property, removal of which might not affect the mass in devland. On the other hand, keeping this configuration property alive, hindered the objective behind ignoring viewports for default components.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
