### PR TITLE
fix(router-lite): viewport adjustment

### DIFF
--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -430,6 +430,7 @@ export function createAndAppendNodes(
 
           for (let i = 0; i < collapse; ++i) {
             const child = vi.children[0];
+            (vi as Writable<ViewportInstruction>).viewport = child.viewport;
             if (residue?.startsWith(child.component.value as string) ?? false) break;
             (vi as Writable<ViewportInstruction>).children = child.children;
           }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This commit fixes the issue of not copying the viewports from child segment. For example a path `route1/param1@vp1` is parsed roughly into the following instruction.

```json5
{
  component: 'route1',
  viewport: '',
  children: [
    {
      component: 'param1',
      viewport: 'vp1'
    }
  ]
}
```

Previously the viewport `vp1` was erroneously discarded.

This commit fixes that issue.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
