### PR TITLE
fix(router-lite): viewport-request and viewport-agent viewport name matching

### DIFF
--- a/packages/__tests__/router-lite/resources/viewport.spec.ts
+++ b/packages/__tests__/router-lite/resources/viewport.spec.ts
@@ -4,6 +4,13 @@ import { assert } from '@aurelia/testing';
 import { start } from '../_shared/create-fixture.js';
 
 describe('viewport', function () {
+
+  function assertText(vps: Element[], expected: string[]) {
+    for (let i = 0; i < expected.length; i++) {
+      assert.html.textContent(vps[i], expected[i], `content #${i + 1}`);
+    }
+  }
+
   it('sibling viewports with non-default routes are supported by binding the default property to null', async function () {
 
     @customElement({ name: 'ce-one', template: 'ce1' })
@@ -260,6 +267,143 @@ describe('viewport', function () {
     await router.load('ce-two/42@$2+ce-one@$1');
     await queue.yield();
     assert.html.textContent(host, 'ce1 ce2 42');
+
+    await au.stop();
+  });
+
+  // precondition: exists a mixture of named and unnamed viewports
+  // action: components are attempted to be loaded into named viewports
+  // expectation: components are loaded into named viewports
+  it('targeted components can be loaded into named viewports even when default viewports are present', async function () {
+    @customElement({ name: 'ce-one', template: 'ce1' })
+    class CeOne implements IRouteViewModel { }
+
+    @customElement({ name: 'ce-two', template: 'ce2 ${id}' })
+    class CeTwo implements IRouteViewModel {
+      id: string;
+      public canLoad(params: Params): boolean {
+        this.id = params.id;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        {
+          path: 'ce-one',
+          component: CeOne,
+        },
+        {
+          path: 'ce-two/:id',
+          component: CeTwo,
+        },
+      ]
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `
+                <au-viewport></au-viewport>
+                <au-viewport name="$1"></au-viewport>
+                <au-viewport></au-viewport>
+                <au-viewport name="$2"></au-viewport>
+                <au-viewport></au-viewport>
+            `
+    })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
+    const queue = container.get(IPlatform).domWriteQueue;
+    const router = container.get<Router>(IRouter);
+
+    await queue.yield();
+    const vps = Array.from(host.querySelectorAll('au-viewport'));
+    const vms = vps.map(vp => CustomElement.for<ViewportCustomElement>(vp).viewModel);
+    assert.deepStrictEqual(vms.map(vm => vm.name), ['default', '$1', 'default', '$2', 'default']);
+
+    await router.load('ce-one@$1');
+    await queue.yield();
+    assertText(vps, ['', 'ce1', '', '', '']);
+
+    await router.load('ce-one@$2+ce-two/42@$1');
+    await queue.yield();
+    assertText(vps, ['', 'ce2 42', '', 'ce1', '']);
+
+    await router.load('ce-one+ce-two/42');
+    await queue.yield();
+    assertText(vps, ['ce1', 'ce2 42', '', '', '']);
+
+    await au.stop();
+  });
+
+  it('viewport configuration for route is respected', async function () {
+    @customElement({ name: 'ce-one', template: 'ce1' })
+    class CeOne implements IRouteViewModel { }
+
+    @customElement({ name: 'ce-two', template: 'ce2 ${id}' })
+    class CeTwo implements IRouteViewModel {
+      id: string;
+      public canLoad(params: Params): boolean {
+        this.id = params.id;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        {
+          path: 'ce-one',
+          component: CeOne,
+          viewport: '$2',
+        },
+        {
+          path: 'ce-two/:id',
+          component: CeTwo,
+          viewport: '$1',
+        },
+      ]
+    })
+    @customElement({
+      name: 'ro-ot',
+      template: `
+                <au-viewport></au-viewport>
+                <au-viewport name="$1"></au-viewport>
+                <au-viewport></au-viewport>
+                <au-viewport name="$2"></au-viewport>
+                <au-viewport></au-viewport>
+            `
+    })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
+    const queue = container.get(IPlatform).domWriteQueue;
+    const router = container.get<Router>(IRouter);
+
+    await queue.yield();
+    const vps = Array.from(host.querySelectorAll('au-viewport'));
+    const vms = vps.map(vp => CustomElement.for<ViewportCustomElement>(vp).viewModel);
+    assert.deepStrictEqual(vms.map(vm => vm.name), ['default', '$1', 'default', '$2', 'default']);
+
+    await router.load('ce-one');
+    await queue.yield();
+    assertText(vps, ['', '', '', 'ce1', '']);
+
+    await router.load('ce-one+ce-two/42');
+    await queue.yield();
+    assertText(vps, ['', 'ce2 42', '', 'ce1', '']);
+
+    try {
+      await router.load('ce-one@$1');
+      assert.fail('expected error for loading ce-one@$1');
+    } catch {
+      /** ignore */
+    }
+
+    try {
+      await router.load('ce-two/42@$2');
+      assert.fail('expected error for loading ce-two/42@$2');
+    } catch {
+      /** ignore */
+    }
 
     await au.stop();
   });

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -430,8 +430,8 @@ export function createAndAppendNodes(
 
           for (let i = 0; i < collapse; ++i) {
             const child = vi.children[0];
-            (vi as Writable<ViewportInstruction>).viewport = child.viewport;
             if (residue?.startsWith(child.component.value as string) ?? false) break;
+            (vi as Writable<ViewportInstruction>).viewport = child.viewport;
             (vi as Writable<ViewportInstruction>).children = child.children;
           }
           log.trace('createNode after adjustment vi:%s', vi);

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -141,7 +141,26 @@ export class ViewportAgent {
     const $vp = this.viewport;
     const reqVp = req.viewportName;
     const vp = $vp.name;
-    if (reqVp !== defaultViewportName && vp !== defaultViewportName && vp !== reqVp) {
+    /*
+                     Name from viewport request
+
+                     D (default)         N (Non-default)
+
+          Name from  +-------------------------------------------+
+     viewport agent  |                   |                       |
+                     |        DD         |          DN           |
+                     |    can handle     |      can't handle     |
+          D (default)|                   |                       |
+                     |                   |                       |
+                     +-------------------------------------------+
+                     |                   |                       |
+     N (Non-default) |        DD         |          DD           |
+                     |    can handle     |   can handle only     |
+                     |                   |   if the names match  |
+                     |                   |                       |
+                     +-------------------------------------------+
+    */
+    if (reqVp !== defaultViewportName && vp !== reqVp) {
       this.logger.trace(`handles(req:%s) -> false (viewport names don't match '%s')`, req, vp);
       return false;
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the viewport name matching between a viewport request and a viewport agent.
There are new tests to make the utility of the changes clear.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
