### PR TITLE
fix(router-lite): various overloads for the load method

### DIFF
--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -1510,7 +1510,7 @@ describe('router (smoke tests)', function () {
     assert.areTaskQueuesEmpty();
   });
 
-  it('Router#load accepts viewport instructions with specific viewport name', async function () {
+  it('Router#load accepts viewport instructions with specific viewport name - component: class', async function () {
     @customElement({ name: 'gc-11', template: 'gc11' })
     class GrandChildOneOne { }
 
@@ -1601,6 +1601,265 @@ describe('router (smoke tests)', function () {
 
     assert.html.textContent(vps[0], 'c1 gc11', 'round#3 vp1');
     assert.html.textContent(vps[1], 'c2 NA gc21', 'round#3 vp2');
+
+    await au.stop();
+  });
+
+  it('Router#load accepts viewport instructions with specific viewport name - component: route-id', async function () {
+    @customElement({ name: 'gc-11', template: 'gc11' })
+    class GrandChildOneOne { }
+
+    @customElement({ name: 'gc-12', template: 'gc12' })
+    class GrandChildOneTwo { }
+
+    @route({
+      routes: [
+        { id: 'gc11', path: ['', 'gc-11'], component: GrandChildOneOne },
+        { id: 'gc12', path: 'gc-12', component: GrandChildOneTwo },
+      ],
+    })
+    @customElement({ name: 'c-one', template: `c1 <au-viewport></au-viewport>`, })
+    class ChildOne { }
+
+    @customElement({ name: 'gc-21', template: 'gc21' })
+    class GrandChildTwoOne { }
+
+    @customElement({ name: 'gc-22', template: 'gc22 ${id}' })
+    class GrandChildTwoTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'gc21', path: ['', 'gc-21'], component: GrandChildTwoOne },
+        { id: 'gc22', path: 'gc-22/:id?', component: GrandChildTwoTwo },
+      ],
+    })
+    @customElement({
+      name: 'c-two',
+      template: `c2 \${id} <au-viewport></au-viewport>`,
+    })
+    class ChildTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        {
+          id: 'c1',
+          path: ['', 'c-1'],
+          component: ChildOne,
+        },
+        {
+          id: 'c2',
+          path: 'c-2/:id?',
+          component: ChildTwo,
+        },
+      ],
+    })
+    @customElement({ name: 'my-app', template: '<au-viewport name="vp1"></au-viewport><au-viewport name="vp2" default.bind="null"></au-viewport>' })
+    class MyApp { }
+
+    const { au, container, host } = await start({ appRoot: MyApp });
+    const router = container.get(IRouter);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    const vps = Array.from(host.querySelectorAll(':scope>au-viewport'));
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#1 vp1');
+    assert.html.textContent(vps[1], '', 'round#1 vp2');
+
+    await router.load([
+      {
+        component: 'c1',
+        children: [{ component: 'gc12' }],
+        viewport: 'vp2',
+      },
+      {
+        component: 'c2',
+        params: { id: 21 },
+        children: [{ component: 'gc22' }],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 21 gc22 NA', 'round#2 vp1');
+    assert.html.textContent(vps[1], 'c1 gc12', 'round#2 vp2');
+
+    await router.load([
+      {
+        component: 'c2',
+        viewport: 'vp2',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#3 vp1');
+    assert.html.textContent(vps[1], 'c2 NA gc21', 'round#3 vp2');
+
+    await router.load([
+      {
+        component: 'c1',
+        children: [{ component: 'gc12' }],
+        viewport: 'vp2',
+      },
+      {
+        component: 'c2',
+        params: { id: 21 },
+        children: [{ component: 'gc22', params: { id: 42 } }],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 21 gc22 42', 'round#4 vp1');
+    assert.html.textContent(vps[1], 'c1 gc12', 'round#4 vp2');
+
+    await router.load([
+      {
+        component: 'c1',
+        children: [{ component: 'gc12' }],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc12', 'round#5 vp1');
+    assert.html.textContent(vps[1], '', 'round#5 vp2');
+
+    await au.stop();
+  });
+
+  it('Router#load accepts viewport instructions with specific viewport name - component: mixed', async function () {
+    @customElement({ name: 'gc-11', template: 'gc11' })
+    class GrandChildOneOne { }
+
+    @customElement({ name: 'gc-12', template: 'gc12' })
+    class GrandChildOneTwo { }
+
+    @route({
+      routes: [
+        { id: 'gc11', path: ['', 'gc-11'], component: GrandChildOneOne },
+        { id: 'gc12', path: 'gc-12', component: GrandChildOneTwo },
+      ],
+    })
+    @customElement({ name: 'c-one', template: `c1 <au-viewport></au-viewport>`, })
+    class ChildOne { }
+
+    @customElement({ name: 'gc-21', template: 'gc21' })
+    class GrandChildTwoOne { }
+
+    @customElement({ name: 'gc-22', template: 'gc22 ${id}' })
+    class GrandChildTwoTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'gc21', path: ['', 'gc-21'], component: GrandChildTwoOne },
+        { id: 'gc22', path: 'gc-22/:id?', component: GrandChildTwoTwo },
+      ],
+    })
+    @customElement({
+      name: 'c-two',
+      template: `c2 \${id} <au-viewport></au-viewport>`,
+    })
+    class ChildTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        {
+          id: 'c1',
+          path: ['', 'c-1'],
+          component: ChildOne,
+        },
+        {
+          id: 'c2',
+          path: 'c-2/:id?',
+          component: ChildTwo,
+        },
+      ],
+    })
+    @customElement({ name: 'my-app', template: '<au-viewport name="vp1"></au-viewport><au-viewport name="vp2" default.bind="null"></au-viewport>' })
+    class MyApp { }
+
+    const { au, container, host } = await start({ appRoot: MyApp });
+    const router = container.get(IRouter);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    const vps = Array.from(host.querySelectorAll(':scope>au-viewport'));
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#1 vp1');
+    assert.html.textContent(vps[1], '', 'round#1 vp2');
+
+    await router.load([
+      {
+        component: 'c1', /* route-id */
+        children: [{ component: 'gc-12' /* path */ }],
+        viewport: 'vp2',
+      },
+      {
+        component: ChildTwo, /* class */
+        params: { id: 21 },
+        children: [{ component: 'gc22' /* route-id */ }],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 21 gc22 NA', 'round#2 vp1');
+    assert.html.textContent(vps[1], 'c1 gc12', 'round#2 vp2');
+
+    await router.load([
+      {
+        component: CustomElement.getDefinition(ChildTwo), /* definition */
+        viewport: 'vp2',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#3 vp1');
+    assert.html.textContent(vps[1], 'c2 NA gc21', 'round#3 vp2');
+
+    await router.load([
+      {
+        component: CustomElement.getDefinition(ChildTwo), /* definition */
+        params: { id: 42 },
+        children: [{ component: GrandChildTwoTwo /* class */, params: { id: 21 } }],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 42 gc22 21', 'round#4 vp1');
+    assert.html.textContent(vps[1], '', 'round#4 vp2');
+
+    await router.load([
+      {
+        component: CustomElement.getDefinition(ChildTwo), /* definition */
+        children: [{ component: GrandChildTwoTwo /* class */}],
+        viewport: 'vp1',
+      },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 NA gc22 NA', 'round#5 vp1');
+    assert.html.textContent(vps[1], '', 'round#5 vp2');
 
     await au.stop();
   });

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -1605,7 +1605,7 @@ describe('router (smoke tests)', function () {
     await au.stop();
   });
 
-  it('Router#load accepts viewport instructions with specific viewport name - component: route-id', async function () {
+  it('Router#load accepts hierarchical viewport instructions with route-id', async function () {
     @customElement({ name: 'gc-11', template: 'gc11' })
     class GrandChildOneOne { }
 
@@ -1737,6 +1737,143 @@ describe('router (smoke tests)', function () {
     await au.stop();
   });
 
+  it('Router#load supports class-returning-function as component', async function () {
+    @customElement({ name: 'gc-11', template: 'gc11' })
+    class GrandChildOneOne { }
+
+    @customElement({ name: 'gc-12', template: 'gc12' })
+    class GrandChildOneTwo { }
+
+    @route({
+      routes: [
+        { id: 'gc11', path: ['', 'gc-11'], component: GrandChildOneOne },
+        { id: 'gc12', path: 'gc-12', component: GrandChildOneTwo },
+      ],
+    })
+    @customElement({ name: 'c-one', template: `c1 <au-viewport></au-viewport>`, })
+    class ChildOne { }
+
+    @customElement({ name: 'gc-21', template: 'gc21' })
+    class GrandChildTwoOne { }
+
+    @customElement({ name: 'gc-22', template: 'gc22 ${id}' })
+    class GrandChildTwoTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'gc21', path: ['', 'gc-21'], component: GrandChildTwoOne },
+        { id: 'gc22', path: 'gc-22/:id?', component: GrandChildTwoTwo },
+      ],
+    })
+    @customElement({
+      name: 'c-two',
+      template: `c2 \${id} <au-viewport></au-viewport>`,
+    })
+    class ChildTwo {
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id ?? 'NA';
+      }
+    }
+
+    @route({
+      routes: [
+        {
+          id: 'c1',
+          path: ['', 'c-1'],
+          component: ChildOne,
+        },
+        {
+          id: 'c2',
+          path: 'c-2/:id?',
+          component: ChildTwo,
+        },
+      ],
+    })
+    @customElement({ name: 'my-app', template: '<au-viewport name="vp1"></au-viewport><au-viewport name="vp2" default.bind="null"></au-viewport>' })
+    class MyApp { }
+
+    const { au, container, host } = await start({ appRoot: MyApp });
+    const router = container.get(IRouter);
+    const queue = container.get(IPlatform).domWriteQueue;
+    await queue.yield();
+    const vps = Array.from(host.querySelectorAll(':scope>au-viewport'));
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#1 vp1');
+    assert.html.textContent(vps[1], '', 'round#1 vp2');
+
+    // single
+    await router.load(() => ChildTwo);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 NA gc21', 'round#2 vp1');
+    assert.html.textContent(vps[1], '', 'round#2 vp2');
+
+    // sibling
+    await router.load([() => ChildTwo, () => ChildOne]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 NA gc21', 'round#3 vp1');
+    assert.html.textContent(vps[1], 'c1 gc11', 'round#3 vp2');
+
+    // viewport instruction
+    await router.load([
+      { component: () => ChildTwo, viewport: 'vp2' },
+      { component: () => ChildOne, viewport: 'vp1' },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc11', 'round#4 vp1');
+    assert.html.textContent(vps[1], 'c2 NA gc21', 'round#4 vp2');
+
+    // viewport instruction - params
+    await router.load([
+      { component: () => ChildTwo, viewport: 'vp1', params: { id: 42 } },
+      { component: () => ChildOne, viewport: 'vp2' },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 42 gc21', 'round#5 vp1');
+    assert.html.textContent(vps[1], 'c1 gc11', 'round#5 vp2');
+
+    // viewport instruction - children
+    await router.load([
+      { component: () => ChildTwo, viewport: 'vp2', children: [() => GrandChildTwoTwo] },
+      { component: () => ChildOne, viewport: 'vp1', children: [() => GrandChildOneTwo] },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc12', 'round#6 vp1');
+    assert.html.textContent(vps[1], 'c2 NA gc22 NA', 'round#6 vp2');
+
+    // viewport instruction - parent-params - children
+    await router.load([
+      { component: () => ChildTwo, viewport: 'vp1', params: { id: 42 }, children: [() => GrandChildTwoTwo] },
+      { component: () => ChildOne, viewport: 'vp2' },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c2 42 gc22 NA', 'round#7 vp1');
+    assert.html.textContent(vps[1], 'c1 gc11', 'round#7 vp2');
+
+    // viewport instruction - parent-params - children-params
+    await router.load([
+      { component: () => ChildTwo, viewport: 'vp2', params: { id: 42 }, children: [{ component: () => GrandChildTwoTwo, params: { id: 21 } }] },
+      { component: () => ChildOne, viewport: 'vp1', children: [() => GrandChildOneTwo] },
+    ]);
+    await queue.yield();
+
+    assert.html.textContent(vps[0], 'c1 gc12', 'round#8 vp1');
+    assert.html.textContent(vps[1], 'c2 42 gc22 21', 'round#8 vp2');
+
+    await au.stop();
+  });
+
   it('Router#load accepts viewport instructions with specific viewport name - component: mixed', async function () {
     @customElement({ name: 'gc-11', template: 'gc11' })
     class GrandChildOneOne { }
@@ -1852,7 +1989,7 @@ describe('router (smoke tests)', function () {
     await router.load([
       {
         component: CustomElement.getDefinition(ChildTwo), /* definition */
-        children: [{ component: GrandChildTwoTwo /* class */}],
+        children: [{ component: GrandChildTwoTwo /* class */ }],
         viewport: 'vp1',
       },
     ]);

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -5,7 +5,7 @@ import { ICustomElementViewModel, ICustomElementController, PartialCustomElement
 import { IRouteViewModel } from './component-agent';
 import { RouteType } from './route';
 import { $RecognizedRoute, IRouteContext, RouteContext } from './route-context';
-import { expectType, isPartialCustomElementDefinition, isPartialViewportInstruction, shallowEquals } from './validation';
+import { expectType, isPartialViewportInstruction, shallowEquals } from './validation';
 import { emptyQuery, INavigationOptions, NavigationOptions } from './router';
 import { RouteExpression } from './route-expression';
 import { mergeURLSearchParams, tryStringify } from './util';

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -30,7 +30,7 @@ export type NavigationInstruction = string | IViewportInstruction | RouteableCom
  * - `PartialCustomElementDefinition`: either a complete `CustomElementDefinition` or a partial definition (e.g. an object literal with at least the `name` property)
  * - `IRouteViewModel`: an existing component instance.
  */
-export type RouteableComponent = RouteType | (() => RouteType) | Promise<IModule> | PartialCustomElementDefinition | IRouteViewModel;
+export type RouteableComponent = RouteType | (() => RouteType) | Promise<IModule> | CustomElementDefinition | IRouteViewModel;
 
 export type Params = { [key: string]: string | undefined };
 
@@ -448,12 +448,6 @@ export class TypedNavigationInstruction<TInstruction extends NavigationInstructi
     if (isCustomElementViewModel(instruction)) return new TypedNavigationInstruction(NavigationInstructionType.IRouteViewModel, instruction);
     // We might have gotten a complete definition. In that case use it as-is.
     if (instruction instanceof CustomElementDefinition) return new TypedNavigationInstruction(NavigationInstructionType.CustomElementDefinition, instruction);
-    if (isPartialCustomElementDefinition(instruction)) {
-      // If we just got a partial definition, define a new anonymous class
-      const Type = CustomElement.define(instruction);
-      const definition = CustomElement.getDefinition(Type);
-      return new TypedNavigationInstruction(NavigationInstructionType.CustomElementDefinition, definition);
-    }
     throw new Error(`Invalid component ${tryStringify(instruction)}: must be either a class, a custom element ViewModel, or a (partial) custom element definition`);
   }
 

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -399,6 +399,26 @@ export function createAndAppendNodes(
           // If the residue matches the whole path it means that empty route is configured, but the path in itself is not configured.
           // Therefore the path matches the configured empty route and puts the whole path into residue.
           if (rr === null || residue === path) {
+            // check if a route-id is used
+            const eagerResult = ctx.generateViewportInstruction({
+              component: vi.component.value,
+              params: vi.params ?? emptyObject,
+              open: vi.open,
+              close: vi.close,
+              viewport: vi.viewport,
+              children: vi.children.slice(),
+            });
+            if(eagerResult !== null) {
+              (node.tree as Writable<RouteTree>).queryParams = mergeURLSearchParams(node.tree.queryParams, eagerResult.query, true);
+              return appendNode(log, node, createConfiguredNode(
+                log,
+                node,
+                eagerResult.vi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>,
+                eagerResult.vi.recognizedRoute!,
+                vi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>));
+            }
+
+            // fallback
             const name = vi.component.value;
             if (name === '') return;
             let vp = vi.viewport;

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -442,9 +442,15 @@ export function createAndAppendNodes(
     case NavigationInstructionType.CustomElementDefinition: {
       const rc = node.context;
       const rd = RouteDefinition.resolve(vi.component.value, rc.definition, null);
-      const { vi: newVi, query } = rc.generateViewportInstruction({ component: rd, params: vi.params ?? emptyObject })!;
+      const { vi: newVi, query } = rc.generateViewportInstruction({
+        component: rd,
+        params: vi.params ?? emptyObject,
+        open: vi.open,
+        close: vi.close,
+        viewport: vi.viewport,
+        children: vi.children.slice(),
+      })!;
       (node.tree as Writable<RouteTree>).queryParams = mergeURLSearchParams(node.tree.queryParams, query, true);
-      (newVi.children as NavigationInstruction[]).push(...vi.children);
       return appendNode(log, node, createConfiguredNode(
         log,
         node,

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -408,7 +408,7 @@ export function createAndAppendNodes(
               viewport: vi.viewport,
               children: vi.children.slice(),
             });
-            if(eagerResult !== null) {
+            if (eagerResult !== null) {
               (node.tree as Writable<RouteTree>).queryParams = mergeURLSearchParams(node.tree.queryParams, eagerResult.query, true);
               return appendNode(log, node, createConfiguredNode(
                 log,
@@ -458,25 +458,29 @@ export function createAndAppendNodes(
           return appendNode(log, node, createConfiguredNode(log, node, vi as ViewportInstruction<ITypedNavigationInstruction_string>, rr, originalInstruction));
         }
       }
+    case NavigationInstructionType.Promise:
     case NavigationInstructionType.IRouteViewModel:
     case NavigationInstructionType.CustomElementDefinition: {
       const rc = node.context;
-      const rd = RouteDefinition.resolve(vi.component.value, rc.definition, null);
-      const { vi: newVi, query } = rc.generateViewportInstruction({
-        component: rd,
-        params: vi.params ?? emptyObject,
-        open: vi.open,
-        close: vi.close,
-        viewport: vi.viewport,
-        children: vi.children.slice(),
-      })!;
-      (node.tree as Writable<RouteTree>).queryParams = mergeURLSearchParams(node.tree.queryParams, query, true);
-      return appendNode(log, node, createConfiguredNode(
-        log,
-        node,
-        newVi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>,
-        newVi.recognizedRoute!,
-        vi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>));
+      return onResolve(
+        RouteDefinition.resolve(vi.component.value, rc.definition, null, rc),
+        rd => {
+          const { vi: newVi, query } = rc.generateViewportInstruction({
+            component: rd,
+            params: vi.params ?? emptyObject,
+            open: vi.open,
+            close: vi.close,
+            viewport: vi.viewport,
+            children: vi.children.slice(),
+          })!;
+          (node.tree as Writable<RouteTree>).queryParams = mergeURLSearchParams(node.tree.queryParams, query, true);
+          return appendNode(log, node, createConfiguredNode(
+            log,
+            node,
+            newVi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>,
+            newVi.recognizedRoute!,
+            vi as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>));
+        });
     }
   }
 }

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -468,17 +468,6 @@ export class Router {
    * router.load({ component: ProductDetail, parameters: { id: 37 } })
    * router.load({ component: 'category', children: ['product(id=20)'] })
    * router.load({ component: 'category', children: [{ component: 'product', parameters: { id: 20 } }] })
-   * router.load({
-   *   component: CustomElement.define({
-   *     name: 'greeter',
-   *     template: 'Hello, ${name}!'
-   *   }, class {
-   *     load(instruction) {
-   *       this.name = instruction.parameters.name;
-   *     }
-   *   }),
-   *   parameters: { name: 'John' }
-   * })
    * ```
    */
   public load(viewportInstruction: IViewportInstruction, options?: INavigationOptions): boolean | Promise<boolean>;

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -445,16 +445,6 @@ export class Router {
    */
   public load(componentTypes: readonly RouteType[], options?: INavigationOptions): Promise<boolean>;
   /**
-   * Loads the provided component definition. May or may not be pre-compiled.
-   *
-   * Examples:
-   *
-   * ```ts
-   * router.load({ name: 'greeter', template: 'Hello!' });
-   * ```
-   */
-  public load(componentDefinition: PartialCustomElementDefinition, options?: INavigationOptions): Promise<boolean>;
-  /**
    * Loads the provided component instance.
    *
    * Examples:

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -1,6 +1,6 @@
 import { isObject } from '@aurelia/metadata';
 import { IContainer, ILogger, DI, IDisposable, onResolve, Writable, resolveAll } from '@aurelia/kernel';
-import { CustomElementDefinition, IPlatform, PartialCustomElementDefinition } from '@aurelia/runtime-html';
+import { CustomElementDefinition, IPlatform } from '@aurelia/runtime-html';
 
 import { IRouteContext, RouteContext } from './route-context';
 import { IRouterEvents, NavigationStartEvent, NavigationEndEvent, NavigationCancelEvent, ManagedState, AuNavId, RoutingTrigger } from './router-events';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the support for couple `Router#load` overloads.

- Viewport name with component class.
- Hierarchical viewport instruction with route-id as component.
- Promise as component for the load method. Typical use-case: `import('./view-model')`.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
