### PR TITLE
fix(router-lite): queryParams and fragment propagation from nav option

### DIFF
--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -2235,6 +2235,15 @@ describe('router (smoke tests)', function () {
       public async redirect4() {
         await this.router.load('a/fizz', { queryParams: { foo: 'bar' } });
       }
+      public async redirect5() {
+        await this.router.load(VmA, { queryParams: { foo: 'bar' } });
+      }
+      public async redirect6() {
+        await this.router.load({ component: VmA, params: { foo: '42' } }, { queryParams: { foo: 'bar' } });
+      }
+      public async redirect7() {
+        await this.router.load({ component: 'a' /** route-id */, params: { foo: '42', bar: 'foo' } }, { queryParams: { bar: 'fizz' } });
+      }
     }
 
     @route({
@@ -2263,7 +2272,7 @@ describe('router (smoke tests)', function () {
       return { host, au, container };
     }
 
-    it('queryString - #1', async function () {
+    it('queryString - #1 - query string in string routing instruction', async function () {
       const { host, au } = await start();
       const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
 
@@ -2274,7 +2283,7 @@ describe('router (smoke tests)', function () {
       await au.stop();
     });
 
-    it('queryString - #2', async function () {
+    it('queryString - #2 - structured query string object', async function () {
       const { host, au } = await start();
       const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
 
@@ -2285,7 +2294,7 @@ describe('router (smoke tests)', function () {
       await au.stop();
     });
 
-    it('queryString - #3', async function () {
+    it('queryString - #3 - multi-valued query string - value from both string path and structured query params', async function () {
       const { host, au } = await start();
       const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
 
@@ -2296,13 +2305,46 @@ describe('router (smoke tests)', function () {
       await au.stop();
     });
 
-    it('queryString - #4', async function () {
+    it('queryString - #4 - structured query string along with path parameter', async function () {
       const { host, au } = await start();
       const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
 
       await vmb.redirect4();
 
       assert.html.textContent(host, 'view-a foo: fizz | query: foo=bar');
+
+      await au.stop();
+    });
+
+    it('queryString - #5 - structured query string with class as routing instruction', async function () {
+      const { host, au } = await start();
+      const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
+
+      await vmb.redirect5();
+
+      assert.html.textContent(host, 'view-a foo: undefined | query: foo=bar');
+
+      await au.stop();
+    });
+
+    it('queryString - #6 - structured query string with viewport instruction', async function () {
+      const { host, au } = await start();
+      const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
+
+      await vmb.redirect6();
+
+      assert.html.textContent(host, 'view-a foo: 42 | query: foo=bar');
+
+      await au.stop();
+    });
+
+    it('queryString - #7 - structured query string with viewport instruction - route-id and multi-valued key', async function () {
+      const { host, au } = await start();
+      const vmb = CustomElement.for<VmB>(host.querySelector('vm-b')).viewModel;
+
+      await vmb.redirect7();
+
+      assert.html.textContent(host, 'view-a foo: 42 | query: bar=fizz&bar=foo');
 
       await au.stop();
     });

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -81,7 +81,7 @@ export class ViewportInstruction<TComponent extends ITypedNavigationInstruction_
     public readonly viewport: string | null,
     public readonly params: Params | null,
     public readonly children: ViewportInstruction[],
-  ) {}
+  ) { }
 
   public static create(instruction: NavigationInstruction): ViewportInstruction {
     if (instruction instanceof ViewportInstruction) return instruction as ViewportInstruction; // eslint is being really weird here
@@ -224,7 +224,7 @@ export class RedirectInstruction implements IRedirectInstruction {
   private constructor(
     public readonly path: string,
     public readonly redirectTo: string,
-  ) {}
+  ) { }
 
   public static create(instruction: IRedirectInstruction): RedirectInstruction {
     if (instruction instanceof RedirectInstruction) {
@@ -273,7 +273,7 @@ export class ViewportInstructionTree {
     public readonly children: ViewportInstruction[],
     public readonly queryParams: Readonly<URLSearchParams>,
     public readonly fragment: string | null,
-  ) {}
+  ) { }
 
   public static create(
     instructionOrInstructions: NavigationInstruction | NavigationInstruction[],
@@ -292,10 +292,10 @@ export class ViewportInstructionTree {
       const len = instructionOrInstructions.length;
       const children = new Array(len);
       const query = new URLSearchParams($options.queryParams ?? emptyObject);
-      for(let i = 0; i<len; i++) {
+      for (let i = 0; i < len; i++) {
         const instruction = instructionOrInstructions[i];
         const eagerVi = hasContext ? context.generateViewportInstruction(instruction) : null;
-        if(eagerVi !== null) {
+        if (eagerVi !== null) {
           children[i] = eagerVi.vi;
           mergeURLSearchParams(query, eagerVi.query, false);
         } else {
@@ -311,19 +311,20 @@ export class ViewportInstructionTree {
     }
 
     const eagerVi = hasContext ? context.generateViewportInstruction(instructionOrInstructions) : null;
+    const query = new URLSearchParams($options.queryParams ?? emptyObject);
     return eagerVi !== null
       ? new ViewportInstructionTree(
         $options,
         false,
         [eagerVi.vi],
-        new URLSearchParams(eagerVi.query ?? emptyObject),
+        mergeURLSearchParams(query, eagerVi.query, false),
         null,
       )
       : new ViewportInstructionTree(
         $options,
         false,
         [ViewportInstruction.create(instructionOrInstructions)],
-        emptyQuery,
+        query,
         null,
       );
   }
@@ -387,11 +388,11 @@ export interface ITypedNavigationInstruction<
   toUrlComponent(): string;
   clone(): this;
 }
-export interface ITypedNavigationInstruction_string extends ITypedNavigationInstruction<string, NavigationInstructionType.string> {}
-export interface ITypedNavigationInstruction_ViewportInstruction extends ITypedNavigationInstruction<ViewportInstruction, NavigationInstructionType.ViewportInstruction> {}
-export interface ITypedNavigationInstruction_CustomElementDefinition extends ITypedNavigationInstruction<CustomElementDefinition, NavigationInstructionType.CustomElementDefinition> {}
-export interface ITypedNavigationInstruction_Promise extends ITypedNavigationInstruction<Promise<IModule>, NavigationInstructionType.Promise> {}
-export interface ITypedNavigationInstruction_IRouteViewModel extends ITypedNavigationInstruction<IRouteViewModel, NavigationInstructionType.IRouteViewModel> {}
+export interface ITypedNavigationInstruction_string extends ITypedNavigationInstruction<string, NavigationInstructionType.string> { }
+export interface ITypedNavigationInstruction_ViewportInstruction extends ITypedNavigationInstruction<ViewportInstruction, NavigationInstructionType.ViewportInstruction> { }
+export interface ITypedNavigationInstruction_CustomElementDefinition extends ITypedNavigationInstruction<CustomElementDefinition, NavigationInstructionType.CustomElementDefinition> { }
+export interface ITypedNavigationInstruction_Promise extends ITypedNavigationInstruction<Promise<IModule>, NavigationInstructionType.Promise> { }
+export interface ITypedNavigationInstruction_IRouteViewModel extends ITypedNavigationInstruction<IRouteViewModel, NavigationInstructionType.IRouteViewModel> { }
 
 export type ITypedNavigationInstruction_T = (
   ITypedNavigationInstruction_Component |
@@ -413,7 +414,7 @@ export class TypedNavigationInstruction<TInstruction extends NavigationInstructi
   private constructor(
     public readonly type: TType,
     public readonly value: TInstruction,
-  ) {}
+  ) { }
 
   public static create(instruction: string): ITypedNavigationInstruction_string;
   public static create(instruction: IViewportInstruction): ITypedNavigationInstruction_ViewportInstruction;

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -302,7 +302,7 @@ export class ViewportInstructionTree {
           children[i] = ViewportInstruction.create(instruction);
         }
       }
-      return new ViewportInstructionTree($options, false, children, query, null);
+      return new ViewportInstructionTree($options, false, children, query, $options.fragment);
     }
 
     if (typeof instructionOrInstructions === 'string') {
@@ -318,14 +318,14 @@ export class ViewportInstructionTree {
         false,
         [eagerVi.vi],
         mergeURLSearchParams(query, eagerVi.query, false),
-        null,
+        $options.fragment,
       )
       : new ViewportInstructionTree(
         $options,
         false,
         [ViewportInstruction.create(instructionOrInstructions)],
         query,
-        null,
+        $options.fragment,
       );
   }
 

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -6,7 +6,7 @@ import { IRouteViewModel } from './component-agent';
 import { RouteType } from './route';
 import { $RecognizedRoute, IRouteContext, RouteContext } from './route-context';
 import { expectType, isPartialViewportInstruction, shallowEquals } from './validation';
-import { emptyQuery, INavigationOptions, NavigationOptions } from './router';
+import { INavigationOptions, NavigationOptions } from './router';
 import { RouteExpression } from './route-expression';
 import { mergeURLSearchParams, tryStringify } from './util';
 

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -17,7 +17,7 @@ import { ViewportAgent, ViewportRequest } from './viewport-agent';
 export interface IRouteContext extends RouteContext { }
 export const IRouteContext = DI.createInterface<IRouteContext>('IRouteContext');
 
-type PathGenerationResult = { vi: ViewportInstruction; query: Params | null };
+type PathGenerationResult = { vi: ViewportInstruction; query: Params };
 
 export type EagerInstruction = {
   component: string | RouteDefinition | PartialCustomElementDefinition | IRouteViewModel | IChildRouteConfig | RouteType;

--- a/packages/router-lite/src/route-expression.ts
+++ b/packages/router-lite/src/route-expression.ts
@@ -196,7 +196,7 @@ export class RouteExpression {
       this.isAbsolute,
       this.root.toInstructions(0, 0),
       mergeURLSearchParams(this.queryParams, options.queryParams, true),
-      this.fragment,
+      this.fragment ?? options.fragment,
     );
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the `queryParams` and `fragment` propagation from the navigation options from the `IRouter#load` method.

```typescript
// prduces -> /home#awesome-possum?foo=bar
router.load(
  'home',
  {
    queryParams: { foo: 'bar' },
    fragment: 'awesome-possum'
  }
);
```
### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
