### PR TITLE
Support TypeScript moduleResolution: "nodenext"/"node16"

### DIFF
--- a/packages-tooling/aot/package.json
+++ b/packages-tooling/aot/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/au/package.json
+++ b/packages-tooling/au/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/babel-jest/package.json
+++ b/packages-tooling/babel-jest/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/http-server/package.json
+++ b/packages-tooling/http-server/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/parcel-transformer/package.json
+++ b/packages-tooling/parcel-transformer/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/plugin-conventions/package.json
+++ b/packages-tooling/plugin-conventions/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/plugin-gulp/package.json
+++ b/packages-tooling/plugin-gulp/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/ts-jest/package.json
+++ b/packages-tooling/ts-jest/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages-tooling/webpack-loader/package.json
+++ b/packages-tooling/webpack-loader/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -5,10 +5,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/compat-v1/package.json
+++ b/packages/compat-v1/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/router-html/package.json
+++ b/packages/router-html/package.json
@@ -5,10 +5,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/router-lite/package.json
+++ b/packages/router-lite/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/ui-virtualization/package.json
+++ b/packages/ui-virtualization/package.json
@@ -5,10 +5,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -4,10 +4,11 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "require": "./dist/cjs/index.cjs",
     "import": "./dist/esm/index.mjs"
   },
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "license": "MIT",
   "homepage": "https://aurelia.io",
   "repository": {

--- a/test/benchmarking-apps/shared/package.json
+++ b/test/benchmarking-apps/shared/package.json
@@ -5,7 +5,7 @@
   "description": "Shared classes for the benchmarking apps",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "dev": "tsc -b -w --preserveWatchOutput",

--- a/test/benchmarking-apps/storage/package.json
+++ b/test/benchmarking-apps/storage/package.json
@@ -5,7 +5,7 @@
   "description": "Implementation of storage services.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "tsc -b && tsc -b ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test/benchmarking-apps/test-result/package.json
+++ b/test/benchmarking-apps/test-result/package.json
@@ -5,7 +5,7 @@
   "description": "Common test result data contracts and storage services.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "typings": "dist/types/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "tsc -b && tsc -b ./tsconfig.cjs.json",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes #1652

I have also changed the name of the `"typings"` property in package.json files to `"types"` (alias), because this seem to have become the industry standard.

### 🎫 Issues

#1652

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ⏭ Next Steps

