### PR TITLE
fix(router-lite): redirectTo URL update + parameter support

### DIFF
--- a/packages/__tests__/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/router-lite/lifecycle-hooks.spec.ts
@@ -223,7 +223,7 @@ describe('lifecycle hooks', function () {
     const router = container.get(IRouter);
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
-    eventLog.assertLog([/AuthHook\] canLoad ''/], 'init');
+    eventLog.assertLog([/AuthHook\] canLoad 'home'/], 'init');
 
     // round 2
     eventLog.clear();
@@ -295,12 +295,12 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad ''/,
-      /Hook2\] canLoad ''/,
-      /Home\] canLoad ''/,
-      /Hook1\] loading ''/,
-      /Hook2\] loading ''/,
-      /Home\] loading ''/,
+      /Hook1\] canLoad 'home'/,
+      /Hook2\] canLoad 'home'/,
+      /Home\] canLoad 'home'/,
+      /Hook1\] loading 'home'/,
+      /Hook2\] loading 'home'/,
+      /Home\] loading 'home'/,
     ], 'init');
 
     // round #2
@@ -308,15 +308,15 @@ describe('lifecycle hooks', function () {
     assert.strictEqual(await router.load('foo'), true);
     assert.html.textContent(host, 'foo');
     eventLog.assertLog([
-      /Hook1\] canUnload ''/,
-      /Hook2\] canUnload ''/,
-      /Home\] canUnload ''/,
+      /Hook1\] canUnload 'home'/,
+      /Hook2\] canUnload 'home'/,
+      /Home\] canUnload 'home'/,
       /Hook1\] canLoad 'foo'/,
       /Hook2\] canLoad 'foo'/,
       /Foo\] canLoad 'foo'/,
-      /Hook1\] unloading ''/,
-      /Hook2\] unloading ''/,
-      /Home\] unloading ''/,
+      /Hook1\] unloading 'home'/,
+      /Hook2\] unloading 'home'/,
+      /Home\] unloading 'home'/,
       /Hook1\] loading 'foo'/,
       /Hook2\] loading 'foo'/,
       /Foo\] loading 'foo'/,
@@ -359,19 +359,19 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
 
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Hook1\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Home\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Hook1\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Home\] loading - end 'home'/,
     ], 'init');
 
     // round #2
@@ -379,12 +379,12 @@ describe('lifecycle hooks', function () {
     assert.strictEqual(await router.load('foo'), true);
     assert.html.textContent(host, 'foo');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
@@ -393,12 +393,12 @@ describe('lifecycle hooks', function () {
       /Foo\] canLoad - start 'foo'/,
       /Foo\] canLoad - end 'foo'/,
 
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Hook1\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Home\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Hook1\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Home\] unloading - end 'home'/,
 
       /Hook1\] loading - start 'foo'/,
       /Hook2\] loading - start 'foo'/,
@@ -445,19 +445,19 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
 
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Hook1\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Home\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Hook1\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Home\] loading - end 'home'/,
     ], 'init');
 
     // round #2
@@ -465,12 +465,12 @@ describe('lifecycle hooks', function () {
     assert.strictEqual(await router.load('foo'), true);
     assert.html.textContent(host, 'foo');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
@@ -479,12 +479,12 @@ describe('lifecycle hooks', function () {
       /Foo\] canLoad - start 'foo'/,
       /Foo\] canLoad - end 'foo'/,
 
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Hook1\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Home\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Hook1\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Home\] unloading - end 'home'/,
 
       /Hook1\] loading - start 'foo'/,
       /Hook2\] loading - start 'foo'/,
@@ -531,20 +531,20 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - unloading');
 
     // round #2
@@ -552,12 +552,12 @@ describe('lifecycle hooks', function () {
     assert.strictEqual(await router.load('foo'), true);
     assert.html.textContent(host, 'foo');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
@@ -567,12 +567,12 @@ describe('lifecycle hooks', function () {
       /Foo\] canLoad - end 'foo'/,
     ], 'round#2');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Home\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Hook1\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Home\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Hook1\] unloading - end 'home'/,
     ], 12, 'round#2 - unloading');
     eventLog.assertLogOrderInvariant([
       /Hook1\] loading - start 'foo'/,
@@ -627,32 +627,32 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), false);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
@@ -703,32 +703,32 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), false);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
@@ -777,32 +777,32 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo/bar'), false, 'round#2-router#load');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo\/bar'/,
       /Hook1\] canLoad - end 'foo\/bar'/,
@@ -817,12 +817,12 @@ describe('lifecycle hooks', function () {
     eventLog.clear();
     assert.strictEqual(await router.load('foo/123'), true, 'round#3-router#load');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo\/123'/,
       /Hook1\] canLoad - end 'foo\/123'/,
@@ -832,12 +832,12 @@ describe('lifecycle hooks', function () {
       /Foo\] canLoad - end 'foo\/123'/,
     ], 'round#3');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Home\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Hook1\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Home\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Hook1\] unloading - end 'home'/,
     ], 12, 'round#3 - unloading');
     eventLog.assertLogOrderInvariant([
       /Hook1\] loading - start 'foo\/123'/,
@@ -903,42 +903,42 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), true);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
 
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'bar'/,
       /Hook1\] canLoad - end 'bar'/,
@@ -948,12 +948,12 @@ describe('lifecycle hooks', function () {
       /Bar\] canLoad - end 'bar'/,
     ], 'round#2');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Home\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Hook1\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Home\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Hook1\] unloading - end 'home'/,
     ], 14, 'round#2 - unloading');
     eventLog.assertLogOrderInvariant([
       /Hook1\] loading - start 'bar'/,
@@ -1012,44 +1012,44 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), true);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo'/,
       /Hook1\] canLoad - end 'foo'/,
       /Hook2\] canLoad - start 'foo'/,
       /Hook2\] canLoad - end 'foo'/,
 
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'bar'/,
       /Hook1\] canLoad - end 'bar'/,
@@ -1059,12 +1059,12 @@ describe('lifecycle hooks', function () {
       /Bar\] canLoad - end 'bar'/,
     ], 'round#2');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Home\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Hook1\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Home\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Hook1\] unloading - end 'home'/,
     ], 14, 'round#2 - unloading');
     eventLog.assertLogOrderInvariant([
       /Hook1\] loading - start 'bar'/,
@@ -1119,32 +1119,32 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo/bar'), true, 'round#2-router#load');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'foo\/bar'/,
       /Hook1\] canLoad - end 'foo\/bar'/,
@@ -1153,12 +1153,12 @@ describe('lifecycle hooks', function () {
       /Foo\] canLoad - start 'foo\/bar'/,
       /Foo\] canLoad - end 'foo\/bar'/,
 
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
 
       /Hook1\] canLoad - start 'bar'/,
       /Hook1\] canLoad - end 'bar'/,
@@ -1168,12 +1168,12 @@ describe('lifecycle hooks', function () {
       /Bar\] canLoad - end 'bar'/,
     ], 'round#2');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] unloading - start ''/,
-      /Hook2\] unloading - start ''/,
-      /Home\] unloading - start ''/,
-      /Home\] unloading - end ''/,
-      /Hook2\] unloading - end ''/,
-      /Hook1\] unloading - end ''/,
+      /Hook1\] unloading - start 'home'/,
+      /Hook2\] unloading - start 'home'/,
+      /Home\] unloading - start 'home'/,
+      /Home\] unloading - end 'home'/,
+      /Hook2\] unloading - end 'home'/,
+      /Hook1\] unloading - end 'home'/,
     ], 24, 'round#2 - unloading');
     eventLog.assertLogOrderInvariant([
       /Hook1\] loading - start 'bar'/,
@@ -1264,28 +1264,28 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), false);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
     ], 'round#2');
     assert.strictEqual(eventLog.log.length, 2);
     await au.stop();
@@ -1333,30 +1333,30 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo'), false);
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
     ], 'round#2');
     assert.strictEqual(eventLog.log.length, 4);
     await au.stop();
@@ -1402,32 +1402,32 @@ describe('lifecycle hooks', function () {
     const eventLog = EventLog.getInstance(container);
     assert.html.textContent(host, 'home');
     eventLog.assertLog([
-      /Hook1\] canLoad - start ''/,
-      /Hook1\] canLoad - end ''/,
-      /Hook2\] canLoad - start ''/,
-      /Hook2\] canLoad - end ''/,
-      /Home\] canLoad - start ''/,
-      /Home\] canLoad - end ''/,
+      /Hook1\] canLoad - start 'home'/,
+      /Hook1\] canLoad - end 'home'/,
+      /Hook2\] canLoad - start 'home'/,
+      /Hook2\] canLoad - end 'home'/,
+      /Home\] canLoad - start 'home'/,
+      /Home\] canLoad - end 'home'/,
     ], 'init');
     eventLog.assertLogOrderInvariant([
-      /Hook1\] loading - start ''/,
-      /Hook2\] loading - start ''/,
-      /Home\] loading - start ''/,
-      /Home\] loading - end ''/,
-      /Hook2\] loading - end ''/,
-      /Hook1\] loading - end ''/,
+      /Hook1\] loading - start 'home'/,
+      /Hook2\] loading - start 'home'/,
+      /Home\] loading - start 'home'/,
+      /Home\] loading - end 'home'/,
+      /Hook2\] loading - end 'home'/,
+      /Hook1\] loading - end 'home'/,
     ], 6, 'init - loading');
 
     // round #2
     eventLog.clear();
     assert.strictEqual(await router.load('foo/bar'), false, 'round#2-router#load');
     eventLog.assertLog([
-      /Hook1\] canUnload - start ''/,
-      /Hook1\] canUnload - end ''/,
-      /Hook2\] canUnload - start ''/,
-      /Hook2\] canUnload - end ''/,
-      /Home\] canUnload - start ''/,
-      /Home\] canUnload - end ''/,
+      /Hook1\] canUnload - start 'home'/,
+      /Hook1\] canUnload - end 'home'/,
+      /Hook2\] canUnload - start 'home'/,
+      /Hook2\] canUnload - end 'home'/,
+      /Home\] canUnload - start 'home'/,
+      /Home\] canUnload - end 'home'/,
     ], 'round#2');
     assert.strictEqual(eventLog.log.length, 6);
 

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -3112,12 +3112,16 @@ describe('router (smoke tests)', function () {
     await au.app({ component: Root, host }).start();
 
     assert.html.textContent(host, 'p2');
+    const location = container.get(ILocation) as unknown as MockBrowserHistoryLocation;
+    assert.match(location.path, /p2$/);
 
     await router.load('p1');
     assert.html.textContent(host, 'p1');
+    assert.match(location.path, /p1$/);
 
     await router.load('foo');
     assert.html.textContent(host, 'p2');
+    assert.match(location.path, /p2$/);
 
     await au.stop();
   });

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -2476,7 +2476,7 @@ describe('router (smoke tests)', function () {
       await vmb.redirectWithQueryAndFragment();
 
       assert.html.textContent(host, 'view-a foo: 42 | query: foo=bar | fragment: foobar');
-      assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42#foobar\?foo=bar$/);
+      assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42\?foo=bar#foobar$/);
 
       await au.stop();
     });
@@ -2488,7 +2488,7 @@ describe('router (smoke tests)', function () {
       await vmb.redirectWithQueryAndFragmentSiblingViewport();
 
       assert.html.textContent(host, 'view-a foo: 42 | query: foo=bar | fragment: foobar view-a foo: 84 | query: foo=bar | fragment: foobar');
-      assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42\+a\/84#foobar\?foo=bar$/);
+      assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42\+a\/84\?foo=bar#foobar$/);
 
       await au.stop();
     });

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -3126,6 +3126,72 @@ describe('router (smoke tests)', function () {
     await au.stop();
   });
 
+  it('parameterized redirect', async function () {
+    @customElement({ name: 'ce-p1', template: 'p1' })
+    class P1 { }
+
+    @customElement({ name: 'ce-p2', template: `p2 \${id}` })
+    class P2 implements IRouteViewModel {
+      private id: string;
+      public loading(params: Params, _next: RouteNode, _current: RouteNode): void | Promise<void> {
+        this.id = params.id;
+      }
+    }
+    @route({
+      routes: [
+        { path: '', redirectTo: 'p2' },
+        { path: 'foo', redirectTo: 'p2/42' },
+        { path: 'fizz/:bar', redirectTo: 'p2/:bar' },
+        { path: 'bar', redirectTo: 'p2/43+p2/44' },
+        { path: 'p1', component: P1, title: 'P1' },
+        { path: 'p2/:id?', component: P2, title: 'P2' },
+      ]
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport><au-viewport default.bind="null"></au-viewport>' })
+    class Root { }
+
+    const ctx = TestContext.create();
+    const { container } = ctx;
+    container.register(
+      StandardConfiguration,
+      TestRouterConfiguration.for(LogLevel.warn),
+      RouterConfiguration,
+      P1,
+      P2,
+    );
+
+    const au = new Aurelia(container);
+    const host = ctx.createElement('div');
+    const router = container.get(IRouter);
+
+    await au.app({ component: Root, host }).start();
+
+    assert.html.textContent(host, 'p2');
+    const location = container.get(ILocation) as unknown as MockBrowserHistoryLocation;
+    assert.match(location.path, /p2$/);
+
+    await router.load('p1');
+    assert.html.textContent(host, 'p1');
+    assert.match(location.path, /p1$/);
+
+    await router.load('foo');
+    assert.html.textContent(host, 'p2 42');
+    assert.match(location.path, /p2\/42$/);
+
+    await router.load('fizz/21');
+    assert.html.textContent(host, 'p2 21');
+    assert.match(location.path, /p2\/21$/);
+
+    try {
+      await router.load('bar');
+      assert.fail('Expected error for non-simple redirect.');
+    } catch(e) {
+      assert.match((e as Error).message, /^Unexpected expression kind/, 'Expected error due to unexpected path segment.');
+    }
+
+    await au.stop();
+  });
+
   describe('path generation', function () {
     it('at root', async function () {
       abstract class BaseRouteViewModel implements IRouteViewModel {

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -360,7 +360,7 @@ export class ViewportInstructionTree {
     let search = this.queryParams.toString();
     search = search === '' ? '' : `?${search}`;
 
-    return `${pathname}${hash}${search}`;
+    return `${pathname}${search}${hash}`;
   }
 
   public toPath(): string {

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -608,7 +608,7 @@ function createConfiguredNode(
 
       if (redirSeg !== null) {
         if (redirSeg.component.isDynamic && (origSeg?.component.isDynamic ?? false)) {
-          newSegs.push(rr.route.params[origSeg!.component.name] as string);
+          newSegs.push(rr.route.params[origSeg!.component.parameterName] as string);
         } else {
           newSegs.push(redirSeg.raw);
         }
@@ -631,9 +631,9 @@ function createConfiguredNode(
         open: vi.open,
         close: vi.close,
       }) as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>,
-      rr,
+      redirRR,
       originalVi,
-      redirRR.route.endpoint.route);
+    );
   });
 }
 

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -620,7 +620,20 @@ function createConfiguredNode(
     const redirRR = ctx.recognize(newPath);
     if (redirRR === null) throw new UnknownRouteError(`'${newPath}' did not match any configured route or registered component name at '${ctx.friendlyPath}' - did you forget to add '${newPath}' to the routes list of the route decorator of '${ctx.component.name}'?`);
 
-    return createConfiguredNode(log, node, vi, rr, originalVi, redirRR.route.endpoint.route);
+    return createConfiguredNode(
+      log,
+      node,
+      ViewportInstruction.create({
+        recognizedRoute: redirRR,
+        component: newPath,
+        children: vi.children,
+        viewport: vi.viewport,
+        open: vi.open,
+        close: vi.close,
+      }) as ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent>,
+      rr,
+      originalVi,
+      redirRR.route.endpoint.route);
   });
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This closes #1654.
Additionally, it fixes: 

- The parameter support for `redirectTo`.

  ```typescript
  @route({
    routes: [
      { path: 'fizz/:bar', redirectTo: 'p2/:bar' },
      { path: 'p2/:id?', component: P2, title: 'P2' },
    ]
  })
  ```
- The fragment (hash) is added to the end of the URL.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
