### PR TITLE
fix(router-lite): redirectTo parameter remapping

### DIFF
--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -608,7 +608,7 @@ function createConfiguredNode(
 
       if (redirSeg !== null) {
         if (redirSeg.component.isDynamic && (origSeg?.component.isDynamic ?? false)) {
-          newSegs.push(rr.route.params[origSeg!.component.parameterName] as string);
+          newSegs.push(rr.route.params[redirSeg.component.parameterName] as string);
         } else {
           newSegs.push(redirSeg.raw);
         }


### PR DESCRIPTION


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This fixes the following use case of `{ path: 'fizz/:foo/:bar', redirectTo: 'p2/:bar/:foo' }`. That is when `/foo/1/2` is attempted to be loaded, the user will be redirected to `/p2/2/1`. Previously, it was erroneously redirected to `/p2/1/2`.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
