### PR TITLE
fix(ast): correctly resolves access keyed on primitve

### DIFF
--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -480,6 +480,39 @@ describe('AccessKeyedExpression', function () {
     assert.strictEqual(binding.calls.length, 2, 'binding.calls.length');
   });
 
+  describe('returns the right value when accessing keyed on primitive', function () {
+
+    it('returns string when accessing string character', function () {
+      const value = astEvaluate(
+        new AccessKeyedExpression(new PrimitiveLiteralExpression('a'), new PrimitiveLiteralExpression(0)),
+        null,
+        null,
+        null
+      );
+      assert.strictEqual(value, 'a');
+    });
+
+    it('returns undefined when accessing keyed on null/undefined', function () {
+      const value = astEvaluate(
+        new AccessKeyedExpression(PrimitiveLiteralExpression.$null, new PrimitiveLiteralExpression(0)),
+        null,
+        null,
+        null
+      );
+      assert.strictEqual(value, undefined);
+    });
+
+    it('returns prototype method when accessing keyed on primitive', function () {
+      const value = astEvaluate(
+        new AccessKeyedExpression(new PrimitiveLiteralExpression(0), new PrimitiveLiteralExpression('toFixed')),
+        null,
+        null,
+        null
+      );
+      assert.strictEqual(value, Number.prototype.toFixed);
+    });
+  });
+
   describe('does not attempt to observe property when object is primitive', function () {
     const objects: [string, any][] = [
       [`     null`, null],

--- a/packages/runtime-html/src/observation/observation-utils.ts
+++ b/packages/runtime-html/src/observation/observation-utils.ts
@@ -15,6 +15,7 @@ const removeListener = (target: EventTarget, name: string, handler: EventListene
 /** @internal */
 export const mixinNodeObserverUseConfig =
   <T extends INodeObserver & EventListenerObject & ISubscriberCollection & { _el: INode; _config: INodeObserverConfigBase; _listened: boolean; _start(): void; _stop?(): void }>(target: Constructable<T>) => {
+    let event: string;
     const prototype = target.prototype;
     defineHiddenProp(prototype, 'subscribe', function (this: T, subscriber: ISubscriber) {
       if (this.subs.add(subscriber) && this.subs.count === 1) {
@@ -46,7 +47,6 @@ export const mixinNodeObserverUseConfig =
       }
     });
 };
-let event: string;
 
 export const mixinNoopSubscribable = (target: Constructable) => {
   defineHiddenProp(target.prototype, 'subscribe', noop);

--- a/packages/runtime/src/binding/ast.eval.ts
+++ b/packages/runtime/src/binding/ast.eval.ts
@@ -171,14 +171,16 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
     }
     case ExpressionKind.AccessKeyed: {
       const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
+      const key = astEvaluate(ast.key, s, e, c) as string;
       if (isObject(instance)) {
-        const key = astEvaluate(ast.key, s, e, c) as string;
         if (c !== null) {
           c.observe(instance, key);
         }
         return instance[key];
       }
-      return void 0;
+      return instance == null
+        ? void 0
+        : instance[key];
     }
     case ExpressionKind.TaggedTemplate: {
       const results = ast.expressions.map(expr => astEvaluate(expr, s, e, c));


### PR DESCRIPTION
closes #1617

# Pull Request

## 📖 Description

Keyed access in is wrongly consider noop atm, change it to proper value access.