### PR TITLE
WIP: refactore dialog DOM creation

### DIFF
--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -8,7 +8,6 @@ export {
   IDialogService,
   IDialogController,
   IDialogDomRenderer,
-  IDialogDom,
 
   // dialog results
   DialogCloseResult,
@@ -46,7 +45,6 @@ export {
 } from './plugins/dialog/dialog-configuration';
 
 export {
-  DefaultDialogDom,
   DefaultDialogDomRenderer,
   DefaultDialogGlobalSettings,
 } from './plugins/dialog/dialog-default-impl';

--- a/packages/dialog/src/plugins/dialog/dialog-controller.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-controller.ts
@@ -73,17 +73,18 @@ export class DialogController implements IDialogController {
 
   /** @internal */
   public activate(settings: IDialogLoadedSettings): Promise<DialogOpenResult> {
+    this.settings = settings;
+
     const container = this.ctn.createChild();
     const { model, template, rejectOnCancel } = settings;
     const dialogTargetHost = settings.host ?? this.p.document.body;
     const renderer = container.get(IDialogDomRenderer);
-    const contentHost = renderer.render(dialogTargetHost, settings, this);
+    const contentHost = renderer.render(dialogTargetHost, this);
     const rootEventTarget = container.has(IEventTarget, true)
       ? container.get(IEventTarget) as Element
       : null;
 
     this.renderer = renderer;
-    this.settings = settings;
     // application root host may be a different element with the dialog root host
     // example:
     // <body>

--- a/packages/dialog/src/plugins/dialog/dialog-controller.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-controller.ts
@@ -81,7 +81,7 @@ export class DialogController implements IDialogController {
     const container = this.ctn.createChild();
     container.register(instanceRegistration(IDialogController, this));
 
-    const renderer = container.get(IDialogDomRenderer);
+    const renderer = this.ctn.get(IDialogDomRenderer);
     container.register(instanceRegistration(IDialogDomRenderer, renderer));
 
     // moved to renderer

--- a/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
@@ -47,12 +47,13 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
 
   public render(dialogHost: HTMLElement, settings: IDialogLoadedSettings, controller: IDialogController): HTMLElement {
     const doc = this.p.document;
-    const h = (name: string, css: string) => {
+    const h = (name: string, css: string): HTMLElement => {
       const el = doc.createElement(name);
       el.style.cssText = css;
       return el;
     };
     const wrapper = dialogHost.appendChild(h('au-dialog-container', wrapperCss));
+    wrapper.setAttribute('tabindex', '-1');
     const overlay = wrapper.appendChild(h('au-dialog-overlay', baseWrapperCss));
     const contentHost = wrapper.appendChild(h('div', hostCss));
 

--- a/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
@@ -1,8 +1,5 @@
 import { IPlatform } from '@aurelia/runtime-html';
-import {
-  IDialogDomRenderer,
-  IDialogGlobalSettings, DialogActionKey, IDialogLoadedSettings, IDialogController,
-} from './dialog-interfaces';
+import { IDialogDomRenderer, IDialogGlobalSettings, DialogActionKey, IDialogController } from './dialog-interfaces';
 
 import { IContainer } from '@aurelia/kernel';
 import { singletonRegistration, transientRegistration } from '../../utilities-di';
@@ -34,9 +31,6 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
   public contentHost!: HTMLElement;
 
   /** @internal */
-  protected settings!: IDialogLoadedSettings;
-
-  /** @internal */
   protected controller!: IDialogController;
 
   public constructor(private readonly p: IPlatform) {}
@@ -45,7 +39,7 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
     transientRegistration(IDialogDomRenderer, this).register(container);
   }
 
-  public render(dialogHost: HTMLElement, settings: IDialogLoadedSettings, controller: IDialogController): HTMLElement {
+  public render(dialogHost: HTMLElement, controller: IDialogController): HTMLElement {
     const doc = this.p.document;
     const h = (name: string, css: string): HTMLElement => {
       const el = doc.createElement(name);
@@ -57,13 +51,12 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
     const overlay = wrapper.appendChild(h('au-dialog-overlay', baseWrapperCss));
     const contentHost = wrapper.appendChild(h('div', hostCss));
 
-    overlay.addEventListener(settings.mouseEvent ?? 'click', this);
+    overlay.addEventListener(controller.settings.mouseEvent ?? 'click', this);
     wrapper.addEventListener('keydown', this);
 
     this.wrapper = wrapper;
     this.overlay = overlay;
     this.contentHost = contentHost;
-    this.settings = settings;
     this.controller = controller;
 
     return contentHost;
@@ -71,7 +64,7 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
 
   public dispose(): void {
     this.wrapper.removeEventListener('keydown', this);
-    this.overlay.removeEventListener(this.settings.mouseEvent ?? 'click', this);
+    this.overlay.removeEventListener(this.controller.settings.mouseEvent ?? 'click', this);
     this.wrapper.remove();
   }
 
@@ -86,7 +79,7 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
         return;
       }
 
-      const keyboard = this.settings.keyboard;
+      const keyboard = controller.settings.keyboard;
       if (key === 'Escape' && keyboard.includes(key)) {
         void controller.cancel();
       } else if (key === 'Enter' && keyboard.includes(key)) {
@@ -96,7 +89,7 @@ export class DefaultDialogDomRenderer implements IDialogDomRenderer, EventListen
     }
 
     // handle overlay click
-    if (/* user allows to dismiss on overlay click */this.settings.overlayDismiss
+    if (/* user allows to dismiss on overlay click */controller.settings.overlayDismiss
       && /* did not click inside the host element */!this.contentHost.contains(event.target as Element)
     ) {
       void controller.cancel();

--- a/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
@@ -1,7 +1,7 @@
 import { createInterface } from '../../utilities-di';
 
 import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
-import type { ICustomElementViewModel } from '@aurelia/runtime-html';
+import type { ICustomElementController, ICustomElementViewModel } from '@aurelia/runtime-html';
 
 /**
  * The dialog service for composing view & view model into a dialog
@@ -46,7 +46,7 @@ export interface IDialogController {
  */
 export const IDialogDomRenderer = createInterface<IDialogDomRenderer>('IDialogDomRenderer');
 export interface IDialogDomRenderer extends IDisposable {
-  render(dialogHost: Element, controller: IDialogController): HTMLElement;
+  render(componentController: ICustomElementController): void | Promise<void>;
 }
 
 // export type IDialogCancellableOpenResult = IDialogOpenResult | IDialogCancelResult;

--- a/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
@@ -45,17 +45,8 @@ export interface IDialogController {
  * An interface describing the object responsible for creating the dom structure of a dialog
  */
 export const IDialogDomRenderer = createInterface<IDialogDomRenderer>('IDialogDomRenderer');
-export interface IDialogDomRenderer {
-  render(dialogHost: Element, settings: IDialogLoadedSettings): IDialogDom;
-}
-
-/**
- * An interface describing the DOM structure of a dialog
- */
-export const IDialogDom = createInterface<IDialogDom>('IDialogDom');
-export interface IDialogDom extends IDisposable {
-  readonly overlay: HTMLElement;
-  readonly contentHost: HTMLElement;
+export interface IDialogDomRenderer extends IDisposable {
+  render(dialogHost: Element, settings: IDialogLoadedSettings, controller: IDialogController): HTMLElement;
 }
 
 // export type IDialogCancellableOpenResult = IDialogOpenResult | IDialogCancelResult;

--- a/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
@@ -46,7 +46,7 @@ export interface IDialogController {
  */
 export const IDialogDomRenderer = createInterface<IDialogDomRenderer>('IDialogDomRenderer');
 export interface IDialogDomRenderer extends IDisposable {
-  render(dialogHost: Element, settings: IDialogLoadedSettings, controller: IDialogController): HTMLElement;
+  render(dialogHost: Element, controller: IDialogController): HTMLElement;
 }
 
 // export type IDialogCancellableOpenResult = IDialogOpenResult | IDialogCancelResult;

--- a/packages/dialog/src/plugins/dialog/dialog-service.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-service.ts
@@ -103,6 +103,7 @@ export class DialogService implements IDialogService {
             dialogController.activate(loadedSettings),
             openResult => {
               if (!openResult.wasCancelled) {
+                this.dlgs.push(dialogController);
                 const $removeController = () => this.remove(dialogController);
                 dialogController.closed.then($removeController, $removeController);
               }

--- a/packages/dialog/src/plugins/dialog/dialog-service.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-service.ts
@@ -2,7 +2,6 @@ import { IContainer, onResolve, resolveAll } from '@aurelia/kernel';
 import { AppTask, IPlatform } from '@aurelia/runtime-html';
 
 import {
-  DialogActionKey,
   DialogCloseResult,
   DialogDeactivationStatuses,
   DialogOpenResult,
@@ -104,10 +103,6 @@ export class DialogService implements IDialogService {
             dialogController.activate(loadedSettings),
             openResult => {
               if (!openResult.wasCancelled) {
-                if (this.dlgs.push(dialogController) === 1) {
-                  this.p.window.addEventListener('keydown', this);
-                }
-
                 const $removeController = () => this.remove(dialogController);
                 dialogController.closed.then($removeController, $removeController);
               }
@@ -151,28 +146,6 @@ export class DialogService implements IDialogService {
     const idx = dlgs.indexOf(controller);
     if (idx > -1) {
       this.dlgs.splice(idx, 1);
-    }
-    if (dlgs.length === 0) {
-      this.p.window.removeEventListener('keydown', this);
-    }
-  }
-
-  /** @internal */
-  public handleEvent(e: Event): void {
-    const keyEvent = e as KeyboardEvent;
-    const key = getActionKey(keyEvent);
-    if (key == null) {
-      return;
-    }
-    const top = this.top;
-    if (top === null || top.settings.keyboard.length === 0) {
-      return;
-    }
-    const keyboard = top.settings.keyboard;
-    if (key === 'Escape' && keyboard.includes(key)) {
-      void top.cancel();
-    } else if (key === 'Enter' && keyboard.includes(key)) {
-      void top.ok();
     }
   }
 }
@@ -237,14 +210,4 @@ function whenClosed<TResult1 = unknown, TResult2 = unknown>(
 function asDialogOpenPromise(promise: Promise<unknown>): DialogOpenPromise {
   (promise as DialogOpenPromise).whenClosed = whenClosed;
   return promise as DialogOpenPromise;
-}
-
-function getActionKey(e: KeyboardEvent): DialogActionKey | undefined {
-  if ((e.code || e.key) === 'Escape' || e.keyCode === 27) {
-    return 'Escape';
-  }
-  if ((e.code || e.key) === 'Enter' || e.keyCode === 13) {
-    return 'Enter';
-  }
-  return undefined;
 }

--- a/packages/dialog/src/utilities-di.ts
+++ b/packages/dialog/src/utilities-di.ts
@@ -11,3 +11,6 @@ export const instanceRegistration = Registration.instance;
 
 /** @internal */
 export const callbackRegistration = Registration.callback;
+
+/** @internal */
+export const transientRegistration = Registration.transient;


### PR DESCRIPTION
# Pull Request

## 📖 Description

The goal of this change is to refactore DialogService and DialogController to be more DOM-agnostic and allow flexible DefaultDialogDomRenderer overriding (for example create BootstrapDialogDomRenderer which renders dialog using Bootstrap's markup and native JS).
Changes include:

- DialogService does not listen and react to dialog's wrapper keydown event, moved to DefaultDialogDomRenderer
- DialogController does not listen and react to dialog's overlay click event, moved to DefaultDialogDomRenderer
- DialogDom is removed, it's functionality is moved to DefaultDialogDomRenderer
- keydown event is now listened on dialog's wrapper elements instead of Window (tabindex="-1" added to wrapper element to make it focusable and thus dispatch this event type). This allows not to warry about dialog hierarhy progmatically - the last open dialog (top) will always receive this event.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
