### PR TITLE
fix(au-slot): register the right view model instance for injection

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -1,5 +1,5 @@
 import { delegateSyntax } from '@aurelia/compat-v1';
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, inject } from '@aurelia/kernel';
 import { BindingMode, Aurelia, AuSlotsInfo, bindable, customElement, CustomElement, IAuSlotsInfo, IPlatform } from '@aurelia/runtime-html';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { assert, createFixture, hJsx, TestContext } from '@aurelia/testing';
@@ -2108,5 +2108,37 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
 
     assertText('p', 'my-el content: hello');
     assertHtml('p > a', 'hello');
+  });
+
+  it('injects the right parent component', async function () {
+    let id = 0;
+    @customElement({
+      name: 'parent',
+      template: '<au-slot>'
+    })
+    class Parent {
+      id = ++id;
+    }
+
+    let parent: Parent | null = null;
+    @inject(Parent)
+    @customElement({
+      name: 'child'
+    })
+    class Child {
+      constructor($parent: Parent) {
+        parent = $parent;
+        debugger;
+      }
+    }
+
+    createFixture(
+      '<parent view-model.ref=parent><child>',
+      class App { parent: Parent; },
+      [Parent, Child]
+    );
+
+    assert.instanceOf(parent, Parent);
+    assert.strictEqual(parent.id, 1);
   });
 });

--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -2128,13 +2128,12 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
     class Child {
       constructor($parent: Parent) {
         parent = $parent;
-        debugger;
       }
     }
 
     createFixture(
       '<parent view-model.ref=parent><child>',
-      class App { parent: Parent; },
+      class App { },
       [Parent, Child]
     );
 


### PR DESCRIPTION
closes #1683

Currently a structure like this
```html
<template>
  <parent>
    <child>
</template>
```
Will have container hierarchy like this
```
container (app)
  | - container (parent)
  | - container (child)
```
This does not enable the injection of `Parent` into `Child` component, and is not matching the behavior of v1.

This PR add a layer of container wrapping the container of child so that the hierarchy will look like this
```
container (app)
  | - container (parent)
  | - container (slot) // this container is aware of container (parent) and can register the instance for injection
    | - (child)
```

Closes #1683 

cc @fkleuver @Sayan751 