### PR TITLE
feat(binding): save property type metadata to bindable definition

### DIFF
--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -8,7 +8,7 @@ import { isString, objectFreeze, objectKeys } from './utilities';
 import type { Constructable, Writable } from '@aurelia/kernel';
 import type { InterceptorFunc } from '@aurelia/runtime';
 
-type PropertyType = typeof Number | typeof String | typeof Boolean | typeof BigInt | { coercer: InterceptorFunc } | Class<unknown>;
+type PropertyType = typeof Number | typeof String | typeof Boolean | typeof BigInt | typeof Array | typeof Object | typeof Function | { coercer: InterceptorFunc } | Class<unknown>;
 
 export type PartialBindableDefinition = {
   mode?: BindingMode;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This change add persistence of bindable() type/nullable properties for later usage at runtime. Currently these properties are configurable, but not persisted, they are used just for coercer setup. Also Typescript decodator metadata types (if available) are saved as defaults. This is usefull for docs geerators/etc. I currently need it for Aurelia Storybook plugin. May be later bindable validation according to these types may added as an opt-in functionality.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
