### PR TITLE
fix(css-modules): class cmd css module

### DIFF
--- a/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
@@ -1,37 +1,9 @@
-import { Aurelia, BindingMode, cssModules, customElement, CustomElement, IPlatform } from '@aurelia/runtime-html';
+import { Aurelia, BindingMode, CustomElement, IPlatform } from '@aurelia/runtime-html';
 import { assert, createFixture, eachCartesianJoin } from '@aurelia/testing';
 import { ClassAttributePattern } from './attribute-pattern.js';
 
 // TemplateCompiler - Binding Commands integration
 describe('3-runtime-html/template-compiler.binding-commands.class.spec.ts', function () {
-  describe('with cssModule', function () {
-    it('works - github #1684', function () {
-      const template = `<p class="strike" selected.class="isSelected">
-I am green if I am selected and red if I am not
-</p>
-<p selected.class="isSelected">
-I am green if I am selected and red if I am not
-</p>
-<pre>\${isSelected}</pre>
-<button type="button" click.trigger="toggle()">Toggle selected state</button>`;
-
-      @customElement({
-        name: 'component',
-        template,
-        dependencies: [cssModules({ selected: 'a_' })]
-      })
-      class Component {
-        isSelected = true;
-      }
-      const { assertAttr } = createFixture(
-        '<component>',
-        void 0,
-        [Component]
-      );
-
-      assertAttr('p:nth-child(1)', 'class', 'au a_ strike');
-    });
-  });
 
   const falsyValues = [0, false, null, undefined, ''];
   const truthyValues = [1, '1', true, {}, [], Symbol(), function () {/**/ }, Number, new Proxy({}, {})];

--- a/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
+++ b/packages/__tests__/3-runtime-html/binding-command.class.spec.ts
@@ -1,12 +1,40 @@
-import { Constructable } from '@aurelia/kernel';
-import { BindingMode, Aurelia, StandardConfiguration, CustomElement, IPlatform } from '@aurelia/runtime-html';
-import { TestContext, eachCartesianJoin, eachCartesianJoinAsync, assert } from '@aurelia/testing';
+import { Aurelia, BindingMode, cssModules, customElement, CustomElement, IPlatform } from '@aurelia/runtime-html';
+import { assert, createFixture, eachCartesianJoin } from '@aurelia/testing';
 import { ClassAttributePattern } from './attribute-pattern.js';
 
 // TemplateCompiler - Binding Commands integration
 describe('3-runtime-html/template-compiler.binding-commands.class.spec.ts', function () {
+  describe('with cssModule', function () {
+    it('works - github #1684', function () {
+      const template = `<p class="strike" selected.class="isSelected">
+I am green if I am selected and red if I am not
+</p>
+<p selected.class="isSelected">
+I am green if I am selected and red if I am not
+</p>
+<pre>\${isSelected}</pre>
+<button type="button" click.trigger="toggle()">Toggle selected state</button>`;
+
+      @customElement({
+        name: 'component',
+        template,
+        dependencies: [cssModules({ selected: 'a_' })]
+      })
+      class Component {
+        isSelected = true;
+      }
+      const { assertAttr } = createFixture(
+        '<component>',
+        void 0,
+        [Component]
+      );
+
+      assertAttr('p:nth-child(1)', 'class', 'au a_ strike');
+    });
+  });
+
   const falsyValues = [0, false, null, undefined, ''];
-  const truthyValues = [1, '1', true, {}, [], Symbol(), function () {/**/}, Number, new Proxy({}, {})];
+  const truthyValues = [1, '1', true, {}, [], Symbol(), function () {/**/ }, Number, new Proxy({}, {})];
 
   const classNameTests: string[] = [
     'background',
@@ -62,12 +90,12 @@ describe('3-runtime-html/template-compiler.binding-commands.class.spec.ts', func
         <child repeat.for="i of 5" value.bind="value"></child>
       `;
       },
-      assert: async (au, platform, host, component, testCase, className) => {
+      assert: (au, platform, host, component, testCase, className) => {
         const childEls = host.querySelectorAll('child');
 
         assert.strictEqual(childEls.length, 6, `childEls.length`);
 
-        await eachCartesianJoinAsync(
+        eachCartesianJoin(
           [falsyValues, truthyValues],
           (falsyValue, truthyValue) => {
             for (let i = 0, ii = childEls.length; ii > i; ++i) {
@@ -127,79 +155,71 @@ describe('3-runtime-html/template-compiler.binding-commands.class.spec.ts', func
   eachCartesianJoin(
     [classNameTests, testCases],
     (className, testCase, callIndex) => {
-      it(testCase.title(className, callIndex), async function () {
-        const { ctx, au, platform, host, component, tearDown } = createFixture(
+      it(`[UNIT] ${testCase.title(className, callIndex)}`, async function () {
+        const { ctx, au, platform, appHost, component } = createFixture(
           testCase.template(className),
           class App {
             public value: unknown = true;
           },
-          ClassAttributePattern,
-          StandardConfiguration,
-          CustomElement.define(
-            {
-              name: 'child',
-              template: `<template ${className}.class="value"></template>`
-            },
-            class Child {
-              public static bindables = {
-                value: { property: 'value', attribute: 'value', mode: BindingMode.twoWay }
-              };
-              public value = true;
-            }
-          )
+          [
+            ClassAttributePattern,
+            CustomElement.define(
+              {
+                name: 'child',
+                template: `<template ${className}.class="value"></template>`
+              },
+              class Child {
+                public static bindables = {
+                  value: { property: 'value', attribute: 'value', mode: BindingMode.twoWay }
+                };
+                public value = true;
+              }
+            )
+          ]
         );
-        au.app({ host, component });
-        await au.start();
-        try {
-          const els = typeof testCase.selector === 'string'
-            ? host.querySelectorAll(testCase.selector)
-            : testCase.selector(ctx.doc) as ArrayLike<HTMLElement>;
-          for (let i = 0, ii = els.length; ii > i; ++i) {
-            const el = els[i];
-            assert.contains(
-              el.classList,
-              className.toLowerCase(),
-              `[true]${el.className}.contains(${className}) 1`
-            );
-          }
-
-          await eachCartesianJoinAsync(
-            [falsyValues, truthyValues],
-            (falsyValue, truthyValue) => {
-              component.value = falsyValue;
-
-              platform.domWriteQueue.flush();
-
-              for (let i = 0, ii = els.length; ii > i; ++i) {
-                const el = els[i];
-                assert.notContains(
-                  el.classList,
-                  className.toLowerCase(),
-                  `[${String(falsyValue)}]${el.className}.contains(${className}) 2`
-                );
-              }
-
-              component.value = truthyValue;
-
-              platform.domWriteQueue.flush();
-
-              for (let i = 0, ii = els.length; ii > i; ++i) {
-                const el = els[i];
-                assert.contains(
-                  el.classList,
-                  className.toLowerCase(),
-                  `[${String(truthyValue)}]${el.className}.contains(${className}) 3`
-                );
-              }
-            }
+        const els = typeof testCase.selector === 'string'
+          ? appHost.querySelectorAll(testCase.selector)
+          : testCase.selector(ctx.doc) as ArrayLike<HTMLElement>;
+        for (let i = 0, ii = els.length; ii > i; ++i) {
+          const el = els[i];
+          assert.contains(
+            el.classList,
+            className.toLowerCase(),
+            `[true]${el.className}.contains(${className}) 1`
           );
-          await testCase.assert(au, platform, host, component, testCase, className);
-        } finally {
-          tearDown();
-          await au.stop();
-
-          au.dispose();
         }
+
+        eachCartesianJoin(
+          [falsyValues, truthyValues],
+          (falsyValue, truthyValue) => {
+            component.value = falsyValue;
+
+            platform.domWriteQueue.flush();
+
+            for (let i = 0, ii = els.length; ii > i; ++i) {
+              const el = els[i];
+              assert.notContains(
+                el.classList,
+                className.toLowerCase(),
+                `[${String(falsyValue)}]${el.className}.contains(${className}) 2`
+              );
+            }
+
+            component.value = truthyValue;
+
+            platform.domWriteQueue.flush();
+
+            for (let i = 0, ii = els.length; ii > i; ++i) {
+              const el = els[i];
+              assert.contains(
+                el.classList,
+                className.toLowerCase(),
+                `[${String(truthyValue)}]${el.className}.contains(${className}) 3`
+              );
+            }
+          }
+        );
+        testCase.assert(au, platform, appHost, component, testCase, className);
       });
     }
   );
@@ -212,22 +232,6 @@ describe('3-runtime-html/template-compiler.binding-commands.class.spec.ts', func
     selector: string | ((document: Document) => ArrayLike<Element>);
     title(...args: unknown[]): string;
     template(...args: string[]): string;
-    assert(au: Aurelia, platform: IPlatform, host: HTMLElement, component: IApp, testCase: ITestCase, className: string): void | Promise<void>;
-  }
-
-  function createFixture<T>(template: string | Node, $class: Constructable<T> | null, ...registrations: any[]) {
-    const ctx = TestContext.create();
-    const { container, platform, observerLocator } = ctx;
-    container.register(...registrations);
-    const host = ctx.doc.body.appendChild(ctx.createElement('app'));
-    const au = new Aurelia(container);
-    const App = CustomElement.define({ name: 'app', template }, $class);
-    const component = new App();
-
-    function tearDown() {
-      ctx.doc.body.removeChild(host);
-    }
-
-    return { container, platform, ctx, host, au, component, observerLocator, tearDown };
+    assert(au: Aurelia, platform: IPlatform, host: HTMLElement, component: IApp, testCase: ITestCase, className: string): void;
   }
 });

--- a/packages/__tests__/3-runtime-html/styles.integration.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.integration.spec.ts
@@ -61,7 +61,7 @@ describe('styles', function () {
     });
 
     it('works with colon in classes when there is NO matching css', async function () {
-      const { appHost, startPromise } = createFixture('<my-el>', undefined, [
+      const { assertClass } = createFixture('<my-el>', undefined, [
         CustomElement.define({
           name: 'my-el',
           template: '<div class="hover:bg-white">',
@@ -69,13 +69,11 @@ describe('styles', function () {
         })
       ]);
 
-      await startPromise;
-
-      assert.deepStrictEqual(appHost.querySelector('div').className, 'hover:bg-white');
+      assertClass('div', 'hover:bg-white');
     });
 
     it('works with colon in classes when there is matching css', async function () {
-      const { appHost, startPromise } = createFixture('<my-el>', undefined, [
+      const { assertClass } = createFixture('<my-el>', undefined, [
         CustomElement.define({
           name: 'my-el',
           template: '<div class="hover:bg-white">',
@@ -83,9 +81,32 @@ describe('styles', function () {
         })
       ]);
 
-      await startPromise;
+      assertClass('div', 'abc');
+    });
 
-      assert.deepStrictEqual(appHost.querySelector('div').className, 'abc');
+    it('works with class binding command - github #1684', function () {
+      const template = `<p class="strike" selected.class="isSelected">
+I am green if I am selected and red if I am not
+</p>
+<p selected.class="isSelected">
+I am green if I am selected and red if I am not
+</p>
+<pre>\${isSelected}</pre>
+<button type="button" click.trigger="toggle()">Toggle selected state</button>`;
+
+      const { assertClass } = createFixture(
+        '<component>',
+        void 0,
+        [CustomElement.define({
+          name: 'component',
+          template,
+          dependencies: [cssModules({ selected: 'a_' })]
+        }, class Component {
+          isSelected = true;
+        })]
+      );
+
+      assertClass('p:nth-child(1)', 'au', 'a_', 'strike');
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/3-runtime-html/styles.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@aurelia/runtime-html';
 import { assert, PLATFORM, TestContext } from '@aurelia/testing';
 
-describe('Styles', function () {
+describe('3-runtime-html/styles.spec.ts', function () {
   async function startApp(configure: (au: Aurelia) => void) {
     const ctx = TestContext.create();
     const au = new Aurelia(ctx.container);
@@ -48,7 +48,7 @@ describe('Styles', function () {
     });
 
     it('class attribute maps class names', function () {
-      const element = { className: '' };
+      const element = PLATFORM.document.createElement('div');
       const container = DI.createContainer();
       container.register(Registration.instance(INode, element));
       const cssModulesLookup = {
@@ -67,7 +67,7 @@ describe('Styles', function () {
     });
 
     it('style function uses correct registry', function () {
-      const element = { className: '' };
+      const element = PLATFORM.document.createElement('div');
       const container = DI.createContainer();
       const childContainer = container.createChild();
       const cssModulesLookup = {

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -37,6 +37,8 @@ export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
 };
 
+export const ICssModulesMapping = createInterface<Record<string, string>>('CssModules');
+
 /**
  * Represents a DocumentFragment
  */

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -960,22 +960,14 @@ export class AttributeBindingRenderer implements IRenderer {
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
   ): void {
-    // if there's a class custom attribute
-    // and this attribute binding is targeting class attribute
-    // then its targetted class should be re-mapped
-    // solution 1: ...
-    // if (renderingCtrl.container.find(CustomAttribute, 'class'))
-
-    // solution 2:
-    // add a css module interface registration token somewhere
-    // and let css module register that when they are registered
-    let classMapping: Record<string, string> | null = null;
-    if (renderingCtrl.container.has(ICssModulesMapping, false)) {
-      classMapping = renderingCtrl.container.get(ICssModulesMapping);
-    }
+    const container = renderingCtrl.container;
+    const classMapping =
+      container.has(ICssModulesMapping, false)
+        ? container.get(ICssModulesMapping)
+        : null;
     renderingCtrl.addBinding(new AttributeBinding(
       renderingCtrl,
-      renderingCtrl.container,
+      container,
       observerLocator,
       platform.domWriteQueue,
       ensureExpression(exprParser, instruction.from, ExpressionType.IsProperty),
@@ -983,7 +975,7 @@ export class AttributeBindingRenderer implements IRenderer {
       instruction.attr/* targetAttribute */,
       classMapping == null
         ? instruction.to/* targetKey */
-        : instruction.to.split(/\s/g).map(c => classMapping![c] ?? c).join(' '),
+        : instruction.to.split(/\s/g).map(c => classMapping[c] ?? c).join(' '),
       BindingMode.toView,
     ));
   }

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -19,6 +19,11 @@ export class CSSModulesProcessorRegistry implements IRegistry {
   ) {}
 
   public register(container: IContainer): void {
+    // it'd be nice to be able to register a template compiler hook instead
+    // so that it's lighter weight on the creation of a custom element with css module
+    // also it'll be more consitent in terms as CSS class output
+    // if custom attribute is used, the class controlled by custom attribute may come after
+    // other bindings, regardless what their declaration order is in the template
     const classLookup = objectAssign({}, ...this.modules) as Record<string, string>;
     const ClassCustomAttribute = defineAttribute({
       name: 'class',
@@ -31,9 +36,9 @@ export class CSSModulesProcessorRegistry implements IRegistry {
 
       public value!: string;
       public constructor(
-        private readonly _element: INode<HTMLElement>,
+        element: INode<HTMLElement>,
       ) {
-        this._accessor = new ClassAttributeAccessor(_element);
+        this._accessor = new ClassAttributeAccessor(element);
       }
 
       public binding() {
@@ -41,12 +46,7 @@ export class CSSModulesProcessorRegistry implements IRegistry {
       }
 
       public valueChanged() {
-        if (!this.value) {
-          this._element.className = '';
-          return;
-        }
-
-        this._accessor.setValue(this.value.split(/\s+/g).map(x => classLookup[x] || x));
+        this._accessor.setValue(this.value?.split(/\s+/g).map(x => classLookup[x] || x) ?? '');
       }
     });
 

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -151,6 +151,13 @@ export function createFixture<T extends object>(
       assert.strictEqual(getInnerHtml(host, compact), selectorOrHtml);
     }
   }
+  function assertClass(selector: string, ...classes: string[]) {
+    const el = queryBy(selector);
+    if (el === null) {
+      throw new Error(`No element found for selector "${selector}" to assert className contains "${classes}"`);
+    }
+    classes.forEach(c => assert.contains(el.classList, c));
+  }
   function assertAttr(selector: string, name: string, value: string | null) {
     const el = queryBy(selector);
     if (el === null) {
@@ -262,6 +269,7 @@ export function createFixture<T extends object>(
     public queryBy = queryBy;
     public assertText = assertText;
     public assertHtml = assertHtml;
+    public assertClass = assertClass;
     public assertAttr = assertAttr;
     public assertAttrNS = assertAttrNS;
     public assertValue = assertValue;
@@ -333,6 +341,10 @@ export interface IFixture<T> {
    * Will throw if there' more than one elements with matching selector
    */
   assertHtml(selector: string, html: string): void;
+  /**
+   * Assert an element based on the given selector has the given css classes
+   */
+  assertClass(selector: string, ...classes: string[]): void;
   /**
    * Assert the attribute value of an element matching the given selector inside the application host equals to a given string.
    *


### PR DESCRIPTION
# Pull Request

## 📖 Description

The bug described in the linked issue is caused by 2 issues:
- css module always override all the classes on an element without considering other sources of class names.
- class binding command doesn't take into account whether any mapping is available

The fix is to make:
- css module work by toggling class the same way with normal class binding
- class binding aware of existing mapping declared inside a custom element

cc @brandonseydel 

closes #1684