### PR TITLE
chore(ci): add approval step for dev publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,7 +552,7 @@ jobs:
       # - checkout_install
       # - run: npm run build
       # just restore some cache from previous steps
-      - run: chown -R $USER:$USER home/circleci
+      - run: chown -R $(whoami) home/circleci
       # - restore_cache:
       #     key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,7 +890,7 @@ workflows:
           name: safari16_select
           path: "packages/__e2e__/select-safari16"
           requires:
-            - build_release
+            - check_doc_abort
       - e2e_test:
           <<: *filter_ignore_develop_release
           name: e2e_hmr_webpack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -947,6 +947,11 @@ workflows:
           dist_file_name: merge_and_dist_topic
           requires:
             - build_release
+            
+      - request_publish_dev:
+          <<: *filter_only_master
+          type: approval
+          no_output_timeout: 20m
       - publish_npm:
           <<: *filter_only_master
           name: publish_npm_dev
@@ -954,7 +959,9 @@ workflows:
           branch: develop
           swap: true
           requires:
+            - request_publish_dev
             - merge_and_dist_master
+          
 
   # Runs build and tests, and pushes the built artifacts to the release branch (which then triggers publish_latest)
   # Triggered by push to tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: cache-{{ checksum "package-lock.json" }}-install
+          key: cache-{{ arch }}-{{ checksum "package-lock.json" }}-install
       - run: |
           # cache restored
           if [[ $(ls -l node_modules | grep -c ^d) -gt 10 ]]; then
@@ -544,20 +544,17 @@ jobs:
       path:
         type: string
     steps:
-      - checkout_install:
+      - checkout_install_cache:
           install_chrome: false
           install_firefox: false
           install: false
       # instead of doing the following 2 commands
       # - checkout_install
-      # - run: npm run build
       # just restore some cache from previous steps
-      - run: |
-          chown -R $(whoami) ../../
-      - restore_cache:
-          key: cache-{{ checksum "package-lock.json" }}-install
-      - restore_cache:
-          key: cache-{{ .Revision }}-build-false
+      # - run: chown -R $USER:$USER /home/circleci
+      - run: npm run build
+      # - restore_cache:
+      #     key: cache-{{ .Revision }}-build-false
       - run:
           name: "Run e2e script"
           working_directory: << parameters.path >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,7 +552,7 @@ jobs:
       # - checkout_install
       # - run: npm run build
       # just restore some cache from previous steps
-      # - run: chown -R $USER:$USER /home/circleci
+      - run: chown -R $USER:$USER home/circleci
       # - restore_cache:
       #     key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,7 @@ jobs:
             npm ci
           fi
       - save_cache:
-          key: cache-{{ checksum "package-lock.json" }}-install
+          key: cache-{{ arch }}-{{ checksum "package-lock.json" }}-install
           paths:
             - node_modules
             - packages/__tests__/node_modules
@@ -581,7 +581,7 @@ jobs:
           name: "Run e2e script"
           working_directory: << parameters.path >>
           command: |
-            npx playwright install chrome webkit
+            npx playwright install webkit
             npm run test
           no_output_timeout: "1m"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ jobs:
       # - run: npm run build
       # just restore some cache from previous steps
       - run: |
-          chown -R $(whoami) ~/home/circleci
+          chown -R $(whoami) ../../
       - restore_cache:
           key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,10 +544,32 @@ jobs:
       path:
         type: string
     steps:
-      - checkout_install_cache:
-          install_chrome: false
-          install_firefox: false
-          install: false
+      - checkout
+      - restore_cache:
+          key: cache-{{ arch }}-{{ checksum "package-lock.json" }}-install
+      - run: |
+          # cache restored
+          if [[ $(ls -l node_modules | grep -c ^d) -gt 10 ]]; then
+            exit 0
+          else
+            npm ci
+          fi
+      - save_cache:
+          key: cache-{{ checksum "package-lock.json" }}-install
+          paths:
+            - node_modules
+            - packages/__tests__/node_modules
+
+            - packages-tooling/__tests__/node_modules
+            - packages-tooling/aot/node_modules
+            - packages-tooling/au/node_modules
+            - packages-tooling/babel-jest/node_modules
+            - packages-tooling/http-server/node_modules
+            - packages-tooling/parcel-transformer/node_modules
+            - packages-tooling/plugin-conventions/node_modules
+            - packages-tooling/plugin-gulp/node_modules
+            - packages-tooling/ts-jest/node_modules
+            - packages-tooling/webpack-loader/node_modules
       # instead of doing the following 2 commands
       # - checkout_install
       # just restore some cache from previous steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,13 +550,13 @@ jobs:
           install: true
       # instead of doing the following 2 commands
       # - checkout_install
-      - run: npm run build
+      # - run: npm run build
       # just restore some cache from previous steps
       # - run: chown -R $USER:$USER /home/circleci
       # - restore_cache:
       #     key: cache-{{ checksum "package-lock.json" }}-install
-      # - restore_cache:
-      #     key: cache-{{ .Revision }}-build-false
+      - restore_cache:
+          key: cache-{{ .Revision }}-build-false
       - run:
           name: "Run e2e script"
           working_directory: << parameters.path >>
@@ -871,6 +871,7 @@ workflows:
           path: "packages/__e2e__/select-safari16"
           requires:
             - check_doc_abort
+            - build_release
       - e2e_test:
           <<: *filter_ignore_develop_release
           name: e2e_hmr_webpack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,14 +547,14 @@ jobs:
       - checkout_install:
           install_chrome: false
           install_firefox: false
-          install: true
+          install: false
       # instead of doing the following 2 commands
       # - checkout_install
       # - run: npm run build
       # just restore some cache from previous steps
       - run: chown -R $(whoami) home/circleci
-      # - restore_cache:
-      #     key: cache-{{ checksum "package-lock.json" }}-install
+      - restore_cache:
+          key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:
           key: cache-{{ .Revision }}-build-false
       - run:
@@ -870,7 +870,6 @@ workflows:
           name: safari16_select
           path: "packages/__e2e__/select-safari16"
           requires:
-            - check_doc_abort
             - build_release
       - e2e_test:
           <<: *filter_ignore_develop_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,7 +552,8 @@ jobs:
       # - checkout_install
       # - run: npm run build
       # just restore some cache from previous steps
-      - run: chown -R $(whoami) home/circleci
+      - run: |
+          chown -R $(whoami) ~/home/circleci
       - restore_cache:
           key: cache-{{ checksum "package-lock.json" }}-install
       - restore_cache:


### PR DESCRIPTION
We no longer need to publish dev tag to npm frequently, put an approval task in front of the publish dev job, so that we can choose when a new dev version go out.

cc @Sayan751 @fkleuver 