### PR TITLE
refactor(compose): rename props and add compat layer

### DIFF
--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -116,6 +116,26 @@ Change it to:
 - `.delegate` command has been removed, use `.trigger` instead. With shadow DOM, even though `.delegate` works, it doesn't feel as natural as `.trigger`, and the performance benefits `.delegate` command used to give when browsers were slow adding many event listeners is no longer as big.
 - `.call` command has been removed, use lambda functions instead to create function that preserves the `this` context. Refer to [lambda expression](../../templates/lambda-expressions.md)
 
+## Compose
+
+- `<compose>` has been renamed to `<au-compose>`. The bindable properties of this component have also been changed:
+  - viewModel -> component
+  - view -> template
+  - model remains the same
+
+- Examples migration fix:
+  ```html
+  v1:
+  <compose view.bind="...">
+  <compose view-model.bind="...">
+
+  v2:
+  <au-compose template.bind="...">
+  <au-compose component.bind="...">
+  ```
+
+  Read more about dynamic composition in v2 in this [dynamic composition doc](../../getting-to-know-aurelia/dynamic-composition.md) and [dynamic ui composition doc](../../app-basics/dynamic-ui-composition.md).
+
 ## General changes
 
 * Templates no longer need to have `<template>` tags as the start and ending tags. Templates can be pure HTML with enhanced Aurelia markup but `<template>` doesn't need to be explicitly defined.

--- a/packages/__tests__/3-runtime-html/au-compose.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-compose.spec.ts
@@ -14,7 +14,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
   describe('view', function () {
     it('works with literal string', async function () {
       const { appHost, startPromise, tearDown } = createFixture(
-        '<au-compose view="<div>hello world</div>">'
+        '<au-compose template="<div>hello world</div>">'
       );
 
       await startPromise;
@@ -30,7 +30,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     // Instead of the bindings getting notified by the changes in the view model
     it('works with dynamic view + interpolation', async function () {
       const { ctx, component, appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view="<div>\${message}</div>">`,
+        `<au-compose template="<div>\${message}</div>">`,
         class App {
           public message = 'hello world';
         }
@@ -42,7 +42,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       component.message = 'hello';
       const auComponentVm = CustomElement.for(appHost.querySelector('au-compose')).viewModel as AuCompose;
 
-      assert.strictEqual(auComponentVm.view, '<div>hello</div>');
+      assert.strictEqual(auComponentVm.template, '<div>hello</div>');
       assert.strictEqual(appHost.textContent, 'hello');
       ctx.platform.domWriteQueue.flush();
       assert.strictEqual(appHost.textContent, 'hello');
@@ -54,7 +54,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('works with view string from view model', async function () {
       const { ctx, component, appHost, startPromise, tearDown } = createFixture(
-        '<au-compose view.bind="view">',
+        '<au-compose template.bind="view">',
         class App {
           public message = 'hello world';
           public view = `<div>\${message}</div>`;
@@ -77,7 +77,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('understands non-inherit scope config', async function () {
       const { ctx, component, appHost, startPromise, tearDown } = createFixture(
-        '<au-compose view.bind="view" scope-behavior="scoped">',
+        '<au-compose template.bind="view" scope-behavior="scoped">',
         class App {
           public message = 'hello world';
           public view = `<div>\${message}</div>`;
@@ -106,7 +106,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('understands view promise', async function () {
       const { ctx, component, appHost, startPromise, tearDown } = createFixture(
-        '<au-compose view.bind="getView()" scope-behavior="scoped">',
+        '<au-compose template.bind="getView()" scope-behavior="scoped">',
         class App {
           public message = 'hello world';
           public view = `<div>\${message}</div>`;
@@ -139,7 +139,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('throws on invalid scope-behavior value', async function () {
       const { component, startPromise, tearDown } = createFixture(
-        '<au-compose view.bind="view" scope-behavior.bind="behavior">',
+        '<au-compose template.bind="view" scope-behavior.bind="behavior">',
         class App {
           public message = 'hello world';
           public view = `<div>\${message}</div>`;
@@ -155,10 +155,10 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     });
   });
 
-  describe('view-model', function () {
+  describe('.component', function () {
     it('works with literal object', async function () {
       const { appHost, tearDown } = createFixture(
-        `\${message}<au-compose view-model.bind="{ activate }">`,
+        `\${message}<au-compose component.bind="{ activate }">`,
         class App {
           public message = 'hello world';
           public view = `<div>\${message}</div>`;
@@ -179,7 +179,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     it('works with custom element', async function () {
       let activateCallCount = 0;
       const { appHost, tearDown } = createFixture(
-        '<au-compose view-model.bind="fieldVm">',
+        '<au-compose component.bind="fieldVm">',
         class App {
           public message = 'hello world';
           public fieldVm = CustomElement.define(
@@ -206,7 +206,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     it('works with promise of custom element', async function () {
       let activateCallCount = 0;
       const { appHost, tearDown } = await createFixture(
-        '<au-compose view-model.bind="getVm()">',
+        '<au-compose component.bind="getVm()">',
         class App {
           public getVm() {
             return Promise.resolve(CustomElement.define(
@@ -235,7 +235,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       const models: unknown[] = [];
       const model = { a: 1, b: Symbol() };
       createFixture(
-        `<au-compose view-model.bind="{ activate }" model.bind="model">`,
+        `<au-compose component.bind="{ activate }" model.bind="model">`,
         class App {
           public model = model;
           public activate = (model: unknown) => {
@@ -251,7 +251,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       let resolve: (v?: unknown) => unknown;
       let attachedCallCount = 0;
       const { startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="{ activate }" view.bind="view">`,
+        `<au-compose component.bind="{ activate }" template.bind="view">`,
         class App {
           public activate = () => {
             return new Promise<unknown>(r => {
@@ -294,7 +294,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
         }
       }
       const { ctx, component } = createFixture(
-        `<au-compose view-model.bind="vm" model.bind="model">`,
+        `<au-compose component.bind="vm" model.bind="model">`,
         class App {
           public model = model;
           public vm = PlainViewModelClass;
@@ -318,7 +318,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
   describe('integration with repeat', function () {
     it('works with repeat in view only composition', function () {
       const { appHost } = createFixture(
-        `<au-compose repeat.for="i of 5" view.bind="getView()">`,
+        `<au-compose repeat.for="i of 5" template.bind="getView()">`,
         class App {
           public getMessage(i: number) {
             return `Hello ${i}`;
@@ -339,7 +339,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     it('works with repeat in literal object composition', function () {
       const models: unknown[] = [];
       createFixture(
-        `<au-compose repeat.for="i of 5" view-model.bind="{ activate }" model.bind="{ index: i }">`,
+        `<au-compose repeat.for="i of 5" component.bind="{ activate }" model.bind="{ index: i }">`,
         class App {
           public activate = (model: unknown) => {
             models.push(model);
@@ -352,7 +352,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('deactivates when collection changes', async function () {
       const { component, appHost } = createFixture(
-        `<au-compose repeat.for="i of items" view.bind="getView()">`,
+        `<au-compose repeat.for="i of items" template.bind="getView()">`,
         class App {
           public items = 5;
           public getMessage(i: number) {
@@ -382,13 +382,13 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
   describe('multi au-compose', function () {
     it('composes au-compose', async function () {
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose repeat.for="i of 5" view.bind="getView()">`,
+        `<au-compose repeat.for="i of 5" template.bind="getView()">`,
         class App {
           public getMessage(i: number) {
             return `Hello ${i}`;
           }
           public getView() {
-            return `<au-compose view.bind="getInnerView()">`;
+            return `<au-compose template.bind="getInnerView()">`;
           }
           public getInnerView() {
             return `<div>div \${i}: \${getMessage(i)}</div>`;
@@ -426,7 +426,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
 
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = El;
         }
@@ -463,7 +463,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
 
       const { ctx, appHost, component, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = Child;
         }
@@ -499,7 +499,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
 
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" view="<div>Hello</div>" model.bind="{ index: 0 }">`,
+        `<au-compose component.bind="El" template="<div>Hello</div>" model.bind="{ index: 0 }">`,
         class App {
           public El = El;
         }
@@ -528,7 +528,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
 
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" view="<div>Hello</div>" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" template="<div>Hello</div>" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = El;
         }
@@ -553,7 +553,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     it('works with containerless on the host element', async function () {
       const models: unknown[] = [];
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="{ activate }" view="<div>Hello world</div>" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="{ activate }" template="<div>Hello world</div>" model.bind="{ index: 0 }" containerless>`,
         class App {
           public activate = (model: unknown) => {
             models.push(model);
@@ -573,7 +573,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
     it('composes non-custom element mutiple times', async function () {
       const models: unknown[] = [];
       const { appHost, component, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="{ activate }" view.bind="view" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="{ activate }" template.bind="view" model.bind="{ index: 0 }" containerless>`,
         class App {
           public activate = (model: unknown) => {
             models.push(model);
@@ -605,7 +605,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       class El { }
 
       const { appHost, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = El;
         }
@@ -633,7 +633,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       class Parent { }
 
       const { appHost, ctx, component, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = Child;
         }
@@ -661,7 +661,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       class El { }
 
       const { appHost, start } = createFixture(
-        `<au-compose view-model.bind="El" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = El;
         },
@@ -696,7 +696,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       class Parent { }
 
       const { appHost, ctx, component, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" view.bind="view" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" template.bind="view" model.bind="{ index: 0 }" containerless>`,
         class App {
           public message = 'app';
           public El: unknown = { message: 'POJO' };
@@ -730,7 +730,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
 
     it('discards stale composition', async function () {
       const { appHost, ctx, component, startPromise, tearDown } = createFixture(
-        `<au-compose view-model.bind="El" view.bind="\`<div>$\\{text}</div>\`" model.bind="{ index: 0 }" containerless>`,
+        `<au-compose component.bind="El" template.bind="\`<div>$\\{text}</div>\`" model.bind="{ index: 0 }" containerless>`,
         class App {
           public El = { text: 'Hello' };
         }
@@ -756,7 +756,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       const baseTimeout = 75;
       let timeout = baseTimeout;
       const { appHost, component, startPromise, tearDown } = createFixture(
-        `\${message}<au-compose view-model.bind="{ activate, value: i }" view.bind="view" view-model.ref="auCompose" containerless>`,
+        `\${message}<au-compose component.bind="{ activate, value: i }" template.bind="view" view-model.ref="auCompose" containerless>`,
         class App {
           public i = 0;
           public message = 'hello world';
@@ -830,7 +830,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
     });
     const { appHost, component, startPromise, tearDown } = createFixture(
-      `\${message}<au-compose view-model.bind="vm" model.bind="message" view-model.ref="auCompose" containerless>`,
+      `\${message}<au-compose component.bind="vm" model.bind="message" view-model.ref="auCompose" containerless>`,
       class App {
         public i = 0;
         public message = 'hello world';
@@ -918,7 +918,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       }
     });
     const { appHost, component, startPromise, tearDown } = createFixture(
-      `\${message}<au-compose view-model.bind="vm" model.bind="message" view-model.ref="auCompose" containerless>`,
+      `\${message}<au-compose component.bind="vm" model.bind="message" view-model.ref="auCompose" containerless>`,
       class App {
         public i = 0;
         public message = 'hello world';
@@ -995,7 +995,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       template: `<p><au-slot>`
     }, class Element1 {});
     const { appHost, startPromise, tearDown } = createFixture(
-      `<au-compose view-model.bind="vm"><input value.bind="message" au-slot>`,
+      `<au-compose component.bind="vm"><input value.bind="message" au-slot>`,
       class App {
         public message = 'Aurelia';
         public vm: any = El1;
@@ -1015,7 +1015,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
       template: `<p><au-slot>`
     }, class Element1 {});
     const { appHost, startPromise } = createFixture(
-      `<au-compose repeat.for="i of 3" view-model.bind="vm"><input value.to-view="message + i" au-slot>`,
+      `<au-compose repeat.for="i of 3" component.bind="vm"><input value.to-view="message + i" au-slot>`,
       class App {
         public message = 'Aurelia';
         public vm: any = El1;
@@ -1045,7 +1045,7 @@ describe('3-runtime-html/au-compose.spec.ts', function () {
         }
       });
       const { component, startPromise, tearDown } = createFixture(
-        `<au-compose repeat.for="vm of components" view-model.bind="vm">`,
+        `<au-compose repeat.for="vm of components" component.bind="vm">`,
         class App {
           public message = 'Aurelia';
           public components: any[] = [];

--- a/packages/__tests__/compat-v1/au-compose.spec.ts
+++ b/packages/__tests__/compat-v1/au-compose.spec.ts
@@ -1,0 +1,108 @@
+import { disableComposeCompat, enableComposeCompat } from '@aurelia/compat-v1';
+import { CustomElement } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+// only smoke tests here, enough to assert the most basic behaviors/expectation
+// main tests should be at the main au-compose spec
+describe('compat-v1/au-compose.spec.ts', function () {
+
+  describe('without enabling of compat', function () {
+    it('does not work', async function () {
+      const { assertText } = createFixture('<au-compose view="hello">');
+
+      assertText('');
+    });
+  });
+  describe('with enabling of compat', function () {
+    this.beforeAll(function () {
+      enableComposeCompat();
+    });
+    this.afterAll(function () {
+      disableComposeCompat();
+    });
+
+    describe('.view', function () {
+      it('works with literal string', async function () {
+        const { tearDown, assertText } = createFixture(
+          '<au-compose view="<div>hello world</div>">'
+        );
+        assertText('hello world');
+
+        await tearDown();
+
+        assertText('');
+      });
+
+      it('works with view string from view model', async function () {
+        const { ctx, component, tearDown, assertText } = createFixture(
+          '<au-compose view.bind="view">',
+          class App {
+            public message = 'hello world';
+            public view = `<div>\${message}</div>`;
+          }
+        );
+
+        assertText('hello world');
+
+        component.message = 'hello';
+
+        assertText('hello world');
+        ctx.platform.domWriteQueue.flush();
+        assertText('hello');
+
+        await tearDown();
+
+        assertText('');
+      });
+    });
+
+    describe('.view-model', function () {
+      it('works with literal object', async function () {
+        const { assertText, tearDown } = createFixture(
+          `\${message}<au-compose view-model.bind="{ activate }">`,
+          class App {
+            public message = 'hello world';
+            public view = `<div>\${message}</div>`;
+            public behavior = "auto";
+
+            public activate = () => {
+              this.message = 'Aurelia!!';
+            };
+          }
+        );
+
+        assertText('Aurelia!!');
+
+        await tearDown();
+        assertText('');
+      });
+
+      it('works with custom element', async function () {
+        let activateCallCount = 0;
+        const { queryBy, assertText, assertValue, tearDown } = createFixture(
+          '<au-compose view-model.bind="fieldVm">',
+          class App {
+            public message = 'hello world';
+            public fieldVm = CustomElement.define(
+              { name: 'input-field', template: '<input value.bind="value">' },
+              class InputField {
+                public value = 'hello';
+                public activate() {
+                  activateCallCount++;
+                }
+              }
+            );
+          }
+        );
+
+        assertText('');
+        assertValue('input', 'hello');
+        assert.strictEqual(activateCallCount, 1);
+
+        await tearDown();
+        assertText('');
+        assert.strictEqual(queryBy('input'), null);
+      });
+    });
+  });
+});

--- a/packages/compat-v1/src/compat-au-compose.ts
+++ b/packages/compat-v1/src/compat-au-compose.ts
@@ -1,0 +1,103 @@
+import { IIndexable } from '@aurelia/kernel';
+import { AuCompose, BindableDefinition, BindablesInfo, CustomElement } from '@aurelia/runtime-html';
+import { defineHiddenProp } from './utilities';
+
+let compatEnabled = false;
+let addedMetadata = false;
+const prototype = AuCompose.prototype;
+const ignore = Symbol();
+const originalAttaching = prototype.attaching;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+const originalPropertyChanged: (name: string) => unknown = (prototype as any).propertyChanged;
+/**
+ * Ensure `<au-compose/>` works with v1 syntaxes:
+ * - Prop: viewModel -> component:
+ * - template syntax: view-model.bind -> component.bind
+ *
+ * - Prop: view -> template
+ * - template syntax: view.bind -> template.bind
+ */
+export function enableComposeCompat() {
+  if (compatEnabled) {
+    return;
+  }
+  compatEnabled = true;
+  if (!addedMetadata) {
+    addedMetadata = true;
+    const def = CustomElement.getDefinition(AuCompose);
+    const viewModelBindable = def.bindables.viewModel = BindableDefinition.create('viewModel', AuCompose);
+    const viewBindable = def.bindables.view = BindableDefinition.create('view', AuCompose);
+
+    const bindableInfo = BindablesInfo.from(def as any, false);
+    // when <au-compose/> is used some where before the enable compat call is invoked
+    // BindableInfo of AuCompose definition has already been cached
+    // and thus will not be updated with view/viewmodel information
+    // so need to add it there too
+    if (!('view' in bindableInfo.attrs)) {
+      bindableInfo.attrs.view = bindableInfo.bindables.view = viewBindable;
+      bindableInfo.attrs['view-model'] = bindableInfo.bindables.viewModel = viewModelBindable;
+    }
+  }
+
+  defineHiddenProp(prototype, 'viewModelChanged', function (this: AuCompose, value: unknown) {
+    this.component = value as any;
+  });
+  defineHiddenProp(prototype, 'viewChanged', function (this: AuCompose, value: unknown) {
+    this.template = value as any;
+  });
+  defineHiddenProp(prototype, 'attaching', function (this: IIndexable<CompatAuCompose>, ...rest: Parameters<typeof originalAttaching>) {
+    this[ignore] = true;
+    if (this.viewModel !== void 0) {
+      this.component = this.viewModel;
+    }
+    if (this.view !== void 0) {
+      this.template = this.view;
+    }
+    this[ignore] = false;
+    return originalAttaching.apply(this, rest);
+  });
+
+  defineHiddenProp(prototype, 'propertyChanged', function (this: IIndexable<AuCompose>, name: string) {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (this[ignore]) {
+      return;
+    }
+    switch (name) {
+      // already handled via the change handler calls
+      case 'viewModel': case 'view': return;
+    }
+    return originalPropertyChanged.call(this, name);
+  });
+}
+
+export function disableComposeCompat() {
+  if (!compatEnabled) {
+    return;
+  }
+  if (addedMetadata) {
+    addedMetadata = false;
+    const def = CustomElement.getDefinition(AuCompose);
+    delete def.bindables.viewModel;
+    delete def.bindables.view;
+
+    const bindableInfo = BindablesInfo.from(def as any, false);
+    if (('view' in bindableInfo.attrs)) {
+      delete bindableInfo.attrs.view;
+      delete bindableInfo.bindables.view;
+      delete bindableInfo.attrs['view-model'];
+      delete bindableInfo.bindables.viewModel;
+    }
+  }
+  compatEnabled = false;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete (prototype as any).viewModelChanged;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  delete (prototype as any).viewChanged;
+  defineHiddenProp(prototype, 'attaching', originalAttaching);
+  defineHiddenProp(prototype, 'propertyChanged', originalPropertyChanged);
+}
+
+interface CompatAuCompose extends AuCompose {
+  viewModel?: AuCompose['component'];
+  view?: AuCompose['template'];
+}

--- a/packages/compat-v1/src/compat-form.ts
+++ b/packages/compat-v1/src/compat-form.ts
@@ -1,5 +1,10 @@
 import { AppTask, IEventTarget } from '@aurelia/runtime-html';
 
+/**
+ * A registration that will enable the default form submission behavior of form without a valid action.
+ *
+ * The default behavior of <form> without action attribute is normally not desirable for SPA applications.
+ */
 export const PreventFormActionlessSubmit = AppTask.creating(IEventTarget, appRoot => {
   appRoot.addEventListener('submit', (e: Event) => {
     const target = e.target as HTMLFormElement;

--- a/packages/compat-v1/src/index.ts
+++ b/packages/compat-v1/src/index.ts
@@ -4,6 +4,7 @@ import { defineBindingMethods } from './compat-binding';
 import { PreventFormActionlessSubmit } from './compat-form';
 import { delegateSyntax } from './compat-delegate';
 import { callSyntax } from './compat-call';
+import { enableComposeCompat } from './compat-au-compose';
 
 /**
  * Register all services/functionalities necessary for a v1 app to work with Aurelia v2.
@@ -14,6 +15,7 @@ export const compatRegistration: IRegistry = {
   register(container: IContainer) {
     defineAstMethods();
     defineBindingMethods();
+    enableComposeCompat();
     container.register(PreventFormActionlessSubmit);
     delegateSyntax.register(container);
     callSyntax.register(container);
@@ -46,3 +48,8 @@ export {
 export {
   BindingEngine,
 } from './compat-binding-engine';
+
+export {
+  enableComposeCompat,
+  disableComposeCompat,
+} from './compat-au-compose';

--- a/packages/compat-v1/src/utilities.ts
+++ b/packages/compat-v1/src/utilities.ts
@@ -31,6 +31,7 @@ export const defineHiddenProp = <T>(obj: object, key: PropertyKey, value: T): T 
   return value;
 };
 
+/** @internal */
 export const ensureExpression = <TFrom>(parser: IExpressionParser, srcOrExpr: TFrom, expressionType: ExpressionType): Exclude<TFrom, string> => {
   if (isString(srcOrExpr)) {
     return parser.parse(srcOrExpr, expressionType) as unknown as Exclude<TFrom, string>;


### PR DESCRIPTION
enhance doc, partially address #1695

# Pull Request

## 📖 Description

- Rename bindable properties on `<au-compose>`:
  - viewModel -> component
  - view -> template
- Add a function to re-enable the v1 naming for migration:
  All in one:
  ```ts
  import { compatRegistration } from '@aurelia/compat-v1';

  Aurelia.register(compatRegistration)
    ...
  ```
  or compose specific:
  ```ts
  import { enableComposeCompat } from '@aurelia/compat-v1';
  ...
  enableComposeCompat();
  ```
- Add breaking change doc for `<compose/>` and links to the new composition doc.

Thanks @ekzobrain 

cc @Sayan751 @fkleuver 
