### PR TITLE
feat(style): add warning messages when binding number to ambiguous properties

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,6 +366,9 @@ jobs:
                 when: always
             - store_test_results:
                 path: packages/__tests__/coverage
+            - store_artifacts:
+                path: packages/__tests__/coverage/test-results.xml
+                destination: test-results
 
   unit_test_esm_node:
     executor: docker_circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,10 +345,10 @@ jobs:
           command: |
             # the following 2 lines work, but the test break on this mode, not in local though
             # it's quite hard to debug on this mode so not using for now
-            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename)
-            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename) > packages/__tests__/tests.txt
-            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name)
-            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name) > packages/__tests__/tests.txt
+            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename)
+            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename) > packages/__tests__/tests.txt
+            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name)
+            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name) > packages/__tests__/tests.txt
       - run:
           name: "Run unit tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,10 +345,10 @@ jobs:
           command: |
             # the following 2 lines work, but the test break on this mode, not in local though
             # it's quite hard to debug on this mode so not using for now
-            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename)
-            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename) > packages/__tests__/tests.txt
-            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name)
-            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name) > packages/__tests__/tests.txt
+            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename)
+            echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=timings --timings-type=filename) > packages/__tests__/tests.txt
+            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name)
+            # echo $(circleci tests glob "packages/__tests__/dist/**/*.spec.js" | circleci tests split --split-by=name) > packages/__tests__/tests.txt
       - run:
           name: "Run unit tests"
           command: |

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -40,8 +40,8 @@ module.exports = {
     'no-await-in-loop': 'off',
     'require-atomic-updates': 'off',
 
-    // Things we maybe need to fix some day, so are marked as off for now as they're quite noisy:
-    "mocha/max-top-level-suites": ['error', {limit: 2}],
+    // can only allow 1, to produce proper junit test format for later consumption
+    "mocha/max-top-level-suites": ['error', {limit: 1}],
     'mocha/no-setup-in-describe': 'off',
     'mocha/no-synchronous-tests': 'off',
 

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -41,7 +41,7 @@ module.exports = {
     'require-atomic-updates': 'off',
 
     // Things we maybe need to fix some day, so are marked as off for now as they're quite noisy:
-    'mocha/max-top-level-suites': 'off',
+    "mocha/max-top-level-suites": ['error', {limit: 2}],
     'mocha/no-setup-in-describe': 'off',
     'mocha/no-synchronous-tests': 'off',
 

--- a/packages/__tests__/1-kernel/di.integration.spec.ts
+++ b/packages/__tests__/1-kernel/di.integration.spec.ts
@@ -25,975 +25,976 @@ describe('1-kernel/di.integration.spec.ts', function () {
       assert.notStrictEqual(foo1, foo2);
     });
   });
-});
 
-describe('DI.getDependencies', function () {
-  it('string param', function () {
-    @singleton
-    class Foo {
-      public constructor(public readonly test: string) {}
-    }
-    const actual = DI.getDependencies(Foo);
-    assert.deepStrictEqual(actual, [String]);
-  });
-
-  it('class param', function () {
-    class Bar {}
-    @singleton
-    class Foo {
-      public constructor(public readonly test: Bar) {}
-    }
-    const actual = DI.getDependencies(Foo);
-    assert.deepStrictEqual(actual, [Bar]);
-  });
-});
-
-describe('DI.createInterface() -> container.get()', function () {
-  let container: IContainer;
-
-  interface ITransient {}
-  class Transient implements ITransient {}
-  let ITransient: InterfaceSymbol<ITransient>;
-
-  interface ISingleton {}
-  class Singleton implements ISingleton {}
-  let ISingleton: InterfaceSymbol<ISingleton>;
-
-  interface IInstance {}
-  class Instance implements IInstance {}
-  let IInstance: InterfaceSymbol<IInstance>;
-  let instance: Instance;
-
-  interface ICallback {}
-  class Callback implements ICallback {}
-  let ICallback: InterfaceSymbol<ICallback>;
-
-  interface ICachedCallback {}
-  class CachedCallback implements ICachedCallback {}
-  let ICachedCallback: InterfaceSymbol<ICachedCallback>;
-  const cachedCallback = 'cachedCallBack';
-  let callbackCount = 0;
-  function callbackToCache() {
-    ++callbackCount;
-    return new CachedCallback();
-  }
-
-  let callback: ISpy<() => ICallback>;
-  let get: ISpy<IContainer['get']>;
-
-  // eslint-disable-next-line mocha/no-hooks
-  beforeEach(function () {
-    callbackCount = 0;
-    container = DI.createContainer();
-    ITransient = DI.createInterface<ITransient>('ITransient', x => x.transient(Transient));
-    ISingleton = DI.createInterface<ISingleton>('ISingleton', x => x.singleton(Singleton));
-    instance = new Instance();
-    IInstance = DI.createInterface<IInstance>('IInstance', x => x.instance(instance));
-    callback = createSpy(() => new Callback());
-    ICallback = DI.createInterface<ICallback>('ICallback', x => x.callback(callback));
-    ICachedCallback = DI.createInterface<ICachedCallback>('ICachedCallback', x => x.cachedCallback(callbackToCache));
-    get = createSpy(container, 'get', true);
-  });
-
-  // eslint-disable-next-line mocha/no-hooks
-  afterEach(function () {
-    get.restore();
-  });
-
-  describe('leaf', function () {
-    it(`transient registration returns a new instance each time`, function () {
-      const actual1 = container.get(ITransient);
-      assert.instanceOf(actual1, Transient, `actual1`);
-
-      const actual2 = container.get(ITransient);
-      assert.instanceOf(actual2, Transient, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ITransient],
-          [ITransient],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`singleton registration returns the same instance each time`, function () {
-      const actual1 = container.get(ISingleton);
-      assert.instanceOf(actual1, Singleton, `actual1`);
-
-      const actual2 = container.get(ISingleton);
-      assert.instanceOf(actual2, Singleton, `actual2`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ISingleton],
-          [ISingleton],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`instance registration returns the same instance each time`, function () {
-      const actual1 = container.get(IInstance);
-      assert.instanceOf(actual1, Instance, `actual1`);
-
-      const actual2 = container.get(IInstance);
-      assert.instanceOf(actual2, Instance, `actual2`);
-
-      assert.strictEqual(actual1, instance, `actual1`);
-      assert.strictEqual(actual2, instance, `actual2`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IInstance],
-          [IInstance],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`callback registration is invoked each time`, function () {
-      const actual1 = container.get(ICallback);
-      assert.instanceOf(actual1, Callback, `actual1`);
-
-      const actual2 = container.get(ICallback);
-      assert.instanceOf(actual2, Callback, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ICallback],
-          [ICallback],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`cachedCallback registration is invoked once`, function () {
-
-      container.register(Registration.cachedCallback(cachedCallback, callbackToCache));
-      const child = container.createChild();
-      child.register(Registration.cachedCallback(cachedCallback, callbackToCache));
-      const actual1 = container.get(cachedCallback);
-      const actual2 = container.get(cachedCallback);
-
-      assert.strictEqual(callbackCount, 1, `only called once`);
-      assert.strictEqual(actual2, actual1, `getting from the same container`);
-
-      const actual3 = child.get(cachedCallback);
-      assert.notStrictEqual(actual3, actual1, `get from child that has new resolver`);
-    });
-
-    it(`cacheCallback multiple root containers`, function () {
-      const container0 = DI.createContainer();
-      const container1 = DI.createContainer();
-      container0.register(Registration.cachedCallback(cachedCallback, callbackToCache));
-      container1.register(Registration.cachedCallback(cachedCallback, callbackToCache));
-
-      const actual11 = container0.get(cachedCallback);
-      const actual12 = container0.get(cachedCallback);
-
-      assert.strictEqual(callbackCount, 1, 'one callback');
-      assert.strictEqual(actual11, actual12);
-
-      const actual21 = container1.get(cachedCallback);
-      const actual22 = container1.get(cachedCallback);
-
-      assert.strictEqual(callbackCount, 2);
-      assert.strictEqual(actual21, actual22);
-    });
-
-    it(`cacheCallback different containers should not create the same singleton GH #1064`, function () {
-      const reg = Registration.cachedCallback(cachedCallback, callbackToCache);
-      const container0 = DI.createContainer();
-      const container1 = DI.createContainer();
-      container0.register(reg);
-      container1.register(reg);
-
-      const actual11 = container0.get(cachedCallback);
-      const actual12 = container0.get(cachedCallback);
-
-      assert.strictEqual(actual11, actual12, "11 equals 12");
-      assert.strictEqual(callbackCount, 1, "callback count 1");
-
-      const actual21 = container1.get(cachedCallback);
-      const actual22 = container1.get(cachedCallback);
-
-      assert.strictEqual(actual21, actual22, "21 equals 22");
-      assert.strictEqual(callbackCount, 2, "callback count 2");
-
-      assert.notStrictEqual(actual11, actual21, "11 does not equal 21");
-    });
-
-    it(`cachedCallback registration on interface is invoked once`, function () {
-      const actual1 = container.get(ICachedCallback);
-      const actual2 = container.get(ICachedCallback);
-
-      assert.strictEqual(callbackCount, 1, `only called once`);
-      assert.strictEqual(actual2, actual1, `getting from the same container`);
-    });
-
-    it(`cacheCallback interface multiple root containers`, function () {
-      const container0 = DI.createContainer();
-      const container1 = DI.createContainer();
-      const actual11 = container0.get(ICachedCallback);
-      const actual12 = container0.get(ICachedCallback);
-
-      assert.strictEqual(callbackCount, 1);
-      assert.strictEqual(actual11, actual12);
-
-      const actual21 = container1.get(ICachedCallback);
-      const actual22 = container1.get(ICachedCallback);
-
-      assert.strictEqual(callbackCount, 2);
-      assert.strictEqual(actual21, actual22);
-    });
-
-    it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function () {
-      interface IAlias {}
-      const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ITransient));
-
-      const actual1 = container.get(IAlias);
-      assert.instanceOf(actual1, Transient, `actual1`);
-
-      const actual2 = container.get(IAlias);
-      assert.instanceOf(actual2, Transient, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IAlias],
-          [ITransient],
-          [IAlias],
-          [ITransient],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function () {
-      interface IAlias {}
-      const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ISingleton));
-
-      const actual1 = container.get(IAlias);
-      assert.instanceOf(actual1, Singleton, `actual1`);
-
-      const actual2 = container.get(IAlias);
-      assert.instanceOf(actual2, Singleton, `actual2`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IAlias],
-          [ISingleton],
-          [IAlias],
-          [ISingleton],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function () {
-      interface IAlias {}
-      const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(IInstance));
-
-      const actual1 = container.get(IAlias);
-      assert.instanceOf(actual1, Instance, `actual1`);
-
-      const actual2 = container.get(IAlias);
-      assert.instanceOf(actual2, Instance, `actual2`);
-
-      assert.strictEqual(actual1, instance, `actual1`);
-      assert.strictEqual(actual2, instance, `actual2`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IAlias],
-          [IInstance],
-          [IAlias],
-          [IInstance],
-        ],
-        `get.calls`,
-      );
-    });
-
-    // TODO: make test work
-    it(`InterfaceSymbol alias to callback registration is invoked each time`, function () {
-      interface IAlias {}
-      const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ICallback));
-
-      const actual1 = container.get(IAlias);
-      assert.instanceOf(actual1, Callback, `actual1`);
-
-      const actual2 = container.get(IAlias);
-      assert.instanceOf(actual2, Callback, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IAlias],
-          [ICallback],
-          [IAlias],
-          [ICallback],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`string alias to transient registration returns a new instance each time`, function () {
-      container.register(Registration.aliasTo(ITransient, 'alias'));
-
-      const actual1 = container.get('alias');
-      assert.instanceOf(actual1, Transient, `actual1`);
-
-      const actual2 = container.get('alias');
-      assert.instanceOf(actual2, Transient, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          ['alias'],
-          [ITransient],
-          ['alias'],
-          [ITransient],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`string alias to singleton registration returns the same instance each time`, function () {
-      container.register(Registration.aliasTo(ISingleton, 'alias'));
-
-      const actual1 = container.get('alias');
-      assert.instanceOf(actual1, Singleton, `actual1`);
-
-      const actual2 = container.get('alias');
-      assert.instanceOf(actual2, Singleton, `actual2`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          ['alias'],
-          [ISingleton],
-          ['alias'],
-          [ISingleton],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`string alias to instance registration returns the same instance each time`, function () {
-      container.register(Registration.aliasTo(IInstance, 'alias'));
-
-      const actual1 = container.get('alias');
-      assert.instanceOf(actual1, Instance, `actual1`);
-
-      const actual2 = container.get('alias');
-      assert.instanceOf(actual2, Instance, `actual2`);
-
-      assert.strictEqual(actual1, instance, `actual1`);
-      assert.strictEqual(actual2, instance, `actual2`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          ['alias'],
-          [IInstance],
-          ['alias'],
-          [IInstance],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`string alias to callback registration is invoked each time`, function () {
-      container.register(Registration.aliasTo(ICallback, 'alias'));
-
-      const actual1 = container.get('alias');
-      assert.instanceOf(actual1, Callback, `actual1`);
-
-      const actual2 = container.get('alias');
-      assert.instanceOf(actual2, Callback, `actual2`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          ['alias'],
-          [ICallback],
-          ['alias'],
-          [ICallback],
-        ],
-        `get.calls`,
-      );
-    });
-  });
-
-  // describe('parent without inject decorator', function () {
-  //   function decorator(): ClassDecorator { return (target: any) => target; }
-  //   interface IParent { dep: any; }
-  //   let IParent: InterfaceSymbol<IParent>;
-
-  //   function register(cls: any) {
-  //     IParent = DI.createInterface<IParent>('IParent', x => x.transient(cls));
-  //   }
-
-  //   it(`transient child registration throws`, function () {
-  //     @decorator()
-  //     class Parent implements IParent { constructor(public dep: ITransient) {} }
-  //     register(Parent);
-
-  //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
-  //   });
-
-  //   it(`singleton child registration throws`, function () {
-  //     @decorator()
-  //     class Parent implements IParent { constructor(public dep: ISingleton) {} }
-  //     register(Parent);
-
-  //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
-  //   });
-
-  //   it(`instance child registration throws`, function () {
-  //     @decorator()
-  //     class Parent implements IParent { constructor(public dep: IInstance) {} }
-  //     register(Parent);
-
-  //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
-  //   });
-
-  //   it(`callback child registration throws`, function () {
-  //     @decorator()
-  //     class Parent implements IParent { constructor(public dep: ICallback) {} }
-  //     register(Parent);
-
-  //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
-  //   });
-  // });
-
-  describe('transient parent', function () {
-    interface ITransientParent { dep: any }
-    let ITransientParent: InterfaceSymbol<ITransientParent>;
-
-    function register(cls: any) {
-      ITransientParent = DI.createInterface<ITransientParent>('ITransientParent', x => x.transient(cls));
-    }
-
-    it(`transient child registration returns a new instance each time`, function () {
-      @inject(ITransient)
-      class TransientParent implements ITransientParent { public constructor(public dep: ITransient) {} }
-      register(TransientParent);
-
-      const actual1 = container.get(ITransientParent);
-      assert.instanceOf(actual1, TransientParent, `actual1`);
-      assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
-
-      const actual2 = container.get(ITransientParent);
-      assert.instanceOf(actual2, TransientParent, `actual2`);
-      assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.notStrictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ITransientParent],
-          [ITransient],
-          [ITransientParent],
-          [ITransient],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`singleton child registration returns the same instance each time`, function () {
-      @inject(ISingleton)
-      class TransientParent implements ITransientParent { public constructor(public dep: ISingleton) {} }
-      register(TransientParent);
-
-      const actual1 = container.get(ITransientParent);
-      assert.instanceOf(actual1, TransientParent, `actual1`);
-      assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
-
-      const actual2 = container.get(ITransientParent);
-      assert.instanceOf(actual2, TransientParent, `actual2`);
-      assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ITransientParent],
-          [ISingleton],
-          [ITransientParent],
-          [ISingleton],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`instance child registration returns the same instance each time`, function () {
-      @inject(IInstance)
-      class TransientParent implements ITransientParent { public constructor(public dep: IInstance) {} }
-      register(TransientParent);
-
-      const actual1 = container.get(ITransientParent);
-      assert.instanceOf(actual1, TransientParent, `actual1`);
-      assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
-
-      const actual2 = container.get(ITransientParent);
-      assert.instanceOf(actual2, TransientParent, `actual2`);
-      assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ITransientParent],
-          [IInstance],
-          [ITransientParent],
-          [IInstance],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`callback child registration is invoked each time`, function () {
-      @inject(ICallback)
-      class TransientParent implements ITransientParent { public constructor(public dep: ICallback) {} }
-      register(TransientParent);
-
-      const actual1 = container.get(ITransientParent);
-      assert.instanceOf(actual1, TransientParent, `actual1`);
-      assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
-
-      const actual2 = container.get(ITransientParent);
-      assert.instanceOf(actual2, TransientParent, `actual2`);
-      assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
-
-      assert.notStrictEqual(actual1, actual2, `actual1`);
-      assert.notStrictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ITransientParent],
-          [ICallback],
-          [ITransientParent],
-          [ICallback],
-        ],
-        `get.calls`,
-      );
-    });
-  });
-
-  describe('singleton parent', function () {
-    interface ISingletonParent { dep: any }
-    let ISingletonParent: InterfaceSymbol<ISingletonParent>;
-
-    function register(cls: any) {
-      ISingletonParent = DI.createInterface<ISingletonParent>('ISingletonParent', x => x.singleton(cls));
-    }
-
-    it(`transient child registration is reused by the singleton parent`, function () {
-      @inject(ITransient)
-      class SingletonParent implements ISingletonParent { public constructor(public dep: ITransient) {} }
-      register(SingletonParent);
-
-      const actual1 = container.get(ISingletonParent);
-      assert.instanceOf(actual1, SingletonParent, `actual1`);
-      assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
-
-      const actual2 = container.get(ISingletonParent);
-      assert.instanceOf(actual2, SingletonParent, `actual2`);
-      assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ISingletonParent],
-          [ITransient],
-          [ISingletonParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`singleton registration is reused by the singleton parent`, function () {
-      @inject(ISingleton)
-      class SingletonParent implements ISingletonParent { public constructor(public dep: ISingleton) {} }
-      register(SingletonParent);
-
-      const actual1 = container.get(ISingletonParent);
-      assert.instanceOf(actual1, SingletonParent, `actual1`);
-      assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
-
-      const actual2 = container.get(ISingletonParent);
-      assert.instanceOf(actual2, SingletonParent, `actual2`);
-      assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ISingletonParent],
-          [ISingleton],
-          [ISingletonParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`instance registration is reused by the singleton parent`, function () {
-      @inject(IInstance)
-      class SingletonParent implements ISingletonParent { public constructor(public dep: IInstance) {} }
-      register(SingletonParent);
-
-      const actual1 = container.get(ISingletonParent);
-      assert.instanceOf(actual1, SingletonParent, `actual1`);
-      assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
-
-      const actual2 = container.get(ISingletonParent);
-      assert.instanceOf(actual2, SingletonParent, `actual2`);
-      assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ISingletonParent],
-          [IInstance],
-          [ISingletonParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`callback registration is reused by the singleton parent`, function () {
-      @inject(ICallback)
-      class SingletonParent implements ISingletonParent { public constructor(public dep: ICallback) {} }
-      register(SingletonParent);
-
-      const actual1 = container.get(ISingletonParent);
-      assert.instanceOf(actual1, SingletonParent, `actual1`);
-      assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
-
-      const actual2 = container.get(ISingletonParent);
-      assert.instanceOf(actual2, SingletonParent, `actual2`);
-      assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [ISingletonParent],
-          [ICallback],
-          [ISingletonParent],
-        ],
-        `get.calls`,
-      );
-    });
-  });
-
-  describe('instance parent', function () {
-    interface IInstanceParent { dep: any }
-    let IInstanceParent: InterfaceSymbol<IInstanceParent>;
-    let instanceParent: IInstanceParent;
-
-    function register(cls: any) {
-      instanceParent = container.get(cls);
-      get.reset();
-      IInstanceParent = DI.createInterface<IInstanceParent>('IInstanceParent', x => x.instance(instanceParent));
-    }
-
-    it(`transient registration is reused by the instance parent`, function () {
-      @inject(ITransient)
-      class InstanceParent implements IInstanceParent { public constructor(public dep: ITransient) {} }
-      register(InstanceParent);
-
-      const actual1 = container.get(IInstanceParent);
-      assert.instanceOf(actual1, InstanceParent, `actual1`);
-      assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
-
-      const actual2 = container.get(IInstanceParent);
-      assert.instanceOf(actual2, InstanceParent, `actual2`);
-      assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IInstanceParent],
-          [IInstanceParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`singleton registration is reused by the instance parent`, function () {
-      @inject(ISingleton)
-      class InstanceParent implements IInstanceParent { public constructor(public dep: ISingleton) {} }
-      register(InstanceParent);
-
-      const actual1 = container.get(IInstanceParent);
-      assert.instanceOf(actual1, InstanceParent, `actual1`);
-      assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
-
-      const actual2 = container.get(IInstanceParent);
-      assert.instanceOf(actual2, InstanceParent, `actual2`);
-      assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IInstanceParent],
-          [IInstanceParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`instance registration is reused by the instance parent`, function () {
-      @inject(IInstance)
-      class InstanceParent implements IInstanceParent { public constructor(public dep: IInstance) {} }
-      register(InstanceParent);
-
-      const actual1 = container.get(IInstanceParent);
-      assert.instanceOf(actual1, InstanceParent, `actual1`);
-      assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
-
-      const actual2 = container.get(IInstanceParent);
-      assert.instanceOf(actual2, InstanceParent, `actual2`);
-      assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IInstanceParent],
-          [IInstanceParent],
-        ],
-        `get.calls`,
-      );
-    });
-
-    it(`callback registration is reused by the instance parent`, function () {
-      @inject(ICallback)
-      class InstanceParent implements IInstanceParent { public constructor(public dep: ICallback) {} }
-      register(InstanceParent);
-
-      const actual1 = container.get(IInstanceParent);
-      assert.instanceOf(actual1, InstanceParent, `actual1`);
-      assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
-
-      const actual2 = container.get(IInstanceParent);
-      assert.instanceOf(actual2, InstanceParent, `actual2`);
-      assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
-
-      assert.strictEqual(actual1, actual2, `actual1`);
-      assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
-
-      assert.deepStrictEqual(
-        callback.calls,
-        [
-          [container, container, container.getResolver(ICallback)],
-        ],
-        `callback.calls`,
-      );
-
-      assert.deepStrictEqual(
-        get.calls,
-        [
-          [IInstanceParent],
-          [IInstanceParent],
-        ],
-        `get.calls`,
-      );
-    });
-  });
-});
-
-describe('defer registration', function () {
-  class FakeCSSService {
-    public constructor(public data: any) {}
-  }
-
-  class FakeCSSHandler {
-    public register(container: IContainer, data) {
-      container.register(
-        Registration.instance(
-          FakeCSSService,
-          new FakeCSSService(data)
-        )
-      );
-    }
-  }
-
-  it(`enables the handler class to provide registrations for data`, function () {
-    const container = DI.createContainer();
-    const data = {};
-
-    container.register(
-      Registration.singleton('.css', FakeCSSHandler)
-    );
-
-    container.register(
-      Registration.defer('.css', data)
-    );
-
-    const service = container.get(FakeCSSService);
-
-    assert.strictEqual(service.data, data);
-  });
-
-  it(`passes the params to the container's register method if no handler is found`, function () {
-    const container = DI.createContainer();
-    const data = {
-      wasCalled: false,
-      register() {
-        this.wasCalled = true;
+  describe('DI.getDependencies', function () {
+    it('string param', function () {
+      @singleton
+      class Foo {
+        public constructor(public readonly test: string) { }
       }
-    };
+      const actual = DI.getDependencies(Foo);
+      assert.deepStrictEqual(actual, [String]);
+    });
 
-    container.register(
-      Registration.defer('.css', data)
-    );
-
-    assert.strictEqual(data.wasCalled, true);
-  });
-
-  [
-    {
-      name: 'string',
-      value: 'some string value'
-    },
-    {
-      name: 'boolean',
-      value: true
-    },
-    {
-      name: 'number',
-      value: 42
-    }
-  ].forEach(x => {
-    it(`does not pass ${x.name} params to the container's register when no handler is found`, function () {
-      const container = DI.createContainer();
-      container.register(
-        Registration.defer('.css', x.value)
-      );
+    it('class param', function () {
+      class Bar { }
+      @singleton
+      class Foo {
+        public constructor(public readonly test: Bar) { }
+      }
+      const actual = DI.getDependencies(Foo);
+      assert.deepStrictEqual(actual, [Bar]);
     });
   });
 
-  // TODO: fix test setup for emitDecoratorMetadata
-  // it('can inject dependencies based on TS metadata', function () {
-  //   const deco: ClassDecorator = function (target) { return target; };
+  describe('DI.createInterface() -> container.get()', function () {
+    let container: IContainer;
 
-  //   class Foo {}
+    interface ITransient { }
+    class Transient implements ITransient { }
+    let ITransient: InterfaceSymbol<ITransient>;
 
-  //   @deco
-  //   class Bar {
-  //     public constructor(
-  //       public readonly foo: Foo
-  //     ) {}
-  //   }
+    interface ISingleton { }
+    class Singleton implements ISingleton { }
+    let ISingleton: InterfaceSymbol<ISingleton>;
 
-  //   const bar = DI.createContainer().get(Bar);
+    interface IInstance { }
+    class Instance implements IInstance { }
+    let IInstance: InterfaceSymbol<IInstance>;
+    let instance: Instance;
 
-  //   assert.instanceOf(bar.foo, Foo);
-  // });
+    interface ICallback { }
+    class Callback implements ICallback { }
+    let ICallback: InterfaceSymbol<ICallback>;
+
+    interface ICachedCallback { }
+    class CachedCallback implements ICachedCallback { }
+    let ICachedCallback: InterfaceSymbol<ICachedCallback>;
+    const cachedCallback = 'cachedCallBack';
+    let callbackCount = 0;
+    function callbackToCache() {
+      ++callbackCount;
+      return new CachedCallback();
+    }
+
+    let callback: ISpy<() => ICallback>;
+    let get: ISpy<IContainer['get']>;
+
+    // eslint-disable-next-line mocha/no-hooks
+    beforeEach(function () {
+      callbackCount = 0;
+      container = DI.createContainer();
+      ITransient = DI.createInterface<ITransient>('ITransient', x => x.transient(Transient));
+      ISingleton = DI.createInterface<ISingleton>('ISingleton', x => x.singleton(Singleton));
+      instance = new Instance();
+      IInstance = DI.createInterface<IInstance>('IInstance', x => x.instance(instance));
+      callback = createSpy(() => new Callback());
+      ICallback = DI.createInterface<ICallback>('ICallback', x => x.callback(callback));
+      ICachedCallback = DI.createInterface<ICachedCallback>('ICachedCallback', x => x.cachedCallback(callbackToCache));
+      get = createSpy(container, 'get', true);
+    });
+
+    // eslint-disable-next-line mocha/no-hooks
+    afterEach(function () {
+      get.restore();
+    });
+
+    describe('leaf', function () {
+      it(`transient registration returns a new instance each time`, function () {
+        const actual1 = container.get(ITransient);
+        assert.instanceOf(actual1, Transient, `actual1`);
+
+        const actual2 = container.get(ITransient);
+        assert.instanceOf(actual2, Transient, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ITransient],
+            [ITransient],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`singleton registration returns the same instance each time`, function () {
+        const actual1 = container.get(ISingleton);
+        assert.instanceOf(actual1, Singleton, `actual1`);
+
+        const actual2 = container.get(ISingleton);
+        assert.instanceOf(actual2, Singleton, `actual2`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ISingleton],
+            [ISingleton],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`instance registration returns the same instance each time`, function () {
+        const actual1 = container.get(IInstance);
+        assert.instanceOf(actual1, Instance, `actual1`);
+
+        const actual2 = container.get(IInstance);
+        assert.instanceOf(actual2, Instance, `actual2`);
+
+        assert.strictEqual(actual1, instance, `actual1`);
+        assert.strictEqual(actual2, instance, `actual2`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IInstance],
+            [IInstance],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`callback registration is invoked each time`, function () {
+        const actual1 = container.get(ICallback);
+        assert.instanceOf(actual1, Callback, `actual1`);
+
+        const actual2 = container.get(ICallback);
+        assert.instanceOf(actual2, Callback, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ICallback],
+            [ICallback],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`cachedCallback registration is invoked once`, function () {
+
+        container.register(Registration.cachedCallback(cachedCallback, callbackToCache));
+        const child = container.createChild();
+        child.register(Registration.cachedCallback(cachedCallback, callbackToCache));
+        const actual1 = container.get(cachedCallback);
+        const actual2 = container.get(cachedCallback);
+
+        assert.strictEqual(callbackCount, 1, `only called once`);
+        assert.strictEqual(actual2, actual1, `getting from the same container`);
+
+        const actual3 = child.get(cachedCallback);
+        assert.notStrictEqual(actual3, actual1, `get from child that has new resolver`);
+      });
+
+      it(`cacheCallback multiple root containers`, function () {
+        const container0 = DI.createContainer();
+        const container1 = DI.createContainer();
+        container0.register(Registration.cachedCallback(cachedCallback, callbackToCache));
+        container1.register(Registration.cachedCallback(cachedCallback, callbackToCache));
+
+        const actual11 = container0.get(cachedCallback);
+        const actual12 = container0.get(cachedCallback);
+
+        assert.strictEqual(callbackCount, 1, 'one callback');
+        assert.strictEqual(actual11, actual12);
+
+        const actual21 = container1.get(cachedCallback);
+        const actual22 = container1.get(cachedCallback);
+
+        assert.strictEqual(callbackCount, 2);
+        assert.strictEqual(actual21, actual22);
+      });
+
+      it(`cacheCallback different containers should not create the same singleton GH #1064`, function () {
+        const reg = Registration.cachedCallback(cachedCallback, callbackToCache);
+        const container0 = DI.createContainer();
+        const container1 = DI.createContainer();
+        container0.register(reg);
+        container1.register(reg);
+
+        const actual11 = container0.get(cachedCallback);
+        const actual12 = container0.get(cachedCallback);
+
+        assert.strictEqual(actual11, actual12, "11 equals 12");
+        assert.strictEqual(callbackCount, 1, "callback count 1");
+
+        const actual21 = container1.get(cachedCallback);
+        const actual22 = container1.get(cachedCallback);
+
+        assert.strictEqual(actual21, actual22, "21 equals 22");
+        assert.strictEqual(callbackCount, 2, "callback count 2");
+
+        assert.notStrictEqual(actual11, actual21, "11 does not equal 21");
+      });
+
+      it(`cachedCallback registration on interface is invoked once`, function () {
+        const actual1 = container.get(ICachedCallback);
+        const actual2 = container.get(ICachedCallback);
+
+        assert.strictEqual(callbackCount, 1, `only called once`);
+        assert.strictEqual(actual2, actual1, `getting from the same container`);
+      });
+
+      it(`cacheCallback interface multiple root containers`, function () {
+        const container0 = DI.createContainer();
+        const container1 = DI.createContainer();
+        const actual11 = container0.get(ICachedCallback);
+        const actual12 = container0.get(ICachedCallback);
+
+        assert.strictEqual(callbackCount, 1);
+        assert.strictEqual(actual11, actual12);
+
+        const actual21 = container1.get(ICachedCallback);
+        const actual22 = container1.get(ICachedCallback);
+
+        assert.strictEqual(callbackCount, 2);
+        assert.strictEqual(actual21, actual22);
+      });
+
+      it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function () {
+        interface IAlias { }
+        const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ITransient));
+
+        const actual1 = container.get(IAlias);
+        assert.instanceOf(actual1, Transient, `actual1`);
+
+        const actual2 = container.get(IAlias);
+        assert.instanceOf(actual2, Transient, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IAlias],
+            [ITransient],
+            [IAlias],
+            [ITransient],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function () {
+        interface IAlias { }
+        const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ISingleton));
+
+        const actual1 = container.get(IAlias);
+        assert.instanceOf(actual1, Singleton, `actual1`);
+
+        const actual2 = container.get(IAlias);
+        assert.instanceOf(actual2, Singleton, `actual2`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IAlias],
+            [ISingleton],
+            [IAlias],
+            [ISingleton],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function () {
+        interface IAlias { }
+        const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(IInstance));
+
+        const actual1 = container.get(IAlias);
+        assert.instanceOf(actual1, Instance, `actual1`);
+
+        const actual2 = container.get(IAlias);
+        assert.instanceOf(actual2, Instance, `actual2`);
+
+        assert.strictEqual(actual1, instance, `actual1`);
+        assert.strictEqual(actual2, instance, `actual2`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IAlias],
+            [IInstance],
+            [IAlias],
+            [IInstance],
+          ],
+          `get.calls`,
+        );
+      });
+
+      // TODO: make test work
+      it(`InterfaceSymbol alias to callback registration is invoked each time`, function () {
+        interface IAlias { }
+        const IAlias = DI.createInterface<IAlias>('IAlias', x => x.aliasTo(ICallback));
+
+        const actual1 = container.get(IAlias);
+        assert.instanceOf(actual1, Callback, `actual1`);
+
+        const actual2 = container.get(IAlias);
+        assert.instanceOf(actual2, Callback, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IAlias],
+            [ICallback],
+            [IAlias],
+            [ICallback],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`string alias to transient registration returns a new instance each time`, function () {
+        container.register(Registration.aliasTo(ITransient, 'alias'));
+
+        const actual1 = container.get('alias');
+        assert.instanceOf(actual1, Transient, `actual1`);
+
+        const actual2 = container.get('alias');
+        assert.instanceOf(actual2, Transient, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            ['alias'],
+            [ITransient],
+            ['alias'],
+            [ITransient],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`string alias to singleton registration returns the same instance each time`, function () {
+        container.register(Registration.aliasTo(ISingleton, 'alias'));
+
+        const actual1 = container.get('alias');
+        assert.instanceOf(actual1, Singleton, `actual1`);
+
+        const actual2 = container.get('alias');
+        assert.instanceOf(actual2, Singleton, `actual2`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            ['alias'],
+            [ISingleton],
+            ['alias'],
+            [ISingleton],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`string alias to instance registration returns the same instance each time`, function () {
+        container.register(Registration.aliasTo(IInstance, 'alias'));
+
+        const actual1 = container.get('alias');
+        assert.instanceOf(actual1, Instance, `actual1`);
+
+        const actual2 = container.get('alias');
+        assert.instanceOf(actual2, Instance, `actual2`);
+
+        assert.strictEqual(actual1, instance, `actual1`);
+        assert.strictEqual(actual2, instance, `actual2`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            ['alias'],
+            [IInstance],
+            ['alias'],
+            [IInstance],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`string alias to callback registration is invoked each time`, function () {
+        container.register(Registration.aliasTo(ICallback, 'alias'));
+
+        const actual1 = container.get('alias');
+        assert.instanceOf(actual1, Callback, `actual1`);
+
+        const actual2 = container.get('alias');
+        assert.instanceOf(actual2, Callback, `actual2`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            ['alias'],
+            [ICallback],
+            ['alias'],
+            [ICallback],
+          ],
+          `get.calls`,
+        );
+      });
+    });
+
+    // describe('parent without inject decorator', function () {
+    //   function decorator(): ClassDecorator { return (target: any) => target; }
+    //   interface IParent { dep: any; }
+    //   let IParent: InterfaceSymbol<IParent>;
+
+    //   function register(cls: any) {
+    //     IParent = DI.createInterface<IParent>('IParent', x => x.transient(cls));
+    //   }
+
+    //   it(`transient child registration throws`, function () {
+    //     @decorator()
+    //     class Parent implements IParent { constructor(public dep: ITransient) {} }
+    //     register(Parent);
+
+    //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
+    //   });
+
+    //   it(`singleton child registration throws`, function () {
+    //     @decorator()
+    //     class Parent implements IParent { constructor(public dep: ISingleton) {} }
+    //     register(Parent);
+
+    //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
+    //   });
+
+    //   it(`instance child registration throws`, function () {
+    //     @decorator()
+    //     class Parent implements IParent { constructor(public dep: IInstance) {} }
+    //     register(Parent);
+
+    //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
+    //   });
+
+    //   it(`callback child registration throws`, function () {
+    //     @decorator()
+    //     class Parent implements IParent { constructor(public dep: ICallback) {} }
+    //     register(Parent);
+
+    //     assert.throws(() => container.get(IParent), /5/, `() => container.get(IParent)`);
+    //   });
+    // });
+
+    describe('transient parent', function () {
+      interface ITransientParent { dep: any }
+      let ITransientParent: InterfaceSymbol<ITransientParent>;
+
+      function register(cls: any) {
+        ITransientParent = DI.createInterface<ITransientParent>('ITransientParent', x => x.transient(cls));
+      }
+
+      it(`transient child registration returns a new instance each time`, function () {
+        @inject(ITransient)
+        class TransientParent implements ITransientParent { public constructor(public dep: ITransient) { } }
+        register(TransientParent);
+
+        const actual1 = container.get(ITransientParent);
+        assert.instanceOf(actual1, TransientParent, `actual1`);
+        assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
+
+        const actual2 = container.get(ITransientParent);
+        assert.instanceOf(actual2, TransientParent, `actual2`);
+        assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.notStrictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ITransientParent],
+            [ITransient],
+            [ITransientParent],
+            [ITransient],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`singleton child registration returns the same instance each time`, function () {
+        @inject(ISingleton)
+        class TransientParent implements ITransientParent { public constructor(public dep: ISingleton) { } }
+        register(TransientParent);
+
+        const actual1 = container.get(ITransientParent);
+        assert.instanceOf(actual1, TransientParent, `actual1`);
+        assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
+
+        const actual2 = container.get(ITransientParent);
+        assert.instanceOf(actual2, TransientParent, `actual2`);
+        assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ITransientParent],
+            [ISingleton],
+            [ITransientParent],
+            [ISingleton],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`instance child registration returns the same instance each time`, function () {
+        @inject(IInstance)
+        class TransientParent implements ITransientParent { public constructor(public dep: IInstance) { } }
+        register(TransientParent);
+
+        const actual1 = container.get(ITransientParent);
+        assert.instanceOf(actual1, TransientParent, `actual1`);
+        assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
+
+        const actual2 = container.get(ITransientParent);
+        assert.instanceOf(actual2, TransientParent, `actual2`);
+        assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ITransientParent],
+            [IInstance],
+            [ITransientParent],
+            [IInstance],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`callback child registration is invoked each time`, function () {
+        @inject(ICallback)
+        class TransientParent implements ITransientParent { public constructor(public dep: ICallback) { } }
+        register(TransientParent);
+
+        const actual1 = container.get(ITransientParent);
+        assert.instanceOf(actual1, TransientParent, `actual1`);
+        assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
+
+        const actual2 = container.get(ITransientParent);
+        assert.instanceOf(actual2, TransientParent, `actual2`);
+        assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
+
+        assert.notStrictEqual(actual1, actual2, `actual1`);
+        assert.notStrictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ITransientParent],
+            [ICallback],
+            [ITransientParent],
+            [ICallback],
+          ],
+          `get.calls`,
+        );
+      });
+    });
+
+    describe('singleton parent', function () {
+      interface ISingletonParent { dep: any }
+      let ISingletonParent: InterfaceSymbol<ISingletonParent>;
+
+      function register(cls: any) {
+        ISingletonParent = DI.createInterface<ISingletonParent>('ISingletonParent', x => x.singleton(cls));
+      }
+
+      it(`transient child registration is reused by the singleton parent`, function () {
+        @inject(ITransient)
+        class SingletonParent implements ISingletonParent { public constructor(public dep: ITransient) { } }
+        register(SingletonParent);
+
+        const actual1 = container.get(ISingletonParent);
+        assert.instanceOf(actual1, SingletonParent, `actual1`);
+        assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
+
+        const actual2 = container.get(ISingletonParent);
+        assert.instanceOf(actual2, SingletonParent, `actual2`);
+        assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ISingletonParent],
+            [ITransient],
+            [ISingletonParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`singleton registration is reused by the singleton parent`, function () {
+        @inject(ISingleton)
+        class SingletonParent implements ISingletonParent { public constructor(public dep: ISingleton) { } }
+        register(SingletonParent);
+
+        const actual1 = container.get(ISingletonParent);
+        assert.instanceOf(actual1, SingletonParent, `actual1`);
+        assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
+
+        const actual2 = container.get(ISingletonParent);
+        assert.instanceOf(actual2, SingletonParent, `actual2`);
+        assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ISingletonParent],
+            [ISingleton],
+            [ISingletonParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`instance registration is reused by the singleton parent`, function () {
+        @inject(IInstance)
+        class SingletonParent implements ISingletonParent { public constructor(public dep: IInstance) { } }
+        register(SingletonParent);
+
+        const actual1 = container.get(ISingletonParent);
+        assert.instanceOf(actual1, SingletonParent, `actual1`);
+        assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
+
+        const actual2 = container.get(ISingletonParent);
+        assert.instanceOf(actual2, SingletonParent, `actual2`);
+        assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ISingletonParent],
+            [IInstance],
+            [ISingletonParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`callback registration is reused by the singleton parent`, function () {
+        @inject(ICallback)
+        class SingletonParent implements ISingletonParent { public constructor(public dep: ICallback) { } }
+        register(SingletonParent);
+
+        const actual1 = container.get(ISingletonParent);
+        assert.instanceOf(actual1, SingletonParent, `actual1`);
+        assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
+
+        const actual2 = container.get(ISingletonParent);
+        assert.instanceOf(actual2, SingletonParent, `actual2`);
+        assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [ISingletonParent],
+            [ICallback],
+            [ISingletonParent],
+          ],
+          `get.calls`,
+        );
+      });
+    });
+
+    describe('instance parent', function () {
+      interface IInstanceParent { dep: any }
+      let IInstanceParent: InterfaceSymbol<IInstanceParent>;
+      let instanceParent: IInstanceParent;
+
+      function register(cls: any) {
+        instanceParent = container.get(cls);
+        get.reset();
+        IInstanceParent = DI.createInterface<IInstanceParent>('IInstanceParent', x => x.instance(instanceParent));
+      }
+
+      it(`transient registration is reused by the instance parent`, function () {
+        @inject(ITransient)
+        class InstanceParent implements IInstanceParent { public constructor(public dep: ITransient) { } }
+        register(InstanceParent);
+
+        const actual1 = container.get(IInstanceParent);
+        assert.instanceOf(actual1, InstanceParent, `actual1`);
+        assert.instanceOf(actual1.dep, Transient, `actual1.dep`);
+
+        const actual2 = container.get(IInstanceParent);
+        assert.instanceOf(actual2, InstanceParent, `actual2`);
+        assert.instanceOf(actual2.dep, Transient, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IInstanceParent],
+            [IInstanceParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`singleton registration is reused by the instance parent`, function () {
+        @inject(ISingleton)
+        class InstanceParent implements IInstanceParent { public constructor(public dep: ISingleton) { } }
+        register(InstanceParent);
+
+        const actual1 = container.get(IInstanceParent);
+        assert.instanceOf(actual1, InstanceParent, `actual1`);
+        assert.instanceOf(actual1.dep, Singleton, `actual1.dep`);
+
+        const actual2 = container.get(IInstanceParent);
+        assert.instanceOf(actual2, InstanceParent, `actual2`);
+        assert.instanceOf(actual2.dep, Singleton, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IInstanceParent],
+            [IInstanceParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`instance registration is reused by the instance parent`, function () {
+        @inject(IInstance)
+        class InstanceParent implements IInstanceParent { public constructor(public dep: IInstance) { } }
+        register(InstanceParent);
+
+        const actual1 = container.get(IInstanceParent);
+        assert.instanceOf(actual1, InstanceParent, `actual1`);
+        assert.instanceOf(actual1.dep, Instance, `actual1.dep`);
+
+        const actual2 = container.get(IInstanceParent);
+        assert.instanceOf(actual2, InstanceParent, `actual2`);
+        assert.instanceOf(actual2.dep, Instance, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IInstanceParent],
+            [IInstanceParent],
+          ],
+          `get.calls`,
+        );
+      });
+
+      it(`callback registration is reused by the instance parent`, function () {
+        @inject(ICallback)
+        class InstanceParent implements IInstanceParent { public constructor(public dep: ICallback) { } }
+        register(InstanceParent);
+
+        const actual1 = container.get(IInstanceParent);
+        assert.instanceOf(actual1, InstanceParent, `actual1`);
+        assert.instanceOf(actual1.dep, Callback, `actual1.dep`);
+
+        const actual2 = container.get(IInstanceParent);
+        assert.instanceOf(actual2, InstanceParent, `actual2`);
+        assert.instanceOf(actual2.dep, Callback, `actual2.dep`);
+
+        assert.strictEqual(actual1, actual2, `actual1`);
+        assert.strictEqual(actual1.dep, actual2.dep, `actual1.dep`);
+
+        assert.deepStrictEqual(
+          callback.calls,
+          [
+            [container, container, container.getResolver(ICallback)],
+          ],
+          `callback.calls`,
+        );
+
+        assert.deepStrictEqual(
+          get.calls,
+          [
+            [IInstanceParent],
+            [IInstanceParent],
+          ],
+          `get.calls`,
+        );
+      });
+    });
+  });
+
+  describe('defer registration', function () {
+    class FakeCSSService {
+      public constructor(public data: any) { }
+    }
+
+    class FakeCSSHandler {
+      public register(container: IContainer, data) {
+        container.register(
+          Registration.instance(
+            FakeCSSService,
+            new FakeCSSService(data)
+          )
+        );
+      }
+    }
+
+    it(`enables the handler class to provide registrations for data`, function () {
+      const container = DI.createContainer();
+      const data = {};
+
+      container.register(
+        Registration.singleton('.css', FakeCSSHandler)
+      );
+
+      container.register(
+        Registration.defer('.css', data)
+      );
+
+      const service = container.get(FakeCSSService);
+
+      assert.strictEqual(service.data, data);
+    });
+
+    it(`passes the params to the container's register method if no handler is found`, function () {
+      const container = DI.createContainer();
+      const data = {
+        wasCalled: false,
+        register() {
+          this.wasCalled = true;
+        }
+      };
+
+      container.register(
+        Registration.defer('.css', data)
+      );
+
+      assert.strictEqual(data.wasCalled, true);
+    });
+
+    [
+      {
+        name: 'string',
+        value: 'some string value'
+      },
+      {
+        name: 'boolean',
+        value: true
+      },
+      {
+        name: 'number',
+        value: 42
+      }
+    ].forEach(x => {
+      it(`does not pass ${x.name} params to the container's register when no handler is found`, function () {
+        const container = DI.createContainer();
+        container.register(
+          Registration.defer('.css', x.value)
+        );
+      });
+    });
+
+    // TODO: fix test setup for emitDecoratorMetadata
+    // it('can inject dependencies based on TS metadata', function () {
+    //   const deco: ClassDecorator = function (target) { return target; };
+
+    //   class Foo {}
+
+    //   @deco
+    //   class Bar {
+    //     public constructor(
+    //       public readonly foo: Foo
+    //     ) {}
+    //   }
+
+    //   const bar = DI.createContainer().get(Bar);
+
+    //   assert.instanceOf(bar.foo, Foo);
+    // });
+  });
 });
+

--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -61,223 +61,223 @@ describe('2-runtime/property-observation.spec.ts', function () {
       assert.strictEqual(new PrimitiveObserver(null, 0).doNotCache, true, `new PrimitiveObserver(null, 0).doNotCache`);
     });
   });
-});
 
-class Foo {}
+  describe('SetterObserver', function () {
+    function createFixture(obj: IIndexable, key: string) {
+      const ctx = TestContext.create();
+      const sut = new SetterObserver(obj, key);
 
-describe('SetterObserver', function () {
-  function createFixture(obj: IIndexable, key: string) {
-    const ctx = TestContext.create();
-    const sut = new SetterObserver(obj, key);
-
-    return { ctx, sut };
-  }
-
-  describe('getValue()', function () {
-    const objectArr = createObjectArr();
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(object, propertyName as any);
-          sut.subscribe(new SpySubscriber());
-          const actual = sut.getValue();
-          assert.strictEqual(actual, object[propertyName], `actual`);
-        });
-      }
+      return { ctx, sut };
     }
-  });
 
-  describe('setValue()', function () {
-    const valueArr = [undefined, null, 0, '', {}];
-    const objectArr = createObjectArr();
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        for (const value of valueArr) {
-          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+    describe('getValue()', function () {
+      const objectArr = createObjectArr();
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
             const { sut } = createFixture(object, propertyName as any);
             sut.subscribe(new SpySubscriber());
-            sut.setValue(value);
-            assert.strictEqual(object[propertyName], value, `object[propertyName]`);
+            const actual = sut.getValue();
+            assert.strictEqual(actual, object[propertyName], `actual`);
           });
         }
       }
-    }
-  });
+    });
 
-  describe('subscribe()', function () {
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
-    const objectArr = createObjectArr();
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(object, propertyName as any);
-          sut.subscribe(new SpySubscriber());
-        });
-      }
-    }
-
-    const valueArr = [0, '', {}];
-    const callsArr = [1, 2];
-    for (const calls of callsArr) {
-      for (const propertyName of propertyNameArr) {
-        for (const value of valueArr) {
-          const subscribersArr = [
-            [new SpySubscriber()],
-            [new SpySubscriber(), new SpySubscriber(), new SpySubscriber()],
-            [new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber()]
-          ];
-          for (const subscribers of subscribersArr) {
-            const object = {};
-            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+    describe('setValue()', function () {
+      const valueArr = [undefined, null, 0, '', {}];
+      const objectArr = createObjectArr();
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          for (const value of valueArr) {
+            it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
               const { sut } = createFixture(object, propertyName as any);
-              for (const subscriber of subscribers) {
-                sut.subscribe(subscriber);
-              }
-              const prevValue = object[propertyName];
+              sut.subscribe(new SpySubscriber());
               sut.setValue(value);
-              for (const subscriber of subscribers) {
-                assert.deepStrictEqual(
-                  subscriber.changes,
-                  [
-                    new ChangeSet(0, value, prevValue),
-                  ],
-                );
-              }
-              if (calls === 2) {
-                sut.setValue(prevValue);
+              assert.strictEqual(object[propertyName], value, `object[propertyName]`);
+            });
+          }
+        }
+      }
+    });
+
+    describe('subscribe()', function () {
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
+      const objectArr = createObjectArr();
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
+            const { sut } = createFixture(object, propertyName as any);
+            sut.subscribe(new SpySubscriber());
+          });
+        }
+      }
+
+      const valueArr = [0, '', {}];
+      const callsArr = [1, 2];
+      for (const calls of callsArr) {
+        for (const propertyName of propertyNameArr) {
+          for (const value of valueArr) {
+            const subscribersArr = [
+              [new SpySubscriber()],
+              [new SpySubscriber(), new SpySubscriber(), new SpySubscriber()],
+              [new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber()]
+            ];
+            for (const subscribers of subscribersArr) {
+              const object = {};
+              it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+                const { sut } = createFixture(object, propertyName as any);
+                for (const subscriber of subscribers) {
+                  sut.subscribe(subscriber);
+                }
+                const prevValue = object[propertyName];
+                sut.setValue(value);
                 for (const subscriber of subscribers) {
                   assert.deepStrictEqual(
                     subscriber.changes,
                     [
                       new ChangeSet(0, value, prevValue),
-                      new ChangeSet(1, prevValue, value),
                     ],
                   );
                 }
-              }
-              for (const subscriber of subscribers) {
-                sut.unsubscribe(subscriber);
-              }
-            });
+                if (calls === 2) {
+                  sut.setValue(prevValue);
+                  for (const subscriber of subscribers) {
+                    assert.deepStrictEqual(
+                      subscriber.changes,
+                      [
+                        new ChangeSet(0, value, prevValue),
+                        new ChangeSet(1, prevValue, value),
+                      ],
+                    );
+                  }
+                }
+                for (const subscriber of subscribers) {
+                  sut.unsubscribe(subscriber);
+                }
+              });
+            }
           }
         }
       }
-    }
-  });
-});
-
-describe('BindableObserver', function () {
-  function createFixture(obj: IIndexable, key: string) {
-    const _ctx = TestContext.create();
-    const sut = new BindableObserver(obj, key, `${key ? key.toString() : `${key}`}Changed`, noop, { } as any, {enableCoercion: false, coerceNullish: false});
-
-    return { sut };
-  }
-
-  it('initializes the default callback to undefined', function () {
-    const values = createObjectArr();
-    values.forEach(_value => {
-      const observer = createFixture({}, 'a');
-      assert.strictEqual(observer['callback'], void 0, `observer['callback']`);
     });
   });
 
-  describe('getValue()', function () {
-    const objectArr = createObjectArr();
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(object, propertyName as any);
-          sut.subscribe(new SpySubscriber());
-          const actual = sut.getValue();
-          assert.strictEqual(actual, object[propertyName], `actual`);
-        });
-      }
-    }
-  });
+  describe('BindableObserver', function () {
+    function createFixture(obj: IIndexable, key: string) {
+      const _ctx = TestContext.create();
+      const sut = new BindableObserver(obj, key, `${key ? key.toString() : `${key}`}Changed`, noop, {} as any, { enableCoercion: false, coerceNullish: false });
 
-  describe('setValue()', function () {
-    const valueArr = [undefined, null, 0, '', {}];
-    const objectArr = createObjectArr();
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        for (const value of valueArr) {
-          it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+      return { sut };
+    }
+
+    it('initializes the default callback to undefined', function () {
+      const values = createObjectArr();
+      values.forEach(_value => {
+        const observer = createFixture({}, 'a');
+        assert.strictEqual(observer['callback'], void 0, `observer['callback']`);
+      });
+    });
+
+    describe('getValue()', function () {
+      const objectArr = createObjectArr();
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 'length', '__proto__'];
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          it(`should correctly handle ${getName(object)}[${typeof propertyName}]`, function () {
             const { sut } = createFixture(object, propertyName as any);
             sut.subscribe(new SpySubscriber());
-            sut.setValue(value);
-            assert.strictEqual(object[propertyName], value, `object[propertyName]`);
+            const actual = sut.getValue();
+            assert.strictEqual(actual, object[propertyName], `actual`);
           });
         }
       }
-    }
-  });
+    });
 
-  describe('subscribe()', function () {
-    const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
-    const objectArr = createObjectArr();
-    for (const object of objectArr) {
-      for (const propertyName of propertyNameArr) {
-        it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
-          const { sut } = createFixture(object, propertyName as any);
-          sut.subscribe(new SpySubscriber());
-        });
-      }
-    }
-
-    const valueArr = [0, '', {}];
-    const callsArr = [1, 2];
-    for (const calls of callsArr) {
-      for (const propertyName of propertyNameArr) {
-        for (const value of valueArr) {
-          const subscribersArr = [
-            [new SpySubscriber()],
-            [new SpySubscriber(), new SpySubscriber(), new SpySubscriber()],
-            [new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber()]
-          ];
-          for (const subscribers of subscribersArr) {
-            const object = {};
-            it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+    describe('setValue()', function () {
+      const valueArr = [undefined, null, 0, '', {}];
+      const objectArr = createObjectArr();
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo'];
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          for (const value of valueArr) {
+            it(`should correctly handle ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
               const { sut } = createFixture(object, propertyName as any);
-              for (const subscriber of subscribers) {
-                sut.subscribe(subscriber);
-              }
-              const prevValue = object[propertyName];
+              sut.subscribe(new SpySubscriber());
               sut.setValue(value);
-              for (const subscriber of subscribers) {
-                assert.deepStrictEqual(
-                  subscriber.changes,
-                  [
-                    new ChangeSet(0, value, prevValue),
-                  ],
-                );
-              }
-              if (calls === 2) {
-                sut.setValue(prevValue);
+              assert.strictEqual(object[propertyName], value, `object[propertyName]`);
+            });
+          }
+        }
+      }
+    });
+
+    describe('subscribe()', function () {
+      const propertyNameArr = [undefined, null, Symbol(), '', 'foo', 1];
+      const objectArr = createObjectArr();
+      for (const object of objectArr) {
+        for (const propertyName of propertyNameArr) {
+          it(`can handle ${getName(object)}[${typeof propertyName}]`, function () {
+            const { sut } = createFixture(object, propertyName as any);
+            sut.subscribe(new SpySubscriber());
+          });
+        }
+      }
+
+      const valueArr = [0, '', {}];
+      const callsArr = [1, 2];
+      for (const calls of callsArr) {
+        for (const propertyName of propertyNameArr) {
+          for (const value of valueArr) {
+            const subscribersArr = [
+              [new SpySubscriber()],
+              [new SpySubscriber(), new SpySubscriber(), new SpySubscriber()],
+              [new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber(), new SpySubscriber()]
+            ];
+            for (const subscribers of subscribersArr) {
+              const object = {};
+              it(`should notify ${subscribers.length} subscriber(s) for ${getName(object)}[${typeof propertyName}]=${getName(value)}`, function () {
+                const { sut } = createFixture(object, propertyName as any);
+                for (const subscriber of subscribers) {
+                  sut.subscribe(subscriber);
+                }
+                const prevValue = object[propertyName];
+                sut.setValue(value);
                 for (const subscriber of subscribers) {
                   assert.deepStrictEqual(
                     subscriber.changes,
                     [
                       new ChangeSet(0, value, prevValue),
-                      new ChangeSet(1, prevValue, value),
                     ],
                   );
                 }
-              }
-              for (const subscriber of subscribers) {
-                sut.unsubscribe(subscriber);
-              }
-            });
+                if (calls === 2) {
+                  sut.setValue(prevValue);
+                  for (const subscriber of subscribers) {
+                    assert.deepStrictEqual(
+                      subscriber.changes,
+                      [
+                        new ChangeSet(0, value, prevValue),
+                        new ChangeSet(1, prevValue, value),
+                      ],
+                    );
+                  }
+                }
+                for (const subscriber of subscribers) {
+                  sut.unsubscribe(subscriber);
+                }
+              });
+            }
           }
         }
       }
-    }
+    });
   });
 });
+
+class Foo { }
 
 function createObjectArr(): any[] {
   return [

--- a/packages/__tests__/2-runtime/property-observation.spec.ts
+++ b/packages/__tests__/2-runtime/property-observation.spec.ts
@@ -62,6 +62,17 @@ describe('2-runtime/property-observation.spec.ts', function () {
     });
   });
 
+  class Foo { }
+
+  function createObjectArr(): any[] {
+    return [
+      // eslint-disable-next-line no-new-wrappers, no-new-wrappers
+      {}, Object.create(null), new Number(), new Boolean(), new String(),
+      new Error(), new Foo(), new Uint8Array(), new WeakMap(), new WeakSet(), JSON.parse('{}'),
+      /asdf/, function () { return; }, Promise.resolve(), new Proxy({}, {})
+    ];
+  }
+
   describe('SetterObserver', function () {
     function createFixture(obj: IIndexable, key: string) {
       const ctx = TestContext.create();
@@ -276,14 +287,3 @@ describe('2-runtime/property-observation.spec.ts', function () {
     });
   });
 });
-
-class Foo { }
-
-function createObjectArr(): any[] {
-  return [
-    // eslint-disable-next-line no-new-wrappers, no-new-wrappers
-    {}, Object.create(null), new Number(), new Boolean(), new String(),
-    new Error(), new Foo(), new Uint8Array(), new WeakMap(), new WeakSet(), JSON.parse('{}'),
-    /asdf/, function () { return; }, Promise.resolve(), new Proxy({}, {})
-  ];
-}

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -188,7 +188,7 @@ module.exports =
       // so disabling for now, if at any point we have the capacity to figure this out
       // this should be enable so that circleCI can use timing of each test to split them better
       // @ts-ignore
-      // junitCircleCi,
+      junitCircleCi,
       // ===============================
       'karma-mocha-reporter',
       'karma-chrome-launcher',
@@ -307,7 +307,7 @@ module.exports =
   };
 
   if (config.coverage) {
-    options.reporters = ['coverage-istanbul', ...options.reporters ?? []];
+    options.reporters = ['coverage-istanbul', 'junit-circleci', ...options.reporters ?? []];
     // @ts-ignore
     options.coverageIstanbulReporter = {
       // something wrong with cobertura on circleCI

--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -180,16 +180,8 @@ module.exports =
       'karma-coverage-istanbul-instrumenter',
       'karma-coverage-istanbul-reporter',
       'karma-min-reporter',
-      // ===============================
-      // when enabling junit report and teach circle CI about the timing of the tests
-      // CircleCI is able to split the test with very even timing across all processes
-      // though somehow all test around array observation got broken, as if there was no observation possible at all
-      // it is quite difficult to observe/debug
-      // so disabling for now, if at any point we have the capacity to figure this out
-      // this should be enable so that circleCI can use timing of each test to split them better
       // @ts-ignore
       junitCircleCi,
-      // ===============================
       'karma-mocha-reporter',
       'karma-chrome-launcher',
       'karma-safari-launcher',
@@ -307,7 +299,15 @@ module.exports =
   };
 
   if (config.coverage) {
-    options.reporters = ['coverage-istanbul', 'junit-circleci', ...options.reporters ?? []];
+    // ===============================
+    // when enabling junit report and teach circle CI about the timing of the tests
+    // CircleCI is able to split the test with very even timing across all processes
+    // though somehow all test around array observation got broken, as if there was no observation possible at all
+    // it is quite difficult to observe/debug
+    // so disabling for now, if at any point we have the capacity to figure this out
+    // this should be enable so that circleCI can use timing of each test to split them better
+    // ===============================
+    options.reporters = ['coverage-istanbul', /* 'junit-circleci', */ ...options.reporters ?? []];
     // @ts-ignore
     options.coverageIstanbulReporter = {
       // something wrong with cobertura on circleCI
@@ -320,22 +320,22 @@ module.exports =
       esModules: true,
     };
     // @ts-ignore
-    options.junitReporter = {
-      outputDir: './packages/__tests__/coverage',
-      outputFile: 'test-results.xml',
-      useBrowserName: false,
-      // specFormatter: (spec, result, suite) => {
-      //   if (!suite.getAttribute('file')) {
-      //     // xml builder is weird
-      //     // @ts-ignore
-      //     suite.att('file', spec.getAttribute('file'));
-      //   }
-      // },
-      fileFormatter: (result) => `packages/__tests__/dist/esm/__tests__/${result.suite[0].replace(/\.tsx?$/, '.js')}`,
-      nameFormatter: (browser, result, spec) => {
-        return result.suite.slice(1).join(' ') + ' ' + result.description;
-      },
-    };
+    // options.junitReporter = {
+    //   outputDir: './packages/__tests__/coverage',
+    //   outputFile: 'test-results.xml',
+    //   useBrowserName: false,
+    //   // specFormatter: (spec, result, suite) => {
+    //   //   if (!suite.getAttribute('file')) {
+    //   //     // xml builder is weird
+    //   //     // @ts-ignore
+    //   //     suite.att('file', spec.getAttribute('file'));
+    //   //   }
+    //   // },
+    //   fileFormatter: (result) => `packages/__tests__/dist/esm/__tests__/${result.suite[0].replace(/\.tsx?$/, '.js')}`,
+    //   nameFormatter: (browser, result, spec) => {
+    //     return result.suite.slice(1).join(' ') + ' ' + result.description;
+    //   },
+    // };
   }
 
   config.set(options);

--- a/packages/__tests__/router/smoke-tests.spec.ts
+++ b/packages/__tests__/router/smoke-tests.spec.ts
@@ -1,8 +1,6 @@
 import {
-  LogLevel,
   Constructable,
   kebabCase,
-  ILogConfig,
 } from '@aurelia/kernel';
 import {
   assert,
@@ -358,7 +356,7 @@ describe('router/smoke-tests.spec.ts', function () {
     });
 
     it(`${name(Root1)} can load ${name(A11)}/${name(A01)},${name(A11)}/${name(A02)} in order`, async function () {
-      const { router, host, tearDown, startTracing, stopTracing } = await createFixture(Root1, Z, getDefaultHIAConfig, getRouterOptions);
+      const { router, host, tearDown } = await createFixture(Root1, Z, getDefaultHIAConfig, getRouterOptions);
 
       await router.load(`a11/a01`);
       assertComponentsVisible(host, [Root1, A11, A01]);

--- a/packages/__tests__/router/viewport-content.spec.ts
+++ b/packages/__tests__/router/viewport-content.spec.ts
@@ -6,7 +6,7 @@ import { createFixture } from './_shared/create-fixture.js';
 const define = (CustomElement as any).define;
 
 describe('router/viewport-content.spec.ts', function () {
-  function $setup(dependencies: any[] = []) {
+  function $setup(_dependencies: any[] = []) {
     const ctx = TestContext.create();
     const container = ctx.container;
     const router = container.get(IRouter);
@@ -15,8 +15,8 @@ describe('router/viewport-content.spec.ts', function () {
   }
 
   it('can be created', function () {
-    const { container, router, viewport } = $setup();
-    const sut = new ViewportContent(router, viewport);
+    const { router, viewport } = $setup();
+    new ViewportContent(router, viewport);
   });
 
   describe('resolving globals', function () {

--- a/packages/__tests__/turbo.json
+++ b/packages/__tests__/turbo.json
@@ -3,7 +3,7 @@
     "extends": ["//"],
     "pipeline": {
       "build": {
-        "inputs": ["**/*.ts", "**/*.tsx", "esbuild.dev.cjs"],
+        "inputs": ["*/**/*.ts", "*/**/*.tsx", "esbuild.dev.cjs", "!z-scripts"],
         "outputs": ["dist/**/*"]
       }
     }

--- a/packages/__tests__/turbo.json
+++ b/packages/__tests__/turbo.json
@@ -3,7 +3,8 @@
     "extends": ["//"],
     "pipeline": {
       "build": {
-        "inputs": ["*/**/*.ts", "*/**/*.tsx", "esbuild.dev.cjs"]
+        "inputs": ["**/*.ts", "**/*.tsx", "esbuild.dev.cjs"],
+        "outputs": ["dist/**/*"]
       }
     }
 }

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -1,3 +1,4 @@
+import { type IIndexable } from '@aurelia/kernel';
 import {
   createIndexMap,
   AccessorType,
@@ -20,14 +21,15 @@ import { def, defineHiddenProp, defineMetadata, getOwnMetadata, isFunction } fro
 import { addCollectionBatch, batching } from './subscriber-batch';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Array object
-const lookupMetadataKey = '__au_array_obs__';
-const observerLookup = (() => {
-  let lookup: WeakMap<unknown[], ArrayObserver> = getOwnMetadata(lookupMetadataKey, Array);
-  if (lookup == null) {
-    defineMetadata(lookupMetadataKey, lookup = new WeakMap<unknown[], ArrayObserver>(), Array);
-  }
-  return lookup;
-})();
+const lookupMetadataKey = Symbol.for('__au_array_obs__');
+const observerLookup = ((Array as IIndexable<typeof Array>)[lookupMetadataKey] ??= new WeakMap()) as WeakMap<unknown[], ArrayObserver>;
+// [] (() => {
+//   let lookup: WeakMap<unknown[], ArrayObserver> = getOwnMetadata(lookupMetadataKey, Array);
+//   if (lookup == null) {
+//     defineMetadata(lookupMetadataKey, lookup = new WeakMap<unknown[], ArrayObserver>(), Array);
+//   }
+//   return lookup;
+// })();
 
 // https://tc39.github.io/ecma262/#sec-sortcompare
 function sortCompare(x: unknown, y: unknown): number {

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -1,4 +1,3 @@
-import { type IIndexable } from '@aurelia/kernel';
 import {
   createIndexMap,
   AccessorType,
@@ -21,15 +20,8 @@ import { def, defineHiddenProp, defineMetadata, getOwnMetadata, isFunction } fro
 import { addCollectionBatch, batching } from './subscriber-batch';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Array object
-const lookupMetadataKey = Symbol.for('__au_array_obs__');
-const observerLookup = ((Array as IIndexable<typeof Array>)[lookupMetadataKey] ??= new WeakMap()) as WeakMap<unknown[], ArrayObserver>;
-// [] (() => {
-//   let lookup: WeakMap<unknown[], ArrayObserver> = getOwnMetadata(lookupMetadataKey, Array);
-//   if (lookup == null) {
-//     defineMetadata(lookupMetadataKey, lookup = new WeakMap<unknown[], ArrayObserver>(), Array);
-//   }
-//   return lookup;
-// })();
+const lookupMetadataKey = Symbol.for('__au_arr_obs__');
+const observerLookup = defineHiddenProp(Array, lookupMetadataKey, new WeakMap<unknown[], ArrayObserver>());
 
 // https://tc39.github.io/ecma262/#sec-sortcompare
 function sortCompare(x: unknown, y: unknown): number {

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -18,10 +18,13 @@ import {
 } from './subscriber-collection';
 import { def, defineHiddenProp, defineMetadata, getOwnMetadata, isFunction } from '../utilities-objects';
 import { addCollectionBatch, batching } from './subscriber-batch';
+import { IIndexable } from '@aurelia/kernel';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Array object
 const lookupMetadataKey = Symbol.for('__au_arr_obs__');
-const observerLookup = defineHiddenProp(Array, lookupMetadataKey, new WeakMap<unknown[], ArrayObserver>());
+const observerLookup = ((Array as IIndexable<typeof Array>)[lookupMetadataKey]
+  ?? defineHiddenProp(Array, lookupMetadataKey, new WeakMap())
+) as WeakMap<unknown[], ArrayObserver>;
 
 // https://tc39.github.io/ecma262/#sec-sortcompare
 function sortCompare(x: unknown, y: unknown): number {

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -9,10 +9,13 @@ import type {
   ICollectionSubscriberCollection,
 } from '../observation';
 import { batching, addCollectionBatch } from './subscriber-batch';
+import { IIndexable } from '@aurelia/kernel';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Map object
 const lookupMetadataKey = Symbol.for('__au_map_obs__');
-const observerLookup = defineHiddenProp(Map, lookupMetadataKey, new WeakMap<Map<unknown, unknown>, MapObserver>());
+const observerLookup = ((Map as IIndexable<typeof Map>)[lookupMetadataKey]
+  ?? defineHiddenProp(Map, lookupMetadataKey, new WeakMap())
+) as WeakMap<Map<unknown, unknown>, MapObserver>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const proto = Map.prototype as { [K in keyof Map<any, any>]: Map<any, any>[K] & { observing?: boolean } };

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -1,7 +1,7 @@
 import { createIndexMap, AccessorType } from '../observation';
 import { CollectionSizeObserver } from './collection-length-observer';
 import { subscriberCollection } from './subscriber-collection';
-import { def, defineMetadata, getOwnMetadata } from '../utilities-objects';
+import { def, defineHiddenProp, defineMetadata, getOwnMetadata } from '../utilities-objects';
 
 import type {
   CollectionKind,
@@ -11,14 +11,8 @@ import type {
 import { batching, addCollectionBatch } from './subscriber-batch';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Map object
-const lookupMetadataKey = '__au_map_obs__';
-const observerLookup = (() => {
-  let lookup: WeakMap<Map<unknown, unknown>, MapObserver> = getOwnMetadata(lookupMetadataKey, Map);
-  if (lookup == null) {
-    defineMetadata(lookupMetadataKey, lookup = new WeakMap<Map<unknown, unknown>, MapObserver>(), Map);
-  }
-  return lookup;
-})();
+const lookupMetadataKey = Symbol.for('__au_map_obs__');
+const observerLookup = defineHiddenProp(Map, lookupMetadataKey, new WeakMap<Map<unknown, unknown>, MapObserver>());
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const proto = Map.prototype as { [K in keyof Map<any, any>]: Map<any, any>[K] & { observing?: boolean } };

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -1,18 +1,12 @@
 import { createIndexMap, AccessorType, type ICollectionSubscriberCollection, type ICollectionObserver, type CollectionKind } from '../observation';
 import { CollectionSizeObserver } from './collection-length-observer';
 import { subscriberCollection } from './subscriber-collection';
-import { def, defineMetadata, getOwnMetadata } from '../utilities-objects';
+import { def, defineHiddenProp, defineMetadata, getOwnMetadata } from '../utilities-objects';
 import { batching, addCollectionBatch } from './subscriber-batch';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Set object
-const lookupMetadataKey = '__au_set_obs__';
-const observerLookup = (() => {
-  let lookup: WeakMap<Set<unknown>, SetObserver> = getOwnMetadata(lookupMetadataKey, Set);
-  if (lookup == null) {
-    defineMetadata(lookupMetadataKey, lookup = new WeakMap<Set<unknown>, SetObserver>(), Set);
-  }
-  return lookup;
-})();
+const lookupMetadataKey = Symbol.for('__au_set_obs__');
+const observerLookup = defineHiddenProp(Set, lookupMetadataKey, new WeakMap<Set<unknown>, SetObserver>());
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const proto = Set.prototype as { [K in keyof Set<any>]: Set<any>[K] & { observing?: boolean } };

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -3,10 +3,13 @@ import { CollectionSizeObserver } from './collection-length-observer';
 import { subscriberCollection } from './subscriber-collection';
 import { def, defineHiddenProp, defineMetadata, getOwnMetadata } from '../utilities-objects';
 import { batching, addCollectionBatch } from './subscriber-batch';
+import { IIndexable } from '@aurelia/kernel';
 
 // multiple applications of Aurelia wouldn't have different observers for the same Set object
 const lookupMetadataKey = Symbol.for('__au_set_obs__');
-const observerLookup = defineHiddenProp(Set, lookupMetadataKey, new WeakMap<Set<unknown>, SetObserver>());
+const observerLookup = ((Set as IIndexable<typeof Set>)[lookupMetadataKey]
+  ?? defineHiddenProp(Set, lookupMetadataKey, new WeakMap())
+) as WeakMap<Set<unknown>, SetObserver>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const proto = Set.prototype as { [K in keyof Set<any>]: Set<any>[K] & { observing?: boolean } };


### PR DESCRIPTION
# Pull Request

## 📖 Description

We often do this
```html
// in real app it's some variable that has number values
<div height.style="200">
```
and forget that `200` is not a valid value for height, it needs to come with a unit. Add a warning in dev mode so that folks can be aware of what's happening.

Also cleanup some test code & lint issues.

Thanks @jsobell