### PR TITLE
refactor(state): action to be comes a single value

### DIFF
--- a/packages/__tests__/state/state.spec.ts
+++ b/packages/__tests__/state/state.spec.ts
@@ -182,9 +182,9 @@ describe('state/state.spec.ts', function () {
 
     it('updates text when state changes', async function () {
       const { trigger, flush, getBy } = await createFixture
-        .html`<input value.bind="text & state" input.dispatch="{ type: '', params: [$event.target.value] }">`
+        .html`<input value.bind="text & state" input.dispatch="$event.target.value">`
         .component({ text: 'from view model' })
-        .deps(StateDefaultConfiguration.init({ text: '1' }, (s, a, v) => ({ text: s.text + v })))
+        .deps(StateDefaultConfiguration.init({ text: '1' }, (s, a) => ({ text: s.text + a })))
         .build().started;
 
       trigger('input', 'input');
@@ -195,7 +195,7 @@ describe('state/state.spec.ts', function () {
     it('updates repeat when state changes', async function () {
       const { trigger, assertText } = await createFixture
         .html`
-          <button click.dispatch="{ type: '' }">change</button>
+          <button click.dispatch="''">change</button>
           <center><div repeat.for="item of items & state">\${item}`
         .deps(StateDefaultConfiguration.init({ items: [1, 2, 3] }, () => ({ items: [4, 5, 6] })))
         .build().started;
@@ -213,11 +213,11 @@ describe('state/state.spec.ts', function () {
     it('dispatches action', async function () {
       const state = { text: '1' };
       const { getBy, trigger, flush } = await createFixture
-        .html`<input value.state="text" input.dispatch="{ type: 'event', params: [$event.target.value] }">`
+        .html`<input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value }">`
         .deps(StateDefaultConfiguration.init(
           state,
-          (s, action: unknown, v: string) =>
-            action === 'event' ? { text: s.text + v } : s
+          (s, { type, v }: { type: string; v: string }) =>
+            type === 'event' ? { text: s.text + v } : s
         ))
         .build().started;
 
@@ -228,19 +228,19 @@ describe('state/state.spec.ts', function () {
       assert.strictEqual(getBy('input').value, '11');
     });
 
-    it('handles multiple action type in a single reducer', async function () {
+    it('handles multiple action types in a single reducer', async function () {
       const state = { text: '1' };
       const { getBy, trigger, flush } = await createFixture
         .html`
-          <input value.state="text" input.dispatch="{ type: 'event', params: [$event.target.value] }">
+          <input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value }">
           <button click.dispatch="{ type: 'clear' }">Clear</button>
         `
         .deps(StateDefaultConfiguration.init(
           state,
-          (s, action: unknown, v: string) =>
-            action === 'event'
+          (s, { type, v}: { type: string; v: string }) =>
+            type === 'event'
               ? { text: s.text + v }
-              : action === 'clear'
+              : type === 'clear'
                 ? { text: '' }
                 : s
         ))
@@ -260,11 +260,11 @@ describe('state/state.spec.ts', function () {
     it('does not throw on unreged action type', async function () {
       const state = { text: '1' };
       const { trigger, flush, getBy } = await createFixture
-        .html`<input value.state="text" input.dispatch="{ type: 'no-reg', params: [$event.target.value] }">`
+        .html`<input value.state="text" input.dispatch="{ type: 'no-reg', v: $event.target.value }">`
         .deps(StateDefaultConfiguration.init(
           state,
-          (s, action: unknown, v: string) =>
-            action === 'event' ? { text: s.text + v } : s
+          (s, { type, v }: { type: string; v: string }) =>
+            type === 'event' ? { text: s.text + v } : s
         ))
         .build().started;
 
@@ -276,11 +276,11 @@ describe('state/state.spec.ts', function () {
     it('works with debounce', async function () {
       const state = { text: '1' };
       const { getBy, trigger, flush } = createFixture
-        .html`<input value.state="text" input.dispatch="{ type: 'event', params: [$event.target.value] } & debounce:1">`
+        .html`<input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value } & debounce:1">`
         .deps(StateDefaultConfiguration.init(
           state,
-          (s, action: unknown, v: string) =>
-            action === 'event' ? { text: s.text + v } : s
+          (s, { type, v }: { type: string; v: string }) =>
+            type === 'event' ? { text: s.text + v } : s
         ))
         .build();
 
@@ -297,11 +297,11 @@ describe('state/state.spec.ts', function () {
       let actionCallCount = 0;
       const state = { text: '1' };
       const { getBy, trigger, flush } = await createFixture
-        .html`<input value.state="text" input.dispatch="{ type: 'event', params: [$event.target.value] } & throttle:1">`
+        .html`<input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value } & throttle:1">`
         .deps(StateDefaultConfiguration.init(
           state,
-          (s, action: unknown, v: string) => {
-            if (action === 'event') {
+          (s, { type, v }: { type: string; v: string }) => {
+            if (type === 'event') {
               actionCallCount++;
               return { text: s.text + v };
             }
@@ -363,7 +363,7 @@ describe('state/state.spec.ts', function () {
     });
 
     it('updates when state changed', async function () {
-      @customElement({ name: 'my-el', template: `<input value.bind="text" input.dispatch="{ type: 'input', params: [$event.target.value] }">` })
+      @customElement({ name: 'my-el', template: `<input value.bind="text" input.dispatch="{ type: 'input', v: $event.target.value }">` })
       class MyEl {
         @fromState<typeof state>(s => s.text)
         text: string;
@@ -372,7 +372,7 @@ describe('state/state.spec.ts', function () {
       const state = { text: '1' };
       const { trigger, flush, getBy } = await createFixture
         .html`<my-el>`
-        .deps(MyEl, StateDefaultConfiguration.init(state, (s, type, value) => ({ text: s.text + value })))
+        .deps(MyEl, StateDefaultConfiguration.init(state, (s, { v }) => ({ text: s.text + v })))
         .build().started;
 
       trigger('input', 'input');

--- a/packages/state/src/action-handler.ts
+++ b/packages/state/src/action-handler.ts
@@ -1,18 +1,18 @@
 import { IContainer, Registration } from '@aurelia/kernel';
-import { IActionHandler, IRegistrableReducer } from './interfaces';
+import { IActionHandler, IRegistrableAction } from './interfaces';
 
 const actionHandlerSymbol = '__au_ah__';
 export const ActionHandler = Object.freeze({
-  define<T extends IActionHandler>(reducer: T): IRegistrableReducer {
-    function registry(state: any, action: unknown, ...params: any[]): unknown {
-      return reducer(state, action, ...params);
+  define<T extends IActionHandler>(actionHandler: T): IRegistrableAction {
+    function registry(state: any, action: unknown): unknown {
+      return actionHandler(state, action);
     }
     registry[actionHandlerSymbol] = true;
     registry.register = function (c: IContainer) {
-      Registration.instance(IActionHandler, reducer).register(c);
+      Registration.instance(IActionHandler, actionHandler).register(c);
     };
 
-    return registry as unknown as IRegistrableReducer;
+    return registry as unknown as IRegistrableAction;
   },
 
   isType: <T>(r: unknown): r is IActionHandler<T> => typeof r === 'function' && actionHandlerSymbol in r,

--- a/packages/state/src/configuration.ts
+++ b/packages/state/src/configuration.ts
@@ -26,16 +26,16 @@ const standardRegistrations = [
   Store,
 ];
 
-const createConfiguration = <T>(initialState: T, reducers: IActionHandler<T>[]) => {
+const createConfiguration = <T>(initialState: T, actionHandlers: IActionHandler<T>[]) => {
   return {
     register: (c: IContainer) => {
       c.register(
         Registration.instance(IState, initialState),
         ...standardRegistrations,
-        ...reducers.map(ActionHandler.define),
+        ...actionHandlers.map(ActionHandler.define),
       );
     },
-    init: <T1>(state: T1, ...reducers: IActionHandler<T1>[]) => createConfiguration(state, reducers),
+    init: <T1>(state: T1, ...actionHandlers: IActionHandler<T1>[]) => createConfiguration(state, actionHandlers),
   };
 };
 

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -8,8 +8,7 @@ export {
   IStore,
   type IStoreSubscriber,
   IActionHandler,
-  type IRegistrableReducer,
-  type IAction,
+  type IRegistrableAction,
 } from './interfaces';
 
 export { StateBinding, } from './state-binding';

--- a/packages/state/src/interfaces.ts
+++ b/packages/state/src/interfaces.ts
@@ -1,10 +1,10 @@
 import { DI, type MaybePromise, type IRegistry, type IDisposable } from '@aurelia/kernel';
 
 export const IActionHandler = DI.createInterface<IActionHandler>('IActionHandler');
-export type IActionHandler<T = any> = (state: T, action: unknown, ...params: any) => MaybePromise<T>;
+export type IActionHandler<T = any> = (state: T, action: unknown) => MaybePromise<T>;
 
 export const IStore = DI.createInterface<IStore<object>>('IStore');
-export interface IStore<T extends object> {
+export interface IStore<T extends object, TAction = unknown> {
   subscribe(subscriber: IStoreSubscriber<T>): void;
   unsubscribe(subscriber: IStoreSubscriber<T>): void;
   getState(): T;
@@ -14,20 +14,15 @@ export interface IStore<T extends object> {
    * @param action - the name or the action to be dispatched
    * @param params - all the parameters to be called with the action
    */
-  dispatch(action: unknown, ...params: any[]): void | Promise<void>;
+  dispatch(action: TAction): void | Promise<void>;
 }
 
 export const IState = DI.createInterface<object>('IState');
 
-export type IRegistrableReducer = IActionHandler & IRegistry;
+export type IRegistrableAction = IActionHandler & IRegistry;
 
 export interface IStoreSubscriber<T extends object> {
   handleStateChange(state: T, prevState: T): void;
-}
-
-export interface IAction {
-  type: unknown;
-  params?: unknown[];
 }
 
 /** @internal */

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -14,7 +14,6 @@ import {
 } from '@aurelia/runtime';
 import { mixinAstEvaluator, mixingBindingLimited } from '@aurelia/runtime-html';
 import {
-  IAction,
   type IStore
 } from './interfaces';
 import { createStateBindingScope } from './state-utilities';
@@ -60,10 +59,7 @@ export class StateDispatchBinding implements IBinding {
     scope.overrideContext.$event = e;
     const value = astEvaluate(this.ast, scope, this, null);
     delete scope.overrideContext.$event;
-    if (!this.isAction(value)) {
-      throw new Error(`Invalid dispatch value from expression on ${this._target} on event: "${e.type}"`);
-    }
-    void this._store.dispatch(value.type, ...(value.params instanceof Array ? value.params : []));
+    void this._store.dispatch(value);
   }
 
   public handleEvent(e: Event) {
@@ -97,13 +93,6 @@ export class StateDispatchBinding implements IBinding {
     const scope = this._scope!;
     const overrideContext = scope.overrideContext as Writable<IOverrideContext>;
     scope.bindingContext = overrideContext.bindingContext = state;
-  }
-
-  /** @internal */
-  private isAction(value: unknown): value is IAction {
-    return value != null
-      && typeof value === 'object'
-      && 'type' in value;
   }
 }
 

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -123,11 +123,10 @@ export class StateBindingInstructionRenderer implements IRenderer {
 
 @renderer('sd')
 export class DispatchBindingInstructionRenderer implements IRenderer {
-  /** @internal */ protected static inject = [IExpressionParser, IStore];
+  /** @internal */ protected static inject = [IStore];
   public readonly target!: 'sd';
 
   public constructor(
-    /** @internal */ private readonly _exprParser: IExpressionParser,
     /** @internal */ private readonly _stateContainer: IStore<object>,
   ) {}
 
@@ -135,8 +134,10 @@ export class DispatchBindingInstructionRenderer implements IRenderer {
     renderingCtrl: IHydratableController,
     target: HTMLElement,
     instruction: DispatchBindingInstruction,
+    platform: IPlatform,
+    exprParser: IExpressionParser,
   ): void {
-    const expr = ensureExpression(this._exprParser, instruction.ast, ExpressionType.IsProperty);
+    const expr = ensureExpression(exprParser, instruction.ast, ExpressionType.IsProperty);
     renderingCtrl.addBinding(new StateDispatchBinding(
       renderingCtrl.container,
       expr,

--- a/packages/state/src/state-utilities.ts
+++ b/packages/state/src/state-utilities.ts
@@ -1,16 +1,13 @@
-import { Constructable } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { type SubscribableValue } from './interfaces';
 
+/** @internal */
 export function createStateBindingScope(state: object, scope: Scope) {
   const overrideContext = { bindingContext: state };
   const stateScope = Scope.create(state, overrideContext, true);
   stateScope.parent = scope;
   return stateScope;
 }
-
-/** @internal */
-export const defProto = (klass: Constructable, prop: PropertyKey, desc: PropertyDescriptor) => Reflect.defineProperty(klass.prototype, prop, desc);
 
 /** @internal */
 export const isPromise = <T>(v: unknown): v is Promise<T> => v instanceof Promise;

--- a/packages/state/src/store.ts
+++ b/packages/state/src/store.ts
@@ -120,7 +120,7 @@ class StateProxyHandler<T extends object> implements ProxyHandler<T> {
 
 /* eslint-disable */
 function typingsTest() {
-  let store: IStore<{ a: number }, { type: 'edit'; value: string } | { type: 'clear' }> = null!;
+  const store = {} as unknown as IStore<{ a: number }, { type: 'edit'; value: string } | { type: 'clear' }>;
 
   store.dispatch({ type: 'clear' });
   // @ts-expect-error

--- a/packages/state/src/store.ts
+++ b/packages/state/src/store.ts
@@ -62,59 +62,6 @@ export class Store<T extends object, TAction = unknown> implements IStore<T> {
     }
 
     this._dispatching++;
-    // const dispatch = ($actionType: unknown, $params: any[]): void | Promise<void> => {
-    //   const $$reducer = this._reducers;
-    //   if ($$reducer.length === 0) {
-    //     if (__DEV__) {
-    //       this._logger.warn(`No reducers registered.`);
-    //     }
-    //     return;
-    //   }
-
-    //   let newState: T | Promise<T> | undefined = void 0;
-    //   try {
-    //     newState = $$reducer(this._state, $actionType, ...$params);
-    //   } catch (ex) {
-    //     this._publishing--;
-    //     throw ex;
-    //   }
-
-    //   if (newState instanceof Promise) {
-    //     return newState.then(s => {
-    //       this._setState(s);
-
-    //       return afterDispatch();
-    //     }).then(() => {
-    //       this._publishing--;
-    //     }, ex => {
-    //       this._publishing--;
-    //       throw ex;
-    //     });
-    //   } else {
-    //     this._setState(newState);
-
-    //     const res = afterDispatch();
-    //     if (res instanceof Promise) {
-    //       return res.then(() => {
-    //         this._publishing--;
-    //       }, ex => {
-    //         this._publishing--;
-    //         throw ex;
-    //       });
-    //     } else {
-    //       this._publishing--;
-    //     }
-    //   }
-    // };
-
-    // const afterDispatch = (): void | Promise<void> => {
-    //   if (this._dispatchQueues.length > 0) {
-    //     const queuedItem = this._dispatchQueues.shift()!;
-    //     return dispatch(queuedItem.action, queuedItem.params);
-    //   }
-    // };
-
-    // return dispatch(action, params);
 
     let $$action: TAction;
     const reduce = ($state: T | Promise<T>, $action: unknown) =>
@@ -178,6 +125,8 @@ function typingsTest() {
   store.dispatch({ type: 'clear' });
   // @ts-expect-error
   store.dispatch({ type: 'edit' });
+  // @ts-expect-error
+  store.dispatch({ type: 'edit', value: 5 });
   // @ts-expect-error
   store.dispatch({ type: 'hello' });
 }


### PR DESCRIPTION
resolves #1608

At the moment, actions and action handlers are in the form of type & parameters spread across multiple parameters/shapes. This creates difficulties when applications want to enforce/enable typings & intellisense on dispatch call. The reason for the current way is because we tried to stay close to v1 store, but now it's no longer necessary.

Change action handler to accept only 2 parameters: `state` and `action`. `action` can be any value now, and it's entirely up to action handler to deal with that. `dispatch` call also got modified so that it can be dispatched with any action, letting applications dictate the convention they want.

Thanks @rmja