### PR TITLE
fix(proxy-observation): prevent proxies from being wrapped in proxies again

### DIFF
--- a/packages/__tests__/2-runtime/proxy-observable.spec.ts
+++ b/packages/__tests__/2-runtime/proxy-observable.spec.ts
@@ -31,6 +31,26 @@ describe('2-runtime/proxy-observable.spec.ts', function () {
     });
   }
 
+  it('does not rewrap a wrapped object', function () {
+    const proxied = ProxyObservable.wrap({});
+    assert.strictEqual(ProxyObservable.wrap(proxied), proxied);
+  });
+
+  it('does not rewrap a wrapped array', function () {
+    const proxied = ProxyObservable.wrap([]);
+    assert.strictEqual(ProxyObservable.wrap(proxied), proxied);
+  });
+
+  it('does not rewrap a wrapped map', function () {
+    const proxied = ProxyObservable.wrap(new Map());
+    assert.strictEqual(ProxyObservable.wrap(proxied), proxied);
+  });
+
+  it('does not rewrap a wrapped set', function () {
+    const proxied = ProxyObservable.wrap(new Set());
+    assert.strictEqual(ProxyObservable.wrap(proxied), proxied);
+  });
+
   it('does not wrap object that has been marked as "nowrap"', function () {
     @nowrap
     class MyModel { }

--- a/packages/runtime/src/observation/proxy-observation.ts
+++ b/packages/runtime/src/observation/proxy-observation.ts
@@ -75,6 +75,7 @@ function createProxy<T extends object>(obj: T): T {
 
   const proxiedObj = new Proxy(obj, handler);
   proxyMap.set(obj, proxiedObj);
+  proxyMap.set(proxiedObj, proxiedObj);
 
   return proxiedObj as T;
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

If you pass in a property that's part of a computed observation structure into another class, the value is already wrapped in a proxy before that property is observed in the new class. If that new class then also uses computed observation, that property will be wrapped in a proxy again, causing a "proxy within a proxy". This can repeat itself endlessly, causing all sorts of issues.

Simply adding the proxy itself as the key to the `proxyMap` will solve that problem at least as far as the issue in our app is concerned.

cc @bigopon 

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
