### PR TITLE
refactor(children): make children observation a binding

### DIFF
--- a/examples/helloworld/rollup.config.js
+++ b/examples/helloworld/rollup.config.js
@@ -1,5 +1,5 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve';
-import { terser } from '@rollup/plugin-terser';
+import terser from '@rollup/plugin-terser';
 
 /** @type {import('rollup').RollupOptions} */
 export default {

--- a/packages/__tests__/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/children-observer.spec.ts
@@ -147,7 +147,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
     it('updates subscribers', async function () {
       @customElement({
         name: 'e-l',
-        template: 'child count: ${nodes.length}<au-slot>',
+        template: 'child count: ${nodes.length}',
         shadowOptions: { mode: 'open' }
       })
       class El {

--- a/packages/__tests__/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/children-observer.spec.ts
@@ -143,6 +143,28 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
       au.dispose();
     });
+
+    it('updates subscribers', async function () {
+      @customElement({
+        name: 'e-l',
+        template: 'child count: ${nodes.length}<au-slot>',
+        shadowOptions: { mode: 'open' }
+      })
+      class El {
+        @children('div') nodes: any[];
+      }
+      const { assertText } = createFixture(
+        '<e-l ref=el><div repeat.for="i of items">',
+        class App {
+          items = 3;
+        },
+        [El]
+      );
+
+      await new Promise(r => setTimeout(r, 50));
+
+      assertText('child count: 3');
+    });
   });
 
   function createAppAndStart(childrenOptions?: PartialChildrenDefinition) {

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -678,7 +678,6 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
     cache: 0,
     dependencies: [],
     bindables: {},
-    childrenObservers: {},
     containerless: false,
     injectable: null,
     isStrictBinding: false,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -682,7 +682,7 @@ export {
   // DefaultComponents as RuntimeHtmlDefaultComponents,
 
   // CompiledTemplate,
-  // ChildrenObserver,
+  ChildrenBinding,
   // IRenderer,
   // IInstructionTypeClassifier,
   // IRenderingEngine,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -499,8 +499,7 @@ export {
   Bindable,
   coercer,
 
-  // PartialChildrenDefinition,
-  // ChildrenDefinition,
+  PartialChildrenDefinition,
   // Children,
   children,
 

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -39,6 +39,7 @@ export class Aurelia implements IDisposable {
     if (this._root == null) {
       if (this.next == null) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0767: root is not defined`);
         else
           throw createError(`AUR0767`);
@@ -58,6 +59,7 @@ export class Aurelia implements IDisposable {
   ) {
     if (container.has(IAurelia, true)) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0768: An instance of Aurelia is already registered with the container or an ancestor of it.`);
       else
         throw createError(`AUR0768`);
@@ -129,6 +131,7 @@ export class Aurelia implements IDisposable {
     if (!this.container.has(IPlatform, false)) {
       if (host.ownerDocument.defaultView === null) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0769: Failed to initialize the platform object. The host element's ownerDocument does not have a defaultView`);
         else
           throw createError(`AUR0769`);
@@ -197,6 +200,7 @@ export class Aurelia implements IDisposable {
   public dispose(): void {
     if (this._isRunning || this._isStopping) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0771: The aurelia instance must be fully stopped before it can be disposed`);
       else
         throw createError(`AUR0771`);

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -21,7 +21,7 @@ import type {
   IsExpression, Scope
 } from '@aurelia/runtime';
 import type { IPlatform } from '../platform';
-import { isArray } from '../utilities';
+import { isArray, safeString } from '../utilities';
 import type { IBindingController } from './interfaces-bindings';
 
 const queueTaskOptions: QueueTaskOptions = {
@@ -346,7 +346,7 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
       target.textContent = '';
       target.parentNode?.insertBefore(value, target);
     } else {
-      target.textContent = String(value);
+      target.textContent = safeString(value);
     }
   }
 

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -387,8 +387,6 @@ export {
 
 export {
   type PartialChildrenDefinition,
-  ChildrenDefinition,
-  Children,
   children,
   ChildrenObserver,
 } from './templating/children';

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -388,7 +388,7 @@ export {
 export {
   type PartialChildrenDefinition,
   children,
-  ChildrenObserver,
+  ChildrenBinding,
 } from './templating/children';
 
 // These exports are temporary until we have a proper way to unit test them

--- a/packages/runtime-html/src/observation/element-attribute-observer.ts
+++ b/packages/runtime-html/src/observation/element-attribute-observer.ts
@@ -1,5 +1,5 @@
 import { subscriberCollection, AccessorType } from '@aurelia/runtime';
-import { createError, isString } from '../utilities';
+import { createError, isString, safeString } from '../utilities';
 
 import type {
   IObserver,
@@ -100,7 +100,7 @@ export class AttributeObserver implements AttributeObserver, ElementMutationSubs
           if (this._value == null) {
             this._obj.removeAttribute(this._attr);
           } else {
-            this._obj.setAttribute(this._attr, String(this._value));
+            this._obj.setAttribute(this._attr, safeString(this._value));
           }
         }
       }

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -17,7 +17,7 @@ import { SelectValueObserver } from './select-value-observer';
 import { StyleAttributeAccessor } from './style-attribute-accessor';
 import { ISVGAnalyzer } from './svg-analyzer';
 import { ValueAttributeObserver } from './value-attribute-observer';
-import { createError, createLookup, isDataAttribute, isString, objectAssign } from '../utilities';
+import { createError, createLookup, isDataAttribute, isString, objectAssign, safeString } from '../utilities';
 import { aliasRegistration, singletonRegistration } from '../utilities-di';
 
 import type { IIndexable, IContainer } from '@aurelia/kernel';
@@ -348,9 +348,10 @@ export class NodeObserverLocator implements INodeObserverLocator {
       // consider:
       // - maybe add a adapter API to handle unknown obj/key combo
       if (__DEV__)
-        throw createError(`AUR0652: Unable to observe property ${String(key)}. Register observation mapping with .useConfig().`);
+        /* istanbul ignore next */
+        throw createError(`AUR0652: Unable to observe property ${safeString(key)}. Register observation mapping with .useConfig().`);
       else
-        throw createError(`AUR0652:${String(key)}`);
+        throw createError(`AUR0652:${safeString(key)}`);
     } else {
       // todo: probably still needs to get the property descriptor via getOwnPropertyDescriptor
       // but let's start with simplest scenario
@@ -373,7 +374,8 @@ export function getCollectionObserver(collection: unknown, observerLocator: IObs
 
 function throwMappingExisted(nodeName: string, key: PropertyKey): never {
   if (__DEV__)
-    throw createError(`AUR0653: Mapping for property ${String(key)} of <${nodeName} /> already exists`);
+    /* istanbul ignore next */
+    throw createError(`AUR0653: Mapping for property ${safeString(key)} of <${nodeName} /> already exists`);
   else
-    throw createError(`AUR0653:${String(key)}@${nodeName}`);
+    throw createError(`AUR0653:${safeString(key)}@${nodeName}`);
 }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -418,6 +418,7 @@ function getRefTarget(refHost: INode, refTargetName: string): object {
     case 'view':
       // todo: returns node sequences for fun?
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0750: Not supported API`);
       else
         throw createError(`AUR0750`);
@@ -432,6 +433,7 @@ function getRefTarget(refHost: INode, refTargetName: string): object {
       const ceController = findElementControllerFor(refHost, { name: refTargetName });
       if (ceController === void 0) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0751: Attempted to reference "${refTargetName}", but it was not found amongst the target's API.`);
         else
           throw createError(`AUR0751:${refTargetName}`);
@@ -579,6 +581,7 @@ export class CustomAttributeRenderer implements IRenderer {
         def = ctxContainer.find(CustomAttribute, instruction.res);
         if (def == null) {
           if (__DEV__)
+            /* istanbul ignore next */
             throw createError(`AUR0753: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
           else
             throw createError(`AUR0753:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
@@ -657,6 +660,7 @@ export class TemplateControllerRenderer implements IRenderer {
         def = ctxContainer.find(CustomAttribute, instruction.res);
         if (def == null) {
           if (__DEV__)
+            /* istanbul ignore next */
             throw createError(`AUR0754: Attribute ${instruction.res} is not registered in ${(renderingCtrl as Controller)['name']}.`);
           else
             throw createError(`AUR0754:${instruction.res}@${(renderingCtrl as Controller)['name']}`);
@@ -1253,12 +1257,14 @@ class ViewFactoryProvider implements IResolver {
     const f = this.f;
     if (f === null) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR7055: Cannot resolve ViewFactory before the provider was prepared.`);
       else
         throw createError(`AUR7055`);
     }
     if (!isString(f.name) || f.name.length === 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0756: Cannot resolve ViewFactory without a (valid) name.`);
       else
         throw createError(`AUR0756`);

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -95,6 +95,7 @@ export const BindingBehavior = objectFreeze<BindingBehaviorKind>({
     const def = getOwnMetadata(bbBaseName, Type) as BindingBehaviorDefinition<T>;
     if (def === void 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0151: No definition found for type ${Type.name}`);
       else
         throw createError(`AUR0151:${Type.name}`);

--- a/packages/runtime-html/src/resources/binding-behaviors/attr.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/attr.ts
@@ -10,6 +10,7 @@ export class AttrBindingBehavior implements BindingBehaviorInstance {
   public bind(_scope: Scope, binding: IBinding): void {
     if (!(binding instanceof PropertyBinding)) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AURxxxx: & attr can be only used on property binding. It's used on ${binding.constructor.name}`);
       else
         throw createError(`AURxxxx`);

--- a/packages/runtime-html/src/resources/binding-behaviors/self.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/self.ts
@@ -8,6 +8,7 @@ export class SelfBindingBehavior implements BindingBehaviorInstance {
   public bind(_scope: Scope, binding: ListenerBinding): void {
     if (!(binding instanceof ListenerBinding)) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0801: Self binding behavior only supports listener binding via trigger/capture command.`);
       else
         throw createError(`AUR0801`);

--- a/packages/runtime-html/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/signals.ts
@@ -18,12 +18,14 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
   public bind(scope: Scope, binding: IConnectableBinding, ...names: string[]): void {
     if (!('handleChange' in binding)) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0817: The signal behavior can only be used with bindings that have a "handleChange" method`);
       else
         throw createError(`AUR0817`);
     }
     if (names.length === 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0818: At least one signal name must be passed to the signal behavior, e.g. "expr & signal:'my-signal'"`);
       else
         throw createError(`AUR0818`);

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -151,20 +151,6 @@ export const BindingCommand = objectFreeze<BindingCommandKind>({
 
     return definition.Type as BindingCommandType<T>;
   },
-  // getDefinition<T extends Constructable>(Type: T): BindingCommandDefinition<T> {
-  //   const def = getOwnMetadata(cmdBaseName, Type);
-  //   if (def === void 0) {
-  //     if (__DEV__)
-  //       throw createError(`AUR0758: No definition found for type ${Type.name}`);
-  //     else
-  //       throw createError(`AUR0758:${Type.name}`);
-  //   }
-
-  //   return def;
-  // },
-  // annotate<K extends keyof PartialBindingCommandDefinition>(Type: Constructable, prop: K, value: PartialBindingCommandDefinition[K]): void {
-  //   defineMetadata(getAnnotationKeyFor(prop), value, Type);
-  // },
   getAnnotation: getCommandAnnotation,
 });
 

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -185,6 +185,7 @@ export const getAttributeDefinition = <T extends Constructable>(Type: T | Functi
   const def = getOwnMetadata(caBaseName, Type) as CustomAttributeDefinition<T>;
   if (def === void 0) {
     if (__DEV__)
+      /* istanbul ignore next */
       throw createError(`No definition found for type ${Type.name}`);
     else
       throw createError(`AUR0759:${Type.name}`);

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -73,7 +73,7 @@ export class Focus implements ICustomAttributeViewModel {
   /**
    * Invoked when the attribute is afterDetachChildren from the DOM.
    */
-  public afterDetachChildren(): void {
+  public detaching(): void {
     const el = this._element;
     el.removeEventListener('focus', this);
     el.removeEventListener('blur', this);
@@ -102,6 +102,8 @@ export class Focus implements ICustomAttributeViewModel {
 
   /**
    * Focus/blur based on current value
+   *
+   * @internal
    */
   private _apply(): void {
     const el = this._element;
@@ -116,7 +118,8 @@ export class Focus implements ICustomAttributeViewModel {
     }
   }
 
-  /** @internal */ private get _isElFocused(): boolean {
+  /** @internal */
+  private get _isElFocused(): boolean {
     return this._element === this._platform.document.activeElement;
   }
 }

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -262,6 +262,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       const def = nameOrDef;
       if (isString(def)) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0761: Cannot create a custom element definition with only a name and no type: ${nameOrDef}`);
         else
           throw createError(`AUR0761:${nameOrDef}`);
@@ -461,6 +462,7 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
         return null!;
       }
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0762: The provided node is not a custom element or containerless host.`);
       else
         throw createError(`AUR0762`);
@@ -472,6 +474,7 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
       const controller = getRef(node, elementBaseName) as Controller<C> | null;
       if (controller === null) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0763: The provided node is not a custom element or containerless host.`);
         else
           throw createError(`AUR0763`);
@@ -503,6 +506,7 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
     }
 
     if (__DEV__)
+      /* istanbul ignore next */
       throw createError(`AUR0764: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
     else
       throw createError(`AUR0764`);
@@ -519,6 +523,7 @@ export const findElementControllerFor = <C extends ICustomElementViewModel = ICu
   }
 
   if (__DEV__)
+    /* istanbul ignore next */
     throw createError(`AUR0765: The provided node does does not appear to be part of an Aurelia app DOM tree, or it was added to the DOM in a way that Aurelia cannot properly resolve its position in the component tree.`);
   else
     throw createError(`AUR0765`);
@@ -647,6 +652,7 @@ function ensureHook<TClass>(target: Constructable<TClass>, hook: string | Proces
 
   if (!isFunction(hook)) {
     if (__DEV__)
+      /* istanbul ignore next */
       throw createError(`AUR0766: Invalid @processContent hook. Expected the hook to be a function (when defined in a class, it needs to be a static function) but got a ${typeof hook}.`);
     else
       throw createError(`AUR0766:${typeof hook}`);

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -9,7 +9,6 @@ import {
 } from '@aurelia/kernel';
 import { Bindable } from '../bindable';
 import { getEffectiveParentNode, getRef } from '../dom';
-import { Children } from '../templating/children';
 import { Watch } from '../watch';
 import { DefinitionType } from './resources-shared';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
@@ -30,7 +29,6 @@ import type {
 } from '@aurelia/kernel';
 import type { BindableDefinition, PartialBindableDefinition } from '../bindable';
 import type { INode } from '../dom';
-import type { PartialChildrenDefinition, ChildrenDefinition } from '../templating/children';
 import type { Controller, ICustomElementViewModel, ICustomElementController } from '../templating/controller';
 import type { IPlatform } from '../platform';
 import type { IInstruction } from '../renderer';
@@ -52,7 +50,6 @@ export type PartialCustomElementDefinition = PartialResourceDefinition<{
   readonly needsCompile?: boolean;
   readonly surrogates?: readonly IInstruction[];
   readonly bindables?: Record<string, PartialBindableDefinition> | readonly string[];
-  readonly childrenObservers?: Record<string, PartialChildrenDefinition>;
   readonly containerless?: boolean;
   readonly isStrictBinding?: boolean;
   readonly shadowOptions?: { mode: 'open' | 'closed' } | null;
@@ -233,7 +230,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly needsCompile: boolean,
     public readonly surrogates: readonly IInstruction[],
     public readonly bindables: Record<string, BindableDefinition>,
-    public readonly childrenObservers: Record<string, ChildrenDefinition>,
     public readonly containerless: boolean,
     public readonly isStrictBinding: boolean,
     public readonly shadowOptions: { mode: 'open' | 'closed' } | null,
@@ -296,7 +292,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         fromDefinitionOrDefault('needsCompile', def, returnTrue),
         mergeArrays(def.surrogates),
         Bindable.from(Type, def.bindables),
-        Children.from(def.childrenObservers),
         fromDefinitionOrDefault('containerless', def, returnFalse),
         fromDefinitionOrDefault('isStrictBinding', def, returnFalse),
         fromDefinitionOrDefault('shadowOptions', def, returnNull),
@@ -329,11 +324,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
           ...Bindable.getAll(Type),
           getElementAnnotation(Type, 'bindables'),
           Type.bindables,
-        ),
-        Children.from(
-          ...Children.getAll(Type),
-          getElementAnnotation(Type, 'childrenObservers'),
-          Type.childrenObservers,
         ),
         fromAnnotationOrTypeOrDefault('containerless', Type, returnFalse),
         fromAnnotationOrTypeOrDefault('isStrictBinding', Type, returnFalse),
@@ -371,12 +361,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         Type.bindables,
         nameOrDef.bindables,
       ),
-      Children.from(
-        ...Children.getAll(Type),
-        getElementAnnotation(Type, 'childrenObservers'),
-        Type.childrenObservers,
-        nameOrDef.childrenObservers,
-      ),
       fromAnnotationOrDefinitionOrTypeOrDefault('containerless', nameOrDef, Type, returnFalse),
       fromAnnotationOrDefinitionOrTypeOrDefault('isStrictBinding', nameOrDef, Type, returnFalse),
       fromAnnotationOrDefinitionOrTypeOrDefault('shadowOptions', nameOrDef, Type, returnNull),
@@ -413,7 +397,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 export type InjectableToken<K = any> = (target: Injectable, property: string | symbol | undefined, index: number) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type InternalInjectableToken<K = any> = InjectableToken<K> & {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -60,6 +60,7 @@ export class AuCompose {
         return v;
       }
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0805: Invalid scope behavior config. Only "scoped" or "auto" allowed.`);
       else
         throw createError(`AUR0805`);
@@ -204,6 +205,7 @@ export class AuCompose {
     if (vmDef !== null) {
       if (vmDef.containerless) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0806: Containerless custom element is not supported by <au-compose/>`);
         else
           throw createError(`AUR0806`);
@@ -425,6 +427,7 @@ class CompositionController implements ICompositionController {
   public activate(initiator?: IHydratedController) {
     if (this.state !== 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0807: Composition has already been activated/deactivated. Id: ${this.controller.name}`);
       else
         throw createError(`AUR0807:${this.controller.name}`);
@@ -440,6 +443,7 @@ class CompositionController implements ICompositionController {
         return this.stop(detachInitator);
       case -1:
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0808: Composition has already been deactivated.`);
         else
           throw createError(`AUR0808`);

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -201,6 +201,7 @@ export class Else implements ICustomAttributeViewModel {
       ifBehavior.viewModel.elseFactory = this._factory;
     } else {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0810: Unsupported If behavior`);
       else
         throw createError(`AUR0810`);

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -254,6 +254,7 @@ export class Portal implements ICustomAttributeViewModel {
     if (target == null) {
       if (this.strict) {
         if (__DEV__)
+          /* istanbul ignore next */
           throw createError(`AUR0812: Portal target not found`);
         else
           throw createError(`AUR0812`);

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -18,7 +18,7 @@ import {
 import { IViewFactory } from '../../templating/view';
 import { attributePattern, AttrSyntax } from '../attribute-pattern';
 import { templateController } from '../custom-attribute';
-import { createError, isPromise } from '../../utilities';
+import { createError, isPromise, safeString } from '../../utilities';
 
 @templateController('promise')
 export class PromiseTemplateController implements ICustomAttributeViewModel {
@@ -74,7 +74,8 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
   private swap(initiator: IHydratedController | null): void {
     const value = this.value;
     if (!isPromise(value)) {
-      this.logger.warn(`The value '${String(value)}' is not a promise. No change will be done.`);
+      /* istanbul ignore next */
+      this.logger.warn(`The value '${safeString(value)}' is not a promise. No change will be done.`);
       return;
     }
     const q = this._platform.domWriteQueue;

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -88,6 +88,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
           this.key = parser.parse(value, ExpressionType.IsProperty);
         } else {
           if (__DEV__) {
+            /* istanbul ignore next */
             throw createError(`AUR775:invalid command ${command}`);
           } else {
             throw createError(`AUR775:${command}`);
@@ -95,6 +96,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
         }
       } else {
         if (__DEV__) {
+          /* istanbul ignore next */
           throw createError(`AUR776:invalid target ${to}`);
         } else {
           throw createError(`AUR776:${to}`);

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -285,6 +285,7 @@ export class Case implements ICustomAttributeViewModel {
       this.linkToSwitch($switch);
     } else {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0815: The parent switch not found; only "*[switch] > *[case|default-case]" relation is supported.`);
       else
         throw createError(`AUR0815`);
@@ -367,6 +368,7 @@ export class DefaultCase extends Case {
   protected linkToSwitch($switch: Switch): void {
     if ($switch.defaultCase !== void 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0816: Multiple 'default-case's are not allowed.`);
       else
         throw createError(`AUR0816`);

--- a/packages/runtime-html/src/resources/value-converter.ts
+++ b/packages/runtime-html/src/resources/value-converter.ts
@@ -104,6 +104,7 @@ export const ValueConverter = objectFreeze<ValueConverterKind>({
     const def = getOwnMetadata(vcBaseName, Type);
     if (def === void 0) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0152: No definition found for type ${Type.name}`);
       else
         throw createError(`AUR0152:${Type.name}`);

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -2,7 +2,7 @@ import { emptyArray, IContainer, IServiceLocator, IDisposable, Key } from '@aure
 import { IBinding, subscriberCollection } from '@aurelia/runtime';
 import { CustomElement, findElementControllerFor } from '../resources/custom-element';
 import { ILifecycleHooks, lifecycleHooks } from './lifecycle-hooks';
-import { createError, def, isString, objectAssign } from '../utilities';
+import { createError, def, isString, objectAssign, safeString } from '../utilities';
 import { instanceRegistration } from '../utilities-di';
 import { type ICustomElementViewModel, type ICustomElementController } from './controller';
 
@@ -280,7 +280,7 @@ class ChildrenLifecycleHooks {
       controller,
       controller.viewModel,
       def.name,
-      def.callback ?? `${String(def.name)}Changed`,
+      def.callback ?? `${safeString(def.name)}Changed`,
       def.query ?? defaultChildQuery,
       def.filter ?? defaultChildFilter,
       def.map ?? defaultChildMap,

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -23,7 +23,7 @@ import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles';
 import { ComputedWatcher, ExpressionWatcher } from './watchers';
 import { LifecycleHooks, LifecycleHooksEntry } from './lifecycle-hooks';
 import { IRendering } from './rendering';
-import { createError, getOwnPropertyNames, isFunction, isPromise, isString } from '../utilities';
+import { createError, getOwnPropertyNames, isFunction, isPromise, isString, safeString } from '../utilities';
 import { isObject } from '@aurelia/metadata';
 import { createInterface, registerResolver } from '../utilities-di';
 // import { SlotWatcher } from './controller.projection';
@@ -1293,9 +1293,10 @@ function createWatchers(
       : Reflect.get(instance, callback) as IWatcherCallback<object>;
     if (!isFunction(callback)) {
       if (__DEV__)
-        throw createError(`AUR0506: Invalid callback for @watch decorator: ${String(callback)}`);
+        /* istanbul ignore next */
+        throw createError(`AUR0506: Invalid callback for @watch decorator: ${safeString(callback)}`);
       else
-        throw createError(`AUR0506:${String(callback)}`);
+        throw createError(`AUR0506:${safeString(callback)}`);
     }
     if (isFunction(expression)) {
       controller.addBinding(new ComputedWatcher(

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -18,7 +18,6 @@ import { BindableObserver } from '../observation/bindable-observer';
 import { convertToRenderLocation, setRef } from '../dom';
 import { CustomElementDefinition, getElementDefinition, elementBaseName, isElementType, findElementControllerFor } from '../resources/custom-element';
 import { CustomAttributeDefinition, getAttributeDefinition } from '../resources/custom-attribute';
-// import { ChildrenObserver } from './children';
 import { IPlatform } from '../platform';
 import { IShadowDOMGlobalStyles, IShadowDOMStyles } from './styles';
 import { ComputedWatcher, ExpressionWatcher } from './watchers';
@@ -131,8 +130,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   private debug!: boolean;
   /** @internal */
   private _fullyNamed: boolean = false;
-  // /** @internal */
-  // private _childrenObs: ChildrenObserver[] = emptyArray;
   /** @internal */
   private readonly _rendering: IRendering;
 

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -369,7 +369,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       createWatchers(this, container, definition, instance);
     }
     createObservers(this, definition, instance);
-    // this._childrenObs = createChildrenObservers(this as Controller, definition, instance);
 
     if (this._hooks.hasDefine) {
       if (__DEV__ && this.debug) { this.logger.trace(`invoking define() hook`); }
@@ -1260,44 +1259,6 @@ function createObservers(
     }
   }
 }
-
-// function createChildrenObservers(
-//   controller: Controller,
-//   definition: CustomElementDefinition,
-//   instance: object,
-// ): ChildrenObserver[] {
-//   const childrenObservers = definition.childrenObservers;
-//   const childObserverNames = getOwnPropertyNames(childrenObservers);
-//   const length = childObserverNames.length;
-//   if (length > 0) {
-//     const observers = getLookup(instance as IIndexable);
-//     const obs: ChildrenObserver[] = [];
-
-//     let name: string;
-//     let i = 0;
-//     let childrenDescription: ChildrenDefinition;
-//     for (; i < length; ++i) {
-//       name = childObserverNames[i];
-
-//       if (observers[name] == null) {
-//         childrenDescription = childrenObservers[name];
-//         obs[obs.length] = observers[name] = new ChildrenObserver(
-//           controller as ICustomElementController,
-//           instance as IIndexable,
-//           name,
-//           childrenDescription.callback,
-//           childrenDescription.query,
-//           childrenDescription.filter,
-//           childrenDescription.map,
-//           childrenDescription.options,
-//         );
-//       }
-//     }
-//     return obs;
-//   }
-
-//   return emptyArray as ChildrenObserver[];
-// }
 
 const AccessScopeAstMap = new Map<PropertyKey, AccessScopeExpression>();
 const getAccessScopeAst = (key: PropertyKey) => {

--- a/packages/runtime-html/src/templating/lifecycle-hooks.ts
+++ b/packages/runtime-html/src/templating/lifecycle-hooks.ts
@@ -1,7 +1,8 @@
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata } from '../utilities-metadata';
 import { createInterface, singletonRegistration } from '../utilities-di';
-import type { Constructable, IContainer, AnyFunction, FunctionPropNames } from '@aurelia/kernel';
 import { getOwnPropertyNames, objectFreeze, baseObjectPrototype } from '../utilities';
+
+import type { Constructable, IContainer, AnyFunction, FunctionPropNames } from '@aurelia/kernel';
 
 export type LifecycleHook<TViewModel, TKey extends keyof TViewModel> =
   TViewModel[TKey] extends (AnyFunction | undefined)
@@ -41,7 +42,7 @@ export class LifecycleHooksDefinition<T extends Constructable = Constructable> {
     while (proto !== baseObjectPrototype) {
       for (const name of getOwnPropertyNames(proto)) {
         // This is the only check we will do for now. Filtering on e.g. function types might not always work properly when decorators come into play. This would need more testing first.
-        if (name !== 'constructor') {
+        if (name !== 'constructor' && !name.startsWith('_')) {
           propertyNames.add(name);
         }
       }

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -131,6 +131,7 @@ export class Rendering {
     const ii = targets.length;
     if (targets.length !== rows.length) {
       if (__DEV__)
+        /* istanbul ignore next */
         throw createError(`AUR0757: The compiled template is not aligned with the render instructions. There are ${ii} targets and ${rows.length} instructions.`);
       else
         throw createError(`AUR0757:${ii}<>${rows.length}`);

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -2,6 +2,8 @@ import type { ISVGAnalyzer } from './observation/svg-analyzer';
 
 const O = Object;
 
+/** @internal */ export const safeString = String;
+
 /** @internal */ export const baseObjectPrototype = O.prototype;
 
 /** @internal */ export const createLookup = <T = unknown>() => O.create(null) as Record<string, T>;

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -3,7 +3,7 @@ import { emptyArray } from '@aurelia/kernel';
 import { getAttributeDefinition, isAttributeType } from './resources/custom-attribute';
 import { getElementDefinition, isElementType } from './resources/custom-element';
 import { defineMetadata, getAnnotationKeyFor, getOwnMetadata } from './utilities-metadata';
-import { createError, isFunction, objectFreeze } from './utilities';
+import { createError, isFunction, objectFreeze, safeString } from './utilities';
 
 import type { Constructable } from '@aurelia/kernel';
 import type { IConnectable } from '@aurelia/runtime';
@@ -84,15 +84,17 @@ export function watch<T extends object = object>(
         && (changeHandlerOrCallback == null || !(changeHandlerOrCallback in Type.prototype))
       ) {
         if (__DEV__)
-          throw createError(`AUR0773: Invalid change handler config. Method "${String(changeHandlerOrCallback)}" not found in class ${Type.name}`);
+          /* istanbul ignore next */
+          throw createError(`AUR0773: Invalid change handler config. Method "${safeString(changeHandlerOrCallback)}" not found in class ${Type.name}`);
         else
-          throw createError(`AUR0773:${String(changeHandlerOrCallback)}@${Type.name}}`);
+          throw createError(`AUR0773:${safeString(changeHandlerOrCallback)}@${Type.name}}`);
       }
     } else if (!isFunction(descriptor?.value)) {
       if (__DEV__)
-        throw createError(`AUR0774: decorated target ${String(key)} is not a class method.`);
+        /* istanbul ignore next */
+        throw createError(`AUR0774: decorated target ${safeString(key)} is not a class method.`);
       else
-        throw createError(`AUR0774:${String(key)}`);
+        throw createError(`AUR0774:${safeString(key)}`);
     }
 
     Watch.add(Type, watchDef as IWatchDefinition);

--- a/packages/runtime/src/binding/expression-parser.ts
+++ b/packages/runtime/src/binding/expression-parser.ts
@@ -40,7 +40,7 @@ import {
   DestructuringAssignmentExpression as DAE,
   ArrowFunction,
 } from './ast';
-import { createError, createInterface, createLookup } from '../utilities-objects';
+import { createError, createInterface, createLookup, objectAssign } from '../utilities-objects';
 
 export interface IExpressionParser extends ExpressionParser {}
 export const IExpressionParser = createInterface<IExpressionParser>('IExpressionParser', x => x.singleton(ExpressionParser));
@@ -1828,7 +1828,7 @@ const TokenValues = [
   'of', '=>'
 ];
 
-const KeywordLookup: Record<string, Token> = Object.assign(Object.create(null), {
+const KeywordLookup: Record<string, Token> = objectAssign(Object.create(null), {
   true: Token.TrueKeyword,
   null: Token.NullKeyword,
   false: Token.FalseKeyword,

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -6,7 +6,7 @@ import { subscriberCollection } from './subscriber-collection';
 import { enterConnectable, exitConnectable } from './connectable-switcher';
 import { connectable } from '../binding/connectable';
 import { wrap, unwrap } from './proxy-observation';
-import { areEqual, createError, def, isFunction } from '../utilities-objects';
+import { areEqual, createError, def, isFunction, objectAssign } from '../utilities-objects';
 
 import type {
   ISubscriber,
@@ -36,12 +36,10 @@ export class ComputedObserver implements
     const getter = descriptor.get!;
     const setter = descriptor.set;
     const observer = new ComputedObserver(obj, getter, setter, useProxy, observerLocator);
-    const $get = ((/* Computed Observer */) => observer.getValue()) as ObservableGetter;
-    $get.getObserver = () => observer;
     def(obj, key, {
       enumerable: descriptor.enumerable,
       configurable: true,
-      get: $get,
+      get: objectAssign(((/* Computed Observer */) => observer.getValue()) as ObservableGetter, { getObserver: () => observer }),
       set: (/* Computed Observer */v) => {
         observer.setValue(v);
       },

--- a/packages/runtime/src/utilities-objects.ts
+++ b/packages/runtime/src/utilities-objects.ts
@@ -65,6 +65,7 @@ export function ensureProto<T extends object, K extends keyof T>(
   }
 }
 
+/** @internal */ export const objectAssign = Object.assign;
 // this is used inside template literal, since TS errs without String(...value)
 /** @internal */ export const safeString = String;
 /** @internal */ export const createInterface = DI.createInterface;

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -5,6 +5,7 @@ import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, Custom
 import { assert } from './assert';
 import { hJsx } from './h';
 import { TestContext } from './test-context';
+import { getVisibleText } from './specialized-assertions';
 
 const fixtureHooks = new EventAggregator();
 export const onFixtureCreated = <T>(callback: (fixture: IFixture<T>) => unknown) => {
@@ -124,9 +125,9 @@ export function createFixture<T extends object>(
       if (el === null) {
         throw new Error(`No element found for selector "${selector}" to compare text content with "${text}"`);
       }
-      assert.strictEqual(el.textContent, text);
+      assert.strictEqual(getVisibleText(el), text);
     } else {
-      assert.strictEqual(host.textContent, selector);
+      assert.strictEqual(getVisibleText(host), selector);
     }
   }
   function getInnerHtml(el: Element, compact?: boolean) {

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -50,7 +50,7 @@ export function createFixture<T extends object>(
       } as unknown as Constructable<K>;
 
   const annotations: (Exclude<keyof CustomElementDefinition, 'Type' | 'key' | 'type' | 'register'>)[] =
-    ['aliases', 'bindables', 'cache', 'capture', 'childrenObservers', 'containerless', 'dependencies', 'enhance'];
+    ['aliases', 'bindables', 'cache', 'capture', 'containerless', 'dependencies', 'enhance'];
   if ($$class !== $class as any && $class != null) {
     annotations.forEach(anno => {
       Metadata.define(anno, CustomElement.getAnnotation($class as unknown as Constructable<K>, anno), $$class);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently children observation is treated slightly different: it's tracked in the element definition and initialized with different timing, as well start + stop calls. These treatments are unnecessary and can be made the same with standard bindings, via lifecycle hooks.

Also make `@children` work like v1 when the argument is a string: currently `@children('div')` means target the div property on the class, while in v1, it means query child `<div/>` element.

This work is part of `@slotted` and `<au-slot/>` feature, where we improve the infra structure around this feature. So if an application doesn't use `@children`, it won't have to pay the cost.

- some extra cleanup & coverage improvement.

## Next steps

- implement `@slotted` for `<au-slot/>`
- add documentation for `@children` and `@slotted`