### PR TITLE
feat(slotted): add slotted decorator WIP

### DIFF
--- a/docs/user-docs/components/shadow-dom-and-slots.md
+++ b/docs/user-docs/components/shadow-dom-and-slots.md
@@ -697,3 +697,40 @@ Having more than one `<au-slot>` with the same name is also supported. This lets
 {% endcode %}
 
 Note that projection for the name is provided once, but it gets duplicated in 2 slots. You can also see this example in action [here](https://stackblitz.com/edit/au-slot-duplicate-slots?file=my-app.html).
+
+## Listening to slot change
+
+### With `@slotted` decorator
+
+Similar like the standard `<slot>` element allows the ability to listen to changes in the content projected, `<au-slot>` also provides the capability to listen & react to changes.
+
+One way to subscribe to `au-slot` changes is via the `@slotted` decorator, like the following example:
+
+{% code title="app.html" %}
+```html
+<my-summary>
+  <p>This is a demo of the @slotted decorator</p>
+  <p>It can get all the "p" elements with a simple decorator</p>
+</my-summary>
+```
+{% endcode %}
+{% code title="my-summary.html" %}
+```html
+<p>Heading text</p>
+<div>
+  <au-slot></au-slot>
+</div>
+```
+{% endcode %}
+
+{% code title="my-summary.ts" %}
+```typescript
+import { slotted } from 'aurelia';
+
+export class MySummaryElement {
+  @slotted('p') paragraphs // assert paragraphs.length === 2
+}
+```
+{% endcode %}
+
+After rendering, the `MySummaryElement` instance will have paragraphs value as an array of 2 `<p>` element as seen in the `app.html`.

--- a/packages/__tests__/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/3-runtime-html/au-slot.slotted.spec.ts
@@ -1,0 +1,73 @@
+import { customElement, slotted } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
+  describe('intitial rendering', function () {
+    it('assigns value', async function () {
+      @customElement({
+        name: 'el',
+        template: '<au-slot>'
+      })
+      class El {
+        @slotted('div') divs;
+
+      }
+
+      const { component: { el } } = createFixture(
+        '<el view-model.ref=el><div></div><div></div>',
+        class App {
+          el: El;
+        },
+        [El,]
+      );
+
+      assert.strictEqual(el.divs.length, 2);
+    });
+
+    it('calls change handler', async function () {
+      let call = 0;
+      @customElement({
+        name: 'el',
+        template: '<au-slot>'
+      })
+      class El {
+        @slotted('div') divs;
+
+        divsChanged() {
+          call = 1;
+        }
+      }
+
+      createFixture(
+        '<el view-model.ref=el><div></div>',
+        class App { },
+        [El,]
+      );
+
+      assert.strictEqual(call, 1);
+    });
+
+    it('does not call change handler there are no matching nodes', function () {
+      let call = 0;
+      @customElement({
+        name: 'el',
+        template: '<au-slot>'
+      })
+      class El {
+        @slotted('div') divs;
+
+        divsChanged() {
+          call = 1;
+        }
+      }
+
+      createFixture(
+        '<el view-model.ref=el><input>',
+        class App { },
+        [El,]
+      );
+
+      assert.strictEqual(call, 0);
+    });
+  });
+});

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -673,6 +673,7 @@ export {
   // Compose,
   IAuSlotsInfo,
   AuSlotsInfo,
+  slotted,
 
   // IProjectorLocatorRegistration,
   // ITargetAccessorLocatorRegistration,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -280,7 +280,6 @@ export {
   AuSlot,
 } from './resources/custom-elements/au-slot';
 export {
-  IProjections,
   AuSlotsInfo,
   IAuSlotsInfo,
 } from './resources/slot-injectables';
@@ -420,6 +419,17 @@ export {
   type IHydratedCustomAttributeViewModel,
   type ISyntheticView,
 } from './templating/controller';
+export {
+  type IProjectionSubscriber,
+  IProjections,
+  type ISlot,
+  type ISlotSubscriber,
+  ISlotWatcher,
+  ISlotsInfo,
+  type PartialSlottedDefinition,
+  SlotsInfo,
+  slotted,
+} from './templating/controller.projection';
 export {
   ILifecycleHooks,
   LifecycleHooksEntry,

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -1,0 +1,240 @@
+import { type ICustomElementViewModel, type ICustomElementController, IHydrationContext } from './controller';
+import { CustomElement, type CustomElementDefinition } from '../resources/custom-element';
+import { createInterface, instanceRegistration, optionalOwn } from '../utilities-di';
+import { type IRateLimitOptions, type Scope, ISubscribable } from '@aurelia/runtime';
+import { Constructable, emptyArray, Key, type IContainer, type IDisposable, type IIndexable, type IServiceLocator } from '@aurelia/kernel';
+import { ILifecycleHooks, lifecycleHooks } from './lifecycle-hooks';
+import { def, objectAssign, safeString } from '../utilities';
+
+export type PartialSlottedDefinition = {
+  callback?: PropertyKey;
+  name?: PropertyKey;
+  slotName?: string;
+  query?: string;
+  // options?: MutationObserverInit;
+  // query?: (controller: ICustomElementController) => ArrayLike<Node>;
+  // filter?: (node: Node, controller?: ICustomElementController | null, viewModel?: ICustomElementViewModel) => boolean;
+  // map?: (node: Node, controller?: ICustomElementController | null, viewModel?: ICustomElementViewModel) => unknown;
+};
+
+export type IProjections = Record<string, CustomElementDefinition>;
+export const IProjections = createInterface<IProjections>("IProjections");
+
+export interface ISlotsInfo {
+  /**
+   * Name of the slots to which content are projected.
+   */
+  readonly projectedSlots: readonly string[];
+}
+export const ISlotsInfo = createInterface<ISlotsInfo>('ISlotsInfo');
+export class SlotsInfo implements ISlotsInfo {
+  public constructor(
+    public readonly projectedSlots: string[],
+  ) { }
+}
+
+export interface ISlot {
+  readonly name: string;
+  readonly nodes: readonly Node[];
+  subscribe(subscriber: ISlotSubscriber): void;
+  unsubscribe(subscriber: ISlotSubscriber): void;
+}
+
+export interface ISlotSubscriber {
+  handleSlotChange(slot: ISlot, nodes: Node[]): void;
+}
+
+export interface IProjectionSubscriber {
+  handleNodesChange(nodes: Node[]): void;
+}
+
+export interface ISlotWatcher {
+  watch(slot: ISlot): void;
+  unwatch(slot: ISlot): void;
+  subscribe(subscriber: IProjectionSubscriber): void;
+  unsubscribe(subscriber: IProjectionSubscriber): void;
+}
+export const ISlotWatcher = createInterface<ISlotWatcher>('ISlotWatcher');
+
+// 1. on hydrating, create a slot watcher (binding) & register with hydration context
+// 2. on slot with projection created, optionally retrieve the slot watcher
+//  2.a if there's NOT a watcher, do nothing
+//  2.b else register the slot
+
+// 1. au-slot should start listening to mutation when attaching
+// 2. au-slot should stop listening to mutation when detaching
+// 3. au-slot should notify slot watcher on mutation
+
+class SlotWatcherBinding implements ISlotWatcher, ISlotSubscriber, ISubscribable<IProjectionSubscriber> {
+
+  public static create(
+    controller: ICustomElementController,
+    name: PropertyKey,
+    callbackName: PropertyKey,
+    query: string,
+  ) {
+    const obj = controller.viewModel;
+    const slotWatcher = new SlotWatcherBinding(controller, obj, callbackName, query);
+    def(obj, name, {
+      enumerable: true,
+      configurable: true,
+      get: objectAssign((/* SlotWatcherBinding */) => slotWatcher.getValue(), { getObserver: () => slotWatcher }),
+      set: (/* SlotWatcherBinding */) => {/* nothing */}
+    });
+
+    return slotWatcher;
+  }
+
+  /** @internal */
+  private readonly _controller: ICustomElementController;
+  /** @internal */
+  private readonly _obj: ICustomElementViewModel;
+  /** @internal */
+  private readonly _callback: (nodes: readonly Node[]) => void;
+  /** @internal */
+  private readonly _query: string;
+  /** @internal */
+  private readonly _slots = new Set<ISlot>();
+  /** @internal */
+  private readonly _subs = new Set<IProjectionSubscriber>();
+
+  /** @internal */
+  private _nodes: Node[] = emptyArray;
+
+  public isBound: boolean = false;
+
+  public constructor(
+    controller: ICustomElementController,
+    obj: ICustomElementViewModel,
+    callback: PropertyKey,
+    query: string,
+  ) {
+    this._controller = controller;
+    this._callback = (this._obj = obj as IIndexable)[callback] as typeof SlotWatcherBinding.prototype._callback;
+    this._query = query;
+  }
+
+  public bind() {
+    this.isBound = true;
+  }
+
+  public unbind(): void {
+    this.isBound = false;
+  }
+
+  public getValue() {
+    return this._nodes;
+  }
+
+  public setValue() {
+    /* nothing */
+  }
+
+  public get(): ReturnType<IServiceLocator['get']> {
+    throw new Error('not implemented');
+  }
+
+  public watch(slot: ISlot): void {
+    if (!this._slots.has(slot)) {
+      this._slots.add(slot);
+      slot.subscribe(this);
+    }
+  }
+
+  public unwatch(slot: ISlot): void {
+    if (this._slots.delete(slot)) {
+      slot.unsubscribe(this);
+    }
+  }
+
+  public handleSlotChange(_slot: ISlot, _nodes: Node[]): void {
+    const $nodes: Node[] = [];
+    for (const $slot of this._slots) {
+      for (const node of $slot.nodes) {
+        if (node.nodeType === 1 && (this._query === '*' || (node as Element).matches(this._query))) {
+          $nodes.push(node);
+        }
+      }
+      // $nodes = $nodes.concat($slot.nodes);
+    }
+    if ($nodes.length !== this._nodes.length || $nodes.some((n, i) => n !== this._nodes[i])) {
+      this._nodes = $nodes;
+      this._callback?.call(this._obj, $nodes);
+      const subs = new Set(this._subs);
+      for (const sub of subs) {
+        sub.handleNodesChange($nodes);
+      }
+    }
+  }
+
+  public subscribe(subscriber: IProjectionSubscriber): void {
+    this._subs.add(subscriber);
+  }
+
+  public unsubscribe(subscriber: IProjectionSubscriber): void {
+    this._subs.delete(subscriber);
+  }
+
+  public useScope(scope: Scope): void {
+    /* not needed */
+  }
+
+  public limit(opts: IRateLimitOptions): IDisposable {
+    throw new Error('not implemented');
+  }
+}
+
+class SlottedLifecycleHooks {
+  public constructor(
+    private readonly def: PartialSlottedDefinition & { name: PropertyKey },
+  ) {}
+
+  public register(c: IContainer) {
+    instanceRegistration(ILifecycleHooks, this).register(c);
+  }
+
+  public hydrating(vm: object, controller: ICustomElementController) {
+    const def = this.def;
+    const watcher = SlotWatcherBinding.create(
+      controller,
+      def.name,
+      def.callback ?? `${safeString(def.name)}Changed`,
+      def.query ?? '*'
+    );
+    instanceRegistration(ISlotWatcher, watcher).register(controller.container.get(IHydrationContext).controller.container);
+    controller.addBinding(watcher);
+  }
+}
+
+lifecycleHooks()(SlottedLifecycleHooks);
+
+export function slotted(query: string) {
+  const dependenciesKey = 'dependencies';
+  function decorator($target: {}, $prop: symbol | string, desc?: PropertyDescriptor): void {
+    const config: PartialSlottedDefinition = {
+      query,
+    };
+    if (arguments.length > 1) {
+      // Non invocation:
+      // - @slotted
+      // Invocation with or w/o opts:
+      // - @slotted()
+      // - @slotted({...opts})
+      config.name = $prop as string;
+    }
+
+    if (typeof $target === 'function' || typeof desc?.value !== 'undefined') {
+      throw new Error(`Invalid usage. @slotted can only be used on a field`);
+    }
+
+    const target = ($target as object).constructor as Constructable;
+
+    let dependencies = CustomElement.getAnnotation(target, dependenciesKey) as Key[] | undefined;
+    if (dependencies == null) {
+      CustomElement.annotate(target, dependenciesKey, dependencies = []);
+    }
+    dependencies.push(new SlottedLifecycleHooks(config as PartialSlottedDefinition & { name: PropertyKey }));
+  }
+
+  return decorator;
+}

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -34,7 +34,7 @@ export const resource = function <T extends Key>(key: T) {
  * A resolver builder for resolving all registrations of a key
  * with resource semantic (leaf + root + ignore middle layer container)
  */
-export const allResources = function <T extends Key>(key: T) {
+export const allResources = <T extends Key>(key: T) => {
   function Resolver(target: Constructable, property?: string | number, descriptor?: PropertyDescriptor | number) {
     DI.inject(Resolver)(target, property, descriptor);
   }
@@ -51,6 +51,18 @@ export const allResources = function <T extends Key>(key: T) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return Resolver as IResolver<Resolved<T>[]> & ((...args: unknown[]) => any);
 };
+
+/** @internal */
+export const optionalOwn = <T extends Key>(key: T): IResolver<T | undefined> => ({
+  $isResolver: true,
+  resolve(handler, requestor) {
+    if (requestor.has(key, false)) {
+      return requestor.get(key);
+    } else {
+      return undefined;
+    }
+  },
+});
 
 /** @internal */
 export const createInterface = DI.createInterface;

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -51,9 +51,9 @@ export interface ICollectionSubscriber {
   handleCollectionChange(collection: Collection, indexMap: IndexMap): void;
 }
 
-export interface ISubscribable {
-  subscribe(subscriber: ISubscriber): void;
-  unsubscribe(subscriber: ISubscriber): void;
+export interface ISubscribable<T = ISubscriber> {
+  subscribe(subscriber: T): void;
+  unsubscribe(subscriber: T): void;
 }
 
 export interface ICollectionSubscribable {


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the moment, there's not a way to listen to changes of the projection within an `<au-slot/>` element. This leads to the inability to have similar pattern like the `@children` deco for `<au-slot/>`, and sometimes one needs to resolve to some complex query with `@children` to achieve the same outcome.

This PR:
- Adds the capability for `<au-slot/>` to watch, capture and notify changes of its projection.
- Adds doc for `@children` decorator
- Adds doc for `@slotted` decorator

Resolves #1694

## 👩‍💻 Reviewer Notes

- `@slotted` decorator will add a `ILifecycleHooks` dependency to the metadata associated with a class, and upon resolving, will provide the infrastructure to hook with `<au-slot/>` for change observation and notifcation

## 📑 Test Plan

- initial rendering
- initial rendering of multiple slots that have elements matching the `@slotted` query
- mutation of a single slot
- mutation of multiple slots that have elements matching the `@slotted` query
- mutiple `@slotted` working together

@Sayan751 @fkleuver @brandonseydel 

Doc can be temporarily viewed here

https://github.com/aurelia/aurelia/blob/feat/slotted-deco/docs/user-docs/components/shadow-dom-and-slots.md#listening-to-slot-change