### PR TITLE
feat(router-lite): extended support for ../ prefix

### DIFF
--- a/docs/user-docs/router-lite/navigating.md
+++ b/docs/user-docs/router-lite/navigating.md
@@ -547,6 +547,16 @@ This is shown in the following example.
 
 {% embed url="https://stackblitz.com/edit/router-lite-load-nullroot-context?ctl=1&embed=1&file=src/child1.ts" %}
 
+When the route context selection involves only ancestor context, then the `../` prefix can be used when using string instruction.
+This also works when using the route-id.
+The following code snippets shows, how the previous example can be written using the `../` prefix.
+
+
+```html
+<a load="route: ../r2">c2</a>
+```
+
+
 ### `active` status
 
 When using the `load` attribute, you can also leverage the bindable `active` property which is `true` whenever the associated route, bound to the `href` is active.

--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -58,10 +58,18 @@ describe('router-lite/resources/load.spec.ts', function () {
   });
 
   it('adds activeClass when configured', async function () {
-    @customElement({ name: 'fo-o', template: '' })
-    class Foo { }
+    @customElement({ name: 'fo-o', template: '${instanceId} ${id}' })
+    class Foo {
+      private static instanceId: number = 0;
+      private readonly instanceId = ++Foo.instanceId;
+      private id: string;
+      public loading(params: Params) {
+        this.id = params.id;
+      }
+    }
 
     @route({
+      transitionPlan: 'replace',
       routes: [
         { id: 'foo', path: 'foo/:id', component: Foo }
       ]
@@ -89,12 +97,24 @@ describe('router-lite/resources/load.spec.ts', function () {
     await queue.yield();
     a2.active = true;
     assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#2');
+    assert.html.textContent(host, '1 2');
+
+    anchors[1].click();
+    await queue.yield();
+    assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#3');
+    assert.html.textContent(host, '2 2');
 
     anchors[0].click();
     await queue.yield();
     a1.active = true;
     a2.active = false;
-    assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#3');
+    assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#4');
+    assert.html.textContent(host, '3 1');
+
+    anchors[0].click();
+    await queue.yield();
+    assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#5');
+    assert.html.textContent(host, '4 1');
 
     await au.stop(true);
 

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -2199,8 +2199,6 @@ describe('router-lite/smoke-tests.spec.ts', function () {
     assert.areTaskQueuesEmpty();
   });
 
-  // TODO(sayan): add more tests
-
   for (const attr of ['href', 'load']) {
     it(`will load the root-level fallback when navigating to a non-existing route - parent-child - children without fallback - attr: ${attr}`, async function () {
       @customElement({ name: 'gc-11', template: 'gc11' })
@@ -6400,5 +6398,74 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await au.stop();
 
     });
+  });
+
+  it('local dependencies of the routed view model works', async function () {
+    @customElement({ name: 'c-11', template: 'c11' })
+    class C11 { }
+    @customElement({ name: 'c-1', template: 'c1 <c-11></c-11>', dependencies: [C11] })
+    class C1 { }
+
+    @customElement({ name: 'c-21', template: 'c21' })
+    class C21 { }
+
+    @customElement({ name: 'c-2', template: 'c2 <c-21></c-21>', dependencies: [C21] })
+    class C2 { }
+
+    @route({
+      routes: [
+        { path: 'c1', component: C1 },
+        { path: 'c2', component: C2 },
+      ]
+    })
+    @customElement({ name: 'root', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root });
+    const router = container.get(IRouter);
+
+    assert.html.textContent(host, '');
+
+    await router.load('c1');
+    assert.html.textContent(host, 'c1 c11');
+
+    await router.load('c2');
+    assert.html.textContent(host, 'c2 c21');
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
+  });
+
+  // use-case: master page
+  it('custom element containing au-viewport works', async function () {
+    @customElement({ name: 'master-page', template: 'mp <au-viewport></au-viewport>' })
+    class MasterPage { }
+    @customElement({ name: 'c-1', template: 'c1' })
+    class C1 { }
+    @customElement({ name: 'c-2', template: 'c2' })
+    class C2 { }
+
+    @route({
+      routes: [
+        { path: 'c1', component: C1 },
+        { path: 'c2', component: C2 },
+      ]
+    })
+    @customElement({ name: 'root', template: '<master-page></master-page>' })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root, registrations: [MasterPage] });
+    const router = container.get(IRouter);
+
+    assert.html.textContent(host, 'mp');
+
+    await router.load('c1');
+    assert.html.textContent(host, 'mp c1');
+
+    await router.load('c2');
+    assert.html.textContent(host, 'mp c2');
+
+    await au.stop(true);
+    assert.areTaskQueuesEmpty();
   });
 });

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -178,7 +178,7 @@ export class ViewportInstruction<TComponent extends ITypedNavigationInstruction_
   public toUrlComponent(recursive: boolean = true): string {
     // TODO(fkleuver): use the context to determine create full tree
     const component = this.component.toUrlComponent();
-    const params = this.params === null || Object.keys(this.params).length === 0 ? '' : `(${stringifyParams(this.params)})`;
+    const params = this.params === null || Object.keys(this.params).length === 0 ? '' : `(${stringifyParams(this.params)})`; /** TODO(sayan): review the path generation usage and correct this stringifyParams artefact. */
     const vp = this.viewport;
     const viewport = component.length === 0 || vp === null || vp.length === 0 || vp === defaultViewportName ? '' : `@${vp}`;
     const thisPart = `${'('.repeat(this.open)}${component}${params}${viewport}${')'.repeat(this.close)}`;

--- a/packages/router-lite/src/resources/load.ts
+++ b/packages/router-lite/src/resources/load.ts
@@ -62,11 +62,7 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
       const active = this.active = this.instructions !== null && this.router.isActive(this.instructions, this.context!);
       const activeClass = this.activeClass;
       if (activeClass === null) return;
-      if (active) {
-        this.el.classList.add(activeClass);
-      } else {
-        this.el.classList.remove(activeClass);
-      }
+      this.el.classList.toggle(activeClass, active);
     });
   }
 

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -405,14 +405,23 @@ export class Router {
     let context: IRouteContext | null = (options?.context ?? null) as IRouteContext | null;
     if (typeof instructionOrInstructions === 'string') {
       instructionOrInstructions = this.locationMgr.removeBaseHref(instructionOrInstructions);
-      if ((instructionOrInstructions as string).startsWith('../') && context !== null) {
-        context = this.resolveContext(context);
-        while ((instructionOrInstructions as string).startsWith('../') && (context?.parent ?? null) !== null) {
-          instructionOrInstructions = (instructionOrInstructions as string).slice(3);
-          context = context!.parent;
-        }
+    }
+
+    const isVpInstr = typeof instructionOrInstructions !== 'string' && 'component' in instructionOrInstructions;
+    let $instruction = isVpInstr ? (instructionOrInstructions as IViewportInstruction).component : instructionOrInstructions;
+    if (typeof $instruction === 'string' && $instruction.startsWith('../') && context !== null) {
+      context = this.resolveContext(context);
+      while (($instruction as string).startsWith('../') && (context?.parent ?? null) !== null) {
+        $instruction = ($instruction as string).slice(3);
+        context = context!.parent;
       }
     }
+    if(isVpInstr) {
+      (instructionOrInstructions as Writable<IViewportInstruction>).component = $instruction;
+    } else {
+      instructionOrInstructions = $instruction;
+    }
+
     const routerOptions = this.options;
     return ViewportInstructionTree.create(
       instructionOrInstructions,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This commit extends the support for ../ prefix. Previously, it was only available to the string instruction. This commit adds support for `{ component: '../../route', params: { what: 'ever' } }`.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

This closes https://github.com/aurelia/aurelia/issues/1728

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
