### PR TITLE
feat(debounce-throttle): flush via signals

### DIFF
--- a/docs/user-docs/components/shadow-dom-and-slots.md
+++ b/docs/user-docs/components/shadow-dom-and-slots.md
@@ -85,6 +85,7 @@ The `<slot>` element comes with an event based way to listen to its changes. Thi
 <slot slotchange.trigger="handleSlotChange($event.target.assignedNodes())"></slot>
 ```
 {% endcode %}
+
 {% code title="my-app.ts overflow="wrap" lineNumbers="true" %}
 ```typescript
 class MyApp {
@@ -126,8 +127,9 @@ the property being decorated, example: `divs` -> `divsChanged`
 | `@children('div') prop` | Observe mutation, and select only `div` elements |
 
 {% hint style="info" %}
+
 Note: the `@children` decorator wont update if the children of a slotted node change — only if you change (e.g. add or delete) the actual nodes themselves.
-{% %}
+{% endhint %}
 
 ## Au-slot
 

--- a/docs/user-docs/templates/binding-behaviors.md
+++ b/docs/user-docs/templates/binding-behaviors.md
@@ -42,6 +42,19 @@ The throttle behavior is particularly useful when binding events to methods on y
 <div mousemove.delegate="mouseMove($event) & throttle"></div>
 ```
 
+### Flush pending throttled calls
+
+Sometimes it's desirable to forcefully run the throttled update, so that the application syncs the latest values. This can happen in a form, when a user previously was typing into a throttled form field, and hit tab key to go to the next field, as an example.
+The `throttle` binding behavior supports this scenario via signal. These signals can be added via the 2nd parameter, like the following example:
+
+{% code title="my-app.html" lineNumbers="true" overflow="wrap" %}
+```html
+<input value.bind="value & throttle :200 :`finishTyping`" blur.trigger="signaler.dispatchSignal('finishTyping')">
+<!-- or it can be a list of signals -->
+<input value.bind="value & throttle :200 :[`finishTyping`, `newUpdate`]">
+```
+{% endcode %}
+
 ## Debounce
 
 The debounce binding behavior is another rate-limiting binding behavior. Debounce prevents the binding from being updated until a specified interval has passed without any changes.
@@ -70,7 +83,20 @@ Here's another example with the `mousemove` event:
 <div mousemove.delegate="mouseMove($event) & debounce:500"></div>
 ```
 
-## **UpdateTrigger**
+### Flush pending debounced calls
+
+Sometimes it's desirable to forcefully run the throttled update, so that the application syncs the latest values. This can happen in a form, when a user previously was typing into a throttled form field, and hit tab key to go to the next field, as an example.
+Similar to the [`throttle` binding behavior](#throttle), The `debounce` binding behavior supports this scenario via signal. These signals can be added via the 2nd parameter, like the following example:
+
+{% code title="my-app.html" lineNumbers="true" overflow="wrap" %}
+```html
+<input value.bind="value & debounce :200 :`finishTyping`" blur.trigger="signaler.dispatchSignal('finishTyping')">
+<!-- or it can be a list of signals -->
+<input value.bind="value & debounce :200 :[`finishTyping`, `newUpdate`]">
+```
+{% endcode %}
+
+## UpdateTrigger
 
 Update trigger allows you to override the input events that cause the element's value to be written to the view-model. The default events are `change` and `input`.
 

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -1,9 +1,9 @@
-import { IDisposable, IServiceLocator, Key, type Constructable } from '@aurelia/kernel';
-import { ITask } from '@aurelia/platform';
+import { type IServiceLocator, Key, type Constructable, IDisposable } from '@aurelia/kernel';
+import { ITask, TaskStatus } from '@aurelia/platform';
 import { astEvaluate, BindingBehaviorInstance, IBinding, IRateLimitOptions, ISignaler, Scope, type ISubscriber, type ValueConverterInstance } from '@aurelia/runtime';
 import { BindingBehavior } from '../resources/binding-behavior';
 import { ValueConverter } from '../resources/value-converter';
-import { createError, def, defineHiddenProp } from '../utilities';
+import { addSignalListener, createError, def, defineHiddenProp, removeSignalListener } from '../utilities';
 import { createInterface, resource } from '../utilities-di';
 import { PropertyBinding } from './property-binding';
 
@@ -158,15 +158,24 @@ export const mixingBindingLimited = <T extends IBinding>(target: Constructable<T
     }
     withLimitationBindings.add(this);
     const prop = getMethodName(this, opts);
+    const signals = opts.signals;
+    const signaler = signals.length > 0 ? this.get(ISignaler) : null;
     const originalFn = this[prop] as unknown as (...args: unknown[]) => unknown;
     const callOriginal = (...args: unknown[]) => originalFn.call(this, ...args);
     const limitedFn = opts.type === 'debounce'
       ? debounced(opts, callOriginal, this)
       : throttled(opts, callOriginal, this);
+    const signalListener = signaler ? { handleChange: limitedFn.flush } : null;
     this[prop] = limitedFn as unknown as typeof this[typeof prop];
+    if (signaler) {
+      signals.forEach(s => addSignalListener(signaler, s, signalListener!));
+    }
 
     return {
       dispose: () => {
+        if (signaler) {
+          signals.forEach(s => removeSignalListener(signaler, s, signalListener!));
+        }
         withLimitationBindings.delete(this);
         limitedFn.dispose();
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
@@ -178,45 +187,54 @@ export const mixingBindingLimited = <T extends IBinding>(target: Constructable<T
 
 /**
  * A helper for creating rated limited functions for binding. For internal use only
- *
- * @param startCounter - indicate at what call number the debounce effect should happens
- * Some bindings calls the debounced method during bind cycle, but that shouldn't be counted as the start of debounce
  */
-const debounced = <T extends (v?: unknown) => unknown>(opts: IRateLimitOptions, callOriginal: T, binding: IBinding) => {
+const debounced = <T extends (v?: unknown) => unknown>(opts: IRateLimitOptions, callOriginal: T, binding: IBinding): LimiterHandle => {
   let limiterTask: ITask | undefined;
   let task: ITask | undefined;
   let latestValue: unknown;
+  let isPending = false;
   const taskQueue = opts.queue;
+  const callOriginalCallback = () => callOriginal(latestValue);
   const fn = (v: unknown) => {
     latestValue = v;
     if (binding.isBound) {
       task = limiterTask;
-      limiterTask = taskQueue.queueTask(() => callOriginal(latestValue), { delay: opts.delay, reusable: false });
+      limiterTask = taskQueue.queueTask(callOriginalCallback, { delay: opts.delay, reusable: false });
       task?.cancel();
     } else {
-      callOriginal(latestValue);
+      callOriginalCallback();
     }
   };
-  fn.dispose = () => {
+  const dispose = fn.dispose = () => {
     task?.cancel();
     limiterTask?.cancel();
+    task = limiterTask = void 0;
+  };
+  fn.flush = () => {
+    // only call callback when there's actually task being queued
+    isPending = limiterTask?.status === TaskStatus.pending;
+    dispose();
+    if (isPending) {
+      callOriginalCallback();
+    }
   };
 
-  return fn as unknown as T & IDisposable;
+  return fn;
 };
 
 /**
  * A helper for creating rated limited functions for binding. For internal use only
  */
-const throttled = <T extends (v?: unknown) => unknown>(opts: IRateLimitOptions, callOriginal: T, binding: IBinding) => {
+const throttled = <T extends (v?: unknown) => unknown>(opts: IRateLimitOptions, callOriginal: T, binding: IBinding): LimiterHandle => {
   let limiterTask: ITask | undefined;
   let task: ITask | undefined;
   let last: number = 0;
   let elapsed = 0;
   let latestValue: unknown;
+  let isPending = false;
   const taskQueue = opts.queue;
   const now = () => opts.now();
-  // const callOriginal = () => originalFn.call(context, latestValue);
+  const callOriginalCallback = () => callOriginal(latestValue);
   const fn = (v: unknown) => {
     latestValue = v;
     if (binding.isBound) {
@@ -224,22 +242,36 @@ const throttled = <T extends (v?: unknown) => unknown>(opts: IRateLimitOptions, 
       task = limiterTask;
       if (elapsed > opts.delay) {
         last = now();
-        callOriginal(latestValue);
+        callOriginalCallback();
       } else {
         // Queue the new one before canceling the old one, to prevent early yield
         limiterTask = taskQueue.queueTask(() => {
           last = now();
-          callOriginal(latestValue);
+          callOriginalCallback();
         }, { delay: opts.delay - elapsed, reusable: false });
       }
       task?.cancel();
     } else {
-      callOriginal(latestValue);
+      callOriginalCallback();
     }
   };
-  fn.dispose = () => {
+  const dispose = fn.dispose = () => {
     task?.cancel();
     limiterTask?.cancel();
+    task = limiterTask = void 0;
   };
-  return fn as unknown as T & IDisposable;
+  fn.flush = () => {
+    // only call callback when there's actually task being queued
+    isPending = limiterTask?.status === TaskStatus.pending;
+    dispose();
+    if (isPending) {
+      callOriginalCallback();
+    }
+  };
+  return fn;
+};
+
+type LimiterHandle = IDisposable & {
+  (v: unknown, oV?: unknown): void;
+  flush(): void;
 };

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -1,6 +1,5 @@
 import {
   emptyArray,
-  type IDisposable,
   InstanceProvider,
   type Key,
   type IServiceLocator,
@@ -1167,14 +1166,6 @@ class SpreadBinding implements IBinding {
       throw createError('Spread binding does not support spreading custom attributes/template controllers');
     }
     this.ctrl.addChild(controller);
-  }
-
-  public limit(): IDisposable {
-    throw createError('not implemented');
-  }
-
-  public useScope(): void {
-    throw createError('not implemented');
   }
 }
 

--- a/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
@@ -1,7 +1,8 @@
-import { IDisposable, IPlatform } from '@aurelia/kernel';
+import { IDisposable, IPlatform, emptyArray } from '@aurelia/kernel';
 import { bindingBehavior } from '../binding-behavior';
 
 import { type BindingBehaviorInstance, type IBinding, type IRateLimitOptions, type Scope } from '@aurelia/runtime';
+import { isString } from '../../utilities';
 
 const bindingHandlerMap: WeakMap<IBinding, IDisposable> = new WeakMap();
 const defaultDelay = 200;
@@ -16,16 +17,17 @@ export class DebounceBindingBehavior implements BindingBehaviorInstance {
     this._platform = platform;
   }
 
-  public bind(scope: Scope, binding: IBinding, delay?: number) {
-    delay = Number(delay);
+  public bind(scope: Scope, binding: IBinding, delay?: number, signals?: string | string[]) {
     const opts: IRateLimitOptions = {
       type: 'debounce',
-      delay: delay > 0 ? delay : defaultDelay,
+      delay: delay ?? defaultDelay,
       now: this._platform.performanceNow,
       queue: this._platform.taskQueue,
+      signals: isString(signals) ? [signals] : (signals ?? emptyArray),
     };
     const handler = binding.limit?.(opts);
     if (handler == null) {
+      /* istanbul ignore next */
       if (__DEV__) {
         // eslint-disable-next-line no-console
         console.warn(`Binding ${binding.constructor.name} does not support debounce rate limiting`);

--- a/packages/runtime-html/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/signals.ts
@@ -1,7 +1,7 @@
 import { ISignaler } from '@aurelia/runtime';
 import { bindingBehavior } from '../binding-behavior';
+import { addSignalListener, createError, removeSignalListener } from '../../utilities';
 import type { BindingBehaviorInstance, IBinding, IConnectableBinding, Scope } from '@aurelia/runtime';
-import { createError } from '../../utilities';
 
 export class SignalBindingBehavior implements BindingBehaviorInstance {
   /** @internal */
@@ -34,7 +34,7 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
     this._lookup.set(binding, names);
     let name: string;
     for (name of names) {
-      this._signaler.addSignalListener(name, binding);
+      addSignalListener(this._signaler, name, binding);
     }
   }
 
@@ -43,7 +43,7 @@ export class SignalBindingBehavior implements BindingBehaviorInstance {
     this._lookup.delete(binding);
     let name: string;
     for (name of names) {
-      this._signaler.removeSignalListener(name, binding);
+      removeSignalListener(this._signaler, name, binding);
     }
   }
 }

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -1,5 +1,5 @@
-import { emptyArray, IContainer, IServiceLocator, IDisposable, Key } from '@aurelia/kernel';
-import { IBinding, subscriberCollection } from '@aurelia/runtime';
+import { emptyArray, type IContainer, type IServiceLocator, Key , IIndexable, Constructable } from '@aurelia/kernel';
+import { type IBinding, subscriberCollection , type ISubscriberCollection } from '@aurelia/runtime';
 import { CustomElement, findElementControllerFor } from '../resources/custom-element';
 import { ILifecycleHooks, lifecycleHooks } from './lifecycle-hooks';
 import { createError, def, isString, objectAssign, safeString } from '../utilities';
@@ -7,8 +7,6 @@ import { instanceRegistration } from '../utilities-di';
 import { type ICustomElementViewModel, type ICustomElementController } from './controller';
 import { createMutationObserver } from '../utilities-dom';
 
-import type { IIndexable, Constructable } from '@aurelia/kernel';
-import type { ISubscriberCollection } from '@aurelia/runtime';
 import type { INode } from '../dom';
 
 export type PartialChildrenDefinition = {
@@ -204,14 +202,6 @@ export class ChildrenBinding implements IBinding {
 
   public get(): ReturnType<IServiceLocator['get']> {
     throw notImplemented('get');
-  }
-
-  public useScope() {
-    /* not implemented */
-  }
-
-  public limit(): IDisposable {
-    throw notImplemented('limit');
   }
 
   /** @internal */

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -1,8 +1,8 @@
 import { type ICustomElementViewModel, type ICustomElementController } from './controller';
 import { CustomElement, type CustomElementDefinition } from '../resources/custom-element';
 import { createInterface, instanceRegistration } from '../utilities-di';
-import { type IRateLimitOptions, type Scope, type ISubscribable, type ISubscriberCollection, subscriberCollection } from '@aurelia/runtime';
-import { type Constructable, emptyArray, type Key, type IContainer, type IDisposable, type IIndexable, type IServiceLocator } from '@aurelia/kernel';
+import { type ISubscribable, type ISubscriberCollection, subscriberCollection } from '@aurelia/runtime';
+import { type Constructable, emptyArray, type Key, type IContainer, type IIndexable, type IServiceLocator } from '@aurelia/kernel';
 import { ILifecycleHooks, lifecycleHooks } from './lifecycle-hooks';
 import { def, objectAssign, safeString } from '../utilities';
 
@@ -170,16 +170,6 @@ class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscr
 
   /* istanbul ignore next */
   public get(): ReturnType<IServiceLocator['get']> {
-    throw new Error('not implemented');
-  }
-
-  /* istanbul ignore next */
-  public useScope(_scope: Scope): void {
-    /* not needed */
-  }
-
-  /* istanbul ignore next */
-  public limit(_opts: IRateLimitOptions): IDisposable {
     throw new Error('not implemented');
   }
 }

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -1,3 +1,4 @@
+import type { ISignaler, ISubscriber } from '@aurelia/runtime';
 import type { ISVGAnalyzer } from './observation/svg-analyzer';
 
 const O = Object;
@@ -45,6 +46,7 @@ const IsDataAttribute: Record<string, boolean> = createLookup();
 /** @internal */ export const isFunction = <K extends Function>(v: unknown): v is K => typeof v === 'function';
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
+/** @internal */ export const isNumber = (v: unknown): v is number => typeof v === 'number';
 /** @internal */ export const defineProp = O.defineProperty;
 /** @internal */ export const rethrow = (err: unknown) => { throw err; };
 /** @internal */ export const areEqual = O.is;
@@ -62,3 +64,8 @@ export const defineHiddenProp = <T>(obj: object, key: PropertyKey, value: T): T 
   });
   return value;
 };
+
+/** @internal */
+export const addSignalListener = (signaler: ISignaler, signal: string, listener: ISubscriber) => signaler.addSignalListener(signal, listener);
+/** @internal */
+export const removeSignalListener = (signaler: ISignaler, signal: string, listener: ISubscriber) => signaler.removeSignalListener(signal, listener);

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -10,8 +10,8 @@ export interface IBinding {
   bind(scope: Scope): void;
   unbind(): void;
   get: IServiceLocator['get'];
-  useScope(scope: Scope): void;
-  limit(opts: IRateLimitOptions): IDisposable;
+  useScope?(scope: Scope): void;
+  limit?(opts: IRateLimitOptions): IDisposable;
 }
 
 export interface IRateLimitOptions {
@@ -19,6 +19,7 @@ export interface IRateLimitOptions {
   delay: number;
   queue: TaskQueue;
   now: () => number;
+  signals: string[];
 }
 
 export const ICoercionConfiguration = DI.createInterface<ICoercionConfiguration>('ICoercionConfiguration');

--- a/packages/state/src/state-binding-behavior.ts
+++ b/packages/state/src/state-binding-behavior.ts
@@ -31,7 +31,11 @@ export class StateBindingBehavior {
         subscriber._wrappedScope = scope;
       }
       this._store.subscribe(subscriber);
-      binding.useScope(scope);
+      if (__DEV__ && !binding.useScope) {
+        // eslint-disable-next-line no-console
+        console.warn(`Binding ${binding.constructor.name} does not support "state" binding behavior`);
+      }
+      binding.useScope?.(scope);
     }
   }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Support a valid use case described in #1145 , where it's desirable to flush throttled/debounced update upon some condition.

- `throttle` & `debounce` now accept a 2nd parameter with type `string | string[]` as signals, to listen to and flush whenever there's a dispatch. Example:

```html
<input value.bind="value & throttle :200 :`finishTyping`" blur.trigger="signaler.dispatchSignal('finishTyping')">
<!-- or it can be a list of signals -->
<input value.bind="value & throttle :200 :[`finishTyping`, `newUpdate`]">
```

Resolves #1145

Thanks @avrahamcool 