### PR TITLE
refactor(router-lite): alias registrations

### DIFF
--- a/packages/router-lite/src/configuration.ts
+++ b/packages/router-lite/src/configuration.ts
@@ -66,6 +66,7 @@ function configure(container: IContainer, options?: IRouterConfigurationOptions)
       return url;
     }),
     Registration.instance(IRouterOptions, routerOptions),
+    Registration.instance(RouterOptions, routerOptions),
     AppTask.hydrated(IContainer, RouteContext.setRoot),
     AppTask.activated(IRouter, router => router.start(true)),
     AppTask.deactivated(IRouter, router => {

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -203,10 +203,9 @@ export class RouteContext {
       true,
     );
 
-    container.registerResolver(
-      IRouteContext,
-      new InstanceProvider<IRouteContext>('IRouteContext', this)
-    );
+    const ctxProvider = new InstanceProvider<IRouteContext>('IRouteContext', this);
+    container.registerResolver(IRouteContext, ctxProvider);
+    container.registerResolver(RouteContext, ctxProvider);
 
     container.register(config);
 
@@ -700,7 +699,6 @@ export class $RecognizedRoute {
   }
 }
 
-export const INavigationModel = DI.createInterface<INavigationModel>('INavigationModel');
 export interface INavigationModel {
   /**
    * Collection of routes.

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -1,5 +1,5 @@
 import { isObject } from '@aurelia/metadata';
-import { IContainer, ILogger, DI, IDisposable, onResolve, Writable, resolveAll } from '@aurelia/kernel';
+import { IContainer, ILogger, DI, IDisposable, onResolve, Writable, resolveAll, Registration, IResolver } from '@aurelia/kernel';
 import { CustomElement, CustomElementDefinition, IPlatform } from '@aurelia/runtime-html';
 
 import { IRouteContext, RouteContext } from './route-context';
@@ -193,6 +193,7 @@ export class Router {
   ) {
     this.logger = logger.root.scopeTo('Router');
     this.instructions = ViewportInstructionTree.create('', options);
+    container.registerResolver(Router, Registration.instance(Router, this) as unknown as IResolver<Router>);
   }
 
   /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

 This PR adds alias registrations for the following. Thus, one from the pair can be used interchangeably as injection symbol.

- `IRouter` and `Router`
- `IRouteContext` and `RouteContext`
- `IRouterOptions` and `RouterOptions`

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

closes #1740

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
