### PR TITLE
chore: add pure annotation for better tree shakability

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -195,7 +195,7 @@ module.exports = {
     'space-in-parens': 'error',
     'spaced-comment': ['error', 'always', {
       line: { markers: ['/'], exceptions: ['-', '+'] },
-      block: { markers: ['!'], exceptions: ['*'], balanced: true }
+      block: { markers: ['!'], exceptions: ['*', '@__PURE__'], balanced: true }
     }],
 
     // Things we maybe need to fix some day, so are marked as warnings for now:

--- a/packages/__e2e__/router-lite/src/router-event-logger-service.ts
+++ b/packages/__e2e__/router-lite/src/router-event-logger-service.ts
@@ -1,7 +1,7 @@
 import { IRouterEvents } from '@aurelia/router-lite';
 import { DI, IDisposable } from 'aurelia';
 
-export const IRouterEventLoggerService = DI.createInterface<IRouterEventLoggerService>('ISomeService', x => x.singleton(RouterEventLoggerService));
+export const IRouterEventLoggerService = /*@__PURE__*/DI.createInterface<IRouterEventLoggerService>('ISomeService', x => x.singleton(RouterEventLoggerService));
 export interface IRouterEventLoggerService extends RouterEventLoggerService { }
 export class RouterEventLoggerService implements IDisposable {
   private readonly subscriptions: IDisposable[];

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -10,7 +10,7 @@ import {
   BindingMode,
   CustomElement,
   InterpolationBinding,
-  SVGAnalyzerRegistration,
+  SVGAnalyzer,
   IPlatform,
   ValueConverter,
 } from '@aurelia/runtime-html';
@@ -704,7 +704,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         class App {
           public progress = 0;
         },
-        [SVGAnalyzerRegistration],
+        [SVGAnalyzer],
       );
 
       await startPromise;

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -8,7 +8,7 @@ import {
   PropertyBindingRenderer,
   TextBindingRenderer,
   TextBindingInstruction,
-  INodeObserverLocatorRegistration,
+  NodeObserverLocator,
   IRendering,
   PropertyBinding,
   HydrateTemplateController,
@@ -496,7 +496,7 @@ describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
   ];
 
   const container = createContainer().register(
-    INodeObserverLocatorRegistration,
+    NodeObserverLocator,
     PropertyBindingRenderer,
     TextBindingRenderer,
   );

--- a/packages/__tests__/3-runtime-html/template-compiler.test-apps.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.test-apps.spec.ts
@@ -1,6 +1,6 @@
 import {
   CustomElement,
-  SVGAnalyzerRegistration,
+  SVGAnalyzer,
 } from '@aurelia/runtime-html';
 import {
   assert,
@@ -20,7 +20,7 @@ describe('3-runtime-html/template-compiler.test-apps.spec.ts', function () {
     const ctx = TestContext.create();
     const state = new State();
     Registration.instance(State, state).register(ctx.container);
-    ctx.container.register(SVGAnalyzerRegistration, createPythagorasElement());
+    ctx.container.register(SVGAnalyzer, createPythagorasElement());
 
     const { startPromise, appHost, component, tearDown } = createFixture(
       `<div style='height: 50px;' css='max-width: \${width}px;'>

--- a/packages/__tests__/router-lite/_shared/create-fixture.ts
+++ b/packages/__tests__/router-lite/_shared/create-fixture.ts
@@ -6,7 +6,7 @@ import { TestContext } from '@aurelia/testing';
 import { IHIAConfig, IHookInvocationAggregator } from './hook-invocation-tracker.js';
 import { TestRouterConfiguration } from './configuration.js';
 
-export const IActivityTracker = DI.createInterface<IActivityTracker>('IActivityTracker', x => x.singleton(ActivityTracker));
+export const IActivityTracker = /*@__PURE__*/DI.createInterface<IActivityTracker>('IActivityTracker', x => x.singleton(ActivityTracker));
 export interface IActivityTracker extends ActivityTracker {}
 export class ActivityTracker {
   public readonly activeVMs: string[] = [];

--- a/packages/__tests__/router-lite/_shared/hook-invocation-tracker.ts
+++ b/packages/__tests__/router-lite/_shared/hook-invocation-tracker.ts
@@ -81,7 +81,7 @@ export class HookInvocationTracker {
   }
 }
 
-export const IHIAConfig = DI.createInterface<IHIAConfig>('IHIAConfig');
+export const IHIAConfig = /*@__PURE__*/DI.createInterface<IHIAConfig>('IHIAConfig');
 export interface IHIAConfig extends HIAConfig {}
 export class HIAConfig {
   public constructor(
@@ -90,7 +90,7 @@ export class HIAConfig {
   ) {}
 }
 
-export const IHookInvocationAggregator = DI.createInterface<IHookInvocationAggregator>('IHookInvocationAggregator', x => x.singleton(HookInvocationAggregator));
+export const IHookInvocationAggregator = /*@__PURE__*/DI.createInterface<IHookInvocationAggregator>('IHookInvocationAggregator', x => x.singleton(HookInvocationAggregator));
 export interface IHookInvocationAggregator extends HookInvocationAggregator {}
 export class HookInvocationAggregator {
   public readonly notifyHistory: string[] = [];

--- a/packages/__tests__/router/_shared/create-fixture.ts
+++ b/packages/__tests__/router/_shared/create-fixture.ts
@@ -67,7 +67,7 @@ export function translateOptions(routerOptionsSpec: IRouterOptionsSpec): IRouter
   };
 }
 
-export const IActivityTracker = DI.createInterface<IActivityTracker>('IActivityTracker', x => x.singleton(ActivityTracker));
+export const IActivityTracker = /*@__PURE__*/DI.createInterface<IActivityTracker>('IActivityTracker', x => x.singleton(ActivityTracker));
 export interface IActivityTracker extends ActivityTracker { }
 export class ActivityTracker {
   public readonly activeVMs: string[] = [];

--- a/packages/__tests__/router/_shared/hook-invocation-tracker.ts
+++ b/packages/__tests__/router/_shared/hook-invocation-tracker.ts
@@ -81,7 +81,7 @@ export class HookInvocationTracker {
   }
 }
 
-export const IHIAConfig = DI.createInterface<IHIAConfig>('IHIAConfig');
+export const IHIAConfig = /*@__PURE__*/DI.createInterface<IHIAConfig>('IHIAConfig');
 export interface IHIAConfig extends HIAConfig {}
 export class HIAConfig {
   public constructor(
@@ -90,7 +90,7 @@ export class HIAConfig {
   ) {}
 }
 
-export const IHookInvocationAggregator = DI.createInterface<IHookInvocationAggregator>('IHookInvocationAggregator', x => x.singleton(HookInvocationAggregator));
+export const IHookInvocationAggregator = /*@__PURE__*/DI.createInterface<IHookInvocationAggregator>('IHookInvocationAggregator', x => x.singleton(HookInvocationAggregator));
 export interface IHookInvocationAggregator extends HookInvocationAggregator {}
 export class HookInvocationAggregator {
   public readonly notifyHistory: string[] = [];

--- a/packages/__tests__/turbo.json
+++ b/packages/__tests__/turbo.json
@@ -3,7 +3,7 @@
     "extends": ["//"],
     "pipeline": {
       "build": {
-        "inputs": ["*/**/*.ts", "*/**/*.tsx", "esbuild.dev.cjs", "!z-scripts"],
+        "inputs": ["*/**/*.ts", "*/**/*.tsx", "**/*.ts", "**/*.tsx", "esbuild.dev.cjs", "!z-scripts"],
         "outputs": ["dist/**/*"]
       }
     }

--- a/packages/compat-v1/src/compat-delegate.ts
+++ b/packages/compat-v1/src/compat-delegate.ts
@@ -280,7 +280,7 @@ class DelegateSubscription implements IDisposable {
 }
 
 export interface IEventDelegator extends EventDelegator { }
-export const IEventDelegator = DI.createInterface<IEventDelegator>('IEventDelegator', x => x.cachedCallback((handler) => {
+export const IEventDelegator = /*@__PURE__*/DI.createInterface<IEventDelegator>('IEventDelegator', x => x.cachedCallback((handler) => {
   const instance = handler.invoke(EventDelegator);
   handler.register(AppTask.deactivating(() => instance.dispose()));
   return instance;

--- a/packages/dialog/src/plugins/dialog/dialog-configuration.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-configuration.ts
@@ -36,7 +36,7 @@ DialogConfiguration.customize(settings => {
 }, [all_implementations_here])
 ```
  */
-export const DialogConfiguration = createDialogConfiguration(() => {
+export const DialogConfiguration = /*@__PURE__*/createDialogConfiguration(() => {
   if (__DEV__)
     throw createError(`AUR0904: Invalid dialog configuration. ` +
       'Specify the implementations for ' +
@@ -51,7 +51,7 @@ export const DialogConfiguration = createDialogConfiguration(() => {
   }
 }]);
 
-export const DialogDefaultConfiguration = createDialogConfiguration(noop, [
+export const DialogDefaultConfiguration = /*@__PURE__*/createDialogConfiguration(noop, [
   DialogService,
   DefaultDialogGlobalSettings,
   DefaultDialogDomRenderer,

--- a/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-interfaces.ts
@@ -6,7 +6,7 @@ import type { ICustomElementViewModel } from '@aurelia/runtime-html';
 /**
  * The dialog service for composing view & view model into a dialog
  */
-export const IDialogService = createInterface<IDialogService>('IDialogService');
+export const IDialogService = /*@__PURE__*/createInterface<IDialogService>('IDialogService');
 export interface IDialogService {
   readonly controllers: IDialogController[];
   /**
@@ -28,7 +28,7 @@ export interface IDialogService {
 /**
  * The controller asscociated with every dialog view model
  */
-export const IDialogController = createInterface<IDialogController>('IDialogController');
+export const IDialogController = /*@__PURE__*/createInterface<IDialogController>('IDialogController');
 export interface IDialogController {
   readonly settings: IDialogLoadedSettings;
   /**
@@ -44,7 +44,7 @@ export interface IDialogController {
 /**
  * An interface describing the object responsible for creating the dom structure of a dialog
  */
-export const IDialogDomRenderer = createInterface<IDialogDomRenderer>('IDialogDomRenderer');
+export const IDialogDomRenderer = /*@__PURE__*/createInterface<IDialogDomRenderer>('IDialogDomRenderer');
 export interface IDialogDomRenderer {
   render(dialogHost: Element, settings: IDialogLoadedSettings): IDialogDom;
 }
@@ -52,7 +52,7 @@ export interface IDialogDomRenderer {
 /**
  * An interface describing the DOM structure of a dialog
  */
-export const IDialogDom = createInterface<IDialogDom>('IDialogDom');
+export const IDialogDom = /*@__PURE__*/createInterface<IDialogDom>('IDialogDom');
 export interface IDialogDom extends IDisposable {
   readonly overlay: HTMLElement;
   readonly contentHost: HTMLElement;
@@ -160,7 +160,7 @@ export type IDialogGlobalSettings = Pick<
   IDialogSettings,
   'lock' | 'startingZIndex' | 'rejectOnCancel'
 >;
-export const IDialogGlobalSettings = createInterface<IDialogGlobalSettings>('IDialogGlobalSettings');
+export const IDialogGlobalSettings = /*@__PURE__*/createInterface<IDialogGlobalSettings>('IDialogGlobalSettings');
 
 export interface DialogError<T> extends Error {
   wasCancelled: boolean;

--- a/packages/fetch-client/src/http-client.ts
+++ b/packages/fetch-client/src/http-client.ts
@@ -5,7 +5,7 @@ import { RetryInterceptor } from './retry-interceptor';
 
 const absoluteUrlRegexp = /^([a-z][a-z0-9+\-.]*:)?\/\//i;
 
-export const IHttpClient = DI.createInterface<IHttpClient>('IHttpClient', x => x.singleton(HttpClient));
+export const IHttpClient = /*@__PURE__*/DI.createInterface<IHttpClient>('IHttpClient', x => x.singleton(HttpClient));
 export interface IHttpClient extends HttpClient {}
 /**
  * An HTTP client based on the Fetch API.

--- a/packages/i18n/src/i18n-configuration-options.ts
+++ b/packages/i18n/src/i18n-configuration-options.ts
@@ -3,7 +3,7 @@ import { InitOptions, Module, ThirdPartyModule } from 'i18next';
 
 export type I18nModule = Module | ThirdPartyModule;
 
-export const I18nInitOptions = DI.createInterface<I18nInitOptions>('I18nInitOptions');
+export const I18nInitOptions = /*@__PURE__*/DI.createInterface<I18nInitOptions>('I18nInitOptions');
 export interface I18nInitOptions extends InitOptions {
   /**
    * Collection of i18next plugins to use.

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -95,7 +95,7 @@ export interface I18N {
    */
   subscribeLocaleChange(subscriber: ILocalChangeSubscriber): void;
 }
-export const I18N = DI.createInterface<I18N>('I18N');
+export const I18N = /*@__PURE__*/DI.createInterface<I18N>('I18N');
 
 export interface ILocalChangeSubscriber {
   handleLocaleChange(locales: { oldLocale: string; newLocale: string }): void;

--- a/packages/i18n/src/i18next-wrapper.ts
+++ b/packages/i18n/src/i18next-wrapper.ts
@@ -1,7 +1,7 @@
 import { DI } from '@aurelia/kernel';
 import i18next from 'i18next';
 
-export const I18nWrapper = DI.createInterface<I18nextWrapper>('I18nextWrapper');
+export const I18nWrapper = /*@__PURE__*/DI.createInterface<I18nextWrapper>('I18nextWrapper');
 
 /**
  * A wrapper class over i18next to facilitate the easy testing and DI.

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -3,7 +3,7 @@ import { isObject } from '@aurelia/metadata';
 import { isNativeFunction } from './functions';
 import { Class, Constructable, IDisposable } from './interfaces';
 import { emptyArray } from './platform';
-import { IResourceKind, Protocol, ResourceDefinition, ResourceType } from './resource';
+import { IResourceKind, ResourceDefinition, ResourceType, getAllResources, hasResources } from './resource';
 import { createError, createObject, getOwnMetadata, isFunction, isString, safeString } from './utilities';
 import { IContainer, type Key, type IResolver, type IDisposableResolver, Factory, ContainerConfiguration, type IRegistry, Registration, Resolver, ResolverStrategy, Transformer, type RegisterSelf, type Resolved, getDependencies, containerGetKey, IFactory, IContainerConfiguration } from './di';
 
@@ -95,8 +95,8 @@ export class Container implements IContainer {
       }
       if (isRegistry(current)) {
         current.register(this);
-      } else if (Protocol.resource.has(current)) {
-        const defs = Protocol.resource.getAll(current);
+      } else if (hasResources(current)) {
+        const defs = getAllResources(current);
         if (defs.length === 1) {
           // Fast path for the very common case
           defs[0].register(this);
@@ -445,8 +445,8 @@ export class Container implements IContainer {
         throw invalidResolverFromRegisterError();
       }
       return registrationResolver as IResolver;
-    } else if (Protocol.resource.has(keyAsValue)) {
-      const defs = Protocol.resource.getAll(keyAsValue);
+    } else if (hasResources(keyAsValue)) {
+      const defs = getAllResources(keyAsValue);
       if (defs.length === 1) {
         // Fast path for the very common case
         defs[0].register(handler);

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -4,7 +4,7 @@ import { isNativeFunction } from './functions';
 import { Class, Constructable, IDisposable } from './interfaces';
 import { emptyArray } from './platform';
 import { IResourceKind, Protocol, ResourceDefinition, ResourceType } from './resource';
-import { createError, createObject, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { createError, createObject, getOwnMetadata, isFunction, isString, safeString } from './utilities';
 import { IContainer, type Key, type IResolver, type IDisposableResolver, Factory, ContainerConfiguration, type IRegistry, Registration, Resolver, ResolverStrategy, Transformer, type RegisterSelf, type Resolved, getDependencies, containerGetKey, IFactory, IContainerConfiguration } from './di';
 
 const InstrinsicTypeNames = new Set<string>('Array ArrayBuffer Boolean DataView Date Error EvalError Float32Array Float64Array Function Int8Array Int16Array Int32Array Map Number Object Promise RangeError ReferenceError RegExp Set SharedArrayBuffer String SyntaxError TypeError Uint8Array Uint8ClampedArray Uint16Array Uint32Array URIError WeakMap WeakSet'.split(' '));
@@ -524,20 +524,20 @@ const registrationError = (deps: Key[]) =>
   // Most likely cause is trying to register a plain object that does not have a
   // register method and is not a class constructor
   __DEV__
-    ? createError(`AUR0006: Unable to autoregister dependency: [${deps.map(toStringSafe)}]`)
-    : createError(`AUR0006:${deps.map(toStringSafe)}`);
+    ? createError(`AUR0006: Unable to autoregister dependency: [${deps.map(safeString)}]`)
+    : createError(`AUR0006:${deps.map(safeString)}`);
 const resourceExistError = (key: Key) =>
   __DEV__
-    ? createError(`AUR0007: Resource key "${toStringSafe(key)}" already registered`)
-    : createError(`AUR0007:${toStringSafe(key)}`);
+    ? createError(`AUR0007: Resource key "${safeString(key)}" already registered`)
+    : createError(`AUR0007:${safeString(key)}`);
 const cantResolveKeyError = (key: Key) =>
   __DEV__
-    ? createError(`AUR0008: Unable to resolve key: ${toStringSafe(key)}`)
-    : createError(`AUR0008:${toStringSafe(key)}`);
+    ? createError(`AUR0008: Unable to resolve key: ${safeString(key)}`)
+    : createError(`AUR0008:${safeString(key)}`);
 const jitRegisterNonFunctionError = (keyAsValue: Key) =>
   __DEV__
-    ? createError(`AUR0009: Attempted to jitRegister something that is not a constructor: '${toStringSafe(keyAsValue)}'. Did you forget to register this resource?`)
-    : createError(`AUR0009:${toStringSafe(keyAsValue)}`);
+    ? createError(`AUR0009: Attempted to jitRegister something that is not a constructor: '${safeString(keyAsValue)}'. Did you forget to register this resource?`)
+    : createError(`AUR0009:${safeString(keyAsValue)}`);
 const jitInstrinsicTypeError = (keyAsValue: any) =>
   __DEV__
     ? createError(`AUR0010: Attempted to jitRegister an intrinsic type: ${keyAsValue.name}. Did you forget to add @inject(Key)`)

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -221,6 +221,7 @@ const getOrCreateAnnotationParamTypes = (Type: Constructable | Injectable): Key[
   return annotationParamtypes;
 };
 
+/** @internal */
 export const getDependencies = (Type: Constructable | Injectable): Key[] => {
   // Note: Every detail of this getDependencies method is pretty deliberate at the moment, and probably not yet 100% tested from every possible angle,
   // so be careful with making changes here as it can have a huge impact on complex end user apps.
@@ -301,24 +302,24 @@ export const getDependencies = (Type: Constructable | Injectable): Key[] => {
  */
 export const createInterface = <K extends Key>(configureOrName?: string | ((builder: ResolverBuilder<K>) => IResolver<K>), configuror?: (builder: ResolverBuilder<K>) => IResolver<K>): InterfaceSymbol<K> => {
  const configure = isFunction(configureOrName) ? configureOrName : configuror;
- const friendlyName = isString(configureOrName) ? configureOrName : undefined;
+ const friendlyName = (isString(configureOrName) ? configureOrName : undefined) ?? '(anonymous)';
 
  const Interface = function (target: Injectable | AbstractInjectable, property: string | symbol | undefined, index: number | undefined): void {
    if (target == null || new.target !== undefined) {
-    throw createNoRegistrationError(Interface.friendlyName);
+    throw createNoRegistrationError(friendlyName);
    }
    const annotationParamtypes = getOrCreateAnnotationParamTypes(target as Injectable);
    annotationParamtypes[index!] = Interface;
  };
  Interface.$isInterface = true;
- Interface.friendlyName = friendlyName == null ? '(anonymous)' : friendlyName;
+ Interface.friendlyName = friendlyName;
 
  if (configure != null) {
    Interface.register = (container: IContainer, key?: Key): IResolver<K> =>
      configure(new ResolverBuilder(container, key ?? Interface));
  }
 
- Interface.toString = (): string => `InterfaceSymbol<${Interface.friendlyName}>`;
+ Interface.toString = (): string => `InterfaceSymbol<${friendlyName}>`;
 
  return Interface;
 };
@@ -467,7 +468,7 @@ export const DI = {
   },
 };
 
-export const IContainer = createInterface<IContainer>('IContainer');
+export const IContainer = /*@__PURE__*/createInterface<IContainer>('IContainer');
 export const IServiceLocator = IContainer as unknown as InterfaceSymbol<IServiceLocator>;
 
 function createResolver(getter: (key: any, handler: IContainer, requestor: IContainer) => any): (key: any) => any {
@@ -581,7 +582,7 @@ const createAllResolver = (
   };
 };
 
-export const all = createAllResolver(
+export const all = /*@__PURE__*/createAllResolver(
   (key: any,
     handler: IContainer,
     requestor: IContainer,
@@ -616,7 +617,7 @@ export const all = createAllResolver(
  * - @param key [[`Key`]]
  * see { @link DI.createInterface } on interactions with interfaces
  */
-export const lazy = createResolver((key: Key, handler: IContainer, requestor: IContainer) =>  {
+export const lazy = /*@__PURE__*/createResolver((key: Key, handler: IContainer, requestor: IContainer) =>  {
   return () => requestor.get(key);
 });
 export type ILazyResolver<K = any> = IResolver<K>
@@ -648,7 +649,7 @@ export type IResolvedLazy<K> = () => Resolved<K>;
  *
  * see { @link DI.createInterface } on interactions with interfaces
  */
-export const optional = createResolver((key: Key, handler: IContainer, requestor: IContainer) =>  {
+export const optional = /*@__PURE__*/createResolver((key: Key, handler: IContainer, requestor: IContainer) =>  {
   if (requestor.has(key, true)) {
     return requestor.get(key);
   } else {
@@ -693,7 +694,7 @@ ignore.resolve = () => undefined;
  * - @param key [[`Key`]]
  * see { @link DI.createInterface } on interactions with interfaces
  */
-export const factory = createResolver((key: any, handler: IContainer, requestor: IContainer) => {
+export const factory = /*@__PURE__*/createResolver((key: any, handler: IContainer, requestor: IContainer) => {
   return (...args: unknown[]) => handler.getFactory(key).construct(requestor, args);
 }) as <K>(key: K) => IFactoryResolver<K>;
 export type IFactoryResolver<K = any> = IResolver<K>
@@ -703,7 +704,7 @@ export type IFactoryResolver<K = any> = IResolver<K>
   & ((...args: unknown[]) => any);
 export type IResolvedFactory<K> = (...args: unknown[]) => Resolved<K>;
 
-export const newInstanceForScope = createResolver(
+export const newInstanceForScope = /*@__PURE__*/createResolver(
   (key: any, handler: IContainer, requestor: IContainer) => {
     const instance = createNewInstance(key, handler, requestor);
     const instanceProvider: InstanceProvider<any> = new InstanceProvider<any>(safeString(key), instance);
@@ -716,7 +717,7 @@ export const newInstanceForScope = createResolver(
     return instance;
   }) as <K>(key: K) => INewInstanceResolver<K>;
 
-export const newInstanceOf = createResolver(
+export const newInstanceOf = /*@__PURE__*/createResolver(
   (key: any, handler: IContainer, requestor: IContainer) => createNewInstance(key, handler, requestor)
 ) as <K>(key: K) => INewInstanceResolver<K>;
 

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -11,7 +11,7 @@ import { isArrayIndex } from './functions';
 import { Container } from './di.container';
 import { Constructable, IDisposable, Writable } from './interfaces';
 import { appendAnnotation, getAnnotationKeyFor, IResourceKind, ResourceDefinition, ResourceType } from './resource';
-import { createError, defineMetadata, getOwnMetadata, isFunction, isString, toStringSafe } from './utilities';
+import { createError, defineMetadata, getOwnMetadata, isFunction, isString, safeString } from './utilities';
 import { instanceRegistration, singletonRegistration, transientRegistation, callbackRegistration, cachedCallbackRegistration, aliasToRegistration, deferRegistration, cacheCallbackResult } from './di.registration';
 
 export type ResolveCallback<T = any> = (handler: IContainer, requestor: IContainer, resolver: IResolver<T>) => T;
@@ -175,8 +175,8 @@ export const DefaultResolver = {
 
 const noResolverForKeyError = (key: Key) =>
   __DEV__
-    ? createError(`AUR0002: ${toStringSafe(key)} not registered, did you forget to add @singleton()?`)
-    : createError(`AUR0002:${toStringSafe(key)}`);
+    ? createError(`AUR0002: ${safeString(key)} not registered, did you forget to add @singleton()?`)
+    : createError(`AUR0002:${safeString(key)}`);
 
 export class ContainerConfiguration implements IContainerConfiguration {
   public static readonly DEFAULT: ContainerConfiguration = ContainerConfiguration.from({});
@@ -706,7 +706,7 @@ export type IResolvedFactory<K> = (...args: unknown[]) => Resolved<K>;
 export const newInstanceForScope = createResolver(
   (key: any, handler: IContainer, requestor: IContainer) => {
     const instance = createNewInstance(key, handler, requestor);
-    const instanceProvider: InstanceProvider<any> = new InstanceProvider<any>(toStringSafe(key), instance);
+    const instanceProvider: InstanceProvider<any> = new InstanceProvider<any>(safeString(key), instance);
     /**
      * By default the new instances for scope are disposable.
      * If need be, we can always enhance the `createNewInstance` to support a 'injection' context, to make a non/disposable registration here.
@@ -807,8 +807,8 @@ const cyclicDependencyError = (name: string) =>
     : createError(`AUR0003:${name}`);
 const nullFactoryError = (key: Key) =>
   __DEV__
-    ? createError(`AUR0004: Resolver for ${toStringSafe(key)} returned a null factory`)
-    : createError(`AUR0004:${toStringSafe(key)}`);
+    ? createError(`AUR0004: Resolver for ${safeString(key)} returned a null factory`)
+    : createError(`AUR0004:${safeString(key)}`);
 const invalidResolverStrategyError = (strategy: ResolverStrategy) =>
   __DEV__
     ? createError(`AUR0005: Invalid resolver strategy specified: ${strategy}.`)

--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -18,7 +18,7 @@ class Handler<T extends Constructable> {
   }
 }
 
-export const IEventAggregator = createInterface<IEventAggregator>('IEventAggregator', x => x.singleton(EventAggregator));
+export const IEventAggregator = /*@__PURE__*/createInterface<IEventAggregator>('IEventAggregator', x => x.singleton(EventAggregator));
 export interface IEventAggregator extends EventAggregator {}
 
 /**

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -44,7 +44,7 @@ export const isArrayIndex = (value: unknown): value is number | string => {
 /**
  * Base implementation of camel and kebab cases
  */
-const baseCase = (function () {
+const baseCase = /*@__PURE__*/(function () {
   _START_CONST_ENUM();
   const enum CharKind {
     none  = 0,
@@ -146,7 +146,7 @@ const baseCase = (function () {
  *
  * Results are cached.
  */
-export const camelCase = (function () {
+export const camelCase = /*@__PURE__*/(function () {
   const cache: Record<string, string | undefined> = createObject();
 
   const callback = (char: string, sep: boolean): string => {
@@ -172,7 +172,7 @@ export const camelCase = (function () {
  *
  * Results are cached.
  */
-export const pascalCase = (function () {
+export const pascalCase = /*@__PURE__*/(function () {
   const cache: Record<string, string | undefined> = createObject();
 
   return (input: string): string => {
@@ -198,7 +198,7 @@ export const pascalCase = (function () {
  *
  * Results are cached.
  */
-export const kebabCase = (function () {
+export const kebabCase = /*@__PURE__*/(function () {
   const cache: Record<string, string | undefined> = createObject();
 
   const callback = (char: string, sep: boolean): string => {
@@ -285,7 +285,7 @@ export const firstDefined = <T>(...values: readonly (T | undefined)[]): T => {
   throw createError(`No default value found`);
 };
 
-export const getPrototypeChain = (function () {
+export const getPrototypeChain = /*@__PURE__*/(function () {
   const functionPrototype = Function.prototype;
   const getPrototypeOf = Object.getPrototypeOf;
 
@@ -362,7 +362,7 @@ export function toLookup(...objs: {}[]): Readonly<{}> {
  * @param fn - The function to check.
  * @returns `true` is the function is a native function, otherwise `false`
  */
-export const isNativeFunction = (function () {
+export const isNativeFunction = /*@__PURE__*/(function () {
   // eslint-disable-next-line @typescript-eslint/ban-types
   const lookup: WeakMap<Function, boolean> = new WeakMap();
   let isNative = false as boolean | undefined;

--- a/packages/kernel/src/logger.ts
+++ b/packages/kernel/src/logger.ts
@@ -160,11 +160,11 @@ export interface ISink {
  */
 export interface ILogger extends DefaultLogger {}
 
-export const ILogConfig = createInterface<ILogConfig>('ILogConfig', x => x.instance(new LogConfig(ColorOptions.noColors, LogLevel.warn)));
-export const ISink = createInterface<ISink>('ISink');
-export const ILogEventFactory = createInterface<ILogEventFactory>('ILogEventFactory', x => x.singleton(DefaultLogEventFactory));
-export const ILogger = createInterface<ILogger>('ILogger', x => x.singleton(DefaultLogger));
-export const ILogScopes = createInterface<string[]>('ILogScope');
+export const ILogConfig = /*@__PURE__*/createInterface<ILogConfig>('ILogConfig', x => x.instance(new LogConfig(ColorOptions.noColors, LogLevel.warn)));
+export const ISink = /*@__PURE__*/createInterface<ISink>('ISink');
+export const ILogEventFactory = /*@__PURE__*/createInterface<ILogEventFactory>('ILogEventFactory', x => x.singleton(DefaultLogEventFactory));
+export const ILogger = /*@__PURE__*/createInterface<ILogger>('ILogger', x => x.singleton(DefaultLogger));
+export const ILogScopes = /*@__PURE__*/createInterface<string[]>('ILogScope');
 
 interface SinkDefinition {
   handles: Exclude<LogLevel, LogLevel.none>[];

--- a/packages/kernel/src/module-loader.ts
+++ b/packages/kernel/src/module-loader.ts
@@ -1,6 +1,6 @@
 import { createInterface } from './di';
 import { emptyArray } from './platform';
-import { Protocol } from './resource';
+import { getAllResources } from './resource';
 import { createError, isFunction } from './utilities';
 
 import type { IRegistry } from './di';
@@ -13,7 +13,7 @@ export interface IModule {
 }
 
 export interface IModuleLoader extends ModuleLoader {}
-export const IModuleLoader = createInterface<IModuleLoader>(x => x.singleton(ModuleLoader));
+export const IModuleLoader = /*@__PURE__*/createInterface<IModuleLoader>(x => x.singleton(ModuleLoader));
 
 const noTransform = <TRet = AnalyzedModule>(m: AnalyzedModule): TRet => m as unknown as TRet;
 
@@ -97,7 +97,7 @@ class ModuleTransformer<TMod extends IModule = IModule, TRet = AnalyzedModule<TM
         case 'function':
           isRegistry = isFunction((value as Constructable & IIndexable).register);
           isConstructable = (value as Constructable).prototype !== void 0;
-          definitions = Protocol.resource.getAll(value as Constructable);
+          definitions = getAllResources(value as Constructable);
           break;
         default:
           continue;

--- a/packages/kernel/src/platform.ts
+++ b/packages/kernel/src/platform.ts
@@ -2,11 +2,11 @@ import { Platform } from '@aurelia/platform';
 import { createInterface } from './di';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const emptyArray: any[] = Object.freeze<any>([]) as any;
+export const emptyArray: any[] = Object.freeze<any>([]);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const emptyObject: any = Object.freeze({}) as any;
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function noop(): void {}
 
 export interface IPlatform extends Platform {}
-export const IPlatform = createInterface<IPlatform>('IPlatform');
+export const IPlatform = /*@__PURE__*/createInterface<IPlatform>('IPlatform');

--- a/packages/kernel/src/resource.ts
+++ b/packages/kernel/src/resource.ts
@@ -76,6 +76,17 @@ const annotation = Object.freeze({
 });
 
 const resBaseName = 'au:resource';
+export const hasResources = (target: unknown): target is Constructable => hasOwnMetadata(resBaseName, target);
+/** @internal */
+export const getAllResources = (target: Constructable): readonly ResourceDefinition[] => {
+  const keys = getOwnMetadata(resBaseName, target) as string[];
+  if (keys === void 0) {
+    return emptyArray;
+  } else {
+    return keys.map(k => getOwnMetadata(k, target));
+  }
+};
+
 const resource = Object.freeze({
   name: resBaseName,
   appendTo(target: Constructable, key: string): void {
@@ -86,15 +97,8 @@ const resource = Object.freeze({
       keys.push(key);
     }
   },
-  has: (target: unknown): target is Constructable => hasOwnMetadata(resBaseName, target),
-  getAll(target: Constructable): readonly ResourceDefinition[] {
-    const keys = getOwnMetadata(resBaseName, target) as string[];
-    if (keys === void 0) {
-      return emptyArray;
-    } else {
-      return keys.map(k => getOwnMetadata(k, target));
-    }
-  },
+  has: hasResources,
+  getAll: getAllResources,
   getKeys(target: Constructable): readonly string[] {
     let keys = getOwnMetadata(resBaseName, target) as string[];
     if (keys === void 0) {

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -1,6 +1,6 @@
 import { Metadata } from '@aurelia/metadata';
 
-/** @internal */ export const toStringSafe = String;
+/** @internal */ export const safeString = String;
 /** @internal */ export const getOwnMetadata = Metadata.getOwn;
 /** @internal */ export const hasOwnMetadata = Metadata.hasOwn;
 /** @internal */ export const defineMetadata = Metadata.define;

--- a/packages/rollup-utils.js
+++ b/packages/rollup-utils.js
@@ -54,7 +54,7 @@ export function rollupTypeScript(overrides, isDevMode) {
     sourceMap: true,
     include: ['../global.d.ts', 'src/**/*.ts'],
     noEmitOnError: false,
-    removeComments: true,
+    removeComments: false,
     inlineSourceMap: isDevMode,
     ...overrides,
   });
@@ -65,9 +65,7 @@ export function rollupTypeScript(overrides, isDevMode) {
  */
 export function rollupTerser(overrides) {
   return terser({
-    compress: {
-      defaults: false,
-    },
+    compress: false,
     mangle: {
       properties: {
         regex: /^_/,
@@ -76,8 +74,11 @@ export function rollupTerser(overrides) {
     },
     nameCache: terserNameCache,
     format: {
+      comments: /@__PURE__/,
+      preserve_annotations: true,
       beautify: true,
     },
+    keep_fnames: true,
     keep_classnames: true,
     ...overrides,
   });

--- a/packages/router-html/src/configuration.ts
+++ b/packages/router-html/src/configuration.ts
@@ -10,7 +10,7 @@ import { IRouter, Router } from './router.js';
 import { IRouterOptions, RouterOptions } from './router-options.js';
 import { BeforeNavigationHookFunction, IRoutingHookOptions, RoutingHook, RoutingHookFunction, RoutingHookIdentity, TransformFromUrlHookFunction, TransformTitleHookFunction, TransformToUrlHookFunction } from './routing-hook.js';
 
-export const IRouterConfiguration = DI.createInterface<IRouterConfiguration>('IRouterConfiguration', x => x.singleton(RouterConfiguration));
+export const IRouterConfiguration = /*@__PURE__*/DI.createInterface<IRouterConfiguration>('IRouterConfiguration', x => x.singleton(RouterConfiguration));
 export interface IRouterConfiguration extends RouterConfiguration { }
 
 export const RouterRegistration = IRouter as unknown as IRegistry;

--- a/packages/router-lite/src/location-manager.ts
+++ b/packages/router-lite/src/location-manager.ts
@@ -7,8 +7,8 @@ import { IRouterEvents, LocationChangeEvent } from './router-events';
 export interface IPopStateEvent extends PopStateEvent {}
 export interface IHashChangeEvent extends HashChangeEvent {}
 
-export const IBaseHref = DI.createInterface<URL>('IBaseHref');
-export const ILocationManager = DI.createInterface<ILocationManager>('ILocationManager', x => x.singleton(BrowserLocationManager));
+export const IBaseHref = /*@__PURE__*/DI.createInterface<URL>('IBaseHref');
+export const ILocationManager = /*@__PURE__*/DI.createInterface<ILocationManager>('ILocationManager', x => x.singleton(BrowserLocationManager));
 export interface ILocationManager extends BrowserLocationManager {}
 
 /**

--- a/packages/router-lite/src/options.ts
+++ b/packages/router-lite/src/options.ts
@@ -13,7 +13,7 @@ function valueOrFuncToValue<T extends string>(instructions: ViewportInstructionT
   return valueOrFunc;
 }
 
-export const IRouterOptions = DI.createInterface<Readonly<RouterOptions>>('RouterOptions');
+export const IRouterOptions = /*@__PURE__*/DI.createInterface<Readonly<RouterOptions>>('RouterOptions');
 export interface IRouterOptions extends Partial<RouterOptions> {}
 export class RouterOptions {
   protected constructor(

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -57,7 +57,7 @@ import { isPartialChildRouteConfig } from './validation';
 import { ViewportAgent, type ViewportRequest } from './viewport-agent';
 
 export interface IRouteContext extends RouteContext { }
-export const IRouteContext = DI.createInterface<IRouteContext>('IRouteContext');
+export const IRouteContext = /*@__PURE__*/DI.createInterface<IRouteContext>('IRouteContext');
 
 type PathGenerationResult = { vi: ViewportInstruction; query: Params };
 

--- a/packages/router-lite/src/router-events.ts
+++ b/packages/router-lite/src/router-events.ts
@@ -36,7 +36,7 @@ class Subscription implements IDisposable {
   }
 }
 
-export const IRouterEvents = DI.createInterface<IRouterEvents>('IRouterEvents', x => x.singleton(RouterEvents));
+export const IRouterEvents = /*@__PURE__*/DI.createInterface<IRouterEvents>('IRouterEvents', x => x.singleton(RouterEvents));
 export interface IRouterEvents extends RouterEvents {}
 export class RouterEvents implements IRouterEvents {
   private subscriptionSerial: number = 0;

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -101,7 +101,7 @@ type RouteConfigLookup = WeakMap<RouteConfig, IRouteContext>;
 type ViewportAgentLookup = Map<ViewportAgent | null, RouteConfigLookup>;
 
 export interface IRouter extends Router { }
-export const IRouter = DI.createInterface<IRouter>('IRouter', x => x.singleton(Router));
+export const IRouter = /*@__PURE__*/DI.createInterface<IRouter>('IRouter', x => x.singleton(Router));
 export class Router {
   private _ctx: RouteContext | null = null;
   private get ctx(): RouteContext {

--- a/packages/router-lite/src/state-manager.ts
+++ b/packages/router-lite/src/state-manager.ts
@@ -49,7 +49,7 @@ class HostElementState {
   }
 }
 
-export const IStateManager = DI.createInterface<IStateManager>('IStateManager', x => x.singleton(ScrollStateManager));
+export const IStateManager = /*@__PURE__*/DI.createInterface<IStateManager>('IStateManager', x => x.singleton(ScrollStateManager));
 export interface IStateManager {
   saveState(controller: ICustomElementController): void;
   restoreState(controller: ICustomElementController): void;

--- a/packages/router/src/configuration.ts
+++ b/packages/router/src/configuration.ts
@@ -9,7 +9,7 @@ import { IRouter, Router } from './router';
 import { IRouterOptions, RouterOptions } from './router-options';
 import { BeforeNavigationHookFunction, IRoutingHookOptions, RoutingHook, RoutingHookFunction, RoutingHookIdentity, TransformFromUrlHookFunction, TransformTitleHookFunction, TransformToUrlHookFunction } from './routing-hook';
 
-export const IRouterConfiguration = DI.createInterface<IRouterConfiguration>('IRouterConfiguration', x => x.singleton(RouterConfiguration));
+export const IRouterConfiguration = /*@__PURE__*/DI.createInterface<IRouterConfiguration>('IRouterConfiguration', x => x.singleton(RouterConfiguration));
 export interface IRouterConfiguration extends RouterConfiguration { }
 
 export const RouterRegistration = IRouter as unknown as IRegistry;

--- a/packages/router/src/resources/link-handler.ts
+++ b/packages/router/src/resources/link-handler.ts
@@ -3,7 +3,7 @@ import { IWindow, CustomAttribute } from '@aurelia/runtime-html';
 import { LoadCustomAttribute } from './load';
 import { IRouter } from '../router';
 
-export const ILinkHandler = DI.createInterface<ILinkHandler>('ILinkHandler', x => x.singleton(LinkHandler));
+export const ILinkHandler = /*@__PURE__*/DI.createInterface<ILinkHandler>('ILinkHandler', x => x.singleton(LinkHandler));
 
 export interface ILinkHandler extends LinkHandler { }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -134,7 +134,7 @@ export interface ILoadOptions {
   replacing?: boolean;
 }
 
-export const IRouter = DI.createInterface<IRouter>('IRouter', x => x.singleton(Router));
+export const IRouter = /*@__PURE__*/DI.createInterface<IRouter>('IRouter', x => x.singleton(Router));
 export interface IRouter extends Router { }
 
 export class Router implements IRouter {

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -16,7 +16,7 @@ export interface ISinglePageApp {
 }
 
 export interface IAppRoot extends AppRoot {}
-export const IAppRoot = createInterface<IAppRoot>('IAppRoot');
+export const IAppRoot = /*@__PURE__*/createInterface<IAppRoot>('IAppRoot');
 
 export class AppRoot implements IDisposable {
   public readonly host: HTMLElement;

--- a/packages/runtime-html/src/app-task.ts
+++ b/packages/runtime-html/src/app-task.ts
@@ -11,7 +11,7 @@ export type TaskSlot =
   | 'deactivating'
   | 'deactivated';
 
-export const IAppTask = createInterface<IAppTask>('IAppTask');
+export const IAppTask = /*@__PURE__*/createInterface<IAppTask>('IAppTask');
 export interface IAppTask {
   readonly slot: TaskSlot;
   register(c: IContainer): IContainer;

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -15,7 +15,7 @@ import type {
 } from '@aurelia/kernel';
 
 export interface IAurelia extends Aurelia {}
-export const IAurelia = createInterface<IAurelia>('IAurelia');
+export const IAurelia = /*@__PURE__*/createInterface<IAurelia>('IAurelia');
 
 export class Aurelia implements IDisposable {
   /** @internal */

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -105,7 +105,7 @@ export interface IFlushable {
   flush(): void;
 }
 
-export const IFlushQueue = createInterface<IFlushQueue>('IFlushQueue', x => x.singleton(FlushQueue));
+export const IFlushQueue = /*@__PURE__*/createInterface<IFlushQueue>('IFlushQueue', x => x.singleton(FlushQueue));
 export interface IFlushQueue {
   get count(): number;
   add(flushable: IFlushable): void;

--- a/packages/runtime-html/src/compiler/attribute-mapper.ts
+++ b/packages/runtime-html/src/compiler/attribute-mapper.ts
@@ -3,7 +3,7 @@ import { ISVGAnalyzer } from '../observation/svg-analyzer';
 import { createInterface } from '../utilities-di';
 
 export interface IAttrMapper extends AttrMapper {}
-export const IAttrMapper = createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
+export const IAttrMapper = /*@__PURE__*/createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
 
 export type IsTwoWayPredicate = (element: Element, attribute: string) => boolean;
 

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -2004,7 +2004,7 @@ const getBindingMode = (bindable: Element): BindingMode => {
  *
  * A feature available to the default template compiler.
  */
-export const ITemplateCompilerHooks = createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
+export const ITemplateCompilerHooks = /*@__PURE__*/createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
 export interface ITemplateCompilerHooks {
   /**
    * Should be invoked immediately before a template gets compiled

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -9,7 +9,7 @@ import { createInterface } from '../utilities-di';
  * so it is always safe to pass in a node without causing unnecessary DOM parsing or template creation.
  */
 export interface ITemplateElementFactory extends TemplateElementFactory {}
-export const ITemplateElementFactory = createInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
+export const ITemplateElementFactory = /*@__PURE__*/createInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
 
 const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -114,9 +114,9 @@ export const SpreadAttributePatternRegistration = SpreadAttributePattern as unkn
  * - `target.command` (dot-separated)
  */
 export const DefaultBindingSyntax = [
-  RefAttributePatternRegistration,
-  DotSeparatedAttributePatternRegistration,
-  SpreadAttributePatternRegistration,
+  RefAttributePattern,
+  DotSeparatedAttributePattern,
+  SpreadAttributePattern,
 ];
 
 /**
@@ -125,8 +125,8 @@ export const DefaultBindingSyntax = [
  * - `:target` (short-hand for `target.bind`)
  */
 export const ShortHandBindingSyntax = [
-  AtPrefixedTriggerAttributePatternRegistration,
-  ColonPrefixedBindAttributePatternRegistration
+  AtPrefixedTriggerAttributePattern,
+  ColonPrefixedBindAttributePattern
 ];
 
 export const DefaultBindingCommandRegistration = DefaultBindingCommand as unknown as IRegistry;
@@ -198,36 +198,36 @@ export const ShowRegistration = Show as unknown as IRegistry;
  * - Value Converters: `sanitize`
  */
 export const DefaultResources = [
-  DebounceBindingBehaviorRegistration,
-  OneTimeBindingBehaviorRegistration,
-  ToViewBindingBehaviorRegistration,
-  FromViewBindingBehaviorRegistration,
-  SignalBindingBehaviorRegistration,
-  ThrottleBindingBehaviorRegistration,
-  TwoWayBindingBehaviorRegistration,
-  SanitizeValueConverterRegistration,
-  IfRegistration,
-  ElseRegistration,
-  RepeatRegistration,
-  WithRegistration,
-  SwitchRegistration,
-  CaseRegistration,
-  DefaultCaseRegistration,
-  PromiseTemplateControllerRegistration,
-  PendingTemplateControllerRegistration,
-  FulfilledTemplateControllerRegistration,
-  RejectedTemplateControllerRegistration,
+  DebounceBindingBehavior,
+  OneTimeBindingBehavior,
+  ToViewBindingBehavior,
+  FromViewBindingBehavior,
+  SignalBindingBehavior,
+  ThrottleBindingBehavior,
+  TwoWayBindingBehavior,
+  SanitizeValueConverter,
+  If,
+  Else,
+  Repeat,
+  With,
+  Switch,
+  Case,
+  DefaultCase,
+  PromiseTemplateController,
+  PendingTemplateController,
+  FulfilledTemplateController,
+  RejectedTemplateController,
   // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-  PromiseAttributePatternRegistration,
-  FulfilledAttributePatternRegistration,
-  RejectedAttributePatternRegistration,
+  PromiseAttributePattern,
+  FulfilledAttributePattern,
+  RejectedAttributePattern,
   AttrBindingBehavior,
-  SelfBindingBehaviorRegistration,
-  UpdateTriggerBindingBehaviorRegistration,
-  AuComposeRegistration,
-  PortalRegistration,
-  FocusRegistration,
-  ShowRegistration,
+  SelfBindingBehavior,
+  UpdateTriggerBindingBehavior,
+  AuCompose,
+  Portal,
+  Focus,
+  Show,
   AuSlot,
 ];
 
@@ -268,7 +268,7 @@ export const DefaultRenderers = [
   SpreadRenderer,
 ];
 
-export const StandardConfiguration = createConfiguration(noop);
+export const StandardConfiguration = /*@__PURE__*/createConfiguration(noop);
 
 function createConfiguration(optionsProvider: ConfigurationOptionsProvider) {
   return {

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -1,4 +1,4 @@
-import { IContainer, IRegistry, noop } from '@aurelia/kernel';
+import { IContainer, noop } from '@aurelia/kernel';
 import {
   AtPrefixedTriggerAttributePattern,
   ColonPrefixedBindAttributePattern,
@@ -50,7 +50,6 @@ import {
 import { DebounceBindingBehavior } from './resources/binding-behaviors/debounce';
 import { SignalBindingBehavior } from './resources/binding-behaviors/signals';
 import { ThrottleBindingBehavior } from './resources/binding-behaviors/throttle';
-import { SVGAnalyzer } from './observation/svg-analyzer';
 import { AttrBindingBehavior } from './resources/binding-behaviors/attr';
 import { SelfBindingBehavior } from './resources/binding-behaviors/self';
 import { UpdateTriggerBindingBehavior } from './resources/binding-behaviors/update-trigger';
@@ -78,17 +77,6 @@ import { NodeObserverLocator } from './observation/observer-locator';
 import { ICoercionConfiguration } from '@aurelia/runtime';
 import { instanceRegistration } from './utilities-di';
 
-export const DebounceBindingBehaviorRegistration = DebounceBindingBehavior as unknown as IRegistry;
-export const OneTimeBindingBehaviorRegistration = OneTimeBindingBehavior as unknown as IRegistry;
-export const ToViewBindingBehaviorRegistration = ToViewBindingBehavior as unknown as IRegistry;
-export const FromViewBindingBehaviorRegistration = FromViewBindingBehavior as unknown as IRegistry;
-export const SignalBindingBehaviorRegistration = SignalBindingBehavior as unknown as IRegistry;
-export const ThrottleBindingBehaviorRegistration = ThrottleBindingBehavior as unknown as IRegistry;
-export const TwoWayBindingBehaviorRegistration = TwoWayBindingBehavior as unknown as IRegistry;
-
-export const ITemplateCompilerRegistration = TemplateCompiler as IRegistry;
-export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry;
-
 /**
  * Default HTML-specific (but environment-agnostic) implementations for the following interfaces:
  * - `ITemplateCompiler`
@@ -96,17 +84,9 @@ export const INodeObserverLocatorRegistration = NodeObserverLocator as IRegistry
  * - `ITargetObserverLocator`
  */
 export const DefaultComponents = [
-  ITemplateCompilerRegistration,
-  INodeObserverLocatorRegistration,
+  TemplateCompiler,
+  NodeObserverLocator,
 ];
-
-export const SVGAnalyzerRegistration = SVGAnalyzer as IRegistry;
-
-export const AtPrefixedTriggerAttributePatternRegistration = AtPrefixedTriggerAttributePattern as unknown as IRegistry;
-export const ColonPrefixedBindAttributePatternRegistration = ColonPrefixedBindAttributePattern as unknown as IRegistry;
-export const RefAttributePatternRegistration = RefAttributePattern as unknown as IRegistry;
-export const DotSeparatedAttributePatternRegistration = DotSeparatedAttributePattern as unknown as IRegistry;
-export const SpreadAttributePatternRegistration = SpreadAttributePattern as unknown as IRegistry;
 
 /**
  * Default binding syntax for the following attribute name patterns:
@@ -129,20 +109,6 @@ export const ShortHandBindingSyntax = [
   ColonPrefixedBindAttributePattern
 ];
 
-export const DefaultBindingCommandRegistration = DefaultBindingCommand as unknown as IRegistry;
-export const ForBindingCommandRegistration = ForBindingCommand as unknown as IRegistry;
-export const FromViewBindingCommandRegistration = FromViewBindingCommand as unknown as IRegistry;
-export const OneTimeBindingCommandRegistration = OneTimeBindingCommand as unknown as IRegistry;
-export const ToViewBindingCommandRegistration = ToViewBindingCommand as unknown as IRegistry;
-export const TwoWayBindingCommandRegistration = TwoWayBindingCommand as unknown as IRegistry;
-export const RefBindingCommandRegistration = RefBindingCommand as unknown as IRegistry;
-export const TriggerBindingCommandRegistration = TriggerBindingCommand as unknown as IRegistry;
-export const CaptureBindingCommandRegistration = CaptureBindingCommand as unknown as IRegistry;
-export const AttrBindingCommandRegistration = AttrBindingCommand as unknown as IRegistry;
-export const ClassBindingCommandRegistration = ClassBindingCommand as unknown as IRegistry;
-export const StyleBindingCommandRegistration = StyleBindingCommand as unknown as IRegistry;
-export const SpreadBindingCommandRegistration = SpreadBindingCommand as unknown as IRegistry;
-
 /**
  * Default HTML-specific (but environment-agnostic) binding commands:
  * - Property observation: `.bind`, `.one-time`, `.from-view`, `.to-view`, `.two-way`
@@ -151,43 +117,20 @@ export const SpreadBindingCommandRegistration = SpreadBindingCommand as unknown 
  * - Event listeners: `.trigger`, `.delegate`, `.capture`
  */
 export const DefaultBindingLanguage = [
-  DefaultBindingCommandRegistration,
-  OneTimeBindingCommandRegistration,
-  FromViewBindingCommandRegistration,
-  ToViewBindingCommandRegistration,
-  TwoWayBindingCommandRegistration,
-  ForBindingCommandRegistration,
-  RefBindingCommandRegistration,
-  TriggerBindingCommandRegistration,
-  CaptureBindingCommandRegistration,
-  ClassBindingCommandRegistration,
-  StyleBindingCommandRegistration,
-  AttrBindingCommandRegistration,
-  SpreadBindingCommandRegistration,
+  DefaultBindingCommand,
+  OneTimeBindingCommand,
+  FromViewBindingCommand,
+  ToViewBindingCommand,
+  TwoWayBindingCommand,
+  ForBindingCommand,
+  RefBindingCommand,
+  TriggerBindingCommand,
+  CaptureBindingCommand,
+  ClassBindingCommand,
+  StyleBindingCommand,
+  AttrBindingCommand,
+  SpreadBindingCommand,
 ];
-
-export const SanitizeValueConverterRegistration = SanitizeValueConverter as unknown as IRegistry;
-export const IfRegistration = If as unknown as IRegistry;
-export const ElseRegistration = Else as unknown as IRegistry;
-export const RepeatRegistration = Repeat as unknown as IRegistry;
-export const WithRegistration = With as unknown as IRegistry;
-export const SwitchRegistration = Switch as unknown as IRegistry;
-export const CaseRegistration = Case as unknown as IRegistry;
-export const DefaultCaseRegistration = DefaultCase as unknown as IRegistry;
-export const PromiseTemplateControllerRegistration = PromiseTemplateController as unknown as IRegistry;
-export const PendingTemplateControllerRegistration = PendingTemplateController as unknown as IRegistry;
-export const FulfilledTemplateControllerRegistration = FulfilledTemplateController as unknown as IRegistry;
-export const RejectedTemplateControllerRegistration = RejectedTemplateController as unknown as IRegistry;
-// TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
-export const PromiseAttributePatternRegistration = PromiseAttributePattern as unknown as IRegistry;
-export const FulfilledAttributePatternRegistration = FulfilledAttributePattern as unknown as IRegistry;
-export const RejectedAttributePatternRegistration = RejectedAttributePattern as unknown as IRegistry;
-export const SelfBindingBehaviorRegistration = SelfBindingBehavior as unknown as IRegistry;
-export const UpdateTriggerBindingBehaviorRegistration = UpdateTriggerBindingBehavior as unknown as IRegistry;
-export const AuComposeRegistration = AuCompose as unknown as IRegistry;
-export const PortalRegistration = Portal as unknown as IRegistry;
-export const FocusRegistration = Focus as unknown as IRegistry;
-export const ShowRegistration = Show as unknown as IRegistry;
 
 /**
  * Default HTML-specific (but environment-agnostic) resources:

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -22,22 +22,22 @@ export function setRef(node: INode, name: string, controller: IHydratedControlle
 export type INode<T extends Node = Node> = T & {
   readonly $au?: Refs;
 };
-export const INode = createInterface<INode>('INode');
+export const INode = /*@__PURE__*/createInterface<INode>('INode');
 
 export type IEventTarget<T extends EventTarget = EventTarget> = T;
-export const IEventTarget = createInterface<IEventTarget>('IEventTarget', x => x.cachedCallback(handler => {
+export const IEventTarget = /*@__PURE__*/createInterface<IEventTarget>('IEventTarget', x => x.cachedCallback(handler => {
   if (handler.has(IAppRoot, true)) {
     return handler.get(IAppRoot).host;
   }
   return handler.get(IPlatform).document;
 }));
 
-export const IRenderLocation = createInterface<IRenderLocation>('IRenderLocation');
+export const IRenderLocation = /*@__PURE__*/createInterface<IRenderLocation>('IRenderLocation');
 export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
 };
 
-export const ICssModulesMapping = createInterface<Record<string, string>>('CssModules');
+export const ICssModulesMapping = /*@__PURE__*/createInterface<Record<string, string>>('CssModules');
 
 /**
  * Represents a DocumentFragment
@@ -410,13 +410,13 @@ export class FragmentNodeSequence implements INodeSequence {
   }
 }
 
-export const IWindow = createInterface<IWindow>('IWindow', x => x.callback(handler => handler.get(IPlatform).window));
+export const IWindow = /*@__PURE__*/createInterface<IWindow>('IWindow', x => x.callback(handler => handler.get(IPlatform).window));
 export interface IWindow extends Window { }
 
-export const ILocation = createInterface<ILocation>('ILocation', x => x.callback(handler => handler.get(IWindow).location));
+export const ILocation = /*@__PURE__*/createInterface<ILocation>('ILocation', x => x.callback(handler => handler.get(IWindow).location));
 export interface ILocation extends Location { }
 
-export const IHistory = createInterface<IHistory>('IHistory', x => x.callback(handler => handler.get(IWindow).history));
+export const IHistory = /*@__PURE__*/createInterface<IHistory>('IHistory', x => x.callback(handler => handler.get(IWindow).history));
 // NOTE: `IHistory` is documented
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/History

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -11,16 +11,6 @@ export {
 } from './observation/bindable-observer';
 
 export {
-  DebounceBindingBehaviorRegistration,
-  OneTimeBindingBehaviorRegistration,
-  ToViewBindingBehaviorRegistration,
-  FromViewBindingBehaviorRegistration,
-  SignalBindingBehaviorRegistration,
-  ThrottleBindingBehaviorRegistration,
-  TwoWayBindingBehaviorRegistration,
-} from './configuration';
-
-export {
   bindingBehavior,
   BindingBehavior,
   BindingBehaviorDefinition,
@@ -319,51 +309,19 @@ export {
 } from './resources/value-converters/sanitize';
 
 export {
-  ITemplateCompilerRegistration,
-  INodeObserverLocatorRegistration,
-
   DefaultComponents,
-
-  RefAttributePatternRegistration,
-  DotSeparatedAttributePatternRegistration,
 
   DefaultBindingSyntax,
 
-  AtPrefixedTriggerAttributePatternRegistration,
-  ColonPrefixedBindAttributePatternRegistration,
-
   ShortHandBindingSyntax,
 
-  SVGAnalyzerRegistration,
-
-  DefaultBindingCommandRegistration,
-  ForBindingCommandRegistration,
-  RefBindingCommandRegistration,
-  FromViewBindingCommandRegistration,
-  OneTimeBindingCommandRegistration,
-  ToViewBindingCommandRegistration,
-  TwoWayBindingCommandRegistration,
-  TriggerBindingCommandRegistration,
-  CaptureBindingCommandRegistration,
-  AttrBindingCommandRegistration,
-  ClassBindingCommandRegistration,
-  StyleBindingCommandRegistration,
-
   DefaultBindingLanguage,
-
-  SanitizeValueConverterRegistration,
-  IfRegistration,
-  ElseRegistration,
-  RepeatRegistration,
-  WithRegistration,
-  SelfBindingBehaviorRegistration,
-  UpdateTriggerBindingBehaviorRegistration,
 
   DefaultResources,
 
   DefaultRenderers,
 
-  StandardConfiguration
+  StandardConfiguration,
 } from './configuration';
 export {
   ITemplateElementFactory

--- a/packages/runtime-html/src/observation/svg-analyzer.ts
+++ b/packages/runtime-html/src/observation/svg-analyzer.ts
@@ -6,7 +6,7 @@ import type { IContainer, IResolver } from '@aurelia/kernel';
 import type { INode } from '../dom';
 
 export interface ISVGAnalyzer extends NoopSVGAnalyzer {}
-export const ISVGAnalyzer = createInterface<ISVGAnalyzer>('ISVGAnalyzer', x => x.singleton(NoopSVGAnalyzer));
+export const ISVGAnalyzer = /*@__PURE__*/createInterface<ISVGAnalyzer>('ISVGAnalyzer', x => x.singleton(NoopSVGAnalyzer));
 
 const o = (keys: string | string[]): Record<string, true | undefined> => {
   const lookup = createLookup<true | undefined>();

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -72,7 +72,7 @@ export type InstructionTypeName = string;
 export interface IInstruction {
   readonly type: InstructionTypeName;
 }
-export const IInstruction = createInterface<IInstruction>('Instruction');
+export const IInstruction = /*@__PURE__*/createInterface<IInstruction>('Instruction');
 
 export function isInstruction(value: unknown): value is IInstruction {
   const type = (value as { type?: string }).type;
@@ -307,7 +307,7 @@ export class SpreadElementPropBindingInstruction {
   ) {}
 }
 
-export const ITemplateCompiler = createInterface<ITemplateCompiler>('ITemplateCompiler');
+export const ITemplateCompiler = /*@__PURE__*/createInterface<ITemplateCompiler>('ITemplateCompiler');
 export interface ITemplateCompiler {
   /**
    * Indicates whether this compiler should compile template in debug mode
@@ -372,7 +372,7 @@ export interface IRenderer<
   ): void;
 }
 
-export const IRenderer = createInterface<IRenderer>('IRenderer');
+export const IRenderer = /*@__PURE__*/createInterface<IRenderer>('IRenderer');
 
 type DecoratableInstructionRenderer<TType extends string, TProto, TClass> = Class<TProto & Partial<IInstructionTypeClassifier<TType> & Pick<IRenderer, 'render'>>, TClass> & Partial<IRegistry>;
 type DecoratedInstructionRenderer<TType extends string, TProto, TClass> =  Class<TProto & IInstructionTypeClassifier<TType> & Pick<IRenderer, 'render'>, TClass> & IRegistry;

--- a/packages/runtime-html/src/resources/attribute-pattern.ts
+++ b/packages/runtime-html/src/resources/attribute-pattern.ts
@@ -287,7 +287,7 @@ export interface ISyntaxInterpreter {
   add(defs: AttributePatternDefinition[]): void;
   interpret(name: string): Interpretation;
 }
-export const ISyntaxInterpreter = createInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
+export const ISyntaxInterpreter = /*@__PURE__*/createInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
 
 export class SyntaxInterpreter implements ISyntaxInterpreter {
   /** @internal */
@@ -443,12 +443,12 @@ export interface IAttributePattern {
   [pattern: string]: (rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax;
 }
 
-export const IAttributePattern = createInterface<IAttributePattern>('IAttributePattern');
+export const IAttributePattern = /*@__PURE__*/createInterface<IAttributePattern>('IAttributePattern');
 
 export interface IAttributeParser {
   parse(name: string, value: string): AttrSyntax;
 }
-export const IAttributeParser = createInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
+export const IAttributeParser = /*@__PURE__*/createInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
 
 export class AttributeParser implements IAttributeParser {
   /** @internal */

--- a/packages/runtime-html/src/resources/value-converters/sanitize.ts
+++ b/packages/runtime-html/src/resources/value-converters/sanitize.ts
@@ -11,7 +11,7 @@ export interface ISanitizer {
   sanitize(input: string): string;
 }
 
-export const ISanitizer = createInterface<ISanitizer>('ISanitizer', x => x.singleton(class {
+export const ISanitizer = /*@__PURE__*/createInterface<ISanitizer>('ISanitizer', x => x.singleton(class {
   public sanitize(): string {
     throw createError('"sanitize" method not implemented');
   }

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -38,6 +38,11 @@ export function children(selector: string): PropertyDecorator;
  */
 export function children(target: {}, prop: string): void;
 export function children(configOrTarget?: PartialChildrenDefinition | {} | string, prop?: string): void | PropertyDecorator | ClassDecorator {
+  if (!mixed) {
+    mixed = true;
+    subscriberCollection(ChildrenBinding);
+    lifecycleHooks()(ChildrenLifecycleHooks);
+  }
   let config: PartialChildrenDefinition;
 
   const dependenciesKey = 'dependencies';
@@ -211,7 +216,6 @@ export class ChildrenBinding implements IBinding {
     return filterChildren(this._controller, this._query, this._filter, this._map);
   }
 }
-subscriberCollection(ChildrenBinding);
 
 const childObserverOptions: MutationObserverInit = { childList: true };
 const notImplemented = (name: string) => createError(`Method "${name}": not implemented`);
@@ -280,4 +284,4 @@ class ChildrenLifecycleHooks {
   }
 }
 
-lifecycleHooks()(ChildrenLifecycleHooks);
+let mixed = false;

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -174,8 +174,6 @@ class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscr
   }
 }
 
-subscriberCollection(AuSlotWatcherBinding);
-
 type SlottedPropDefinition = PartialSlottedDefinition & { name: PropertyKey };
 class SlottedLifecycleHooks {
   public constructor(
@@ -199,8 +197,6 @@ class SlottedLifecycleHooks {
     controller.addBinding(watcher);
   }
 }
-
-lifecycleHooks()(SlottedLifecycleHooks);
 
 /**
  * Decorate a property of a class to get updates from the projection of the decorated custom element
@@ -231,6 +227,11 @@ export function slotted(query: string, slotName: string): PropertyDecorator;
 export function slotted(def: PartialSlottedDefinition): PropertyDecorator;
 export function slotted(queryOrDef?: string | PartialSlottedDefinition, slotName?: string): PropertyDecorator;
 export function slotted(queryOrDef?: string | PartialSlottedDefinition, slotName?: string) {
+  if (!mixed) {
+    mixed = true;
+    subscriberCollection(AuSlotWatcherBinding);
+    lifecycleHooks()(SlottedLifecycleHooks);
+  }
   const dependenciesKey = 'dependencies';
 
   function decorator($target: {}, $prop: symbol | string, desc?: PropertyDescriptor): void {
@@ -271,3 +272,5 @@ function testDecorator() {
     a4: any;
   }
 }
+
+let mixed = false;

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -27,7 +27,7 @@ export interface IAuSlotsInfo {
 /**
  * Describing the projection information statically available for a custom element
  */
-export const IAuSlotsInfo = createInterface<IAuSlotsInfo>('IAuSlotsInfo');
+export const IAuSlotsInfo = /*@__PURE__*/createInterface<IAuSlotsInfo>('IAuSlotsInfo');
 export class AuSlotsInfo implements IAuSlotsInfo {
   public constructor(
     public readonly projectedSlots: string[],
@@ -61,7 +61,7 @@ export interface IAuSlotWatcher extends ISubscribable {
   watch(slot: IAuSlot): void;
   unwatch(slot: IAuSlot): void;
 }
-export const IAuSlotWatcher = createInterface<IAuSlotWatcher>('IAuSlotWatcher');
+export const IAuSlotWatcher = /*@__PURE__*/createInterface<IAuSlotWatcher>('IAuSlotWatcher');
 
 // 1. on hydrating, create a slot watcher (binding) & register with hydration context
 // 2. on slot with projection created, optionally retrieve the slot watcher

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1683,9 +1683,9 @@ export interface ICustomElementController<C extends ICustomElementViewModel = IC
   ): void | Promise<void>;
 }
 
-export const IController = createInterface<IController>('IController');
+export const IController = /*@__PURE__*/createInterface<IController>('IController');
 
-export const IHydrationContext = createInterface<IHydrationContext>('IHydrationContext');
+export const IHydrationContext = /*@__PURE__*/createInterface<IHydrationContext>('IHydrationContext');
 export interface IHydrationContext<T extends ICustomElementViewModel = ICustomElementViewModel> {
   readonly controller: ICustomElementController<T>;
   readonly instruction: IControllerElementHydrationInstruction | null;

--- a/packages/runtime-html/src/templating/lifecycle-hooks.ts
+++ b/packages/runtime-html/src/templating/lifecycle-hooks.ts
@@ -10,7 +10,7 @@ export type LifecycleHook<TViewModel, TKey extends keyof TViewModel> =
     : never;
 
 export type ILifecycleHooks<TViewModel = {}, TKey extends keyof TViewModel = keyof TViewModel> = { [K in TKey]-?: LifecycleHook<TViewModel, K>; };
-export const ILifecycleHooks = createInterface<ILifecycleHooks<object>>('ILifecycleHooks');
+export const ILifecycleHooks = /*@__PURE__*/createInterface<ILifecycleHooks<object>>('ILifecycleHooks');
 
 export type LifecycleHooksLookup<TViewModel = {}> = {
   [K in FunctionPropNames<TViewModel>]?: readonly LifecycleHooksEntry<TViewModel, K>[];

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -10,7 +10,7 @@ import { IViewFactory, ViewFactory } from './view';
 import type { IHydratableController } from './controller';
 import { createInterface } from '../utilities-di';
 
-export const IRendering = createInterface<IRendering>('IRendering', x => x.singleton(Rendering));
+export const IRendering = /*@__PURE__*/createInterface<IRendering>('IRendering', x => x.singleton(Rendering));
 export interface IRendering extends Rendering { }
 
 export class Rendering {

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -65,7 +65,7 @@ export interface IShadowDOMStyleFactory {
   createStyles(localStyles: (string | CSSStyleSheet)[], sharedStyles: IShadowDOMStyles | null): IShadowDOMStyles;
 }
 
-export const IShadowDOMStyleFactory = createInterface<IShadowDOMStyleFactory>('IShadowDOMStyleFactory', x => x.cachedCallback(handler => {
+export const IShadowDOMStyleFactory = /*@__PURE__*/createInterface<IShadowDOMStyleFactory>('IShadowDOMStyleFactory', x => x.cachedCallback(handler => {
   if (AdoptedStyleSheetsStyles.supported(handler.get(IPlatform))) {
     return handler.get(AdoptedStyleSheetsStylesFactory);
   }
@@ -112,8 +112,8 @@ export interface IShadowDOMStyles {
   applyTo(shadowRoot: ShadowRoot): void;
 }
 
-export const IShadowDOMStyles = createInterface<IShadowDOMStyles>('IShadowDOMStyles');
-export const IShadowDOMGlobalStyles = createInterface<IShadowDOMStyles>('IShadowDOMGlobalStyles', x => x.instance({ applyTo: noop }));
+export const IShadowDOMStyles = /*@__PURE__*/createInterface<IShadowDOMStyles>('IShadowDOMStyles');
+export const IShadowDOMGlobalStyles = /*@__PURE__*/createInterface<IShadowDOMStyles>('IShadowDOMGlobalStyles', x => x.instance({ applyTo: noop }));
 
 export class AdoptedStyleSheetsStyles implements IShadowDOMStyles {
   private readonly styleSheets: CSSStyleSheet[];

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -8,7 +8,7 @@ import type { PartialCustomElementDefinition } from '../resources/custom-element
 import type { ICustomAttributeController, ICustomElementController, ISyntheticView } from './controller';
 
 export interface IViewFactory extends ViewFactory {}
-export const IViewFactory = createInterface<IViewFactory>('IViewFactory');
+export const IViewFactory = /*@__PURE__*/createInterface<IViewFactory>('IViewFactory');
 export class ViewFactory implements IViewFactory {
   public static maxCacheSize: number = 0xFFFF;
 

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -22,7 +22,7 @@ export interface IRateLimitOptions {
   signals: string[];
 }
 
-export const ICoercionConfiguration = DI.createInterface<ICoercionConfiguration>('ICoercionConfiguration');
+export const ICoercionConfiguration = /*@__PURE__*/DI.createInterface<ICoercionConfiguration>('ICoercionConfiguration');
 export interface ICoercionConfiguration {
   /** When set to `true`, enables the automatic type-coercion for bindables globally. */
   enableCoercion: boolean;

--- a/packages/state/src/interfaces.ts
+++ b/packages/state/src/interfaces.ts
@@ -1,9 +1,9 @@
 import { DI, type MaybePromise, type IRegistry, type IDisposable } from '@aurelia/kernel';
 
-export const IActionHandler = DI.createInterface<IActionHandler>('IActionHandler');
+export const IActionHandler = /*@__PURE__*/DI.createInterface<IActionHandler>('IActionHandler');
 export type IActionHandler<T = any> = (state: T, action: unknown) => MaybePromise<T>;
 
-export const IStore = DI.createInterface<IStore<object>>('IStore');
+export const IStore = /*@__PURE__*/DI.createInterface<IStore<object>>('IStore');
 export interface IStore<T extends object, TAction = unknown> {
   subscribe(subscriber: IStoreSubscriber<T>): void;
   unsubscribe(subscriber: IStoreSubscriber<T>): void;
@@ -17,7 +17,7 @@ export interface IStore<T extends object, TAction = unknown> {
   dispatch(action: TAction): void | Promise<void>;
 }
 
-export const IState = DI.createInterface<object>('IState');
+export const IState = /*@__PURE__*/DI.createInterface<object>('IState');
 
 export type IRegistrableAction = IActionHandler & IRegistry;
 

--- a/packages/ui-virtualization/src/interfaces.ts
+++ b/packages/ui-virtualization/src/interfaces.ts
@@ -15,7 +15,7 @@ export interface IVirtualRepeater<T extends Collection = Collection> extends ISc
   getDistances(): [top: number, bottom: number];
 }
 
-export const IDomRenderer = DI.createInterface<IDomRenderer>('IDomRenderer');
+export const IDomRenderer = /*@__PURE__*/DI.createInterface<IDomRenderer>('IDomRenderer');
 export interface IDomRenderer {
   render(target: HTMLElement | IRenderLocation): IVirtualRepeatDom;
 }
@@ -32,7 +32,7 @@ export interface IVirtualRepeatDom extends IDisposable {
   update(top: number, bot: number): void;
 }
 
-export const IScrollerObsererLocator = DI.createInterface<IScrollerObsererLocator>('IScrollerObsererLocator');
+export const IScrollerObsererLocator = /*@__PURE__*/DI.createInterface<IScrollerObsererLocator>('IScrollerObsererLocator');
 export interface IScrollerObsererLocator {
   getObserver(scroller: HTMLElement): IScrollerObserver;
 }
@@ -61,7 +61,7 @@ export interface IScrollerInfo {
   readonly height: number;
 }
 
-export const ICollectionStrategyLocator = DI.createInterface<ICollectionStrategyLocator>('ICollectionStrategyLocator');
+export const ICollectionStrategyLocator = /*@__PURE__*/DI.createInterface<ICollectionStrategyLocator>('ICollectionStrategyLocator');
 export interface ICollectionStrategyLocator {
   getStrategy(items: unknown): ICollectionStrategy;
 }

--- a/packages/validation-html/src/subscribers/validation-result-presenter-service.ts
+++ b/packages/validation-html/src/subscribers/validation-result-presenter-service.ts
@@ -7,7 +7,7 @@ const resultIdAttribute = 'validation-result-id';
 const resultContainerAttribute = 'validation-result-container';
 
 export interface IValidationResultPresenterService extends ValidationResultPresenterService { }
-export const IValidationResultPresenterService = DI.createInterface<IValidationResultPresenterService>('IValidationResultPresenterService', (x) => x.transient(ValidationResultPresenterService));
+export const IValidationResultPresenterService = /*@__PURE__*/DI.createInterface<IValidationResultPresenterService>('IValidationResultPresenterService', (x) => x.transient(ValidationResultPresenterService));
 
 export class ValidationResultPresenterService implements ValidationResultsSubscriber {
   public constructor(

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -51,7 +51,7 @@ export enum ValidationTrigger {
   changeOrFocusout = 'changeOrFocusout',
 }
 
-export const IDefaultTrigger = DI.createInterface<ValidationTrigger>('IDefaultTrigger');
+export const IDefaultTrigger = /*@__PURE__*/DI.createInterface<ValidationTrigger>('IDefaultTrigger');
 
 const validationConnectorMap = new WeakMap<IBinding, ValidatitionConnector>();
 const validationTargetSubscriberMap = new WeakMap<PropertyBinding, WithValidationTargetSubscriber>();

--- a/packages/validation-html/src/validation-controller.ts
+++ b/packages/validation-html/src/validation-controller.ts
@@ -293,7 +293,7 @@ export interface IValidationController {
    */
   reset(instruction?: ValidateInstruction): void;
 }
-export const IValidationController = DI.createInterface<IValidationController>('IValidationController');
+export const IValidationController = /*@__PURE__*/DI.createInterface<IValidationController>('IValidationController');
 
 export class ValidationController implements IValidationController {
 

--- a/packages/validation-i18n/src/localization.ts
+++ b/packages/validation-i18n/src/localization.ts
@@ -13,7 +13,7 @@ export interface ValidationI18nCustomizationOptions extends ValidationHtmlCustom
 }
 
 export type I18nKeyConfiguration = Pick<ValidationI18nCustomizationOptions, 'DefaultNamespace' | 'DefaultKeyPrefix'>;
-export const I18nKeyConfiguration = DI.createInterface<I18nKeyConfiguration>('I18nKeyConfiguration');
+export const I18nKeyConfiguration = /*@__PURE__*/DI.createInterface<I18nKeyConfiguration>('I18nKeyConfiguration');
 
 export class LocalizedValidationController extends ValidationController {
   private readonly localeChangeSubscription: IDisposable;

--- a/packages/validation/src/rule-interfaces.ts
+++ b/packages/validation/src/rule-interfaces.ts
@@ -84,7 +84,7 @@ export interface IValidationVisitor {
   visitPropertyRule(propertyRule: IPropertyRule): string;
 }
 
-export const IValidationExpressionHydrator = DI.createInterface<IValidationExpressionHydrator>('IValidationExpressionHydrator');
+export const IValidationExpressionHydrator = /*@__PURE__*/DI.createInterface<IValidationExpressionHydrator>('IValidationExpressionHydrator');
 export interface IValidationExpressionHydrator {
   readonly astDeserializer: Deserializer;
   readonly parser: IExpressionParser;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -47,7 +47,7 @@ export interface ICustomMessage<TRule extends IValidationRule = IValidationRule>
 }
 
 /* @internal */
-export const ICustomMessages = DI.createInterface<ICustomMessage[]>('ICustomMessages');
+export const ICustomMessages = /*@__PURE__*/DI.createInterface<ICustomMessage[]>('ICustomMessages');
 
 export class RuleProperty implements IRuleProperty {
   public static $TYPE: string = 'RuleProperty';
@@ -467,7 +467,7 @@ export interface IValidationRules<TObject extends IValidateable = IValidateable>
   off<TAnotherObject extends IValidateable = IValidateable>(target?: Class<TAnotherObject> | TAnotherObject, tag?: string): void;
   applyModelBasedRules(target: IValidateable, rules: ModelBasedRule[]): void;
 }
-export const IValidationRules = DI.createInterface<IValidationRules>('IValidationRules');
+export const IValidationRules = /*@__PURE__*/DI.createInterface<IValidationRules>('IValidationRules');
 
 export class ValidationRules<TObject extends IValidateable = IValidateable> implements IValidationRules<TObject> {
   public rules: PropertyRule[] = [];

--- a/packages/validation/src/rules.ts
+++ b/packages/validation/src/rules.ts
@@ -36,7 +36,7 @@ export interface IValidationMessageProvider {
   getDisplayName(propertyName: string | number | undefined, displayName?: string | null | ValidationDisplayNameAccessor): string | undefined;
 }
 
-export const IValidationMessageProvider = DI.createInterface<IValidationMessageProvider>('IValidationMessageProvider');
+export const IValidationMessageProvider = /*@__PURE__*/DI.createInterface<IValidationMessageProvider>('IValidationMessageProvider');
 
 export interface ValidationRuleAlias {
   name: string;

--- a/packages/validation/src/validator.ts
+++ b/packages/validation/src/validator.ts
@@ -24,7 +24,7 @@ export class ValidateInstruction<TObject extends IValidateable = IValidateable> 
   ) { }
 }
 
-export const IValidator = DI.createInterface<IValidator>('IValidator');
+export const IValidator = /*@__PURE__*/DI.createInterface<IValidator>('IValidator');
 
 /**
  * The core validator contract.

--- a/packages/web-components/src/web-components.ts
+++ b/packages/web-components/src/web-components.ts
@@ -12,7 +12,7 @@ import {
   setRef
 } from '@aurelia/runtime-html';
 
-export const IWcElementRegistry = DI.createInterface<IWcElementRegistry>(x => x.singleton(WcCustomElementRegistry));
+export const IWcElementRegistry = /*@__PURE__*/DI.createInterface<IWcElementRegistry>(x => x.singleton(WcCustomElementRegistry));
 export interface IWcElementRegistry {
   /**
    * Define a web-component custom element for a set of given parameters


### PR DESCRIPTION
## 📖 Description

Add `/*@__PURE__*/` annotation to all non native function calls so that application terser/minifier can drop unused imports from Aurelia modules.