### PR TITLE
feat(di): property injection with `resolve`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-git reset --quiet -- yarn.lock
+git reset --quiet -- yarn.lock packages/__tests__/tsconfig.json
 git checkout --quiet -- yarn.lock

--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/README.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/README.md
@@ -225,10 +225,10 @@ The section below describes how to use `resolve` function to perform property in
 
 ### Context
 
-Often times as application grows, there's a need to extract group some common functionalities to apply to multiple classes. There are many ways/techniques to do this,
-e.g mixin, decorator or sub classing. When working in class based application, subclassing is the more one commonly seen technique. Normally there would be a base class
+Often times as application grows, there's a need to extract & group some common functionalities to apply to multiple classes. There are many ways/techniques to do this,
+e.g mixin, decorator, sub classing etc.... When working in class based applications, subclassing is the more one commonly seen technique. Normally there would be a base class
 that requires a set of parameters during its construction, and provides a certain set of behaviors. In order to provide the base class the set of parameters it needs
-during construction, we have to pass those from the constructor of the subclass. Dependency injection cannot help in this case as it won't be able to call the
+during construction, we have to pass those from the constructor of the subclass. Constructor dependency injection cannot help in this case as it won't be able to call the
 base call constructor to provide (or "inject") its required dependencies. The following example won't work:
 
 ```typescript
@@ -262,7 +262,7 @@ export class MyInput extends FormElementBase {
   constructor(host, formController) {
     // "inject" the dependencies
     super(host, formController);
-    // do its own setup work here that doesn't need host or formControllere
+    // do its own setup work here that doesn't need host or formController
   }
 }
 ```
@@ -314,8 +314,8 @@ export class MyInput extends FormElementBase {
 }
 ```
 
-Because the `resolve(key)` call infers the returned type based on the type of `key` parameter, so the properties `form` and `formController` will automatically get
-the right types too, there's no need to do duplicate work as in the case with decorator.
+Because the `resolve(key)` call infers the returned type based on the type of `key` parameter, the properties `form` and `formController` will automatically get
+the right types, there's no need to do duplicate work as in the case with decorator.
 
 `resolve` can also be called with multiple keys, to get multiple values at once, like the following example:
 
@@ -338,13 +338,16 @@ You can also move `resolve` to a helper function that resolve a dependency and d
 
 {% code title="useFieldListeners.js" %}
 ```typescript
-import { resolve } from 'aurelia';
+import { resolve, all } from 'aurelia';
 
 export function useFieldListeners(field) {
-  const listeners = resolve(IFieldListeners);
+  const listeners = resolve(all(IFieldListeners));
 
   if (field.type === 'checkbox') {
-    return listeners.filter(listener => listener.type === 'change' || listener.type === 'validate');
+    return listeners.filter(listener =>
+      listener.type === 'change'
+      || listener.type === 'validate'
+    );
   }
 
   return listeners;

--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/README.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/README.md
@@ -229,7 +229,7 @@ Often times as application grows, there's a need to extract & group some common 
 e.g mixin, decorator, sub classing etc.... When working in class based applications, subclassing is the more one commonly seen technique. Normally there would be a base class
 that requires a set of parameters during its construction, and provides a certain set of behaviors. In order to provide the base class the set of parameters it needs
 during construction, we have to pass those from the constructor of the subclass. Constructor dependency injection cannot help in this case as it won't be able to call the
-base call constructor to provide (or "inject") its required dependencies. The following example won't work:
+base constructor to provide (or "inject") its required dependencies. The following example won't work:
 
 ```typescript
 abstract class FormElementBase {
@@ -240,10 +240,12 @@ abstract class FormElementBase {
     this.formController = formController;
   }
 }
+
+export class MyInput extends FormElementBase {}
 ```
 
 Even though we declared the `static inject` on the `FormElementBase`, at runtime, Aurelia won't be able to see this information, or able to do anything with it,
-as it will be constructing the subclass of this `FormElementBase` class. This results in undesirable boilerplate sometimes, especially when the parameters used in the
+as it will be constructing the subclass `MyInput`. This results in undesirable boilerplate sometimes, especially when the parameters used in the
 base class aren't needed in the subclass, like the following example:
 
 ```typescript
@@ -289,7 +291,7 @@ export class MyInput extends FormElementBase {
 
 There's not much boilerplate anymore, and it's easier to manage the dependencies now, as when the base class needs more dependencies, it can declare on its own
 and Aurelia DI system can just take care of that. From this example, we see there's a desirable use cases for the property injection capability.
-<!-- maybe explain the draw back of using decorator with the old decorator -->
+<!-- maybe explain the draw back of using decorator with the legacy decorator feature -->
 Aurelia provides a function `resolve` to meet this need.
 
 ### Using `resolve`
@@ -329,7 +331,7 @@ abstract class FormElementBase {
 ```
 
 Note that `resolve` can only be used when there is an active container. In other words, it can only be used within a dependency injection context. An attemp to `new FormElementBase` will result in an error as there's no active container.
-Because Aurelia applications and its tests are mostly in the context of the dependency injection system, this constraint should not be an issue.
+Because Aurelia applications and tests are mostly in the context of the dependency injection system, this constraint should not be an issue.
 
 ### Other `resolve` usages
 

--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
@@ -64,6 +64,7 @@ You can create your own resolver by implementing the `IResolver` interface. Here
 
 ```typescript
 export interface IResolver<T = any> {
+  $isResolver: true;
   resolve(handler: IContainer, requestor: IContainer): T;
   getFactory?(container: IContainer): IFactory<T> | null;
 }

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -25,7 +25,7 @@ module.exports = {
     'mocha/no-exports': 'off',
     'mocha/no-async-describe': 'error',
     'mocha/no-exclusive-tests': 'warn',
-    'mocha/no-hooks': 'error',
+    'mocha/no-hooks': 'off',
     'mocha/no-hooks-for-single-case': 'off', // Disabled to avoid duplicates, because 'no-hooks' is enabled
     'mocha/no-identical-title': 'error',
     'mocha/no-mocha-arrows': 'error',

--- a/packages/__tests__/1-kernel/di.containerconfiguration.spec.ts
+++ b/packages/__tests__/1-kernel/di.containerconfiguration.spec.ts
@@ -8,7 +8,6 @@ describe('1-kernel/di.containerconfiguration.spec.ts', function () {
   describe('child', function () {
     describe('defaultResolver - transient', function () {
       describe('root container', function () {
-        // eslint-disable-next-line mocha/no-hooks
         beforeEach(function () {
           container0 = DI.createContainer({
             ...ContainerConfiguration.DEFAULT,
@@ -36,7 +35,6 @@ describe('1-kernel/di.containerconfiguration.spec.ts', function () {
       });
 
       describe('one child container', function () {
-        // eslint-disable-next-line mocha/no-hooks
         beforeEach(function () {
           container0 = DI.createContainer();
 

--- a/packages/__tests__/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/1-kernel/di.get.spec.ts
@@ -892,6 +892,33 @@ describe('1-kernel/di.get.spec.ts', function () {
       assert.strictEqual(parent.model.details, container.get(Details));
     });
 
-    // add inheritance tests
+    describe('with [inheritance]', function () {
+      it('works for basic inheritance', function () {
+        let i = 0;
+        class Model { v = ++i; }
+        class Base {
+          a = injected(Model);
+        }
+        const { a: { v } } = container.get(class extends Base {});
+        assert.strictEqual(v, 1);
+      });
+
+      it('works with deeply nested injected(...)', function () {
+        let id = 0;
+        class Model { id = ++id; }
+        class Value {
+          a = injected(newInstanceOf(Model));
+        }
+        class V2 extends Value {
+          a = injected(newInstanceOf(Model));
+        }
+        class V3 extends V2 {
+          a = injected(newInstanceOf(Model));
+        }
+        const { a } = container.get(V3);
+
+        assert.strictEqual(a.id, 3);
+      });
+    });
   });
 });

--- a/packages/__tests__/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/1-kernel/di.get.spec.ts
@@ -1,4 +1,4 @@
-import { all, Constructable, DI, factory, IContainer, inject, injected, IResolvedFactory, lazy, newInstanceForScope, newInstanceOf, optional, Registration, singleton, transient } from '@aurelia/kernel';
+import { all, Constructable, DI, factory, IContainer, inject, resolve, IResolvedFactory, lazy, newInstanceForScope, newInstanceOf, optional, Registration, singleton, transient } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.get.spec.ts', function () {
@@ -9,7 +9,7 @@ describe('1-kernel/di.get.spec.ts', function () {
   });
 
   afterEach(function () {
-    assert.throws(() => injected(class Abc{}));
+    assert.throws(() => resolve(class Abc{}));
   });
 
   describe('@lazy', function () {
@@ -767,22 +767,22 @@ describe('1-kernel/di.get.spec.ts', function () {
     // to see if things work smoothly... TODO?
   });
 
-  describe('injected', function () {
-    it('works with injected(all(...))', function () {
+  describe('resolve', function () {
+    it('works with resolve(all(...))', function () {
       let id = 0;
       const II = DI.createInterface<{ a: Model }>();
       class Model {
         id = ++id;
       }
       class A {
-        a = injected(all(II));
+        a = resolve(all(II));
       }
       container.register(
         Registration.transient(II, class I1 {
-          a = injected(Model);
+          a = resolve(Model);
         }),
         Registration.transient(II, class I2 {
-          a = injected(newInstanceOf(Model));
+          a = resolve(newInstanceOf(Model));
         })
       );
       const { a } = container.get(A);
@@ -794,74 +794,74 @@ describe('1-kernel/di.get.spec.ts', function () {
       let i = 0;
       class Model { v = ++i; }
       class Base {
-        a = injected(Model, newInstanceOf(Model));
+        a = resolve(Model, newInstanceOf(Model));
       }
       const { a: [{ v }, { v: v1 }] } = container.get(Base);
       assert.strictEqual(v, 1);
       assert.strictEqual(v1, 2);
     });
 
-    it('works with injected(transient(...))', function () {
+    it('works with resolve(transient(...))', function () {
       let id = 0;
       class Model { id = ++id; }
       const { a, b } = container.get(class A {
-        a = injected(transient(Model));
-        b = injected(transient(Model));
+        a = resolve(transient(Model));
+        b = resolve(transient(Model));
       });
 
       assert.deepStrictEqual([a.id, b.id], [1, 2]);
     });
 
-    it('works with injected(lazy(...))', function () {
+    it('works with resolve(lazy(...))', function () {
       let id = 0;
       class Model { id = ++id; }
       const { a, b } = container.get(class A {
-        a = injected(lazy(Model));
-        b = injected(lazy(Model));
+        a = resolve(lazy(Model));
+        b = resolve(lazy(Model));
       });
 
       assert.deepStrictEqual([a().id, b().id], [1, 1]);
       assert.deepStrictEqual([a().id, b().id], [1, 1]);
     });
 
-    it('works with injected(optional(...))', function () {
+    it('works with resolve(optional(...))', function () {
       let id = 0;
       class Model { id = ++id; }
       const { a, b } = container.get(class A {
-        a = injected(optional(Model));
-        b = injected(optional(Model));
+        a = resolve(optional(Model));
+        b = resolve(optional(Model));
       });
 
       assert.deepStrictEqual([a?.id, b?.id], [undefined, undefined]);
     });
 
-    it('works with injected(newInstanceOf(...))', function () {
+    it('works with resolve(newInstanceOf(...))', function () {
       let id = 0;
       class Model { id = ++id; }
       const { a, b } = container.get(class A {
-        _ = injected(Model);
-        a = injected(newInstanceOf(Model));
-        b = injected(newInstanceOf(Model));
+        _ = resolve(Model);
+        a = resolve(newInstanceOf(Model));
+        b = resolve(newInstanceOf(Model));
       });
 
       assert.deepStrictEqual([a.id, b.id], [2, 3]);
       assert.strictEqual(container.getAll(Model).length, 1);
     });
 
-    it('works with injected(newInstanceForScope(...))', function () {
+    it('works with resolve(newInstanceForScope(...))', function () {
       let id = 0;
       class Model { id = ++id; }
       const { a, b } = container.get(class A {
-        _ = injected(Model);
-        a = injected(newInstanceForScope(Model));
-        b = injected(newInstanceForScope(Model));
+        _ = resolve(Model);
+        a = resolve(newInstanceForScope(Model));
+        b = resolve(newInstanceForScope(Model));
       });
 
       assert.deepStrictEqual([a.id, b.id], [2, 3]);
       assert.strictEqual(container.getAll(Model).length, 3);
     });
 
-    it('works with injected(factory(...))', function () {
+    it('works with resolve(factory(...))', function () {
       let id = 0;
       class Model {
         id = ++id;
@@ -874,28 +874,28 @@ describe('1-kernel/di.get.spec.ts', function () {
         }
       }
       const { a, b } = container.get(class A {
-        a = injected(factory(Model));
-        b = injected(factory(Model));
+        a = resolve(factory(Model));
+        b = resolve(factory(Model));
       });
 
       assert.deepStrictEqual([a(1, 2).sum, b(1, 2).sum], [4, 5]);
     });
 
-    it('works with deeply nested injected(...)', function () {
+    it('works with deeply nested resolve(...)', function () {
       let i = 0;
       class Address { n: number = ++i; }
       class Details {
-        address1 = injected(Address);
-        address2 = injected(newInstanceForScope(Address));
+        address1 = resolve(Address);
+        address2 = resolve(newInstanceForScope(Address));
       }
       class Profile {
-        details = injected(Details);
+        details = resolve(Details);
       }
       class Parent {
-        model = injected(Profile);
+        model = resolve(Profile);
       }
       class Child {
-        parent = injected(Parent);
+        parent = resolve(Parent);
       }
       const { parent } = container.get(Child);
       assert.strictEqual(parent.model.details.address1.n, 1);
@@ -908,23 +908,23 @@ describe('1-kernel/di.get.spec.ts', function () {
         let i = 0;
         class Model { v = ++i; }
         class Base {
-          a = injected(Model);
+          a = resolve(Model);
         }
         const { a: { v } } = container.get(class extends Base {});
         assert.strictEqual(v, 1);
       });
 
-      it('works with deeply nested injected(...)', function () {
+      it('works with deeply nested resolve(...)', function () {
         let id = 0;
         class Model { id = ++id; }
         class Value {
-          a = injected(newInstanceOf(Model));
+          a = resolve(newInstanceOf(Model));
         }
         class V2 extends Value {
-          a = injected(newInstanceOf(Model));
+          a = resolve(newInstanceOf(Model));
         }
         class V3 extends V2 {
-          a = injected(newInstanceOf(Model));
+          a = resolve(newInstanceOf(Model));
         }
         const { a } = container.get(V3);
 
@@ -935,7 +935,7 @@ describe('1-kernel/di.get.spec.ts', function () {
         let i = 0;
         class Model { v = ++i; }
         class Base {
-          a = injected(Model, newInstanceOf(Model));
+          a = resolve(Model, newInstanceOf(Model));
         }
         const { a: [{ v }, { v: v1 }] } = container.get(class extends Base {});
         assert.strictEqual(v, 1);
@@ -947,7 +947,7 @@ describe('1-kernel/di.get.spec.ts', function () {
         let j = 0;
         class Model { v = ++i; }
         class Base {
-          a = injected(newInstanceForScope(Model), newInstanceForScope(Model));
+          a = resolve(newInstanceForScope(Model), newInstanceForScope(Model));
         }
         const I = DI.createInterface<Base>();
         container.register(
@@ -957,7 +957,7 @@ describe('1-kernel/di.get.spec.ts', function () {
           }),
         );
         container.invoke(class {
-          b = injected(all(I), all(I));
+          b = resolve(all(I), all(I));
         });
 
         assert.strictEqual(container.getAll(Model).length, 8);

--- a/packages/__tests__/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/1-kernel/di.get.spec.ts
@@ -7,6 +7,7 @@ describe('1-kernel/di.get.spec.ts', function () {
   beforeEach(function () {
     container = DI.createContainer();
   });
+
   afterEach(function () {
     assert.throws(() => injected(class Abc{}));
   });
@@ -176,7 +177,7 @@ describe('1-kernel/di.get.spec.ts', function () {
     });
   });
 
-  describe.only('intrinsic', function () {
+  describe('intrinsic', function () {
 
     describe('bad', function () {
 

--- a/packages/__tests__/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/1-kernel/di.get.spec.ts
@@ -4,9 +4,11 @@ import { assert } from '@aurelia/testing';
 describe('1-kernel/di.get.spec.ts', function () {
   let container: IContainer;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
+  });
+  afterEach(function () {
+    assert.throws(() => injected(class Abc{}));
   });
 
   describe('@lazy', function () {
@@ -174,7 +176,7 @@ describe('1-kernel/di.get.spec.ts', function () {
     });
   });
 
-  describe('intrinsic', function () {
+  describe.only('intrinsic', function () {
 
     describe('bad', function () {
 
@@ -889,8 +891,6 @@ describe('1-kernel/di.get.spec.ts', function () {
       assert.strictEqual(parent.model.details, container.get(Details));
     });
 
-    it('throws on calling without an active container', function () {
-      assert.throws(() => injected(class Abc {}));
-    });
+    // add inheritance tests
   });
 });

--- a/packages/__tests__/1-kernel/di.getAll.spec.ts
+++ b/packages/__tests__/1-kernel/di.getAll.spec.ts
@@ -5,7 +5,6 @@ import { assert } from '@aurelia/testing';
 describe('1-kernel/di.getAll.spec.ts', function () {
   let container: IContainer;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
   });

--- a/packages/__tests__/1-kernel/di.getAll.spec.ts
+++ b/packages/__tests__/1-kernel/di.getAll.spec.ts
@@ -1,5 +1,4 @@
-// import { Metadata } from '@aurelia/metadata';
-import { all, DI, IContainer, injected, newInstanceOf, Registration } from '@aurelia/kernel';
+import { all, DI, IContainer, resolve, newInstanceOf, Registration } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.getAll.spec.ts', function () {
@@ -101,7 +100,7 @@ describe('1-kernel/di.getAll.spec.ts', function () {
     }
   });
 
-  describe('injected()', function () {
+  describe('resolve()', function () {
     it('works with .getAll()', function () {
       let id = 0;
       const II = DI.createInterface<{ a: Model }>();
@@ -110,10 +109,10 @@ describe('1-kernel/di.getAll.spec.ts', function () {
       }
       container.register(
         Registration.transient(II, class I1 {
-          a = injected(Model);
+          a = resolve(Model);
         }),
         Registration.transient(II, class I2 {
-          a = injected(newInstanceOf(Model));
+          a = resolve(newInstanceOf(Model));
         })
       );
       const iis = container.getAll(II);

--- a/packages/__tests__/1-kernel/di.getAll.spec.ts
+++ b/packages/__tests__/1-kernel/di.getAll.spec.ts
@@ -1,5 +1,5 @@
 // import { Metadata } from '@aurelia/metadata';
-import { all, DI, IContainer, Registration } from '@aurelia/kernel';
+import { all, DI, IContainer, injected, newInstanceOf, Registration } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.getAll.spec.ts', function () {
@@ -100,5 +100,26 @@ describe('1-kernel/di.getAll.spec.ts', function () {
         );
       });
     }
+  });
+
+  describe('injected()', function () {
+    it('works with .getAll()', function () {
+      let id = 0;
+      const II = DI.createInterface<{ a: Model }>();
+      class Model {
+        id = ++id;
+      }
+      container.register(
+        Registration.transient(II, class I1 {
+          a = injected(Model);
+        }),
+        Registration.transient(II, class I2 {
+          a = injected(newInstanceOf(Model));
+        })
+      );
+      const iis = container.getAll(II);
+
+      assert.deepStrictEqual(iis.map(a => a.a.id), [1, 2]);
+    });
   });
 });

--- a/packages/__tests__/1-kernel/di.integration.spec.ts
+++ b/packages/__tests__/1-kernel/di.integration.spec.ts
@@ -80,7 +80,6 @@ describe('1-kernel/di.integration.spec.ts', function () {
     let callback: ISpy<() => ICallback>;
     let get: ISpy<IContainer['get']>;
 
-    // eslint-disable-next-line mocha/no-hooks
     beforeEach(function () {
       callbackCount = 0;
       container = DI.createContainer();
@@ -94,7 +93,6 @@ describe('1-kernel/di.integration.spec.ts', function () {
       get = createSpy(container, 'get', true);
     });
 
-    // eslint-disable-next-line mocha/no-hooks
     afterEach(function () {
       get.restore();
     });

--- a/packages/__tests__/1-kernel/di.invoke.spec.ts
+++ b/packages/__tests__/1-kernel/di.invoke.spec.ts
@@ -4,9 +4,12 @@ import { assert } from '@aurelia/testing';
 describe('1-kernel/di.invoke.spec.ts', function () {
   let container: IContainer;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
+  });
+
+  afterEach(function () {
+    assert.throws(() => injected(class Abc{}));
   });
 
   it('plain usage', function () {

--- a/packages/__tests__/1-kernel/di.invoke.spec.ts
+++ b/packages/__tests__/1-kernel/di.invoke.spec.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer, injected, newInstanceForScope, newInstanceOf } from '@aurelia/kernel';
+import { DI, IContainer, resolve, newInstanceForScope, newInstanceOf } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.invoke.spec.ts', function () {
@@ -9,7 +9,7 @@ describe('1-kernel/di.invoke.spec.ts', function () {
   });
 
   afterEach(function () {
-    assert.throws(() => injected(class Abc{}));
+    assert.throws(() => resolve(class Abc{}));
   });
 
   it('plain usage', function () {
@@ -84,14 +84,14 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     assert.deepStrictEqual(instanceDeps[1], [depInstance, 'dep4', 'dep5']);
   });
 
-  it('works with injected', function () {
+  it('works with resolve', function () {
     let id = 0;
     class Model {
       id = ++id;
     }
     const { a, b } = container.invoke(class {
-      a = injected(Model);
-      b = injected(Model);
+      a = resolve(Model);
+      b = resolve(Model);
     });
 
     assert.strictEqual(id, 1);
@@ -99,14 +99,14 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     assert.strictEqual(b.id, 1);
   });
 
-  it('works with resolver + injected', function () {
+  it('works with resolver + resolve', function () {
     let id = 0;
     class Model {
       id = ++id;
     }
     const { a, b } = container.invoke(class {
-      a = injected(Model);
-      b = injected(newInstanceForScope(Model));
+      a = resolve(Model);
+      b = resolve(newInstanceForScope(Model));
     });
 
     assert.strictEqual(id, 2);
@@ -118,7 +118,7 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     let i = 0;
     class Model { v = ++i; }
     class Base {
-      a = injected(Model, newInstanceOf(Model));
+      a = resolve(Model, newInstanceOf(Model));
     }
     const { a: [{ v }, { v: v1 }] } = container.invoke(Base);
     assert.strictEqual(v, 1);
@@ -130,7 +130,7 @@ describe('1-kernel/di.invoke.spec.ts', function () {
       let i = 0;
       class Model { v = ++i; }
       class Base {
-        a = injected(Model, newInstanceOf(Model));
+        a = resolve(Model, newInstanceOf(Model));
       }
       const { a: [{ v }, { v: v1 }] } = container.invoke(class extends Base {});
       assert.strictEqual(v, 1);

--- a/packages/__tests__/1-kernel/di.invoke.spec.ts
+++ b/packages/__tests__/1-kernel/di.invoke.spec.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer } from '@aurelia/kernel';
+import { DI, IContainer, injected, newInstanceForScope } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.invoke.spec.ts', function () {
@@ -79,5 +79,35 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     assert.strictEqual(instanceDeps.length, 2);
     assert.deepStrictEqual(instanceDeps[0], [depInstance, 'dep1', 'dep2', 'dep3']);
     assert.deepStrictEqual(instanceDeps[1], [depInstance, 'dep4', 'dep5']);
+  });
+
+  it('works with injected', function () {
+    let id = 0;
+    class Model {
+      id = ++id;
+    }
+    const { a, b } = container.invoke(class {
+      a = injected(Model);
+      b = injected(Model);
+    });
+
+    assert.strictEqual(id, 1);
+    assert.strictEqual(a.id, 1);
+    assert.strictEqual(b.id, 1);
+  });
+
+  it('works with resolver + injected', function () {
+    let id = 0;
+    class Model {
+      id = ++id;
+    }
+    const { a, b } = container.invoke(class {
+      a = injected(Model);
+      b = injected(newInstanceForScope(Model));
+    });
+
+    assert.strictEqual(id, 2);
+    assert.strictEqual(a.id, 1);
+    assert.strictEqual(b.id, 2);
   });
 });

--- a/packages/__tests__/1-kernel/di.invoke.spec.ts
+++ b/packages/__tests__/1-kernel/di.invoke.spec.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer, injected, newInstanceForScope } from '@aurelia/kernel';
+import { DI, IContainer, injected, newInstanceForScope, newInstanceOf } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.invoke.spec.ts', function () {
@@ -112,5 +112,29 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     assert.strictEqual(id, 2);
     assert.strictEqual(a.id, 1);
     assert.strictEqual(b.id, 2);
+  });
+
+  it('works with a list of keys', function () {
+    let i = 0;
+    class Model { v = ++i; }
+    class Base {
+      a = injected(Model, newInstanceOf(Model));
+    }
+    const { a: [{ v }, { v: v1 }] } = container.invoke(Base);
+    assert.strictEqual(v, 1);
+    assert.strictEqual(v1, 2);
+  });
+
+  describe('inheritance', function () {
+    it('works with a list of keys', function () {
+      let i = 0;
+      class Model { v = ++i; }
+      class Base {
+        a = injected(Model, newInstanceOf(Model));
+      }
+      const { a: [{ v }, { v: v1 }] } = container.invoke(class extends Base {});
+      assert.strictEqual(v, 1);
+      assert.strictEqual(v1, 2);
+    });
   });
 });

--- a/packages/__tests__/1-kernel/di.spec.ts
+++ b/packages/__tests__/1-kernel/di.spec.ts
@@ -305,11 +305,10 @@ describe('1-kernel/di.spec.ts', function () {
     describe(`getDependencies()`, function () {
       let getDesignParamtypes: ISpy<typeof DI.getDesignParamtypes>;
 
-      // eslint-disable-next-line mocha/no-hooks
       beforeEach(function () {
         getDesignParamtypes = createSpy(DI, 'getDesignParamtypes', true);
       });
-      // eslint-disable-next-line mocha/no-hooks
+
       afterEach(function () {
         getDesignParamtypes.restore();
       });

--- a/packages/__tests__/2-runtime/array-observer.spec.ts
+++ b/packages/__tests__/2-runtime/array-observer.spec.ts
@@ -57,7 +57,6 @@ public constructor(
 describe(`2-runtime/array-observer.spec.ts`, function () {
   let sut: ArrayObserver;
 
-  // eslint-disable-next-line mocha/no-hooks
   before(function () {
     disableArrayObservation();
     enableArrayObservation();

--- a/packages/__tests__/2-runtime/ast.spec.ts
+++ b/packages/__tests__/2-runtime/ast.spec.ts
@@ -422,7 +422,6 @@ describe('2-runtime/ast.spec.ts', function () {
   describe('AccessKeyedExpression', function () {
     let expression: AccessKeyedExpression;
 
-    // eslint-disable-next-line mocha/no-hooks
     before(function () {
       expression = new AccessKeyedExpression(new AccessScopeExpression('foo', 0), new PrimitiveLiteralExpression('bar'));
     });

--- a/packages/__tests__/2-runtime/binding-behavior.spec.ts
+++ b/packages/__tests__/2-runtime/binding-behavior.spec.ts
@@ -5,7 +5,6 @@ import { assert } from '@aurelia/testing';
 describe(`2-runtime/binding-behavior.spec.ts`, function () {
   let container: IContainer;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
   });

--- a/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/2-runtime/binding-mode-behaviors.spec.ts
@@ -33,7 +33,6 @@ describe('2-runtime/binding-mode-behaviors.spec.ts', function () {
 
     for (const initMode of initModeArr) {
       describe(Behavior.name, function () {
-        // eslint-disable-next-line mocha/no-hooks
         beforeEach(function () {
           sut = new Behavior();
           binding = new PropertyBinding(

--- a/packages/__tests__/2-runtime/dirty-checker.spec.ts
+++ b/packages/__tests__/2-runtime/dirty-checker.spec.ts
@@ -5,7 +5,6 @@ import {
 import { assert, TestContext } from '@aurelia/testing';
 
 describe('2-runtime/dirty-checker.spec.ts', function () {
-  // eslint-disable-next-line mocha/no-hooks
   afterEach(function () {
     DirtyCheckSettings.resetToDefault();
   });

--- a/packages/__tests__/2-runtime/value-converter.spec.ts
+++ b/packages/__tests__/2-runtime/value-converter.spec.ts
@@ -5,7 +5,6 @@ import { assert } from '@aurelia/testing';
 describe(`2-runtime/value-converter.spec.ts`, function () {
   let container: IContainer;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     container = DI.createContainer();
   });

--- a/packages/__tests__/3-runtime-html/bindable-coercer.spec.ts
+++ b/packages/__tests__/3-runtime-html/bindable-coercer.spec.ts
@@ -624,7 +624,6 @@ describe('3-runtime-html/bindable-coercer.spec.ts', function () {
     }
   }
   {
-    // eslint-disable-next-line mocha/no-hooks
     beforeEach(function () { Person2.coerced = 0; });
     class Person2 extends Person {
       @coercer

--- a/packages/__tests__/3-runtime-html/checked-observer.spec.ts
+++ b/packages/__tests__/3-runtime-html/checked-observer.spec.ts
@@ -327,7 +327,6 @@ describe('3-runtime-html/checked-observer.spec.ts', function () {
 
   describe('[UNIT]', function () {
 
-    // eslint-disable-next-line mocha/no-hooks
     before(function () {
       enableArrayObservation();
     });

--- a/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
@@ -1,9 +1,11 @@
+import { injected } from '@aurelia/kernel';
 import {
   alias,
   bindable,
   customAttribute,
   INode,
-  CustomAttribute
+  CustomAttribute,
+  IAurelia
 } from '@aurelia/runtime-html';
 import { assert, eachCartesianJoin, createFixture } from '@aurelia/testing';
 
@@ -741,6 +743,24 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
 
         await options.tearDown();
       });
+    });
+  });
+
+  describe('injected', function () {
+    afterEach(function () {
+      assert.throws(() => injected(class Abc {}));
+    });
+
+    it('works with injected and inheritance', function () {
+      class Base { au = injected(IAurelia); }
+      @customAttribute('attr')
+      class Attr extends Base {}
+
+      const { au, component } = createFixture('<div attr attr.ref="attr">', class App {
+        attr: Attr;
+      }, [Attr]);
+
+      assert.strictEqual(au, component.attr.au);
     });
   });
 });

--- a/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-attributes.spec.ts
@@ -1,4 +1,4 @@
-import { injected } from '@aurelia/kernel';
+import { resolve } from '@aurelia/kernel';
 import {
   alias,
   bindable,
@@ -746,13 +746,13 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
     });
   });
 
-  describe('injected', function () {
+  describe('resolve', function () {
     afterEach(function () {
-      assert.throws(() => injected(class Abc {}));
+      assert.throws(() => resolve(class Abc {}));
     });
 
-    it('works with injected and inheritance', function () {
-      class Base { au = injected(IAurelia); }
+    it('works with resolve and inheritance', function () {
+      class Base { au = resolve(IAurelia); }
       @customAttribute('attr')
       class Attr extends Base {}
 

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -1,11 +1,11 @@
 import { Aurelia, BindingMode, customElement, CustomElement, IAurelia, ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 import { delegateSyntax } from '@aurelia/compat-v1';
-import { injected } from '@aurelia/kernel';
+import { resolve } from '@aurelia/kernel';
 
 describe('3-runtime-html/custom-elements.spec.ts', function () {
   it('injects right aurelia instance', function () {
-    const { component: { au, au1 } } = createFixture(``, class { au = injected(Aurelia); au1 = injected(IAurelia); });
+    const { component: { au, au1 } } = createFixture(``, class { au = resolve(Aurelia); au1 = resolve(IAurelia); });
     assert.strictEqual(au, au1);
   });
 
@@ -167,21 +167,21 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
     assert.strictEqual(clicked, 1);
   });
 
-  describe('injected', function () {
+  describe('resolve', function () {
     afterEach(function () {
-      assert.throws(() => injected(class Abc {}));
+      assert.throws(() => resolve(class Abc {}));
     });
 
     it('works basic', function () {
       const { au, component } = createFixture(
         '',
-        class App { au = injected(IAurelia); }
+        class App { au = resolve(IAurelia); }
       );
       assert.strictEqual(au, component.au);
     });
 
     it('works with inheritance', function () {
-      class Base { au = injected(IAurelia); }
+      class Base { au = resolve(IAurelia); }
       @customElement('el')
       class El extends Base {}
 

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -1,9 +1,14 @@
-import { BindingMode, customElement, CustomElement, IAurelia, ValueConverter } from '@aurelia/runtime-html';
+import { Aurelia, BindingMode, customElement, CustomElement, IAurelia, ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 import { delegateSyntax } from '@aurelia/compat-v1';
 import { injected } from '@aurelia/kernel';
 
 describe('3-runtime-html/custom-elements.spec.ts', function () {
+  it('injects right aurelia instance', function () {
+    const { component: { au, au1 } } = createFixture(``, class { au = injected(Aurelia); au1 = injected(IAurelia); });
+    assert.strictEqual(au, au1);
+  });
+
   it('works with multiple layers of change propagation & <input/>', function () {
     const { ctx, appHost } = createFixture(
       `<input value.bind="first_name | properCase">

--- a/packages/__tests__/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/3-runtime-html/custom-elements.spec.ts
@@ -1,6 +1,7 @@
-import { BindingMode, customElement, CustomElement, ValueConverter } from '@aurelia/runtime-html';
+import { BindingMode, customElement, CustomElement, IAurelia, ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 import { delegateSyntax } from '@aurelia/compat-v1';
+import { injected } from '@aurelia/kernel';
 
 describe('3-runtime-html/custom-elements.spec.ts', function () {
   it('works with multiple layers of change propagation & <input/>', function () {
@@ -159,5 +160,31 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
     );
     trigger('button', 'bs.open-modal');
     assert.strictEqual(clicked, 1);
+  });
+
+  describe('injected', function () {
+    afterEach(function () {
+      assert.throws(() => injected(class Abc {}));
+    });
+
+    it('works basic', function () {
+      const { au, component } = createFixture(
+        '',
+        class App { au = injected(IAurelia); }
+      );
+      assert.strictEqual(au, component.au);
+    });
+
+    it('works with inheritance', function () {
+      class Base { au = injected(IAurelia); }
+      @customElement('el')
+      class El extends Base {}
+
+      const { au, component } = createFixture('<el view-model.ref="el">', class App {
+        el: El;
+      }, [El]);
+
+      assert.strictEqual(au, component.el.au);
+    });
   });
 });

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -63,7 +63,6 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
     let sut: ITemplateCompiler;
     let container: IContainer;
 
-    // eslint-disable-next-line mocha/no-hooks
     beforeEach(function () {
       ctx = TestContext.create();
       container = ctx.container;

--- a/packages/__tests__/3-runtime-html/template-element-factory.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-element-factory.spec.ts
@@ -6,7 +6,6 @@ describe('3-runtime-html/template-element-factory.spec.ts', function () {
   let sut: ITemplateElementFactory;
   let ctx: TestContext;
 
-  // eslint-disable-next-line mocha/no-hooks
   beforeEach(function () {
     ctx = TestContext.create();
     sut = ctx.container.get(ITemplateElementFactory);

--- a/packages/__tests__/validation/expression-serialization.spec.ts
+++ b/packages/__tests__/validation/expression-serialization.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable mocha/no-hooks,mocha/no-sibling-hooks */
+/* eslint-disable mocha/no-sibling-hooks */
 import {
   IExpressionParser,
   ExpressionType,

--- a/packages/__tests__/validation/rule-provider.spec.ts
+++ b/packages/__tests__/validation/rule-provider.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-constant-condition, mocha/no-hooks, mocha/no-sibling-hooks */
+/* eslint-disable no-constant-condition, mocha/no-sibling-hooks */
 import { Metadata } from '@aurelia/metadata';
 import {
   DI,

--- a/packages/__tests__/validation/serialization.spec.ts
+++ b/packages/__tests__/validation/serialization.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable mocha/no-hooks, mocha/no-sibling-hooks */
+/* eslint-disable mocha/no-sibling-hooks */
 import { IExpressionParser } from '@aurelia/runtime';
 import { assert, TestContext } from '@aurelia/testing';
 import {

--- a/packages/__tests__/validation/validator.spec.ts
+++ b/packages/__tests__/validation/validator.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable mocha/no-hooks, mocha/no-sibling-hooks */
+/* eslint-disable mocha/no-sibling-hooks */
 import { DI, Class } from '@aurelia/kernel';
 import {
   ValidationConfiguration,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -100,6 +100,7 @@ export {
   // IDefaultableInterfaceSymbol,
   // IFactory,
   inject,
+  resolve,
   type IRegistration,
   type IRegistry,
   type IResolver,

--- a/packages/i18n/src/utils.ts
+++ b/packages/i18n/src/utils.ts
@@ -1,12 +1,13 @@
 import { BindingBehaviorExpression, IBinding, IsValueConverter, ValueConverterExpression } from '@aurelia/runtime';
 import { Writable } from '@aurelia/kernel';
 
-export const enum Signals {
-  I18N_EA_CHANNEL = 'i18n:locale:changed',
-  I18N_SIGNAL = 'aurelia-translation-signal',
-  RT_SIGNAL = 'aurelia-relativetime-signal'
-}
+export const Signals = {
+  I18N_EA_CHANNEL: 'i18n:locale:changed',
+  I18N_SIGNAL: 'aurelia-translation-signal',
+  RT_SIGNAL: 'aurelia-relativetime-signal'
+} as const;
 
+/** @internal */
 export const enum ValueConverters {
   translationValueConverterName = 't',
   dateFormatValueConverterName = 'df',

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -597,15 +597,15 @@ export type IResolvedInjection<K extends Key> =
                 : Resolved<K>;
 
 /**
- * Retrieve the resolved value of a key from the currently active container.
+ * Retrieve the resolved value of a key, or values of a list of keys from the currently active container.
  *
  * Calling this without an active container will result in an error.
  */
-export function injected<K extends Key>(keys: K): IResolvedInjection<K>;
-export function injected<K extends Key[]>(...keys: K): IResolvedInjection<K>;
-export function injected<K extends Key, A extends K[]>(...keys: A): Resolved<K> | Resolved<K>[] {
+export function resolve<K extends Key>(key: K): IResolvedInjection<K>;
+export function resolve<K extends Key[]>(...keys: K): IResolvedInjection<K>;
+export function resolve<K extends Key, A extends K[]>(...keys: A): Resolved<K> | Resolved<K>[] {
   if (currentContainer == null) {
-    throw createInvalidInjectedCallError();
+    throw createInvalidResolveCallError();
   }
   return keys.length === 1
     ? currentContainer.get(keys[0])
@@ -613,13 +613,13 @@ export function injected<K extends Key, A extends K[]>(...keys: A): Resolved<K> 
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, prefer-const */
-function testInjected() {
+function testResolve() {
   class Abc { public a = 1; }
   class Def { public b = 2; }
   class Abc2 { public c = '3'; }
-  const [{ a: _ }] = injected(all(Abc));
-  const [ [{ a: a_ }], [{ b: b_ }], [{ c: c_ }]] = injected(all(Abc), all(Def), all(Abc2));
-  let [{ a }, { b }, { c }, lazyDef, factoryAbc2, optionalAbc, newDef, newAbc] = injected(Abc, Def, Abc2, lazy(Def), factory(Abc2), optional(Abc), newInstanceForScope(Def), newInstanceOf(Abc));
+  const [{ a: _ }] = resolve(all(Abc));
+  const [ [{ a: a_ }], [{ b: b_ }], [{ c: c_ }]] = resolve(all(Abc), all(Def), all(Abc2));
+  let [{ a }, { b }, { c }, lazyDef, factoryAbc2, optionalAbc, newDef, newAbc] = resolve(Abc, Def, Abc2, lazy(Def), factory(Abc2), optional(Abc), newInstanceForScope(Def), newInstanceOf(Abc));
   a = 3; b = 4; c = '1';
   lazyDef().b = 5;
   factoryAbc2(1, 2, 3).c = '2';
@@ -704,7 +704,7 @@ const createNativeInvocationError = (Type: Constructable): Error =>
   __DEV__
     ? createError(`AUR0015: ${Type.name} is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`)
     : createError(`AUR0015:${Type.name}`);
-const createInvalidInjectedCallError = () =>
+const createInvalidResolveCallError = () =>
   __DEV__
-    ? createError(`AUR0016: There is not a currently active container. Are you trying to "new Class(...)"?`)
+    ? createError(`AUR0016: There is not a currently active container. Are you trying to "new Class(...)" that has a resolve(...) call?`)
     : createError(`AUR0016`);

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -568,9 +568,7 @@ export const all = <T extends Key>(key: T, searchAncestors: boolean = false): IA
   }
 
   resolver.$isResolver = true;
-  resolver.resolve = function (handler: IContainer, requestor: IContainer): any {
-    return requestor.getAll(key, searchAncestors);
-  };
+  resolver.resolve = (handler: IContainer, requestor: IContainer) => requestor.getAll(key, searchAncestors);
 
   return resolver as IAllResolver<T>;
 };

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -8,7 +8,7 @@ import { applyMetadataPolyfill } from '@aurelia/metadata';
 applyMetadataPolyfill(Reflect, false, false);
 
 import { isArrayIndex } from './functions';
-import { Container, injected } from './di.container';
+import { Container, resolve } from './di.container';
 import { Constructable, IDisposable, Writable } from './interfaces';
 import { appendAnnotation, getAnnotationKeyFor, IResourceKind, ResourceDefinition, ResourceType } from './resource';
 import { createError, defineMetadata, getOwnMetadata, isFunction, isString, safeString } from './utilities';
@@ -653,7 +653,7 @@ function testLazy() {
 
   @inject(lazy(I))
   class G {
-    public i = injected(lazy(I));
+    public i = resolve(lazy(I));
     public b: I = this.i();
   }
 }
@@ -713,7 +713,7 @@ function testOptional() {
 
   @inject(optional(I))
   class G {
-    public i = injected(optional(I));
+    public i = resolve(optional(I));
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     public b: I = this.i;
@@ -826,9 +826,9 @@ function testNewInstance() {
 
   @inject(newInstanceOf(I))
   class G {
-    public i = injected(newInstanceOf(I));
+    public i = resolve(newInstanceOf(I));
     public ii: I = this.i;
-    public j = injected(newInstanceForScope(I));
+    public j = resolve(newInstanceForScope(I));
     public jj: I = this.j;
   }
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -40,6 +40,10 @@ export {
 } from './di';
 
 export {
+  injected,
+} from './di.container';
+
+export {
   type Class,
   type Constructable,
   type ConstructableClass,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -5,8 +5,11 @@ export {
 export {
   all,
   factory,
+  type IAllResolver,
   type IFactoryResolver,
+  type IOptionalResolver,
   type IResolvedFactory,
+  type INewInstanceResolver,
   DI,
   IContainer,
   type IFactory,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -43,7 +43,8 @@ export {
 } from './di';
 
 export {
-  injected,
+  resolve,
+  type IResolvedInjection,
 } from './di.container';
 
 export {

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -1,14 +1,14 @@
 import { InstanceProvider, onResolve, resolveAll } from '@aurelia/kernel';
-import { INode } from './dom';
 import { IAppTask } from './app-task';
 import { isElementType } from './resources/custom-element';
 import { Controller, IControllerElementHydrationInstruction } from './templating/controller';
-import { createInterface, registerResolver } from './utilities-di';
+import { createInterface } from './utilities-di';
 
 import type { Constructable, IContainer, IDisposable } from '@aurelia/kernel';
 import type { TaskSlot } from './app-task';
 import type { ICustomElementViewModel, ICustomElementController } from './templating/controller';
 import type { IPlatform } from './platform';
+import { registerHostNode } from './dom';
 
 export interface ISinglePageApp {
   host: HTMLElement;
@@ -21,7 +21,7 @@ export const IAppRoot = /*@__PURE__*/createInterface<IAppRoot>('IAppRoot');
 export class AppRoot implements IDisposable {
   public readonly host: HTMLElement;
 
-  public controller: ICustomElementController = (void 0)!;
+  public controller!: ICustomElementController;
 
   /** @internal */
   private _hydratePromise: Promise<void> | void = void 0;
@@ -35,15 +35,7 @@ export class AppRoot implements IDisposable {
     this.host = config.host;
     rootProvider.prepare(this);
 
-    registerResolver(
-      container,
-      platform.HTMLElement,
-      registerResolver(
-        container,
-        platform.Element,
-        registerResolver(container, INode, new InstanceProvider('ElementResolver', config.host))
-      )
-    );
+    registerHostNode(container, platform, config.host);
 
     this._hydratePromise = onResolve(this._runAppTasks('creating'), () => {
       const component = config.component as Constructable | ICustomElementViewModel;

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -1,10 +1,10 @@
-import { type Writable } from '@aurelia/kernel';
+import { IContainer, InstanceProvider, type Writable } from '@aurelia/kernel';
 import { IAppRoot } from './app-root';
 import { IPlatform } from './platform';
 import { findElementControllerFor } from './resources/custom-element';
 import { MountTarget } from './templating/controller';
 import type { IHydratedController } from './templating/controller';
-import { createInterface } from './utilities-di';
+import { createInterface, registerResolver } from './utilities-di';
 import { markerToLocation } from './utilities-dom';
 
 export class Refs {
@@ -509,3 +509,17 @@ export interface IHistory extends History {
    */
   replaceState(state: {} | null, title: string, url?: string | null): void;
 }
+
+/** @internal */
+export const registerHostNode = (container: IContainer, platform: IPlatform, host: INode | null) => {
+  registerResolver(
+    container,
+    platform.HTMLElement,
+    registerResolver(
+      container,
+      platform.Element,
+      registerResolver(container, INode, new InstanceProvider('ElementResolver', host))
+    )
+  );
+  return container;
+};

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -30,7 +30,7 @@ import { RefBinding } from './binding/ref-binding';
 import { ListenerBinding, ListenerBindingOptions } from './binding/listener-binding';
 import { CustomElement, CustomElementDefinition, findElementControllerFor } from './resources/custom-element';
 import { CustomAttribute, CustomAttributeDefinition, findAttributeControllerFor } from './resources/custom-attribute';
-import { convertToRenderLocation, IRenderLocation, INode, setRef, ICssModulesMapping } from './dom';
+import { convertToRenderLocation, IRenderLocation, INode, setRef, ICssModulesMapping, registerHostNode } from './dom';
 import { Controller, ICustomElementController, ICustomElementViewModel, IController, ICustomAttributeViewModel, IHydrationContext, ViewModelKind } from './templating/controller';
 import { IPlatform } from './platform';
 import { IViewFactory } from './templating/view';
@@ -1202,20 +1202,7 @@ function createElementContainer(
 ): IContainer {
   const ctn = renderingCtrl.container.createChild();
 
-  // todo:
-  // both node provider and location provider may not be allowed to throw
-  // if there's no value associated, unlike InstanceProvider
-  // reason being some custom element can have `containerless` attribute on them
-  // causing the host to disappear, and replace by a location instead
-  registerResolver(
-    ctn,
-    p.HTMLElement,
-    registerResolver(
-      ctn,
-      p.Element,
-      registerResolver(ctn, INode, new InstanceProvider('ElementResolver', host))
-    )
-  );
+  registerHostNode(ctn, p, host);
   registerResolver(ctn, IController, new InstanceProvider(controllerProviderName, renderingCtrl));
   registerResolver(ctn, IInstruction, new InstanceProvider(instructionProviderName, instruction));
   registerResolver(ctn, IRenderLocation, location == null
@@ -1275,15 +1262,7 @@ function invokeAttribute(
   auSlotsInfo?: IAuSlotsInfo,
 ): { vm: ICustomAttributeViewModel; ctn: IContainer } {
   const ctn = renderingCtrl.container.createChild();
-  registerResolver(
-    ctn,
-    p.HTMLElement,
-    registerResolver(
-      ctn,
-      p.Element,
-      registerResolver(ctn, INode, new InstanceProvider('ElementResolver', host))
-    )
-  );
+  registerHostNode(ctn, p, host);
   renderingCtrl = renderingCtrl instanceof Controller
     ? renderingCtrl
     : (renderingCtrl as unknown as SpreadBinding).ctrl;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -422,13 +422,13 @@ const returnTrue = () => true;
 const returnEmptyArray = () => emptyArray;
 
 /** @internal */
-export const elementBaseName = getResourceKeyFor('custom-element');
+export const elementBaseName = /*@__PURE__*/getResourceKeyFor('custom-element');
 
 /** @internal */
 export const getElementKeyFrom = (name: string): string => `${elementBaseName}:${name}`;
 
 /** @internal */
-export const generateElementName = (() => {
+export const generateElementName = /*@__PURE__*/(() => {
   let id = 0;
 
   return () => `unnamed-${++id}`;
@@ -574,7 +574,7 @@ export const createElementInjectable = <K extends Key = Key>(): InjectableToken<
 };
 
 /** @internal */
-export const generateElementType = (function () {
+export const generateElementType = /*@__PURE__*/(function () {
   const nameDescriptor: PropertyDescriptor = {
     value: '',
     writable: false,
@@ -624,7 +624,7 @@ export const CustomElement = objectFreeze<CustomElementKind>({
 type DecoratorFactoryMethod<TClass> = (target: Constructable<TClass>, propertyKey: string, descriptor: PropertyDescriptor) => void;
 type ProcessContentHook = (node: INode, platform: IPlatform) => boolean | void;
 
-const pcHookMetadataProperty = getAnnotationKeyFor('processContent');
+const pcHookMetadataProperty = /*@__PURE__*/getAnnotationKeyFor('processContent');
 export function processContent(hook: ProcessContentHook): CustomElementDecorator;
 export function processContent<TClass>(): DecoratorFactoryMethod<TClass>;
 export function processContent<TClass extends {}>(hook?: ProcessContentHook): CustomElementDecorator | DecoratorFactoryMethod<TClass> {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,7 +1,7 @@
 import { Constructable, IContainer, InstanceProvider, onResolve, transient } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
-import { INode, IRenderLocation, isRenderLocation } from '../../dom';
+import { INode, IRenderLocation, isRenderLocation, registerHostNode } from '../../dom';
 import { IPlatform } from '../../platform';
 import { HydrateElementInstruction, IInstruction } from '../../renderer';
 import { Controller, IController, ICustomElementController, IHydratedController, ISyntheticView } from '../../templating/controller';
@@ -308,15 +308,7 @@ export class AuCompose {
 
     const p = this._platform;
     const isLocation = isRenderLocation(host);
-    registerResolver(
-      container,
-      p.Element,
-      registerResolver(
-        container,
-        INode,
-        new InstanceProvider('ElementResolver', isLocation ? null : host)
-      )
-    );
+    registerHostNode(container, p, isLocation ? null : host);
     registerResolver(
       container,
       IRenderLocation,

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -4,11 +4,11 @@ import {
   Registration,
   type IResolver,
   type Key,
-  type Resolved,
   type Constructable,
   type IContainer,
   type IResourceKind,
   type ResourceDefinition,
+  type IAllResolver,
 } from '@aurelia/kernel';
 import { defineMetadata, getAnnotationKeyFor, getOwnMetadata } from './utilities-metadata';
 
@@ -48,8 +48,7 @@ export const allResources = <T extends Key>(key: T) => {
       ? requestor.getAll(key, false).concat(requestor.root.getAll(key, false))
       : requestor.root.getAll(key, false);
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return Resolver as IResolver<Resolved<T>[]> & ((...args: unknown[]) => any);
+  return Resolver as IAllResolver<T>;
 };
 
 /** @internal */

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -1,5 +1,5 @@
-import { IRenderLocation } from './dom';
-import { IPlatform } from './platform';
+import { type IRenderLocation } from './dom';
+import { type IPlatform } from './platform';
 import { createError } from './utilities';
 
 /** @internal */

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -27,14 +27,14 @@ export interface IObjectObservationAdapter {
 }
 
 export interface IObserverLocator extends ObserverLocator {}
-export const IObserverLocator = createInterface<IObserverLocator>('IObserverLocator', x => x.singleton(ObserverLocator));
+export const IObserverLocator = /*@__PURE__*/createInterface<IObserverLocator>('IObserverLocator', x => x.singleton(ObserverLocator));
 
 export interface INodeObserverLocator {
   handles(obj: unknown, key: PropertyKey, requestor: IObserverLocator): boolean;
   getObserver(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
   getAccessor(obj: object, key: PropertyKey, requestor: IObserverLocator): IAccessor | IObserver;
 }
-export const INodeObserverLocator = createInterface<INodeObserverLocator>('INodeObserverLocator', x => x.cachedCallback(handler => {
+export const INodeObserverLocator = /*@__PURE__*/createInterface<INodeObserverLocator>('INodeObserverLocator', x => x.cachedCallback(handler => {
   if (__DEV__) {
     handler.getAll(ILogger).forEach(logger => {
       logger.error('Using default INodeObserverLocator implementation. Will not be able to observe nodes (HTML etc...).');

--- a/scripts/generate-tests/template-compiler.static.ts
+++ b/scripts/generate-tests/template-compiler.static.ts
@@ -3,7 +3,6 @@ import { PropertyDeclaration, Statement } from 'typescript';
 import project from '../project';
 import {
   $$call,
-  $$comment,
   $$const,
   $$functionDecl,
   $$functionExpr,
@@ -146,6 +145,7 @@ interface TextBinding extends Identifiable {
 }
 interface TplCtrl extends Identifiable {
   attr: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any;
   properties: PropertyDeclaration[];
   prop?: string;
@@ -1129,21 +1129,17 @@ function generateAndEmit(): void {
       $$functionExpr('describe', [
         $expression(`generated.template-compiler.${suffix}`),
         $functionExpr([
-          $$comment('eslint-disable-next-line mocha/no-hooks',
-            $$functionExpr('before', [
-              $functionExpr([
-                $$call('Profiler.enable')
-              ])
+          $$functionExpr('before', [
+            $functionExpr([
+              $$call('Profiler.enable')
             ])
-          ),
-          $$comment('eslint-disable-next-line mocha/no-hooks',
-            $$functionExpr('after', [
-              $functionExpr([
-                $$call('Profiler.disable'),
-                $$call('writeProfilerReport', [$expression(suffix)])
-              ])
+          ]),
+          $$functionExpr('after', [
+            $functionExpr([
+              $$call('Profiler.disable'),
+              $$call('writeProfilerReport', [$expression(suffix)])
             ])
-          ),
+          ]),
           $$functionDecl(
             'createFixture',
             [


### PR DESCRIPTION
## 📖 Description

Resolves #1742 

### 🎫 Issues

Add an export `resolve` to support the use case described in #1742. So now it's simpler to do this

Before:
```ts
abstract class Base {
  constructor(obj1: SomeType, obj2: SomeType2) {}
}

@inject(SomeType, SomeType2)
class MyElement extends Base {
  constructor(obj1: SomeType, obj2: SomeType2) {
    super(obj1, obj2)
  }
}
```

After:
```ts
import { resolve } from 'aurelia';

abstract class Base {
  obj1 = resolve(SomeType);
  obj2 = resolve(SomeType2);
}

class MyElement extends Base {}
```

It's also possible to call `resolve` with multiple keys at once:
```ts
const [abc, all_def_instances, someOther] = resolve(Abc, all(Def), optional(SomeOtherClass));
```