### PR TITLE
feat(observer-locator): ability to create getter based observer

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/observation/effect-observation.md
+++ b/docs/user-docs/getting-to-know-aurelia/observation/effect-observation.md
@@ -17,45 +17,76 @@ class MouseTracker {
 
 The property `coord` of a `MouseTracker` instance will be turned into a reactive property and is also aware of effect function dependency tracking.
 
+{% hint style="info" %}
+Properties decorated with `@observable` and any proxy based property access will be tracked as dependencies of the effect
+{% endhint %}
+
+The effect APIs are provided via the default implementation of the interface `IObservation`, which can be retrieved like one of the following examples:
+
+  - **Getting from a container directly**:
+  ```typescript
+  import { IObservation } from 'aurelia';
+
+  ...
+  const observation = someContainer.get(IObservation);
+  ```
+
+  - **Getting through injection**:
+  ```typescript
+  import { inject, IObservation } from 'aurelia';
+
+  @inject(IObservation)
+  class MyElement {
+    constructor(observation) {
+      // ...
+    }
+  }
+  ```
+  Or
+
+  ```typescript
+  class MyElement {
+    constructor(@IObservation readonly observation) {
+      // ...
+    }
+  }
+  ```
+
+After getting the observation object, there are two APIs that can be used to created effects as described in the following sections:
+
+## Watch effect
+
+Watch effect is a way to describe a getter based observation of an object. An example to create watch effect is per the following:
+
+```typescript
+import { inject, IObservation } from 'aurelia';
+
+@inject(IObservation)
+class PersonalInfo {
+  constructor(observation) {
+    const effect = observation.watch(this.primaryInfo, (primaryInfo) => primaryInfo.name, function nameChanged(newName, oldName) {
+      // do something with name
+    });
+
+    // effect.stop() later when necessary
+  }
+}
+```
+
+Note that the effect function will be run immediately. If you do not want to run the callback immediately, pass an option `immediate: false` as the 4th parameter:
+```typescript
+observation.watch(obj, getter, callback, { immediate: false });
+```
+
+By default, a watch effect is independent of any application lifecycle, which means it does not stop when the application that owns the `observation` instance has stopped. To stop/destroy an effect, call the method `stop()` on the effect object.
+
+## Run effect
+
+Run effects describe a function to be called repeatedly whenever any dependency tracked inside it changes.
+
 ### Creating an Effect
 
-The effect API is provided via the default implementation of an interface named `IObservation`.
-
-An example to retrieve an instance of this interface is per following:
-
-#### Getting from a container directly
-
-```typescript
- import { IObservation } from 'aurelia';
-
- ...
- const observation = someContainer.get(IObservation);
-```
-
-#### Getting through injection
-
-```typescript
- import { inject, IObservation } from 'aurelia';
-
- @inject(IObservation)
- class MyElement {
-   constructor(observation) {
-     // ...
-   }
- }
-```
-
-#### Autoinjection (if you are using TypeScript)
-
-```typescript
- class MyElement {
-   constructor(@IObservation readonly observation) {
-     // ...
-   }
- }
-```
-
-After getting ahold of an `IObservation` instance, an effect can be created via the method `run` of it:
+After getting an `IObservation` instance, a run effect can be created via the method `run` of it:
 
 ```typescript
 const effect = observation.run(() => {
@@ -65,7 +96,7 @@ const effect = observation.run(() => {
 
 Note that the effect function will be run immediately.
 
-By default, an effect is independent of any application lifecycle, which means it does not stop when the application that owns the `observation` instance has stopped. To stop/destroy an effect, call the method `stop()` on the effect object:
+By default, a effect is independent of any application lifecycle, which means it does not stop when the application that owns the `observation` instance has stopped. To stop/destroy an effect, call the method `stop()` on the effect object:
 
 ```typescript
 const effect = IObservation.run(() => {
@@ -76,58 +107,60 @@ const effect = IObservation.run(() => {
 effect.stop();
 ```
 
-### Effect Observation & Reaction Examples
+## Effect examples
 
-#### Creating an effect that logs the user mouse movement on the document
+The following section gives some examples of what it looks like when combining `@observable` and run effect.
+
+### Creating a run effect that logs the user mouse movement on the document
 
 ```typescript
- import { inject, IObservation, observable } from 'aurelia'
+import { inject, IObservation, observable } from 'aurelia'
 
- class MouseTracker {
-   @observable coord = [0, 0]; // x: 0, y: 0 is the default value
- }
+class MouseTracker {
+  @observable coord = [0, 0]; // x: 0, y: 0 is the default value
+}
 
- // Inside an application:
- @inject(IObservation)
- class App {
-   constructor(observation) {
-     const mouseTracker = new MouseTracker();
+// Inside an application:
+@inject(IObservation)
+class App {
+  constructor(observation) {
+    const mouseTracker = new MouseTracker();
 
-     document.addEventListener('mousemove', (e) => {
-       mouseTracker.coord = [e.pageX, e.pageY]
-     });
+    document.addEventListener('mousemove', (e) => {
+      mouseTracker.coord = [e.pageX, e.pageY]
+    });
 
-     observation.run(() => {
-       console.log(mouseTracker.coord)
-     });
-   }
- }
+    observation.run(() => {
+      console.log(mouseTracker.coord)
+    });
+  }
+}
 ```
 
 Now whenever the user moves the mouse around, a log will be added to the console with the coordinate of the mouse.
 
-#### Creating an effect that sends a request whenever user focus/unfocus the browser tab
+### Creating a run effect that sends a request whenever user focus/unfocus the browser tab
 
 ```typescript
- import { inject, IObservation, observable } from 'aurelia'
+import { inject, IObservation, observable } from 'aurelia'
 
- class PageActivity {
-   @observable active = false
- }
+class PageActivity {
+  @observable active = false
+}
 
- // Inside an application:
- @inject(IObservation)
- class App {
-   constructor(observation) {
-     const pageActivity = new PageActivity();
+// Inside an application:
+@inject(IObservation)
+class App {
+  constructor(observation) {
+    const pageActivity = new PageActivity();
 
-     document.addEventListener(visibilityChange, (e) => {
-       pageActivity.active = !document.hidden;
-     });
+    document.addEventListener(visibilityChange, (e) => {
+      pageActivity.active = !document.hidden;
+    });
 
-     observation.run(() => {
-       fetch('my-game/user-activity', { body: JSON.stringify({ active: pageActivity.active }) })
-     });
-   }
- }
+    observation.run(() => {
+      fetch('my-game/user-activity', { body: JSON.stringify({ active: pageActivity.active }) })
+    });
+  }
+}
 ```

--- a/packages/__tests__/2-runtime/computed-observer.spec.ts
+++ b/packages/__tests__/2-runtime/computed-observer.spec.ts
@@ -138,7 +138,7 @@ describe('2-runtime/computed-observer.spec.ts', function () {
       }
 
       // TODO: use tracer to deeply verify calls
-      const sut = ComputedObserver.create(instance, 'prop', propDescriptor, locator, true);
+      const sut = new ComputedObserver(instance, propDescriptor.get, propDescriptor.set, locator, true);
       sut.subscribe(subscriber1);
       sut.subscribe(subscriber2);
 
@@ -285,7 +285,7 @@ describe('2-runtime/computed-observer.spec.ts', function () {
       }
     };
 
-    const sut = ComputedObserver.create(parent, 'getter', pd, locator, true);
+    const sut = new ComputedObserver(parent, pd.get, pd.set, locator, true);
     sut.subscribe(subscriber1);
 
     let verifiedCount = 0;
@@ -349,18 +349,20 @@ describe('2-runtime/computed-observer.spec.ts', function () {
     let getterCallCount = 0;
     const { locator } = createFixture();
     const obj = { prop: 1, prop1: 1 };
-    const observer = ComputedObserver.create(
+    const observer = new ComputedObserver(
       obj,
-      'prop',
-      {
-        get() {
-          getterCallCount++;
-          return this.prop1;
-        }
+      function (obj) {
+        getterCallCount++;
+        return obj.prop1;
       },
+      void 0,
       locator,
       true,
     );
+    Object.defineProperty(obj, 'prop', {
+      get: () => observer.getValue(),
+      set: (v) => {observer.setValue(v);}
+    });
     let _handleChangeCallCount = 0;
     observer.subscribe({
       handleChange() {

--- a/packages/__tests__/3-runtime-html/observer-locator.spec.ts
+++ b/packages/__tests__/3-runtime-html/observer-locator.spec.ts
@@ -296,7 +296,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     }
   }
 
-  it(_`getObserver() - Array.foo - returns ArrayObserver`, function () {
+  it(`getObserver() - Array.foo - returns ArrayObserver`, function () {
     const { sut } = createFixture();
     const obj = [];
     const actual = sut.getObserver(obj, 'foo');
@@ -304,7 +304,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, SetterObserver, `actual`);
   });
 
-  it(_`getObserver() - Array.length - returns ArrayObserver`, function () {
+  it(`getObserver() - Array.length - returns ArrayObserver`, function () {
     const { sut } = createFixture();
     const obj = [];
     const actual = sut.getObserver(obj, 'length');
@@ -312,7 +312,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, CollectionLengthObserver, `actual`);
   });
 
-  it(_`getObserver() - Set.foo - returns SetObserver`, function () {
+  it(`getObserver() - Set.foo - returns SetObserver`, function () {
     const { sut } = createFixture();
     const obj = new Set();
     const actual = sut.getObserver(obj, 'foo');
@@ -320,7 +320,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, SetterObserver, `actual`);
   });
 
-  it(_`getObserver() - Set.size - returns SetObserver`, function () {
+  it(`getObserver() - Set.size - returns SetObserver`, function () {
     const { sut } = createFixture();
     const obj = new Set();
     const actual = sut.getObserver(obj, 'size');
@@ -328,7 +328,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, CollectionSizeObserver, `actual`);
   });
 
-  it(_`getObserver() - Map.foo - returns MapObserver`, function () {
+  it(`getObserver() - Map.foo - returns MapObserver`, function () {
     const { sut } = createFixture();
     const obj = new Map();
     const actual = sut.getObserver(obj, 'foo');
@@ -336,7 +336,7 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, SetterObserver, `actual`);
   });
 
-  it(_`getObserver() - Map.size - returns MapObserver`, function () {
+  it(`getObserver() - Map.size - returns MapObserver`, function () {
     const { sut } = createFixture();
     const obj = new Map();
     const actual = sut.getObserver(obj, 'size');
@@ -344,4 +344,27 @@ describe('3-runtime-html/observer-locator.spec.ts', function () {
     assert.instanceOf(actual, CollectionSizeObserver, `actual`);
   });
 
+  describe('with getter fn', function () {
+    it('on normal object', function () {
+      const { sut } = createFixture();
+      const obj = { prop: 1 };
+      let v = 0;
+      sut.getObserver(obj, o => o.prop).subscribe({
+        handleChange: () => v = 1
+      });
+      obj.prop = 2;
+      assert.strictEqual(v, 1);
+    });
+
+    it('on array', function () {
+      const { sut } = createFixture();
+      const obj = [{ prop: 1 }];
+      let v = 0;
+      sut.getObserver(obj, o => o[0].prop).subscribe({
+        handleChange: () => v = 1
+      });
+      obj.splice(0, 1, { prop: 2 });
+      assert.strictEqual(v, 1);
+    });
+  });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -111,7 +111,7 @@ export {
   type IEffect,
   IObservation,
   Observation,
-  type EffectFunc,
+  type EffectRunFunc,
 } from './observation/observation';
 export {
   type IObservableDefinition,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -178,7 +178,7 @@ export interface IAccessor<TValue = unknown> {
 /**
  * An interface describing a standard contract of an observer in Aurelia binding & observation system
  */
-export interface IObserver extends IAccessor, ISubscribable {
+export interface IObserver<TValue = unknown> extends IAccessor<TValue>, ISubscribable {
   doNotCache?: boolean;
 }
 

--- a/packages/runtime/src/observation/computed-observer.ts
+++ b/packages/runtime/src/observation/computed-observer.ts
@@ -17,7 +17,8 @@ import type {
 import type { IConnectableBinding } from '../binding/connectable';
 import type { IObserverLocator } from './observer-locator';
 
-export type ComputedGetterFn<T extends object = object> = (this: T, obj: T, observer: IConnectable) => unknown;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ComputedGetterFn<T = any, R = any> = (this: T, obj: T, observer: IConnectable) => R;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface ComputedObserver<T extends object> extends IConnectableBinding, ISubscriberCollection { }

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -85,7 +85,7 @@ export class ObserverLocator {
   }
 
   public getObserver(obj: unknown, key: PropertyKey): IObserver;
-  public getObserver<T extends object>(obj: T, key: ComputedGetterFn<T>): IObserver;
+  public getObserver<T, R>(obj: T, key: ComputedGetterFn<T, R>): IObserver<R>;
   public getObserver(obj: unknown, key: PropertyKey | ComputedGetterFn): IObserver {
     if (obj == null) {
       throw nullObjectError(safeString(key));

--- a/packages/runtime/src/observation/observer-locator.ts
+++ b/packages/runtime/src/observation/observer-locator.ts
@@ -1,13 +1,13 @@
 import { Primitive, isArrayIndex, ILogger } from '@aurelia/kernel';
 import { getArrayObserver } from './array-observer';
-import { ComputedObserver } from './computed-observer';
+import { ComputedGetterFn, ComputedObserver } from './computed-observer';
 import { IDirtyChecker } from './dirty-checker';
 import { getMapObserver } from './map-observer';
 import { PrimitiveObserver } from './primitive-observer';
 import { PropertyAccessor } from './property-accessor';
 import { getSetObserver } from './set-observer';
 import { SetterObserver } from './setter-observer';
-import { safeString, createLookup, def, hasOwnProp, isArray, createInterface, createError, isMap, isSet, isObject } from '../utilities-objects';
+import { safeString, createLookup, def, hasOwnProp, isArray, createInterface, createError, isMap, isSet, isObject, objectAssign, isFunction } from '../utilities-objects';
 
 import type {
   Collection,
@@ -84,12 +84,17 @@ export class ObserverLocator {
     this._adapters.push(adapter);
   }
 
-  public getObserver(obj: unknown, key: PropertyKey): IObserver {
+  public getObserver(obj: unknown, key: PropertyKey): IObserver;
+  public getObserver<T extends object>(obj: T, key: ComputedGetterFn<T>): IObserver;
+  public getObserver(obj: unknown, key: PropertyKey | ComputedGetterFn): IObserver {
     if (obj == null) {
-      throw nullObjectError(key);
+      throw nullObjectError(safeString(key));
     }
     if (!isObject(obj)) {
-      return new PrimitiveObserver(obj as Primitive, key);
+      return new PrimitiveObserver(obj as Primitive, isFunction(key) ? '' : key);
+    }
+    if (isFunction(key)) {
+      return new ComputedObserver(obj, key, void 0, this, true);
     }
     const lookup = getObserverLookup(obj);
     let observer = lookup[key];
@@ -174,7 +179,7 @@ export class ObserverLocator {
 
       return obs == null
         ? pd.configurable
-          ? ComputedObserver.create(obj, key, pd, this, /* AOT: not true for IE11 */ true)
+          ? this._createComputedObserver(obj, key, pd, true)
           : this._dirtyChecker.createProperty(obj, key)
         : obs;
     }
@@ -182,6 +187,21 @@ export class ObserverLocator {
     // Ordinary get/set observation (the common use case)
     // TODO: think about how to handle a data property that does not sit on the instance (should we do anything different?)
     return new SetterObserver(obj, key);
+  }
+
+  /** @internal */
+  private _createComputedObserver(obj: object, key: PropertyKey, pd: PropertyDescriptor, useProxy?: boolean) {
+    const observer = new ComputedObserver(obj, pd.get!, pd.set, this, !!useProxy);
+    def(obj, key, {
+      enumerable: pd.enumerable,
+      configurable: true,
+      get: objectAssign(((/* Computed Observer */) => observer.getValue()) as ObservableGetter, { getObserver: () => observer }),
+      set: (/* Computed Observer */v) => {
+        observer.setValue(v);
+      },
+    });
+
+    return observer;
   }
 
   /** @internal */


### PR DESCRIPTION
## 📖 Description

Resolves #1747 

### 🎫 Issues

At the moment, most of our observer locator are still around the interface `.getObserver(object, key)`. Sometimes this doesnt suffice, as there may be the need to observe more than 1 key at once. One can resolve to a getter property and observe that property, but it's cumbersome and not always appropriate/doable.
This PR adds a new overload on the `getObserver` of the observer locator, where it allows the 2nd parameter to be a function, treated as a getter, to be passed in. When a function is passed in the 2nd parameter, a different kind of observer that can deal with getter observation will be used instead.
This API also makes it simpler to create higher level API on top, so add a new API `watch` on `IObservation` for a common case:
```ts
observation.watch(obj, o => o.some.expression, (newValue) => doSomething(newValue));
```

## ⏭ Next Steps

See if other APIs can reuse this `.getObserver(obj, getter)` to remove unnecessary infra as much as possible.