### PR TITLE
refactor: cleanup up unused code & decouple interface from default impl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@typescript-eslint/eslint-plugin": "5.51.0",
         "@typescript-eslint/parser": "5.51.0",
         "chalk": "4.1.2",
-        "chromedriver": "^111.0.0",
+        "chromedriver": "113.0.0",
         "codecov": "^3.8.3",
         "concurrently": "7.6.0",
         "cross-env": "7.0.3",
@@ -4666,9 +4666,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "113.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
+      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4684,7 +4684,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/chromedriver/node_modules/compare-versions": {
@@ -20327,9 +20327,9 @@
       "version": "1.0.3"
     },
     "chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "113.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-113.0.0.tgz",
+      "integrity": "sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@typescript-eslint/eslint-plugin": "5.51.0",
     "@typescript-eslint/parser": "5.51.0",
     "chalk": "4.1.2",
-    "chromedriver": "^111.0.0",
+    "chromedriver": "113.0.0",
     "codecov": "^3.8.3",
     "concurrently": "7.6.0",
     "cross-env": "7.0.3",

--- a/packages/__tests__/2-runtime/computed-observer.spec.ts
+++ b/packages/__tests__/2-runtime/computed-observer.spec.ts
@@ -16,6 +16,7 @@ describe('2-runtime/computed-observer.spec.ts', function () {
     const nodeLocator = {
       handles() { return false; }
     };
+    Registration.instance(IDirtyChecker, {}).register(container);
     Registration.instance(IPlatform, {}).register(container);
     Registration.instance(INodeObserverLocator, nodeLocator).register(container);
     const locator = container.get(IObserverLocator);

--- a/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/3-runtime-html/repeater.unit.spec.ts
@@ -1,4 +1,4 @@
-import { Scope, AccessScopeExpression, ForOfStatement, BindingIdentifier, BindingContext } from '@aurelia/runtime';
+import { Scope, AccessScopeExpression, ForOfStatement, BindingIdentifier, BindingContext, DirtyChecker } from '@aurelia/runtime';
 import {
   Repeat,
   Controller,
@@ -496,6 +496,7 @@ describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
   ];
 
   const container = createContainer().register(
+    DirtyChecker,
     NodeObserverLocator,
     PropertyBindingRenderer,
     TextBindingRenderer,

--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -33,7 +33,7 @@
     "test-chrome:debugger:verbose": "karma start karma.conf.cjs --browsers=ChromeDebugging --watch-extensions js,html --reporter=mocha",
     "test-safari": "karma start karma.conf.cjs --browsers=Safari --single-run --reporter=mocha",
     "test:debugger": "npm run test-chrome:debugger",
-    "pretest": "node z-scripts/lint-tests.cjs",
+    "prebuild": "node z-scripts/lint-tests.cjs",
     "test": "npm run test-chrome",
     "build": "tsc --build",
     "dev": "cross-env DEV_MODE=true node esbuild.dev.cjs",

--- a/packages/kernel/src/api-test.ts
+++ b/packages/kernel/src/api-test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DI, all, inject, lazy, optional, newInstanceOf, newInstanceForScope, factory } from './di';
+import { resolve } from './di.container';
+
+function testAll() {
+  const d = DI.createContainer();
+  const I = DI.createInterface<I>();
+  interface I {
+    c: number;
+  }
+  const instances = d.get(all(class Abc { public b: number = 5; }));
+  instances.forEach(i => i.b);
+
+  const ii = d.get(all(I));
+  ii.forEach(i => i.c);
+
+  class Def {
+    public constructor(@all(I) private readonly i: I) {}
+  }
+
+  @inject(all(I))
+  class G {}
+}
+
+function testLazy() {
+  const d = DI.createContainer();
+  const I = DI.createInterface<I>();
+  interface I {
+    c: number;
+  }
+  const instance = d.get(lazy(class Abc { public b: number = 5; }));
+  if (instance().b === 5) {
+    // good
+  }
+
+  class Def {
+    public constructor(@lazy(I) private readonly i: I) {}
+  }
+
+  @inject(lazy(I))
+  class G {
+    public i = resolve(lazy(I));
+    public b: I = this.i();
+  }
+}
+
+function testOptional() {
+  const d = DI.createContainer();
+  const I = DI.createInterface<I>();
+  interface I {
+    c: number;
+  }
+  const instance = d.get(optional(class Abc { public b: number = 5; }));
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-expect-error
+  if (instance.b === 5) {
+    // good
+  }
+
+  class Def {
+    public constructor(@optional(I) private readonly i: I) { }
+  }
+
+  @inject(optional(I))
+  class G {
+    public i = resolve(optional(I));
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    public b: I = this.i;
+  }
+}
+
+function testNewInstance() {
+  const d = DI.createContainer();
+  const I = DI.createInterface<I>();
+  interface I {
+    c: number;
+  }
+  const instance = d.get(newInstanceOf(class Abc { public b: number = 5; }));
+  if (instance.b === 5) {
+    // good
+  }
+  const instance2 = d.get(newInstanceForScope(class Abc { public b: number = 5; }));
+  if (instance2.b === 5) {
+    // good
+  }
+
+  class Def {
+    public constructor(
+      @newInstanceOf(I) private readonly i: I,
+      @newInstanceForScope(I) private readonly j: I,
+    ) { }
+  }
+
+  @inject(newInstanceOf(I))
+  class G {
+    public i = resolve(newInstanceOf(I));
+    public ii: I = this.i;
+    public j = resolve(newInstanceForScope(I));
+    public jj: I = this.j;
+  }
+}
+
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, prefer-const */
+function testResolve() {
+  class Abc { public a = 1; }
+  class Def { public b = 2; }
+  class Abc2 { public c = '3'; }
+  const [{ a: _ }] = resolve(all(Abc));
+  const [ [{ a: a_ }], [{ b: b_ }], [{ c: c_ }]] = resolve(all(Abc), all(Def), all(Abc2));
+  let [{ a }, { b }, { c }, lazyDef, factoryAbc2, optionalAbc, newDef, newAbc] = resolve(Abc, Def, Abc2, lazy(Def), factory(Abc2), optional(Abc), newInstanceForScope(Def), newInstanceOf(Abc));
+  a = 3; b = 4; c = '1';
+  lazyDef().b = 5;
+  factoryAbc2(1, 2, 3).c = '2';
+  // @ts-expect-error
+  if (optionalAbc.a) {/*  */}
+  newDef.b = 4;
+  newAbc.a = 2;
+}
+/* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, prefer-const */

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -29,12 +29,6 @@ import {
   type IResolvedLazy,
   type IAllResolver,
   type IOptionalResolver,
-  all,
-  lazy,
-  factory,
-  optional,
-  newInstanceForScope,
-  newInstanceOf
 } from './di';
 
 const InstrinsicTypeNames = new Set<string>('Array ArrayBuffer Boolean DataView Date Error EvalError Float32Array Float64Array Function Int8Array Int16Array Int32Array Map Number Object Promise RangeError ReferenceError RegExp Set SharedArrayBuffer String SyntaxError TypeError Uint8Array Uint8ClampedArray Uint16Array Uint32Array URIError WeakMap WeakSet'.split(' '));
@@ -611,24 +605,6 @@ export function resolve<K extends Key, A extends K[]>(...keys: A): Resolved<K> |
     ? currentContainer.get(keys[0])
     : keys.map(containerGetKey, currentContainer);
 }
-
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, prefer-const */
-function testResolve() {
-  class Abc { public a = 1; }
-  class Def { public b = 2; }
-  class Abc2 { public c = '3'; }
-  const [{ a: _ }] = resolve(all(Abc));
-  const [ [{ a: a_ }], [{ b: b_ }], [{ c: c_ }]] = resolve(all(Abc), all(Def), all(Abc2));
-  let [{ a }, { b }, { c }, lazyDef, factoryAbc2, optionalAbc, newDef, newAbc] = resolve(Abc, Def, Abc2, lazy(Def), factory(Abc2), optional(Abc), newInstanceForScope(Def), newInstanceOf(Abc));
-  a = 3; b = 4; c = '1';
-  lazyDef().b = 5;
-  factoryAbc2(1, 2, 3).c = '2';
-  // @ts-expect-error
-  if (optionalAbc.a) {/*  */}
-  newDef.b = 4;
-  newAbc.a = 2;
-}
-/* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, prefer-const */
 
 const buildAllResponse = (resolver: IResolver, handler: IContainer, requestor: IContainer): any[] => {
   if (resolver instanceof Resolver && resolver._strategy === ResolverStrategy.array) {

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -344,7 +344,6 @@ export class Container implements IContainer {
           current = current.parent;
 
           if (current == null) {
-            currentContainer = previousContainer;
             return emptyArray;
           }
         } else {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -579,26 +579,6 @@ export type IAllResolver<T> = IResolver<readonly Resolved<T>[]> & {
   (...args: unknown[]): any;
 };
 
-function testAll() {
-  const d = DI.createContainer();
-  const I = DI.createInterface<I>();
-  interface I {
-    c: number;
-  }
-  const instances = d.get(all(class Abc { public b: number = 5; }));
-  instances.forEach(i => i.b);
-
-  const ii = d.get(all(I));
-  ii.forEach(i => i.c);
-
-  class Def {
-    public constructor(@all(I) private readonly i: I) {}
-  }
-
-  @inject(all(I))
-  class G {}
-}
-
 /**
  * Lazily inject a dependency depending on whether the [[`Key`]] is present at the time of function call.
  *
@@ -636,28 +616,6 @@ export type ILazyResolver<K extends Key = Key> = IResolver<() => K>
   & ((...args: unknown[]) => any);
 export type IResolvedLazy<K> = () => Resolved<K>;
 
-function testLazy() {
-  const d = DI.createContainer();
-  const I = DI.createInterface<I>();
-  interface I {
-    c: number;
-  }
-  const instance = d.get(lazy(class Abc { public b: number = 5; }));
-  if (instance().b === 5) {
-    // good
-  }
-
-  class Def {
-    public constructor(@lazy(I) private readonly i: I) {}
-  }
-
-  @inject(lazy(I))
-  class G {
-    public i = resolve(lazy(I));
-    public b: I = this.i();
-  }
-}
-
 /**
  * Allows you to optionally inject a dependency depending on whether the [[`Key`]] is present, for example
  * ```ts
@@ -693,32 +651,6 @@ export type IOptionalResolver<K extends Key = Key> = IResolver<K | undefined> & 
   // any is needed for decorator usages
   (...args: unknown[]): any;
 };
-
-function testOptional() {
-  const d = DI.createContainer();
-  const I = DI.createInterface<I>();
-  interface I {
-    c: number;
-  }
-  const instance = d.get(optional(class Abc { public b: number = 5; }));
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-expect-error
-  if (instance.b === 5) {
-    // good
-  }
-
-  class Def {
-    public constructor(@optional(I) private readonly i: I) {}
-  }
-
-  @inject(optional(I))
-  class G {
-    public i = resolve(optional(I));
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    public b: I = this.i;
-  }
-}
 
 /**
  * ignore tells the container not to try to inject a dependency
@@ -801,37 +733,6 @@ export type INewInstanceResolver<T> = IResolver<T> & {
 const createNewInstance = (key: any, handler: IContainer, requestor: IContainer) => {
   return handler.getFactory(key).construct(requestor);
 };
-
-function testNewInstance() {
-  const d = DI.createContainer();
-  const I = DI.createInterface<I>();
-  interface I {
-    c: number;
-  }
-  const instance = d.get(newInstanceOf(class Abc { public b: number = 5; }));
-  if (instance.b === 5) {
-    // good
-  }
-  const instance2 = d.get(newInstanceForScope(class Abc { public b: number = 5; }));
-  if (instance2.b === 5) {
-    // good
-  }
-
-  class Def {
-    public constructor(
-      @newInstanceOf(I) private readonly i: I,
-      @newInstanceForScope(I) private readonly j: I,
-    ) {}
-  }
-
-  @inject(newInstanceOf(I))
-  class G {
-    public i = resolve(newInstanceOf(I));
-    public ii: I = this.i;
-    public j = resolve(newInstanceForScope(I));
-    public jj: I = this.j;
-  }
-}
 
 _START_CONST_ENUM();
 /** @internal */

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -1,4 +1,5 @@
 import { IContainer, noop } from '@aurelia/kernel';
+import { DirtyChecker, ICoercionConfiguration } from '@aurelia/runtime';
 import {
   AtPrefixedTriggerAttributePattern,
   ColonPrefixedBindAttributePattern,
@@ -74,7 +75,6 @@ import { AuCompose } from './resources/custom-elements/au-compose';
 import { AuSlot } from './resources/custom-elements/au-slot';
 import { SanitizeValueConverter } from './resources/value-converters/sanitize';
 import { NodeObserverLocator } from './observation/observer-locator';
-import { ICoercionConfiguration } from '@aurelia/runtime';
 import { instanceRegistration } from './utilities-di';
 
 /**
@@ -85,6 +85,7 @@ import { instanceRegistration } from './utilities-di';
  */
 export const DefaultComponents = [
   TemplateCompiler,
+  DirtyChecker,
   NodeObserverLocator,
 ];
 
@@ -111,10 +112,9 @@ export const ShortHandBindingSyntax = [
 
 /**
  * Default HTML-specific (but environment-agnostic) binding commands:
- * - Property observation: `.bind`, `.one-time`, `.from-view`, `.to-view`, `.two-way`
- * - Function call: `.call`
+ * - Property observation: `.bind`, `.one-time`, `.from-view`, `.to-view`, `.two-way
  * - Collection observation: `.for`
- * - Event listeners: `.trigger`, `.delegate`, `.capture`
+ * - Event listeners: `.trigger`, `.capture`
  */
 export const DefaultBindingLanguage = [
   DefaultBindingCommand,

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -73,7 +73,7 @@ export class ClassAttributeAccessor implements IAccessor {
   }
 }
 
-export function getClassesToAdd(object: Record<string, unknown> | [] | string): string[] {
+function getClassesToAdd(object: Record<string, unknown> | [] | string): string[] {
   if (isString(object)) {
     return splitClassString(object);
   }

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -1,6 +1,6 @@
 import { emptyArray } from '@aurelia/kernel';
 import { AccessorType } from '@aurelia/runtime';
-import { hasOwnProperty, isString } from '../utilities';
+import { isString } from '../utilities';
 
 import type { IAccessor } from '@aurelia/runtime';
 import { mixinNoopSubscribable } from './observation-utils';
@@ -9,17 +9,13 @@ export class ClassAttributeAccessor implements IAccessor {
   public get doNotCache(): true { return true; }
   public type: AccessorType = AccessorType.Node | AccessorType.Layout;
 
-  public value: unknown = '';
   /** @internal */
-  private _oldValue: unknown = '';
+  private _value: unknown = '';
 
   /** @internal */
-  private _nameIndex: Record<string, number> = {};
+  private readonly _nameIndex: Record<string, number> = {};
   /** @internal */
   private _version: number = 0;
-
-  /** @internal */
-  private _hasChanges: boolean = false;
 
   public constructor(
     public readonly obj: HTMLElement,
@@ -27,68 +23,55 @@ export class ClassAttributeAccessor implements IAccessor {
   }
 
   public getValue(): unknown {
-    // is it safe to assume the observer has the latest value?
-    // todo: ability to turn on/off cache based on type
-    return this.value;
+    return this._value;
   }
 
   public setValue(newValue: unknown): void {
-    this.value = newValue;
-    this._hasChanges = newValue !== this._oldValue;
-    this._flushChanges();
-  }
-
-  /** @internal */
-  private _flushChanges(): void {
-    if (this._hasChanges) {
-      this._hasChanges = false;
-      const currentValue = this.value;
-      const nameIndex = this._nameIndex;
-      const classesToAdd = getClassesToAdd(currentValue as string | Record<string, unknown> | []);
-      let version = this._version;
-      this._oldValue = currentValue;
-
-      // Get strings split on a space not including empties
-      if (classesToAdd.length > 0) {
-        this._addClassesAndUpdateIndex(classesToAdd);
-      }
-
-      this._version += 1;
-
-      // First call to setValue?  We're done.
-      if (version === 0) {
-        return;
-      }
-
-      // Remove classes from previous version.
-      version -= 1;
-      for (const name in nameIndex) {
-        if (!hasOwnProperty.call(nameIndex, name) || nameIndex[name] !== version) {
-          continue;
-        }
-
-        // TODO: this has the side-effect that classes already present which are added again,
-        // will be removed if they're not present in the next update.
-        // Better would be do have some configurability for this behavior, allowing the user to
-        // decide whether initial classes always need to be kept, always removed, or something in between
-        this.obj.classList.remove(name);
-      }
+    if (newValue !== this._value) {
+      this._value = newValue;
+      this._flushChanges();
     }
   }
 
   /** @internal */
-  private _addClassesAndUpdateIndex(classes: string[]) {
-    const node = this.obj;
-    const ii = classes.length;
+  private _flushChanges(): void {
+    const nameIndex = this._nameIndex;
+    const version = ++this._version;
+    const classList = this.obj.classList;
+    const classesToAdd = getClassesToAdd(this._value as string | Record<string, unknown> | []);
+    const ii = classesToAdd.length;
     let i = 0;
-    let className: string;
-    for (; i < ii; i++) {
-      className = classes[i];
-      if (className.length === 0) {
+    let name: string;
+
+    // Get strings split on a space not including empties
+    if (ii > 0) {
+      for (; i < ii; i++) {
+        name = classesToAdd[i];
+        if (name.length === 0) {
+          continue;
+        }
+        nameIndex[name] = this._version;
+        classList.add(name);
+      }
+    }
+
+    // First call to setValue?  We're done.
+    if (version === 1) {
+      return;
+    }
+
+    for (name in nameIndex) {
+      if (nameIndex[name] === version) {
         continue;
       }
-      this._nameIndex[className] = this._version;
-      node.classList.add(className);
+
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete nameIndex[name];
+      // TODO: this has the side-effect that classes already present which are added again,
+      // will be removed if they're not present in the next update.
+      // Better would be do have some configurability for this behavior, allowing the user to
+      // decide whether initial classes always need to be kept, always removed, or something in between
+      classList.remove(name);
     }
   }
 }

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -64,9 +64,6 @@ export class ClassAttributeAccessor implements IAccessor {
       if (nameIndex[name] === version) {
         continue;
       }
-
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete nameIndex[name];
       // TODO: this has the side-effect that classes already present which are added again,
       // will be removed if they're not present in the next update.
       // Better would be do have some configurability for this behavior, allowing the user to

--- a/packages/runtime-html/src/observation/observation-utils.ts
+++ b/packages/runtime-html/src/observation/observation-utils.ts
@@ -48,6 +48,7 @@ export const mixinNodeObserverUseConfig =
     });
 };
 
+/** @internal */
 export const mixinNoopSubscribable = (target: Constructable) => {
   defineHiddenProp(target.prototype, 'subscribe', noop);
   defineHiddenProp(target.prototype, 'unsubscribe', noop);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -105,6 +105,7 @@ export {
 } from './observation/computed-observer';
 export {
   IDirtyChecker,
+  DirtyChecker,
   DirtyCheckProperty,
   DirtyCheckSettings,
 } from './observation/dirty-checker';

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -142,10 +142,10 @@ export type ObservedCollectionKindToType<T> =
             never;
 
 export const enum AccessorType {
-  None          = 0b0_0000_0000,
-  Observer      = 0b0_0000_0001,
+  None          = 0b0_000_000,
+  Observer      = 0b0_000_001,
 
-  Node          = 0b0_0000_0010,
+  Node          = 0b0_000_010,
 
   // misc characteristic of accessors/observers when update
   //
@@ -155,15 +155,7 @@ export const enum AccessorType {
   // queue it instead
   // todo: https://gist.github.com/paulirish/5d52fb081b3570c81e3a
   // todo: https://csstriggers.com/
-  Layout        = 0b0_0000_0100,
-  // by default, everything is an object
-  // eg: a property is accessed on an object
-  // unless explicitly not so
-  Primtive      = 0b0_0000_1000,
-
-  Array         = 0b0_0001_0010,
-  Set           = 0b0_0010_0010,
-  Map           = 0b0_0100_0010,
+  Layout        = 0b0_000_100,
 }
 
 /**

--- a/packages/runtime/src/observation/array-observer.ts
+++ b/packages/runtime/src/observation/array-observer.ts
@@ -381,7 +381,7 @@ export function disableArrayObservation(): void {
 export interface ArrayObserver extends ICollectionObserver<CollectionKind.array>, ICollectionSubscriberCollection {}
 
 export class ArrayObserver {
-  public type: AccessorType = AccessorType.Array;
+  public type: AccessorType = AccessorType.Observer;
 
   private readonly indexObservers: Record<string | number, ArrayIndexObserver | undefined>;
   private lenObs?: CollectionLengthObserver;

--- a/packages/runtime/src/observation/collection-length-observer.ts
+++ b/packages/runtime/src/observation/collection-length-observer.ts
@@ -1,6 +1,6 @@
 import { AccessorType, Collection, CollectionKind, IObserver } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
-import { createError, ensureProto, isMap } from '../utilities-objects';
+import { createError, ensureProto } from '../utilities-objects';
 
 import type { Constructable } from '@aurelia/kernel';
 import type {
@@ -14,7 +14,7 @@ import type {
 export interface CollectionLengthObserver extends ISubscriberCollection {}
 
 export class CollectionLengthObserver implements IObserver, ICollectionSubscriber {
-  public readonly type: AccessorType = AccessorType.Array;
+  public readonly type: AccessorType = AccessorType.Observer;
 
   /** @internal */
   private _value: number;
@@ -62,7 +62,7 @@ export class CollectionLengthObserver implements IObserver, ICollectionSubscribe
 export interface CollectionSizeObserver extends ISubscriberCollection {}
 
 export class CollectionSizeObserver implements ICollectionSubscriber {
-  public readonly type: AccessorType;
+  public readonly type: AccessorType = AccessorType.Observer;
 
   /** @internal */
   private _value: number;
@@ -74,7 +74,6 @@ export class CollectionSizeObserver implements ICollectionSubscriber {
     public readonly owner: ICollectionObserver<CollectionKind.map | CollectionKind.set>,
   ) {
     this._value = (this._obj = owner.collection).size;
-    this.type = isMap(this._obj) ? AccessorType.Map : AccessorType.Set;
   }
 
   public getValue(): number {

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -1,13 +1,18 @@
-import { IPlatform } from '@aurelia/kernel';
+import { IContainer, IPlatform, Registration } from '@aurelia/kernel';
 import { AccessorType, type IObserver, type ISubscriberCollection, type IObservable, type ISubscriber } from '../observation';
 import { subscriberCollection } from './subscriber-collection';
 import { createError, createInterface, safeString } from '../utilities-objects';
 
-import type { ITask, QueueTaskOptions } from '@aurelia/platform';
+import type { ITask } from '@aurelia/platform';
 import type { IIndexable } from '@aurelia/kernel';
 
 export interface IDirtyChecker extends DirtyChecker {}
-export const IDirtyChecker = createInterface<IDirtyChecker>('IDirtyChecker', x => x.singleton(DirtyChecker));
+export const IDirtyChecker = /*@__PURE__*/ createInterface<IDirtyChecker>('IDirtyChecker', __DEV__
+  ? x => x.callback(() => {
+    throw createError('AURxxxx: There is no registration for IDirtyChecker interface. If you want to use your own dirty checker, make sure you register it.');
+  })
+  : void 0
+);
 
 export const DirtyCheckSettings = {
   /**
@@ -42,23 +47,29 @@ export const DirtyCheckSettings = {
   }
 };
 
-const queueTaskOpts: QueueTaskOptions = {
-  persistent: true,
-};
-
 export class DirtyChecker {
   /**
    * @internal
    */
   public static inject = [IPlatform];
+  public static register(c: IContainer) {
+    c.register(
+      Registration.singleton(IDirtyChecker, this),
+      Registration.aliasTo(this, IDirtyChecker),
+    );
+  }
   private readonly tracked: DirtyCheckProperty[] = [];
 
+  /** @internal */
   private _task: ITask | null = null;
+  /** @internal */
   private _elapsedFrames: number = 0;
 
   public constructor(
     private readonly p: IPlatform,
-  ) {}
+  ) {
+    subscriberCollection(DirtyCheckProperty);
+  }
 
   public createProperty(obj: object, key: PropertyKey): DirtyCheckProperty {
     if (DirtyCheckSettings.throw) {
@@ -74,7 +85,7 @@ export class DirtyChecker {
     this.tracked.push(property);
 
     if (this.tracked.length === 1) {
-      this._task = this.p.taskQueue.queueTask(this.check, queueTaskOpts);
+      this._task = this.p.taskQueue.queueTask(this.check, { persistent: true });
     }
   }
 
@@ -160,5 +171,3 @@ export class DirtyCheckProperty implements DirtyCheckProperty {
     }
   }
 }
-
-subscriberCollection(DirtyCheckProperty);

--- a/packages/runtime/src/observation/map-observer.ts
+++ b/packages/runtime/src/observation/map-observer.ts
@@ -153,7 +153,7 @@ export function disableMapObservation(): void {
 export interface MapObserver extends ICollectionObserver<CollectionKind.map>, ICollectionSubscriberCollection {}
 
 export class MapObserver {
-  public type: AccessorType = AccessorType.Map;
+  public type: AccessorType = AccessorType.Observer;
   private lenObs?: CollectionSizeObserver;
 
   public constructor(map: Map<unknown, unknown>) {

--- a/packages/runtime/src/observation/observable.ts
+++ b/packages/runtime/src/observation/observable.ts
@@ -55,6 +55,10 @@ export function observable(
   key?: PropertyKey,
   descriptor?: PropertyDescriptor
 ): ClassDecorator | PropertyDecorator {
+  if (!SetterNotifier.mixed) {
+    SetterNotifier.mixed = true;
+    subscriberCollection(SetterNotifier);
+  }
   // either this check, or arguments.length === 3
   // or could be both, so can throw against user error for better DX
   if (key == null) {
@@ -164,6 +168,7 @@ type ChangeHandlerCallback = (this: object, value: unknown, oldValue: unknown) =
 export interface SetterNotifier extends IAccessor, ISubscriberCollection {}
 
 export class SetterNotifier implements IAccessor {
+  public static mixed = false;
   public readonly type: AccessorType = AccessorType.Observer;
 
   /** @internal */
@@ -213,8 +218,6 @@ export class SetterNotifier implements IAccessor {
     }
   }
 }
-
-subscriberCollection(SetterNotifier);
 
 /*
           | typescript       | babel

--- a/packages/runtime/src/observation/set-observer.ts
+++ b/packages/runtime/src/observation/set-observer.ts
@@ -133,7 +133,7 @@ export function disableSetObservation(): void {
 export interface SetObserver extends ICollectionObserver<CollectionKind.set>, ICollectionSubscriberCollection {}
 
 export class SetObserver {
-  public type: AccessorType = AccessorType.Set;
+  public type: AccessorType = AccessorType.Observer;
   private lenObs?: CollectionSizeObserver;
 
   public constructor(observedSet: Set<unknown>) {

--- a/packages/runtime/src/observation/subscriber-collection.ts
+++ b/packages/runtime/src/observation/subscriber-collection.ts
@@ -19,7 +19,12 @@ export function subscriberCollection(target?: Function): ClassDecorator | void {
   return target == null ? subscriberCollectionDeco : subscriberCollectionDeco(target);
 }
 
+const decoratedTarget = new WeakSet<Function>();
 function subscriberCollectionDeco(target: Function): void { // ClassDecorator expects it to be derived from Function
+  if (decoratedTarget.has(target)) {
+    return;
+  }
+  decoratedTarget.add(target);
   const proto = target.prototype as ISubscriberCollection;
   // not configurable, as in devtool, the getter could be invoked on the prototype,
   // and become permanently broken
@@ -29,185 +34,6 @@ function subscriberCollectionDeco(target: Function): void { // ClassDecorator ex
   ensureProto(proto, 'unsubscribe', removeSubscriber);
 }
 /* eslint-enable @typescript-eslint/ban-types */
-
-// export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
-//   /**
-//    * subscriber flags: bits indicating the existence status of the subscribers of this record
-//    */
-//   private sf: SubFlags = SubFlags.None;
-//   private s0?: T;
-//   private s1?: T;
-//   private s2?: T;
-//   /**
-//    * subscriber rest: When there's more than 3 subscribers, use an array to store the subscriber references
-//    */
-//   private sr?: T[];
-
-//   public count: number = 0;
-
-//   public add(subscriber: T): boolean {
-//     if (this.has(subscriber)) {
-//       return false;
-//     }
-//     const subscriberFlags = this.sf;
-//     if ((subscriberFlags & SubFlags.Sub0) === 0) {
-//       this.s0 = subscriber;
-//       this.sf |= SubFlags.Sub0;
-//     } else if ((subscriberFlags & SubFlags.Sub1) === 0) {
-//       this.s1 = subscriber;
-//       this.sf |= SubFlags.Sub1;
-//     } else if ((subscriberFlags & SubFlags.Sub2) === 0) {
-//       this.s2 = subscriber;
-//       this.sf |= SubFlags.Sub2;
-//     } else if ((subscriberFlags & SubFlags.SubRest) === 0) {
-//       this.sr = [subscriber];
-//       this.sf |= SubFlags.SubRest;
-//     } else {
-//       this.sr!.push(subscriber); // Non-null is implied by else branch of (subscriberFlags & SF.SubscribersRest) === 0
-//     }
-//     ++this.count;
-//     return true;
-//   }
-
-//   public has(subscriber: T): boolean {
-//     // Flags here is just a perf tweak
-//     // Compared to not using flags, it's a moderate speed-up when this collection does not have the subscriber;
-//     // and minor slow-down when it does, and the former is more common than the latter.
-//     const subscriberFlags = this.sf;
-//     if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
-//       return true;
-//     }
-//     if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
-//       return true;
-//     }
-//     if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
-//       return true;
-//     }
-//     if ((subscriberFlags & SubFlags.SubRest) > 0) {
-//       const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-//       const ii = subscribers.length;
-//       let i = 0;
-//       for (; i < ii; ++i) {
-//         if (subscribers[i] === subscriber) {
-//           return true;
-//         }
-//       }
-//     }
-//     return false;
-//   }
-
-//   public any(): boolean {
-//     return this.sf !== SubFlags.None;
-//   }
-
-//   public remove(subscriber: T): boolean {
-//     const subscriberFlags = this.sf;
-//     if ((subscriberFlags & SubFlags.Sub0) > 0 && this.s0 === subscriber) {
-//       this.s0 = void 0;
-//       this.sf = (this.sf | SubFlags.Sub0) ^ SubFlags.Sub0;
-//       --this.count;
-//       return true;
-//     } else if ((subscriberFlags & SubFlags.Sub1) > 0 && this.s1 === subscriber) {
-//       this.s1 = void 0;
-//       this.sf = (this.sf | SubFlags.Sub1) ^ SubFlags.Sub1;
-//       --this.count;
-//       return true;
-//     } else if ((subscriberFlags & SubFlags.Sub2) > 0 && this.s2 === subscriber) {
-//       this.s2 = void 0;
-//       this.sf = (this.sf | SubFlags.Sub2) ^ SubFlags.Sub2;
-//       --this.count;
-//       return true;
-//     } else if ((subscriberFlags & SubFlags.SubRest) > 0) {
-//       const subscribers = this.sr!; // Non-null is implied by (subscriberFlags & SF.SubscribersRest) > 0
-//       const ii = subscribers.length;
-//       let i = 0;
-//       for (; i < ii; ++i) {
-//         if (subscribers[i] === subscriber) {
-//           subscribers.splice(i, 1);
-//           if (ii === 1) {
-//             this.sf = (this.sf | SubFlags.SubRest) ^ SubFlags.SubRest;
-//           }
-//           --this.count;
-//           return true;
-//         }
-//       }
-//     }
-//     return false;
-//   }
-
-//   public notify(val: unknown, oldVal: unknown): void {
-//     if (batching) {
-//       addValueBatch(this, val, oldVal);
-//       return;
-//     }
-//     /**
-//      * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
-//      * callSubscribers invocation, so we're caching them all before invoking any.
-//      * Subscribers added during this invocation are not invoked (and they shouldn't be).
-//      * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
-//      * however this is accounted for via $isBound and similar flags on the subscriber objects)
-//      */
-//     const sub0 = this.s0 as ISubscriber;
-//     const sub1 = this.s1 as ISubscriber;
-//     const sub2 = this.s2 as ISubscriber;
-//     let subs = this.sr as ISubscriber[];
-//     if (subs !== void 0) {
-//       subs = subs.slice();
-//     }
-
-//     if (sub0 !== void 0) {
-//       sub0.handleChange(val, oldVal);
-//     }
-//     if (sub1 !== void 0) {
-//       sub1.handleChange(val, oldVal);
-//     }
-//     if (sub2 !== void 0) {
-//       sub2.handleChange(val, oldVal);
-//     }
-//     if (subs !== void 0) {
-//       const ii = subs.length;
-//       let sub: ISubscriber | undefined;
-//       let i = 0;
-//       for (; i < ii; ++i) {
-//         sub = subs[i];
-//         if (sub !== void 0) {
-//           sub.handleChange(val, oldVal);
-//         }
-//       }
-//     }
-//   }
-
-//   public notifyCollection(collection: Collection, indexMap: IndexMap): void {
-//     const sub0 = this.s0 as ICollectionSubscriber;
-//     const sub1 = this.s1 as ICollectionSubscriber;
-//     const sub2 = this.s2 as ICollectionSubscriber;
-//     let subs = this.sr as ICollectionSubscriber[];
-//     if (subs !== void 0) {
-//       subs = subs.slice();
-//     }
-
-//     if (sub0 !== void 0) {
-//       sub0.handleCollectionChange(collection, indexMap);
-//     }
-//     if (sub1 !== void 0) {
-//       sub1.handleCollectionChange(collection, indexMap);
-//     }
-//     if (sub2 !== void 0) {
-//       sub2.handleCollectionChange(collection, indexMap);
-//     }
-//     if (subs !== void 0) {
-//       const ii = subs.length;
-//       let sub: ICollectionSubscriber | undefined;
-//       let i = 0;
-//       for (; i < ii; ++i) {
-//         sub = subs[i];
-//         if (sub !== void 0) {
-//           sub.handleCollectionChange(collection, indexMap);
-//         }
-//       }
-//     }
-//   }
-// }
 
 export class SubscriberRecord<T extends IAnySubscriber> implements ISubscriberRecord<T> {
   public count: number = 0;
@@ -276,16 +102,3 @@ function addSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber):
 function removeSubscriber(this: ISubscriberCollection, subscriber: IAnySubscriber): boolean {
   return this.subs.remove(subscriber as ISubscriber & ICollectionSubscriber);
 }
-
-// /**
-//  * Subscriber flags to indicate subcription on a record
-//  */
-// const enum SubFlags {
-//   None      = 0,
-//   Sub0      = 0b0001,
-//   Sub1      = 0b0010,
-//   Sub2      = 0b0100,
-//   SubRest   = 0b1000,
-//   Any       = 0b1111,
-// }
-


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some cleanup in between features. Part of the process of decoupling our default implementations from the corresponding interfaces.

@Sayan751 I've moved all the `test*` functions to a separate file for doing the API test. Thanks for the discussion in the other PR.