### PR TITLE
feat(all): allow injection of implementation

### DIFF
--- a/docs/user-docs/aurelia-packages/dialog.md
+++ b/docs/user-docs/aurelia-packages/dialog.md
@@ -526,8 +526,6 @@ Each dialog instance goes through the full lifecycle once.
 
 ## V1 Dialog Migration
 
-* `DialogService` is no longer injectable. Inject `IDialogService` instead.
-* `DialogController` is no longer injectable. Inject `IDialogController` instead.
 * `viewModel` setting in `DialogService.prototype.open` is changed to `component`.
 * `view` setting in `DialogService.prototype.open` is changed to `template`.
 * `keyboard` setting in `DialogService.prototype.open` is changed to accept an array of `Enter`/`Escape` only. Boolean variants are no longer valid. In the future, the API may become less strict.

--- a/docs/user-docs/developer-guides/error-messages/README.md
+++ b/docs/user-docs/developer-guides/error-messages/README.md
@@ -121,7 +121,6 @@ Dependency Injection errors can be found [here](0001-to-0015/).
 | Error Code | Plugin name | Description                                                                                                                        |
 | ---------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | AUR0901    | Dialog      | This happens when an application is closed with some dialogs still open                                                            |
-| AUR0902    | Dialog      | This happens when `DialogController` injection is requested. It's a error prevention for v1->v2 migration of the dialog plugin     |
 | AUR0903    | Dialog      | This happens when `IDialogService.open` is called without both `component` and `template` property                                 |
 | AUR0904    | Dialog      | This happens when the default configuration of the dialog plugin is used, as there's no registration associated for key interfaces |
 

--- a/packages/__tests__/router/viewport-content.spec.ts
+++ b/packages/__tests__/router/viewport-content.spec.ts
@@ -83,7 +83,6 @@ describe('router/viewport-content.spec.ts', function () {
       const connectedCE = viewport.connectedCE;
 
       container.register(Global);
-      // Registration.aliasTo(CustomElement.keyFrom('global'), Global).register(container);
 
       const viewportContent = new ViewportContent(router, viewport, null, true, RoutingInstruction.create('global'), null, connectedCE);
       const component = viewportContent.toComponentInstance(connectedCE.container, connectedCE.controller, connectedCE.element);

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,7 +1,7 @@
 export {
   // enums
-  DialogActionKey,
-  DialogMouseEventType,
+  type DialogActionKey,
+  type DialogMouseEventType,
   DialogDeactivationStatuses,
 
   // main interfaces
@@ -42,7 +42,7 @@ export {
 export {
   DialogConfiguration,
   DialogDefaultConfiguration,
-  DialogConfigurationProvider,
+  type DialogConfigurationProvider,
 } from './plugins/dialog/dialog-configuration';
 
 export {

--- a/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-default-impl.ts
@@ -5,7 +5,7 @@ import {
   IDialogGlobalSettings,
 } from './dialog-interfaces';
 
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, resolve } from '@aurelia/kernel';
 import { singletonRegistration } from '../../utilities-di';
 
 export class DefaultDialogGlobalSettings implements IDialogGlobalSettings {
@@ -22,14 +22,10 @@ export class DefaultDialogGlobalSettings implements IDialogGlobalSettings {
 const baseWrapperCss = 'position:absolute;width:100%;height:100%;top:0;left:0;';
 
 export class DefaultDialogDomRenderer implements IDialogDomRenderer {
-
-  /** @internal */
-  protected static inject = [IPlatform];
-
-  public constructor(private readonly p: IPlatform) {}
+  private readonly p = resolve(IPlatform);
 
   public static register(container: IContainer) {
-    singletonRegistration(IDialogDomRenderer, this).register(container);
+    container.register(singletonRegistration(IDialogDomRenderer, this));
   }
 
   private readonly wrapperCss: string = `${baseWrapperCss} display:flex;`;

--- a/packages/dialog/src/plugins/dialog/dialog-service.ts
+++ b/packages/dialog/src/plugins/dialog/dialog-service.ts
@@ -1,4 +1,4 @@
-import { IContainer, onResolve, onResolveAll } from '@aurelia/kernel';
+import { IContainer, Registration, onResolve, onResolveAll, resolve } from '@aurelia/kernel';
 import { AppTask, IPlatform } from '@aurelia/runtime-html';
 
 import {
@@ -13,7 +13,7 @@ import {
 } from './dialog-interfaces';
 import { DialogController } from './dialog-controller';
 import { createError, isFunction, isPromise } from '../../utilities';
-import { callbackRegistration, instanceRegistration, singletonRegistration } from '../../utilities-di';
+import { instanceRegistration, singletonRegistration } from '../../utilities-di';
 
 import type {
   DialogOpenPromise,
@@ -24,6 +24,25 @@ import type {
  * A default implementation for the dialog service allowing for the creation of dialogs.
  */
 export class DialogService implements IDialogService {
+  public static register(container: IContainer) {
+    container.register(
+      singletonRegistration(this, this),
+      Registration.aliasTo(this, IDialogService),
+      AppTask.deactivating(IDialogService, dialogService => onResolve(
+        dialogService.closeAll(),
+        (openDialogController) => {
+          if (openDialogController.length > 0) {
+            // todo: what to do?
+            if (__DEV__)
+              throw createError(`AUR0901: There are still ${openDialogController.length} open dialog(s).`);
+            else
+              throw createError(`AUR0901:${openDialogController.length}`);
+          }
+        }
+      ))
+    );
+  }
+
   public get controllers() {
     return this.dlgs.slice(0);
   }
@@ -39,32 +58,9 @@ export class DialogService implements IDialogService {
     return dlgs.length > 0 ? dlgs[dlgs.length - 1] : null;
   }
 
-  // tslint:disable-next-line:member-ordering
-  protected static get inject() { return [IContainer, IPlatform, IDialogGlobalSettings]; }
-
-  public constructor(
-    private readonly _ctn: IContainer,
-    private readonly p: IPlatform,
-    private readonly _defaultSettings: IDialogGlobalSettings,
-  ) {}
-
-  public static register(container: IContainer) {
-    container.register(
-      singletonRegistration(IDialogService, this),
-      AppTask.deactivating(IDialogService, dialogService => onResolve(
-        dialogService.closeAll(),
-        (openDialogController) => {
-          if (openDialogController.length > 0) {
-            // todo: what to do?
-            if (__DEV__)
-              throw createError(`AUR0901: There are still ${openDialogController.length} open dialog(s).`);
-            else
-              throw createError(`AUR0901:${openDialogController.length}`);
-          }
-        }
-      ))
-    );
-  }
+  /** @internal */ private readonly _ctn = resolve(IContainer);
+  /** @internal */ private readonly p = resolve(IPlatform);
+  /** @internal */ private readonly _defaultSettings = resolve(IDialogGlobalSettings);
 
   /**
    * Opens a new dialog.
@@ -92,13 +88,10 @@ export class DialogService implements IDialogService {
         $settings.load(),
         loadedSettings => {
           const dialogController = container.invoke(DialogController);
-          container.register(instanceRegistration(IDialogController, dialogController));
-          container.register(callbackRegistration(DialogController, () => {
-            if (__DEV__)
-              throw createError(`AUR0902: Invalid injection of DialogController. Use IDialogController instead.`);
-            else
-              throw createError(`AUR0902`);
-          }));
+          container.register(
+            instanceRegistration(IDialogController, dialogController),
+            instanceRegistration(DialogController, dialogController)
+          );
 
           return onResolve(
             dialogController.activate(loadedSettings),

--- a/packages/runtime-html/src/compiler/attribute-mapper.ts
+++ b/packages/runtime-html/src/compiler/attribute-mapper.ts
@@ -1,6 +1,7 @@
 import { createError, createLookup, isDataAttribute } from '../utilities';
 import { ISVGAnalyzer } from '../observation/svg-analyzer';
 import { createInterface } from '../utilities-di';
+import { resolve } from '@aurelia/kernel';
 
 export interface IAttrMapper extends AttrMapper {}
 export const IAttrMapper = /*@__PURE__*/createInterface<IAttrMapper>('IAttrMapper', x => x.singleton(AttrMapper));
@@ -8,14 +9,12 @@ export const IAttrMapper = /*@__PURE__*/createInterface<IAttrMapper>('IAttrMappe
 export type IsTwoWayPredicate = (element: Element, attribute: string) => boolean;
 
 export class AttrMapper {
-  /** @internal */ public static get inject(): unknown[] { return [ISVGAnalyzer]; }
   /** @internal */ private readonly fns: IsTwoWayPredicate[] = [];
   /** @internal */ private readonly _tagAttrMap: Record<string, Record<string, PropertyKey>> = createLookup();
   /** @internal */ private readonly _globalAttrMap: Record<string, PropertyKey> = createLookup();
+  private readonly svg = resolve(ISVGAnalyzer);
 
-  public constructor(
-    private readonly svg: ISVGAnalyzer,
-  ) {
+  public constructor() {
     this.useMapping({
       LABEL: { for: 'htmlFor' },
       IMG: { usemap: 'useMap' },

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -49,7 +49,7 @@ import type { IAuSlotProjections } from '../templating/controller.projection';
 export class TemplateCompiler implements ITemplateCompiler {
   public static register(container: IContainer): void {
     container.register(
-      singletonRegistration(ITemplateCompiler, this),
+      singletonRegistration(this, this),
       aliasRegistration(this, ITemplateCompiler)
     );
   }

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -29,14 +29,13 @@ import { CustomAttribute } from '../resources/custom-attribute';
 import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from '../resources/custom-element';
 import { BindingCommand, CommandType } from '../resources/binding-command';
 import { createError, createLookup, def, isString, objectAssign, objectFreeze } from '../utilities';
-import { allResources, createInterface, singletonRegistration } from '../utilities-di';
+import { aliasRegistration, allResources, createInterface, singletonRegistration } from '../utilities-di';
 import { appendManyToTemplate, appendToTemplate, createComment, createElement, createText, insertBefore, insertManyBefore, getPreviousSibling } from '../utilities-dom';
 import { appendResourceKey, defineMetadata, getResourceKeyFor } from '../utilities-metadata';
 import { BindingMode } from '../binding/interfaces-bindings';
 
 import type {
   IContainer,
-  IResolver,
   Constructable,
   Writable,
 } from '@aurelia/kernel';
@@ -48,8 +47,11 @@ import type { ICompliationInstruction, IInstruction, } from '../renderer';
 import type { IAuSlotProjections } from '../templating/controller.projection';
 
 export class TemplateCompiler implements ITemplateCompiler {
-  public static register(container: IContainer): IResolver<ITemplateCompiler> {
-    return singletonRegistration(ITemplateCompiler, this).register(container);
+  public static register(container: IContainer): void {
+    container.register(
+      singletonRegistration(ITemplateCompiler, this),
+      aliasRegistration(this, ITemplateCompiler)
+    );
   }
 
   public debug: boolean = false;

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -1,3 +1,4 @@
+import { resolve } from '@aurelia/kernel';
 import { IPlatform } from '../platform';
 import { isString } from '../utilities';
 import { createInterface } from '../utilities-di';
@@ -15,17 +16,9 @@ const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 
 export class TemplateElementFactory {
   /** @internal */
-  public static inject = [IPlatform];
-
+  private readonly p = resolve(IPlatform);
   /** @internal */
-  private _template: HTMLTemplateElement;
-  /** @internal */
-  private readonly p: IPlatform;
-
-  public constructor(p: IPlatform) {
-    this.p = p;
-    this._template = createTemplate(this.p);
-  }
+  private _template = createTemplate(this.p);
 
   public createTemplate(markup: string): HTMLTemplateElement;
   public createTemplate(node: Node): HTMLTemplateElement;

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -346,7 +346,6 @@ export {
   isCustomElementController,
   isCustomElementViewModel,
   ViewModelKind,
-  HooksDefinition,
   State,
   type ControllerVisitor,
   type IViewModel,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -36,7 +36,7 @@ import { IPlatform } from './platform';
 import { IViewFactory } from './templating/view';
 import { IRendering } from './templating/rendering';
 import type { AttrSyntax } from './resources/attribute-pattern';
-import { createError, defineProp, objectKeys, isString } from './utilities';
+import { createError, objectKeys, isString, def } from './utilities';
 import { createInterface, registerResolver, singletonRegistration } from './utilities-di';
 import { IAuSlotProjections, IAuSlotsInfo, AuSlotsInfo } from './templating/controller.projection';
 
@@ -384,7 +384,7 @@ export function renderer<TType extends string>(targetType: TType): InstructionRe
     target.register = function (container: IContainer): void {
       singletonRegistration(IRenderer, this).register(container);
     };
-    defineProp(target.prototype, 'target', {
+    def(target.prototype, 'target', {
       configurable: true,
       get: function () { return targetType; }
     });

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -69,7 +69,7 @@ export class BindingBehaviorDefinition<T extends Constructable = Constructable> 
   }
 }
 
-const bbBaseName = getResourceKeyFor('binding-behavior');
+const bbBaseName = /*@__PURE__*/getResourceKeyFor('binding-behavior');
 const getBehaviorAnnotation = <K extends keyof PartialBindingBehaviorDefinition>(
   Type: Constructable,
   prop: K,

--- a/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
@@ -1,4 +1,4 @@
-import { IDisposable, IPlatform, emptyArray } from '@aurelia/kernel';
+import { IDisposable, IPlatform, emptyArray, resolve } from '@aurelia/kernel';
 import { bindingBehavior } from '../binding-behavior';
 
 import { type BindingBehaviorInstance, type IBinding, type IRateLimitOptions, type Scope } from '@aurelia/runtime';
@@ -9,13 +9,7 @@ const defaultDelay = 200;
 
 export class DebounceBindingBehavior implements BindingBehaviorInstance {
   /** @internal */
-  protected static inject = [IPlatform];
-  /** @internal */
-  private readonly _platform: IPlatform;
-
-  public constructor(platform: IPlatform) {
-    this._platform = platform;
-  }
+  private readonly _platform = resolve(IPlatform);
 
   public bind(scope: Scope, binding: IBinding, delay?: number, signals?: string | string[]) {
     const opts: IRateLimitOptions = {

--- a/packages/runtime-html/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/signals.ts
@@ -2,18 +2,13 @@ import { ISignaler } from '@aurelia/runtime';
 import { bindingBehavior } from '../binding-behavior';
 import { addSignalListener, createError, removeSignalListener } from '../../utilities';
 import type { BindingBehaviorInstance, IBinding, IConnectableBinding, Scope } from '@aurelia/runtime';
+import { resolve } from '@aurelia/kernel';
 
 export class SignalBindingBehavior implements BindingBehaviorInstance {
   /** @internal */
-  protected static inject = [ISignaler];
-  /** @internal */
   private readonly _lookup: Map<IBinding, string[]> = new Map();
   /** @internal */
-  private readonly _signaler: ISignaler;
-
-  public constructor(signaler: ISignaler) {
-    this._signaler = signaler;
-  }
+  private readonly _signaler = resolve(ISignaler);
 
   public bind(scope: Scope, binding: IConnectableBinding, ...names: string[]): void {
     if (!('handleChange' in binding)) {

--- a/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
@@ -1,4 +1,4 @@
-import { IPlatform, type IDisposable, emptyArray } from '@aurelia/kernel';
+import { IPlatform, type IDisposable, emptyArray, resolve } from '@aurelia/kernel';
 import { TaskQueue } from '@aurelia/platform';
 import { BindingBehaviorInstance, type IBinding, type IRateLimitOptions, type Scope } from '@aurelia/runtime';
 import { bindingBehavior } from '../binding-behavior';
@@ -9,15 +9,12 @@ const defaultDelay = 200;
 
 export class ThrottleBindingBehavior implements BindingBehaviorInstance {
   /** @internal */
-  protected static inject = [IPlatform];
-  /** @internal */
   private readonly _now: () => number;
   /** @internal */
   private readonly _taskQueue: TaskQueue;
 
-  public constructor(platform: IPlatform) {
-    this._now = platform.performanceNow;
-    this._taskQueue = platform.taskQueue;
+  public constructor() {
+    ({ performanceNow: this._now, taskQueue: this._taskQueue } = resolve(IPlatform));
   }
 
   public bind(scope: Scope, binding: IBinding, delay?: number, signals?: string | string[]) {

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -5,23 +5,16 @@ import { bindingBehavior } from '../binding-behavior';
 
 import { PropertyBinding } from '../../binding/property-binding';
 import { createError } from '../../utilities';
+import { resolve } from '@aurelia/kernel';
 
 export class UpdateTriggerBindingBehavior implements BindingBehaviorInstance {
-  /** @internal */ protected static inject = [IObserverLocator, INodeObserverLocator];
-  /** @internal */ private readonly _observerLocator: IObserverLocator;
-  /** @internal */ private readonly _nodeObserverLocator: NodeObserverLocator;
-  public constructor(
-    observerLocator: IObserverLocator,
-    nodeObserverLocator: INodeObserverLocator,
-  ) {
-    if (!(nodeObserverLocator instanceof NodeObserverLocator)) {
-      throw createError('AURxxxx: updateTrigger binding behavior only works with the default implementation of Aurelia HTML observation. Implement your own node observation + updateTrigger');
-    }
-    this._observerLocator = observerLocator;
-    this._nodeObserverLocator = nodeObserverLocator;
-  }
+  /** @internal */ private readonly _observerLocator = resolve(IObserverLocator);
+  /** @internal */ private readonly _nodeObserverLocator = resolve(INodeObserverLocator) as NodeObserverLocator;
 
   public bind(_scope: Scope, binding: IBinding, ...events: string[]): void {
+    if (!(this._nodeObserverLocator instanceof NodeObserverLocator)) {
+      throw createError('AURxxxx: updateTrigger binding behavior only works with the default implementation of Aurelia HTML observation. Implement your own node observation + updateTrigger');
+    }
     if (events.length === 0) {
       if (__DEV__)
         throw createError(`AUR0802: The updateTrigger binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`);

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -129,7 +129,7 @@ export class BindingCommandDefinition<T extends Constructable = Constructable> i
   }
 }
 
-const cmdBaseName = getResourceKeyFor('binding-command');
+const cmdBaseName = /*@__PURE__*/getResourceKeyFor('binding-command');
 const getCommandKeyFrom = (name: string): string => `${cmdBaseName}:${name}`;
 const getCommandAnnotation = <K extends keyof PartialBindingCommandDefinition>(
   Type: Constructable,

--- a/packages/runtime-html/src/resources/custom-attributes/focus.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/focus.ts
@@ -4,6 +4,7 @@ import { IPlatform } from '../../platform';
 import { customAttribute } from '../custom-attribute';
 import { bindable } from '../../bindable';
 import type { ICustomAttributeController, ICustomAttributeViewModel } from '../../templating/controller';
+import { resolve } from '@aurelia/kernel';
 
 /**
  * Focus attribute for element focus binding
@@ -22,16 +23,12 @@ export class Focus implements ICustomAttributeViewModel {
    * @internal
    */
   private _needsApply: boolean = false;
-  /** @internal */ private readonly _element: INode<HTMLElement>;
-  /** @internal */ private readonly _platform: IPlatform;
 
-  public constructor(
-    element: INode<HTMLElement>,
-    platform: IPlatform,
-  ) {
-    this._element = element;
-    this._platform = platform;
-  }
+  /** @internal */
+  private readonly _element = resolve(INode) as INode<HTMLElement>;
+
+  /** @internal */
+  private readonly _platform = resolve(IPlatform);
 
   public binding(): void {
     this.valueChanged();
@@ -112,7 +109,7 @@ export class Focus implements ICustomAttributeViewModel {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (shouldFocus && !isFocused) {
       el.focus();
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     } else if (!shouldFocus && isFocused) {
       el.blur();
     }

--- a/packages/runtime-html/src/resources/custom-attributes/show.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/show.ts
@@ -9,20 +9,22 @@ import type { ITask } from '@aurelia/platform';
 import type { ICustomAttributeViewModel } from '../../templating/controller';
 import type { HydrateAttributeInstruction } from '../../renderer';
 import { alias } from '../../utilities-di';
+import { resolve } from '@aurelia/kernel';
 
 export class Show implements ICustomAttributeViewModel {
   @bindable public value: unknown;
 
-  /** @internal */ private _isToggled: boolean;
+  private readonly el = resolve(INode) as INode<HTMLElement>;
+  private readonly p = resolve(IPlatform);
+
   /** @internal */ private _isActive: boolean = false;
   /** @internal */ private _task: ITask | null = null;
+
+  /** @internal */ private _isToggled: boolean;
   /** @internal */ private readonly _base: boolean;
 
-  public constructor(
-    @INode private readonly el: INode<HTMLElement>,
-    @IPlatform private readonly p: IPlatform,
-    @IInstruction instr: HydrateAttributeInstruction,
-  ) {
+  public constructor() {
+    const instr = resolve(IInstruction) as HydrateAttributeInstruction;
     // if this is declared as a 'hide' attribute, then this.base will be false, inverting everything.
     this._isToggled = this._base = instr.alias !== 'hide';
   }

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -12,7 +12,7 @@ import { getEffectiveParentNode, getRef } from '../dom';
 import { Watch } from '../watch';
 import { DefinitionType } from './resources-shared';
 import { appendResourceKey, defineMetadata, getAnnotationKeyFor, getOwnMetadata, getResourceKeyFor, hasOwnMetadata } from '../utilities-metadata';
-import { createError, isFunction, isString, objectAssign, objectFreeze } from '../utilities';
+import { createError, def, isFunction, isString, objectAssign, objectFreeze } from '../utilities';
 import { aliasRegistration, registerAliases, transientRegistration } from '../utilities-di';
 
 import type {
@@ -582,12 +582,11 @@ export const generateElementType = /*@__PURE__*/(function () {
     configurable: true,
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const defaultProto = {} as any;
+  const defaultProto = {};
 
   return function <P extends {} = {}>(
     name: string,
-    proto: P = defaultProto,
+    proto: P = defaultProto as P,
   ): CustomElementType<Constructable<P>> {
     // Anonymous class ensures that minification cannot cause unintended side-effects, and keeps the class
     // looking similarly from the outside (when inspected via debugger, etc).
@@ -596,7 +595,7 @@ export const generateElementType = /*@__PURE__*/(function () {
     // Define the name property so that Type.name can be used by end users / plugin authors if they really need to,
     // even when minified.
     nameDescriptor.value = name;
-    Reflect.defineProperty(Type, 'name', nameDescriptor);
+    def(Type, 'name', nameDescriptor);
 
     // Assign anything from the prototype that was passed in
     if (proto !== defaultProto) {

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,4 +1,4 @@
-import { Constructable, IContainer, InstanceProvider, onResolve, transient } from '@aurelia/kernel';
+import { Constructable, IContainer, InstanceProvider, onResolve, resolve, transient } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
 import { INode, IRenderLocation, isRenderLocation, registerHostNode } from '../../dom';
@@ -29,12 +29,6 @@ type ChangeSource = keyof Pick<AuCompose, 'template' | 'component' | 'model' | '
 // <au-component template.bind="<string>" model.bind="" />
 //
 export class AuCompose {
-
-  /** @internal */
-  protected static get inject() {
-    return [IContainer, IController, INode, IRenderLocation, IPlatform, IInstruction, transient(CompositionContextFactory)];
-  }
-
   /* determine what template used to compose the component */
   @bindable
   public template?: string | Promise<string>;
@@ -83,25 +77,14 @@ export class AuCompose {
     return this._composition;
   }
 
-  /** @internal */ private readonly _rendering: IRendering;
-  /** @internal */ private readonly _instruction: HydrateElementInstruction;
-  /** @internal */ private readonly _contextFactory: CompositionContextFactory;
-
-  public constructor(
-    /** @internal */ private readonly _container: IContainer,
-    /** @internal */ private readonly parent: ISyntheticView | ICustomElementController,
-    /** @internal */ private readonly host: HTMLElement,
-    /** @internal */ private readonly _location: IRenderLocation,
-    /** @internal */ private readonly _platform: IPlatform,
-    // todo: use this to retrieve au-slot instruction
-    //        for later enhancement related to <au-slot/> + compose
-    instruction: HydrateElementInstruction,
-    contextFactory: CompositionContextFactory,
-  ) {
-    this._rendering = _container.get(IRendering);
-    this._instruction = instruction;
-    this._contextFactory = contextFactory;
-  }
+  /** @internal */ private readonly _container = resolve(IContainer);
+  /** @internal */ private readonly parent = resolve(IController) as ISyntheticView | ICustomElementController;
+  /** @internal */ private readonly host = resolve(INode) as HTMLElement;
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
+  /** @internal */ private readonly _platform = resolve(IPlatform);
+  /** @internal */ private readonly _rendering = resolve(IRendering);
+  /** @internal */ private readonly _instruction = resolve(IInstruction) as HydrateElementInstruction;
+  /** @internal */ private readonly _contextFactory = resolve(transient(CompositionContextFactory));
 
   public attaching(initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
     return this._pending = onResolve(

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -8,7 +8,7 @@ import { IRendering } from '../../templating/rendering';
 import { registerResolver } from '../../utilities-di';
 import { createMutationObserver } from '../../utilities-dom';
 
-import { IContainer, InstanceProvider, Writable, emptyArray, onResolve } from '@aurelia/kernel';
+import { IContainer, InstanceProvider, Writable, emptyArray, onResolve, resolve } from '@aurelia/kernel';
 import type { ControllerVisitor, ICustomElementController, ICustomElementViewModel, IHydratedController, IHydratedParentController, ISyntheticView } from '../../templating/controller';
 import type { IViewFactory } from '../../templating/view';
 import type { HydrateElementInstruction } from '../../renderer';
@@ -20,8 +20,6 @@ import { type IAuSlot, type IAuSlotSubscriber, IAuSlotWatcher } from '../../temp
   containerless: true
 })
 export class AuSlot implements ICustomElementViewModel, IAuSlot {
-  /** @internal */ public static get inject() { return [IRenderLocation, IInstruction, IHydrationContext, IRendering]; }
-
   public readonly view: ISyntheticView;
   /** @internal */
   public readonly $controller!: ICustomElementController<this>; // This is set by the controller after this instance is constructed
@@ -47,17 +45,16 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
   @bindable
   public slotchange: ((name: string, nodes: readonly Node[]) => void) | null = null;
 
-  public constructor(
-    location: IRenderLocation,
-    instruction: HydrateElementInstruction,
-    hdrContext: IHydrationContext,
-    rendering: IRendering,
-  ) {
-    let factory: IViewFactory;
-    let container: IContainer;
+  public constructor() {
+    const location = resolve(IRenderLocation);
+    const instruction = resolve(IInstruction) as HydrateElementInstruction;
+    const hdrContext = resolve(IHydrationContext);
+    const rendering = resolve(IRendering);
     const slotInfo = instruction.auSlot!;
     const projection = hdrContext.instruction?.projections?.[slotInfo.name];
     const contextController = hdrContext.controller;
+    let factory: IViewFactory;
+    let container: IContainer;
     this.name = slotInfo.name;
     if (projection == null) {
       factory = rendering.getViewFactory(slotInfo.fallback, contextController.container);
@@ -129,13 +126,13 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       initiator,
       this.$controller,
       this._hasProjection ? this._outerScope! : this._parentScope!,
-      ), () => {
-        if (this._hasSlotWatcher) {
-          this._slotwatchers.forEach(w => w.watch(this));
-          this._observe();
-          this._notifySlotChange();
-          this._attached = true;
-        }
+    ), () => {
+      if (this._hasSlotWatcher) {
+        this._slotwatchers.forEach(w => w.watch(this));
+        this._observe();
+        this._notifySlotChange();
+        this._attached = true;
+      }
     });
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { onResolve } from '@aurelia/kernel';
+import { onResolve, resolve } from '@aurelia/kernel';
 import { IRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';
 import { templateController } from '../custom-attribute';
@@ -11,8 +11,6 @@ import type { INode } from '../../dom';
 import { createError } from '../../utilities';
 
 export class If implements ICustomAttributeViewModel {
-  /** @internal */ protected static inject = [IViewFactory, IRenderLocation];
-
   public elseFactory?: IViewFactory = void 0;
   public elseView?: ISyntheticView = void 0;
   public ifView?: ISyntheticView = void 0;
@@ -31,16 +29,8 @@ export class If implements ICustomAttributeViewModel {
   private pending: void | Promise<void> = void 0;
   /** @internal */ private _wantsDeactivate: boolean = false;
   /** @internal */ private _swapId: number = 0;
-  /** @internal */ private readonly _ifFactory: IViewFactory;
-  /** @internal */ private readonly _location: IRenderLocation;
-
-  public constructor(
-    ifFactory: IViewFactory,
-    location: IRenderLocation,
-  ) {
-    this._ifFactory = ifFactory;
-    this._location = location;
-  }
+  /** @internal */ private readonly _ifFactory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
 
   public attaching(initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
     let view: ISyntheticView | undefined;
@@ -179,13 +169,7 @@ export class If implements ICustomAttributeViewModel {
 templateController('if')(If);
 
 export class Else implements ICustomAttributeViewModel {
-  /** @internal */ public static inject = [IViewFactory];
-
-  /** @internal */ private readonly _factory: IViewFactory;
-
-  public constructor(factory: IViewFactory) {
-    this._factory = factory;
-  }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
 
   public link(
     controller: IHydratableController,

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -1,4 +1,4 @@
-import { onResolve } from '@aurelia/kernel';
+import { onResolve, resolve } from '@aurelia/kernel';
 import { IRenderLocation, setEffectiveParentNode } from '../../dom';
 import { IPlatform } from '../../platform';
 import { IViewFactory } from '../../templating/view';
@@ -14,7 +14,6 @@ type ResolvedTarget = Element;
 export type PortalLifecycleCallback = (target: PortalTarget, view: ISyntheticView) => void | Promise<void>;
 
 export class Portal implements ICustomAttributeViewModel {
-  public static inject = [IViewFactory, IRenderLocation, IPlatform];
 
   public readonly $controller!: ICustomAttributeController<this>;
 
@@ -51,11 +50,10 @@ export class Portal implements ICustomAttributeViewModel {
   /** @internal */ private readonly _platform: IPlatform;
   /** @internal */ private readonly _targetLocation: IRenderLocation;
 
-  public constructor(
-    factory: IViewFactory,
-    originalLoc: IRenderLocation,
-    p: IPlatform,
-  ) {
+  public constructor() {
+    const factory = resolve(IViewFactory);
+    const originalLoc = resolve(IRenderLocation);
+    const p = resolve(IPlatform);
     this._platform = p;
     // to make the shape of this object consistent.
     // todo: is this necessary

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,5 +1,5 @@
 import { Task, TaskAbortError, TaskStatus } from '@aurelia/platform';
-import { ILogger, onResolve, onResolveAll } from '@aurelia/kernel';
+import { ILogger, onResolve, onResolveAll, resolve } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
 import { INode, IRenderLocation } from '../../dom';
@@ -36,16 +36,10 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
   private postSettledTask: Task<void | Promise<void>> | null = null;
   private postSettlePromise!: Promise<void>;
 
-  /** @internal */ private readonly logger: ILogger;
-
-  public constructor(
-  /** @internal */ @IViewFactory private readonly _factory: IViewFactory,
-  /** @internal */ @IRenderLocation private readonly _location: IRenderLocation,
-  /** @internal */ @IPlatform private readonly _platform: IPlatform,
-    @ILogger logger: ILogger,
-  ) {
-    this.logger = logger.scopeTo('promise.resolve');
-  }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
+  /** @internal */ private readonly _platform = resolve(IPlatform);
+  /** @internal */ private readonly logger = resolve(ILogger).scopeTo('promise.resolve');
 
   public link(
     _controller: IHydratableController,
@@ -171,10 +165,8 @@ export class PendingTemplateController implements ICustomAttributeViewModel {
 
   public view: ISyntheticView | undefined = void 0;
 
-  public constructor(
-    /** @internal */ @IViewFactory private readonly _factory: IViewFactory,
-    /** @internal */ @IRenderLocation private readonly _location: IRenderLocation,
-  ) { }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
 
   public link(
     controller: IHydratableController,
@@ -218,10 +210,8 @@ export class FulfilledTemplateController implements ICustomAttributeViewModel {
 
   public view: ISyntheticView | undefined = void 0;
 
-  public constructor(
-    /** @internal */ @IViewFactory private readonly _factory: IViewFactory,
-    /** @internal */ @IRenderLocation private readonly _location: IRenderLocation,
-  ) { }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
 
   public link(
     controller: IHydratableController,
@@ -266,10 +256,8 @@ export class RejectedTemplateController implements ICustomAttributeViewModel {
 
   public view: ISyntheticView | undefined = void 0;
 
-  public constructor(
-    @IViewFactory private readonly _factory: IViewFactory,
-    @IRenderLocation private readonly _location: IRenderLocation,
-  ) { }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
 
   public link(
     controller: IHydratableController,

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -1,8 +1,8 @@
 import {
   ILogger,
-  LogLevel,
   onResolve,
   onResolveAll,
+  resolve,
   Writable,
 } from '@aurelia/kernel';
 import {
@@ -40,10 +40,8 @@ export class Switch implements ICustomAttributeViewModel {
    */
   public readonly promise: Promise<void> | void = void 0;
 
-  public constructor(
-    @IViewFactory private readonly _factory: IViewFactory,
-    @IRenderLocation private readonly _location: IRenderLocation,
-  ) { }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
 
   public link(
     _controller: IHydratableController,
@@ -237,8 +235,6 @@ export class Switch implements ICustomAttributeViewModel {
 let caseId = 0;
 @templateController('case')
 export class Case implements ICustomAttributeViewModel {
-  /** @internal */ protected static inject = [IViewFactory, IObserverLocator, IRenderLocation, ILogger];
-
   /** @internal */ public readonly id: number = ++caseId;
   public readonly $controller!: ICustomAttributeController<this>; // This is set by the controller after this instance is constructed
 
@@ -258,19 +254,12 @@ export class Case implements ICustomAttributeViewModel {
 
   public view: ISyntheticView | undefined = void 0;
   private $switch!: Switch;
-  /** @internal */ private readonly _debug: boolean;
-  /** @internal */ private readonly _logger: ILogger;
   /** @internal */ private _observer: ICollectionObserver<CollectionKind.array> | undefined;
 
-  public constructor(
-    /** @internal */ private readonly _factory: IViewFactory,
-    /** @internal */ private readonly _locator: IObserverLocator,
-    /** @internal */ private readonly _location: IRenderLocation,
-    logger: ILogger,
-  ) {
-    this._debug = logger.config.level <= LogLevel.debug;
-    this._logger = logger.scopeTo(`${this.constructor.name}-#${this.id}`);
-  }
+  /** @internal */ private readonly _factory = resolve(IViewFactory);
+  /** @internal */ private readonly _locator = resolve(IObserverLocator);
+  /** @internal */ private readonly _location = resolve(IRenderLocation);
+  /** @internal */ private readonly _logger = resolve(ILogger).scopeTo(`${this.constructor.name}-#${this.id}`);
 
   public link(
     controller: IHydratableController,

--- a/packages/runtime-html/src/resources/template-controllers/with.ts
+++ b/packages/runtime-html/src/resources/template-controllers/with.ts
@@ -3,23 +3,15 @@ import { IRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';
 import { templateController } from '../custom-attribute';
 import { bindable } from '../../bindable';
-import type { ISyntheticView, ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor } from '../../templating/controller';
+import type { ICustomAttributeController, ICustomAttributeViewModel, IHydratedController, IHydratedParentController, ControllerVisitor } from '../../templating/controller';
+import { resolve } from '@aurelia/kernel';
 
 export class With implements ICustomAttributeViewModel {
-  /** @internal */ protected static inject = [IViewFactory, IRenderLocation];
-
-  public view: ISyntheticView;
-
   public readonly $controller!: ICustomAttributeController<this>; // This is set by the controller after this instance is constructed
 
   @bindable public value?: object;
 
-  public constructor(
-    factory: IViewFactory,
-    location: IRenderLocation
-  ) {
-    this.view = factory.create().setLocation(location);
-  }
+  private view = resolve(IViewFactory).create().setLocation(resolve(IRenderLocation));
 
   public valueChanged(
     newValue: unknown,

--- a/packages/runtime-html/src/resources/value-converters/sanitize.ts
+++ b/packages/runtime-html/src/resources/value-converters/sanitize.ts
@@ -1,3 +1,4 @@
+import { resolve } from '@aurelia/kernel';
 import { createError } from '../../utilities';
 import { createInterface } from '../../utilities-di';
 import { valueConverter } from '../value-converter';
@@ -21,9 +22,7 @@ export const ISanitizer = /*@__PURE__*/createInterface<ISanitizer>('ISanitizer',
  * Simple html sanitization converter to preserve whitelisted elements and attributes on a bound property containing html.
  */
 export class SanitizeValueConverter {
-  public constructor(
-    /** @internal */ @ISanitizer private readonly _sanitizer: ISanitizer,
-  ) {}
+  /** @internal */ private readonly _sanitizer = resolve(ISanitizer);
 
   /**
    * Process the provided markup that flows to the view.

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -74,26 +74,6 @@ export const IAuSlotWatcher = /*@__PURE__*/createInterface<IAuSlotWatcher>('IAuS
 
 interface AuSlotWatcherBinding extends ISubscriberCollection {}
 class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscriberCollection {
-
-  public static create(
-    controller: ICustomElementController,
-    name: PropertyKey,
-    callbackName: PropertyKey,
-    slotName: string,
-    query: string,
-  ) {
-    const obj = controller.viewModel;
-    const slotWatcher = new AuSlotWatcherBinding(obj, callbackName, slotName, query);
-    def(obj, name, {
-      enumerable: true,
-      configurable: true,
-      get: objectAssign((/* SlotWatcherBinding */) => slotWatcher.getValue(), { getObserver: () => slotWatcher }),
-      set: (/* SlotWatcherBinding */) => {/* nothing */}
-    });
-
-    return slotWatcher;
-  }
-
   /** @internal */
   private readonly _obj: ICustomElementViewModel;
   /** @internal */
@@ -110,7 +90,7 @@ class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscr
 
   public isBound: boolean = false;
 
-  private constructor(
+  public constructor(
     obj: ICustomElementViewModel,
     callback: PropertyKey,
     slotName: string,
@@ -177,7 +157,7 @@ class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscr
 type SlottedPropDefinition = PartialSlottedDefinition & { name: PropertyKey };
 class SlottedLifecycleHooks {
   public constructor(
-    private readonly def: SlottedPropDefinition,
+    private readonly _def: SlottedPropDefinition,
   ) {}
 
   public register(c: IContainer) {
@@ -185,14 +165,20 @@ class SlottedLifecycleHooks {
   }
 
   public hydrating(vm: object, controller: ICustomElementController) {
-    const def = this.def;
-    const watcher = AuSlotWatcherBinding.create(
-      controller,
-      def.name,
-      def.callback ?? `${safeString(def.name)}Changed`,
-      def.slotName ?? 'default',
-      def.query ?? '*'
+    const $def = this._def;
+    const watcher = new AuSlotWatcherBinding(
+      vm,
+      $def.callback ?? `${safeString($def.name)}Changed`,
+      $def.slotName ?? 'default',
+      $def.query ?? '*'
     );
+    def(vm, $def.name, {
+      enumerable: true,
+      configurable: true,
+      get: objectAssign((/* SlotWatcherBinding */) => watcher.getValue(), { getObserver: () => watcher }),
+      set: (/* SlotWatcherBinding */) => {/* nothing */}
+    });
+
     instanceRegistration(IAuSlotWatcher, watcher).register(controller.container);
     controller.addBinding(watcher);
   }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -639,19 +639,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     let i = 0;
     let ii = 0;
-    // let ii = this._childrenObs.length;
     let ret: void | Promise<void>;
-    // timing: after binding, before bound
-    // reason: needs to start observing before all the bindings finish their bind phase,
-    //         so that changes in one binding can be reflected into the other, regardless the index of the binding
-    //
-    // todo: is this timing appropriate?
-    // if (ii > 0) {
-    //   while (ii > i) {
-    //     this._childrenObs[i].start();
-    //     ++i;
-    //   }
-    // }
 
     if (this.bindings !== null) {
       i = 0;
@@ -802,6 +790,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         this.state = State.deactivating;
         // we are about to deactivate, the error from activation can be ignored
         prevActivation = this.$promise?.catch(__DEV__
+          /* istanbul-ignore-next */
           ? err => {
             this.logger.warn('The activation error will be ignored, as the controller is already scheduled for deactivation. The activation was rejected with: %s', err);
           }
@@ -821,6 +810,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
           throw createError(`AUR0505:${this.name} ${stringifyState(this.state)}`);
     }
 
+    /* istanbul-ignore-next */
     if (__DEV__ && this.debug) { this.logger!.trace(`deactivate()`); }
 
     this.$initiator = initiator;
@@ -831,14 +821,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
     let i = 0;
     let ret: void | Promise<void>;
-    // timing: before deactiving
-    // reason: avoid queueing a callback from the mutation observer, caused by the changes of nodes by repeat/if etc...
-    // todo: is this appropriate timing?
-    // if (this._childrenObs.length) {
-    //   for (; i < this._childrenObs.length; ++i) {
-    //     this._childrenObs[i].stop();
-    //   }
-    // }
 
     if (this.children !== null) {
       for (i = 0; i < this.children.length; ++i) {
@@ -846,8 +828,8 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         void this.children[i].deactivate(initiator, this as IHydratedController);
       }
     }
-    return onResolve(prevActivation, () => {
 
+    return onResolve(prevActivation, () => {
       if (this.isBound) {
         if (this.vmKind !== ViewModelKind.synthetic && this._lifecycleHooks!.detaching != null) {
           if (__DEV__ && this.debug) { this.logger!.trace(`lifecycleHooks.detaching()`); }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -137,10 +137,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   private readonly _rendering: IRendering;
 
   /** @internal */
-  public _hooks: HooksDefinition;
-  public get hooks(): HooksDefinition {
-    return this._hooks;
-  }
+  public _vmHooks: HooksDefinition;
 
   /** @internal */
   public _vm: BindingContext<C> | null;
@@ -149,7 +146,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   }
   public set viewModel(v: BindingContext<C> | null) {
     this._vm = v;
-    this._hooks = v == null || this.vmKind === ViewModelKind.synthetic ? HooksDefinition.none : new HooksDefinition(v);
+    this._vmHooks = v == null || this.vmKind === ViewModelKind.synthetic ? HooksDefinition.none : new HooksDefinition(v);
   }
 
   public coercion: ICoercionConfiguration | undefined;
@@ -180,7 +177,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     location: IRenderLocation | null,
   ) {
     this._vm = viewModel;
-    this._hooks = vmKind === ViewModelKind.synthetic ? HooksDefinition.none : new HooksDefinition(viewModel!);
+    this._vmHooks = vmKind === ViewModelKind.synthetic ? HooksDefinition.none : new HooksDefinition(viewModel!);
     if (__DEV__) {
       this.logger = null!;
       this.debug = false;
@@ -373,7 +370,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
     createObservers(this, definition, instance as IIndexable<ICustomElementViewModel>);
 
-    if (this._hooks.hasDefine) {
+    if (this._vmHooks._define) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger.trace(`invoking define() hook`); }
       const result = instance.define(
@@ -416,7 +413,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     if (this._lifecycleHooks!.hydrating != null) {
       this._lifecycleHooks!.hydrating.forEach(callHydratingHook, this);
     }
-    if (this._hooks.hasHydrating) {
+    if (this._vmHooks._hydrating) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking hydrating() hook`); }
       (this._vm as BindingContext<C>).hydrating(this as ICustomElementController);
@@ -463,7 +460,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       this._lifecycleHooks!.hydrated.forEach(callHydratedHook, this);
     }
 
-    if (this._hooks.hasHydrated) {
+    if (this._vmHooks._hydrated) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking hydrated() hook`); }
       (this._vm as BindingContext<C>).hydrated(this as ICustomElementController);
@@ -482,7 +479,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     if (this._lifecycleHooks!.created !== void 0) {
       this._lifecycleHooks!.created.forEach(callCreatedHook, this);
     }
-    if (this._hooks.hasCreated) {
+    if (this._vmHooks._created) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking created() hook`); }
       (this._vm as BindingContext<C>).created(this as ICustomElementController);
@@ -505,7 +502,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     if (this._lifecycleHooks!.created !== void 0) {
       this._lifecycleHooks!.created.forEach(callCreatedHook, this);
     }
-    if (this._hooks.hasCreated) {
+    if (this._vmHooks._created) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`invoking created() hook`); }
       (this._vm as BindingContext<C>).created(this as ICustomAttributeController);
@@ -608,7 +605,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = onResolveAll(...this._lifecycleHooks!.binding!.map(callBindingHook, this));
     }
 
-    if (this._hooks.hasBinding) {
+    if (this._vmHooks._binding) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`binding()`); }
 
@@ -672,7 +669,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = onResolveAll(...this._lifecycleHooks!.bound.map(callBoundHook, this));
     }
 
-    if (this._hooks.hasBound) {
+    if (this._vmHooks._bound) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`bound()`); }
 
@@ -763,7 +760,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       ret = onResolveAll(...this._lifecycleHooks!.attaching!.map(callAttachingHook, this));
     }
 
-    if (this._hooks.hasAttaching) {
+    if (this._vmHooks._attaching) {
       /* istanbul ignore next */
       if (__DEV__ && this.debug) { this.logger!.trace(`attaching()`); }
 
@@ -858,7 +855,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
           ret = onResolveAll(...this._lifecycleHooks!.detaching.map(callDetachingHook, this));
         }
 
-        if (this._hooks.hasDetaching) {
+        if (this._vmHooks._detaching) {
           if (__DEV__ && this.debug) { this.logger!.trace(`detaching()`); }
 
           ret = onResolveAll(ret, this._vm!.detaching(this.$initiator, this.parent));
@@ -1029,7 +1026,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
         _retPromise = onResolveAll(...this._lifecycleHooks!.attached.map(callAttachedHook, this));
       }
 
-      if (this._hooks.hasAttached) {
+      if (this._vmHooks._attached) {
         /* istanbul ignore next */
         if (__DEV__ && this.debug) { this.logger!.trace(`attached()`); }
 
@@ -1094,7 +1091,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
             ret = onResolveAll(...cur._lifecycleHooks!.unbinding.map(callUnbindingHook, cur));
           }
 
-          if (cur._hooks.hasUnbinding) {
+          if (cur._vmHooks._unbinding) {
             if (cur.debug) { cur.logger!.trace('unbinding()'); }
 
             ret = onResolveAll(ret, cur.viewModel!.unbinding(cur.$initiator, cur.parent));
@@ -1229,7 +1226,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     }
     this.state |= State.disposed;
 
-    if (this._hooks.hasDispose) {
+    if (this._vmHooks._dispose) {
       this._vm!.dispose();
     }
 
@@ -1260,7 +1257,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       return true;
     }
 
-    if (this._hooks.hasAccept && this._vm!.accept(visitor) === true) {
+    if (this._vmHooks._accept && this._vm!.accept(visitor) === true) {
       return true;
     }
 
@@ -1390,43 +1387,43 @@ export function isCustomElementViewModel(value: unknown): value is ICustomElemen
   return isObject(value) && isElementType(value.constructor);
 }
 
-export class HooksDefinition {
+class HooksDefinition {
   public static readonly none: Readonly<HooksDefinition> = new HooksDefinition({});
 
-  public readonly hasDefine: boolean;
+  public readonly _define: boolean;
 
-  public readonly hasHydrating: boolean;
-  public readonly hasHydrated: boolean;
-  public readonly hasCreated: boolean;
+  public readonly _hydrating: boolean;
+  public readonly _hydrated: boolean;
+  public readonly _created: boolean;
 
-  public readonly hasBinding: boolean;
-  public readonly hasBound: boolean;
-  public readonly hasAttaching: boolean;
-  public readonly hasAttached: boolean;
+  public readonly _binding: boolean;
+  public readonly _bound: boolean;
+  public readonly _attaching: boolean;
+  public readonly _attached: boolean;
 
-  public readonly hasDetaching: boolean;
-  public readonly hasUnbinding: boolean;
+  public readonly _detaching: boolean;
+  public readonly _unbinding: boolean;
 
-  public readonly hasDispose: boolean;
-  public readonly hasAccept: boolean;
+  public readonly _dispose: boolean;
+  public readonly _accept: boolean;
 
   public constructor(target: object) {
-    this.hasDefine = 'define' in target;
+    this._define = 'define' in target;
 
-    this.hasHydrating = 'hydrating' in target;
-    this.hasHydrated = 'hydrated' in target;
-    this.hasCreated = 'created' in target;
+    this._hydrating = 'hydrating' in target;
+    this._hydrated = 'hydrated' in target;
+    this._created = 'created' in target;
 
-    this.hasBinding = 'binding' in target;
-    this.hasBound = 'bound' in target;
-    this.hasAttaching = 'attaching' in target;
-    this.hasAttached = 'attached' in target;
+    this._binding = 'binding' in target;
+    this._bound = 'bound' in target;
+    this._attaching = 'attaching' in target;
+    this._attached = 'attached' in target;
 
-    this.hasDetaching = 'detaching' in target;
-    this.hasUnbinding = 'unbinding' in target;
+    this._detaching = 'detaching' in target;
+    this._unbinding = 'unbinding' in target;
 
-    this.hasDispose = 'dispose' in target;
-    this.hasAccept = 'accept' in target;
+    this._dispose = 'dispose' in target;
+    this._accept = 'accept' in target;
   }
 }
 

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -1,4 +1,4 @@
-import { IContainer } from '@aurelia/kernel';
+import { IContainer, resolve } from '@aurelia/kernel';
 import { IExpressionParser, IObserverLocator } from '@aurelia/runtime';
 
 import { FragmentNodeSequence, INode, INodeSequence } from '../dom';
@@ -14,8 +14,6 @@ export const IRendering = /*@__PURE__*/createInterface<IRendering>('IRendering',
 export interface IRendering extends Rendering { }
 
 export class Rendering {
-  /** @internal */
-  protected static inject: unknown[] = [IContainer];
   /** @internal */
   private readonly _ctn: IContainer;
   /** @internal */
@@ -40,11 +38,9 @@ export class Rendering {
     }, createLookup<IRenderer>());
   }
 
-  public constructor(
-    container: IContainer,
-  ) {
-    const ctn = container.root;
-    this._platform = (this._ctn = ctn).get(IPlatform);
+  public constructor() {
+    const ctn = this._ctn = resolve(IContainer).root;
+    this._platform = ctn.get(IPlatform);
     this._exprParser= ctn.get(IExpressionParser);
     this._observerLocator = ctn.get(IObserverLocator);
     this._empty = new FragmentNodeSequence(this._platform, this._platform.document.createDocumentFragment());

--- a/packages/runtime-html/src/utilities.ts
+++ b/packages/runtime-html/src/utilities.ts
@@ -47,7 +47,6 @@ const IsDataAttribute: Record<string, boolean> = /*@__PURE__*/createLookup();
 
 /** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
 /** @internal */ export const isNumber = (v: unknown): v is number => typeof v === 'number';
-/** @internal */ export const defineProp = O.defineProperty;
 /** @internal */ export const rethrow = (err: unknown) => { throw err; };
 /** @internal */ export const areEqual = O.is;
 

--- a/packages/runtime/src/observation/dirty-checker.ts
+++ b/packages/runtime/src/observation/dirty-checker.ts
@@ -54,7 +54,7 @@ export class DirtyChecker {
   public static inject = [IPlatform];
   public static register(c: IContainer) {
     c.register(
-      Registration.singleton(IDirtyChecker, this),
+      Registration.singleton(this, this),
       Registration.aliasTo(this, IDirtyChecker),
     );
   }


### PR DESCRIPTION
## 📖 Description

As noted by @ekzobrain , it's actually not always nice to force injection on the interface only. An implementation can register itself too. Changed this so all our default implementation will start registering themselves. Example: injecting `IDialogService` and injecting `DialogService` will yield the same instance, and both are valid.

cc @fkleuver @Sayan751 