### PR TITLE
feat(di): ability to use newInstance() with interface

### DIFF
--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -372,6 +372,10 @@ export class Container implements IContainer {
     }
   }
 
+  public hasFactory<T extends Constructable>(key: T): boolean {
+    return this._factories.has(key);
+  }
+
   public getFactory<K extends Constructable>(Type: K): IFactory<K> {
     let factory = this._factories.get(Type);
     if (factory === void 0) {


### PR DESCRIPTION
resolves #1765

At the moment, `@newInstanceOf` doesn't work with interface because it expects an implementation. This creates an inconsistency where all other resolvers/APIs of the container works well with both interface and implementation. Add the ability to support `@newInstanceOf`/`@newInstanceForScope` for interface.

Thanks @mt-mshorrosh.