### PR TITLE
fix(router-lite): hash compatibility with v1

### DIFF
--- a/packages/__tests__/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/router-lite/resources/load.spec.ts
@@ -686,7 +686,7 @@ describe('router-lite/resources/load.spec.ts', function () {
     await queue.yield();
 
     const anchors = Array.from(host.querySelectorAll('a'));
-    assert.deepStrictEqual(anchors.map(a => a.getAttribute('href')), ['#ce-one', '#ce-two', '#ce-two']);
+    assert.deepStrictEqual(anchors.map(a => a.getAttribute('href')), ['/#/ce-one', '/#/ce-two', '/#/ce-two']);
 
     anchors[1].click();
     await queue.yield();

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -288,7 +288,7 @@ export class ViewportInstructionTree {
     }
 
     if (typeof instructionOrInstructions === 'string') {
-      const expr = RouteExpression.parse(instructionOrInstructions as string, routerOptions.useUrlFragmentHash);
+      const expr = RouteExpression.parse(instructionOrInstructions, routerOptions.useUrlFragmentHash);
       return expr.toInstructionTree($options);
     }
 
@@ -358,8 +358,8 @@ export class ViewportInstructionTree {
 
     const currentPath = this.toPath();
     if (useUrlFragmentHash) {
-      pathname = '';
-      hash = parentPath.length > 0 ? `#${parentPath}/${currentPath}` : `#${currentPath}`;
+      pathname = '/';
+      hash = parentPath.length > 0 ? `#/${parentPath}/${currentPath}` : `#/${currentPath}`;
     } else {
       pathname = parentPath.length > 0 ? `${parentPath}/${currentPath}` : currentPath;
       const fragment = this.fragment;
@@ -382,6 +382,10 @@ export class ViewportInstructionTree {
   }
 }
 
+_START_CONST_ENUM();
+/**
+ * @internal
+ */
 export const enum NavigationInstructionType {
   string,
   ViewportInstruction,
@@ -389,6 +393,8 @@ export const enum NavigationInstructionType {
   Promise,
   IRouteViewModel,
 }
+_END_CONST_ENUM();
+
 export interface ITypedNavigationInstruction<
   TInstruction extends NavigationInstruction,
   TType extends NavigationInstructionType

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -860,6 +860,8 @@ function ensureTransitionHasNotErrored(tr: Transition): void {
   if (tr.error !== void 0 && !tr.erredWithUnknownRoute) throw tr.error;
 }
 
+_START_CONST_ENUM();
+/** @internal */
 export const enum State {
   curr              = 0b1111111_0000000,
   currIsEmpty       = 0b1000000_0000000,
@@ -879,6 +881,7 @@ export const enum State {
   nextActivate      = 0b0000000_0000001,
   bothAreEmpty      = 0b1000000_1000000,
 }
+_END_CONST_ENUM();
 
 type CurrState = (
   State.currIsEmpty |


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
This commit makes the URL hash compatible with Au1. This has been reported here: https://discourse.aurelia.io/t/url-fragment-hash-difference-between-router-lite-and-router/5176.

Additionally, it also addresses the review comments from #1778

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
