### PR TITLE
refactor: bindable property -> name

### DIFF
--- a/docs/user-docs/components/components.md
+++ b/docs/user-docs/components/components.md
@@ -70,7 +70,7 @@ If you don't want to use conventions, a `@customElement` decorator allows you to
 {% code title="app-loader.ts" %}
 ```typescript
 import { customElement } from 'aurelia';
-import template from './app-loader.html'; 
+import template from './app-loader.html';
 
 @customElement({
     name: 'app-loader',
@@ -145,7 +145,7 @@ Components can have explicit dependencies declared from within the `customElemen
 
 ```typescript
 import { customElement } from 'aurelia';
-import { NumberInput } from './number-input'; 
+import { NumberInput } from './number-input';
 
 @customElement({
   name: 'app-loader',
@@ -214,7 +214,7 @@ Sometimes you want a custom element with bindable properties. Aurelia allows you
 
 {% code title="app-loader.html" %}
 ```html
-<bindable property="loading"></bindable>
+<bindable name="loading"></bindable>
 
 <p>${loading ? 'Loading...' : ''}</p>
 ```
@@ -312,11 +312,11 @@ import { customElement, ICustomElementViewModel } from 'aurelia';
     name: 'my-component',
     containerless: true
 })
-export class MyComponent implements ICustomElementViewModel {    
+export class MyComponent implements ICustomElementViewModel {
     constructor() {
 
     }
- }   
+ }
 ```
 
 ### The containerless decorator
@@ -328,11 +328,11 @@ import { ICustomElementViewModel } from 'aurelia';
 import { containerless } from '@aurelia/runtime-html';
 
 @containerless
-export class MyComponent implements ICustomElementViewModel {    
+export class MyComponent implements ICustomElementViewModel {
     constructor() {
 
     }
- }   
+ }
 ```
 
 When referencing our component using `<my-component></my-component>` Aurelia will strip out the tags and leave the inner part.

--- a/docs/user-docs/components/shadow-dom-and-slots.md
+++ b/docs/user-docs/components/shadow-dom-and-slots.md
@@ -598,7 +598,7 @@ Let's consider another example of `$host` which highlights the communication bet
 {% tab title="my-app.html" %}
 ```markup
 <template as-custom-element="my-element">
-  <bindable property="people"></bindable>
+  <bindable name="people"></bindable>
   <au-slot name="grid">
     <au-slot name="header">
       <h4>First Name</h4>

--- a/docs/user-docs/templates/conditional-rendering.md
+++ b/docs/user-docs/templates/conditional-rendering.md
@@ -249,7 +249,7 @@ This section includes few more interesting examples that you might encounter in 
   {% code title="my-app.html" %}
   ```html
   <template as-custom-element="foo-bar">
-    <bindable property="status"></bindable>
+    <bindable name="status"></bindable>
     <div switch.bind="status">
       <au-slot name="s1" case="received">Order received.</au-slot>
       <au-slot name="s2" case="dispatched">On the way.</au-slot>

--- a/docs/user-docs/templates/local-templates.md
+++ b/docs/user-docs/templates/local-templates.md
@@ -15,7 +15,7 @@ In many instances, when working with templated views in Aurelia, you will be app
 {% tab title="my-app.html" %}
 ```markup
 <template as-custom-element="person-info">
-  <bindable property="person"></bindable>
+  <bindable name="person"></bindable>
   <div>
     <label>Name:</label>
     <span>${person.name}</span>
@@ -64,7 +64,7 @@ In this case, it is named as `person-info`. A custom element defined that way ca
 Local templates can also optionally specify bindable properties using the `<bindable>` tag as shown above. Apart from `property`, other allowed attributes that can be used in this tag are `attribute`, and `mode`. In that respect, the following two declarations are synonymous.
 
 ```markup
-<bindable property="foo" mode="twoWay" attribute="fiz-baz"></bindable>
+<bindable name="foo" mode="twoWay" attribute="fiz-baz"></bindable>
 ```
 
 ```typescript
@@ -87,7 +87,7 @@ This means that the following is a perfectly valid example. Note that the local 
 {% tab title="level-one.html" %}
 ```markup
 <template as-custom-element="foo-bar">
-  <bindable property='prop'></bindable>
+  <bindable name='prop'></bindable>
 
   Level One ${prop}
 </template>
@@ -106,7 +106,7 @@ class LevelOne {
 {% tab title="level-two.html" %}
 ```markup
 <template as-custom-element="foo-bar">
-  <bindable property='prop'></bindable>
+  <bindable name='prop'></bindable>
   Level Two ${prop}
   <level-one prop="fiz baz"></level-one>
 </template>
@@ -141,7 +141,7 @@ Like anything, there is always an upside and downside: local templates are no di
 <foo-bar foo.bind="'John'"></foo-bar>
 
 <template as-custom-element="foo-bar">
-  <bindable property="foo"></bindable>
+  <bindable name="foo"></bindable>
   <div> ${foo} </div>
 </template>
 ```
@@ -225,7 +225,7 @@ The following example will cause a (jit) compilation error.
 ```markup
 <template as-custom-element="foo-bar">
   <div>
-    <bindable property="prop"></bindable>
+    <bindable name="prop"></bindable>
   </div>
 </template>
 <div></div>

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -2075,7 +2075,7 @@ describe('3-runtime-html/promise.spec.ts', function () {
             <div au-slot="rejected">r2</div>
           </foo-bar>
           <template as-custom-element="foo-bar">
-            <bindable property="p"></bindable>
+            <bindable name="p"></bindable>
             <template ${pattribute}="p">
               <au-slot name="pending" pending></au-slot>
               <au-slot then></au-slot>

--- a/packages/__tests__/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/3-runtime-html/spread.spec.ts
@@ -208,7 +208,7 @@ describe('3-runtime-html/spread.spec.ts', function () {
         name: 'form-input',
         template: '<input value.bind="value">',
         bindables: {
-          value: { property: 'value', attribute: 'value', mode: BindingMode.twoWay }
+          value: { name: 'value', attribute: 'value', mode: BindingMode.twoWay }
         }
       }),
     ];

--- a/packages/__tests__/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/3-runtime-html/switch.spec.ts
@@ -1274,7 +1274,7 @@ describe('3-runtime-html/switch.spec.ts', function () {
           initialStatus: Status.delivered,
           template: `
       <template as-custom-element="foo-bar">
-        <bindable property="status"></bindable>
+        <bindable name="status"></bindable>
         <div switch.bind="status">
           <case-host case="received"   ce-id="1">Order received.</case-host>
           <case-host case="dispatched" ce-id="2">On the way.</case-host>
@@ -1306,7 +1306,7 @@ describe('3-runtime-html/switch.spec.ts', function () {
           initialStatus: Status.received,
           template: `
       <template as-custom-element="foo-bar">
-        <bindable property="status"></bindable>
+        <bindable name="status"></bindable>
         <div switch.bind="status">
           <au-slot name="s1" case="received">Order received.</au-slot>
           <au-slot name="s2" case="dispatched">On the way.</au-slot>

--- a/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.local-templates.spec.ts
@@ -58,8 +58,8 @@ class ElementInfo {
       for (prop in bindables) {
         bindable = bindables[prop];
         // explicitly provided property name has priority over the implicit property name
-        if (bindable.property !== void 0) {
-          prop = bindable.property;
+        if (bindable.name !== void 0) {
+          prop = bindable.name;
         }
         // explicitly provided attribute name has priority over the derived implicit attribute name
         if (bindable.attribute !== void 0) {
@@ -136,8 +136,8 @@ class AttrInfo {
       for (prop in bindables) {
         bindable = bindables[prop];
         // explicitly provided property name has priority over the implicit property name
-        if (bindable.property !== void 0) {
-          prop = bindable.property;
+        if (bindable.name !== void 0) {
+          prop = bindable.name;
         }
         if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
           mode = bindable.mode;
@@ -289,7 +289,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
           const attr = kebabCase(attributeName !== void 0 ? `${attributeName}${i + 1}` : prop);
           ei.bindables[attr] = bi;
 
-          bindables += `<bindable property='${prop}'${bindingMode !== void 0 ? ` mode="${bindingMode}"` : ''}${attributeName !== void 0 ? ` attribute="${attr}"` : ''}></bindable>`;
+          bindables += `<bindable name='${prop}'${bindingMode !== void 0 ? ` mode="${bindingMode}"` : ''}${attributeName !== void 0 ? ` attribute="${attr}"` : ''}></bindable>`;
           templateBody += ` \${${prop}}`;
           const content = `${value}${i + 1}`;
           attrExpr += ` ${attr}="${content}"`;
@@ -369,7 +369,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
     it('throws error if bindable is not under root', function () {
       const template = `<template as-custom-element="foo-bar">
         <div>
-          <bindable property="prop"></bindable>
+          <bindable name="prop"></bindable>
         </div>
       </template>
       <div></div>`;
@@ -388,8 +388,8 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
 
     it('throws error if duplicate bindable properties are found', function () {
       const template = `<template as-custom-element="foo-bar">
-        <bindable property="prop" attribute="bar"></bindable>
-        <bindable property="prop" attribute="baz"></bindable>
+        <bindable name="prop" attribute="bar"></bindable>
+        <bindable name="prop" attribute="baz"></bindable>
       </template>
       <div></div>`;
       const { container, sut } = createFixture();
@@ -401,8 +401,8 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
 
     it('throws error if duplicate bindable attributes are found', function () {
       const template = `<template as-custom-element="foo-bar">
-        <bindable property="prop1" attribute="bar"></bindable>
-        <bindable property="prop2" attribute="bar"></bindable>
+        <bindable name="prop1" attribute="bar"></bindable>
+        <bindable name="prop2" attribute="bar"></bindable>
       </template>
       <div></div>`;
       const { container, sut } = createFixture();
@@ -415,7 +415,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
     for (const attr of ['if.bind="true"', 'if.bind="false"', 'else', 'repeat.for="item of items"', 'with.bind="{a:1}"', 'switch.bind="cond"', 'case="case1"']) {
       it(`throws error if local-template surrogate has template controller - ${attr}`, function () {
         const template = `<template as-custom-element="foo-bar" ${attr}>
-        <bindable property="prop1" attribute="bar"></bindable>
+        <bindable name="prop1" attribute="bar"></bindable>
       </template>
       <foo-bar></foo-bar>`;
         const { ctx, container } = createFixture();
@@ -430,7 +430,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
 
     it('warns if bindable element has more attributes other than the allowed', function () {
       const template = `<template as-custom-element="foo-bar">
-        <bindable property="prop" unknown-attr who-cares="no one"></bindable>
+        <bindable name="prop" unknown-attr who-cares="no one"></bindable>
       </template>
       <div></div>`;
       const { container, sut } = createFixture();
@@ -444,7 +444,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
         assert.strictEqual(event.severity, LogLevel.warn);
         assert.includes(
           event.toString(),
-          'The attribute(s) unknown-attr, who-cares will be ignored for <bindable property="prop" unknown-attr="" who-cares="no one"></bindable>. Only property, attribute, mode are processed.'
+          'The attribute(s) unknown-attr, who-cares will be ignored for <bindable name="prop" unknown-attr="" who-cares="no one"></bindable>. Only property, attribute, mode are processed.'
         );
       }
     });
@@ -452,7 +452,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
 
   it('works with if', async function () {
     const template = `<template as-custom-element="foo-bar">
-      <bindable property='prop'></bindable>
+      <bindable name='prop'></bindable>
       \${prop}
      </template>
      <foo-bar prop="awesome possum" if.bind="true"></foo-bar>
@@ -476,7 +476,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
 
   it('works with for', async function () {
     const template = `<template as-custom-element="foo-bar">
-      <bindable property='prop'></bindable>
+      <bindable name='prop'></bindable>
       \${prop}
      </template>
      <foo-bar repeat.for="i of 5" prop.bind="i"></foo-bar>`;
@@ -498,14 +498,14 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
   });
 
   it('works with nested templates - 1', async function () {
-    @customElement({ name: 'level-one', template: `<template as-custom-element="foo-bar"><bindable property='prop'></bindable>Level One \${prop}</template><foo-bar prop.bind="prop"></foo-bar>` })
+    @customElement({ name: 'level-one', template: `<template as-custom-element="foo-bar"><bindable name='prop'></bindable>Level One \${prop}</template><foo-bar prop.bind="prop"></foo-bar>` })
     class LevelOne {
       @bindable public prop: string;
     }
     @customElement({
       name: 'level-two', template: `
       <template as-custom-element="foo-bar">
-        <bindable property='prop'></bindable>
+        <bindable name='prop'></bindable>
         Level Two \${prop}
         <level-one prop="inter-dimensional portal"></level-one>
       </template>
@@ -638,7 +638,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
       <my-ce></my-ce>
       <my-le repeat.for="prop of 5" if.bind="prop % 2 === 0" prop.bind></my-le>
       <template as-custom-element="my-le">
-        <bindable property="prop"></bindable>
+        <bindable name="prop"></bindable>
         \${prop}
         <my-ce></my-ce>
       </template>
@@ -666,7 +666,7 @@ describe('3-runtime-html/template-compiler.local-templates.spec.ts', function ()
         my-app-content
         <my-le prop.bind></my-le>
         <template as-custom-element="my-le">
-          <bindable property="prop"></bindable>
+          <bindable name="prop"></bindable>
           my-le-content
           <my-app if.bind="prop"></my-app>
         </template>`;

--- a/packages/__tests__/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/3-runtime-html/template-compiler.spec.ts
@@ -587,8 +587,8 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         for (prop in bindables) {
           bindable = bindables[prop];
           // explicitly provided property name has priority over the implicit property name
-          if (bindable.property !== void 0) {
-            prop = bindable.property;
+          if (bindable.name !== void 0) {
+            prop = bindable.name;
           }
           // explicitly provided attribute name has priority over the derived implicit attribute name
           if (bindable.attribute !== void 0) {
@@ -665,8 +665,8 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         for (prop in bindables) {
           bindable = bindables[prop];
           // explicitly provided property name has priority over the implicit property name
-          if (bindable.property !== void 0) {
-            prop = bindable.property;
+          if (bindable.name !== void 0) {
+            prop = bindable.name;
           }
           if (bindable.mode !== void 0 && bindable.mode !== BindingMode.default) {
             mode = bindable.mode;
@@ -1005,18 +1005,18 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
     if (!!bindableDescription) {
       if (!!cmd && validCommands.includes(cmd)) {
         const type = TT.propertyBinding;
-        const to = bindableDescription.property;
+        const to = bindableDescription.name;
         const from = parseExpression(attributeValue);
         return { type, to, mode, from };
       } else {
         const from = parseExpression(attributeValue, ExpressionType.Interpolation);
         if (!!from) {
           const type = TT.interpolation;
-          const to = bindableDescription.property;
+          const to = bindableDescription.name;
           return { type, to, from };
         } else {
           const type = TT.setProperty;
-          const to = bindableDescription.property;
+          const to = bindableDescription.name;
           const value = attributeValue;
           return { type, to, value };
         }
@@ -1194,10 +1194,10 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         [
           (_ctx) => [undefined, undefined, 'value'],
           (_ctx) => [{}, undefined, 'value'] as any,
-          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', property: 'bazBaz', mode: BindingMode.oneTime }), BindingMode.oneTime, 'bazBaz'],
-          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', property: 'bazBaz', mode: BindingMode.fromView }), BindingMode.fromView, 'bazBaz'],
-          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', property: 'bazBaz', mode: BindingMode.twoWay }), BindingMode.twoWay, 'bazBaz'],
-          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', property: 'bazBaz', mode: BindingMode.default }), BindingMode.default, 'bazBaz']
+          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', name: 'bazBaz', mode: BindingMode.oneTime }), BindingMode.oneTime, 'bazBaz'],
+          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', name: 'bazBaz', mode: BindingMode.fromView }), BindingMode.fromView, 'bazBaz'],
+          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', name: 'bazBaz', mode: BindingMode.twoWay }), BindingMode.twoWay, 'bazBaz'],
+          (_ctx) => [BindableDefinition.create('asdf', class MyClass { }, { attribute: 'bazBaz', name: 'bazBaz', mode: BindingMode.default }), BindingMode.default, 'bazBaz']
         ] as ((ctx: TestContext) => [Record<string, BindableDefinition> | undefined, BindingMode | undefined, string])[],
         [
           (_ctx) => ['foo', '', class Foo1 { }],
@@ -1280,11 +1280,11 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
           (ctx, pdName) => `${pdName}Bar` // descriptor.property is different from the actual property name
         ] as ((ctx: TestContext, $1: string) => string)[],
         [
-          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.default }) }),
-          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.oneTime }) }),
-          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.toView }) }),
-          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.fromView }) }),
-          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.twoWay }) })
+          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.default }) }),
+          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.oneTime }) }),
+          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.toView }) }),
+          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.fromView }) }),
+          (ctx, pdName, pdProp) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: kebabCase(pdProp), mode: BindingMode.twoWay }) })
         ] as ((ctx: TestContext, $1: string, $2: string) => Bindables)[],
         [
           (_ctx) => [``, `''`],
@@ -1658,11 +1658,11 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
           (ctx, pdName, pdProp) => `${kebabCase(pdProp)}-baz` // descriptor.attribute is different from kebab-cased descriptor.property
         ] as ((ctx: TestContext, $1: string, $2: string) => string)[],
         [
-          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: pdAttr, mode: BindingMode.default }) }),
-          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: pdAttr, mode: BindingMode.oneTime }) }),
-          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: pdAttr, mode: BindingMode.toView }) }),
-          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: pdAttr, mode: BindingMode.fromView }) }),
-          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { property: pdProp, attribute: pdAttr, mode: BindingMode.twoWay }) })
+          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: pdAttr, mode: BindingMode.default }) }),
+          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: pdAttr, mode: BindingMode.oneTime }) }),
+          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: pdAttr, mode: BindingMode.toView }) }),
+          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: pdAttr, mode: BindingMode.fromView }) }),
+          (ctx, pdName, pdProp, pdAttr) => ({ [pdName]: BindableDefinition.create(pdName, class MyClass { }, { name: pdProp, attribute: pdAttr, mode: BindingMode.twoWay }) })
         ] as ((ctx: TestContext, $1: string, $2: string, $3: string) => Bindables)[],
         [
           (_ctx) => [``, `''`],

--- a/packages/compat-v1/src/compat-call.ts
+++ b/packages/compat-v1/src/compat-call.ts
@@ -38,7 +38,7 @@ export class CallBindingCommand implements BindingCommandInstance {
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     const target = info.bindable === null
       ? camelCase(info.attr.target)
-      : info.bindable.property;
+      : info.bindable.name;
     return new CallBindingInstruction(
       exprParser.parse(info.attr.rawValue, (ExpressionType.IsProperty | ExpressionType.IsFunction) as ExpressionType) as IsBindingBehavior,
       target

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -59,7 +59,7 @@ export class TranslationParametersBindingCommand implements BindingCommandInstan
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new TranslationParametersBindingInstruction(exprParser.parse(attr.rawValue, ExpressionType.IsProperty), target);
   }

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -58,7 +58,7 @@ export class TranslationBindingCommand implements BindingCommandInstance {
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new TranslationBindingInstruction(new CustomExpression(info.attr.rawValue) as IsBindingBehavior, target);
   }
@@ -122,7 +122,7 @@ export class TranslationBindBindingCommand implements BindingCommandInstance {
         // use the default behavior, which is camel-casing
         ?? camelCase(info.attr.target);
     } else {
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new TranslationBindBindingInstruction(exprParser.parse(info.attr.rawValue, ExpressionType.IsProperty), target);
   }

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -14,7 +14,7 @@ export type PartialBindableDefinition = {
   mode?: BindingMode;
   callback?: string;
   attribute?: string;
-  property?: string;
+  name?: string;
   primary?: boolean;
   set?: InterceptorFunc;
   type?: PropertyType;
@@ -27,7 +27,7 @@ export type PartialBindableDefinition = {
   nullable?: boolean;
 };
 
-type PartialBindableDefinitionPropertyOmitted = Omit<PartialBindableDefinition, 'property'>;
+type PartialBindableDefinitionPropertyOmitted = Omit<PartialBindableDefinition, 'name'>;
 
 /**
  * Decorator: Specifies custom behavior for a bindable property.
@@ -58,7 +58,7 @@ export function bindable(configOrTarget?: PartialBindableDefinition | {}, prop?:
       // Invocation with or w/o opts:
       // - @bindable()
       // - @bindable({...opts})
-      config.property = $prop;
+      config.name = $prop;
     }
 
     defineMetadata(baseName, BindableDefinition.create($prop, $target as Constructable, config), $target.constructor, $prop);
@@ -113,7 +113,7 @@ export const Bindable = objectFreeze({
       if (isArray(maybeList)) {
         maybeList.forEach(addName);
       } else if (maybeList instanceof BindableDefinition) {
-        bindables[maybeList.property] = maybeList;
+        bindables[maybeList.name] = maybeList;
       } else if (maybeList !== void 0) {
         objectKeys(maybeList).forEach(name => addDescription(name, maybeList[name]));
       }
@@ -152,7 +152,7 @@ export class BindableDefinition {
     public readonly callback: string,
     public readonly mode: BindingMode,
     public readonly primary: boolean,
-    public readonly property: string,
+    public readonly name: string,
     public readonly set: InterceptorFunc,
   ) { }
 
@@ -162,7 +162,7 @@ export class BindableDefinition {
       def.callback ?? `${prop}Changed`,
       def.mode ?? BindingMode.toView,
       def.primary ?? false,
-      def.property ?? prop,
+      def.name ?? prop,
       def.set ?? getInterceptor(prop, target, def),
     );
   }

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -188,8 +188,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             expr = exprParser.parse(attrValue, ExpressionType.Interpolation);
             attrBindableInstructions = [
               expr === null
-                ? new SetPropertyInstruction(attrValue, primaryBindable.property)
-                : new InterpolationInstruction(expr, primaryBindable.property)
+                ? new SetPropertyInstruction(attrValue, primaryBindable.name)
+                : new InterpolationInstruction(expr, primaryBindable.name)
             ];
           } else {
             // custom attribute with binding command:
@@ -230,8 +230,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             instructions.push(
               new SpreadElementPropBindingInstruction(
                 expr == null
-                  ? new SetPropertyInstruction(attrValue, bindable.property)
-                  : new InterpolationInstruction(expr, bindable.property)
+                  ? new SetPropertyInstruction(attrValue, bindable.name)
+                  : new InterpolationInstruction(expr, bindable.name)
               )
             );
 
@@ -382,8 +382,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             expr = exprParser.parse(realAttrValue, ExpressionType.Interpolation);
             attrBindableInstructions = [
               expr === null
-                ? new SetPropertyInstruction(realAttrValue, primaryBindable.property)
-                : new InterpolationInstruction(expr, primaryBindable.property)
+                ? new SetPropertyInstruction(realAttrValue, primaryBindable.name)
+                : new InterpolationInstruction(expr, primaryBindable.name)
             ];
           } else {
             // custom attribute with binding command:
@@ -773,8 +773,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             expr = exprParser.parse(realAttrValue, ExpressionType.Interpolation);
             attrBindableInstructions = [
               expr === null
-                ? new SetPropertyInstruction(realAttrValue, primaryBindable.property)
-                : new InterpolationInstruction(expr, primaryBindable.property)
+                ? new SetPropertyInstruction(realAttrValue, primaryBindable.name)
+                : new InterpolationInstruction(expr, primaryBindable.name)
             ];
           } else {
             // custom attribute with binding command:
@@ -826,8 +826,8 @@ export class TemplateCompiler implements ITemplateCompiler {
             expr = exprParser.parse(realAttrValue, ExpressionType.Interpolation);
             (elBindableInstructions ??= []).push(
               expr == null
-                ? new SetPropertyInstruction(realAttrValue, bindable.property)
-                : new InterpolationInstruction(expr, bindable.property)
+                ? new SetPropertyInstruction(realAttrValue, bindable.name)
+                : new InterpolationInstruction(expr, bindable.name)
             );
 
             removeAttr();
@@ -1449,8 +1449,8 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (command === null) {
           expr = context._exprParser.parse(attrValue, ExpressionType.Interpolation);
           instructions.push(expr === null
-            ? new SetPropertyInstruction(attrValue, bindable.property)
-            : new InterpolationInstruction(expr, bindable.property)
+            ? new SetPropertyInstruction(attrValue, bindable.name)
+            : new InterpolationInstruction(expr, bindable.name)
           );
         } else {
           commandBuildInfo.node = node;
@@ -1503,7 +1503,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (bindableEl.parentNode !== content) {
           throw createMappedError(ErrorNames.compiler_local_el_bindable_not_under_root, name);
         }
-        const property = bindableEl.getAttribute(LocalTemplateBindableAttributes.property);
+        const property = bindableEl.getAttribute(LocalTemplateBindableAttributes.name);
         if (property === null) {
           throw createMappedError(ErrorNames.compiler_local_el_bindable_name_missing, bindableEl, name);
         }
@@ -1913,13 +1913,13 @@ export class BindablesInfo<T extends 0 | 1 = 0> {
 
 _START_CONST_ENUM();
 const enum LocalTemplateBindableAttributes {
-  property = "property",
+  name = "name",
   attribute = "attribute",
   mode = "mode",
 }
 _END_CONST_ENUM();
 const allowedLocalTemplateBindableAttributes: readonly string[] = objectFreeze([
-  LocalTemplateBindableAttributes.property,
+  LocalTemplateBindableAttributes.name,
   LocalTemplateBindableAttributes.attribute,
   LocalTemplateBindableAttributes.mode
 ]);

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -173,7 +173,7 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
       if (value === '' && info.def.type === DefinitionType.Element) {
         value = camelCase(target);
       }
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, ExpressionType.IsProperty), target, BindingMode.oneTime);
   }
@@ -198,7 +198,7 @@ export class ToViewBindingCommand implements BindingCommandInstance {
       if (value === '' && info.def.type === DefinitionType.Element) {
         value = camelCase(target);
       }
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, ExpressionType.IsProperty), target, BindingMode.toView);
   }
@@ -223,7 +223,7 @@ export class FromViewBindingCommand implements BindingCommandInstance {
       if (value === '' && info.def.type === DefinitionType.Element) {
         value = camelCase(target);
       }
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, ExpressionType.IsProperty), target, BindingMode.fromView);
   }
@@ -248,7 +248,7 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
       if (value === '' && info.def.type === DefinitionType.Element) {
         value = camelCase(target);
       }
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, ExpressionType.IsProperty), target, BindingMode.twoWay);
   }
@@ -284,7 +284,7 @@ export class DefaultBindingCommand implements BindingCommandInstance {
           ? BindingMode.toView
           : defaultMode
         : bindable.mode;
-      target = bindable.property;
+      target = bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, ExpressionType.IsProperty), target, mode);
   }
@@ -306,7 +306,7 @@ export class ForBindingCommand implements BindingCommandInstance {
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
     const target = info.bindable === null
       ? camelCase(info.attr.target)
-      : info.bindable.property;
+      : info.bindable.name;
     const forOf = exprParser.parse(info.attr.rawValue, ExpressionType.IsIterator);
     let props: MultiAttrInstruction[] = emptyArray;
     if (forOf.semiIdx > -1) {

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -58,7 +58,7 @@ export class StateBindingCommand implements BindingCommandInstance {
       if (value === '' && info.def.type === DefinitionType.Element) {
         value = camelCase(target);
       }
-      target = info.bindable.property;
+      target = info.bindable.name;
     }
     return new StateBindingInstruction(value, target);
   }

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -522,8 +522,8 @@ customAttribute({
   isTemplateController: true,
   name: 'virtual-repeat',
   bindables: {
-    local: { property: 'local' },
-    items: { property: 'items', primary: true }
+    local: { name: 'local' },
+    items: { name: 'items', primary: true }
   }
 })(VirtualRepeat);
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Closes #1091.

This is a BREAKING CHANGE, especially for the devs using local templates and the Bindable API directly.

With this change, the current code needs to be migrated as follows.

```diff
 <!-- local template -->
 <template as-custom-element="foo-bar">
-   <bindable property="status"></bindable>
+   <bindable name="status"></bindable>
 </template>
```

```diff
 // Bindable API
 BindableDefinition.create({
-  proerty: 'foo',
+  name: 'foo',
 })

 @bindable({
-  proerty: 'foo',
+  name: 'foo',
 })
```

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
