### PR TITLE
refactor(text-binding): always evaluate expressions in strict mode

### DIFF
--- a/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
+++ b/packages/__tests__/3-runtime-html/arrow-fn.spec.ts
@@ -373,7 +373,7 @@ describe('3-runtime-html/arrow-fn.spec.ts', function () {
         .component({ items: [1] })
         .html`\${items.find(x => x === 2)}`
         .build();
-      assertText('undefined');
+      assertText('');
 
       component.items.push(2);
       flush();
@@ -381,7 +381,7 @@ describe('3-runtime-html/arrow-fn.spec.ts', function () {
 
       component.items.splice(0);
       flush();
-      assertText('undefined');
+      assertText('');
     });
 
     it('observes on .flat()', function () {

--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -663,7 +663,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
             MyElement,
           ],
           { 'my-element': [
-            `<h4>Meta</h4> <h4>Surname</h4> <h4>Given name</h4> <div>index: 0 undefined</div> <div>Doe</div> <div>John</div> <div>index: 1 undefined</div> <div>Mustermann</div> <div>Max</div>`,
+            `<h4>Meta</h4> <h4>Surname</h4> <h4>Given name</h4> <div>index: 0 </div> <div>Doe</div> <div>John</div> <div>index: 1 </div> <div>Mustermann</div> <div>Max</div>`,
             new AuSlotsInfo(['header', 'content'])
           ]},
         );
@@ -1829,7 +1829,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
         `<my-element><div au-slot>\${$host.value}</div>`,
         [createMyElement('<input value.bind="message"/><au-slot expose.bind="{ value: message }">')],
         {
-          'my-element': ['<input><div>undefined</div>', undefined]
+          'my-element': ['<input><div></div>', undefined]
         },
         function ({ host, platform }) {
           const input = host.querySelector('input');
@@ -1845,7 +1845,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
         `<my-element>`,
         [createMyElement(`<input value.bind="message"/><au-slot expose.bind="{ value: message }">\${message}</au-slot>`)],
         {
-          'my-element': ['<input>undefined', undefined]
+          'my-element': ['<input>', undefined]
         },
         function ({ host, platform }) {
           const input = host.querySelector('input');

--- a/packages/__tests__/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/3-runtime-html/interpolation.spec.ts
@@ -38,43 +38,87 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         expected: 'wOOt', expectedStrictMode: 'wOOt', app: class { public value?: string | number = 'wOOt'; public value1?: string | number; }, interpolation: `$\{value}`, it: 'Renders expected text'
       },
       {
-        expected: '', expectedStrictMode: 'undefined', app: class { public value = undefined; }, interpolation: `$\{value}`, it: 'Undefined value renders nothing'
+        expected: '',
+        expectedStrictMode: '',
+        app: class { public value = undefined; },
+        interpolation: `$\{value}`,
+        it: 'Undefined value renders nothing',
       },
       {
-        expected: 5, expectedStrictMode: 'NaN', app: class { public value1 = undefined; public value = 5; }, interpolation: `$\{value1 + value}`, it: 'Two values one undefined sum correctly'
+        expected: NaN,
+        expectedStrictMode: 'NaN',
+        app: class { public value1 = undefined; public value = 5; },
+        interpolation: `$\{value1 + value}`,
+        it: 'Two values one undefined sum correctly',
       },
       {
-        expected: -5, expectedStrictMode: 'NaN', app: class { public value = undefined; public value1 = 5; }, interpolation: `$\{value - value1}`, it: 'Two values one undefined minus correctly'
+        expected: NaN,
+        expectedStrictMode: 'NaN',
+        expectedValueAfterChange: '-4', // ((value || 0) + 1) - value1
+        app: class { public value = undefined; public value1 = 5; },
+        interpolation: `$\{value - value1}`,
+        it: 'Two values one undefined minus correctly',
       },
       {
-        expected: '', expectedStrictMode: 'null', app: class { isStrictMode = true; public value = null; }, interpolation: `$\{value}`, it: 'Null value renders nothing'
+        expected: '',
+        expectedStrictMode: '',
+        app: class { isStrictMode = true; public value = null; },
+        interpolation: `$\{value}`,
+        it: 'Null value renders nothing',
       },
       {
-        expected: 5, expectedStrictMode: '5', app: class { public value1 = null; public value = 5; }, interpolation: `$\{value1 + value}`, it: 'Two values one Null sum correctly'
+        expected: 5,
+        expectedStrictMode: '5',
+        app: class { public value1 = null; public value = 5; },
+        interpolation: `$\{value1 + value}`,
+        it: 'Two values one Null sum correctly',
       },
       {
-        expected: -5, expectedStrictMode: '-5', app: class { public value = null; public value1 = 5; }, interpolation: `$\{value - value1}`, it: 'Two values one Null minus correctly'
+        expected: -5,
+        expectedStrictMode: '-5',
+        app: class { public value = null; public value1 = 5; },
+        interpolation: `$\{value - value1}`,
+        it: 'Two values one Null minus correctly',
       },
       {
-        expected: 'Infinity', expectedStrictMode: 'NaN', expectedValueAfterChange: 5, app: class { public value = undefined; public value1 = 5; }, interpolation: `$\{value1/value}`, it: 'Number divided by undefined is Infinity'
+        expected: 'NaN',
+        expectedStrictMode: 'NaN',
+        expectedValueAfterChange: 5,
+        app: class { public value = undefined; public value1 = 5; },
+        interpolation: `$\{value1/value}`,
+        it: 'Number divided by undefined is Infinity',
       },
       {
-        expected: 1, expectedStrictMode: 1, expectedValueAfterChange: 0.8333333333333334, app: class { public value = 5; public value1 = 5; }, interpolation: `$\{value1/value}`, it: 'Number divided by number works as planned'
+        expected: 1,
+        expectedStrictMode: 1,
+        expectedValueAfterChange: 0.8333333333333334,
+        app: class { public value = 5; public value1 = 5; },
+        interpolation: `$\{value1/value}`,
+        it: 'Number divided by number works as planned',
       },
       {
-        expected: 1, expectedStrictMode: 1, app: class { Math = Math; public value = 1.2; public value1 = 5; }, interpolation: `$\{Math.round(value)}`, it: 'Global Aliasing works'
+        expected: 'true',
+        expectedValueAfterChange: 'false',
+        changeFnc: (val) => !val,
+        app: class { public value = true; },
+        interpolation: `$\{value}`,
+        it: 'Boolean prints true',
       },
       {
-        expected: 2, expectedStrictMode: 2, app: class { Math = Math; public value = 1.5; public value1 = 5; }, interpolation: `$\{Math.round(value)}`, it: 'Global Aliasing works #2'
+        expected: 'false',
+        expectedValueAfterChange: 'true',
+        changeFnc: (val) => !val,
+        app: class { public value = false; },
+        interpolation: `$\{value}`,
+        it: 'Boolean prints false'
       },
       {
-        expected: 'true', expectedValueAfterChange: 'false', changeFnc: (val) => !val, app: class { public value = true; }, interpolation: `$\{value}`, it: 'Boolean prints true'
-      },
-      {
-        expected: 'false', expectedValueAfterChange: 'true', changeFnc: (val) => !val, app: class { public value = false; }, interpolation: `$\{value}`, it: 'Boolean prints false'
-      },
-      {
-        expected: 'false', expectedValueAfterChange: 'false', changeFnc: (val) => !val, app: class { public value = false; }, interpolation: `$\{value && false}`, it: 'Boolean prints false with && no matter what'
+        expected: 'false',
+        expectedValueAfterChange: 'false',
+        changeFnc: (val) => !val,
+        app: class { public value = false; },
+        interpolation: `$\{value && false}`,
+        it: 'Boolean prints false with && no matter what',
       },
       {
         expected: 'test',
@@ -91,22 +135,22 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         interpolation: `$\{value}`, it: 'Date works and setDate triggers change properly'
       },
       {
-        expected: testDateString,
+        expected: `undefined${testDateString}`,
         expectedStrictMode: `undefined${testDateString}`,
-        expectedValueAfterChange: ThreeDaysDateString,
+        expectedValueAfterChange: `undefined${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
-        interpolation: `$\{undefined + value}`, it: 'Date works with undefined expression and setDate triggers change properly'
+        interpolation: `$\{undefined + value}`, it: 'Date works with undefined expression and setDate triggers change properly',
       },
       {
-        expected: testDateString,
+        expected: `null${testDateString}`,
         expectedStrictMode: `null${testDateString}`,
-        expectedValueAfterChange: ThreeDaysDateString,
+        expectedValueAfterChange: `null${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
-        interpolation: `$\{null + value}`, it: 'Date works with null expression and setDate triggers change properly'
+        interpolation: `$\{null + value}`, it: 'Date works with null expression and setDate triggers change properly',
       },
       {
         expected: testDateString,
@@ -473,7 +517,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
       'hey ${id}',
       CustomElement.define({ name: 'app', isStrictBinding: true }, class { id = undefined; })
     );
-    assertText('hey undefined');
+    assertText('hey ');
 
     component.id = '1';
     flush();
@@ -481,7 +525,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
 
     component.id = null;
     flush();
-    assertText('hey null');
+    assertText('hey ');
   });
 
   it('observes and updates when bound with array', async function () {

--- a/packages/__tests__/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/3-runtime-html/promise.spec.ts
@@ -2610,6 +2610,8 @@ describe('3-runtime-html/promise.spec.ts', function () {
               : `<div> <div>'foo-bar' 'modified foo-bar'</div> </div>`,
             [],
             [],
+            // void 0,
+            // true
           );
           yield new TestData<App1>(
             `shows scoped content correctly #2 - ${$resolve ? 'fulfilled' : 'rejected'}`,
@@ -2655,8 +2657,8 @@ describe('3-runtime-html/promise.spec.ts', function () {
             },
             null,
             $resolve
-              ? `<div> <div>42 42</div> </div> 42 undefined`
-              : `<div> <div>'foo-bar' 'foo-bar'</div> </div> undefined foo-bar`,
+              ? `<div> <div>42 42</div> </div> 42`
+              : `<div> <div>'foo-bar' 'foo-bar'</div> </div> foo-bar`,
             [],
             [],
             (ctx) => {
@@ -2673,7 +2675,7 @@ describe('3-runtime-html/promise.spec.ts', function () {
               }
               assert.strictEqual('data' in oc, false, 'data in oc');
               assert.strictEqual('err' in oc, false, 'err in oc');
-            },
+            }
           );
 
           yield new TestData<App1>(

--- a/packages/__tests__/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/i18n/t/translation-integration.spec.ts
@@ -959,7 +959,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       @customElement(baseDef)
       class App { private readonly dt: string | number | Date = input; }
       $it(`${name} STRICT`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${output}`);
+        assertTextContent(host, 'span', `${output ?? ''}`);
       }, { component: App });
 
       @customElement({ ...baseDef, isStrictBinding: false })
@@ -1010,7 +1010,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       @customElement(baseDef)
       class App { private readonly dt: string | number | Date = input; }
       $it(`${name} STRICT`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${output}`);
+        assertTextContent(host, 'span', `${output ?? ''}`);
       }, { component: App });
 
       @customElement({ ...baseDef, isStrictBinding: false })
@@ -1057,7 +1057,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       class App { private readonly num: string | boolean | Date = value; }
 
       $it(`returns the value itself if the value is not a number STRICT binding, for example: ${value}`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${value}`);
+        assertTextContent(host, 'span', `${value ?? ''}`);
       }, { component: App });
 
       @customElement(def)
@@ -1118,7 +1118,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       @customElement(strictDef)
       class App { private readonly num: string | boolean | Date = value; }
       $it(`returns the value itself if the value is not a number STRICT binding, for example: ${value}`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${value}`);
+        assertTextContent(host, 'span', `${value ?? ''}`);
       }, { component: App });
 
       @customElement(def)
@@ -1186,7 +1186,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       @customElement(strictDef)
       class App { private readonly dt: string | number | boolean = value; }
       $it(`returns the value itself if the value is not a number STRICT, for example: ${value}`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${value}`);
+        assertTextContent(host, 'span', `${value ?? ''}`);
       }, { component: App });
 
       @customElement(def)
@@ -1301,7 +1301,7 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       @customElement(strictDef)
       class App { private readonly dt: string | number | boolean = value; }
       $it(`returns the value itself if the value is not a number STRICT binding, for example: ${value}`, function ({ host }: I18nIntegrationTestContext<App>) {
-        assertTextContent(host, 'span', `${value}`);
+        assertTextContent(host, 'span', `${value ?? ''}`);
       }, { component: App });
 
       @customElement(def)

--- a/packages/__tests__/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/router-lite/smoke-tests.spec.ts
@@ -3441,7 +3441,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectToPath();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: foo=bar | fragment:');
+      assert.html.textContent(host, 'view-a foo: | query: foo=bar | fragment:');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\?foo=bar$/);
 
       await au.stop(true);
@@ -3453,7 +3453,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectWithQueryObj();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: foo=bar | fragment:');
+      assert.html.textContent(host, 'view-a foo: | query: foo=bar | fragment:');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\?foo=bar$/);
 
       await au.stop(true);
@@ -3465,7 +3465,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectWithMultivaluedQuery();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: foo=fizz&foo=bar | fragment:');
+      assert.html.textContent(host, 'view-a foo: | query: foo=fizz&foo=bar | fragment:');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\?foo=fizz&foo=bar$/);
 
       await au.stop(true);
@@ -3489,7 +3489,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectWithClassAndQueryObj();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: foo=bar | fragment:');
+      assert.html.textContent(host, 'view-a foo: | query: foo=bar | fragment:');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\?foo=bar$/);
 
       await au.stop(true);
@@ -3525,7 +3525,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectSiblingViewport();
 
-      assert.html.textContent(host, 'view-a foo: 42 | query: foo=bar | fragment: view-a foo: undefined | query: foo=bar | fragment:');
+      assert.html.textContent(host, 'view-a foo: 42 | query: foo=bar | fragment: view-a foo: | query: foo=bar | fragment:');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42\+a\?foo=bar$/);
 
       await au.stop(true);
@@ -3537,7 +3537,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectFragment();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: | fragment: foobar');
+      assert.html.textContent(host, 'view-a foo: | query: | fragment: foobar');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a#foobar$/);
 
       await au.stop(true);
@@ -3549,7 +3549,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectFragmentInNavOpt();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: | fragment: foobar');
+      assert.html.textContent(host, 'view-a foo: | query: | fragment: foobar');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a#foobar$/);
 
       await au.stop(true);
@@ -3561,7 +3561,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectFragmentInPathAndNavOpt();
 
-      assert.html.textContent(host, 'view-a foo: undefined | query: | fragment: foobar');
+      assert.html.textContent(host, 'view-a foo: | query: | fragment: foobar');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a#foobar$/);
 
       await au.stop(true);
@@ -3597,7 +3597,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
       await vmb.redirectFragmentSiblingViewport();
 
-      assert.html.textContent(host, 'view-a foo: 42 | query: | fragment: foobar view-a foo: undefined | query: | fragment: foobar');
+      assert.html.textContent(host, 'view-a foo: 42 | query: | fragment: foobar view-a foo: | query: | fragment: foobar');
       assert.match((container.get(ILocation) as unknown as MockBrowserHistoryLocation).path, /a\/42\+a#foobar$/);
 
       await au.stop(true);
@@ -4350,35 +4350,35 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       type NavBar = InstanceType<typeof navBarCe>;
       const rootNavbar = CustomElement.for<NavBar>(host.querySelector('nav-bar')).viewModel;
-      rootNavbar.assert([{ href: '', text: 'null', active: true }, { href: 'p1', text: 'P1', active: true }, { href: 'p2', text: 'P2', active: false }], 'start root');
+      rootNavbar.assert([{ href: '', text: '', active: true }, { href: 'p1', text: 'P1', active: true }, { href: 'p2', text: 'P2', active: false }], 'start root');
       let childNavBar = CustomElement.for<NavBar>(host.querySelector('ce-p1>nav-bar')).viewModel;
-      childNavBar.assert([{ href: '', text: 'null', active: true }, { href: 'c11', text: 'C11', active: true }, { href: 'c12', text: 'C12', active: false }], 'start child navbar');
+      childNavBar.assert([{ href: '', text: '', active: true }, { href: 'c11', text: 'C11', active: true }, { href: 'c12', text: 'C12', active: false }], 'start child navbar');
 
       // Round#1
       await router.load('p2');
       await queue.yield();
-      rootNavbar.assert([{ href: '', text: 'null', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: true }], 'round#1 root');
+      rootNavbar.assert([{ href: '', text: '', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: true }], 'round#1 root');
       childNavBar = CustomElement.for<NavBar>(host.querySelector('ce-p2>nav-bar')).viewModel;
-      childNavBar.assert([{ href: '', text: 'null', active: true }, { href: 'c21', text: 'C21', active: false }, { href: 'c22', text: 'C22', active: true }], 'round#1 child navbar');
+      childNavBar.assert([{ href: '', text: '', active: true }, { href: 'c21', text: 'C21', active: false }, { href: 'c22', text: 'C22', active: true }], 'round#1 child navbar');
 
       // Round#2
       await router.load('p1/c12');
       await queue.yield();
-      rootNavbar.assert([{ href: '', text: 'null', active: false }, { href: 'p1', text: 'P1', active: true }, { href: 'p2', text: 'P2', active: false }], 'round#2 root');
+      rootNavbar.assert([{ href: '', text: '', active: false }, { href: 'p1', text: 'P1', active: true }, { href: 'p2', text: 'P2', active: false }], 'round#2 root');
       childNavBar = CustomElement.for<NavBar>(host.querySelector('ce-p1>nav-bar')).viewModel;
-      childNavBar.assert([{ href: '', text: 'null', active: false }, { href: 'c11', text: 'C11', active: false }, { href: 'c12', text: 'C12', active: true }], 'round#2 navbar');
+      childNavBar.assert([{ href: '', text: '', active: false }, { href: 'c11', text: 'C11', active: false }, { href: 'c12', text: 'C12', active: true }], 'round#2 navbar');
 
       // Round#3
       await router.load('p2/c21');
       await queue.yield();
-      rootNavbar.assert([{ href: '', text: 'null', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: true }], 'round#3 root');
+      rootNavbar.assert([{ href: '', text: '', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: true }], 'round#3 root');
       childNavBar = CustomElement.for<NavBar>(host.querySelector('ce-p2>nav-bar')).viewModel;
-      childNavBar.assert([{ href: '', text: 'null', active: false }, { href: 'c21', text: 'C21', active: true }, { href: 'c22', text: 'C22', active: false }], 'round#3 navbar');
+      childNavBar.assert([{ href: '', text: '', active: false }, { href: 'c21', text: 'C21', active: true }, { href: 'c22', text: 'C22', active: false }], 'round#3 navbar');
 
       // Round#4 - nav:false, but routeable
       await router.load('p3');
       await queue.yield();
-      rootNavbar.assert([{ href: '', text: 'null', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: false }], 'round#4 root');
+      rootNavbar.assert([{ href: '', text: '', active: false }, { href: 'p1', text: 'P1', active: false }, { href: 'p2', text: 'P2', active: false }], 'round#4 root');
       assert.notEqual(host.querySelector('ce-p3'), null);
 
       await au.stop(true);

--- a/packages/__tests__/turbo.json
+++ b/packages/__tests__/turbo.json
@@ -4,7 +4,8 @@
     "pipeline": {
       "build": {
         "inputs": [],
-        "outputs": ["dist/**/*"]
+        "outputs": ["dist/**/*"],
+        "cache": false
       }
     }
 }

--- a/packages/__tests__/turbo.json
+++ b/packages/__tests__/turbo.json
@@ -4,7 +4,7 @@
     "pipeline": {
       "build": {
         "inputs": [],
-        "outputs": ["dist/**/*", "!dist/tsconfig.tsbuildinfo"]
+        "outputs": ["dist/**/*"]
       }
     }
 }

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -128,6 +128,7 @@ export class AttributeBinding implements IBinding {
 
   public handleChange(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
 
@@ -167,6 +168,7 @@ export class AttributeBinding implements IBinding {
   public bind(_scope: Scope): void {
     if (this.isBound) {
       if (this._scope === _scope) {
+      /* istanbul-ignore-next */
         return;
       }
       this.unbind();
@@ -186,6 +188,7 @@ export class AttributeBinding implements IBinding {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -65,6 +65,8 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
   /** @internal */
   public readonly boundFn = false;
 
+  public strict = true;
+
   public constructor(
     controller: IBindingController,
     locator: IServiceLocator,
@@ -73,7 +75,6 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
     private readonly p: IPlatform,
     public readonly ast: IsExpression,
     public readonly target: Text,
-    public readonly strict: boolean
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -99,6 +99,7 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
 
   public handleChange(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.obs.version++;
@@ -128,6 +129,7 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
 
   public handleCollectionChange(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.obs.version++;
@@ -152,6 +154,7 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
   public bind(_scope: Scope): void {
     if (this.isBound) {
       if (this._scope === _scope) {
+      /* istanbul-ignore-next */
         return;
       }
       this.unbind();
@@ -176,6 +179,7 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -95,7 +95,8 @@ export class ContentBinding implements IBinding, ICollectionSubscriber {
       value = '';
       this._needsRemoveNode = true;
     }
-    target.textContent = safeString(value);
+    // console.log({ value, type: typeof value });
+    target.textContent = safeString(value ?? '');
   }
 
   public handleChange(): void {

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -61,6 +61,7 @@ export class LetBinding implements IBinding {
 
   public handleChange(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.obs.version++;
@@ -76,6 +77,7 @@ export class LetBinding implements IBinding {
   public bind(_scope: Scope): void {
     if (this.isBound) {
       if (this._scope === _scope) {
+      /* istanbul-ignore-next */
         return;
       }
       this.unbind();
@@ -93,6 +95,7 @@ export class LetBinding implements IBinding {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -73,6 +73,7 @@ export class ListenerBinding implements IBinding {
   public handleEvent(event: Event): void {
     if (this.self) {
       if (this.target !== event.composedPath()[0]) {
+      /* istanbul-ignore-next */
         return;
       }
     }
@@ -82,6 +83,7 @@ export class ListenerBinding implements IBinding {
   public bind(scope: Scope): void {
     if (this.isBound) {
       if (this._scope === scope) {
+      /* istanbul-ignore-next */
         return;
       }
       this.unbind();
@@ -97,6 +99,7 @@ export class ListenerBinding implements IBinding {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -79,6 +79,7 @@ export class PropertyBinding implements IBinding {
 
   public handleChange(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
 
@@ -115,6 +116,7 @@ export class PropertyBinding implements IBinding {
   public bind(scope: Scope): void {
     if (this.isBound) {
       if (this._scope === scope) {
+      /* istanbul-ignore-next */
         return;
       }
       this.unbind();
@@ -155,6 +157,7 @@ export class PropertyBinding implements IBinding {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -23,6 +23,7 @@ export class RefBinding implements IBinding {
   public bind(_scope: Scope): void {
     if (this.isBound) {
       if (this._scope === _scope) {
+      /* istanbul-ignore-next */
         return;
       }
 
@@ -40,6 +41,7 @@ export class RefBinding implements IBinding {
 
   public unbind(): void {
     if (!this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/binding/spread-binding.ts
+++ b/packages/runtime-html/src/binding/spread-binding.ts
@@ -120,6 +120,7 @@ export class SpreadBinding implements IBinding, IHasController {
 
   public bind(_scope: Scope): void {
     if (this.isBound) {
+      /* istanbul-ignore-next */
       return;
     }
     this.isBound = true;

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -834,7 +834,6 @@ export class TextBindingRenderer implements IRenderer {
       platform,
       ensureExpression(exprParser, instruction.from, ExpressionType.IsProperty),
       target as Text,
-      instruction.strict,
     ));
   }
 }

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -105,21 +105,17 @@ validPackages
     console.log(`${pkgDisplay} built in ${getElapsed(Date.now(), start)}s`);
   });
 
-const validToolingPackages = fs.readdirSync(path.resolve(__dirname, '../packages-tooling'))
-  .filter(p =>
-    p !== '__tests__'
-    && p !== 'aot'
-    && fs.statSync(path.resolve(__dirname, '../packages-tooling', p)).isDirectory()
-  );
-// const a = [
-//   'plugin-conventions',
-//   'plugin-gulp',
-//   'ts-jest',
-//   'babel-jest',
-//   'parcel-transformer',
-//   'vite-plugin',
-//   'webpack-loader',
-// ];
+const validToolingPackages =  [
+  'plugin-conventions',
+  'plugin-gulp',
+  'ts-jest',
+  'babel-jest',
+  'parcel-transformer',
+  'vite-plugin',
+  'webpack-loader',
+  'http-server',
+  'au',
+];
 
 validToolingPackages
   .filter(pkg => !isFullyBuilt(path.resolve(__dirname, `../packages-tooling/${pkg}`)))
@@ -142,7 +138,6 @@ const validApps = [
   'router-animation',
 ];
 const toolings = args.l;
-console.log({ toolings });
 
 if (apps.length > 0) {
   if (apps.some(a => !validApps.includes(a))) {


### PR DESCRIPTION
## 📖 Description

Currently all bindings are evaluating expressions in strict mode, and have proved to be working fine for applications migrating from v1. Text binding (content binding), however, was not using this strict by default mode as there could be some bug regards to how null/undefined are handled.
This exception creates a discrepancy that is hard to explain, also there's not a lot of benefits doing this. Remove this behavior.

This open the way for us to remove non-strict mode in expression evaluation, as optional syntaxes are already supported. Though this will be another follow up PR.

Closes #1769 #1798 