### PR TITLE
fix(au-slot): correctly prepare resources for slotted view

### DIFF
--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -2150,10 +2150,28 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
           name: 'el',
           template: '<el-with-slot>${"hey" | upper}</el-with-slot>',
           dependencies: [
-            CustomElement.define({ name: 'el-with-slot', template: '<au-slot>' }),
+            CustomElement.define({ name: 'el-with-slot', template: '<au-slot>' }, class ElWithSlot {}),
             ValueConverter.define('upper', class { toView = v => v.toUpperCase(); }),
           ]
-        }),
+        }, class El {}),
+      ]
+    );
+    assertText('HEY');
+  });
+
+  it('provides right resources for passed through <au-slot>', function () {
+    const { assertText } = createFixture(
+      '<el></el>',
+      {  },
+      [
+        CustomElement.define({
+          name: 'el',
+          template: '<el-with-slot><au-slot>${"hey" | upper}</au-slot></el-with-slot>',
+          dependencies: [
+            CustomElement.define({ name: 'el-with-slot', template: '<au-slot>' }, class ElWithSlot {}),
+            ValueConverter.define('upper', class { toView = v => v.toUpperCase(); }),
+          ]
+        }, class El {}),
       ]
     );
     assertText('HEY');

--- a/packages/__tests__/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/3-runtime-html/au-slot.spec.tsx
@@ -1,6 +1,6 @@
 import { delegateSyntax } from '@aurelia/compat-v1';
 import { IContainer, inject } from '@aurelia/kernel';
-import { BindingMode, Aurelia, AuSlotsInfo, bindable, customElement, CustomElement, IAuSlotsInfo, IPlatform } from '@aurelia/runtime-html';
+import { BindingMode, Aurelia, AuSlotsInfo, bindable, customElement, CustomElement, IAuSlotsInfo, IPlatform, ValueConverter } from '@aurelia/runtime-html';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { assert, createFixture, hJsx, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../util.js';
@@ -2139,5 +2139,23 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
 
     assert.instanceOf(parent, Parent);
     assert.strictEqual(parent.id, 1);
+  });
+
+  it('provides right resources for slotted view', function () {
+    const { assertText } = createFixture(
+      '<el></el>',
+      {  },
+      [
+        CustomElement.define({
+          name: 'el',
+          template: '<el-with-slot>${"hey" | upper}</el-with-slot>',
+          dependencies: [
+            CustomElement.define({ name: 'el-with-slot', template: '<au-slot>' }),
+            ValueConverter.define('upper', class { toView = v => v.toUpperCase(); }),
+          ]
+        }),
+      ]
+    );
+    assertText('HEY');
   });
 });

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -60,7 +60,7 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       factory = rendering.getViewFactory(slotInfo.fallback, contextController.container);
       this._hasProjection = false;
     } else {
-      container = hdrContext.parent!.controller.container.createChild();
+      container = hdrContext.parent!.controller.container.createChild({ inheritParentResources: true });
       registerResolver(
         container,
         contextController.definition.Type,

--- a/packages/runtime/src/binding/ast.eval.ts
+++ b/packages/runtime/src/binding/ast.eval.ts
@@ -290,6 +290,7 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
     case ExpressionKind.ValueConverter: {
       const vc = e?.getConverter?.(ast.name);
       if (vc == null) {
+        debugger;
         throw createMappedError(ErrorNames.ast_converter_not_found, ast.name);
       }
       if ('toView' in vc) {

--- a/packages/runtime/src/binding/ast.eval.ts
+++ b/packages/runtime/src/binding/ast.eval.ts
@@ -290,7 +290,6 @@ export function astEvaluate(ast: IsExpressionOrStatement, s: Scope, e: IAstEvalu
     case ExpressionKind.ValueConverter: {
       const vc = e?.getConverter?.(ast.name);
       if (vc == null) {
-        debugger;
         throw createMappedError(ErrorNames.ast_converter_not_found, ast.name);
       }
       if ('toView' in vc) {


### PR DESCRIPTION
## 📖 Description

Supersedes #1799
Closes #

### 🎫 Issues

Currently inheriting resources from parent container doesn't register right resolvers. This PR fixes this. 

Thanks @ekzobrain 