### PR TITLE
fix(router-lite): transition plan selection

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -169,8 +169,8 @@
         "5000",
         "--watch-extensions",
         "js",
-        "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/setup-node.js",
-        "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/router-lite/**/*.spec.js"
+        "${workspaceRoot}/packages/__tests__/dist/setup-node.js",
+        "${workspaceRoot}/packages/__tests__/dist/router-lite/**/*.spec.js"
       ],
       "cwd": "${workspaceRoot}",
       "internalConsoleOptions": "openOnSessionStart"
@@ -284,9 +284,9 @@
        "--watch-extensions",
        "js",
        "--bail",
-       "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/setup-node.js",
-       "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/2-runtime/*.spec.js",
-       "${workspaceRoot}/packages/__tests__/dist/esm/__tests__/3-runtime-html/*.spec.js"
+       "${workspaceRoot}/packages/__tests__/dist/setup-node.js",
+       "${workspaceRoot}/packages/__tests__/dist/2-runtime/*.spec.js",
+       "${workspaceRoot}/packages/__tests__/dist/3-runtime-html/*.spec.js"
       ],
       "cwd": "${workspaceRoot}",
       "internalConsoleOptions": "openOnSessionStart"

--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -22,7 +22,7 @@ import {
   Registration,
 } from '@aurelia/kernel';
 import { IRouter, IRouteViewModel, IViewportInstruction, NavigationInstruction, Params, route, RouteNode, RouterConfiguration } from '@aurelia/router-lite';
-import { Aurelia, CustomElement, customElement, IHydratedController, ILifecycleHooks, IPlatform, lifecycleHooks, StandardConfiguration } from '@aurelia/runtime-html';
+import { Aurelia, CustomElement, customElement, IHydratedController, ILifecycleHooks, lifecycleHooks, StandardConfiguration } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 import { TestRouterConfiguration } from './_shared/configuration.js';
 import { start } from './_shared/create-fixture.js';

--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -6164,7 +6164,7 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
     });
   }
 
-  it.only('multi-level hierarchical configuration -> navigation to sibling route from child -> parent is not replaced (transitionPlan: replace)', async function () {
+  it('multi-level hierarchical configuration -> navigation to sibling route from child -> parent is not replaced (transitionPlan: replace)', async function () {
     const ticks = 0;
     @customElement({ name: 'l-121', template: `l-121 <a load="../l122/1"></a><a load="../l122/2"></a>` })
     class L121 extends AsyncBaseViewModelWithAllHooks {

--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -22,7 +22,7 @@ import {
   Registration,
 } from '@aurelia/kernel';
 import { IRouter, IRouteViewModel, IViewportInstruction, NavigationInstruction, Params, route, RouteNode, RouterConfiguration } from '@aurelia/router-lite';
-import { Aurelia, CustomElement, customElement, IHydratedController, ILifecycleHooks, lifecycleHooks, StandardConfiguration } from '@aurelia/runtime-html';
+import { Aurelia, CustomElement, customElement, IHydratedController, ILifecycleHooks, IPlatform, lifecycleHooks, StandardConfiguration } from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 import { TestRouterConfiguration } from './_shared/configuration.js';
 import { start } from './_shared/create-fixture.js';
@@ -187,6 +187,56 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
 
   function createHookTimingConfiguration(option: Partial<Record<Hooks, number>> = {}) {
     return { canLoad: 1, loading: 1, canUnload: 1, unloading: 1, ...option };
+  }
+
+  abstract class AsyncBaseViewModelWithAllHooks implements IRouteViewModel {
+    private _ceName: string | null = null;
+    private get ceName(): string {
+      return this._ceName ??= CustomElement.getDefinition(this.constructor).name;
+    }
+    public constructor(
+      @ILogger protected readonly logger: ILogger,
+      private readonly ticks: number,
+    ) {
+      this.logger = logger.scopeTo(this.constructor.name);
+    }
+
+    public binding(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+      return log('binding', this.ceName, this.ticks, this.logger);
+    }
+    public bound(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+      return log('bound', this.ceName, this.ticks, this.logger);
+    }
+    public attaching(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+      return log('attaching', this.ceName, this.ticks, this.logger);
+    }
+    public attached(_initiator: IHydratedController): void | Promise<void> {
+      return log('attached', this.ceName, this.ticks, this.logger);
+    }
+    public detaching(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+      return log('detaching', this.ceName, this.ticks, this.logger);
+    }
+    public unbinding(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+      return log('unbinding', this.ceName, this.ticks, this.logger);
+    }
+    public dispose(): void {
+      this.logger.trace(`dispose - ${this.ceName}`);
+    }
+
+    public async canLoad(_params: Params, _next: RouteNode, _current: RouteNode): Promise<boolean | NavigationInstruction> {
+      await log('canLoad', this.ceName, this.ticks, this.logger);
+      return true;
+    }
+    public async loading(_params: Params, _next: RouteNode, _current: RouteNode): Promise<void> {
+      await log('loading', this.ceName, this.ticks, this.logger);
+    }
+    public async canUnload(_rn: RouteNode, _current?: RouteNode): Promise<boolean> {
+      await log('canUnload', this.ceName, this.ticks, this.logger);
+      return true;
+    }
+    public async unloading(_rn: RouteNode, _current?: RouteNode): Promise<void> {
+      await log('unloading', this.ceName, this.ticks, this.logger);
+    }
   }
 
   // the simplified textbook example of authorization hook
@@ -1614,58 +1664,8 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
   }
 
   function* getSiblingHookTestData(): Generator<SiblingHookTestData> {
-    abstract class AsyncBaseViewModel implements IRouteViewModel {
-      private _ceName: string | null = null;
-      private get ceName(): string {
-        return this._ceName ??= CustomElement.getDefinition(this.constructor).name;
-      }
-      public constructor(
-        @ILogger protected readonly logger: ILogger,
-        private readonly ticks: number,
-      ) {
-        this.logger = logger.scopeTo(this.constructor.name);
-      }
-
-      public binding(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
-        return log('binding', this.ceName, this.ticks, this.logger);
-      }
-      public bound(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
-        return log('bound', this.ceName, this.ticks, this.logger);
-      }
-      public attaching(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
-        return log('attaching', this.ceName, this.ticks, this.logger);
-      }
-      public attached(_initiator: IHydratedController): void | Promise<void> {
-        return log('attached', this.ceName, this.ticks, this.logger);
-      }
-      public detaching(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
-        return log('detaching', this.ceName, this.ticks, this.logger);
-      }
-      public unbinding(_initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
-        return log('unbinding', this.ceName, this.ticks, this.logger);
-      }
-      public dispose(): void {
-        this.logger.trace(`dispose - ${this.ceName}`);
-      }
-
-      public async canLoad(_params: Params, _next: RouteNode, _current: RouteNode): Promise<boolean | NavigationInstruction> {
-        await log('canLoad', this.ceName, this.ticks, this.logger);
-        return true;
-      }
-      public async loading(_params: Params, _next: RouteNode, _current: RouteNode): Promise<void> {
-        await log('loading', this.ceName, this.ticks, this.logger);
-      }
-      public async canUnload(_rn: RouteNode, _current?: RouteNode): Promise<boolean> {
-        await log('canUnload', this.ceName, this.ticks, this.logger);
-        return true;
-      }
-      public async unloading(_rn: RouteNode, _current?: RouteNode): Promise<void> {
-        await log('unloading', this.ceName, this.ticks, this.logger);
-      }
-    }
-
     function createRoot(ticks: number): [root: Class<unknown>, scopes: string[]] {
-      abstract class Base extends AsyncBaseViewModel {
+      abstract class Base extends AsyncBaseViewModelWithAllHooks {
         public constructor(@ILogger logger: ILogger) {
           super(logger, ticks);
         }
@@ -6163,6 +6163,162 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
       data.assertStopLog(eventLog);
     });
   }
+
+  it.only('multi-level hierarchical configuration -> navigation to sibling route from child -> parent is not replaced (transitionPlan: replace)', async function () {
+    const ticks = 0;
+    @customElement({ name: 'l-121', template: `l-121 <a load="../l122/1"></a><a load="../l122/2"></a>` })
+    class L121 extends AsyncBaseViewModelWithAllHooks {
+      public constructor(@ILogger logger: ILogger) {
+        super(logger, ticks);
+      }
+    }
+
+    @customElement({ name: 'l-122', template: `l-122 \${id} <a load="../../l1"></a>` })
+    class L122 extends AsyncBaseViewModelWithAllHooks {
+      id: unknown;
+      public constructor(@ILogger logger: ILogger) {
+        super(logger, ticks);
+      }
+      public async canLoad(params: Params, _next: RouteNode, _current: RouteNode): Promise<boolean> {
+        await super.canLoad(params, _next, _current);
+        this.id = params.id;
+        return true;
+      }
+    }
+
+    @route({
+      routes: [
+        { path: '', component: L121 },
+        { path: 'l122/:id', component: L122 },
+      ]
+    })
+    @customElement({ name: 'l-1', template: `<au-viewport></au-viewport>` })
+    class L1 extends AsyncBaseViewModelWithAllHooks {
+      public constructor(@ILogger logger: ILogger) {
+        super(logger, ticks);
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'l1', path: ['', 'l1'], component: L1 },
+      ],
+      transitionPlan: 'replace',
+    })
+    @customElement({ name: 'ro-ot', template: '<au-viewport name="root"></au-viewport>' })
+    class Root extends AsyncBaseViewModelWithAllHooks {
+      public constructor(@ILogger logger: ILogger) {
+        super(logger, ticks);
+      }
+    }
+
+    const { au, host, container } = await createFixture(Root,
+      Registration.instance(IKnownScopes, [Root.name, L1.name, L121.name, L122.name])
+    );
+    const router = container.get(IRouter);
+    const eventLog = EventLog.getInstance(container);
+
+    assert.html.textContent(host, 'l-121');
+    const anchors = Array.from(host.querySelectorAll('a'));
+    const hrefs = anchors.map(a => a.href);
+    assert.match(hrefs[0], /l122\/1$/);
+    assert.match(hrefs[1], /l122\/2$/);
+
+    // phase1
+    eventLog.clear();
+    anchors[0].click();
+    await router.currentTr.promise;
+    eventLog.assertLog([
+      /L121\] canUnload - start l-121/,
+      /L121\] canUnload - end l-121/,
+      /L122\] canLoad - start l-122/,
+      /L122\] canLoad - end l-122/,
+
+      /L121\] unloading - start l-121/,
+      /L121\] unloading - end l-121/,
+      /L122\] loading - start l-122/,
+      /L122\] loading - end l-122/,
+
+      /L121\] detaching - start l-121/,
+      /L121\] detaching - end l-121/,
+      /L121\] unbinding - start l-121/,
+      /L121\] unbinding - end l-121/,
+      /L121\] dispose - l-121/,
+
+      /L122\] binding - start l-122/,
+      /L122\] binding - end l-122/,
+      /L122\] bound - start l-122/,
+      /L122\] bound - end l-122/,
+      /L122\] attaching - start l-122/,
+      /L122\] attaching - end l-122/,
+      /L122\] attached - start l-122/,
+      /L122\] attached - end l-122/,
+    ], 'phase1');
+
+    // phase2 - go-back
+    eventLog.clear();
+    host.querySelector('a').click();
+    await router.currentTr.promise;
+    eventLog.assertLog([
+      /L122\] canUnload - start l-122/,
+      /L122\] canUnload - end l-122/,
+      /L121\] canLoad - start l-121/,
+      /L121\] canLoad - end l-121/,
+
+      /L122\] unloading - start l-122/,
+      /L122\] unloading - end l-122/,
+      /L121\] loading - start l-121/,
+      /L121\] loading - end l-121/,
+
+      /L122\] detaching - start l-122/,
+      /L122\] detaching - end l-122/,
+      /L122\] unbinding - start l-122/,
+      /L122\] unbinding - end l-122/,
+      /L122\] dispose - l-122/,
+
+      /L121\] binding - start l-121/,
+      /L121\] binding - end l-121/,
+      /L121\] bound - start l-121/,
+      /L121\] bound - end l-121/,
+      /L121\] attaching - start l-121/,
+      /L121\] attaching - end l-121/,
+      /L121\] attached - start l-121/,
+      /L121\] attached - end l-121/,
+    ], 'phase2');
+
+    // phase3
+    eventLog.clear();
+    host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
+    await router.currentTr.promise;
+    eventLog.assertLog([
+      /L121\] canUnload - start l-121/,
+      /L121\] canUnload - end l-121/,
+      /L122\] canLoad - start l-122/,
+      /L122\] canLoad - end l-122/,
+
+      /L121\] unloading - start l-121/,
+      /L121\] unloading - end l-121/,
+      /L122\] loading - start l-122/,
+      /L122\] loading - end l-122/,
+
+      /L121\] detaching - start l-121/,
+      /L121\] detaching - end l-121/,
+      /L121\] unbinding - start l-121/,
+      /L121\] unbinding - end l-121/,
+      /L121\] dispose - l-121/,
+
+      /L122\] binding - start l-122/,
+      /L122\] binding - end l-122/,
+      /L122\] bound - start l-122/,
+      /L122\] bound - end l-122/,
+      /L122\] attaching - start l-122/,
+      /L122\] attaching - end l-122/,
+      /L122\] attached - start l-122/,
+      /L122\] attached - end l-122/,
+    ], 'phase3');
+
+    await au.stop(true);
+  });
   // #endregion
 
   it('navigate away -> false from canUnload -> navigate away with same path', async function () {

--- a/packages/__tests__/src/router-lite/resources/load.spec.ts
+++ b/packages/__tests__/src/router-lite/resources/load.spec.ts
@@ -98,24 +98,24 @@ describe('router-lite/resources/load.spec.ts', function () {
     await queue.yield();
     a2.active = true;
     assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#2');
-    assert.html.textContent(host, '1 2');
+    assert.html.textContent(host, '1 2', 'round#2 - text');
 
     anchors[1].click();
     await queue.yield();
     assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#3');
-    assert.html.textContent(host, '2 2');
+    assert.html.textContent(host, '1 2', 'round#3 - text');
 
     anchors[0].click();
     await queue.yield();
     a1.active = true;
     a2.active = false;
     assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#4');
-    assert.html.textContent(host, '3 1');
+    assert.html.textContent(host, '2 1', 'round#4 - text');
 
     anchors[0].click();
     await queue.yield();
     assertAnchorsWithClass(anchors, [a1, a2], activeClass, 'round#5');
-    assert.html.textContent(host, '4 1');
+    assert.html.textContent(host, '2 1', 'round#5 - text');
 
     await au.stop(true);
 
@@ -1133,7 +1133,7 @@ describe('router-lite/resources/load.spec.ts', function () {
     await au.stop(true);
   });
 
-  it.skip('allow navigating to route defined in parent context using ../ prefix with replace transitionPlan and child viewport', async function () {
+  it('allow navigating to route defined in parent context using ../ prefix with replace transitionPlan and child viewport', async function () {
     @customElement({ name: 'product-details', template: `product \${id} <a load="../../products"></a>` })
     class Product {
       id: unknown;
@@ -1173,25 +1173,24 @@ describe('router-lite/resources/load.spec.ts', function () {
     assert.match(hrefs[0], /product\/1$/);
     assert.match(hrefs[1], /product\/2$/);
 
-    console.log('---------------- clicking anchor#1 ----------------'.toUpperCase());
     anchors[0].click();
     await queue.yield();
-    assert.html.textContent(host, 'product 1');
+    assert.html.textContent(host, 'product 1', 'round#1');
     // go back
     const back = host.querySelector<HTMLAnchorElement>('a');
-    assert.match(back.href, /products$/);
+    assert.match(back.href, /products$/, 'round#1 - back - href');
     back.click();
     await queue.yield();
-    assert.html.textContent(host, 'product init');
+    assert.html.textContent(host, 'product init', 'round#1 - back - text');
 
     // 2nd round
     host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
     await queue.yield();
-    assert.html.textContent(host, 'product 2');
+    assert.html.textContent(host, 'product 2', 'round#2');
     // go back
     host.querySelector<HTMLAnchorElement>('a').click();
     await queue.yield();
-    assert.html.textContent(host, 'products');
+    assert.html.textContent(host, 'product init', 'round#2 - back - text');
 
     await au.stop(true);
   });

--- a/packages/__tests__/src/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/src/router-lite/smoke-tests.spec.ts
@@ -5331,12 +5331,12 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: 'ce1',
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           },
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><a load="ce1/1"></a><au-viewport></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5346,7 +5346,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await queue.yield();
       assert.html.textContent(host, 'ce1 2 2', 'round#2');
 
@@ -5383,17 +5383,17 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: ['ce1'],
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           },
           {
             id: 'ce2',
-            path: ['ce2'],
+            path: ['ce2', 'ce2/:id'],
             component: CeTwo,
           },
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><a load="ce1/2@$1+ce2/1@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5403,7 +5403,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1 ce2 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await queue.yield();
       assert.html.textContent(host, 'ce1 2 2 ce2 2 2', 'round#2');
 
@@ -5430,12 +5430,12 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: ['ce1'],
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           },
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><a load="ce1/1"></a><au-viewport></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5447,7 +5447,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await router.currentTr.promise;
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 2', 'round#2');
@@ -5488,17 +5488,17 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: ['ce1'],
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           },
           {
             id: 'ce2',
-            path: ['ce2'],
+            path: ['ce2', 'ce2/:id'],
             component: CeTwo,
           },
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1@$1+ce2@$2"></a><a load="ce1/2@$1+ce2/1@$2"></a><au-viewport name="$1"></au-viewport> <au-viewport name="$2"></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5510,7 +5510,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1 ce2 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await router.currentTr.promise;
       await queue.yield();
       assert.html.textContent(host, 'ce1 2 2 ce2 1 2', 'round#2');
@@ -5560,12 +5560,12 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: ['ce1'],
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           }
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><a load="ce1/1"></a><au-viewport></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5577,7 +5577,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1 ce2 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await router.currentTr.promise;
       await queue.yield();
       assert.html.textContent(host, 'ce1 2 2 ce2 2 2', 'round#2'); // this happens as the ce-one (parent) is replaced causing replacement of child
@@ -5627,12 +5627,12 @@ describe('router-lite/smoke-tests.spec.ts', function () {
         routes: [
           {
             id: 'ce1',
-            path: ['ce1'],
+            path: ['ce1', 'ce1/:id'],
             component: CeOne,
           }
         ]
       })
-      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><au-viewport></au-viewport>' })
+      @customElement({ name: 'ro-ot', template: '<a load="ce1"></a><a load="ce1/1"></a><au-viewport></au-viewport>' })
       class Root { }
 
       const { au, container, host } = await start({ appRoot: Root, registrations: [CeOne] });
@@ -5644,10 +5644,10 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       await queue.yield();
       assert.html.textContent(host, 'ce1 1 1 ce2 1 1', 'round#1');
 
-      host.querySelector('a').click();
+      host.querySelector<HTMLAnchorElement>('a:nth-of-type(2)').click();
       await router.currentTr.promise;
       await queue.yield();
-      assert.html.textContent(host, 'ce1 1 2 ce2 2 2', 'round#2');
+      assert.html.textContent(host, 'ce1 1 2 ce2 1 1', 'round#2'); // note that as the parent is not replaced, the child is retained.
 
       await au.stop(true);
     });
@@ -6163,7 +6163,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       @route({
         routes: [
           { path: '', component: C1, title: 't1', data: { foo: 'bar' } },
-          { path: 'c1', component: C1, title: 't2', data: { awesome: 'possum' } },
+          { path: 'c1/:id', component: C1, title: 't2', data: { awesome: 'possum' } },
         ],
         transitionPlan: 'replace'
       })
@@ -6180,7 +6180,7 @@ describe('router-lite/smoke-tests.spec.ts', function () {
       let ce = CustomElement.for<C1>(host.querySelector('c-1')).viewModel;
       assert.deepStrictEqual(ce.data, { foo: 'bar' });
 
-      await router.load('c1');
+      await router.load('c1/1');
 
       assert.html.textContent(host, 'c1 2');
       assert.strictEqual(doc.title, 't2');

--- a/packages/router-lite/src/resources/viewport.ts
+++ b/packages/router-lite/src/resources/viewport.ts
@@ -89,11 +89,6 @@ export class ViewportCustomElement implements ICustomElementViewModel, IViewport
             propStrings.push(`${prop}:'${value}'`);
           }
           break;
-        case 'boolean':
-          if (value) {
-            propStrings.push(`${prop}:${value}`);
-          }
-          break;
         default: {
           propStrings.push(`${prop}:${String(value)}`);
         }

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -78,6 +78,7 @@ export class RouteNode implements IRouteNode {
   /** @internal */
   private _isInstructionsFinalized: boolean = false;
   public get isInstructionsFinalized(): boolean { return this._isInstructionsFinalized; }
+  public readonly children: RouteNode[] = [];
 
   private constructor(
     /**
@@ -119,7 +120,6 @@ export class RouteNode implements IRouteNode {
     public readonly _viewport: string | null,
     public readonly title: string | ((node: RouteNode) => string | null) | null,
     public readonly component: CustomElementDefinition,
-    public readonly children: RouteNode[],
     /**
      * Not-yet-resolved viewport instructions.
      *
@@ -149,7 +149,6 @@ export class RouteNode implements IRouteNode {
       /*    viewport */input._viewport ?? null,
       /*       title */input.title ?? null,
       /*   component */input.component,
-      /*    children */input.children ?? [],
       /*     residue */input.residue ?? [],
     );
   }
@@ -256,9 +255,13 @@ export class RouteNode implements IRouteNode {
       this._viewport,
       this.title,
       this.component,
-      this.children.map(x => x._clone()),
       [...this.residue],
     );
+    const children = this.children;
+    const len = children.length;
+    for (let i = 0; i < len; ++i) {
+      clone.children.push(children[i]._clone());
+    }
     clone._version = this._version + 1;
     if (clone.context.node === this) {
       clone.context.node = clone;

--- a/packages/router-lite/src/route.ts
+++ b/packages/router-lite/src/route.ts
@@ -13,14 +13,6 @@ import { Events, getMessage } from './events';
 
 export const noRoutes = emptyArray as RouteConfig['routes'];
 
-function defaultReentryBehavior(current: RouteNode, next: RouteNode): TransitionPlan {
-  if (!shallowEquals(current.params, next.params)) {
-    return 'replace';
-  }
-
-  return 'none';
-}
-
 // Every kind of route configurations are normalized to this `RouteConfig` class.
 export class RouteConfig implements IRouteConfig, IChildRouteConfig {
   /** @internal */
@@ -143,8 +135,13 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
   }
 
   /** @internal */
-  public _getTransitionPlan(cur: RouteNode, next: RouteNode) {
-    const plan = this.transitionPlan ?? defaultReentryBehavior;
+  public _getTransitionPlan(cur: RouteNode, next: RouteNode, overridingTransitionPlan: TransitionPlan | null) {
+    const hasSameParameters = shallowEquals(cur.params, next.params);
+    if (hasSameParameters) return 'none';
+
+    if (overridingTransitionPlan != null) return overridingTransitionPlan;
+
+    const plan = this.transitionPlan ?? 'replace';
     return typeof plan === 'function' ? plan(cur, next) : plan;
   }
 

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -698,7 +698,7 @@ export class ViewportAgent {
       this._$plan = 'replace';
     } else {
       // Component is the same, so determine plan based on config and/or convention
-      this._$plan = options.transitionPlan ?? next.context.config._getTransitionPlan(cur, next);
+      this._$plan = next.context.config._getTransitionPlan(cur, next, options.transitionPlan);
     }
 
     if (__DEV__) trace(this._logger, Events.vpaScheduleUpdate, this);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

The previous strategy of transition plan selection did not involve checking the parameters. If the parameters are the same, then the transition plan must be `none` in order to ensure that the component is not deactivated. 

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

Closes #1789.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

Update the docs and demos. Need a new published version for that. Hence, those changes could not be included in this PR.

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
