### PR TITLE
Adding Vanilla JS code examples for fetch client

### DIFF
--- a/docs/user-docs/aurelia-packages/fetch-client.md
+++ b/docs/user-docs/aurelia-packages/fetch-client.md
@@ -47,6 +47,8 @@ Where possible, you should avoid creating new instances of the Fetch client. Ins
 
 Taking a service-based approach to encapsulating your HTTP calls, you might create something like this:
 
+{% tabs %}
+{% tab title="Typescript" %}
 ```typescript
 import { IHttpClient } from '@aurelia/fetch-client';
 import { newInstanceOf } from '@aurelia/kernel';
@@ -71,6 +73,33 @@ export class ApiService {
     }
  }   
 ```
+{% endtab %}
+
+{% tab title="Vanilla JS" %}
+```javascript
+import { resolve, newInstanceOf } from '@aurelia/kernel';
+import { IHttpClient } from '@aurelia/fetch-client';
+
+export class ApiServiceervice {
+    http = resolve(newInstanceOf(IHttpClient));
+  
+    getProducts() {
+        const request = await this.http.fetch(`/products`);
+        const response = await request.json();
+        
+        return response;
+      }
+    
+    getProduct(id) {
+        const request = await this.http.fetch(`/products/${id}`);
+        const response = await request.json();
+        
+        return response;
+    }
+}
+```
+{% endtab %}
+{% endtabs %}
 
 ## Configuring the fetch client
 

--- a/docs/user-docs/aurelia-packages/fetch-client.md
+++ b/docs/user-docs/aurelia-packages/fetch-client.md
@@ -83,14 +83,14 @@ import { IHttpClient } from '@aurelia/fetch-client';
 export class ApiServiceervice {
     http = resolve(newInstanceOf(IHttpClient));
   
-    getProducts() {
+    async getProducts() {
         const request = await this.http.fetch(`/products`);
         const response = await request.json();
         
         return response;
       }
     
-    getProduct(id) {
+    async getProduct(id) {
         const request = await this.http.fetch(`/products/${id}`);
         const response = await request.json();
         

--- a/docs/user-docs/router-lite/navigation-model.md
+++ b/docs/user-docs/router-lite/navigation-model.md
@@ -45,6 +45,10 @@ export class NavBar {
   public constructor(@IRouteContext routeCtx: IRouteContext) {
     this.navModel = routeCtx.navigationModel;
   }
+
+  public async binding() {
+    await this.navModel.resolve()
+  }
 }
 ```
 


### PR DESCRIPTION
GitBook has a awesome feature where you can add a tabs to code examples. Would you guys be open to also add in examples for Vanilla JS code? Here is an example of one of the fetch client code snippets.

I would be happy to help out here whenever I have a bit of spare time 🙂.

![Screenshot 2023-10-19 at 10 41 16](https://github.com/aurelia/aurelia/assets/5493114/8e2fa27b-8462-4089-bb12-8f172e128435)
![Screenshot 2023-10-19 at 10 41 21](https://github.com/aurelia/aurelia/assets/5493114/56316533-2bc9-419e-841c-cd7432936c49)
