### PR TITLE
fix(i18n): translating camelCased bindables

### DIFF
--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -1,4 +1,4 @@
-import { toArray } from '@aurelia/kernel';
+import { camelCase, toArray } from '@aurelia/kernel';
 import {
   AccessorType,
   CustomExpression,
@@ -238,7 +238,7 @@ export class TranslationBinding implements IConnectableBinding {
         } else {
           const controller = CustomElement.for(this.target, forOpts);
           const accessor = controller?.viewModel
-            ? this.oL.getAccessor(controller.viewModel, attribute)
+            ? this.oL.getAccessor(controller.viewModel, camelCase(attribute))
             : this.oL.getAccessor(this.target, attribute);
           const shouldQueueUpdate = this._controller.state !== State.activating && (accessor.type & AccessorType.Layout) > 0;
           if (shouldQueueUpdate) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

This PR fixes the following issue:

```html
<!-- 
  This doesn't work; although it should.
  That is also the default behavior  in au1.
--> 
<my-el my-value="does not work" t="[my-value]displayTextTest"></my-el>

<!--
  This works; although it shouldn't.
  Also this is inconsistent.
  The conversion to the camelCase from the kebab-cased property was missing.
--> 
<my-el my-value="works" t="[myValue]displayTextTest"></my-el>
```

Reproduction: https://stackblitz.com/edit/translating-bindables?file=src%2Fmy-app.ts

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
