### PR TITLE
fix(validation): property accessor ignore instrumenter

### DIFF
--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -445,6 +445,14 @@ describe('validation/rule-provider.spec.ts', function () {
       sut.off();
     });
 
+    it('calling .off on an object without rules does not cause error', function () {
+      const { sut } = setup();
+      const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
+      assert.equal(validationRulesRegistrar.get(obj), void 0);
+      sut.off(obj);
+      assert.equal(validationRulesRegistrar.get(obj), void 0);
+    });
+
     it('can define multiple ruleset for the same object using tagging', function () {
       const { sut } = setup();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -843,6 +843,7 @@ describe('validation/rule-provider.spec.ts', function () {
     }
 
     const cov_1wjh4ld5ut: any = {};
+    const cov_1wjh4ld5ut1: () => any = () => ({});
     const a: string = 'foo';
     const positiveDataRows = [
       { property: 'prop',                   expected: 'prop' },
@@ -949,14 +950,14 @@ describe('validation/rule-provider.spec.ts', function () {
       { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut.f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
 
       // for the instrumenter: @jsdevtools/coverage-istanbul-loader
-      { property: function (o: any) { cov_1wjh4ld5ut().s[50]++; return o.prop; },                                      expected: 'prop' },
-      { property: function (o: any) { cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },                expected: 'prop' },
-      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut().s[50]++; return o.prop; },                        expected: 'prop' },
-      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
-      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut().s[50]++; return o.prop; },                                      expected: 'prop' },
-      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },                expected: 'prop' },
-      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut().s[50]++; return o.prop; },                        expected: 'prop' },
-      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
+      { property: function (o: any) { cov_1wjh4ld5ut1().s[50]++; return o.prop; },                                      expected: 'prop' },
+      { property: function (o: any) { cov_1wjh4ld5ut1().f[9]++;cov_1wjh4ld5ut1().s[50]++; return o.prop; },                expected: 'prop' },
+      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut1().s[50]++; return o.prop; },                        expected: 'prop' },
+      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut1().f[9]++;cov_1wjh4ld5ut1().s[50]++; return o.prop; },  expected: 'prop' },
+      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut1().s[50]++; return o.prop; },                                      expected: 'prop' },
+      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut1().f[9]++;cov_1wjh4ld5ut1().s[50]++; return o.prop; },                expected: 'prop' },
+      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut1().s[50]++; return o.prop; },                        expected: 'prop' },
+      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut1().f[9]++;cov_1wjh4ld5ut1().s[50]++; return o.prop; },  expected: 'prop' },
     ];
     for(const { property, expected } of positiveDataRows) {
       it(`parses ${property.toString()} to ${expected}`, function () {

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -947,6 +947,16 @@ describe('validation/rule-provider.spec.ts', function () {
       { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut.f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },                expected: 'prop' },
       { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut.s[50]++; return o.prop; },                        expected: 'prop' },
       { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut.f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
+
+      // for the instrumenter: @jsdevtools/coverage-istanbul-loader
+      { property: function (o: any) { cov_1wjh4ld5ut().s[50]++; return o.prop; },                                      expected: 'prop' },
+      { property: function (o: any) { cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },                expected: 'prop' },
+      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut().s[50]++; return o.prop; },                        expected: 'prop' },
+      { property: function (o: any) { "use strict"; cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
+      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut().s[50]++; return o.prop; },                                      expected: 'prop' },
+      { property: function (o: any) { /* istanbul ignore next */ cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },                expected: 'prop' },
+      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut().s[50]++; return o.prop; },                        expected: 'prop' },
+      { property: function (o: any) { "use strict"; /* istanbul ignore next */ cov_1wjh4ld5ut().f[9]++;cov_1wjh4ld5ut.s[50]++; return o.prop; },  expected: 'prop' },
     ];
     for(const { property, expected } of positiveDataRows) {
       it(`parses ${property.toString()} to ${expected}`, function () {

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -80,7 +80,8 @@ export const validationRulesRegistrar = Object.freeze({
     return Metadata.get(key, target) ?? Metadata.getOwn(key, target.constructor);
   },
   unset(target: IValidateable, tag?: string): void {
-    const keys = Metadata.getOwn(Protocol.annotation.name, target) as string[];
+    const keys = Metadata.getOwn(Protocol.annotation.name, target);
+    if (!Array.isArray(keys)) return;
     for (const key of keys.slice(0)) {
       if (key.startsWith(validationRulesRegistrar.name) && (tag === void 0 || key.endsWith(tag))) {
         Metadata.delete(Protocol.annotation.keyFor(key), target);
@@ -111,7 +112,7 @@ class ValidationMessageEvaluationContext {
   }
 }
 
-export interface PropertyRule extends IAstEvaluator {}
+export interface PropertyRule extends IAstEvaluator { }
 export class PropertyRule<TObject extends IValidateable = IValidateable, TValue = unknown> implements IPropertyRule {
   public static readonly $TYPE: string = 'PropertyRule';
   private latestRule?: IValidationRule;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -533,7 +533,7 @@ export class ValidationRules<TObject extends IValidateable = IValidateable> impl
 }
 
 // eslint-disable-next-line no-useless-escape
-const classicAccessorPattern = /^function\s*\([$_\w\d]+\)\s*\{(?:\s*["']{1}use strict["']{1};)?(?:[$_\s\w\d\/\*.['"\]+;]+)?\s*return\s+[$_\w\d]+((\.[$_\w\d]+|\[['"$_\w\d]+\])+)\s*;?\s*\}$/;
+const classicAccessorPattern = /^function\s*\([$_\w\d]+\)\s*\{(?:\s*["']{1}use strict["']{1};)?(?:[$_\s\w\d\/\*.['"\]+;\(\)]+)?\s*return\s+[$_\w\d]+((\.[$_\w\d]+|\[['"$_\w\d]+\])+)\s*;?\s*\}$/;
 const arrowAccessorPattern = /^\(?[$_\w\d]+\)?\s*=>\s*[$_\w\d]+((\.[$_\w\d]+|\[['"$_\w\d]+\])+)$/;
 export const rootObjectSymbol = '$root';
 export type PropertyAccessor<TObject extends IValidateable = IValidateable, TValue = unknown> = (object: TObject) => TValue;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

- This supports instrumentation code from @jsdevtools/coverage-istanbul-loader.
- Additionally, made a minor change where `@IValidationRules#off()` is allowed to be called for an object without any defined rules.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

Applied the fix for the au1 issue: https://github.com/aurelia/validation/issues/571

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
