### PR TITLE
feat(docs): update binding behaviors with more custom examples

### DIFF
--- a/docs/user-docs/templates/binding-behaviors.md
+++ b/docs/user-docs/templates/binding-behaviors.md
@@ -1,16 +1,16 @@
 # Binding behaviors
 
-Binding behaviors are a category of view resource, just like value converters, custom attributes and custom elements. Binding behaviors are most like [value converters](value-converters.md) in that you use them declaratively in binding expressions to affect the binding.
+Binding behaviors are a category of view resources, just like value converters, custom attributes and custom elements. Binding behaviors are most like [value converters](value-converters.md) in that you use them declaratively in binding expressions to affect the binding.
 
-The primary difference between a binding behavior and a value converter is _binding behaviors have full access to the binding instance, throughout it's lifecycle_. Contrast this with a value converter which only has the ability to intercept values passing from the model to the view and visa versa.
+The primary difference between a binding behavior and a value converter is _binding behaviors have full access to the binding instance, throughout its lifecycle_. Contrast this with a value converter, which can only intercept values passing from the model to the view and visa versa.
 
-The additional "access" afforded to binding behaviors gives them the ability to change the behavior of the binding, enabling a lot of interesting scenarios which you'll see below.
+The additional "access" afforded to binding behaviors gives them the ability to change the behaviour of the binding, enabling a lot of interesting scenarios, which you'll see below.
 
 ## Throttle
 
 Aurelia ships with a handful of behaviors out of the box to enable common scenarios. The first is the throttle binding behavior which limits the rate at which the view-model is updated in two-way bindings or the rate at which the view is updated in to-view binding scenarios.
 
-By default `throttle` will only allow updates every 200ms. You can customize the rate of course. Here are a few examples.
+By default, `throttle` will only allow updates every 200ms. You can customize the rate, of course. Here are a few examples.
 
 **Updating a property, at most, every 200ms**
 
@@ -20,7 +20,7 @@ HTML
 <input type="text" value.bind="query & throttle">
 ```
 
-The first thing you probably noticed in the example above is the `&` symbol, which is used to declare binding behavior expressions. Binding behavior expressions use the same syntax pattern as value converter expressions:
+The first thing you probably noticed in the example above is the `&` symbol, used to declare binding behavior expressions. Binding behavior expressions use the same syntax pattern as value converter expressions:
 
 * Binding behaviors can accept arguments: `firstName & myBehavior:arg1:arg2:arg3`
 * A binding expression can contain multiple binding behaviors: `firstName & behavior1 & behavior2:arg1`.
@@ -44,11 +44,11 @@ The throttle behavior is particularly useful when binding events to methods on y
 
 ### Flush pending throttled calls
 
-Sometimes it's desirable to forcefully run the throttled update, so that the application syncs the latest values. This can happen in a form, when a user previously was typing into a throttled form field, and hit tab key to go to the next field, as an example.
+Sometimes, it's desirable to forcefully run the throttled update so that the application syncs the latest values. This can happen in a form when a user previously was typing into a throttled form field and hit the tab key to go to the next field, as an example.
 The `throttle` binding behavior supports this scenario via signal. These signals can be added via the 2nd parameter, like the following example:
 
 {% code title="my-app.html" lineNumbers="true" overflow="wrap" %}
-```html
+```HTML
 <input value.bind="value & throttle :200 :`finishTyping`" blur.trigger="signaler.dispatchSignal('finishTyping')">
 <!-- or it can be a list of signals -->
 <input value.bind="value & throttle :200 :[`finishTyping`, `newUpdate`]">
@@ -77,7 +77,7 @@ Like throttle, the `debounce` binding behavior shines in event binding.
 
 Here's another example with the `mousemove` event:
 
-**Call mouseMove after mouse stopped moving for 500ms**
+**Call mouseMove after the mouse stops moving for 500ms**
 
 ```html
 <div mousemove.delegate="mouseMove($event) & debounce:500"></div>
@@ -85,7 +85,7 @@ Here's another example with the `mousemove` event:
 
 ### Flush pending debounced calls
 
-Sometimes it's desirable to forcefully run the throttled update, so that the application syncs the latest values. This can happen in a form, when a user previously was typing into a throttled form field, and hit tab key to go to the next field, as an example.
+Sometimes, it's desirable to forcefully run the throttled update so that the application syncs the latest values. This can happen in a form when a user previously was typing into a throttled form field and hit the tab key to go to the next field, as an example.
 Similar to the [`throttle` binding behavior](#throttle), The `debounce` binding behavior supports this scenario via signal. These signals can be added via the 2nd parameter, like the following example:
 
 {% code title="my-app.html" lineNumbers="true" overflow="wrap" %}
@@ -98,7 +98,7 @@ Similar to the [`throttle` binding behavior](#throttle), The `debounce` binding 
 
 ## UpdateTrigger
 
-Update trigger allows you to override the input events that cause the element's value to be written to the view-model. The default events are `change` and `input`.
+The update trigger allows you to override the input events that cause the element's value to be written to the view model. The default events are `change` and `input`.
 
 Here's how you would tell the binding to only update the model on `blur`:
 
@@ -120,11 +120,11 @@ Multiple events are supported:
 
 The signal binding behavior enables you to "signal" the binding to refresh. This is especially useful when a binding result is impacted by global changes outside \*\*\*\* the observation path.
 
-For example, if you have a "translate" value converter that converts a key to a localized string- eg `${'greeting-key' | translate}` and your site allows users to change the current language, how would you refresh the bindings when that happens?
+For example, if you have a "translate" value converter that converts a key to a localized string- e.g. `${'greeting-key' | translate}` and your site allows users to change the current language, how would you refresh the bindings when that happens?
 
-Another example is a value converter that uses the current time to convert a record's datetime to a "time ago" value: `posted ${postDateTime | timeAgo}`. The moment this binding expression is evaluated it will correctly result in `posted a minute ago`. As time passes, it will eventually become inaccurate. How can we refresh this binding periodically so that it correctly displays `5 minutes ago`, then `15 minutes ago`, `an hour ago`, etc?
+Another example is a value converter that uses the current time to convert a record's datetime to a "time ago" value: `posted ${postDateTime | timeAgo}`. When this binding expression is evaluated, it will correctly result in `posted a minute ago`. As time passes, it will eventually become inaccurate. How can we refresh this binding periodically to correctly display `5 minutes ago`, then `15 minutes ago`, `an hour ago`, etc?
 
-Here's how you would accomplish this using the `signal` binding behavior:
+Here's how you would accomplish this using the `signal` binding behaviour:
 
 **Using a Signal**
 
@@ -173,7 +173,7 @@ There are also binding behaviors for `toView` and `twoWay` which you could use l
 ```
 
 {% hint style="warning" %}
-The casing for binding modes is different depending on whether they appear as a **binding command** or as a **binding behavior**. Because HTML is case-insensitive, binding commands cannot use capitals. Thus, the binding modes, when specified in this place, use lowercase, dashed names. However, when used within a binding expression as a binding behavior, they must not use a dash because that is not a valid symbol for variable names in JavaScript. So, in this case, camel casing is used.
+The casing for binding modes is different depending on whether they appear as a **binding command** or as a **binding behavior**. Because HTML is case-insensitive, binding commands cannot use capitals. Thus, when specified in this place, the binding modes use lowercase, dashed names. However, when used within a binding expression as a binding behavior, they must not use a dash because that is not a valid symbol for variable names in JavaScript. So, in this case, camel casing is used.
 {% endhint %}
 
 ## Self
@@ -184,7 +184,7 @@ For example, in the following markup
 
 **Self-binding behavior**
 
-```html
+```HTML
 <panel>
   <header mousedown.delegate='onMouseDown($event)' ref='header'>
     <button>Settings</button>
@@ -207,7 +207,7 @@ onMouseDown(event) {
 }
 ```
 
-This works, but now business/ component logic is mixed up with DOM event handling, which is not necessary. Using `self` binding behavior can help you achieve the same goal without filling up your methods with unnecessary code:
+This works, but now business/ component logic is mixed up with DOM event handling, which is unnecessary. Using `self` binding behaviour can help you achieve the same goal without filling up your methods with unnecessary code:
 
 **Using self-binding behavior**
 
@@ -234,7 +234,9 @@ onMouseDown(event) {
 
 ## Custom binding behaviors
 
-You can build custom binding behaviors just like you can build value converters. Instead of `toView` and `fromView` methods you'll create `bind(binding, scope, [...args])` and `unbind(binding, scope)` methods. In the bind method you'll add your behavior to the binding and in the unbind method you should clean up whatever you did in the bind method to restore the binding instance to it's original state. The `binding` argument is the binding instance whose behavior you want to change. It's an implementation of the `Binding` interface. The `scope` argument is the binding's data context. It provides access to the model the binding will be bound to via it's `bindingContext` and `overrideContext` properties.
+You can build custom binding behaviors just like you can build value converters. Instead of `toView` and `fromView` methods, you'll create `bind(binding, scope, [...args])` and `unbind(binding, scope)` methods. In the bind method, you'll add your behavior to the binding, and in the unbind method, you should clean up whatever you did in the bind method to restore the binding instance to its original state. 
+
+The `binding` argument is the binding instance whose behavior you want to change. It's an implementation of the `Binding` interface. The `scope` argument is the binding's data context. It provides access to the model the binding will be bound to via its `bindingContext` and `overrideContext` properties.
 
 Here's a custom binding behavior that calls a method on your view model each time the binding's `updateSource` / `updateTarget` and `callSource` methods are invoked.
 
@@ -275,4 +277,90 @@ Here's a custom binding behavior that calls a method on your view model each tim
 <div mousemove.delegate="mouseMove($event) & intercept:myFunc"></div>
 
 <input value.bind="foo & intercept:myFunc">
+```
+
+### Log Binding Behavior
+
+Logs the current binding context to the console whenever the binding updates. This is useful for understanding the data context of a particular binding at runtime.
+
+```typescript
+import { bindingBehavior } from '@aurelia/runtime-HTML';
+import { type IBinding, type Scope } from '@aurelia/runtime';
+
+export class LogBindingContextBehavior {
+  public bind(scope: Scope, binding: IBinding) {
+    const originalUpdateTarget = binding.updateTarget;
+
+    binding.updateTarget = (value) => {
+      console.log('Binding context:', scope.bindingContext);
+      originalUpdateTarget(value);
+    };
+  }
+}
+
+bindingBehavior('logBindingContext')(LogBindingContextBehavior);
+```
+
+```html
+<import from="./log-binding-behavior"></import>
+<input value.bind="name & logBindingContext"></div>
+```
+
+### Tooltip Binding Behavior
+
+Temporarily adds a tooltip to the element, showing the current value of the binding. This can be a quick way to inspect binding values without console logging.
+
+```typescript
+import { bindingBehavior } from '@aurelia/runtime-HTML';
+import { type IBinding, type Scope } from '@aurelia/runtime';
+
+export class InspectBindingBehavior {
+  public bind(scope: Scope, binding: IBinding) {
+    const originalUpdateTarget = binding.updateTarget;
+
+    binding.updateTarget = (value) => {
+      originalUpdateTarget(value);
+      binding.target.title = `Current value: ${value}`;
+    };
+  }
+}
+
+bindingBehavior('inspect')(InspectBindingBehavior);
+```
+
+```html
+<import from="./inspect-binding-behavior"></import>
+<input value.bind="name & inspect"></div>
+```
+
+### Highlight Updates Binding Behavior
+
+This binding behavior will highlight an element by changing its background color temporarily whenever the binding's target value changes. This visual cue can help developers quickly identify which UI parts react to data changes.
+
+```typescript
+import { bindingBehavior } from '@aurelia/runtime-html';
+import { type IBinding, type Scope } from '@aurelia/runtime';
+
+export class HighlightUpdatesBindingBehavior {
+  public bind(scope: Scope, binding: IBinding, highlightColor: string = 'yellow', duration: number = 500) {
+    const originalUpdateTarget = binding.updateTarget;
+
+    binding.updateTarget = (value) => {
+      originalUpdateTarget.call(binding, value);
+      const originalBg = binding.target.style.backgroundColor;
+      
+      binding.target.style.backgroundColor = highlightColor;
+      setTimeout(() => {
+        binding.target.style.backgroundColor = originalBg;
+      }, duration);
+    };
+  }
+}
+
+bindingBehavior('highlightUpdates')(HighlightUpdatesBindingBehavior);
+```
+
+```html
+<import from="./highlight-updates-binding-behavior"></import>
+<div textContent.bind="user.message & highlightUpdates:'lightblue':'1000'"></div>
 ```

--- a/docs/user-docs/templates/binding-behaviors.md
+++ b/docs/user-docs/templates/binding-behaviors.md
@@ -48,7 +48,7 @@ Sometimes, it's desirable to forcefully run the throttled update so that the app
 The `throttle` binding behavior supports this scenario via signal. These signals can be added via the 2nd parameter, like the following example:
 
 {% code title="my-app.html" lineNumbers="true" overflow="wrap" %}
-```HTML
+```html
 <input value.bind="value & throttle :200 :`finishTyping`" blur.trigger="signaler.dispatchSignal('finishTyping')">
 <!-- or it can be a list of signals -->
 <input value.bind="value & throttle :200 :[`finishTyping`, `newUpdate`]">
@@ -173,7 +173,7 @@ There are also binding behaviors for `toView` and `twoWay` which you could use l
 ```
 
 {% hint style="warning" %}
-The casing for binding modes is different depending on whether they appear as a **binding command** or as a **binding behavior**. Because HTML is case-insensitive, binding commands cannot use capitals. Thus, when specified in this place, the binding modes use lowercase, dashed names. However, when used within a binding expression as a binding behavior, they must not use a dash because that is not a valid symbol for variable names in JavaScript. So, in this case, camel casing is used.
+The casing for binding modes differs depending on whether they appear as a **binding command** or as a **binding behavior**. Because HTML is case-insensitive, binding commands cannot use capitals. Thus, when specified in this place, the binding modes use lowercase, dashed names. However, when used within a binding expression as a binding behavior, they must not use a dash because that is not a valid symbol for variable names in JavaScript. So, in this case, camel casing is used.
 {% endhint %}
 
 ## Self
@@ -184,7 +184,7 @@ For example, in the following markup
 
 **Self-binding behavior**
 
-```HTML
+```html
 <panel>
   <header mousedown.delegate='onMouseDown($event)' ref='header'>
     <button>Settings</button>
@@ -193,7 +193,7 @@ For example, in the following markup
 </panel>
 ```
 
-`onMouseDown` is your event handler, and it will be called not only when user `mousedown` on header element, but also all elements inside it, which in this case are the buttons `settings` and `close`. However, this is not always desired behavior. Sometimes you want the component only to react when user clicks on the header itself, not the buttons. To achieve this, `onMouseDown` method needs some modification:
+`onMouseDown` is your event handler, and it will be called not only when user `mousedown` on header element, but also all elements inside it, which in this case are the buttons `settings` and `close`. However, this is not always the desired behaviour. Sometimes, you want the component only to react when the user clicks on the header itself, not the buttons. To achieve this, `onMouseDown` method needs some modification:
 
 **Handler without self-binding behavior**
 
@@ -207,7 +207,7 @@ onMouseDown(event) {
 }
 ```
 
-This works, but now business/ component logic is mixed up with DOM event handling, which is unnecessary. Using `self` binding behaviour can help you achieve the same goal without filling up your methods with unnecessary code:
+This works, but business/ component logic is now mixed up with DOM event handling, which is unnecessary. Using `self` binding behaviour can help you achieve the same goal without filling up your methods with unnecessary code:
 
 **Using self-binding behavior**
 


### PR DESCRIPTION
The binding behavior docs were lacking in the binding behaviors department.