### PR TITLE
fix(popover): properly set attrs and add tests

### DIFF
--- a/packages/__tests__/src/3-runtime-html/input.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/input.spec.ts
@@ -125,4 +125,15 @@ describe('3-runtime-html/input.spec.ts', function () {
 
     assertAttr('input', 'title', null);
   });
+
+  it('sets popover API attrs', function () {
+    const { assertAttr } = createFixture
+      .component({ target: 'a', toggle: 'auto' })
+      // both button and input will be the same so it's fine
+      .html`<input popover="null" popovertarget='\${target}' popovertargetaction=\${toggle}>`
+      .build();
+
+    assertAttr('input', 'popovertarget', 'a');
+    assertAttr('input', 'popovertargetaction', 'auto');
+  });
 });

--- a/packages/runtime-html/src/compiler/attribute-mapper.ts
+++ b/packages/runtime-html/src/compiler/attribute-mapper.ts
@@ -16,10 +16,6 @@ export class AttrMapper {
   private readonly svg = resolve(ISVGAnalyzer);
 
   public constructor() {
-    const popoverApiMapping = {
-      popovertarget: 'popoverTargetElement',
-      popovertargetaction: 'popoverTargetAction'
-    };
     this.useMapping({
       LABEL: { for: 'htmlFor' },
       IMG: { usemap: 'useMap' },
@@ -32,10 +28,8 @@ export class AttrMapper {
         formnovalidate: 'formNoValidate',
         formtarget: 'formTarget',
         inputmode: 'inputMode',
-        ...popoverApiMapping
       },
       TEXTAREA: { maxlength: 'maxLength' },
-      BUTTON: { ...popoverApiMapping },
       TD: { rowspan: 'rowSpan', colspan: 'colSpan' },
       TH: { rowspan: 'rowSpan', colspan: 'colSpan' },
     });
@@ -106,13 +100,6 @@ export class AttrMapper {
    * Retrieves the mapping information this mapper have for an attribute on an element
    */
   public map(node: Element, attr: string): string | null {
-    /* istanbul-ignore-next */
-    if (__DEV__) {
-      if ((attr === 'popovertarget' || attr === 'popovertargetaction') && node.nodeName !== 'INPUT' && node.nodeName !== 'BUTTON') {
-        // eslint-disable-next-line no-console
-        console.warn(`[aurelia] Popover API are only valid on <input> or <button>. Detected ${attr} on <${node.nodeName.toLowerCase()}>`);
-      }
-    }
     return this._tagAttrMap[node.nodeName]?.[attr] as string
       ?? this._globalAttrMap[attr]
       ?? (isDataAttribute(node, attr, this.svg)

--- a/packages/runtime-html/src/observation/observer-locator.ts
+++ b/packages/runtime-html/src/observation/observer-locator.ts
@@ -250,6 +250,15 @@ export class NodeObserverLocator implements INodeObserverLocator {
       case 'size':
       case 'pattern':
       case 'title':
+      case 'popovertarget':
+      case 'popovertargetaction':
+        /* istanbul-ignore-next */
+        if (__DEV__) {
+          if ((key === 'popovertarget' || key === 'popovertargetaction') && obj.nodeName !== 'INPUT' && obj.nodeName !== 'BUTTON') {
+            // eslint-disable-next-line no-console
+            console.warn(`[aurelia] Popover API are only valid on <input> or <button>. Detected ${key} on <${obj.nodeName.toLowerCase()}>`);
+          }
+        }
         // assigning null/undefined to size on input is an error
         // though it may be fine on other elements.
         // todo: make an effort to distinguish properties based on element name

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -288,6 +288,12 @@ export function createFixture<T extends object>(
       return Promise.resolve(this);
     }
 
+    public printHtml(): string {
+      const html = host.innerHTML;
+      console.log(html);
+      return html;
+    }
+
     public getBy = getBy;
     public getAllBy = getAllBy;
     public queryBy = queryBy;
@@ -330,6 +336,11 @@ export interface IFixture<T> {
   tearDown(): void | Promise<void>;
   stop(dispose?: boolean): void | Promise<void>;
   readonly started: Promise<IFixture<T>>;
+
+  /**
+   * Print to console and return the innerHTML of the current application
+   */
+  printHtml(): string;
 
   /**
    * Returns the first element that is a descendant of node that matches selectors, and throw if there is more than one, or none found


### PR DESCRIPTION
## 📖 Description

in a previous PR, mapping was used so properties are used instead of attr. But attr is more flexible and less restrictive than properties for popover API, so change it. Add tests.