### PR TITLE
Add development subpath to package exports (#1856)

### DIFF
--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -5,10 +5,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/compat-v1/package.json
+++ b/packages/compat-v1/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/router-html/package.json
+++ b/packages/router-html/package.json
@@ -5,10 +5,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/router-lite/package.json
+++ b/packages/router-lite/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/ui-virtualization/package.json
+++ b/packages/ui-virtualization/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -4,10 +4,17 @@
   "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.mjs",
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "require": "./dist/cjs/index.cjs",
-    "import": "./dist/esm/index.mjs",
-    "development": "./dist/esm/index.dev.mjs"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/esm/index.mjs",
+      "development": "./dist/esm/index.dev.mjs"
+    },
+    "./development": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.dev.cjs",
+      "import": "./dist/esm/index.dev.mjs"
+    }
   },
   "types": "dist/types/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description
This adds a "./development" subpath to all packages under "/packages" so that dev builds can be directly imported in nodejs without using a bundler:
```js
import { ... } from "@aurelia/runtime/development";
```

### 🎫 Issues
+ #1856

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
