### PR TITLE
fix(router): store root/default page instruction correctly

### DIFF
--- a/packages/__e2e__/router/src/app.html
+++ b/packages/__e2e__/router/src/app.html
@@ -10,8 +10,8 @@
   <a load="child">Child</a>
   <a load="something/missing">Something missing</a>
 
-  <a load="pages/one-route">Pages one-route</a>
-  <a load="pages/two-route">Pages two-route</a>
+  <a id="page-one-link" load="pages/one-route">Pages one-route</a>
+  <a id="page-two-link" load="pages/two-route">Pages two-route</a>
 </nav>
 
 <au-viewport id="root-vp" name="root-vp" fallback="fallback" fallback-action="abort"></au-viewport>

--- a/packages/__e2e__/router/src/router-configured.spec.ts
+++ b/packages/__e2e__/router/src/router-configured.spec.ts
@@ -80,4 +80,79 @@ test.describe('router', () => {
     await expect(page.locator('#child-auth-link')).toHaveAttribute('href', 'auth');
     await expect(page.locator('#child-something-missing-link')).toHaveAttribute('href', 'child/something/missing');
   });
+
+  test('from home to auth page, then go back', async ({ page, baseURL }) => {
+    // Home
+    await expect(page.locator('#root-vp')).toHaveText('Home page');
+
+    // Go to Auth
+    await Promise.all([
+      page.waitForURL(`${baseURL}/auth`),
+      page.click('#auth-link'),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/auth`);
+    await expect(page.locator('#root-vp')).toContainText('Auth page');
+
+    // Go to Home using the 'home' url
+    await Promise.all([
+      page.waitForURL(`${baseURL}/`),
+      page.click('#-link'),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/`);
+    await expect(page.locator('#root-vp')).toHaveText('Home page');
+
+    // Go to Auth again
+    await Promise.all([
+      page.waitForURL(`${baseURL}/auth`),
+      page.click('#auth-link'),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/auth`);
+    await expect(page.locator('#root-vp')).toContainText('Auth page');
+
+    // Got to Home using the go back
+    await Promise.all([
+      page.waitForURL(`${baseURL}/`),
+      page.goBack(),
+    ]);
+
+    expect(page.url()).toBe(`${baseURL}/`);
+    await expect(page.locator('#root-vp')).toHaveText('Home page');
+  });
+
+  test('from home to component page, then go back', async ({ page, baseURL }) => {
+    // Home
+    await expect(page.locator('#root-vp')).toHaveText('Home page');
+
+    // Go to "one"
+    await Promise.all([
+      page.waitForURL(`${baseURL}/pages/one-route`),
+      page.click('#page-one-link'),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/pages/one-route`);
+    await expect(page.locator('#root-vp')).toContainText('One page');
+
+    // Go to "two"
+    await Promise.all([
+      page.waitForURL(`${baseURL}/pages/two-route`),
+      page.click('#page-two-link'),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/pages/two-route`);
+    await expect(page.locator('#root-vp')).toContainText('Two page');
+
+    // Go back to "one"
+    await Promise.all([
+      page.waitForURL(`${baseURL}/pages/one-route`),
+      page.goBack(),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/pages/one-route`);
+    await expect(page.locator('#root-vp')).toContainText('One page');
+
+    // Go back to "home"
+    await Promise.all([
+      page.waitForURL(`${baseURL}/`),
+      page.goBack(),
+    ]);
+    expect(page.url()).toBe(`${baseURL}/`);
+    await expect(page.locator('#root-vp')).toContainText('Home page');
+  });
 });

--- a/packages/__tests__/src/router/router.spec.ts
+++ b/packages/__tests__/src/router/router.spec.ts
@@ -1949,6 +1949,8 @@ describe('router/router.spec.ts', function () {
             await $goBack(router, platform);
             assert.strictEqual(host.textContent, '!root!', '8) back to root default content');
             assert.strictEqual(locationPath, '/', '8) back to root default path');
+
+            await $teardown();
           });
         }
       });

--- a/packages/__tests__/src/router/router.spec.ts
+++ b/packages/__tests__/src/router/router.spec.ts
@@ -1885,10 +1885,10 @@ describe('router/router.spec.ts', function () {
       {
         useUrlFragmentHash: false,
       }
-    ]
-    
+    ];
+
     for (const routerConfig of routerConfigs) {
-      describe(`With router config ${JSON.stringify(routerConfig)}`, () => {
+      describe(`With router config ${JSON.stringify(routerConfig)}`, function () {
         let locationPath: string;
         const locationCallback = (type, data, title, path) => {
           if (routerConfig.useUrlFragmentHash) {
@@ -1904,35 +1904,35 @@ describe('router/router.spec.ts', function () {
         for (const test of tests) {
           it(`to route in canLoad (${test.load})`, async function () {
             const { platform, host, router, $teardown } = await $setup(routerConfig, [DefaultPage, Zero, One, Two, Three, Four], routes, locationCallback);
-    
+
             // 0) Default root page
             assert.strictEqual(host.textContent, '!root!', '0) root default page');
             assert.strictEqual(locationPath, '/', '0) root path');
-    
+
             // 1) The default root page will be loaded at the beginning, so we do "minus" to clear the page/content.
             await $load('-', router, platform);
             await platform.domWriteQueue.yield();
             assert.strictEqual(host.textContent, '', `1) ${test.load} -`);
             assert.strictEqual(locationPath, '/', `1) ${test.load} - path`);
-    
+
             // 2) Load the wanted page
             await $load(test.load, router, platform);
             await platform.domWriteQueue.yield();
             assert.strictEqual(host.textContent, test.result, `2) ${test.load}`);
             assert.strictEqual(locationPath, test.path, `2) ${test.load} path`);
-    
+
             // 3) Unload
             await $load('-', router, platform);
             await platform.domWriteQueue.yield();
             assert.strictEqual(host.textContent, '', `3) ${test.load} -`);
             assert.strictEqual(locationPath, '/', `3) ${test.load} - path`);
-    
+
             // 4) reload
             await $load(test.load, router, platform);
             await platform.domWriteQueue.yield();
             assert.strictEqual(host.textContent, test.result, `4) ${test.load}`);
             assert.strictEqual(locationPath, test.path, `4) ${test.load} path`);
-    
+
             // 5. back to (3) empty
             await $goBack(router, platform);
             assert.strictEqual(host.textContent, '', `5) back to empty content (-)`);
@@ -1949,8 +1949,6 @@ describe('router/router.spec.ts', function () {
             await $goBack(router, platform);
             assert.strictEqual(host.textContent, '!root!', '8) back to root default content');
             assert.strictEqual(locationPath, '/', '8) back to root default path');
-  
-    
           });
         }
       });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -22,6 +22,7 @@ import { NavigationCoordinator } from './navigation-coordinator';
 import { Runner, Step } from './utilities/runner';
 import { Title } from './title';
 import { RoutingHook } from './routing-hook';
+import { FoundRoute } from './found-route';
 import { IRouterConfiguration } from './index';
 
 /**
@@ -800,7 +801,13 @@ export class Router implements IRouter {
     navigation.path = basePath + (state as string) + query + fragment;
     // }
 
-    const fullViewportStates = [RoutingInstruction.create(RoutingInstruction.clear(this)) as RoutingInstruction];
+    const fullViewportStates: RoutingInstruction[] = [];
+    // Handle default / root page, because "-" + "" = "-" (so just a "clear")
+    const targetRoute = instructions.length === 1 ? instructions[0].route : null;
+    if (!(targetRoute != null && ((typeof targetRoute === 'string' && targetRoute === '') || ((targetRoute as FoundRoute).matching === '')))) {
+      fullViewportStates.push(RoutingInstruction.create(RoutingInstruction.clear(this)) as RoutingInstruction);
+    }
+
     fullViewportStates.push(...RoutingInstruction.clone(instructions, this.statefulHistory));
     navigation.fullStateInstruction = fullViewportStates;
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->
When a user used the browser's "back" button, the root ("/") default page was not correctly reloaded.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolves #1812.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->
In the current code (without this PR), all routing instructions are always prepended with `-` (`updateNavigation`).

The issue is due to a simple fact: `-` + ` ` *(empty)* equals `-`. And `-` *(minus)* is used to **clear** the current path/page. Thus, when we navigate to `/`, then to another page, the root page is lost and replaced by `-`.


My current fix simply checks whether the instruction is empty, and if so, it prevent the clear instruction to be added.


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
- Added new e2e tests for this specific case.
- Updated the existing tests to reflect a more realistic navigation flow.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
