### PR TITLE
fix(runtime-html): template wrapping 

### DIFF
--- a/packages/__tests__/src/3-runtime-html/template-compiler.ce_and_surrogate.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.ce_and_surrogate.spec.ts
@@ -133,6 +133,96 @@ describe('3-runtime-html/template-compiler.ce_and_surrogate.spec.ts', function (
       }
     },
     {
+      title: 'Basic surrogate with text nodes and template',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: 'before <template>ignored</template> after'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'before after');
+      }
+    },
+    {
+      title: 'Basic surrogate with before text nodes and template',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: 'before <template>ignored</template>'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'before');
+      }
+    },
+    {
+      title: 'Basic surrogate with after text nodes and template',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: '<template>ignored</template> after'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'after');
+      }
+    },
+    {
+      title: 'Basic surrogate with text nodes and template',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: 'before <div>foo</div> after'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'before foo after');
+      }
+    },
+    {
+      title: 'Basic surrogate with before text nodes and template',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: 'before <div>foo</div>'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'before foo');
+      }
+    },
+    {
+      title: 'Basic surrogate with after text nodes and element',
+      template: '<foo>',
+      resources: [
+        CustomElement.define(
+          {
+            name: 'foo',
+            template: '<div>foo</div> after'
+          }
+        )
+      ],
+      assertFn: (ctx, host, _comp) => {
+        assert.html.textContent(host, 'foo after');
+      }
+    },
+    {
       title: 'Basic surrogate [style] merge scenario',
       template: '<foo style="height: 100px;">',
       resources: [

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -77,8 +77,7 @@ export class TemplateElementFactory {
       const prevSibling = node.previousSibling;
       if (prevSibling != null) {
         switch (prevSibling.nodeType) {
-          case 1: // Element
-            return true;
+          // The previous sibling cannot be an element, because the node is the first element in the template.
           case 3: // Text
             return prevSibling.textContent!.trim().length > 0;
         }

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -65,8 +65,15 @@ export class TemplateElementFactory {
     function needsWrapping(node: Element | null | undefined): boolean {
       if (node == null) return true;
       if (node.nodeName !== 'TEMPLATE') return true;
+
       // At this point the node is a template element.
       // If the template has meaningful siblings, then it needs wrapping.
+
+      // low-hanging fruit: check the next element sibling
+      const nextElementSibling = node.nextElementSibling;
+      if (nextElementSibling != null) return true;
+
+      // check the previous sibling
       const prevSibling = node.previousSibling;
       if (prevSibling != null) {
         switch (prevSibling.nodeType) {
@@ -81,8 +88,7 @@ export class TemplateElementFactory {
       const nextSibling = node.nextSibling;
       if (nextSibling != null) {
         switch (nextSibling.nodeType) {
-          case 1: // Element
-            return true;
+          // element is already checked above
           case 3: // Text
             return nextSibling.textContent!.trim().length > 0;
         }

--- a/packages/runtime-html/src/compiler/template-element-factory.ts
+++ b/packages/runtime-html/src/compiler/template-element-factory.ts
@@ -36,13 +36,13 @@ export class TemplateElementFactory {
         const node = template.content.firstElementChild;
         // if the input is either not wrapped in a template or there is more than one node,
         // return the whole template that wraps it/them (and create a new one for the next input)
-        if (node == null || node.nodeName !== 'TEMPLATE' || node.nextElementSibling != null) {
+        if (needsWrapping(node)) {
           this._template = this.t();
           result = template;
         } else {
           // the node to return is both a template and the only node, so return just the node
           // and clean up the template for the next input
-          template.content.removeChild(node);
+          template.content.removeChild(node!);
           result = node as HTMLTemplateElement;
         }
 
@@ -61,5 +61,35 @@ export class TemplateElementFactory {
     // do any other processing
     input.parentNode?.removeChild(input);
     return input.cloneNode(true) as HTMLTemplateElement;
+
+    function needsWrapping(node: Element | null | undefined): boolean {
+      if (node == null) return true;
+      if (node.nodeName !== 'TEMPLATE') return true;
+      // At this point the node is a template element.
+      // If the template has meaningful siblings, then it needs wrapping.
+      const prevSibling = node.previousSibling;
+      if (prevSibling != null) {
+        switch (prevSibling.nodeType) {
+          case 1: // Element
+            return true;
+          case 3: // Text
+            return prevSibling.textContent!.trim().length > 0;
+        }
+      }
+
+      // the previous sibling was not meaningful, so check the next sibling
+      const nextSibling = node.nextSibling;
+      if (nextSibling != null) {
+        switch (nextSibling.nodeType) {
+          case 1: // Element
+            return true;
+          case 3: // Text
+            return nextSibling.textContent!.trim().length > 0;
+        }
+      }
+
+      // neither the previous nor the next sibling was meaningful, hence the template does not need wrapping
+      return false;
+    }
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the template wrapping for following templates:

```html
before
<template></template>
after
```

For this template, only the `template` element is considered, and the rest is ignored. This PR ensures that the whole template is wrapped with a `template` element.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
