### PR TITLE
fix(validation): evaluation of tagged rules from bindings

### DIFF
--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -1487,24 +1487,24 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
 
       const controller = component.controller;
 
-      let result = await controller.validate(ValidateInstruction.create({ propertyTag: 't1' }));
+      let result = await controller.validate({ propertyTag: 't1' });
       assert.strictEqual(result.valid, false, 'result.valid1');
       let results = result.results.filter(x => !x.valid);
       assert.strictEqual(results.every(x => x.propertyName === 'name'), true, 'results.every(x => x.propertyName === \'name\')');
 
       component.person.name = 'foo';
-      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't1' }));
+      result = await controller.validate({ propertyTag: 't1' });
       assert.strictEqual(result.valid, true, 'result.valid2');
       results = result.results.filter(x => !x.valid);
       assert.strictEqual(results.length, 0, 'results.length2');
 
-      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't2' }));
+      result = await controller.validate({ propertyTag: 't2' });
       assert.strictEqual(result.valid, false, 'result.valid3');
       results = result.results.filter(x => !x.valid);
       assert.strictEqual(results.every(x => x.propertyName === 'age'), true, 'results.every(x => x.propertyName === \'age\')');
 
       component.person.age = 42;
-      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't2' }));
+      result = await controller.validate({ propertyTag: 't2' });
       assert.strictEqual(result.valid, true, 'result.valid4');
       results = result.results.filter(x => !x.valid);
       assert.strictEqual(results.length, 0, 'results.length4');

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -1509,6 +1509,18 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
       results = result.results.filter(x => !x.valid);
       assert.strictEqual(results.length, 0, 'results.length4');
 
+      assert.strictEqual((await controller.validate()).valid, true, 'await controller.validate()');
+
+      component.person.name = (void 0)!;
+      component.person.age = (void 0)!;
+      result = await controller.validate();
+      assert.strictEqual(result.valid, false, 'result.valid5');
+      assert.deepStrictEqual(
+        result.results.map(x => [x.propertyName, x.valid]),
+        [['name', false], ['age', false]],
+        'result.results.every(x => !x.valid)'
+      );
+
       await stop(true);
     });
   });

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -19,8 +19,8 @@ import {
   INode,
   Aurelia,
 } from '@aurelia/runtime-html';
-import { assert, createSpy, ISpy, TestContext } from '@aurelia/testing';
-import { IValidationRules, PropertyRule, RangeRule, RequiredRule } from '@aurelia/validation';
+import { assert, createFixture, createSpy, ISpy, TestContext } from '@aurelia/testing';
+import { IValidationRules, PropertyRule, RangeRule, RequiredRule, ValidateInstruction } from '@aurelia/validation';
 import {
   BindingWithBehavior,
   IValidationController,
@@ -1448,6 +1448,68 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
       ctx.doc.body.removeChild(host);
 
       au.dispose();
+    });
+
+    it('tagged rules works with binding behavior', async function () {
+
+      class App {
+        public person: Person = new Person((void 0)!, (void 0)!);
+
+        public constructor(
+          @newInstanceOf(IValidationController) public readonly controller: ValidationController,
+          @IValidationRules private readonly validationRules: IValidationRules,
+        ) {
+          validationRules
+            .on(this.person)
+
+            .ensure('name')
+            .required()
+            .tag('t1')
+
+            .ensure('age')
+            .required()
+            .tag('t2')
+            ;
+        }
+
+        public unbinding() {
+          this.validationRules.off();
+        }
+      }
+
+      const { startPromise, stop, component } = createFixture(
+        '<input id="target-name" type="text" value.two-way="person.name & validate:undefined:controller"><input id="target-age" type="text" value.two-way="person.age & validate:undefined:controller">',
+        App,
+        [ValidationHtmlConfiguration]
+      );
+
+      await startPromise;
+
+      const controller = component.controller;
+
+      let result = await controller.validate(ValidateInstruction.create({ propertyTag: 't1' }));
+      assert.strictEqual(result.valid, false, 'result.valid1');
+      let results = result.results.filter(x => !x.valid);
+      assert.strictEqual(results.every(x => x.propertyName === 'name'), true, 'results.every(x => x.propertyName === \'name\')');
+
+      component.person.name = 'foo';
+      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't1' }));
+      assert.strictEqual(result.valid, true, 'result.valid2');
+      results = result.results.filter(x => !x.valid);
+      assert.strictEqual(results.length, 0, 'results.length2');
+
+      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't2' }));
+      assert.strictEqual(result.valid, false, 'result.valid3');
+      results = result.results.filter(x => !x.valid);
+      assert.strictEqual(results.every(x => x.propertyName === 'age'), true, 'results.every(x => x.propertyName === \'age\')');
+
+      component.person.age = 42;
+      result = await controller.validate(ValidateInstruction.create({ propertyTag: 't2' }));
+      assert.strictEqual(result.valid, true, 'result.valid4');
+      results = result.results.filter(x => !x.valid);
+      assert.strictEqual(results.length, 0, 'results.length4');
+
+      await stop(true);
     });
   });
 });

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -20,7 +20,7 @@ import {
   Aurelia,
 } from '@aurelia/runtime-html';
 import { assert, createFixture, createSpy, ISpy, TestContext } from '@aurelia/testing';
-import { IValidationRules, PropertyRule, RangeRule, RequiredRule, ValidateInstruction } from '@aurelia/validation';
+import { IValidationRules, PropertyRule, RangeRule, RequiredRule } from '@aurelia/validation';
 import {
   BindingWithBehavior,
   IValidationController,

--- a/packages/validation/src/validator.ts
+++ b/packages/validation/src/validator.ts
@@ -22,17 +22,6 @@ export class ValidateInstruction<TObject extends IValidateable = IValidateable> 
     public objectTag: string = (void 0)!,
     public propertyTag: string = (void 0)!,
   ) { }
-
-  public static create<TObj extends IValidateable = IValidateable>(input: Partial<ValidateInstruction<TObj>>): ValidateInstruction<TObj> {
-    if (input instanceof ValidateInstruction) return input;
-    return new ValidateInstruction<TObj>(
-      input.object,
-      input.propertyName,
-      input.rules,
-      input.objectTag,
-      input.propertyTag,
-    );
-  }
 }
 
 export const IValidator = /*@__PURE__*/DI.createInterface<IValidator>('IValidator');

--- a/packages/validation/src/validator.ts
+++ b/packages/validation/src/validator.ts
@@ -22,6 +22,17 @@ export class ValidateInstruction<TObject extends IValidateable = IValidateable> 
     public objectTag: string = (void 0)!,
     public propertyTag: string = (void 0)!,
   ) { }
+
+  public static create<TObj extends IValidateable = IValidateable>(input: Partial<ValidateInstruction<TObj>>): ValidateInstruction<TObj> {
+    if (input instanceof ValidateInstruction) return input;
+    return new ValidateInstruction<TObj>(
+      input.object,
+      input.propertyName,
+      input.rules,
+      input.objectTag,
+      input.propertyTag,
+    );
+  }
 }
 
 export const IValidator = /*@__PURE__*/DI.createInterface<IValidator>('IValidator');


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the issue where a validate instruction with tags is used to validate the bindings. So far, such tags are ignored while collecting the rules from all the bindings. That results in validating all the bindings, irrespective of the tags provided with the instruction. This PR fixes that issue.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
