### PR TITLE
fix(au-slot): properly handle nested projection registration

### DIFF
--- a/examples/helloworld/package.json
+++ b/examples/helloworld/package.json
@@ -9,7 +9,6 @@
   "version": "2.0.0-alpha.15",
   "scripts": {
     "build": "rollup -c",
-    "serve": "node ../../node_modules/@aurelia/http-server/dist/esm/cli.js au.conf.js",
     "build:kernel": "cd ../../packages/kernel && npm run build",
     "build:runtime": "cd ../../packages/runtime && npm run build",
     "build:runtime-html": "cd ../../packages/runtime-html && npm run build",

--- a/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
@@ -34,7 +34,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><div></div>',
-        class App {},
+        class App { },
         [El,]
       );
 
@@ -53,7 +53,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       const { assertText } = createFixture(
         // projecting 3 divs to 2 different slots
         '<el><div au-slot="1"></div><div></div><div></div>',
-        class App {},
+        class App { },
         [El,]
       );
 
@@ -270,7 +270,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       const { assertText } = createFixture(
         // projecting 3 divs to 2 different slots
         '<el><div au-slot="1"></div><div></div><div></div>',
-        class App {},
+        class App { },
         [El,]
       );
 
@@ -288,7 +288,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><div au-slot="1"></div>',
-        class App {},
+        class App { },
         [El,]
       );
 
@@ -300,7 +300,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot>'
       })
-      class Parent {}
+      class Parent { }
 
       @customElement({
         name: 'el',
@@ -312,7 +312,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent><div></div>',
-        class App {},
+        class App { },
         [Parent, El]
       );
 
@@ -324,7 +324,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot><div>'
       })
-      class Parent {}
+      class Parent { }
 
       @customElement({
         name: 'el',
@@ -336,7 +336,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App {},
+        class App { },
         [Parent, El]
       );
 
@@ -348,7 +348,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot au-slot=1><input><input>'
       })
-      class Parent {}
+      class Parent { }
 
       @customElement({
         name: 'el',
@@ -360,7 +360,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App {},
+        class App { },
         [Parent, El]
       );
 
@@ -378,7 +378,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><input></el> | <el><input><input>',
-        class App {},
+        class App { },
         [El]
       );
 
@@ -390,7 +390,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><input></el> | <el><input><input>'
       })
-      class Parent {}
+      class Parent { }
       @customElement({
         name: 'el',
         template: 'inputs count: ${inputs.length}<au-slot></au-slot><div>'
@@ -401,7 +401,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App {},
+        class App { },
         [Parent, El]
       );
 
@@ -532,7 +532,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         template: '<button click.trigger="show = true"></button><el><input></el> | <el><input><input>' +
           '<template if.bind="show"><input>'
       })
-      class Parent {}
+      class Parent { }
       @customElement({
         name: 'el',
         template: 'inputs count: ${inputs.length}<au-slot></au-slot><div>'
@@ -543,7 +543,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText, trigger, flush } = createFixture(
         '<parent>',
-        class App {},
+        class App { },
         [Parent, El]
       );
 
@@ -592,7 +592,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         `<modal-basic>
           <div au-slot=test>from \${$host.msg}</div>
         `,
-        class {},
+        class { },
         [CustomElement.define({
           name: 'modal-basic',
           shadowOptions: { mode: 'open' },
@@ -611,7 +611,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       `<modal-basic>
         hi <div au-slot=test>from \${$host.msg}</div>
       `,
-      class {},
+      class { },
       [CustomElement.define({
         name: 'modal-basic',
         shadowOptions: { mode: 'open' },

--- a/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
@@ -34,7 +34,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><div></div>',
-        class App { },
+        class App {},
         [El,]
       );
 
@@ -53,7 +53,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       const { assertText } = createFixture(
         // projecting 3 divs to 2 different slots
         '<el><div au-slot="1"></div><div></div><div></div>',
-        class App { },
+        class App {},
         [El,]
       );
 
@@ -270,7 +270,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       const { assertText } = createFixture(
         // projecting 3 divs to 2 different slots
         '<el><div au-slot="1"></div><div></div><div></div>',
-        class App { },
+        class App {},
         [El,]
       );
 
@@ -288,7 +288,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><div au-slot="1"></div>',
-        class App { },
+        class App {},
         [El,]
       );
 
@@ -300,7 +300,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot>'
       })
-      class Parent { }
+      class Parent {}
 
       @customElement({
         name: 'el',
@@ -312,7 +312,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent><div></div>',
-        class App { },
+        class App {},
         [Parent, El]
       );
 
@@ -324,7 +324,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot><div>'
       })
-      class Parent { }
+      class Parent {}
 
       @customElement({
         name: 'el',
@@ -336,7 +336,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App { },
+        class App {},
         [Parent, El]
       );
 
@@ -348,7 +348,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><au-slot au-slot=1><input><input>'
       })
-      class Parent { }
+      class Parent {}
 
       @customElement({
         name: 'el',
@@ -360,7 +360,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App { },
+        class App {},
         [Parent, El]
       );
 
@@ -378,7 +378,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<el><input></el> | <el><input><input>',
-        class App { },
+        class App {},
         [El]
       );
 
@@ -390,7 +390,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         name: 'parent',
         template: '<el><input></el> | <el><input><input>'
       })
-      class Parent { }
+      class Parent {}
       @customElement({
         name: 'el',
         template: 'inputs count: ${inputs.length}<au-slot></au-slot><div>'
@@ -401,7 +401,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText } = createFixture(
         '<parent>',
-        class App { },
+        class App {},
         [Parent, El]
       );
 
@@ -532,7 +532,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         template: '<button click.trigger="show = true"></button><el><input></el> | <el><input><input>' +
           '<template if.bind="show"><input>'
       })
-      class Parent { }
+      class Parent {}
       @customElement({
         name: 'el',
         template: 'inputs count: ${inputs.length}<au-slot></au-slot><div>'
@@ -543,7 +543,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
 
       const { assertText, trigger, flush } = createFixture(
         '<parent>',
-        class App { },
+        class App {},
         [Parent, El]
       );
 
@@ -592,7 +592,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         `<modal-basic>
           <div au-slot=test>from \${$host.msg}</div>
         `,
-        class { },
+        class {},
         [CustomElement.define({
           name: 'modal-basic',
           shadowOptions: { mode: 'open' },
@@ -611,7 +611,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       `<modal-basic>
         hi <div au-slot=test>from \${$host.msg}</div>
       `,
-      class { },
+      class {},
       [CustomElement.define({
         name: 'modal-basic',
         shadowOptions: { mode: 'open' },

--- a/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
@@ -2260,10 +2260,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
       assert.strictEqual(l3Id, 2, '2 instances of CeL3');
     });
 
-    // not supposed to work since `Foo` is registered on CeL1 container
-    // CeL1 container shouldn't be available to its projection view
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('injects right instance when used together with newInstance & newInstanceForScope', function () {
+    it('injects right instance when used together with newInstance & newInstanceForScope', function () {
 
       class Foo {
         private static id: number = 0;

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -426,6 +426,13 @@ export class Container implements IContainer {
     disposableResolvers.clear();
   }
 
+  public useResources(container: Container): void {
+    const res = container.res;
+    for (const key in res) {
+      this.registerResolver(key, res[key]!);
+    }
+  }
+
   public find<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): TDef | null {
     const key = kind.keyFrom(name);
     let resolver = this.res[key];

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -81,6 +81,12 @@ export interface IContainer extends IServiceLocator, IDisposable {
   getFactory<T extends Constructable>(key: T): IFactory<T>;
   createChild(config?: IContainerConfiguration): IContainer;
   disposeResolvers(): void;
+  /**
+   * Register resources from another container, an API for manually registering resources
+   *
+   * This is a semi private API, apps should avoid using it directly
+   */
+  useResources(container: IContainer): void;
   find<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): TDef | null;
   create<TType extends ResourceType, TDef extends ResourceDefinition>(kind: IResourceKind<TType, TDef>, name: string): InstanceType<TType> | null;
 }

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -83,23 +83,6 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       // since we are construction the projection (2) view based on the
       // container of <my-app>, we need to pre-register all information stored
       // in projection (1) into the container created for the projection (2) view
-      // -------------------------------------------
-      //
-      // Another consideration:
-      // if <au-slot> inside <s-2> is not having a projection, or projection (2) doesn't exist
-      // we also need to block inner projection hierarchy of <s-2> template from reaching projection 1
-      // example inner template of <s-2>:
-      // <s-2-1>
-      //  ---projection 1.1---
-      //    <s-2-2>
-      //
-      // without proper blocking, projection (1.1) may accidentally retrieve projection (1) information
-      // blocking is done by registering a null projection context in an <au-slot> without projection
-      //
-      // BUT!!! Blocking doesn't matter, since all projection information is about the host CE
-      // which is always available in the container of the <au-slot> without projection
-      // In the first example template, <au-slot> within <s-2> will always be able to see <s-1>,
-      // or <au-slot> within <s-3> will always be able to see <s-2>
 
       projectionContext = resolve(optional(IProjectionContext));
       container = hdrContext.parent!.controller.container.createChild(inheritParentResourcesOptions);
@@ -108,16 +91,13 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
         //
         // also need to build the current context
         //
-        projectionContext = new ProjectionContext(contextController, projectionContext ?? null)
+        projectionContext = new ProjectionContext(contextController, projectionContext ?? noProjection)
       );
-      projections.forEach(p => {
-        const controller = p._controller;
-        registerResolver(
-          container,
-          controller.definition.Type,
-          new InstanceProvider(void 0, controller.viewModel)
-        );
-      });
+      projections.forEach(p => registerResolver(
+        container,
+        p._controller.definition.Type,
+        new InstanceProvider(void 0, p._controller.viewModel)
+      ));
       registerResolver(
         container,
         IProjectionContext,

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -84,8 +84,8 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       // container of <my-app>, we need to pre-register all information stored
       // in projection (1) into the container created for the projection (2) view
 
-      projectionContext = resolve(optional(IProjectionContext));
       container = hdrContext.parent!.controller.container.createChild(inheritParentResourcesOptions);
+      projectionContext = resolve(optional(IProjectionContext));
       projections = projectionContext != null ? resolveProjections(projectionContext) : [];
       projections.unshift(
         //
@@ -282,7 +282,6 @@ const noProjection = new ProjectionContext(null!, null);
 const inheritParentResourcesOptions = { inheritParentResources: true };
 
 const resolveProjections = (context: IProjectionContext) => {
-  // walk up the context hierarchy and get all controllers
   const projections = [];
   let curr: IProjectionContext | null = context;
   while (curr != null && curr !== noProjection) {

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -83,8 +83,10 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       // since we are construction the projection (2) view based on the
       // container of <my-app>, we need to pre-register all information stored
       // in projection (1) into the container created for the projection (2) view
+      // -------------------------------------------
       //
-      // but if <au-slot> inside <s-2> is not having a projection, or projection (2) doesn't exist
+      // Another consideration:
+      // if <au-slot> inside <s-2> is not having a projection, or projection (2) doesn't exist
       // we also need to block inner projection hierarchy of <s-2> template from reaching projection 1
       // example inner template of <s-2>:
       // <s-2-1>

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -121,11 +121,6 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
         IProjectionContext,
         new InstanceProvider(void 0, projectionContext)
       );
-      registerResolver(
-        container,
-        contextController.definition.Type,
-        new InstanceProvider(void 0, contextController.viewModel)
-      );
       factory = rendering.getViewFactory(projection, container);
       this._hasProjection = true;
       this._slotwatchers = contextController.container.getAll(IAuSlotWatcher, false)?.filter(w => w.slotName === '*' || w.slotName === slotInfo.name) ?? emptyArray;


### PR DESCRIPTION
## 📖 Description

Currently in nested projection, the container hierarchy does not have all information related to projector and projection context making it unable to resolve the right instances of projectors. This PR fix this.

## 📑 Test Plan

Added a test based on reported case from related PR with slightly more complicated usage.

- close #1873
- close #1874