### PR TITLE
fix(portal): remove target marker when deactivated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ executors:
     parameters:
       node:
         type: string
-        default: "18.18.1"
+        default: "18.19.0"
     working_directory: *working_dir
     resource_class: large
     docker:
@@ -73,13 +73,13 @@ executors:
     working_directory: *working_dir
     resource_class: large
     docker:
-      - image: "cimg/node:18.18.1"
+      - image: "cimg/node:18.19.0"
 
   docker_circleci_bench:
     working_directory: *working_dir
     resource_class: large
     docker:
-      - image: "cimg/node:18.18.1-browsers"
+      - image: "cimg/node:18.19.0-browsers"
 
   docker_playwright_jammy:
     docker:

--- a/packages/__tests__/src/3-runtime-html/portal.spec.tsx
+++ b/packages/__tests__/src/3-runtime-html/portal.spec.tsx
@@ -4,7 +4,6 @@ import { CustomElement, Aurelia } from '@aurelia/runtime-html';
 import {
   assert,
   eachCartesianJoin,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hJsx, // deepscan-disable-line UNUSED_IMPORT
   TestContext,
   createFixture,
@@ -74,6 +73,22 @@ describe('3-runtime-html/portal.spec.tsx', function () {
     );
     component.position = 'beforebegin';
     assertHtml('<!--au-start--><button>click me</button><!--au-end--><div id="d1">hello</div><!--au-start--><!--au-end-->');
+  });
+
+  it('removes location marker when portal is deactivated', function () {
+    const { component, assertHtml } = createFixture(
+      <>
+        <div id="dest"></div>
+        <p id="package" if$bind="open" portal="#dest"></p>
+      </>,
+      { open: false }
+    );
+
+    assertHtml('div', '');
+    component.open = true;
+    assertHtml('div', '<!--au-start--><p id="package"></p><!--au-end-->');
+    component.open = false;
+    assertHtml('div', '');
   });
 
   describe('basic', function () {

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -214,7 +214,10 @@ export class Portal implements ICustomAttributeViewModel {
   ): void | Promise<void> {
     const { deactivated, callbackContext, view } = this;
 
-    return deactivated?.call(callbackContext, target, view);
+    return onResolve(
+      deactivated?.call(callbackContext, target, view),
+      () => this._removeLocation()
+    );
   }
 
   /** @internal */
@@ -255,6 +258,12 @@ export class Portal implements ICustomAttributeViewModel {
     }
 
     return target;
+  }
+
+  /** @internal */
+  private _removeLocation(): void {
+    this._targetLocation.remove();
+    this._targetLocation.$start!.remove();
   }
 
   /** @internal */


### PR DESCRIPTION
## 📖 Description

Currently `Portal` only move the markers around but never remove them when deactivated (like inside an if view) causing left over comments in some nodes. This PR fixes this.

### 🎫 Issues

close #1861