### PR TITLE
fix(templating): custom element takes priority over custom attribute

### DIFF
--- a/packages/__tests__/src/3-runtime-html/custom-elements.harmony.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.harmony.spec.ts
@@ -7,9 +7,11 @@ import {
 } from '@aurelia/runtime-html';
 import {
   assert,
+  createFixture,
   TestContext,
 } from '@aurelia/testing';
 import { isFirefox, isNode } from '../util.js';
+import { resolve } from '@aurelia/kernel';
 
 describe('3-runtime-html/custom-elements.harmony.spec.ts', function () {
   interface IHarmoniousCompilationTestCase {
@@ -304,95 +306,6 @@ describe('3-runtime-html/custom-elements.harmony.spec.ts', function () {
         assert.equal(comp.count, 1);
       },
     },
-    {
-      title: 'props are always camelized',
-      template: '<input type="number" value-as-number.to-view="1">',
-      assertFn: (ctx, host, _comp: { count: number }) => {
-        const input = host.querySelector('input');
-        assert.equal(input.valueAsNumber, 1);
-      },
-    },
-    {
-      title: 'special property valueAsNumber on <input type=number>',
-      template: '<input type="number" value-as-number.bind="count">',
-      browserOnly: true,
-      assertFn: (ctx, host, comp: { count: number }) => {
-        const input = host.querySelector('input');
-        assert.strictEqual(input.valueAsNumber, 0);
-
-        input.valueAsNumber = 5;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, 5);
-
-        input.valueAsNumber = NaN;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, NaN);
-
-        input.valueAsNumber = 'abc' as any;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, NaN);
-
-        // reset first
-        input.valueAsNumber = 0;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, 0);
-
-        // then bogus value
-        comp.count = 'abc' as any;
-        ctx.platform.domWriteQueue.flush();
-        assert.strictEqual(input.valueAsNumber, NaN);
-        // input.valueAsNumber observer does not propagate the value back
-        // this may result in some GH issues
-        assert.strictEqual(comp.count, 'abc', 'comp.count === abc');
-
-        input.value = '123';
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, 123);
-      },
-    },
-    {
-      title: 'special property valueAsNumber on <input type=date>',
-      template: '<input type="date" value-as-number.bind="count">',
-      browserOnly: true,
-      assertFn: (ctx, host, comp: { count: number }) => {
-        const input = host.querySelector('input');
-        assert.strictEqual(input.valueAsNumber, 0);
-
-        // invalid, though not propagating change to view model just yet
-        // because the value of the input hasn't actually been changed in the observer:
-        // when adding the first subscriber, input valueAsNumber observer gets its initial value as 0
-        // so now, it wouldn't detect any change -> comp.count === undefined
-        input.valueAsNumber = 5;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, undefined);
-
-        const todayInMs = new Date(2021, 1, 14).getTime();
-        // when entering a Date, its YYYY-MM-DD format is used to display
-        // unfortunately, this creates a loss, as it's in UTC,
-        // and when converting back to number of Ms, it's different with the input
-        // so calculating the real value here using the string representation of the date in the <input/>
-        // example:       for GMT+11
-        // when enter:    input.valueAsNumber = new Date(2021, 01, 14)
-        // will display:  13/02/2021
-        input.valueAsNumber = todayInMs;
-        const actualReturnedTimeInMs = new Date(input.valueAsDate).getTime();
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(input.valueAsNumber, actualReturnedTimeInMs, 'input[type=date].valueAsNumber === today_in_ms');
-        assert.strictEqual(comp.count, actualReturnedTimeInMs, 'vm.count === today_in_ms');
-
-        input.valueAsNumber = 'abc' as any;
-        input.dispatchEvent(new ctx.CustomEvent('change'));
-        assert.strictEqual(comp.count, NaN, 'comp.count === NaN when input.valueAsNumber is bogus');
-
-        // then bogus value
-        comp.count = 'abc' as any;
-        ctx.platform.domWriteQueue.flush();
-        assert.strictEqual(input.valueAsNumber, NaN);
-        // input.valueAsNumber observer does not propagate the value back
-        // this may result in some GH issues
-        assert.strictEqual(comp.count, 'abc', 'comp.count === abc');
-      },
-    },
   ];
 
   testCases.forEach((testCase, idx) => {
@@ -439,5 +352,31 @@ describe('3-runtime-html/custom-elements.harmony.spec.ts', function () {
         body?.focus();
       }
     });
+  });
+
+  it('gives priority to custom element bindable over custom attribute with the same name', function () {
+    const { assertStyles, printHtml } = createFixture(
+      `<square size.bind="width"></square>`,
+      { width: 10 },
+      [
+        CustomElement.define({ name: 'square', bindables: ['size'] }, class Square {
+          host = resolve(INode) as HTMLElement;
+          size: number;
+          attached() {
+            this.host.style.width = `${this.size}px`;
+          }
+        }),
+        CustomAttribute.define('size', class Size  {
+          value: any;
+          host = resolve(INode) as Element;
+          attached() {
+            this.host.setAttribute('size', this.value);
+          }
+        })
+      ]
+    );
+
+    printHtml();
+    assertStyles('square', { width: '10px' });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/input.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/input.spec.ts
@@ -97,7 +97,7 @@ describe('3-runtime-html/input.spec.ts', function () {
     it('special property valueAsNumber on <input type=date>', function () {
       const { appHost: host, component: comp, ctx } = createFixture(
         `<input type=date value-as-number.bind="count">`,
-        { count: 0 }
+        { count: undefined }
       );
       const input = host.querySelector('input');
       assert.strictEqual(input.valueAsNumber, 0);

--- a/packages/__tests__/src/3-runtime-html/input.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/input.spec.ts
@@ -55,6 +55,87 @@ describe('3-runtime-html/input.spec.ts', function () {
         ctx.platform.domWriteQueue.flush();
       });
     });
+
+    it('special property valueAsNumber on <input type=number> + bad value', function () {
+      const { appHost: host, component: comp, ctx } = createFixture(
+        `<input type=number value-as-number.bind="count">`,
+        { count: 0 }
+      );
+      const input = host.querySelector('input');
+      assert.strictEqual(input.valueAsNumber, 0);
+
+      input.valueAsNumber = 5;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, 5);
+
+      input.valueAsNumber = NaN;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, NaN);
+
+      input.valueAsNumber = 'abc' as any;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, NaN);
+
+      // reset first
+      input.valueAsNumber = 0;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, 0);
+
+      // then bogus value
+      comp.count = 'abc' as any;
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(input.valueAsNumber, NaN);
+      // input.valueAsNumber observer does not propagate the value back
+      // this may result in some GH issues
+      assert.strictEqual(comp.count, 'abc', 'comp.count === abc');
+
+      input.value = '123';
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, 123);
+    });
+
+    it('special property valueAsNumber on <input type=date>', function () {
+      const { appHost: host, component: comp, ctx } = createFixture(
+        `<input type=date value-as-number.bind="count">`,
+        { count: 0 }
+      );
+      const input = host.querySelector('input');
+      assert.strictEqual(input.valueAsNumber, 0);
+
+      // invalid, though not propagating change to view model just yet
+      // because the value of the input hasn't actually been changed in the observer:
+      // when adding the first subscriber, input valueAsNumber observer gets its initial value as 0
+      // so now, it wouldn't detect any change -> comp.count === undefined
+      input.valueAsNumber = 5;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, undefined);
+
+      const todayInMs = new Date(2021, 1, 14).getTime();
+      // when entering a Date, its YYYY-MM-DD format is used to display
+      // unfortunately, this creates a loss, as it's in UTC,
+      // and when converting back to number of Ms, it's different with the input
+      // so calculating the real value here using the string representation of the date in the <input/>
+      // example:       for GMT+11
+      // when enter:    input.valueAsNumber = new Date(2021, 01, 14)
+      // will display:  13/02/2021
+      input.valueAsNumber = todayInMs;
+      const actualReturnedTimeInMs = new Date(input.valueAsDate).getTime();
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(input.valueAsNumber, actualReturnedTimeInMs, 'input[type=date].valueAsNumber === today_in_ms');
+      assert.strictEqual(comp.count, actualReturnedTimeInMs, 'vm.count === today_in_ms');
+
+      input.valueAsNumber = 'abc' as any;
+      input.dispatchEvent(new ctx.CustomEvent('change'));
+      assert.strictEqual(comp.count, NaN, 'comp.count === NaN when input.valueAsNumber is bogus');
+
+      // then bogus value
+      comp.count = 'abc' as any;
+      ctx.platform.domWriteQueue.flush();
+      assert.strictEqual(input.valueAsNumber, NaN);
+      // input.valueAsNumber observer does not propagate the value back
+      // this may result in some GH issues
+      assert.strictEqual(comp.count, 'abc', 'comp.count === abc');
+    });
   }
 
   it('works: textarea + value.bind', function () {

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -167,7 +167,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
           });
         });
 
-        it('understands attr precendence: custom attr > element prop', function () {
+        it('understands attr precendence: element prop > custom attr', function () {
           @customElement('el')
           class El {
             @bindable() public prop1: string;
@@ -176,31 +176,30 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
           }
 
           @customAttribute('prop3')
-          class Prop { }
+          class Prop3 { }
 
           const actual = compileWith(
             `<template>
             <el prop1.bind="p" prop2.bind="p" prop3.bind="t" prop3="t"></el>
           </template>`,
-            [El, Prop]
+            [El, Prop3]
           );
+          // only 1 target
           assert.strictEqual(actual.instructions.length, 1, `actual.instructions.length`);
-          assert.strictEqual(actual.instructions[0].length, 3, `actual.instructions[0].length`);
-          const siblingInstructions = actual.instructions[0].slice(1);
-          const expectedSiblingInstructions = [
-            { toVerify: ['type', 'res', 'to'], type: TT.hydrateAttribute, res: CustomAttribute.getDefinition(Prop) },
-            { toVerify: ['type', 'res', 'to'], type: TT.hydrateAttribute, res: CustomAttribute.getDefinition(Prop) }
-          ];
-          verifyInstructions(siblingInstructions, expectedSiblingInstructions);
+          // the target has only 1 instruction, which is hydrate custom element <el>
+          assert.strictEqual(actual.instructions[0].length, 1, `actual.instructions[0].length`);
+
           const rootInstructions = actual.instructions[0][0]['props'];
           const expectedRootInstructions = [
             { toVerify: ['type', 'res', 'to'], type: TT.propertyBinding, to: 'prop1' },
-            { toVerify: ['type', 'res', 'to'], type: TT.propertyBinding, to: 'prop2' }
+            { toVerify: ['type', 'res', 'to'], type: TT.propertyBinding, to: 'prop2' },
+            { toVerify: ['type', 'res', 'to'], type: TT.propertyBinding, to: 'prop3' },
+            { toVerify: ['type', 'res', 'to'], type: TT.setProperty, to: 'prop3' }
           ];
           verifyInstructions(rootInstructions, expectedRootInstructions);
         });
 
-        it('distinguishs element properties / normal attributes', function () {
+        it('distinguishes element properties / normal attributes', function () {
           @customElement('el')
           class El {
 

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -759,7 +759,7 @@ export class TemplateCompiler implements ITemplateCompiler {
                 ? new SetPropertyInstruction(realAttrValue, bindable.name)
                 : new InterpolationInstruction(expr, bindable.name)
             );
-           } else {
+          } else {
             commandBuildInfo.node = el;
             commandBuildInfo.attr = attrSyntax;
             commandBuildInfo.bindable = bindable;

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -543,7 +543,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (__DEV__) {
           // eslint-disable-next-line no-console
           console.warn(
-            `Property ${realAttrTarget} is declared with literal string ${realAttrValue}. ` +
+            `[DEV:aurelia] Property "${realAttrTarget}" is declared with literal string ${realAttrValue}. ` +
             `Did you mean ${realAttrTarget}.bind="${realAttrValue}"?`
           );
         }
@@ -772,6 +772,16 @@ export class TemplateCompiler implements ITemplateCompiler {
           }
 
           removeAttr();
+
+          if (__DEV__) {
+            attrDef = context._findAttr(realAttrTarget);
+            if (attrDef !== null) {
+              // eslint-disable-next-line no-console
+              console.warn(`[DEV:aurelia] Binding with bindable "${realAttrTarget}" on custom element "${elDef.name}" is ambiguous.` +
+                `There is a custom attribute with the same name.`
+              );
+            }
+          }
           continue;
         }
       }
@@ -1506,7 +1516,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (ignoredAttributes.length > 0) {
           if (__DEV__)
             // eslint-disable-next-line no-console
-            console.warn(`The attribute(s) ${ignoredAttributes.map(attr => attr.name).join(', ')} will be ignored for ${bindableEl.outerHTML}. Only ${allowedLocalTemplateBindableAttributes.join(', ')} are processed.`);
+            console.warn(`[DEV:aurelia] The attribute(s) ${ignoredAttributes.map(attr => attr.name).join(', ')} will be ignored for ${bindableEl.outerHTML}. Only ${allowedLocalTemplateBindableAttributes.join(', ')} are processed.`);
         }
 
         bindableEl.remove();

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -541,7 +541,8 @@ export class TemplateCompiler implements ITemplateCompiler {
       expr = exprParser.parse(realAttrValue, etInterpolation);
       if (expr === null) {
         if (__DEV__) {
-          context._logger.warn(
+          // eslint-disable-next-line no-console
+          console.warn(
             `Property ${realAttrTarget} is declared with literal string ${realAttrValue}. ` +
             `Did you mean ${realAttrTarget}.bind="${realAttrValue}"?`
           );
@@ -724,7 +725,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         }
       }
 
-      if (bindingCommand !== null && bindingCommand.type === ctIgnoreAttr) {
+      if (bindingCommand?.type === ctIgnoreAttr) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
         // active.class="..."
@@ -742,11 +743,48 @@ export class TemplateCompiler implements ITemplateCompiler {
         continue;
       }
 
-      // if not a ignore attribute binding command
-      // then process with the next possibilities
+      // reaching here means:
+      // + there may or may not be a binding command, but it won't be an overriding command
+
+      if (isCustomElement) {
+        // if the element is a custom element
+        // - prioritize bindables on a custom element before plain attributes
+        bindablesInfo = BindablesInfo.from(elDef, false);
+        bindable = bindablesInfo.attrs[realAttrTarget];
+        if (bindable !== void 0) {
+          if (bindingCommand === null) {
+            expr = exprParser.parse(realAttrValue, etInterpolation);
+            (elBindableInstructions ??= []).push(
+              expr == null
+                ? new SetPropertyInstruction(realAttrValue, bindable.name)
+                : new InterpolationInstruction(expr, bindable.name)
+            );
+           } else {
+            commandBuildInfo.node = el;
+            commandBuildInfo.attr = attrSyntax;
+            commandBuildInfo.bindable = bindable;
+            commandBuildInfo.def = elDef;
+            (elBindableInstructions ??= []).push(bindingCommand.build(
+              commandBuildInfo,
+              context._exprParser,
+              context._attrMapper
+            ));
+          }
+
+          removeAttr();
+          continue;
+        }
+      }
+
+      // reaching here means:
+      // + there may or may not be a binding command, but it won't be an overriding command
+      // + the attribute is not targeting a bindable property of a custom element
+      //
+      // + maybe it's a custom attribute
+      // + maybe it's a plain attribute
+
+      // check for custom attributes before plain attributes
       attrDef = context._findAttr(realAttrTarget);
-      // when encountering an attribute,
-      // custom attribute takes precedence over custom element bindables
       if (attrDef !== null) {
         bindablesInfo = BindablesInfo.from(attrDef, true);
         // Custom attributes are always in multiple binding mode,
@@ -813,27 +851,11 @@ export class TemplateCompiler implements ITemplateCompiler {
         continue;
       }
 
+      // reaching here means:
+      // + it's a plain attribute
+      // + there may or may not be a binding command, but it won't be an overriding command
+
       if (bindingCommand === null) {
-        // reaching here means:
-        // + maybe a bindable attribute with interpolation
-        // + maybe a plain attribute with interpolation
-        // + maybe a plain attribute
-        if (isCustomElement) {
-          bindablesInfo = BindablesInfo.from(elDef, false);
-          bindable = bindablesInfo.attrs[realAttrTarget];
-          if (bindable !== void 0) {
-            expr = exprParser.parse(realAttrValue, etInterpolation);
-            (elBindableInstructions ??= []).push(
-              expr == null
-                ? new SetPropertyInstruction(realAttrValue, bindable.name)
-                : new InterpolationInstruction(expr, bindable.name)
-            );
-
-            removeAttr();
-            continue;
-          }
-        }
-
         // reaching here means:
         // + maybe a plain attribute with interpolation
         // + maybe a plain attribute
@@ -851,8 +873,6 @@ export class TemplateCompiler implements ITemplateCompiler {
             context._attrMapper.map(el, realAttrTarget) ?? camelCase(realAttrTarget)
           ));
         }
-        // if not a custom attribute + no binding command + not a bindable + not an interpolation
-        // then it's just a plain attribute, do nothing
         continue;
       }
 
@@ -860,30 +880,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       // + has binding command
       // + not an overriding binding command
       // + not a custom attribute
-      removeAttr();
-
-      if (isCustomElement) {
-        // if the element is a custom element
-        // - prioritize bindables on a custom element before plain attributes
-        bindablesInfo = BindablesInfo.from(elDef, false);
-        bindable = bindablesInfo.attrs[realAttrTarget];
-        if (bindable !== void 0) {
-          commandBuildInfo.node = el;
-          commandBuildInfo.attr = attrSyntax;
-          commandBuildInfo.bindable = bindable;
-          commandBuildInfo.def = elDef;
-          (elBindableInstructions ??= []).push(bindingCommand.build(
-            commandBuildInfo,
-            context._exprParser,
-            context._attrMapper
-          ));
-          continue;
-        }
-      }
-
-      // reaching here means:
-      // + a plain attribute
-      // + has binding command
+      // + not a custom element bindable
 
       commandBuildInfo.node = el;
       commandBuildInfo.attr = attrSyntax;
@@ -894,6 +891,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         context._exprParser,
         context._attrMapper
       ));
+      removeAttr();
     }
 
     resetCommandBuildInfo();
@@ -1507,7 +1505,8 @@ export class TemplateCompiler implements ITemplateCompiler {
         const ignoredAttributes = toArray(bindableEl.attributes).filter((attr) => !allowedLocalTemplateBindableAttributes.includes(attr.name));
         if (ignoredAttributes.length > 0) {
           if (__DEV__)
-            context._logger.warn(`The attribute(s) ${ignoredAttributes.map(attr => attr.name).join(', ')} will be ignored for ${bindableEl.outerHTML}. Only ${allowedLocalTemplateBindableAttributes.join(', ')} are processed.`);
+            // eslint-disable-next-line no-console
+            console.warn(`The attribute(s) ${ignoredAttributes.map(attr => attr.name).join(', ')} will be ignored for ${bindableEl.outerHTML}. Only ${allowedLocalTemplateBindableAttributes.join(', ')} are processed.`);
         }
 
         bindableEl.remove();

--- a/packages/runtime/src/observation/scope.ts
+++ b/packages/runtime/src/observation/scope.ts
@@ -105,7 +105,7 @@ export class Scope {
     if (bc == null) {
       throw createMappedError(ErrorNames.create_scope_with_null_context);
     }
-    return new Scope(null, bc as IBindingContext, oc == null ? new OverrideContext() : oc, isBoundary ?? false);
+    return new Scope(null, bc as IBindingContext, oc ?? new OverrideContext(), isBoundary ?? false);
   }
 
   public static fromParent(ps: Scope | null, bc: object): Scope {

--- a/packages/runtime/src/observation/signaler.ts
+++ b/packages/runtime/src/observation/signaler.ts
@@ -19,13 +19,7 @@ export class Signaler {
   }
 
   public addSignalListener(name: string, listener: ISubscriber): void {
-    const signals = this.signals;
-    const listeners = signals[name];
-    if (listeners === undefined) {
-      signals[name] = new Set([listener]);
-    } else {
-      listeners.add(listener);
-    }
+    (this.signals[name] ??= new Set()).add(listener);
   }
 
   public removeSignalListener(name: string, listener: ISubscriber): void {


### PR DESCRIPTION
## 📖 Description

Currently custom attribute is considered before a bindable of custom element, causing unexpected behavior in some cases. This PR tweaks this order and makes element bindable always considered before custom attributes. Also add a warning so that devs can be aware of the name conflict.

### 🎫 Issues

Resolve #1896 