### PR TITLE
fix(di): new instance resolver

### DIFF
--- a/packages/__tests__/src/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.get.spec.ts
@@ -658,15 +658,15 @@ describe('1-kernel/di.get.spec.ts', function () {
   });
 
   describe('@newInstanceForScope', function () {
-    it('jit-registers and instantiates when there is a default impl for an interface', function () {
+    it('instantiates, but does not jit-registers, when there is a default impl for an interface', function () {
       const container = DI.createContainer();
       class Impl {}
       const I = DI.createInterface('I', x => x.singleton(Impl));
       assert.instanceOf(container.get(newInstanceForScope(I)), Impl);
-      assert.strictEqual(container.getAll(I).length, 2);
+      assert.strictEqual(container.getAll(I).length, 1);
     });
 
-    it('jit-registers resolver and instance in child', function () {
+    it('does not jit-registers in parent', function () {
       const container = DI.createContainer();
       const child = container.createChild();
       class Impl {}
@@ -678,7 +678,7 @@ describe('1-kernel/di.get.spec.ts', function () {
       // has resolver, no instance
       // has resolver because createNewInstance/scope auto-registers a resolver
       // no instance because new instance forScope doesn't register on handler
-      assert.strictEqual(container.has(I, false), true);
+      assert.strictEqual(container.has(I, false), false);
     });
     // the following test tests a more common, expected scenario,
     // where some instance is scoped to a child container,

--- a/packages/__tests__/src/fetch-client/fetch-client.spec.ts
+++ b/packages/__tests__/src/fetch-client/fetch-client.spec.ts
@@ -1,4 +1,4 @@
-import { DI, IContainer, resolve } from '@aurelia/kernel';
+import { DI, IContainer, newInstanceForScope, resolve } from '@aurelia/kernel';
 import { HttpClient, HttpClientConfiguration, HttpClientEvent, IHttpClient, json } from '@aurelia/fetch-client';
 import { assert, createFixture } from '@aurelia/testing';
 import { isNode } from '../util.js';
@@ -138,6 +138,14 @@ describe('fetch-client/fetch-client.spec.ts', function () {
       );
     });
 
+    it('resolves to the same instance when injecting IHttpClient then HttpClient', async function () {
+      const { component: { http: client, http2: http2 } } = createFixture('${message}', class App {
+        http = resolve(IHttpClient);
+        http2 = resolve(HttpClient);
+      });
+      assert.strictEqual(client, http2);
+    });
+
     it('works when injecting HttpClient', async function () {
       const { component: { http: client, http2: http2 } } = createFixture('${message}', class App {
         http = resolve(HttpClient);
@@ -148,6 +156,17 @@ describe('fetch-client/fetch-client.spec.ts', function () {
         await client.fetch('/a'),
         { method: 'GET', url: '/a', headers: {} }
       );
+    });
+
+    it('allows injection by newInstanceForScope resolver', function () {
+      const { component: { http, http2 } } = createFixture('${message}', class App {
+        http = resolve(newInstanceForScope(IHttpClient));
+        http2 = resolve(IHttpClient);
+      });
+
+      assert.instanceOf(http, HttpClient);
+      // should be the same instance
+      assert.strictEqual(http, http2);
     });
 
     it('makes requests with full url string inputs', async function () {

--- a/packages/kernel/src/di.ts
+++ b/packages/kernel/src/di.ts
@@ -749,9 +749,18 @@ const createNewInstance = (key: any, handler: IContainer, requestor: IContainer)
   // 2. if key is an interface
   if (isInterface(key)) {
     const hasDefault = isFunction((key as unknown as IRegistry).register);
-    const resolver = handler.getResolver(key, hasDefault) as IResolver<Constructable<typeof key>>;
-    const factory = resolver?.getFactory?.(handler);
-    // 2.1 and has factory
+    const resolver = handler.getResolver(key, false) as IResolver<Constructable<typeof key>>;
+    let factory: IFactory | null | undefined;
+    if (resolver == null) {
+      if (hasDefault) {
+        // creating a child as we do not want to pollute the resolver registry
+        // there may be a better way but wasting a container probably isn't the worst
+        factory = createContainer().getResolver(key, true)?.getFactory?.(handler);
+      }
+    } else {
+      factory = resolver.getFactory?.(handler);
+    }
+    // 2.1 and has resolvable factory
     if (factory != null) {
       return factory.construct(requestor);
     }

--- a/packages/kernel/src/errors.ts
+++ b/packages/kernel/src/errors.ts
@@ -52,7 +52,8 @@ const errorsMap: Record<ErrorNames, string>  = {
     `A common cause is circular dependency with bundler, did you accidentally introduce circular dependency into your module graph?`,
   [ErrorNames.no_construct_native_fn]: `'{{0}}' is a native function and cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.`,
   [ErrorNames.no_active_container_for_resolve]: `There is not a currently active container to resolve "{{0}}". Are you trying to "new Class(...)" that has a resolve(...) call?`,
-  [ErrorNames.invalid_new_instance_on_interface]: `Failed to instantiate '{{0}}' via @newInstanceOf/@newInstanceForScope, there's no registration and no default implementation.`,
+  [ErrorNames.invalid_new_instance_on_interface]: `Failed to instantiate '{{0}}' via @newInstanceOf/@newInstanceForScope, there's no registration and no default implementation,`
+    + ` or the default implementation does not result in factory for constructing the instances.`,
   [ErrorNames.event_aggregator_publish_invalid_event_name]: `Invalid channel name or instance: '{{0}}'.`,
   [ErrorNames.event_aggregator_subscribe_invalid_event_name]: `Invalid channel name or type: {{0}}.`,
   [ErrorNames.first_defined_no_value]: `No defined value found when calling firstDefined()`,

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -60,7 +60,7 @@ export function createFixture<T extends object>(
   const existingDefs = (CustomElement.isType($$class) ? CustomElement.getDefinition($$class) : {}) as CustomElementDefinition;
   const App = CustomElement.define<Constructable<K>>({
     ...existingDefs,
-    name: 'app',
+    name: existingDefs.name ?? 'app',
     template,
   }, $$class);
 


### PR DESCRIPTION
## 📖 Description

Currently the new client resolvers `newInstanceOf`/`newInstanceForScope` are automatically causing a resolver registered whenever they are used on a container with an unregister key. This will cause surprise when child container (from child ce for example) tries to inject the same key, as the actual resolver of the `newInstanceForScope` will be the 2nd resolver registered. Also resolve an issue with `newInstanceOf` + `IHttpClient`.