### PR TITLE
feat(au-compose): ability to compose string as element name

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
+++ b/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
@@ -33,7 +33,27 @@ export class App {
 
 {% hint style="info" %}
 With a custom element as a view model, all standard lifecycles and `activate` will be called during the composition.
+
+`activate` will be called right after `constructor`, before all other lifecycles.
 {% endhint %}
+
+### Composition with string as custom element name
+
+When using a string value for `component` binding on `<au-compose>`, the value will be understood as a custom element name, and will be used to lookup the actual element definition.
+If there's no element definition found either locally or globally, an error will be thrown.
+
+The following usages are valid:
+
+```html
+<import from="./my-input"></import>
+
+<au-compose component="my-input">
+```
+
+or, suppose `my-input` is a globally available custom element:
+```html
+<au-compose component="my-input">
+```
 
 ## Composing Without a Custom Element
 

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -94,8 +94,7 @@ export const enum ErrorNames {
   update_trigger_behavior_no_triggers = 802,
   update_trigger_invalid_usage = 803,
   au_compose_invalid_scope_behavior = 805,
-  // originally not supported
-  // au_compose_containerless = 806,
+  au_compose_component_name_not_found = 806,
   au_compose_invalid_run = 807,
   au_compose_duplicate_deactivate = 808,
   else_without_if = 810,
@@ -210,7 +209,7 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.update_trigger_invalid_usage]: `"& updateTrigger" invalid usage. This binding behavior can only be applied to two-way/ from-view bindings.`,
   [ErrorNames.au_compose_invalid_scope_behavior]: `Invalid scope behavior "{{0}}" on <au-compose />. Only "scoped" or "auto" allowed.`,
   // originally not supported
-  // [ErrorNames.au_compose_containerless]: `Containerless custom element {{0:name}} is not supported by <au-compose />`,
+  [ErrorNames.au_compose_component_name_not_found]: `<au-compose /> couldn't find a custom element with name "{{0}}", did you forget to register it locally or globally?`,
   [ErrorNames.au_compose_invalid_run]: `Composition has already been activated/deactivated. Id: {{0:controller}}`,
   [ErrorNames.au_compose_duplicate_deactivate]: `Composition has already been deactivated.`,
   [ErrorNames.else_without_if]: `Invalid [else] usage, it should follow an [if]`,

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -36,7 +36,17 @@ export class AuCompose {
   @bindable
   public template?: string | Promise<string>;
 
-  /* determine the component instance used to compose the component */
+  /**
+   * Determine the component instance used to compose the component.
+   *
+   * - When a string is given as a value, it will be used as the name of the custom element to compose.
+   * If there is no locally or globally registered custom element with that name, an error will be thrown.
+   *
+   * - When an object is given as a value, the object will be used as the component instance.
+   * - When a constructor is given as a value, the constructor will be used to create the component instance.
+   * - When a null/undefined is given as a value, the component will be composed as a template-only composition with an empty component instance.
+   * - When a promise is given as a value, the promise will be awaited and the resolved value will be used as the value.
+   */
   @bindable
   public component?: string | Constructable | object | Promise<string | Constructable | object>;
 

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,4 +1,4 @@
-import { Constructable, IContainer, InstanceProvider, emptyArray, onResolve, resolve, transient } from '@aurelia/kernel';
+import { Constructable, IContainer, InstanceProvider, MaybePromise, emptyArray, onResolve, resolve, transient } from '@aurelia/kernel';
 import { IExpressionParser, IObserverLocator, Scope } from '@aurelia/runtime';
 import { bindable } from '../../bindable';
 import { INode, IRenderLocation, convertToRenderLocation, registerHostNode } from '../../dom';
@@ -25,7 +25,6 @@ export interface IDynamicComponentActivate<T> {
   activate?(model?: T): unknown;
 }
 
-type MaybePromise<T> = T | Promise<T>;
 type ChangeSource = keyof Pick<AuCompose, 'template' | 'component' | 'model' | 'scopeBehavior' | 'composing' | 'composition' | 'tag'>;
 
 // Desired usage:
@@ -39,7 +38,7 @@ export class AuCompose {
 
   /* determine the component instance used to compose the component */
   @bindable
-  public component?: Constructable | object | Promise<Constructable | object>;
+  public component?: string | Constructable | object | Promise<string | Constructable | object>;
 
   /* the model used to pass to activate lifecycle of the component */
   @bindable
@@ -200,9 +199,18 @@ export class AuCompose {
     // todo: when both component and template are empty
     //       should it throw or try it best to proceed?
     //       current: proceed
-    const { _template: template, _component: component, _model: model } = context.change;
-    const { _container: container, $controller, _location: loc, _instruction } = this;
-    const vmDef = this.getDef(component);
+    const {
+      _template: template,
+      _component: component,
+      _model: model
+    } = context.change;
+    const {
+      _container: container,
+      $controller,
+      _location: loc,
+      _instruction
+    } = this;
+    const vmDef = this._getDefinition(this._hydrationContext.controller.container, component);
     const childCtn: IContainer = container.createChild();
 
     const compositionHost = this._platform.document.createElement(vmDef == null ? this.tag ?? 'div' : vmDef.name);
@@ -231,7 +239,12 @@ export class AuCompose {
       }
     };
 
-    const comp = this._createCompInstance(childCtn, component, compositionHost, compositionLocation);
+    const comp = this._createComponentInstance(
+      childCtn,
+      typeof component === 'string' ? vmDef!.Type : component,
+      compositionHost,
+      compositionLocation
+    );
     const compose: () => ICompositionController = () => {
       const aucomposeCapturedAttrs = _instruction.captures! ?? emptyArray;
       // custom element based composition
@@ -257,12 +270,11 @@ export class AuCompose {
           vmDef,
           compositionLocation
         );
-        const bindings = this._createSpreadBindings(compositionHost, vmDef, transferedToHostBindingAttrs);
         // Theoretically these bindings aren't bindings of the composed custom element
         // Though they are meant to be activated (bound)/ deactivated (unbound) together
         // with the custom element controller, so it's practically ok to let the composed
         // custom element manage these bindings
-        bindings.forEach(b => controller.addBinding(b));
+        this._createSpreadBindings(compositionHost, vmDef, transferedToHostBindingAttrs).forEach(b => controller.addBinding(b));
 
         return new CompositionController(
           controller,
@@ -295,8 +307,7 @@ export class AuCompose {
         if (compositionLocation == null) {
           // only spread the bindings if there is an actual host
           // otherwise we may accidentally do unnecessary work
-          const spreadBindings = this._createSpreadBindings(compositionHost, targetDef, aucomposeCapturedAttrs);
-          spreadBindings.forEach(b => controller.addBinding(b));
+          this._createSpreadBindings(compositionHost, targetDef, aucomposeCapturedAttrs).forEach(b => controller.addBinding(b));
         } else {
           controller.setLocation(compositionLocation);
         }
@@ -328,7 +339,7 @@ export class AuCompose {
   }
 
   /** @internal */
-  private _createCompInstance(
+  private _createComponentInstance(
     container: IContainer,
     comp: Constructable | object | undefined,
     host: HTMLElement | IRenderLocation,
@@ -356,7 +367,15 @@ export class AuCompose {
   }
 
   /** @internal */
-  private getDef(component?: object | Constructable) {
+  private _getDefinition(container: IContainer, component?: string | object | Constructable) {
+    if (typeof component === 'string') {
+      const def = container.find(CustomElement, component);
+      if (def == null) {
+        throw createMappedError(ErrorNames.au_compose_component_name_not_found, component);
+      }
+      return def;
+    }
+
     const Ctor = (isFunction(component)
       ? component
       : component?.constructor) as Constructable;
@@ -426,7 +445,7 @@ class CompositionContextFactory {
 class ChangeInfo {
   public constructor(
     public readonly _template: MaybePromise<string> | undefined,
-    public readonly _component: MaybePromise<Constructable | object> | undefined,
+    public readonly _component: MaybePromise<string | Constructable | object> | undefined,
     public readonly _model: unknown,
     public readonly _src: ChangeSource | undefined,
   ) { }
@@ -447,7 +466,7 @@ class ChangeInfo {
 class LoadedChangeInfo {
   public constructor(
     public readonly _template: string | undefined,
-    public readonly _component: Constructable | object | undefined,
+    public readonly _component: string | Constructable | object | undefined,
     public readonly _model: unknown,
     public readonly _src: ChangeSource | undefined,
   ) { }

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -167,23 +167,29 @@ export function createFixture<T extends object>(
   function assertHtml(selectorOrHtml: string, html: string | IHtmlAssertOptions = selectorOrHtml, options?: IHtmlAssertOptions) {
     let $html;
     let $options: IHtmlAssertOptions | undefined;
+
+    // assertHtml('some html content')
     if (arguments.length === 1) {
       assert.strictEqual(getInnerHtml(host), selectorOrHtml);
       return;
     }
 
+    // assertHtml('some selector', void 0/ null);
     if (html == null) {
       throw new Error('Invalid null/undefined expected html value');
     }
 
-    const el = strictQueryBy(selectorOrHtml, `to compare innerHTML against "${html}`);
+    // assertHtml('some html content', { compact: true/false })
     if (typeof html !== 'string') {
       $html = selectorOrHtml;
       $options = html;
-      assert.strictEqual(getInnerHtml(el, $options?.compact), $html);
+      assert.strictEqual(getInnerHtml(host, $options?.compact), $html);
       return;
     }
 
+    // assertHtml('selector', 'some html content')
+    // assertHtml('selector', 'some html content', { compact: true/false })
+    const el = strictQueryBy(selectorOrHtml, `to compare innerHTML against "${html}`);
     $options = options;
     assert.strictEqual(getInnerHtml(el, $options?.compact), html);
   }


### PR DESCRIPTION
## 📖 Description

Adds the ability to understand string as element name to `<au-compose/>`, it'll throw in case of the name doesn't result in a registered element. All the following usages of `<au-compose>` will yield the same result:

```html
<au-compose component.bind="el" style="width: 20%;" v="aurelia"></au-compose>
<au-compose component="my-el" style="width: 20%;" v="aurelia"></au-compose>
```
For component classes:
```ts
class MyApp {
  el = MyEl
}

class MyEl {
  @bindable v
}
```

just as the direct usage of `<my-el>`:

```html
<my-el style="width: 20%;" v="aurelia"></my-el>
```

* When composing directly with a custom element constructor, the constructor does not need to be a dependency of the element that owns `<au-compose>`
* When composing with a custom element name, there must be either a locally or globally registered a custom element with the same name

Closes #1806 

cc @fkleuver @Sayan751 @ekzobrain 