### PR TITLE
feat(enhance): call app tasks with `.enhance` API

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/enhance.md
+++ b/docs/user-docs/getting-to-know-aurelia/enhance.md
@@ -27,13 +27,13 @@ Key Points to Understand:
 1. **Anonymous Custom Element Hydration:** The enhancement treats the target node as an anonymous custom element, allowing Aurelia to apply its behavior to the existing DOM structure.
 2. **Component Flexibility:** The component parameter in enhance can be a custom element class, a class instance, or an object literal. If a class is provided, it's instantiated by Aurelia's dependency injection container, which can be either provided or automatically created.
 3. **Host Element:** The host is typically an existing DOM node that is not yet under Aurelia's control. It's crucial to note that `enhance ' neither detaches nor attaches the `host` to the DOM. Existing event handlers on the `host` or its descendants remain unaffected.
-4. **Controller Deactivation:** an `enhance` call results in a custom element controller that requires manual deactivation or integration into an existing controller hierarchy for automatic framework management.
+4. **Controller Deactivation:** an `enhance` call results in an application root that requires manual deactivation or integration into an existing controller hierarchy for automatic framework management.
 
 Example of deactivating a controller:
 
 ```typescript
-const controller = au.enhance({ host, component });
-controller.deactivate(controller, null, LifecycleFlags.none);
+const root = au.enhance({ host, component });
+root.deactivate();
 ```
 
 ## Enhancing During Application Startup
@@ -59,18 +59,37 @@ Now, let's enhance our application by using the `enhance`API inside of `main.ts`
 ```typescript
 import Aurelia from 'aurelia';
 import { MyApp } from './my-app';
+try {
+Aurelia
+  .register(MyApp)
+  .enhance({
+      host: document.querySelector('div#app'),
+      component: {},
+  });
+} catch (error) {
+  console.error(error);
+}
+```
+Or if your component has one of its lifecycle return a promise:
+```typescript
+import Aurelia from 'aurelia';
+import { MyApp } from './my-app';
 
-(async () => {
+;(async () => {
+  try {
     await Aurelia
-        .register(MyApp)
-        .enhance({
-            host: document.querySelector('div#app'),
-            component: {},
-        });
-})().catch(console.error);
+      .register(MyApp)
+      .enhance({
+          host: document.querySelector('div#app'),
+          component: {},
+      });
+  } catch (error) {
+    console.error(error);
+  }
+})();
 ```
 
-We first wrap our async code in an anonymous async function. This allows us to catch errors and throw them to the console if enhancement fails, but take note of the `enhance` call itself. We supply the container (in our case, it's a DIV with an ID of `app` as the host).
+We first wrap our async code in an anonymous async function. This allows us to catch errors and throw them to the console if enhancement fails, but take note of the `enhance` call itself. We supply the host element (in our case, it's a DIV with an ID of `app` as the host).
 
 Above our `enhance` call, we register our main component, `MyApp`, the initial component our application will render.
 
@@ -82,17 +101,17 @@ This approach will work for existing applications as well. Say you have a WordPr
 
 ## Enhancing on the fly within components
 
-While using the `enhance` During registration, the `enhance` API is convenient for situations where you want to control how an Aurelia application is enhanced. There are times when you want to enhance HTML programmatically from within components. This may be HTML loaded from the server or elements created on the fly.
+While using the `enhance` during registration, the `enhance` API is convenient for situations where you want to control how an Aurelia application is enhanced. There are times when you want to enhance HTML programmatically from within components. This may be HTML loaded from the server or elements created on the fly.
 
 In the following example, we query our markup for an `item-list` element and insert some Aurelia-specific markup into it (a repeater).
 
 ```typescript
-import Aurelia, { IAurelia } from 'aurelia';
+import Aurelia, { IAurelia, resolve } from 'aurelia';
 
 export class MyApp {
   items = [1, 2, 3];
 
-  constructor(@IAurelia private readonly au: Aurelia) {}
+  constructor(private readonly au = resolve(Aurelia)) {}
 
   attached() {
     const itemList = document.getElementById('item-list');

--- a/docs/user-docs/getting-to-know-aurelia/enhance.md
+++ b/docs/user-docs/getting-to-know-aurelia/enhance.md
@@ -29,7 +29,7 @@ Key Points to Understand:
 3. **Host Element:** The host is typically an existing DOM node that is not yet under Aurelia's control. It's crucial to note that `enhance ' neither detaches nor attaches the `host` to the DOM. Existing event handlers on the `host` or its descendants remain unaffected.
 4. **Controller Deactivation:** an `enhance` call results in an application root that requires manual deactivation or integration into an existing controller hierarchy for automatic framework management.
 
-Example of deactivating a controller:
+Example of deactivating an application root:
 
 ```typescript
 const root = au.enhance({ host, component });

--- a/packages/__tests__/src/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/enhance.spec.ts
@@ -199,6 +199,14 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     au.dispose();
   });
 
+  it('throws when enhancing a realmless node (without window connected document)', function () {
+    const ctx = TestContext.create();
+    assert.throws(() => new Aurelia().enhance({
+      host: new ctx.DOMParser().parseFromString('<div></div>', 'text/html').body.firstElementChild as HTMLElement,
+      component: {}
+    }));
+  });
+
   it(`enhance works on detached node`, async function () {
     @customElement({ name: 'my-element', template: '<span>${value}</span>' })
     class MyElement {

--- a/packages/__tests__/src/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/enhance.spec.ts
@@ -1,6 +1,6 @@
 // This is to test for some intrinsic properties of enhance which is otherwise difficult to test in Data-driven tests parallel to `.app`
 import { BrowserPlatform } from '@aurelia/platform-browser';
-import { Constructable, DI, IContainer, Registration } from '@aurelia/kernel';
+import { Constructable, DI, IContainer, Registration, onResolve } from '@aurelia/kernel';
 import {
   CustomElement,
   ICustomElementViewModel,
@@ -13,6 +13,7 @@ import {
   ICustomElementController,
   IAurelia,
   ValueConverter,
+  IAppRoot,
 } from '@aurelia/runtime-html';
 import { assert, TestContext, createFixture } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../util.js';
@@ -60,13 +61,13 @@ describe('3-runtime-html/enhance.spec.ts', function () {
 
     const container = ctx.container;
     const au = new Aurelia(container);
-    const controller = await au.enhance({ host, component: getComponent() });
+    const enhanceRoot = await au.enhance({ host, component: getComponent() });
 
-    const app = controller.scope.bindingContext;
+    const app = enhanceRoot.controller.scope.bindingContext;
     await testFunction(new EnhanceTestExecutionContext(ctx, container, host, app, child));
 
     await au.stop();
-    await controller.deactivate(controller, null);
+    await enhanceRoot.deactivate();
     ctx.doc.body.removeChild(host);
     au.dispose();
   }
@@ -146,8 +147,8 @@ describe('3-runtime-html/enhance.spec.ts', function () {
       } else {
         host.innerHTML = template;
         component = CustomElement.define('app', App2);
-        const controller = await au.enhance({ host, component });
-        dispose = () => controller.deactivate(controller, null);
+        const enhanceRoot = await au.enhance({ host, component });
+        dispose = () => onResolve(enhanceRoot.deactivate(), () => enhanceRoot.dispose());
       }
 
       assert.html.textContent('div', message, 'div', host);
@@ -183,10 +184,10 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     };
     const container = ctx.container;
     const au = new Aurelia(container);
-    const controller = await au.enhance({ host, component });
+    const enhanceRoot = await au.enhance({ host, component });
 
     await au.stop();
-    await controller.deactivate(controller, null);
+    await enhanceRoot.deactivate();
     ctx.doc.body.removeChild(host);
 
     assert.deepStrictEqual(component.eventLog, [
@@ -212,11 +213,11 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     })
     class App {
       private enhancedHost: HTMLElement;
-      private enhanceView: ICustomElementController;
+      private enhanceView: IAppRoot;
       private readonly container!: HTMLDivElement;
 
       public async bound() {
-        const _host = this.enhancedHost = new ctx.DOMParser().parseFromString('<div><my-element value.bind="42.toString()"></my-element></div>', 'text/html').body.firstElementChild as HTMLElement;
+        const _host = this.enhancedHost = ctx.doc.adoptNode(new ctx.DOMParser().parseFromString('<div><my-element value.bind="42.toString()"></my-element></div>', 'text/html').body.firstElementChild as HTMLElement);
         // this.container.appendChild(this.enhancedHost);
         const _au = new Aurelia(
           DI.createContainer()
@@ -239,7 +240,7 @@ describe('3-runtime-html/enhance.spec.ts', function () {
 
       // The inverse order of the stop and detaching is intentional
       public async detaching() {
-        await this.enhanceView.deactivate(this.enhanceView, null);
+        await this.enhanceView.deactivate();
         assert.html.innerEqual(this.enhancedHost, '<my-element></my-element>', 'enhanced.innerHtml');
         assert.html.innerEqual(this.container, '<div><my-element></my-element></div>', 'enhanced.innerHtml');
       }
@@ -276,73 +277,75 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     const container = ctx.container;
     const au = new Aurelia(container);
     host.innerHTML = `<div repeat.for="i of 3">\${i}</div>`;
-    const controller = await au.enhance({ host, component: { message: 'hello world' } });
+    const root = await au.enhance({ host, component: { message: 'hello world' } });
     assert.html.textContent(host, '012');
     assert.strictEqual(host.querySelectorAll('div').length, 3);
 
-    await controller.deactivate(controller, null);
+    await root.deactivate();
     assert.html.textContent(host, '');
 
-    await controller.activate(controller, null);
+    await root.activate();
     assert.html.textContent(host, '012');
     assert.strictEqual(host.querySelectorAll('div').length, 3);
   });
 
-  it('can connect with parent controller if any', async function () {
-    let parentController: IController;
-    const { appHost, component, start, tearDown } = createFixture(
-      '<my-el html.bind="html" controller.ref="myElController">',
-      class App {
-        public html = `<div>\${message}</div>`;
-        public myElController: ICustomElementController;
-      },
-      [
-        CustomElement.define({
-          name: 'my-el',
-          template: '<div innerhtml.bind="html" ref="div">',
-          bindables: ['html']
-        }, class MyEl {
-          public static inject = [IAurelia];
-          public div: HTMLDivElement;
-          public enhancedView: ICustomElementController;
-          public constructor(private readonly au$: Aurelia) {}
+  // we dont need to support this since the activation/deactivation can be awaited in the life cycle of any component
+  //
+  // it('can connect with parent controller if any', async function () {
+  //   let parentController: IController;
+  //   const { appHost, component, start, tearDown } = createFixture(
+  //     '<my-el html.bind="html" controller.ref="myElController">',
+  //     class App {
+  //       public html = `<div>\${message}</div>`;
+  //       public myElController: ICustomElementController;
+  //     },
+  //     [
+  //       CustomElement.define({
+  //         name: 'my-el',
+  //         template: '<div innerhtml.bind="html" ref="div">',
+  //         bindables: ['html']
+  //       }, class MyEl {
+  //         public static inject = [IAurelia];
+  //         public div: HTMLDivElement;
+  //         public enhancedRoot: ICustomElementController;
+  //         public constructor(private readonly au$: Aurelia) {}
 
-          public async attaching() {
-            this.div.removeAttribute('class');
-            this.enhancedView = await this.au$.enhance(
-              {
-                host: this.div,
-                component: {
-                  message: 'Hello _div_',
-                  attaching(_, parent) {
-                    parentController = parent;
-                  }
-                }
-              },
-              (this as any).$controller
-            );
-          }
+  //         public async attaching() {
+  //           this.div.removeAttribute('class');
+  //           this.enhancedRoot = await this.au$.enhance(
+  //             {
+  //               host: this.div,
+  //               component: {
+  //                 message: 'Hello _div_',
+  //                 attaching(_, parent) {
+  //                   parentController = parent;
+  //                 }
+  //               }
+  //             },
+  //             (this as any).$controller
+  //           );
+  //         }
 
-          public detaching() {
-            void this.enhancedView.deactivate(this.enhancedView, null);
-            parentController = void 0;
-          }
-        }),
-      ],
-      false,
-    );
+  //         public detaching() {
+  //           void this.enhancedRoot.deactivate(this.enhancedRoot, null);
+  //           parentController = void 0;
+  //         }
+  //       }),
+  //     ],
+  //     false,
+  //   );
 
-    await start();
+  //   await start();
 
-    assert.notStrictEqual(parentController, void 0);
-    assert.strictEqual(component.myElController === parentController, true);
-    assert.html.innerEqual(appHost, '<my-el><div><div>Hello _div_</div></div></my-el>');
+  //   assert.notStrictEqual(parentController, void 0);
+  //   assert.strictEqual(component.myElController === parentController, true);
+  //   assert.html.innerEqual(appHost, '<my-el><div><div>Hello _div_</div></div></my-el>');
 
-    await tearDown();
-    assert.strictEqual(parentController, void 0);
-    assert.strictEqual(component.myElController, null);
-    assert.html.innerEqual(appHost, '');
-  });
+  //   await tearDown();
+  //   assert.strictEqual(parentController, void 0);
+  //   assert.strictEqual(component.myElController, null);
+  //   assert.html.innerEqual(appHost, '');
+  // });
 
   it('uses resources in existing root container', async function () {
     const ctx = TestContext.create();
@@ -355,7 +358,7 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     }));
     const au = new Aurelia(container);
     host.innerHTML = '<div data-id.bind="1 | x2 | plus10"></div>';
-    const controller = await au.enhance({
+    const root = await au.enhance({
       host,
       component: {},
       container: container.createChild().register(ValueConverter.define('plus10', class Plus10 {
@@ -366,7 +369,7 @@ describe('3-runtime-html/enhance.spec.ts', function () {
     });
 
     assert.strictEqual(host.innerHTML, '<div data-id="12"></div>');
-    await controller.deactivate(controller, null);
+    await root.deactivate();
   });
 
   it('uses resources given in the container', async function () {
@@ -380,7 +383,7 @@ describe('3-runtime-html/enhance.spec.ts', function () {
       i_id: number;
     }
     host.innerHTML = '<div data-id.bind="i | plus10"></div>';
-    const controller = await au.enhance({
+    const root = await au.enhance({
       host,
       component: { i: 1 },
       container: container.createChild().register(
@@ -394,6 +397,6 @@ describe('3-runtime-html/enhance.spec.ts', function () {
 
     assert.strictEqual(host.innerHTML, '<div data-id="11"></div>');
     assert.strictEqual(container.find(ValueConverter, 'plus10'), null, 'It should register resources with child contaienr only.');
-    await controller.deactivate(controller, null);
+    await root.deactivate();
   });
 });

--- a/packages/__tests__/src/3-runtime-html/enhance.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/enhance.spec.ts
@@ -9,13 +9,10 @@ import {
   customElement,
   bindable,
   StandardConfiguration,
-  IController,
-  ICustomElementController,
-  IAurelia,
   ValueConverter,
   IAppRoot,
 } from '@aurelia/runtime-html';
-import { assert, TestContext, createFixture } from '@aurelia/testing';
+import { assert, TestContext } from '@aurelia/testing';
 import { createSpecFunction, TestExecutionContext, TestFunction } from '../util.js';
 import { delegateSyntax } from '@aurelia/compat-v1';
 

--- a/packages/__tests__/src/3-runtime-html/portal.spec.tsx
+++ b/packages/__tests__/src/3-runtime-html/portal.spec.tsx
@@ -504,7 +504,7 @@ describe('3-runtime-html/portal.spec.tsx', function () {
     renderContext?: HTMLElement;
   }
 
-  function $setup<T>(options: { root: Constructable<T>; resources?: IRegistry[] }) {
+  function $setup<T extends object>(options: { root: Constructable<T>; resources?: IRegistry[] }) {
     const { root: Root, resources = []} = options;
     const ctx = TestContext.create();
     ctx.container.register(...resources);

--- a/packages/__tests__/src/3-runtime-html/process-content.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/process-content.spec.ts
@@ -39,9 +39,9 @@ describe('3-runtime-html/process-content.spec.ts', function () {
       au.register(...registrations);
       if (enhance) {
         host.innerHTML = template;
-        const controller = await au.enhance({ host, component: CustomElement.define({ name: 'app' }, App) });
-        app = controller.viewModel;
-        stop = () => controller.deactivate(controller, null);
+        const enhanceRoot = await au.enhance({ host, component: CustomElement.define({ name: 'app' }, App) });
+        app = enhanceRoot.controller.viewModel;
+        stop = () => enhanceRoot.deactivate();
       } else {
         await au.app({ host, component: CustomElement.define({ name: 'app', template }, App) })
           .start();

--- a/packages/__tests__/src/integration/app/startup.ts
+++ b/packages/__tests__/src/integration/app/startup.ts
@@ -46,7 +46,7 @@ export async function startup(config: StartupConfiguration = {}): Promise<TestEx
     componentClass = CustomElement.define('app', App);
     host.innerHTML = template;
   }
-  let component: unknown;
+  let component: object;
   switch (config.componentMode) {
     case ComponentMode.class:
       component = componentClass;
@@ -62,8 +62,8 @@ export async function startup(config: StartupConfiguration = {}): Promise<TestEx
     au.app({ host, component });
     await au.start();
   } else {
-    const controller = (await au.enhance({ host, component }));
-    $deactivate = () => controller.deactivate(controller, null);
+    const enhanceRoot = (await au.enhance({ host, component }));
+    $deactivate = () => enhanceRoot.deactivate();
   }
 
   async function tearDown() {

--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -88,7 +88,7 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
     const au = new Aurelia(container);
     const host = ctx.createElement('div');
 
-    await au.app({ component: rootComponent, host }).start();
+    await au.app({ component: rootComponent as object, host }).start();
     return { au, container, host };
   }
 

--- a/packages/__tests__/src/router/_shared/view-models.ts
+++ b/packages/__tests__/src/router/_shared/view-models.ts
@@ -63,7 +63,6 @@ export class HookSpecs {
     input: Partial<HookSpecs>,
   ): HookSpecs {
     return new HookSpecs(
-      // TODO: use '??' instead of '||' but gotta figure out first why ts-node doesn't understand ES2020 syntax
       input.binding || hookSpecsMap.binding.sync,
       input.bound || hookSpecsMap.bound.sync,
       input.attaching || hookSpecsMap.attaching.sync,

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
-import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, IHydratedParentController, ICustomElementViewModel } from '@aurelia/runtime-html';
+import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, ICustomElementViewModel } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import type { ISinglePageApp, IEnhancementConfig } from '@aurelia/runtime-html';
 
@@ -23,19 +23,19 @@ export class Aurelia extends $Aurelia {
     return new Aurelia().start(root);
   }
 
-  public static app(config: ISinglePageApp | CustomElementType): Omit<Aurelia, 'register' | 'app' | 'enhance'> {
+  public static app(config: ISinglePageApp<object> | CustomElementType): Omit<Aurelia, 'register' | 'app' | 'enhance'> {
     return new Aurelia().app(config);
   }
 
-  public static enhance<T extends ICustomElementViewModel>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController): ReturnType<$Aurelia['enhance']> {
-    return new Aurelia().enhance(config, parentController);
+  public static enhance<T extends ICustomElementViewModel>(config: IEnhancementConfig<T>): ReturnType<$Aurelia['enhance']> {
+    return new Aurelia().enhance(config);
   }
 
   public static register(...params: readonly unknown[]): Aurelia {
     return new Aurelia().register(...params);
   }
 
-  public app(config: ISinglePageApp | CustomElementType): Omit<this, 'register' | 'app' | 'enhance'> {
+  public app(config: ISinglePageApp<object> | CustomElementType): Omit<this, 'register' | 'app' | 'enhance'> {
     if (CustomElement.isType(config)) {
       // Default to custom element element name
       const definition = CustomElement.getDefinition(config);

--- a/packages/rollup-utils.mjs
+++ b/packages/rollup-utils.mjs
@@ -180,7 +180,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           rollupReplace({ '_START_CONST_ENUM': '(() => {})', '_END_CONST_ENUM': '(() => {})' }),
           esbuild({
             minify: false,
-            target: 'es2020',
+            target: 'es2021',
             define: { ...envVars, __DEV__: 'true' },
             sourceMap: true,
           }),
@@ -230,7 +230,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           rollupReplace({ '_START_CONST_ENUM': '(() => {})', '_END_CONST_ENUM': '(() => {})' }),
           esbuild({
             minify: false,
-            target: 'es2020',
+            target: 'es2021',
             define: { ...envVars, __DEV__: 'false' },
             sourceMap: true,
           }),

--- a/packages/runtime-html/src/api-test.ts
+++ b/packages/runtime-html/src/api-test.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { onResolve } from '@aurelia/kernel';
+import { Aurelia } from './aurelia';
+
+// test .app + .enhance
+// but mostly test the auto inferrence of the component type on the .enhance API
+function testAureliaApi(au: Aurelia) {
+  class Abc { public abc = 5; }
+  return [
+    // if necessary, we can try enhance the typing for Aurelia & IAurelia
+    // to make it auto infer the type of the component in the main app root
+    onResolve(au.app({ host: document.body, component: Abc }).start(), (root) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return au.root.controller.viewModel.abc;
+    }),
+    onResolve(au.enhance({ component: Abc, host: document.body }), (root) => {
+      return root.controller.viewModel.abc;
+    })
+  ];
+}

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -13,17 +13,13 @@ import { registerHostNode } from './dom';
 import { isFunction } from './utilities';
 import { ErrorNames, createMappedError } from './errors';
 
-export interface ISinglePageApp<T extends object = object> {
-  host: HTMLElement;
-  component: T | Constructable<T>;
-}
-
 export interface IAppRootConfig<T extends object = object> {
   host: HTMLElement;
   component: T | Constructable<T>;
 }
 
 export interface IAppRoot<C extends object = object> extends IDisposable {
+  readonly config: IAppRootConfig<C>;
   /**
    * The host element of an application
    */
@@ -64,7 +60,7 @@ export class AppRoot<
   }
 
   public constructor(
-    public readonly config: IAppRootConfig<T>,
+    public readonly config: IAppRootConfig<K>,
     public readonly container: IContainer,
     rootProvider: InstanceProvider<IAppRoot>,
     enhance?: boolean

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -1,12 +1,7 @@
 import { DI, InstanceProvider, onResolve } from '@aurelia/kernel';
-import { BrowserPlatform } from '@aurelia/platform-browser';
-import { AppRoot, IAppRoot, ISinglePageApp } from './app-root';
-import { IEventTarget, registerHostNode } from './dom';
-import { IPlatform } from './platform';
-import { CustomElementDefinition, generateElementName } from './resources/custom-element';
-import { Controller, ICustomElementController, ICustomElementViewModel, IHydratedParentController } from './templating/controller';
-import { isFunction, isPromise } from './utilities';
-import { createInterface, instanceRegistration, registerResolver } from './utilities-di';
+import { AppRoot, IAppRoot } from './app-root';
+import { isPromise } from './utilities';
+import { createInterface, registerResolver } from './utilities-di';
 
 import type {
   Constructable,
@@ -68,40 +63,47 @@ export class Aurelia implements IDisposable {
     return this;
   }
 
-  public app(config: ISinglePageApp): Omit<this, 'register' | 'app' | 'enhance'> {
-    this.next = new AppRoot(config, this._initPlatform(config.host), this.container, this._rootProvider);
+  public app(config: ISinglePageAppConfig<object>): Omit<this, 'register' | 'app' | 'enhance'> {
+    this.next = new AppRoot(config, this.container, this._rootProvider);
     return this;
   }
 
   /**
    * @param parentController - The owning controller of the view created by this enhance call
    */
-  public enhance<T extends ICustomElementViewModel, K extends ICustomElementViewModel = T extends Constructable<infer I extends ICustomElementViewModel> ? I : T>(config: IEnhancementConfig<T>, parentController?: IHydratedParentController | null): ICustomElementController<K> | Promise<ICustomElementController<K>> {
-    const ctn = config.container ?? this.container.createChild();
-    const host = config.host as HTMLElement;
-    const p = this._initPlatform(host);
-    const comp = config.component as unknown as K;
-    let bc: ICustomElementViewModel & K;
-    if (isFunction(comp)) {
-      registerHostNode(ctn, p, host);
-      bc = ctn.invoke(comp as unknown as Constructable<ICustomElementViewModel & K>);
-    } else {
-      bc = comp;
-    }
-    registerResolver(ctn, IEventTarget, new InstanceProvider('IEventTarget', host));
-    parentController = parentController ?? null;
+  public enhance<T extends object>(config: IEnhancementConfig<T>): IAppRoot<T> | Promise<IAppRoot<T>> {
+    const appRoot = new AppRoot(
+      { host: config.host as HTMLElement, component: config.component },
+      config.container ?? this.container.createChild(),
+      new InstanceProvider('IAppRoot'),
+      true
+    );
+    return onResolve(appRoot.activate(), () => appRoot) as IAppRoot<T> | Promise<IAppRoot<T>>;
+    // const ctn = config.container ?? this.container.createChild();
+    // const host = config.host as HTMLElement;
+    // const p = this._initPlatform(ctn, host);
+    // const comp = config.component as unknown as K;
+    // let bc: ICustomElementViewModel & K;
+    // if (isFunction(comp)) {
+    //   registerHostNode(ctn, p, host);
+    //   bc = ctn.invoke(comp as unknown as Constructable<ICustomElementViewModel & K>);
+    // } else {
+    //   bc = comp;
+    // }
+    // registerResolver(ctn, IEventTarget, new InstanceProvider('IEventTarget', host));
+    // parentController = parentController ?? null;
 
-    const view = Controller.$el(
-      ctn,
-      bc,
-      host,
-      null,
-      CustomElementDefinition.create({ name: generateElementName(), template: host, enhance: true }),
-    );
-    return onResolve(
-      view.activate(view, parentController),
-      () => view
-    );
+    // const view = Controller.$el(
+    //   ctn,
+    //   bc,
+    //   host,
+    //   null,
+    //   CustomElementDefinition.create({ name: generateElementName(), template: host, enhance: true }),
+    // );
+    // return onResolve(
+    //   view.activate(view, parentController),
+    //   () => view
+    // );
   }
 
   public async waitForIdle(): Promise<void> {
@@ -109,21 +111,6 @@ export class Aurelia implements IDisposable {
     await platform.domWriteQueue.yield();
     await platform.domReadQueue.yield();
     await platform.taskQueue.yield();
-  }
-
-  /** @internal */
-  private _initPlatform(host: HTMLElement): IPlatform {
-    let p: IPlatform;
-    if (!this.container.has(IPlatform, false)) {
-      if (host.ownerDocument.defaultView === null) {
-        throw createMappedError(ErrorNames.invalid_platform_impl);
-      }
-      p = new BrowserPlatform(host.ownerDocument.defaultView);
-      this.container.register(instanceRegistration(IPlatform, p));
-    } else {
-      p = this.container.get(IPlatform);
-    }
-    return p;
   }
 
   /** @internal */
@@ -190,12 +177,23 @@ export class Aurelia implements IDisposable {
   }
 }
 
+export interface ISinglePageAppConfig<T = unknown> {
+  /**
+   * The host element of the app
+   */
+  host: HTMLElement;
+  /**
+   * The root component of the app
+   */
+  component: T | Constructable<T>;
+}
+
 export interface IEnhancementConfig<T> {
   host: Element;
   /**
    * The binding context of the enhancement. Will be instantiate by DI if a constructor is given
    */
-  component: T;
+  component: T | Constructable<T>;
   /**
    * A predefined container for the enhanced view.
    */

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -77,33 +77,8 @@ export class Aurelia implements IDisposable {
       config.container ?? this.container.createChild(),
       new InstanceProvider('IAppRoot'),
       true
-    );
-    return onResolve(appRoot.activate(), () => appRoot) as IAppRoot<T> | Promise<IAppRoot<T>>;
-    // const ctn = config.container ?? this.container.createChild();
-    // const host = config.host as HTMLElement;
-    // const p = this._initPlatform(ctn, host);
-    // const comp = config.component as unknown as K;
-    // let bc: ICustomElementViewModel & K;
-    // if (isFunction(comp)) {
-    //   registerHostNode(ctn, p, host);
-    //   bc = ctn.invoke(comp as unknown as Constructable<ICustomElementViewModel & K>);
-    // } else {
-    //   bc = comp;
-    // }
-    // registerResolver(ctn, IEventTarget, new InstanceProvider('IEventTarget', host));
-    // parentController = parentController ?? null;
-
-    // const view = Controller.$el(
-    //   ctn,
-    //   bc,
-    //   host,
-    //   null,
-    //   CustomElementDefinition.create({ name: generateElementName(), template: host, enhance: true }),
-    // );
-    // return onResolve(
-    //   view.activate(view, parentController),
-    //   () => view
-    // );
+    ) as IAppRoot<T>;
+    return onResolve(appRoot.activate(), () => appRoot);
   }
 
   public async waitForIdle(): Promise<void> {

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -26,7 +26,7 @@ import { BindableDefinition, PartialBindableDefinition } from '../bindable';
 import { AttrSyntax, IAttributeParser } from '../resources/attribute-pattern';
 import { CustomAttribute } from '../resources/custom-attribute';
 import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from '../resources/custom-element';
-import { BindingCommandInstance, ICommandBuildInfo, ctIgnoreAttr, BindingCommand } from '../resources/binding-command';
+import { BindingCommandInstance, ICommandBuildInfo, ctIgnoreAttr, BindingCommand, BindingCommandDefinition } from '../resources/binding-command';
 import { createLookup, def, etInterpolation, etIsProperty, isString, objectAssign, objectFreeze } from '../utilities';
 import { aliasRegistration, allResources, createInterface, singletonRegistration } from '../utilities-di';
 import { appendManyToTemplate, appendToTemplate, createComment, createElement, createText, insertBefore, insertManyBefore, isElement, isTextNode } from '../utilities-dom';
@@ -1791,9 +1791,13 @@ class CompilationContext {
       return null;
     }
     let result = this._commands[name];
+    let commandDef: BindingCommandDefinition;
     if (result === void 0) {
-      result = this.c.create(BindingCommand, name) as BindingCommandInstance;
-      if (result === null) {
+      commandDef = this.c.find(BindingCommand, name) as BindingCommandDefinition;
+      if (commandDef != null) {
+        result = this.c.invoke(commandDef.Type);
+      }
+      if (result == null) {
         throw createMappedError(ErrorNames.compiler_unknown_binding_command, name);
       }
       this._commands[name] = result;

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -180,7 +180,7 @@ const errorsMap: Record<ErrorNames, string> = {
 
   [ErrorNames.root_not_found]: `Aurelia.root was accessed without a valid root.`,
   [ErrorNames.aurelia_instance_existed_in_container]: `An instance of Aurelia is already registered with the container or an ancestor of it.`,
-  [ErrorNames.invalid_platform_impl]: `Failed to initialize the platform object. The host element's ownerDocument does not have a defaultView`,
+  [ErrorNames.invalid_platform_impl]: `Failed to initialize the platform object. The host element's ownerDocument does not have a defaultView, did you create the host from a DOMParser and forget to call adoptNode()?`,
   [ErrorNames.no_composition_root]: `Aurelia.start() was called without a composition root`,
   [ErrorNames.invalid_dispose_call]: `The aurelia instance must be fully stopped before it can be disposed`,
   [ErrorNames.not_supported_view_ref_api]: `view.ref is not supported. If you are migrating from v1, this can be understood as the controller.`,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -37,9 +37,15 @@ export {
   Aurelia,
   IAurelia,
   type IEnhancementConfig,
+  /**
+   * @deprecated
+   * Use `ISinglePageAppConfig` instead
+   */
+  type ISinglePageAppConfig as ISinglePageApp,
+  type ISinglePageAppConfig,
 } from './aurelia';
 export {
-  type ISinglePageApp,
+  type IAppRootConfig,
   AppRoot,
   IAppRoot,
 } from './app-root';

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -94,7 +94,6 @@ export const BindingBehavior = objectFreeze<BindingBehaviorKind>({
   define<T extends Constructable<BindingBehaviorInstance>>(nameOrDef: string | PartialBindingBehaviorDefinition, Type: T): BindingBehaviorType<T> {
     const definition = BindingBehaviorDefinition.create(nameOrDef, Type as Constructable<BindingBehaviorInstance>);
     defineMetadata(bbBaseName, definition, definition.Type);
-    defineMetadata(bbBaseName, definition, definition);
     appendResourceKey(Type, bbBaseName);
 
     return definition.Type as BindingBehaviorType<T>;

--- a/packages/runtime-html/src/resources/binding-command.ts
+++ b/packages/runtime-html/src/resources/binding-command.ts
@@ -152,7 +152,6 @@ export const BindingCommand = objectFreeze<BindingCommandKind>({
   define<T extends Constructable<BindingCommandInstance>>(nameOrDef: string | PartialBindingCommandDefinition, Type: T): T & BindingCommandType<T> {
     const definition = BindingCommandDefinition.create(nameOrDef, Type as Constructable<BindingCommandInstance>);
     defineMetadata(cmdBaseName, definition, definition.Type);
-    defineMetadata(cmdBaseName, definition, definition);
     appendResourceKey(Type, cmdBaseName);
 
     return definition.Type as BindingCommandType<T>;

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -185,7 +185,6 @@ export const findAttributeControllerFor = <C extends ICustomAttributeViewModel =
 export const defineAttribute = <T extends Constructable>(nameOrDef: string | PartialCustomAttributeDefinition, Type: T): CustomAttributeType<T> => {
   const definition = CustomAttributeDefinition.create(nameOrDef, Type as Constructable);
   defineMetadata(caBaseName, definition, definition.Type);
-  defineMetadata(caBaseName, definition, definition);
   appendResourceKey(Type, caBaseName);
 
   return definition.Type as CustomAttributeType<T>;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -427,7 +427,6 @@ const annotateElementMetadata = <K extends keyof PartialCustomElementDefinition>
 export const defineElement = <C extends Constructable>(nameOrDef: string | PartialCustomElementDefinition, Type?: C | null): CustomElementType<C> => {
   const definition = CustomElementDefinition.create(nameOrDef, Type as Constructable | null);
   defineMetadata(elementBaseName, definition, definition.Type);
-  defineMetadata(elementBaseName, definition, definition);
   appendResourceKey(definition.Type, elementBaseName);
 
   return definition.Type as CustomElementType<C>;

--- a/packages/runtime-html/src/resources/value-converter.ts
+++ b/packages/runtime-html/src/resources/value-converter.ts
@@ -102,7 +102,6 @@ export const ValueConverter = objectFreeze<ValueConverterKind>({
   define<T extends Constructable<ValueConverterInstance>>(nameOrDef: string | PartialValueConverterDefinition, Type: T): ValueConverterType<T> {
     const definition = ValueConverterDefinition.create(nameOrDef, Type as Constructable<ValueConverterInstance>);
     defineMetadata(vcBaseName, definition, definition.Type);
-    defineMetadata(vcBaseName, definition, definition);
     appendResourceKey(Type, vcBaseName);
 
     return definition.Type as ValueConverterType<T>;

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -210,7 +210,19 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       return controllerLookup.get(viewModel) as unknown as ICustomElementController<C>;
     }
 
-    definition = definition ?? getElementDefinition(viewModel.constructor as Constructable);
+    if (__DEV__) {
+      if (definition == null) {
+        try {
+          definition = getElementDefinition(viewModel.constructor as Constructable);
+        } catch (ex) {
+          // eslint-disable-next-line no-console
+          console.error(`[DEV:aurelia] Custom element definition not found for creating a controller with host: <${host.nodeName} /> and component ${JSON.stringify(viewModel)}`);
+          throw ex;
+        }
+      }
+    } else {
+      definition = definition ?? getElementDefinition(viewModel.constructor as Constructable);
+    }
 
     const controller = new Controller<C>(
       /* container      */ctn,

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "pretty": true,
     "lib": ["esnext"],
-    "target": "ES2020",
+    "target": "ES2021",
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": false,


### PR DESCRIPTION
## 📖 Description

In a PR awhile ago, the return value of the `enhance` call was changed from an `IAppRoot` to a controller for simplicity. This was necessary at the time because the app root created by enhance would override an existing app root on an Aurelia instance. This , however, resulted in the loss of the ability to call app tasks in the `.enhance` call.

This PR makes `.enhance` create an app root again, but this app root would not be used by the owning Aurelia instance.

Changes:
- BREAKING CHANGE: enhance results in an app root instance instead of a controller
- improve typings of `.enhance` & `IAppRoot` to auto infer component instance type
- script dist target changed from es2020 to es2021
- remove `.create` API on container

Resolves #1787 

cc @Sayan751 @Vheissu 