### PR TITLE
feat(dev): better DI error messages for instantiation

### DIFF
--- a/packages-tooling/rollup-utils.mjs
+++ b/packages-tooling/rollup-utils.mjs
@@ -123,7 +123,8 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     input: inputFile,
     external: Object.keys(pkg.dependencies ?? {})
       .concat(Object.keys(pkg.devDependencies ?? {}))
-      .concat('os', 'path', 'fs', 'http', 'https', 'http2', 'url', 'stream'),
+      .concat('os', 'path', 'fs', 'http', 'https', 'http2', 'url', 'stream')
+      .concat('node:module', 'node:path'),
     output: [
       {
         file: esmDist,

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -2,6 +2,9 @@ import { IOptionalPreprocessOptions, preprocess } from '@aurelia/plugin-conventi
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
 
 export default function au(options: {
   include?: FilterPattern;
@@ -25,7 +28,7 @@ export default function au(options: {
   const devPlugin: import('vite').Plugin = {
     name: 'aurelia:dev-alias',
     config(config) {
-      const isDev = useDev || (!useDev && config.mode !== 'production');
+      const isDev = useDev === true || (useDev == null && config.mode !== 'production');
       if (!isDev) {
         return;
       }

--- a/packages-tooling/vite-plugin/tsconfig.json
+++ b/packages-tooling/vite-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig-build.json",
   "compilerOptions": {
+    "module": "esnext",
     "rootDir": "src",
     "declarationDir": "dist/types",
     "outDir": "dist/cjs",

--- a/packages/__tests__/src/1-kernel/di.invoke.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.invoke.spec.ts
@@ -125,6 +125,10 @@ describe('1-kernel/di.invoke.spec.ts', function () {
     assert.strictEqual(v1, 2);
   });
 
+  it('throws when invoking intrinsic types', function () {
+    assert.throws(() => container.invoke(String));
+  });
+
   describe('inheritance', function () {
     it('works with a list of keys', function () {
       let i = 0;

--- a/packages/kernel/src/errors.ts
+++ b/packages/kernel/src/errors.ts
@@ -77,3 +77,7 @@ function pleaseHelpCreateAnIssue(title: string, body?: string) {
     + `https://github.com/aurelia/aurelia/issues/new?title=${encodeURIComponent(title)}`
     + (body != null ? `&body=${encodeURIComponent(body)}` : '&template=bug_report.md');
 }
+
+/** @internal */
+// eslint-disable-next-line
+export const logError = (...args: unknown[]) => (globalThis as any).console.error(...args);

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -412,9 +412,8 @@ export const isNativeFunction = /*@__PURE__*/(function () {
         charCodeAt(sourceText, i - 12) === 0x74 && // t
         charCodeAt(sourceText, i - 13) === 0x61 && // a
         charCodeAt(sourceText, i - 14) === 0x6E && // n
-        charCodeAt(sourceText, i - 15) === 0x58    // [
+        charCodeAt(sourceText, i - 15) === 0x5B    // [
       );
-
       lookup.set(fn, isNative);
     }
     return isNative;


### PR DESCRIPTION
## 📖 Description

Currently, when there is an error during the instantiation of a class, there is not enough information what went wrong. This is quite an issue once there are multiple changes being added in at once, like in a dependency upgrade.

Enhance the DEV mode error message by catching the dependency resolution error while instantiate, so that there will be more information for debugging.

### Examples

1. for the following code with `inject`:
    ```ts
    
    export class App {
      static inject = [class Abc {
        constructor() {
          throw new Error('testing testing');
        }
      }]
    }
    ```
    The error messages logged will look like this:
    
    ![image](https://github.com/aurelia/aurelia/assets/9994529/7b9eaad3-3d05-4bef-abc8-374ab44f41cf)

2. For the following code with `resolve`:
    ```ts
    
    export class App {
      abc = resolve(class Abc {
        constructor() {
          throw new Error('testing testing');
        }
      });
    }
    ```
    
    The error messages logged will look like this
    ![image](https://github.com/aurelia/aurelia/assets/9994529/74ddff59-3c1b-44af-b9fb-09161a3c9b5a)


### 🎫 Issues

Resolves #913 

cc @xenoterracide @Sayan751 @fkleuver 