### PR TITLE
feat(template-controller): ability to have a container per factory

### DIFF
--- a/docs/user-docs/advanced-scenarios/css-in-js-with-emotion.md
+++ b/docs/user-docs/advanced-scenarios/css-in-js-with-emotion.md
@@ -79,7 +79,7 @@ export class MyApp {
 
 Go to your view and add emotion custom attribute to an HTML tag.
 
-```markup
+```html
 <div class="message" emotion.bind="cssObject">${message}</div>
 ```
 

--- a/docs/user-docs/advanced-scenarios/strongly-typed-template.md
+++ b/docs/user-docs/advanced-scenarios/strongly-typed-template.md
@@ -60,7 +60,7 @@ The idea behind the code is really simple. First, we separate strings and variab
 
 string\(s\):
 
-```markup
+```html
 <button class="btn btn-primary btn-
 
 " ref="atButtonTemplate">

--- a/docs/user-docs/advanced-scenarios/write-custom-plugin.md
+++ b/docs/user-docs/advanced-scenarios/write-custom-plugin.md
@@ -253,7 +253,7 @@ Go to the `src` folder of `bootstrap-v5` package, create a `button` folder then 
 
 Create `bs-button.html` file.
 
-```markup
+```html
 <button class="btn btn-primary btn-${size}" ref="bsButtonTemplate">
     Primary Button
 </button>
@@ -387,7 +387,7 @@ We support configuration so we should introduce it to `register` method too.
 
 Now, You are able to use your `bs-button` inside `src/my-app.html`.
 
-```markup
+```html
 <bs-button></bs-button>
 <bs-button size="lg"></bs-button>
 ```

--- a/docs/user-docs/app-basics/building-a-contact-manager-app.md
+++ b/docs/user-docs/app-basics/building-a-contact-manager-app.md
@@ -35,7 +35,7 @@ Once the creation process has finished, you will be presented with instructions 
 
 We now have a barebones Aurelia application. Let's tweak some of the markup to support the structure of our contact manager application.
 
-```markup
+```html
 <nav class="navbar navbar-light bg-light border-bottom" role="navigation">
     <a class="navbar-brand" href="#">
         <i class="fa fa-user"></i>
@@ -79,7 +79,7 @@ Aurelia
 
 We then have to add a viewport into our `my-app.html` file which is the root of our application. This is where our contact details and whatnot will be rendered. Let's replace the placeholder text with the `<au-viewport>` element where contacts will be rendered.
 
-```markup
+```html
 <div class="container">
 
     <div class="row">
@@ -103,7 +103,7 @@ As you can see, we already have this from the previous sections of this tutorial
 
 **Create a new folder called `components` inside of the `src` directory and create a file called `no-selection.html`**
 
-```markup
+```html
 <div class="text-center">
     <h1>No contact selected</h1>
 </div>
@@ -111,7 +111,7 @@ As you can see, we already have this from the previous sections of this tutorial
 
 **Now, let's update our `my-app.html` file and import the `no-selection` component**
 
-```markup
+```html
 <import from="./components/no-selection.html"></import>
 
 <div class="container mt-3">

--- a/docs/user-docs/aurelia-packages/dialog.md
+++ b/docs/user-docs/aurelia-packages/dialog.md
@@ -392,7 +392,7 @@ The Dialog host element is the target where an application chooses to add the di
 
 An example of the html structure when document body is the dialog host:
 
-```markup
+```html
 <body>
   <au-dialog-container> <!-- wrapper -->
     <au-dialog-overlay> <!-- overlay -->

--- a/docs/user-docs/aurelia-packages/internationalization.md
+++ b/docs/user-docs/aurelia-packages/internationalization.md
@@ -41,7 +41,7 @@ Aurelia
 
 The above example shows how to initialize the i18n plugin and, thereby, i18next with translation resources. There are alternatives ways of doing this, which are discussed [later](internationalization.md#managing-translation-resources). Once registered, the plugin can be used in your view using the translation attribute `t` (this is the default translation attribute name, but an [alias can be configured](internationalization.md#configuring-translation-attribute-aliases)), and the translation keys that have been registered.
 
-```markup
+```html
 <span t="key"></span>
 ```
 
@@ -94,7 +94,7 @@ Additionally, all [`i18next` plugins](https://www.i18next.com/overview/plugins-a
 
 As mentioned above, Aurelia views access translation resources using the `t` attribute by default (see the details [here](internationalization.md#translation)).
 
-```markup
+```html
 <element t="key"></element>
 ```
 
@@ -111,7 +111,7 @@ new Aurelia()
 
 The registered aliases can then be used in your view in place of `t`.
 
-```markup
+```html
 <element i18n="key1"></element>
 <element tr="key2"></element>
 ```
@@ -278,7 +278,7 @@ Aurelia uses an attribute pattern to replace the content or attribute values. (T
 
 **Syntax**
 
-```markup
+```html
 <element
   t="
     [optional-attribute-list1]translation-key;
@@ -304,7 +304,7 @@ This is the most common use case and the default behavior.
 }
 ```
 
-```markup
+```html
 <span t="key"></span>
 ```
 
@@ -318,7 +318,7 @@ class MyView {
 }
 ```
 
-```markup
+```html
 <span t.bind="i18nKey"></span>
 ```
 
@@ -332,7 +332,7 @@ The aforementioned `t="key"` syntax behaves a bit differently for `img` elements
 }
 ```
 
-```markup
+```html
 <img t="key">
 ```
 
@@ -348,13 +348,13 @@ As mentioned above, by default, the plugin will set the `textContent` property o
 }
 ```
 
-```markup
+```html
 <span t="title">Title</span>
 ```
 
 Therefore, in the above example, the HTML tags will be escaped, and the output will be `&lt;b&gt;bold&lt;/b&gt;`. The `[html]` attribute must be added before the translation key to allow HTML markup.
 
-```markup
+```html
 <span t="[html]title">Title</span>
 ```
 
@@ -371,7 +371,7 @@ So far, we have seen that the contents are replaced. There are two special attri
 }
 ```
 
-```markup
+```html
 <span t="[prepend]pre;[append]post">tac</span>
 ```
 
@@ -387,7 +387,7 @@ The plugin can be used to translate HTML-element attributes.
 }
 ```
 
-```markup
+```html
 <span t="[title]title"></span>
 ```
 
@@ -405,7 +405,7 @@ export class CustomMessage {
 }
 ```
 
-```markup
+```html
 <template>
   <span>${message}</span>
 </template>
@@ -413,13 +413,13 @@ export class CustomMessage {
 
 Use the custom element as follows.
 
-```markup
+```html
 <custom-message t="[message]bar"></custom-message>
 ```
 
 Which produces the following result.
 
-```markup
+```html
 <custom-message>
   <span>[TRANSLATED VALUE OF BAR KEY]</span>
 </custom-message>
@@ -437,7 +437,7 @@ Let's see how this works in Aurelia with some basic examples. For further detail
 { "key": "{{what}} is {{how}}" }
 ```
 
-```markup
+```html
 <span t="key" t-params.bind="{ what: 'i18next', how: 'great' }"></span>
 ```
 
@@ -453,7 +453,7 @@ The above results in `<span>i18next is great</span>`.
 }
 ```
 
-```markup
+```html
 <span t="status" t-params.bind="{ context: 'dispatched' }"></span>
 ```
 
@@ -468,7 +468,7 @@ The above results in `<span>Your order has been dispatched</span>`.
 }
 ```
 
-```markup
+```html
 <span t="itemWithCount" t-params.bind="{ count: 0 }"></span>
 <span t="itemWithCount" t-params.bind="{ count: 1 }"></span>
 <span t="itemWithCount" t-params.bind="{ count: 10 }"></span>
@@ -476,7 +476,7 @@ The above results in `<span>Your order has been dispatched</span>`.
 
 The above results in the following.
 
-```markup
+```html
 <span>0 items</span>
 <span>1 item</span>
 <span>10 items</span>
@@ -494,7 +494,7 @@ Sometimes, simple plural contexts are not enough, and another translation is req
 }
 ```
 
-```markup
+```html
 <span t="itemWithCount_interval"  t-params.bind="{postProcess: 'interval', count: 0}"></span>
 <span t="itemWithCount_interval"  t-params.bind="{postProcess: 'interval', count: 1}"></span>
 <span t="itemWithCount_interval"  t-params.bind="{postProcess: 'interval', count: 2}"></span>
@@ -506,7 +506,7 @@ Sometimes, simple plural contexts are not enough, and another translation is req
 
 This results in the following.
 
-```markup
+```html
 <span>0 items</span>
 <span>1 item</span>
 <span>2 items</span>
@@ -520,7 +520,7 @@ This results in the following.
 
 If the key expression is evaluated to `null`, or `undefined`, a default value can be provided as follows.
 
-```markup
+```html
 <span
   t.bind="exprEvaluatedToNullOrUnd"
   t-params.bind="{defaultValue: 'foo-bar'}"
@@ -533,7 +533,7 @@ The example above produces `<span>foo-bar</span>`, given that `exprEvaluatedToNu
 
 To do translations in a more declarative way from within your HTML markup, you can use the `t` ValueConverter and BindingBehavior.
 
-```markup
+```html
 <span> ${'itemWithCount' | t : {count: 10}} </span>
 <span> ${'itemWithCount' & t : {count: 10}} </span>
 ```
@@ -579,7 +579,7 @@ The `@aurelia/i18n` plugin provides number formatting using [`Intl` API](https:/
 
 #### Format number in view using ValueConverter and/or BindingBehavior
 
-```markup
+```html
 <span> ${ 123456789.12 | nf } </span>
 <span> ${ 123456789.12 & nf : undefined : 'de'} </span>
 <span> ${ 123456789.12 | nf: {style:'currency', currency: 'EUR' } : 'de' } </span>
@@ -662,7 +662,7 @@ export class MyDemoVm {
 }
 ```
 
-```markup
+```html
 <span> ${ date | df } </span> <!-- 8/20/2019 -->
 <span> ${ '2019-08-10T13:42:35.209Z' | df } </span> <!-- 8/20/2019 -->
 <span> ${ 0 | df } </span> <!-- 1/1/1970 -->
@@ -734,7 +734,7 @@ export class MyDemoVm {
 }
 ```
 
-```markup
+```html
 <span> ${ date | rt } </span>                             <!-- 5 seconds ago -->
 <span> ${ date & rt : { style: 'short' } : 'de' } </span> <!-- vor 5 Sek. -->
 ```

--- a/docs/user-docs/aurelia-packages/validation/README.md
+++ b/docs/user-docs/aurelia-packages/validation/README.md
@@ -110,7 +110,7 @@ export class AwesomeComponent {
 
 Inside our HTML, we use the `validate` binding behavior to signal to Aurelia that we want to validate these bindings. You might notice that both `name` and `age` appear in our view model above where we set some rules up.
 
-```markup
+```html
 <form submit.delegate="submit()">
   <input value.bind="person.name & validate">
   <input value.bind="person.age & validate">

--- a/docs/user-docs/aurelia-packages/validation/displaying-errors.md
+++ b/docs/user-docs/aurelia-packages/validation/displaying-errors.md
@@ -6,7 +6,7 @@ description: How to display validation errors in your UI.
 
 The validation controller maintains the active list of validation results which can be iterated to display the errors in UI.
 
-```markup
+```html
 <ul>
   <li repeat.for="result of validationController.results">
     <template if.bind="!result.valid">${result}</template>
@@ -22,7 +22,7 @@ There are also some out-of-the-box components that can be used to display the er
 
 This custom attribute can be used to bind the errors for children the target elements.
 
-```markup
+```html
 <div validation-errors.from-view="nameErrors"> <!--binds all errors for name to the "nameErrors" property-->
   <input value.bind="person.name & validate">
   <div>
@@ -43,7 +43,7 @@ Note that this in itself does not show any error, unless errors are iterated to 
 
 A point to note is that multiple validation targets can also be used for a single `validation-errors` custom attribute, and the errors for multiple targets will be captured the same way.
 
-```markup
+```html
 <div validation-errors.from-view="errors"> <!--binds all errors for name, and age to the "errors" property-->
   <input value.bind="person.name & validate">
   <input value.bind="person.age & validate">
@@ -74,7 +74,7 @@ This is useful if you have a custom attribute of the same name, and want to use 
 
 The `validation-container`custom element also has similar goal of capturing the validation errors for the children target elements. Additionally, it provides a template to display the errors as well. This helps in reducing the boilerplate created by the `validation-errors` custom attribute. For example, using this custom element, displaying the errors reduces to the following.
 
-```markup
+```html
 <validation-container>
   <input value.bind="person.name & validate">
 </validation-container>
@@ -87,7 +87,7 @@ The `validation-container`custom element also has similar goal of capturing the 
 
 There are couple of important points to note about the examples shown above. The first validation target shown in the example uses the default template of the custom element. This custom element template is based on two `slot`s as shown below.
 
-```markup
+```html
 <slot>
   <!--meant for validation target-->
 </slot>

--- a/docs/user-docs/aurelia-packages/validation/validate-binding-behavior.md
+++ b/docs/user-docs/aurelia-packages/validation/validate-binding-behavior.md
@@ -6,7 +6,7 @@ This is how the validation controller comes to know of the bindings that need to
 
 You must have noticed plenty examples of the `validate` binding behavior in the demos so far. For completeness, this can be used as follows.
 
-```markup
+```html
 <html-element target.bind="source & validate:[trigger]:[validationController]:[rules]"></html-element>
 ```
 

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -64,7 +64,7 @@ export class NameComponent {
 {% endtab %}
 
 {% tab title="name-component.html" %}
-```markup
+```html
 <p>Hello ${firstName} ${lastName}. How are you today?</p>
 ```
 {% endtab %}
@@ -190,7 +190,7 @@ In some cases, you want to make an impact on the value that is binding. For such
 
 Suppose you have a `carousel` component in which you want to enable `navigator` feature for it.
 
-```markup
+```html
 <!-- Enable -->
 <my-carousel navigator.bind="true">
 <my-carousel navigator="true">
@@ -566,7 +566,7 @@ export class FormInput {
 
 with the template
 
-```markup
+```html
 <label>${label}
   <input value.bind="value">
 </label>
@@ -589,7 +589,7 @@ export class FormInput {
 
 And the usage of our component would look like this:
 
-```markup
+```html
 <form-input
   label.bind="label"
   value.bind="message"
@@ -599,7 +599,7 @@ And the usage of our component would look like this:
 
 to be repeated like this inside:
 
-```markup
+```html
 <label>${label}
   <input value.bind tooltip.bind validation.bind min.bind max.bind>
 </label>
@@ -607,7 +607,7 @@ to be repeated like this inside:
 
 To juggle all the relevant pieces for such a task isn't difficult, but somewhat tedious. With attribute transferring, which is roughly close to object spreading in JavaScript, the above template should be as simple as:
 
-```markup
+```html
 <label>${label}
   <input ...$attrs>
 </label>
@@ -659,7 +659,7 @@ Using the ellipsis syntax which you might be accustomed to from Javascript, we c
 
 In case you want to spread all attributes while explicitly overriding individual ones, make sure these come after the spread operator.
 
-```markup
+```html
 <input value.bind="..." ...$attrs> spread wins
 <input ...$attrs value.bind="..."> explicit wins
 ```
@@ -672,7 +672,7 @@ It's recommended that this feature should not be overused in multi-level capturi
 
 Aurelia conventions enable the setting of `capture` metadata from the template via `<capture>` tag, like the following example:
 
-```markup
+```html
 <capture>
 
 <input ...$attrs>
@@ -705,7 +705,7 @@ export class FormInput {
 A usage example is as follows:
 
 {% code title="my-app.html" %}
-```markup
+```html
 <form-input
   if.bind="needsComment"
   label.bind="label"
@@ -736,7 +736,7 @@ This means `.bind` command will work as expected when it's transferred from some
 
 It also means that spreading onto a custom element will also work: if a captured attribute targets a bindable property of the applied custom element. An example:
 
-```markup
+```html
 app.html
 <input-field value.bind="message">
 

--- a/docs/user-docs/components/components.md
+++ b/docs/user-docs/components/components.md
@@ -39,7 +39,7 @@ export class AppLoader {
 {% endtab %}
 
 {% tab title="app-loader.html" %}
-```markup
+```html
 <p>Loading...</p>
 ```
 {% endtab %}

--- a/docs/user-docs/components/scope-and-binding-context.md
+++ b/docs/user-docs/components/scope-and-binding-context.md
@@ -25,7 +25,7 @@ When we start an Aurelia app, the compilation pipeline JIT compiles the template
 
 Most of the bindings also contain expressions.
 
-```markup
+```html
 <!-- interpolation binding -->
 ${firstName}
 

--- a/docs/user-docs/components/shadow-dom-and-slots.md
+++ b/docs/user-docs/components/shadow-dom-and-slots.md
@@ -162,7 +162,7 @@ static content
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <!-- Usage without projection -->
 <my-element></my-element>
 <!-- Rendered (simplified): -->
@@ -207,7 +207,7 @@ In the example above, the `my-element` custom element defines two slots: one def
 Similar to native shadow DOM and `<slot/>`/`[slot]` pair, `[au-slot]` attribute is not mandatory if you are targeting the default slot. All content without explicit `[au-slot]` is treated as targeting the default slot. Having no `[au-slot]` is also equal to having explicit `au-slot` on the content:
 
 {% code title="my-app.html" %}
-```markup
+```html
 <template as-custom-element="my-element">
   <au-slot>dfb</au-slot>
 </template>
@@ -226,7 +226,7 @@ Similar to native shadow DOM and `<slot/>`/`[slot]` pair, `[au-slot]` attribute 
 Another important point to note is that the usage of `[au-slot]` attribute is supported only on the direct children elements of a custom element. This means that the following examples do not work.
 
 {% code title="my-app.html" %}
-```markup
+```html
 <!-- Do NOT work. -->
 
 <div au-slot></div>
@@ -247,7 +247,7 @@ It is possible to inject an instance of `IAuSlotsInfo` in a custom element view 
 
 {% tabs %}
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot>dfb</au-slot>
 <au-slot name="s1">s1fb</au-slot>
 <au-slot name="s2">s2fb</au-slot>
@@ -269,7 +269,7 @@ class MyElement {
 {% endtab %}
 
 {% tab title="my-app.html" %}
-```markup
+```html
 <!-- my_element_instance_1 -->
 <my-element>
   <div au-slot="default">dp</div>
@@ -283,7 +283,7 @@ class MyElement {
 
 The followingrk would be logged to the console for the instances of `my-element`.
 
-```markup
+```html
 // my_element_instance_1
 ['default', 's1']
 
@@ -309,7 +309,7 @@ Let's consider the following example with interpolation.
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element>
   <div au-slot="s1">${message}</div>
 </my-element>
@@ -331,7 +331,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1">${message}</au-slot>
 ```
 {% endtab %}
@@ -349,7 +349,7 @@ Although the `my-element` has a `message` property, but as `my-app` projects to 
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element>
   <foo-bar au-slot="s1" foo.bind="message"></foo-bar>
 </my-element>
@@ -371,7 +371,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1">${message}</au-slot>
 ```
 {% endtab %}
@@ -385,7 +385,7 @@ export class MyElement {
 {% endtab %}
 
 {% tab title="foo-bar.html" %}
-```markup
+```html
 ${foo}
 ```
 {% endtab %}
@@ -405,7 +405,7 @@ Let's consider the following example with interpolation. This is the same exampl
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element></my-element>
 <!-- Rendered (simplified): -->
 <!--
@@ -425,7 +425,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1">${message}</au-slot>
 ```
 {% endtab %}
@@ -443,7 +443,7 @@ Note that in the absence of projection, the fallback content uses the scope of `
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element></my-element>
 <!-- Rendered (simplified): -->
 <!--
@@ -463,7 +463,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1">
   <foo-bar foo.bind="message"></foo-bar>
 </au-slot>
@@ -479,7 +479,7 @@ export class MyElement {
 {% endtab %}
 
 {% tab title="foo-bar.html" %}
-```markup
+```html
 ${foo}
 ```
 {% endtab %}
@@ -499,7 +499,7 @@ The outer custom element can access the inner custom element's scope using the `
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element>
   <div au-slot="s1">${$host.message}</div>
   <div au-slot="s2">${message}</div>
@@ -523,7 +523,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1"></au-slot>
 <au-slot name="s2"></au-slot>
 ```
@@ -542,7 +542,7 @@ Note that using the `$host.message` expression, `MyApp` can access the `MyElemen
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <my-element>
   <foo-bar au-slot="s1" foo.bind="$host.message"></foo-bar>
 </my-element>
@@ -564,7 +564,7 @@ export class MyApp {
 {% endtab %}
 
 {% tab title="my-element.html" %}
-```markup
+```html
 <au-slot name="s1"></au-slot>
 ```
 {% endtab %}
@@ -578,7 +578,7 @@ export class MyElement {
 {% endtab %}
 
 {% tab title="foo-bar.html" %}
-```markup
+```html
 ${foo}
 ```
 {% endtab %}
@@ -596,7 +596,7 @@ Let's consider another example of `$host` which highlights the communication bet
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <template as-custom-element="my-element">
   <bindable name="people"></bindable>
   <au-slot name="grid">
@@ -680,7 +680,7 @@ It is possible to provide multiple projections to a single slot.
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <my-element>
   <div au-slot="s2">p20</div>
   <div au-slot="s1">p11</div>
@@ -710,7 +710,7 @@ This is useful for many cases. One evident example would a 'tabs' custom element
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <my-tabs>
   <h3 au-slot="header">Tab1</h3>
   <div au-slot="content">Tab1 content</div>
@@ -743,7 +743,7 @@ Having more than one `<au-slot>` with the same name is also supported. This lets
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <person-card>
   <span au-slot="name"> John Doe </span>
   <span au-slot="role"> Role1 </span>

--- a/docs/user-docs/developer-guides/building-plugins.md
+++ b/docs/user-docs/developer-guides/building-plugins.md
@@ -260,7 +260,7 @@ Go to the `src` folder of `bootstrap-v5` package, create a `button` folder then 
 
 Create `bs-button.html` file.
 
-```markup
+```html
 <button class="btn btn-primary btn-${size}" ref="bsButtonTemplate">
     Primary Button
 </button>
@@ -394,7 +394,7 @@ We support configuration so we should introduce it to `register` method too.
 
 Now, You are able to use your `bs-button` inside `src/my-app.html`.
 
-```markup
+```html
 <bs-button></bs-button>
 <bs-button size="lg"></bs-button>
 ```

--- a/docs/user-docs/developer-guides/cheat-sheet.md
+++ b/docs/user-docs/developer-guides/cheat-sheet.md
@@ -26,7 +26,7 @@ Note: you can copy-paste the markup below into an html file and open it directly
 
 **index.html**
 
-```markup
+```html
 <!DOCTYPE html>
 <html>
 <head></head>
@@ -55,7 +55,7 @@ Note: you can copy-paste the markup below into an html file and open it directly
 
 **index.html**
 
-```markup
+```html
 <!DOCTYPE html>
 <html>
 <head><title>${title}</title></head>
@@ -426,7 +426,7 @@ export class BananaInBox {
 
 ## Templating syntax
 
-```markup
+```html
 <!-- Render the 'firstName' and 'lastName' properties interpolated with some static text (reactive) -->
 <div>Hello, ${firstName} ${lastName}</div>
 <!-- Render the 'bgColor' property as a class name, interpolated with some static text (reactive) -->
@@ -481,7 +481,7 @@ export class BananaInBox {
 
 ## Built-in custom attributes & template controllers (AKA directives)
 
-```markup
+```html
 <!-- Conditionally render this nav-link (element is not created and will not exist in DOM if false) -->
 <nav-link if.bind="isLoggedIn">
 <!-- Conditionally display this nav-link (element is only hidden via CSS if false, and will always be created and exist in DOM) -->
@@ -720,7 +720,7 @@ export class MyComponent {
 
 #### Example that blocks rendering (but is simplest to develop)
 
-```markup
+```html
 <div>${data}</div>
 ```
 
@@ -734,7 +734,7 @@ export class MyComponent {
 
 #### Example that does not block rendering and avoids race conditions (without task queue)
 
-```markup
+```html
 <div if.bind="loadDataPromise">Loading...</div>
 <div else>...</div>
 ```
@@ -755,7 +755,7 @@ export class MyComponent {
 
 #### Example that does not block rendering and avoids race conditions (_with_ task queue)
 
-```markup
+```html
 <div if.bind="loadDataTask">Loading...</div>
 <div else>...</div>
 ```

--- a/docs/user-docs/developer-guides/forms/README.md
+++ b/docs/user-docs/developer-guides/forms/README.md
@@ -29,7 +29,7 @@ Creating forms in Aurelia requires no special configuration or treatment. Simply
 Firstly, let's create the markup for our login form:
 
 {% code title="login-component.html" %}
-```markup
+```html
 <form submit.trigger="handleLogin()">
     <div>
         <label for="email">Email:</label>
@@ -79,7 +79,7 @@ Binding to text inputs uses similar syntax to that of binding to other elements 
 
 ### Text Input
 
-```markup
+```html
 <form>
   <label>User value</label><br>
   <input type="text" value.bind="userValue" />
@@ -88,7 +88,7 @@ Binding to text inputs uses similar syntax to that of binding to other elements 
 
 You can even bind to other attributes on form elements such as the `placeholder` attribute.
 
-```markup
+```html
 <form>
   <label>User value</label><br>
   <input type="text" value.bind="userValue" placeholder.bind="myPlaceholder" />
@@ -99,7 +99,7 @@ You can even bind to other attributes on form elements such as the `placeholder`
 
 A textarea element is just like any other form element. It allows you to bind to its value and by default `value.bind` will be two-way binding \(meaning changes flow from out of the view into the view-model and changes in the view-model flow back to the view\).
 
-```markup
+```html
 <form role="form">
   <textarea value.bind="textAreaValue"></textarea>
 </form>
@@ -121,7 +121,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -156,7 +156,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -193,7 +193,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -227,7 +227,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -271,7 +271,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -309,7 +309,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -342,7 +342,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -371,7 +371,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -414,7 +414,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Do you like cake?</h4>
@@ -452,7 +452,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -496,7 +496,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -528,7 +528,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -565,7 +565,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -592,7 +592,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Do you like tacos?:
@@ -617,7 +617,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -649,7 +649,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -680,7 +680,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -710,7 +710,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -731,7 +731,7 @@ export class App {
 
 Most of the time, a `<form>` element should be used to group one or many controls in a form, it acts a container for those controls, and can also be used for layout purposes with CSS. Normally, HTML forms can be submitted without involving any JavaScript, via the `action` and `method` attributes on a `<form>`. Though it's also common in applications that forms are driven by JavaScript. In Aurelia, driving form via script can be achieved via `submit` event on the form, with the basic usage looks like the following example:
 
-```markup
+```html
 <form submit.trigger="submitMyForm()">
   ...
 </form>

--- a/docs/user-docs/developer-guides/forms/validating-form-input/README.md
+++ b/docs/user-docs/developer-guides/forms/validating-form-input/README.md
@@ -64,7 +64,7 @@ This guide explains how to validate the user input for your app using the valida
   }
   ```
 
-  ```markup
+  ```html
   <form submit.delegate="submit()">
     <input value.bind="person.name & validate">
     <input value.bind="person.age & validate">

--- a/docs/user-docs/developer-guides/forms/validating-form-input/displaying-errors.md
+++ b/docs/user-docs/developer-guides/forms/validating-form-input/displaying-errors.md
@@ -6,7 +6,7 @@ description: How to display validation errors in your UI.
 
 The validation controller maintains the active list of validation results which can be iterated to display the errors in UI.
 
-```markup
+```html
 <ul>
   <li repeat.for="result of validationController.results">
     <template if.bind="!result.valid">${result}</template>
@@ -22,7 +22,7 @@ There are also some out-of-the-box components that can be used to display the er
 
 This custom attribute can be used to bind the errors for children the target elements.
 
-```markup
+```html
 <div validation-errors.from-view="nameErrors"> <!--binds all errors for name to the "nameErrors" property-->
   <input value.bind="person.name & validate">
   <div>
@@ -43,7 +43,7 @@ Note that this in itself does not show any error, unless errors are iterated to 
 
 A point to note is that multiple validation targets can also be used for a single `validation-errors` custom attribute, and the errors for multiple targets will be captured the same way.
 
-```markup
+```html
 <div validation-errors.from-view="errors"> <!--binds all errors for name, and age to the "errors" property-->
   <input value.bind="person.name & validate">
   <input value.bind="person.age & validate">
@@ -74,7 +74,7 @@ This is useful if you have a custom attribute of the same name, and want to use 
 
 The `validation-container`custom element also has similar goal of capturing the validation errors for the children target elements. Additionally, it provides a template to display the errors as well. This helps in reducing the boilerplate created by the `validation-errors` custom attribute. For example, using this custom element, displaying the errors reduces to the following.
 
-```markup
+```html
 <validation-container>
   <input value.bind="person.name & validate">
 </validation-container>
@@ -87,7 +87,7 @@ The `validation-container`custom element also has similar goal of capturing the 
 
 There are couple of important points to note about the examples shown above. The first validation target shown in the example uses the default template of the custom element. This custom element template is based on two `slot`s as shown below.
 
-```markup
+```html
 <slot>
   <!--meant for validation target-->
 </slot>

--- a/docs/user-docs/developer-guides/forms/validating-form-input/validate-binding-behavior.md
+++ b/docs/user-docs/developer-guides/forms/validating-form-input/validate-binding-behavior.md
@@ -4,7 +4,7 @@ The `validate` binding behavior, as the name suggests adds the validation behavi
 
 You must have noticed plenty example of the `validate` binding behavior in the demos so far. For completeness, this can be used as follows.
 
-```markup
+```html
 <html-element target.bind="source & validate:[trigger]:[validationController]:[rules]"></html-element>
 ```
 

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -68,13 +68,13 @@ This is to make terminologies consistent as we are moving towards component orie
 
 * The primary property of `If` has been renamed from `condition` to `value`. If you are using `if.bind`, you are not affected. If you are using the multi prop binding syntax, the template looks like this:
 
-```markup
+```html
 <div if="condition.bind: yes">
 ```
 
 Change it to:
 
-```markup
+```html
 <div if="value.bind: yes">
 ```
 

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -8,7 +8,7 @@ The first entry point of an Aurelia application is the main HTML page-loading an
 
 {% tabs %}
 {% tab title="Aurelia 1" %}
-```markup
+```html
 <!-- index.ejs -->
 ​
 <!DOCTYPE html>
@@ -28,7 +28,7 @@ The first entry point of an Aurelia application is the main HTML page-loading an
 {% endtab %}
 
 {% tab title="Aurelia 2" %}
-```markup
+```html
 <!-- index.ejs -->
 ​
 <!DOCTYPE html>
@@ -180,7 +180,7 @@ The root of any Aurelia application is a `single` component, which contains ever
 
 {% tabs %}
 {% tab title="Aurelia 1" %}
-```markup
+```html
 <!-- View -->
 <!-- src/app.html -->
 ​
@@ -207,7 +207,7 @@ export class App {
 {% endtab %}
 
 {% tab title="Aurelia 2" %}
-```markup
+```html
 <!-- View -->
 <!-- src/my-app.html -->
 ​
@@ -249,7 +249,7 @@ a:hover {
 * Unlike version 1, There is a convention for loading your CSS file when the name is the same as the component,  just like `my-app.css`, so you don't need to import it manually.
 * To import any style, component or etc you should use `import`. An alternative to `require` in version 1. By default, the components you create aren't global. What that means is that you can't use a component within another component, unless that component has been imported.
 
-```markup
+```html
 <import from="./name-tag">
 ​
 <h2>${message} <name-tag name.bind="to"></name-tag>!</h2>

--- a/docs/user-docs/developer-guides/routing/component-configured-routing.md
+++ b/docs/user-docs/developer-guides/routing/component-configured-routing.md
@@ -36,7 +36,7 @@ export class UserProfileCustomElement implements IRouteViewModel {
 
 **Your view might be something basic like this:**
 
-```markup
+```html
 <div class="user-profile-container">
     <ul>
       <li class="nav-item">

--- a/docs/user-docs/developer-guides/scenarios/attributepattern.md
+++ b/docs/user-docs/developer-guides/scenarios/attributepattern.md
@@ -47,7 +47,7 @@ export class AngularTwoWayBindingAttributePattern {
 }
 ```
 
-```markup
+```html
 <!-- Angular two-way binding usage -->
 <input [(value)]="message">
 ```
@@ -79,7 +79,7 @@ export class SharpRefAttributePattern {
 
 Given the above example and the implementation, the parameters would have values like the following:
 
-```markup
+```html
 <!-- #uploadInput="" -->
 <input type="file" #uploadInput/>
 ```

--- a/docs/user-docs/developer-guides/scenarios/css-in-js-with-emotion.md
+++ b/docs/user-docs/developer-guides/scenarios/css-in-js-with-emotion.md
@@ -81,6 +81,6 @@ export class MyApp {
 
 Go to your view and add emotion custom attribute to an HTML tag.
 
-```markup
+```html
 <div class="message" emotion.bind="cssObject">${message}</div>
 ```

--- a/docs/user-docs/developer-guides/scenarios/extending-templating-syntax.md
+++ b/docs/user-docs/developer-guides/scenarios/extending-templating-syntax.md
@@ -10,7 +10,7 @@ description: >-
 
 Sometimes you will see the following template in an Aurelia application:
 
-```markup
+```html
 <input value.bind="message">
 ```
 
@@ -29,7 +29,7 @@ You may sometimes come across some custom input element in a component library, 
 
 Regardless of the lib choice an application takes, what is needed in common is the ability to have a concise syntax to describe the two way binding intention with those custom elements. Some examples for the above custom input elements:
 
-```markup
+```html
 <fast-text-field value.bind="message">
 <ion-input value.bind="message">
 <paper-input value.bind="message">
@@ -37,7 +37,7 @@ Regardless of the lib choice an application takes, what is needed in common is t
 
 should be treated as:
 
-```markup
+```html
 <fast-text-field value.two-way="message">
 <ion-input value.two-way="message">
 <paper-input value.two-way="message">
@@ -161,7 +161,7 @@ Aurelia
 
 And with the above, your Aurelia application will get two way binding flow seamlessly:
 
-```markup
+```html
 <fast-text-field value.bind="message"></fast-text-field>
 <fast-text-area value.bind="description"></fast-text-area>
 <fast-slider value.bind="fontSize"></fast-slider>

--- a/docs/user-docs/developer-guides/scenarios/process-content.md
+++ b/docs/user-docs/developer-guides/scenarios/process-content.md
@@ -21,7 +21,7 @@ First is the `node` argument.
 It is the DOM tree on the usage-side for the custom element.
 For example, if there is a custom element named `my-element`, on which a 'processContent' hook is defined, and it is used somewhere as shown in the following markup, then when the hook is invoked, the `node` argument will provide the DOM tree that represents the following markup.
 
-```markup
+```html
 <my-element>
  <foo></foo>
  <bar></bar>
@@ -92,7 +92,7 @@ Let us say that we want to create a custom elements that behaves as a tabs contr
 That is this custom element shows different sets of information grouped under a set of headers, and when the header is clicked the associated content is shown.
 To this end, we can conceptualize the markup for this custom element as follows.
 
-```markup
+```html
 <!--tabs.html-->
 <div class="header">
   <au-slot name="header"></au-slot>
@@ -110,7 +110,7 @@ If you are unfamiliar with the `au-slot` then visit the [documentation](#au-slot
 'processContent' can be very potent with `au-slot`.
 {% endhint %}
 
-```markup
+```html
 <!--app.html-->
 <tabs>
   <tab header="Tab one">

--- a/docs/user-docs/developer-guides/scenarios/strongly-typed-template.md
+++ b/docs/user-docs/developer-guides/scenarios/strongly-typed-template.md
@@ -60,7 +60,7 @@ The idea behind the code is really simple. First, we separate strings and variab
 
 string(s):
 
-```markup
+```html
 <button class="btn btn-primary btn-lg" ref="atButtonTemplate">
 
 </button>

--- a/docs/user-docs/getting-started/quick-start-guide/your-first-component-part-1-the-view-model.md
+++ b/docs/user-docs/getting-started/quick-start-guide/your-first-component-part-1-the-view-model.md
@@ -18,7 +18,7 @@ export class MyApp {
 
 The class property `message` contains a string and within our view, we are displaying it using interpolation.
 
-```markup
+```html
 <div class="message">${message}</div>
 ```
 

--- a/docs/user-docs/getting-started/quick-start-guide/your-first-component-part-2-the-view.md
+++ b/docs/user-docs/getting-started/quick-start-guide/your-first-component-part-2-the-view.md
@@ -10,7 +10,7 @@ Inside the `src` directory create a new file called `hello-name.html` this will 
 
 Firstly, let's write the code to display the value. Notice how we are using interpolation to print the value like the default generated `my-app.html` file was? `${name}` the value inside the curly braces references the class property we defined in the previous section, by the name of `name`.
 
-```markup
+```html
 <div>
     <h4>Hello, ${name}!</h4>
 </div>
@@ -20,7 +20,7 @@ I would say run the app and see it in action, but we haven't imported our custom
 
 Inside of `my-app.html` replace the entire file with the following:
 
-```markup
+```html
 <import from="./hello-name"></import>
 
 <hello-name></hello-name>
@@ -36,7 +36,7 @@ If you were to run the app using `npm start` you would then see your application
 
 We have a functional custom element, but we promised we would be able to update the name with any value we want. Inside of `hello-name.html` add the following beneath the existing heading. 
 
-```markup
+```html
 <div>
     <h4>Hello, ${name}!</h4>
     

--- a/docs/user-docs/getting-to-know-aurelia/components/bindable-setter.md
+++ b/docs/user-docs/getting-to-know-aurelia/components/bindable-setter.md
@@ -12,7 +12,7 @@ In some cases, you want to make an impact on the value that is binding. For such
 
 Suppose you have a `carousel` component in which you want to enable `navigator` feature for it. You probably imagine such a thing for yourself.
 
-```markup
+```html
 <!-- Enable -->
 <my-carousel navigator.bind="true">
 <my-carousel navigator="true">

--- a/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
+++ b/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
@@ -218,7 +218,7 @@ The composition in Aurelia 2 is fundamentally different from Aurelia 1. The same
 If you still want a view supporting a dynamically loaded module, you can create a value converter that achieves this.
 
 {% code title="my-component.html" %}
-```markup
+```html
   <au-compose template="https://my-server.com/templates/${componentName} | loadTemplate">
 ```
 {% endcode %}

--- a/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features.md
+++ b/docs/user-docs/getting-to-know-aurelia/introduction/built-in-template-features.md
@@ -10,7 +10,7 @@ When `if.bind` is passed `false` Aurelia will remove the element all of its chil
 
 In the following example, we are passing a value called `isLoading` which is populated whenever something is loading from the server. We will use it to show a loading message in our view.
 
-```markup
+```html
 <div if.bind="isLoading">Loading...</div>
 ```
 
@@ -24,7 +24,7 @@ When `show.bind` is passed `false` the element will be hidden, but unlike `if.bi
 
 In the following example, we are passing a value called `isLoading` which is populated whenever something is loading from the server. We will use it to show a loading message in our view.
 
-```markup
+```html
 <div show.bind="isLoading">Loading...</div>
 ```
 
@@ -34,7 +34,7 @@ When `isLoading` is a truthy value, the element will be visible. When `isLoading
 
 In Javascript we have the ability to use `switch/case` statements which act as neater `if` statements. We can use `switch.bind` to achieve the same thing within our templates.
 
-```markup
+```html
 <p switch.bind="selectedAction">
   <span case="mask">You are more protected from aerosol particles, and others are protected from you.</span>
   <span case="sanitizer">You are making sure viruses won't be spreaded easily.</span>
@@ -52,23 +52,23 @@ When working with promises in Aurelia, previously in version 1 you had to resolv
 
 The `promise.bind` template controller allows you to use `then`, `pending` and `catch` in your views removing unnecessary boilerplate.
 
-In the following example, notice how we have a parent `div` with the `promise.bind` binding and then a method called `fetchAdvice`? Followed by other attributes inside `then.from-view` and `catch.from-view` which handle both the resolved value as well as any errors.
+In the following example, notice how we have a parent `div` with the `promise.bind` binding and then a method called `fetchAdvice`? Followed by other attributes inside `then` and `catch` which handle both the resolved value as well as any errors.
 
 Ignore the `i` variable being incremented, this is only there to make Aurelia fire off a call to our `fetchAdvice` method as it sees the parameter value has changed.
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <let i.bind="0"></let>
 
 <div promise.bind="fetchAdvice(i)">
   <span pending>Fetching advice...</span>
-  <span then.from-view="data">
+  <span then="data">
     Advice id: ${data.slip.id}<br>
     ${data.slip.advice}
     <button click.trigger="i = i+1">try again</button>
   </span>
-  <span catch.from-view="err">
+  <span catch="err">
     Cannot get an addvice, error: ${err}
     <button click.trigger="i = i+1">try again</button>
   </span>
@@ -97,7 +97,7 @@ To see live examples of `repeat.for` being used, you can consult the examples pa
 
 You can use the `repeat.for` binding to iterate over collections of data in your templates. Think of `repeat.for` as a for loop, it can iterate arrays, maps and sets.
 
-```markup
+```html
 <ul>
     <li repeat.for="item of items">${item.name}</li>
 </ul>
@@ -123,7 +123,7 @@ The `repeat.for` functionality doesn't just allow you to work with collections, 
 
 In the following example, we generate a range of numbers to 10. We subtract the value from the index inside to create a reverse countdown.
 
-```markup
+```html
 <p repeat.for="i of 10">${10-i}</p>
 <p>Blast Off!<p>
 ```
@@ -142,7 +142,7 @@ Aurelia's binding engine makes several special properties available to you in yo
 
 Inside of the `repeat.for` these can be accessed. In the following example we display the current index value.
 
-```markup
+```html
 <ul>
     <li repeat.for="item of items">${$index}</li>
 </ul>

--- a/docs/user-docs/getting-to-know-aurelia/introduction/class-and-style-binding.md
+++ b/docs/user-docs/getting-to-know-aurelia/introduction/class-and-style-binding.md
@@ -65,7 +65,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p style="color: ${textColor}; font-weight: bold; background: ${backgroundColor};">Hello there</p>
 
 ```
@@ -89,7 +89,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p style.bind="styleObject">Hello there</p>
 
 ```

--- a/docs/user-docs/getting-to-know-aurelia/portalling-elements.md
+++ b/docs/user-docs/getting-to-know-aurelia/portalling-elements.md
@@ -10,7 +10,7 @@ While the location of the rendered element changes, it retains its current bindi
 
 Using the `portal` attribute without any configuration options will portal the element to beneath the document body (before the closing body tag).
 
-```markup
+```html
 <div portal>My markup moves to beneath the body by default</div>
 ```
 
@@ -21,7 +21,7 @@ If you want to choose where a portalled element is moved to, you can supply a CS
 Target an element with an ID of `somewhere:`
 
 {% code overflow="wrap" %}
-```markup
+```html
 <div portal="#somewhere">My markup moves toto DIV with ID somewhere</div>
 
 <div id="somewhere"><!-- The element will be portalled here --></div>

--- a/docs/user-docs/reference/examples/custom-attributes/binding-to-element-size.md
+++ b/docs/user-docs/reference/examples/custom-attributes/binding-to-element-size.md
@@ -100,7 +100,7 @@ RectSize.ResizeObserver = ResizeObserver;
 
 For the above implementation, the usage would be:
 
-```markup
+```html
 <form rectsize.bind="formSize">
   ...
 </form>

--- a/docs/user-docs/router-lite/viewports.md
+++ b/docs/user-docs/router-lite/viewports.md
@@ -321,7 +321,7 @@ Note that specifying a value for the `name` attribute of viewport is optional, a
 
 In the following example, we have the `main` viewport for our main content and then another viewport called `sidebar` for our sidebar content.
 
-```markup
+```html
 <main>
     <au-viewport name="main"></au-viewport>
 </main>

--- a/docs/user-docs/routing/navigating.md
+++ b/docs/user-docs/routing/navigating.md
@@ -95,7 +95,7 @@ The router also allows you to decorate links and buttons in your application usi
 
 If you have routes defined on a root level (inside of `my-app.ts`) you will need to add a forward slash in front of any routes you attempt to load. The following would work in the case of an application using configured routes.
 
-```markup
+```html
 <a load="/products/12">Product #12</a>
 ```
 

--- a/docs/user-docs/routing/viewports.md
+++ b/docs/user-docs/routing/viewports.md
@@ -6,7 +6,7 @@ The `<au-viewport>` element is where all of the routing magic happens, the outle
 
 The router allows you to add multiple viewports to your application and render components into each viewport element by their name. The `<au-viewport>` element supports a name attribute, which you'll want to use if you have more than one.
 
-```markup
+```html
 <main>
     <au-viewport name="main"></au-viewport>
 </main>

--- a/docs/user-docs/templates/class-and-style-bindings.md
+++ b/docs/user-docs/templates/class-and-style-bindings.md
@@ -72,7 +72,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p style="color: ${textColor}; font-weight: bold; background: ${backgroundColor};">Hello there</p>
 ```
 {% endcode %}
@@ -95,7 +95,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p style.bind="styleObject">Hello there</p>
 ```
 {% endcode %}

--- a/docs/user-docs/templates/conditional-rendering.md
+++ b/docs/user-docs/templates/conditional-rendering.md
@@ -50,7 +50,7 @@ Be mindful that `if.bind` modifies the DOM structure, which can trigger reflow a
 
 The `show.bind` directive offers an alternative approach to conditional rendering. Instead of adding or removing elements from the DOM, it toggles their visibility. This is akin to applying `display: none;` in CSS—the element remains in the DOM but is not visible to the user.
 
-```markup
+```html
 <div show.bind="isDataLoaded">Data loaded successfully!</div>
 ```
 

--- a/docs/user-docs/templates/forms.md
+++ b/docs/user-docs/templates/forms.md
@@ -26,7 +26,7 @@ Creating forms in Aurelia requires no special configuration or treatment. Create
 **Firstly, let's create the markup for our login form:**
 
 {% code title="login-component.html" %}
-```markup
+```html
 <form submit.trigger="handleLogin()">
     <div>
         <label for="email">Email:</label>
@@ -76,7 +76,7 @@ Binding to text inputs uses a syntax similar to binding to other elements in Aur
 
 ### Text Input
 
-```markup
+```html
 <form>
   <label>User value</label><br>
   <input type="text" value.bind="userValue" />
@@ -85,7 +85,7 @@ Binding to text inputs uses a syntax similar to binding to other elements in Aur
 
 You can even bind to other attributes on form elements such as the `placeholder` attribute.
 
-```markup
+```html
 <form>
   <label>User value</label><br>
   <input type="text" value.bind="userValue" placeholder.bind="myPlaceholder" />
@@ -96,7 +96,7 @@ You can even bind to other attributes on form elements such as the `placeholder`
 
 A textarea element is just like any other form element. It allows you to bind to its value and, by default, `value.bind` will be two-way binding (meaning changes flow from out of the view into the view model and changes in the view-model flow back to the view).
 
-```markup
+```html
 <form role="form">
   <textarea value.bind="textAreaValue"></textarea>
 </form>
@@ -118,7 +118,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -151,7 +151,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -186,7 +186,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -220,7 +220,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -264,7 +264,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -302,7 +302,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -333,7 +333,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -362,7 +362,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -403,7 +403,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Do you like cake?</h4>
@@ -439,7 +439,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <form>
     <h4>Products</h4>
@@ -483,7 +483,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -513,7 +513,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -550,7 +550,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -575,7 +575,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Do you like tacos?:
@@ -598,7 +598,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select product:<br>
@@ -628,7 +628,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -657,7 +657,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -685,7 +685,7 @@ export class App {
 }
 ```
 
-```markup
+```html
 <template>
   <label>
     Select products:
@@ -708,7 +708,7 @@ Normally, HTML forms can be submitted without involving any JavaScript via the `
 
 In Aurelia, driving form via script can be achieved via `submit` event on the form, with the basic usage looking like the following example:
 
-```markup
+```html
 <form submit.trigger="submitMyForm()">
   ...
 </form>

--- a/docs/user-docs/templates/local-templates.md
+++ b/docs/user-docs/templates/local-templates.md
@@ -13,7 +13,7 @@ In many instances, when working with templated views in Aurelia, you will be app
 
 {% tabs %}
 {% tab title="my-app.html" %}
-```markup
+```html
 <template as-custom-element="person-info">
   <bindable name="person"></bindable>
   <div>
@@ -63,7 +63,7 @@ In this case, it is named as `person-info`. A custom element defined that way ca
 
 Local templates can also optionally specify bindable properties using the `<bindable>` tag as shown above. Apart from `property`, other allowed attributes that can be used in this tag are `attribute`, and `mode`. In that respect, the following two declarations are synonymous.
 
-```markup
+```html
 <bindable name="foo" mode="twoWay" attribute="fiz-baz"></bindable>
 ```
 
@@ -85,7 +85,7 @@ This means that the following is a perfectly valid example. Note that the local 
 
 {% tabs %}
 {% tab title="level-one.html" %}
-```markup
+```html
 <template as-custom-element="foo-bar">
   <bindable name='prop'></bindable>
 
@@ -104,7 +104,7 @@ class LevelOne {
 {% endtab %}
 
 {% tab title="level-two.html" %}
-```markup
+```html
 <template as-custom-element="foo-bar">
   <bindable name='prop'></bindable>
   Level Two ${prop}
@@ -124,7 +124,7 @@ class LevelTwo {
 {% endtab %}
 
 {% tab title="my-app.html" %}
-```markup
+```html
 <level-two prop="foo2"></level-two>
 <level-one prop="foo1"></level-one>
 ```
@@ -137,7 +137,7 @@ Like anything, there is always an upside and downside: local templates are no di
 
 ### Local templates are hoisted.
 
-```markup
+```html
 <foo-bar foo.bind="'John'"></foo-bar>
 
 <template as-custom-element="foo-bar">
@@ -152,7 +152,7 @@ Although it might provide a stronger cohesion, as the level of nesting grows, it
 
 In this respect, a good thumb rule is to keep the local function analogy in mind.
 
-```markup
+```html
 <template as-custom-element="el-one">
 <template as-custom-element="one-two">
   1
@@ -177,7 +177,7 @@ The following examples will cause a (jit) compilation error.
 
 {% tabs %}
 {% tab title="invalid-example2.html" %}
-```markup
+```html
 <!--Having such custom element does not help much either.-->
 <template as-custom-element="foo-bar">Does this work?</template>
 <template as-custom-element="fiz-baz">Of course not!</template>
@@ -191,7 +191,7 @@ The following example will cause a (jit) compilation error.
 
 {% tabs %}
 {% tab title="invalid-example1.html" %}
-```markup
+```html
 <div>
   <template as-custom-element="foo-bar">This does not work.</template>
 </div>
@@ -203,7 +203,7 @@ The following example will cause a (jit) compilation error.
 
 The following example will cause a (jit) compilation error.
 
-```markup
+```html
 <template as-custom-element="">foo-bar</template>
 <div></div>
 ```
@@ -212,7 +212,7 @@ The following example will cause a (jit) compilation error.
 
 The following example will cause a (jit) compilation error.
 
-```markup
+```html
 <template as-custom-element="foo-bar">foo-bar1</template>
 <template as-custom-element="foo-bar">foo-bar2</template>
 <div></div>
@@ -222,7 +222,7 @@ The following example will cause a (jit) compilation error.
 
 The following example will cause a (jit) compilation error.
 
-```markup
+```html
 <template as-custom-element="foo-bar">
   <div>
     <bindable name="prop"></bindable>
@@ -235,7 +235,7 @@ The following example will cause a (jit) compilation error.
 
 The following example will cause a (jit) compilation error.
 
-```markup
+```html
 <template as-custom-element="foo-bar">
   <bindable attribute="prop"></bindable>
 </template>

--- a/docs/user-docs/templates/repeats-and-list-rendering.md
+++ b/docs/user-docs/templates/repeats-and-list-rendering.md
@@ -13,7 +13,7 @@ Aurelia supports working with different types of data. Array, Set, and Map are a
 
 You can use the `repeat.for` binding to iterate over data collections in your templates. Think of `repeat.for` as a for loop. It can iterate arrays, maps and sets.
 
-```markup
+```html
 <ul>
     <li repeat.for="item of items">${item.name}</li>
 </ul>
@@ -150,7 +150,7 @@ You may need this when a property on the current scope masks a property on the o
 
 These can be accessed inside the `repeat.for`. In the following example, we display the current index value.
 
-```markup
+```html
 <ul>
     <li repeat.for="item of items">${$parent.$index}</li>
 </ul>
@@ -189,7 +189,7 @@ The `repeat.for` functionality doesn't just allow you to work with collections. 
 
 In the following example, we generate a range of numbers up to 10. We subtract the value from the index inside to create a reverse countdown.
 
-```markup
+```html
 <p repeat.for="i of 10">${10-i}</p>
 <p>Blast Off!<p>
 ```

--- a/docs/user-docs/templates/template-syntax/text-interpolation.md
+++ b/docs/user-docs/templates/template-syntax/text-interpolation.md
@@ -17,7 +17,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p>Hello, my name is ${myName}</p>
 ```
 {% endcode %}
@@ -47,7 +47,7 @@ export class MyApp {
 {% endcode %}
 
 {% code title="my-app.html" %}
-```markup
+```html
 <p>Behold mathematics, 6 + 1 = ${adder(6, 1)}</p>
 ```
 {% endcode %}

--- a/docs/user-docs/templates/value-converters.md
+++ b/docs/user-docs/templates/value-converters.md
@@ -22,7 +22,7 @@ To apply a value converter, you use the pipe `|` character followed by the name 
 
 While Aurelia itself comes with no prebuilt value converters, this is what using them looks like for an imaginary value converter that converts a string to lowercase.
 
-```markup
+```html
 <h1>${someValue | toLowercase}</h1>
 ```
 
@@ -42,7 +42,7 @@ export class ToLowercaseValueConverter {
 
 Value converters can be chained, meaning you can transform a value and then transform it through another value converter. To chain value converters, you separate your value converters using the pipe `|`. In this fictitious example, we are making our value lowercase and then running it through another value converter called bold which will wrap it in `strong` tags to make it bold.
 
-```markup
+```html
 <h1>${someValue | toLowercase | bold }</h1>
 ```
 
@@ -54,7 +54,7 @@ Parameters are supplied using the colon `:` character, and like the pipe, for mu
 
 #### Static parameters
 
-```markup
+```html
 <h1>${someValue | date:'en-UK'}
 ```
 
@@ -62,7 +62,7 @@ Furthermore, value converter parameters also support bound values. Unlike other 
 
 #### Bound parameters
 
-```markup
+```html
 <h1>${someValue | date:format}
 ```
 

--- a/docs/user-docs/tutorials/building-a-realtime-cryptocurrency-price-tracker.md
+++ b/docs/user-docs/tutorials/building-a-realtime-cryptocurrency-price-tracker.md
@@ -139,7 +139,7 @@ export class MyApp {
 
 We now have our crypto prices. Let's display them. Inside of `my-app.html` (our view for the app) we'll reference these price values.
 
-```markup
+```html
 <div class="panels">
     <div class="panel"><h4>Bitcoin</h4> ${prices.bitcoin.usd}</div>
     <div class="panel"><h4>Ethereum</h4> ${prices.ethereum.usd}</div>
@@ -229,7 +229,7 @@ If you want to learn about other ways you can inject dependencies, consult the d
 
 Open up `my-app.html` again and add in the following:
 
-```markup
+```html
 <import from="./resources/value-converters/currency-value-converter"></import>
 
 <div class="panels">
@@ -288,7 +288,7 @@ This now injects Bootstrap styles into all of our Shadow DOM components. The onl
 
 However, you can fix this by adding the Bootstrap CSS into the header of our `index.html` if you want those. Or, you can add them yourself. If you want them, add the Bootstrap CDN include in the header of `index.html`. You can get the most up-to-date style include [here](https://getbootstrap.com/docs/5.0/getting-started/introduction/).
 
-```markup
+```html
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 ```
 
@@ -296,7 +296,7 @@ However, you can fix this by adding the Bootstrap CSS into the header of our `in
 
 Now we have Bootstrap added. It's time to update the markup in `my-app.html` to add the data into a styled table. This is all purely markup, so we are not using any new Aurelia concepts here. You can safely copy and paste this.
 
-```markup
+```html
 <import from="./resources/value-converters/currency"></import>
 
 <div class="container">

--- a/docs/user-docs/tutorials/building-a-todo-application.md
+++ b/docs/user-docs/tutorials/building-a-todo-application.md
@@ -145,7 +145,7 @@ Believe it or not, this view model code forms the basis for adding and deleting 
 
 The view is the most simple part of our application. Inside of `todo-component.html` add in the following HTML, and then we'll explain what is going on.
 
-```markup
+```html
 <import from="./todo-item.html"></import>
 
 <div class="todo">
@@ -229,7 +229,7 @@ We have created our main todo component, but you might have noticed we were impo
 
 For this component, we are going to be creating an HTML-only component. It means it'll just be HTML. No view model needed:
 
-```markup
+```html
 <bindable name="todo"></bindable>
 <bindable name="index"></bindable>
 <bindable name="deleteTodo"></bindable>
@@ -301,7 +301,7 @@ Create a new file `todo-item.css` in the `components` directory and add the foll
 
 To round it all off, let's open up `my-app.html` and add the following:
 
-```markup
+```html
 <import from="./components/todo-component"></import>
 
 <todo-component></todo-component>

--- a/docs/user-docs/tutorials/create-a-dashboard-using-dynamic-composition.md
+++ b/docs/user-docs/tutorials/create-a-dashboard-using-dynamic-composition.md
@@ -121,19 +121,19 @@ Inside of the `fetchDog` method we are doing the following:
 
 Now, we create a `dog-component.html` file inside of the `components` directory:
 
-```markup
+```html
 <div class="component dog-component" promise.bind="fetchDog()">
     <template pending>Fetching doggo...</template>
-    <template then.from-view="dog">
+    <template then="dog">
         <img src.bind="dog.url" loading="lazy">
     </template>
-    <template catch.from-view="err">
+    <template catch="err">
         <p>${err}</p>
     </template>
 </div>
 ```
 
-If you have [read up on the promise controller](../templates/template-syntax.md#using-promise-bindings-inside-of-a-repeat.for), this syntax will be familiar to you. We make the call to our `fetchDog` method while we wait for it to resolve, the `pending` attribute will show the element it is used on. Once the promise resolves on `then.from-view` we get the return object, we can work with it. We then bind the returned URL `src` attribute of the image. If there is an error, the `catch.from-view` will be triggered and pass our error.
+If you have [read up on the promise controller](../templates/template-syntax.md#using-promise-bindings-inside-of-a-repeat.for), this syntax will be familiar to you. We make the call to our `fetchDog` method while we wait for it to resolve, the `pending` attribute will show the element it is used on. Once the promise resolves on `then` we get the return object, we can work with it. We then bind the returned URL `src` attribute of the image. If there is an error, the `catch` will be triggered and pass our error.
 
 ## Base styling
 
@@ -260,7 +260,7 @@ export class MyApp {
 
 The missing piece is now adding the actual dynamic composition to our view. Open `my-app.html` and add in the following:
 
-```markup
+```html
 <div class="container">
     <template repeat.for="component of components">
         <au-compose containerless component.bind="component"></au-compose>
@@ -305,17 +305,17 @@ We actually don't need to explain what is happening here. This is pretty much a 
 
 Now, let's create the view for our geoip component. Create an HTML file called `geoip-component.html` in the `src/components` directory:
 
-```markup
+```html
 <div class="component geoip-component" promise.bind="getUserInfo()">
     <template pending><p>Getting details...</p></template>
 
-    <ul then.from-view="details">
+    <ul then="details">
         <li><h3>IP address:</h3> <span> ${details.ip}</span></li>
         <li><h3>Country:</h3> <span> ${details.country_name}</span></li>
         <li><h3>Timezone:</h3> <span> ${details.time_zone}</span></li>
     </ul>
 
-    <template catch.from-view="err">
+    <template catch="err">
         <p>${err}</p>
     </template>
 </div>
@@ -384,7 +384,7 @@ export class NotesComponent {
 
 We now need the markup for our component. Create a new file called `notes-component.html` alongside our `notes-component.ts` file and add the following:
 
-```markup
+```html
 <div class="component notes-component">
 
     <textarea value.bind="note" spellcheck="false"></textarea><br>
@@ -468,10 +468,10 @@ Like component 4 and component 2, the code is basically the same (the method nam
 
 Now, we create the view for our component `exchange-component.html`
 
-```markup
+```html
 <div class="component exchange-component" promise.bind="getExchangeData()">
     <template pending><p>Fetching data...</p></template>
-    <template then.from-view="data">
+    <template then="data">
         <h3>$1 USD equals:</h3>
         <ul class="amounts-list">
             <li>$${data.rates.AUD} Australian Dollars (AUD)</li>
@@ -480,13 +480,13 @@ Now, we create the view for our component `exchange-component.html`
             <li>£${data.rates.GBP} British Pounds (GBP)</li>
         </ul>
     </template>
-    <template catch.from-view="err">
+    <template catch="err">
         <p>${err}</p>
     </template>
 </div>
 ```
 
-Like the other promise-based examples before this one (component 4 and component 2), we use the promise controller syntax. Inside  `then.from-view` we assign the response to a variable called `data` and then we can access the properties. In our case, we are accessing exchange rates.
+Like the other promise-based examples before this one (component 4 and component 2), we use the promise controller syntax. Inside  `then` we assign the response to a variable called `data` and then we can access the properties. In our case, we are accessing exchange rates.
 
 Now, let's create the accompanying CSS file for our component of the same name, `exchange-component.css`
 
@@ -567,7 +567,7 @@ export class DogComponent {
 
 Inside of `dog-component.html` replace the existing `promise.bind` with this one:
 
-```markup
+```html
 promise.bind="api.fetchData('https://random.dog/woof.json', 'Unable to fetch doggo :(')"
 ```
 
@@ -587,7 +587,7 @@ export class ExchangeComponent {
 
 Once more, inside of `exchange-component.html` we replace the existing `promise.bind` with this one:
 
-```markup
+```html
 promise.bind="api.fetchData('https://api.exchangerate-api.com/v4/latest/USD')"
 ```
 

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -403,7 +403,6 @@ export {
   // IController,
   // IContainer,
   // IViewCache,
-  // IViewFactory,
   // MountStrategy,
 
   // AccessorOrObserver,
@@ -566,10 +565,10 @@ export {
   // IViewModel,
   type ICustomAttributeViewModel,
   type ICustomElementViewModel,
-  // IController,
+  IController,
   // IContainer,
   // IViewCache,
-  // IViewFactory,
+  IViewFactory,
   // MountStrategy,
 
   // AccessorOrObserver,

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -365,7 +365,7 @@ export class Container implements IContainer {
     throw createMappedError(ErrorNames.unable_resolve_key, key);
   }
 
-  public getAll<K extends Key>(key: K, searchAncestors: boolean = false): readonly Resolved<K>[] {
+  public getAll<K extends Key>(key: K, searchAncestors: boolean = false): Resolved<K>[] {
     validateKey(key);
 
     const previousContainer = currentContainer;
@@ -637,7 +637,7 @@ function containerGetKey(this: IContainer, d: Key) {
 
 export type IResolvedInjection<K extends Key> =
   K extends IAllResolver<infer R>
-    ? readonly Resolved<R>[]
+    ? Resolved<R>[]
     : K extends INewInstanceResolver<infer R>
       ? Resolved<R>
       : K extends ILazyResolver<infer R>

--- a/packages/kernel/src/di.resolvers.ts
+++ b/packages/kernel/src/di.resolvers.ts
@@ -40,7 +40,7 @@ export const all = <T extends Key>(key: T, searchAncestors: boolean = false): IA
 
   return resolver as IAllResolver<T>;
 };
-export type IAllResolver<T> = IResolver<readonly Resolved<T>[]> & {
+export type IAllResolver<T> = IResolver<Resolved<T>[]> & {
   // type only hack
   __isAll: undefined;
   // any for decorator

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -646,7 +646,16 @@ export class TemplateControllerRenderer implements IRenderer {
       default:
         def = instruction.res;
     }
-    const viewFactory = this._rendering.getViewFactory(instruction.def, ctxContainer);
+    // const viewFactory = this._rendering.getViewFactory(
+    //   instruction.def,
+    //   ctxContainer
+    // );
+    const viewFactory = this._rendering.getViewFactory(
+      instruction.def,
+      def.containerStrategy === 'new'
+        ? ctxContainer.createChild({ inheritParentResources: true })
+        : ctxContainer
+    );
     const renderLocation = convertToRenderLocation(target);
     const results = invokeAttribute(
       /* platform         */platform,

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -40,6 +40,17 @@ export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
   readonly noMultiBindings?: boolean;
   readonly watches?: IWatchDefinition[];
   readonly dependencies?: readonly Key[];
+  /**
+   * **Only used by template controller custom attributes.**
+   *
+   * Container strategy for the view factory of this template controller.
+   *
+   * By default, the view factory will be reusing the container of the parent view (controller),
+   * as this container has information about the resources registered.
+   *
+   * Specify `'new'` to create a new container for the view factory.
+   */
+  readonly containerStrategy?: 'reuse' | 'new';
 }>;
 
 export type CustomAttributeType<T extends Constructable = Constructable> = ResourceType<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition>;
@@ -105,6 +116,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
     public readonly noMultiBindings: boolean,
     public readonly watches: IWatchDefinition[],
     public readonly dependencies: Key[],
+    public readonly containerStrategy: 'reuse' | 'new',
   ) {}
 
   public static create<T extends Constructable = Constructable>(
@@ -132,6 +144,7 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
       firstDefined(getAttributeAnnotation(Type, 'noMultiBindings'), def.noMultiBindings, Type.noMultiBindings, false),
       mergeArrays(Watch.getDefinitions(Type), Type.watches),
       mergeArrays(getAttributeAnnotation(Type, 'dependencies'), def.dependencies, Type.dependencies),
+      firstDefined(getAttributeAnnotation(Type, 'containerStrategy'), def.containerStrategy, Type.containerStrategy, 'reuse'),
     );
   }
 


### PR DESCRIPTION
## 📖 Description

Currently template controllers reuse the container from their owning renderer (custom element), as an optimization, also a requirement since they need to retrieve the resources information from there. This works well for all built in template controllers as they don't need to do anything special with their view factories.
Though, for application custom controller, sometimes it's more desirable to have separate container for dynamic DI work.

This PR adds a new option `containerStrategy` for custom attribute definition to enable this. The acceptable values are `reuse` and `new`, and the default is `reuse`, which is the existing behavior.
![image](https://github.com/aurelia/aurelia/assets/9994529/2f2bc162-ed38-4c3e-818c-6c2e307fc0e3)


### 🎫 Issues

Resolves #1923

Thanks @mxjp 