### PR TITLE
feat(process-content): ability to add information to a data object

### DIFF
--- a/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
@@ -477,13 +477,13 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
         [
           MyElement,
         ],
-        { 'my-element': [`<h4>First Name</h4> <h4>Last Name</h4> <div>John</div> <div>Doe</div> <div>Max</div> <div>Mustermann</div>`, new AuSlotsInfo([])] },
+        { 'my-element': [`<h4>First Name</h4><h4>Last Name</h4> <div>John</div><div>Doe</div> <div>Max</div><div>Mustermann</div>`, new AuSlotsInfo([])] },
         async function ({ app, host, platform }) {
           app.people.push(new Person('Jane', 'Doe', []));
           platform.domWriteQueue.flush();
           assert.html.innerEqual(
             'my-element',
-            `<h4>First Name</h4> <h4>Last Name</h4> <div>John</div> <div>Doe</div> <div>Max</div> <div>Mustermann</div> <div>Jane</div> <div>Doe</div>`,
+            `<h4>First Name</h4><h4>Last Name</h4> <div>John</div><div>Doe</div> <div>Max</div><div>Mustermann</div> <div>Jane</div><div>Doe</div>`,
             'my-element.innerHTML',
             host);
         }
@@ -1079,7 +1079,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo([])] },
+        { 'my-element': ['<h4>First Name</h4><h4>Last Name</h4><h4>Pets</h4> <div>John</div><div>Doe</div><coll-vwr><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div><div>Mustermann</div><coll-vwr><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo([])] },
       );
 
       yield new TestData(
@@ -1098,7 +1098,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
           MyElement,
         ],
         { 'my-element': [
-          '<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>',
+          '<h4>First Name</h4><h4>Last Name</h4><h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>',
           new AuSlotsInfo(['content'])
         ]},
       );
@@ -1119,7 +1119,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
+        { 'my-element': ['<h4>First Name</h4><h4>Last Name</h4><h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>', new AuSlotsInfo(['content'])] },
       );
 
       yield new TestData(
@@ -1140,7 +1140,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
         ],
         {
           'my-element': [
-            '<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>',
+            '<h4>First Name</h4><h4>Last Name</h4><h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><ul><li>Browny</li><li>Smokey</li></ul></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><ul><li>Sea biscuit</li><li>Swift Thunder</li></ul></coll-vwr>',
             new AuSlotsInfo(['content'])
           ],
         }
@@ -1156,7 +1156,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
           CollVwr,
           MyElement,
         ],
-        { 'my-element': ['<h4>First Name</h4> <h4>Last Name</h4> <h4>Pets</h4> <div>John</div> <div>Doe</div> <coll-vwr><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div> <div>Mustermann</div> <coll-vwr><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo(['colleslawt'])] },
+        { 'my-element': ['<h4>First Name</h4><h4>Last Name</h4><h4>Pets</h4> <div>John</div><div>Doe</div><coll-vwr><div>Browny</div><div>Smokey</div></coll-vwr> <div>Max</div><div>Mustermann</div><coll-vwr><div>Sea biscuit</div><div>Swift Thunder</div></coll-vwr>', new AuSlotsInfo(['colleslawt'])] },
       );
 
       yield new TestData(

--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -313,7 +313,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
 
       type HEI = HydrateElementInstruction;
       const allInstructions = compiledDefinition.instructions.flat();
-      // console.log(allInstructions.map(i => (i as any).projections));
+
       for (const expectedSlotInfo of expectedSlotInfos) {
         const actualInstruction = allInstructions.find((i) =>
           i.type === InstructionType.hydrateElement
@@ -323,9 +323,10 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
           && expectedSlotInfo.slotName === (i as HEI).data.name
         ) as HydrateElementInstruction;
         assert.notEqual(actualInstruction, void 0, 'instruction');
+
         const slotFallback = actualInstruction.projections?.default;
-        assert.deepStrictEqual((slotFallback.template as HTMLElement).outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
-        assert.deepStrictEqual(slotFallback.needsCompile, false, 'needsCompile');
+        assert.deepStrictEqual((slotFallback?.template as HTMLElement).outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
+        assert.deepStrictEqual(slotFallback?.needsCompile, false, 'needsCompile');
       }
 
       // for each element instruction found

--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -325,7 +325,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
         assert.notEqual(actualInstruction, void 0, 'instruction');
 
         const slotFallback = actualInstruction.projections?.default;
-        assert.deepStrictEqual((slotFallback?.template as HTMLElement).outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
+        assert.deepStrictEqual((slotFallback?.template as HTMLElement)?.outerHTML, `<template>${expectedSlotInfo.content}</template>`, 'content');
         assert.deepStrictEqual(slotFallback?.needsCompile, false, 'needsCompile');
       }
 

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -878,10 +878,10 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
       type: TT.hydrateElement,
       res: tagNameOrDef,
       props: childInstructions as IInstruction[],
-      auSlot: null,
       containerless: false,
       projections: null,
       captures: [],
+      data: {},
     };
     const def = typeof tagNameOrDef === 'string'
       ? CustomElement.find(ctx.container, tagNameOrDef)

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -290,6 +290,7 @@ export {
   type CustomElementType,
   CustomElementDefinition,
   type PartialCustomElementDefinition,
+  type ProcessContentHook,
   useShadowDOM,
   processContent,
 } from './resources/custom-element';

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -154,13 +154,8 @@ export class MultiAttrInstruction {
   ) {}
 }
 
-export class HydrateElementInstruction {
+export class HydrateElementInstruction<T extends Record<PropertyKey, unknown> = Record<PropertyKey, unknown>> {
   public readonly type = hydrateElement;
-
-  /**
-   * A special property that can be used to store <au-slot/> usage information
-   */
-  public auSlot: { name: string; fallback: CustomElementDefinition } | null = null;
 
   public constructor(
     /**
@@ -169,7 +164,6 @@ export class HydrateElementInstruction {
     // in theory, Constructor of resources should be accepted too
     // though it would be unnecessary right now
     public res: string | /* Constructable |  */CustomElementDefinition,
-    public alias: string | undefined,
     /**
      * Bindable instructions for the custom element instance
      */
@@ -186,6 +180,10 @@ export class HydrateElementInstruction {
      * A list of captured attr syntaxes
      */
     public captures: AttrSyntax[] | undefined,
+    /**
+     * Any data associated with this instruction
+     */
+    public readonly data: T,
   ) {
   }
 }

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -591,7 +591,7 @@ export const CustomElement = objectFreeze<CustomElementKind>({
 });
 
 type DecoratorFactoryMethod<TClass> = (target: Constructable<TClass>, propertyKey: string, descriptor: PropertyDescriptor) => void;
-type ProcessContentHook = (node: INode, platform: IPlatform) => boolean | void;
+export type ProcessContentHook = (node: HTMLElement, platform: IPlatform, metadata: Record<PropertyKey, unknown>) => boolean | void;
 
 const pcHookMetadataProperty = /*@__PURE__*/getAnnotationKeyFor('processContent');
 export function processContent(hook: ProcessContentHook): CustomElementDecorator;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -591,7 +591,7 @@ export const CustomElement = objectFreeze<CustomElementKind>({
 });
 
 type DecoratorFactoryMethod<TClass> = (target: Constructable<TClass>, propertyKey: string, descriptor: PropertyDescriptor) => void;
-export type ProcessContentHook = (node: HTMLElement, platform: IPlatform, metadata: Record<PropertyKey, unknown>) => boolean | void;
+export type ProcessContentHook = (node: HTMLElement, platform: IPlatform, data: Record<PropertyKey, unknown>) => boolean | void;
 
 const pcHookMetadataProperty = /*@__PURE__*/getAnnotationKeyFor('processContent');
 export function processContent(hook: ProcessContentHook): CustomElementDecorator;

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -8,6 +8,11 @@ import { def, objectAssign, safeString } from '../utilities';
 import { ErrorNames, createMappedError } from '../errors';
 import { isElement } from '../utilities-dom';
 
+/** @internal */
+export const defaultSlotName = 'default';
+/** @internal */
+export const auslotAttr = 'au-slot';
+
 export type PartialSlottedDefinition = {
   callback?: PropertyKey;
   slotName?: string;


### PR DESCRIPTION
## 📖 Description

- add a 3rd argument to the process content hook call to store compilation or pre-compilation information and pass it onto the custom element.
- remove the special treatment of `<au-slot>` from the default compiler, this helps cleanup oddness /coupling between the default compiler and the au-slot element. This also helps cleanup the whitespace inconsistency between normal projection and au-slot fallback (which is also a projection) templates.

### 🎫 Issues

- resolve #1204

cc @Sayan751