### PR TITLE
feat(custom-attribute): ability to find closest attr by name or ctor

### DIFF
--- a/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
@@ -968,6 +968,14 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
       host = resolve(INode);
       value: any;
     });
+    const Baz = CustomAttribute.define('baz', class Baz {
+      host = resolve(INode);
+      value: any;
+      parent = CustomAttribute.closest<typeof Foo>(this.host, 'foo')?.viewModel;
+      bound() {
+        this.host.textContent = this.parent?.value ?? this.value;
+      }
+    });
     const Bar = CustomAttribute.define('bar', class Bar {
       host = resolve(INode);
       value: any;
@@ -978,7 +986,7 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
     });
 
     it('finds closest custom attribute using string', function () {
-      const { assertText } = createFixture(`<div foo="1"><div bar="2"></div></div>`, class App {}, [Foo, Bar]);
+      const { assertText } = createFixture(`<div foo="1"><div baz="2"></div></div>`, class App {}, [Foo, Baz]);
       assertText('1');
     });
 
@@ -993,8 +1001,9 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
       `
         <div foo="1"></div>
         <div bar="2"></div>
-      `, class App {}, [Foo, Bar]);
-      assertText('2', { compact: true });
+        <div baz="3"></div>
+      `, class App {}, [Foo, Bar, Baz]);
+      assertText('2 3', { compact: true });
     });
 
     it('finds closest custom attribute when nested multiple dom layers', function () {
@@ -1002,13 +1011,14 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
         <div foo="1">
           <center>
             <div bar="2"></div>
+            <div baz="3"></div>
           </center>
         </div>
         `,
         class App {},
-        [Foo, Bar]
+        [Foo, Bar, Baz]
       );
-      assertText('1', { compact: true });
+      assertText('1 1', { compact: true });
     });
 
     it('finds closest custom attribute when nested multiple dom layers + multiple parent attributes', function () {
@@ -1018,13 +1028,14 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
             <div foo="3">
               <div bar="2"></div>
             </div>
+            <div baz="4"></div>
           </center>
         </div>
         `,
         class App {},
-        [Foo, Bar]
+        [Foo, Bar, Baz]
       );
-      assertText('3', { compact: true });
+      assertText('3 1', { compact: true });
     });
 
     it('throws when theres no attribute definition associated with the type', function () {

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -145,8 +145,8 @@ export function getEffectiveParentNode(node: Node): Node | null {
 
   if (node.parentNode === null && node.nodeType === NodeType.DocumentFragment) {
     // Could be a shadow root; see if there's a controller and if so, get the original host via the projector
-    const controller = findElementControllerFor(node);
-    if (controller === void 0) {
+    const controller = findElementControllerFor(node, { optional: true });
+    if (controller == null) {
       // Not a shadow root (or at least, not one created by Aurelia)
       // Nothing more we can try, just return null
       return null;

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -1,7 +1,7 @@
 import { mergeArrays, firstDefined, Key, resourceBaseName, getResourceKeyFor } from '@aurelia/kernel';
 import { Bindable } from '../bindable';
 import { Watch } from '../watch';
-import { getRef } from '../dom';
+import { INode, getEffectiveParentNode, getRef } from '../dom';
 import { defineMetadata, getAnnotationKeyFor, getOwnMetadata, hasOwnMetadata } from '../utilities-metadata';
 import { isFunction, isString, objectFreeze } from '../utilities';
 import { aliasRegistration, transientRegistration } from '../utilities-di';
@@ -15,7 +15,7 @@ import type {
   ResourceType,
 } from '@aurelia/kernel';
 import type { BindableDefinition, PartialBindableDefinition } from '../bindable';
-import type { ICustomAttributeViewModel, ICustomAttributeController } from '../templating/controller';
+import type { ICustomAttributeViewModel, ICustomAttributeController, Controller } from '../templating/controller';
 import type { IWatchDefinition } from '../watch';
 import { ErrorNames, createMappedError } from '../errors';
 import { dtAttribute, type IResourceKind } from './resources-shared';
@@ -56,6 +56,8 @@ export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
 export type CustomAttributeType<T extends Constructable = Constructable> = ResourceType<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition>;
 export type CustomAttributeKind = IResourceKind & {
   for<C extends ICustomAttributeViewModel = ICustomAttributeViewModel>(node: Node, name: string): ICustomAttributeController<C> | undefined;
+  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>, TType2 extends TType = TType>(node: Node, Type: CustomAttributeType<TType2>): ICustomAttributeController<InstanceType<TType2>> | null;
+  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>, TType2 extends TType = TType>(node: Node, name: string): ICustomAttributeController<InstanceType<TType2>> | null;
   isType<T>(value: T): value is (T extends Constructable ? CustomAttributeType<T> : never);
   define<T extends Constructable>(name: string, Type: T): CustomAttributeType<T>;
   define<T extends Constructable>(def: PartialCustomAttributeDefinition, Type: T): CustomAttributeType<T>;
@@ -214,11 +216,40 @@ export const getAttributeDefinition = <T extends Constructable>(Type: T | Functi
   return def;
 };
 
+const findClosestControllerByName = (node: Node, attrNameOrType: string | CustomAttributeType): ICustomAttributeController | null => {
+  let key = '';
+  let attrName = '';
+  if (typeof attrNameOrType === 'string') {
+    key = getAttributeKeyFrom(attrNameOrType);
+    attrName = attrNameOrType;
+  } else {
+    try {
+      const definition = getAttributeDefinition(attrNameOrType);
+      key = definition.key;
+      attrName = definition.name;
+    } catch (ex) {
+      throw createMappedError(ErrorNames.attribute_def_not_found, attrNameOrType);
+    }
+  }
+  let cur = node as INode | null;
+  while (cur !== null) {
+    const controller = getRef(cur, key) as Controller | null;
+    if (controller?.is(attrName)) {
+      return controller as ICustomAttributeController;
+    }
+
+    cur = getEffectiveParentNode(cur);
+  }
+
+  return null;
+};
+
 export const CustomAttribute = objectFreeze<CustomAttributeKind>({
   name: caBaseName,
   keyFrom: getAttributeKeyFrom,
   isType: isAttributeType,
   for: findAttributeControllerFor,
+  closest: findClosestControllerByName,
   define: defineAttribute,
   getDefinition: getAttributeDefinition,
   annotate<K extends keyof PartialCustomAttributeDefinition>(Type: Constructable, prop: K, value: PartialCustomAttributeDefinition[K]): void {

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -56,8 +56,8 @@ export type PartialCustomAttributeDefinition = PartialResourceDefinition<{
 export type CustomAttributeType<T extends Constructable = Constructable> = ResourceType<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition>;
 export type CustomAttributeKind = IResourceKind & {
   for<C extends ICustomAttributeViewModel = ICustomAttributeViewModel>(node: Node, name: string): ICustomAttributeController<C> | undefined;
-  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>, TType2 extends TType = TType>(node: Node, Type: CustomAttributeType<TType2>): ICustomAttributeController<InstanceType<TType2>> | null;
-  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>, TType2 extends TType = TType>(node: Node, name: string): ICustomAttributeController<InstanceType<TType2>> | null;
+  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A> = A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>>(node: Node, Type: CustomAttributeType<TType>): ICustomAttributeController<InstanceType<TType>> | null;
+  closest<A extends object | Constructable, TType extends A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A> = A extends Constructable<infer T extends object> ? Constructable<T> : Constructable<A>>(node: Node, name: string): ICustomAttributeController<InstanceType<TType>> | null;
   isType<T>(value: T): value is (T extends Constructable ? CustomAttributeType<T> : never);
   define<T extends Constructable>(name: string, Type: T): CustomAttributeType<T>;
   define<T extends Constructable>(def: PartialCustomAttributeDefinition, Type: T): CustomAttributeType<T>;
@@ -219,17 +219,13 @@ export const getAttributeDefinition = <T extends Constructable>(Type: T | Functi
 const findClosestControllerByName = (node: Node, attrNameOrType: string | CustomAttributeType): ICustomAttributeController | null => {
   let key = '';
   let attrName = '';
-  if (typeof attrNameOrType === 'string') {
+  if (isString(attrNameOrType)) {
     key = getAttributeKeyFrom(attrNameOrType);
     attrName = attrNameOrType;
   } else {
-    try {
-      const definition = getAttributeDefinition(attrNameOrType);
-      key = definition.key;
-      attrName = definition.name;
-    } catch (ex) {
-      throw createMappedError(ErrorNames.attribute_def_not_found, attrNameOrType);
-    }
+    const definition = getAttributeDefinition(attrNameOrType);
+    key = definition.key;
+    attrName = definition.name;
   }
   let cur = node as INode | null;
   while (cur !== null) {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -35,6 +35,7 @@ import type {
   IContainer,
   IDisposable,
   IServiceLocator,
+  ResourceDefinition,
   Writable,
 } from '@aurelia/kernel';
 import type {
@@ -1106,11 +1107,9 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
   public is(name: string): boolean {
     switch (this.vmKind) {
-      case vmkCa: {
-        return getAttributeDefinition(this._vm!.constructor).name === name;
-      }
+      case vmkCa:
       case vmkCe: {
-        return getElementDefinition(this._vm!.constructor).name === name;
+        return (this.definition as ResourceDefinition).name === name;
       }
       case vmkSynth:
         return this.viewFactory!.name === name;


### PR DESCRIPTION
## 📖 Description

Part of the improvement in v2 compared to v1, where attribute and elements are both participating in the container hierarchy and causing resolver shadowing/issues with container resolution, is that only element participates in the container hierarchy.
This, however, makes finding/injecting custom attribute in a group of attributes a challenge. This is a valid need, since often times that custom attributes are developed in grouped, as discussed in #660 or https://discourse.aurelia.io/t/au2-access-parent-component-viewmodel-in-a-clean-way/5378/5

This PR adds a new utility `closest` in `CustomAttribute`, to enable walking the DOM and finding a custom attribute controller via name or constructor, like the following example:


```html
<div foo="1">
  <div bar="2">
  </div>
</div>
```

```ts
import { CustomAttribute, resolve, INode } from 'aurelia';

@customAttribute('bar')
export class Bar {
  host = resolve(INode);
  parent = CustomAttribute.closest(this.host, 'foo');
}
```

Or the following also works if you want to search using the constructor:

```ts
import { CustomAttribute, resolve, INode } from 'aurelia';
import { Foo } from './foo';

@customAttribute('bar')
export class Bar {
  host = resolve(INode);
  parent = CustomAttribute.closest(this.host, Foo); // <--- use constructor instead of string 'foo'
}
```

In the discussion in #660 , `closest` was chosen instead of a  `@parent` injection as it's closer to DOM API, and the way we walk & find, also it's less ambiguous since `@parent` doesn't indicate whether it's immediate or any of the ancestors.

Thanks @migajek @rluba 