### PR TITLE
fix(form): prevent actionless submission

### DIFF
--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -27,9 +27,10 @@ An quickest way to get an application in v1 up an running in v2 is to include th
 
 In v2, `preventDefault` is no longer called by default. This breaking change could show up in unexpected places:
 - click events: in v1, clicking on a button inside a form will not submit the form, while it will in v2, as the click event default behavior is no longer prevented
-  {% hint style="info" %}
-  Even though clicking default behavior is not prevented, form submission without an action will not reload the page as this default behavior is still prevented in v2, so you don't need to add `:prevent` to every button `click`, or form `submit` listener.
-  {% endhint %}
+    {% hint style="info" %}
+    Even though clicking default behavior is not prevented, form submission without an action will not reload the page as this default behavior is still prevented in v2, so you don't need to add `:prevent` to every button `click`, or form `submit` listener.
+    {% endhint %}
+
 - drag events: in v1, implementing drag/drop will have `preventDefault` called automatically, but in v2, they will need to be explicitly called by the application
 
 Sometimes, if it's desirable to call `preventDefault` in an event binding, use `prevent` modifier, like the following example:
@@ -44,7 +45,7 @@ Read more about modifiers in [event modifier doc here](../../templates/template-
 
 ### Scope selection
 
-In v2, when trying to bind with a non-existent property, the closest boundary scope will be selected, instead of the immediate scope of the binding (v1 behavior).
+In v2, when trying to bind with a non-existent property, the closest boundary scope (scope of the owning custom element) will be selected, instead of the immediate scope of the binding (v1 behavior).
 
 ### Internal binding property `observeProperty` has been renamed to `observe`
 

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -140,6 +140,12 @@ Read more about dynamic composition in v2 in this [dynamic composition doc](../.
 
 ## General changes
 
+* Custom attributes are no longer considered to have a binding to the primary bindable when their template usage is with an empty string, like the following examples:
+    ```html
+    <div my-attr>
+    <div my-attr="">
+    ```
+    Both of the above usages will be considered as "plain" usage, to avoid overriding the defaul value in the custom attribute component instance.
 * Templates no longer need to have `<template>` tags as the start and ending tags. Templates can be pure HTML with enhanced Aurelia markup but `<template>` doesn't need to be explicitly defined.
 * `PLATFORM.moduleName` is gone. This was to address a limitation in Aurelia 1. Aurelia 2 now works well with all bundlers and does not require the addition of this code to use code splitting or tell the bundler where template code is.
 * Better intellisense support for TypeScript applications. Using the new injection interfaces, you can now inject strongly typed Aurelia packages such as Fetch Client, Router or Internationalization. These packages are prefixed with an "I" such as `IHttpClient`, `IRouter` and so on.

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -27,6 +27,9 @@ An quickest way to get an application in v1 up an running in v2 is to include th
 
 In v2, `preventDefault` is no longer called by default. This breaking change could show up in unexpected places:
 - click events: in v1, clicking on a button inside a form will not submit the form, while it will in v2, as the click event default behavior is no longer prevented
+  {% hint style="info" %}
+  Even though clicking default behavior is not prevented, form submission without an action will not reload the page as this default behavior is still prevented in v2, so you don't need to add `:prevent` to every button `click`, or form `submit` listener.
+  {% endhint %}
 - drag events: in v1, implementing drag/drop will have `preventDefault` called automatically, but in v2, they will need to be explicitly called by the application
 
 Sometimes, if it's desirable to call `preventDefault` in an event binding, use `prevent` modifier, like the following example:

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, Registration } from '@aurelia/kernel';
-import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, IAppRoot, CustomElementType, CustomElement, ICustomElementViewModel } from '@aurelia/runtime-html';
+import { StandardConfiguration, Aurelia as $Aurelia, IPlatform, CustomElementType, CustomElement, ICustomElementViewModel } from '@aurelia/runtime-html';
 import { BrowserPlatform } from '@aurelia/platform-browser';
 import type { ISinglePageAppConfig, IEnhancementConfig } from '@aurelia/runtime-html';
 
@@ -17,10 +17,6 @@ function createContainer(): IContainer {
 export class Aurelia extends $Aurelia {
   public constructor(container: IContainer = createContainer()) {
     super(container);
-  }
-
-  public static start(root: IAppRoot | undefined): void | Promise<void> {
-    return new Aurelia().start(root);
   }
 
   public static app(config: ISinglePageAppConfig<object> | CustomElementType): Omit<Aurelia, 'register' | 'app' | 'enhance'> {

--- a/packages/compat-v1/src/index.ts
+++ b/packages/compat-v1/src/index.ts
@@ -1,7 +1,6 @@
 import { IContainer, IRegistry } from '@aurelia/kernel';
 import { defineAstMethods } from './compat-ast';
 import { defineBindingMethods } from './compat-binding';
-import { PreventFormActionlessSubmit } from './compat-form';
 import { delegateSyntax, eventPreventDefaultBehavior } from './compat-event';
 import { callSyntax } from './compat-call';
 import { enableComposeCompat } from './compat-au-compose';
@@ -17,16 +16,11 @@ export const compatRegistration: IRegistry = {
     defineBindingMethods();
     enableComposeCompat();
     container.register(
-      PreventFormActionlessSubmit,
       eventPreventDefaultBehavior,
       delegateSyntax,
       callSyntax,
     );
   }
-};
-
-export {
-  PreventFormActionlessSubmit,
 };
 
 export {

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -161,6 +161,13 @@ export interface ISinglePageAppConfig<T = unknown> {
    * The root component of the app
    */
   component: T | Constructable<T>;
+  /**
+   * When a HTML form is submitted, the default behavior is to "redirect" the page to the action of the form
+   * This is not desirable for SPA applications, so by default, this behavior is prevented.
+   *
+   * This option re-enables the default behavior of HTML forms.
+   */
+  allowActionlessForm?: boolean;
 }
 
 export interface IEnhancementConfig<T> {
@@ -173,4 +180,11 @@ export interface IEnhancementConfig<T> {
    * A predefined container for the enhanced view.
    */
   container?: IContainer;
+  /**
+   * When a HTML form is submitted, the default behavior is to "redirect" the page to the action of the form
+   * This is not desirable for SPA applications, so by default, this behavior is prevented.
+   *
+   * This option re-enables the default behavior of HTML forms.
+   */
+  allowActionlessForm?: boolean;
 }

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -1,7 +1,7 @@
 import { Constructable, EventAggregator, IContainer, ILogger, MaybePromise } from '@aurelia/kernel';
 import { Metadata } from '@aurelia/metadata';
 import { IObserverLocator } from '@aurelia/runtime';
-import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition } from '@aurelia/runtime-html';
+import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig } from '@aurelia/runtime-html';
 import { assert } from './assert';
 import { hJsx } from './h';
 import { TestContext } from './test-context';
@@ -28,6 +28,7 @@ export function createFixture<T extends object>(
   registrations: unknown[] = [],
   autoStart: boolean = true,
   ctx: TestContext = TestContext.create(),
+  appConfig: IFixtureConfig =  {},
 ): IFixture<ICustomElementViewModel & ObjectType<T>> {
   type K = ObjectType<T>;
   const { container } = ctx;
@@ -76,7 +77,7 @@ export function createFixture<T extends object>(
   function startFixtureApp() {
     if (autoStart) {
       try {
-        au.app({ host: host, component });
+        au.app({ host: host, component, ...appConfig });
         fixture.startPromise = startPromise = au.start();
       } catch (ex) {
         try {
@@ -542,9 +543,10 @@ export interface IFixtureBuilderBase<T, E = {}> {
   html<M>(html: TemplateStringsArray, ...values: TemplateValues<M>[]): this & E;
   component(comp: T): this & E;
   deps(...args: unknown[]): this & E;
+  config(config: IFixtureConfig): this & E;
 }
 
-type BuilderMethodNames = 'html' | 'component' | 'deps';
+type BuilderMethodNames = 'html' | 'component' | 'deps' | 'config';
 type CreateBuilder<T, Availables extends BuilderMethodNames> = {
   [key in Availables]:
     key extends 'html'
@@ -560,11 +562,14 @@ type CreateBuilder<T, Availables extends BuilderMethodNames> = {
 type TaggedTemplateLambda<M> = (vm: M) => unknown;
 type TemplateValues<M> = string | number | TaggedTemplateLambda<M>;
 
+export type IFixtureConfig = Pick<IAppRootConfig, 'allowActionlessForm'>;
+
 class FixtureBuilder<T> {
   private _html?: string | TemplateStringsArray;
   private _htmlArgs?: TemplateValues<T>[];
   private _comp?: T;
   private _args?: unknown[];
+  private _config?: IFixtureConfig;
 
   public html(html: string | TemplateStringsArray, ...htmlArgs: TemplateValues<T>[]): CreateBuilder<T, Exclude<BuilderMethodNames, 'html'>> {
     this._html = html;
@@ -580,6 +585,11 @@ class FixtureBuilder<T> {
   public deps(...args: unknown[]): CreateBuilder<T, Exclude<BuilderMethodNames, 'deps'>> {
     this._args = args;
     return this as CreateBuilder<T, Exclude<BuilderMethodNames, 'deps'>>;
+  }
+
+  public config(config: IFixtureConfig): CreateBuilder<T, Exclude<BuilderMethodNames, 'config'>> {
+    this._config = config;
+    return this as CreateBuilder<T, Exclude<BuilderMethodNames, 'config'>>;
   }
 
   public build() {
@@ -605,6 +615,7 @@ function brokenProcessFastTemplate(html: TemplateStringsArray, ..._args: unknown
 createFixture.html = <T = Record<PropertyKey, any>>(html: string | TemplateStringsArray, ...values: TemplateValues<T>[]) => new FixtureBuilder<T>().html(html, ...values);
 createFixture.component = <T, K extends ObjectType<T>>(component: T) => new FixtureBuilder<K>().component(component as unknown as K);
 createFixture.deps = <T = Record<PropertyKey, any>>(...deps: unknown[]) => new FixtureBuilder<T>().deps(...deps);
+createFixture.config = <T = Record<PropertyKey, any>>(config: IFixtureConfig) => new FixtureBuilder<T>().config(config);
 
 /* eslint-disable */
 function testBuilderTypings() {

--- a/packages/testing/src/test-context.ts
+++ b/packages/testing/src/test-context.ts
@@ -19,6 +19,7 @@ export class TestContext {
   public get CustomEvent() { return this.platform.globalThis.CustomEvent; }
   public get KeyboardEvent() { return this.platform.globalThis.KeyboardEvent; }
   public get MouseEvent() { return this.platform.globalThis.MouseEvent; }
+  public get SubmitEvent() { return this.platform.globalThis.SubmitEvent; }
   public get Node() { return this.platform.globalThis.Node; }
   public get Element() { return this.platform.globalThis.Element; }
   public get HTMLElement() { return this.platform.globalThis.HTMLElement; }


### PR DESCRIPTION
## 📖 Description

Currently, form actionless submission is a part of the compat package, though it's not necessarily most useful there. Move it to be part of the main application via config `allowActionlessForm`, so that the submit event on form without an `action` attribute will be called `preventDefault()`. This is to avoid reloading the whole page, which is 99.99% of the times not wanted in an SPA.

This behavior can be configured like the following examples:

```ts
Aurelia.app({
  host: ...,
  component: ...,
  allowActionlessForm: true, // <-- this will reload page by default
})

// or

Aurelia.register(AppTask.creating(IAppRoot, root => root.config.allowActionlessForm = true));
```

BREAKING CHANGE:
- Move actionless form submit prevention from compat to application config, though this behavior is the same with v1, so it's mostly a change compared to previous version of v2 only.

cc @Sayan751 @fkleuver @CollinHerber 