### PR TITLE
fix(vite-plugin): when using ShadowDOM, need to load css as string

### DIFF
--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -82,6 +82,7 @@ export default function au(options: {
             ? s
             : s.replace(/\.html$/, '.$au.ts');
         },
+        stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions
       });
       return result;


### PR DESCRIPTION
# Pull Request

## 📖 Description

To make shadow dom option work in our vite plugin with default config.

### 🎫 Issues

Vite app with shadow dom turned on fails to run, because vite is trying to handle css injection to html head. We need to use `./foo.css?inline` to tell vite to bypass that.

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

Test basic app, and shadow dom app.

## ⏭ Next Steps

More tests will be covered in aurelia/new's e2e tests.