### PR TITLE
fix(vite-plugin): missed some default options in "load" preprocess

### DIFF
--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -107,7 +107,9 @@ export default function au(options: {
         contents: code,
       }, {
         hmrModule: 'import.meta',
-        transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts')
+        transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
+        stringModuleWrap: (id) => `${id}?inline`,
+        ...additionalOptions
       });
       return result!.code;
     }


### PR DESCRIPTION
closes #1935

