### PR TITLE
feat: update email validation pattern

### DIFF
--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -308,7 +308,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
    */
   public email(this: PropertyRule<TObject, string>) {
     // eslint-disable-next-line no-useless-escape
-    const emailPattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+    const emailPattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z0-9]{2,}$/;   // update the regex pattern
     return this.addRule(new RegexRule(emailPattern, 'email'));
   }
 


### PR DESCRIPTION
[aurelia/packages/validation/src/rule-provider.ts](https://github.com/aurelia/aurelia/blob/2fca6ea3703f51a2b7b87d719bfa45c9bb35d6e1/packages/validation/src/rule-provider.ts#L311)

Line 311 in [2fca6ea](https://github.com/aurelia/aurelia/commit/2fca6ea3703f51a2b7b87d719bfa45c9bb35d6e1)

 const emailPattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/; 
Not sure if this is the intended behavior.

At the moment the behaviour is like this

test -> not valid
test@ -> not valid
test@test -> valid
test@test. -> not valid
test@test.c -> valid

Should test@test also not be valid?

If yes, then changing the regex to something like this:

^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z0-9]{2,}$


I have change the emailpattern, please review it and merge my pull request