### PR TITLE
refactor: move scope to runtime html

### DIFF
--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -39,8 +39,8 @@ import {
   Unparser,
   AccessBoundaryExpression,
 } from '@aurelia/expression-parser';
-import { IObserverLocatorBasedConnectable, Scope } from '@aurelia/runtime';
-import { type IAstEvaluator, astAssign, astEvaluate, astBind, IBinding } from '@aurelia/runtime-html';
+import { IObserverLocatorBasedConnectable } from '@aurelia/runtime';
+import { type IAstEvaluator, astAssign, astEvaluate, astBind, IBinding, Scope } from '@aurelia/runtime-html';
 
 const $false = PrimitiveLiteralExpression.$false;
 const $true = PrimitiveLiteralExpression.$true;

--- a/packages/__tests__/src/2-runtime/binding-context.spec.ts
+++ b/packages/__tests__/src/2-runtime/binding-context.spec.ts
@@ -1,4 +1,4 @@
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 
 describe('2-runtime/binding-context.spec.ts', function () {

--- a/packages/__tests__/src/3-runtime-html/binding-behavior.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/binding-behavior.spec.ts
@@ -1,6 +1,6 @@
 import { resolve } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
 import {
+  Scope,
   type BindingBehaviorInstance,
   type IBinding,
   bindingBehavior,

--- a/packages/__tests__/src/3-runtime-html/promise.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/promise.spec.ts
@@ -17,8 +17,8 @@ import {
   Class,
   resolve,
 } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
 import {
+  Scope,
   type BindingBehaviorInstance,
   type IBinding,
   valueConverter,

--- a/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
@@ -1,6 +1,8 @@
 import { AccessScopeExpression, ForOfStatement, BindingIdentifier } from '@aurelia/expression-parser';
-import { Scope, BindingContext, DirtyChecker } from '@aurelia/runtime';
+import { DirtyChecker } from '@aurelia/runtime';
 import {
+  Scope,
+  BindingContext,
   Repeat,
   Controller,
   CustomElementDefinition,

--- a/packages/__tests__/src/3-runtime-html/switch.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/switch.spec.ts
@@ -13,8 +13,6 @@ import {
 } from '@aurelia/kernel';
 import {
   Scope,
-} from '@aurelia/runtime';
-import {
   AuSlot,
   type BindingBehaviorInstance,
   type IBinding,

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -4,9 +4,9 @@ import { Unparser } from '@aurelia/expression-parser';
 import {
   ArrayObserver,
   IObserverLocator,
-  Scope,
 } from '@aurelia/runtime';
 import {
+  Scope,
   type BindingBehaviorInstance,
   type IBinding,
   bindable,

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -15,8 +15,8 @@ import {
 } from '@aurelia/expression-parser';
 import {
   Scope,
-} from '@aurelia/runtime';
-import { astEvaluate } from '@aurelia/runtime-html';
+  astEvaluate,
+} from '@aurelia/runtime-html';
 import { assert, TestContext } from '@aurelia/testing';
 import {
   EqualsRule,

--- a/packages/compat-v1/src/compat-binding-engine.ts
+++ b/packages/compat-v1/src/compat-binding-engine.ts
@@ -1,7 +1,7 @@
 import { IExpressionParser } from '@aurelia/expression-parser';
 import { IDisposable, resolve } from '@aurelia/kernel';
-import { Collection, getCollectionObserver, ICollectionSubscriber, IndexMap, IObserverLocator, ISubscriber, Scope } from '@aurelia/runtime';
-import { ExpressionWatcher } from '@aurelia/runtime-html';
+import { Collection, getCollectionObserver, ICollectionSubscriber, IndexMap, IObserverLocator, ISubscriber } from '@aurelia/runtime';
+import { ExpressionWatcher, Scope } from '@aurelia/runtime-html';
 
 export class BindingEngine {
   public readonly parser = resolve(IExpressionParser);

--- a/packages/compat-v1/src/compat-call.ts
+++ b/packages/compat-v1/src/compat-call.ts
@@ -1,5 +1,5 @@
 import { camelCase, type IContainer, type IServiceLocator } from '@aurelia/kernel';
-import { IAccessor, IObserverLocator, IObserverLocatorBasedConnectable, Scope } from '@aurelia/runtime';
+import { IAccessor, IObserverLocator, IObserverLocatorBasedConnectable } from '@aurelia/runtime';
 import {
   astBind,
   astEvaluate,
@@ -17,6 +17,7 @@ import {
   IPlatform,
   type IAstEvaluator,
   type IBinding,
+  Scope,
 } from '@aurelia/runtime-html';
 import { ensureExpression, etIsFunction } from './utilities';
 import { BindingCommandStaticAuDefinition } from '@aurelia/runtime-html/dist/types/resources/binding-command';

--- a/packages/compat-v1/src/compat-event.ts
+++ b/packages/compat-v1/src/compat-event.ts
@@ -1,5 +1,5 @@
 import { DI, IContainer, resolve } from '@aurelia/kernel';
-import { IObserverLocatorBasedConnectable, type Scope } from '@aurelia/runtime';
+import { IObserverLocatorBasedConnectable } from '@aurelia/runtime';
 import {
   AppTask,
   type BindingCommandInstance,
@@ -21,6 +21,7 @@ import {
   astUnbind,
   type IAstEvaluator,
   type IBinding,
+  type Scope,
 } from '@aurelia/runtime-html';
 import { createLookup, ensureExpression, etIsFunction, isFunction } from './utilities';
 import { IExpressionParser, IsBindingBehavior } from '@aurelia/expression-parser';

--- a/packages/i18n/src/df/date-format-binding-behavior.ts
+++ b/packages/i18n/src/df/date-format-binding-behavior.ts
@@ -1,7 +1,6 @@
-import { type Scope } from '@aurelia/runtime';
 import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters, behaviorTypeName } from '../utils';
 
-import { type BindingBehaviorStaticAuDefinition, type BindingBehaviorInstance, } from '@aurelia/runtime-html';
+import { type Scope, type BindingBehaviorStaticAuDefinition, type BindingBehaviorInstance, } from '@aurelia/runtime-html';
 
 export class DateFormatBindingBehavior implements BindingBehaviorInstance {
   public static readonly $au: BindingBehaviorStaticAuDefinition = {

--- a/packages/i18n/src/nf/number-format-binding-behavior.ts
+++ b/packages/i18n/src/nf/number-format-binding-behavior.ts
@@ -1,6 +1,5 @@
-import { type Scope } from '@aurelia/runtime';
 import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters, behaviorTypeName } from '../utils';
-import { type BindingBehaviorStaticAuDefinition, type BindingBehaviorInstance, } from '@aurelia/runtime-html';
+import { type Scope, type BindingBehaviorStaticAuDefinition, type BindingBehaviorInstance, } from '@aurelia/runtime-html';
 
 export class NumberFormatBindingBehavior implements BindingBehaviorInstance {
   public static readonly $au: BindingBehaviorStaticAuDefinition = {

--- a/packages/i18n/src/rt/relative-time-binding-behavior.ts
+++ b/packages/i18n/src/rt/relative-time-binding-behavior.ts
@@ -1,7 +1,5 @@
-import { type Scope } from '@aurelia/runtime';
-import { type BindingWithBehavior, createIntlFormatValueConverterExpression, ValueConverters, behaviorTypeName } from '../utils';
-
-import { type BindingBehaviorStaticAuDefinition, type BindingBehaviorInstance } from '@aurelia/runtime-html';
+import { type BindingBehaviorInstance, type BindingBehaviorStaticAuDefinition, type Scope } from '@aurelia/runtime-html';
+import { ValueConverters, behaviorTypeName, createIntlFormatValueConverterExpression, type BindingWithBehavior } from '../utils';
 
 export class RelativeTimeBindingBehavior implements BindingBehaviorInstance {
   public static readonly $au: BindingBehaviorStaticAuDefinition = {

--- a/packages/i18n/src/t/translation-binding-behavior.ts
+++ b/packages/i18n/src/t/translation-binding-behavior.ts
@@ -1,6 +1,5 @@
 import { type Writable } from '@aurelia/kernel';
-import { type Scope } from '@aurelia/runtime';
-import { BindingBehavior, type BindingBehaviorInstance } from '@aurelia/runtime-html';
+import { type Scope, BindingBehavior, type BindingBehaviorInstance } from '@aurelia/runtime-html';
 import { type BindingWithBehavior, ValueConverters } from '../utils';
 import { type BindingBehaviorExpression, IsValueConverter, ValueConverterExpression } from '@aurelia/expression-parser';
 

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -15,7 +15,8 @@ import {
   mixingBindingLimited,
   type IHydratableController,
   type INode,
-  IBinding
+  IBinding,
+  type Scope,
 } from '@aurelia/runtime-html';
 import type * as i18next from 'i18next';
 import { I18N } from '../i18n';
@@ -24,7 +25,6 @@ import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import type { IContainer, IServiceLocator } from '@aurelia/kernel';
 import { IExpressionParser, IsExpression, CustomExpression } from '@aurelia/expression-parser';
 import type {
-  Scope,
   IObserverLocator,
   IAccessor,
   IObserverLocatorBasedConnectable,

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -8,7 +8,8 @@ import {
   type IsExpressionOrStatement,
 } from '@aurelia/expression-parser';
 import { AnyFunction, IIndexable, isArrayIndex } from '@aurelia/kernel';
-import { IBindingContext, IConnectable, IObservable, IOverrideContext, ISubscriber, Scope } from '@aurelia/runtime';
+import { IConnectable, IObservable, ISubscriber } from '@aurelia/runtime';
+import { Scope, type IBindingContext, IOverrideContext } from './binding/scope';
 import { ErrorNames, createMappedError } from './errors';
 import { isArray, isFunction, isObject, safeString } from './utilities';
 import { ISignaler } from './signaler';
@@ -42,7 +43,7 @@ export const {
   astEvaluate,
   astBind,
   astUnbind
-} = (() => {
+} = /*@__PURE__*/(() => {
   const ekAccessThis = 'AccessThis';
   const ekAccessBoundary = 'AccessBoundary';
   const ekAccessGlobal = 'AccessGlobal';

--- a/packages/runtime-html/src/binding/attribute.ts
+++ b/packages/runtime-html/src/binding/attribute.ts
@@ -1,11 +1,11 @@
 import {
   connectable,
   type IObserverLocator,
-  type Scope,
   IObserverLocatorBasedConnectable,
   ISubscriber,
   ICollectionSubscriber
 } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import {
   astBind,
   astEvaluate,

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -1,6 +1,6 @@
 import { type IServiceLocator, Key, type Constructable, IDisposable, IContainer } from '@aurelia/kernel';
 import { ITask } from '@aurelia/platform';
-import { Scope, type ISubscriber } from '@aurelia/runtime';
+import { type ISubscriber } from '@aurelia/runtime';
 import { astEvaluate } from '../ast.eval';
 import { type IBinding, type IRateLimitOptions } from './interfaces-bindings';
 import { BindingBehavior, BindingBehaviorInstance } from '../resources/binding-behavior';
@@ -10,6 +10,7 @@ import { createInterface } from '../utilities-di';
 import { PropertyBinding } from './property-binding';
 import { ErrorNames, createMappedError } from '../errors';
 import { ISignaler } from '../signaler';
+import { type Scope } from './scope';
 
 /**
  * A subscriber that is used for subcribing to target observer & invoking `updateSource` on a binding

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -16,8 +16,8 @@ import type {
   IObserverLocator,
   IObserverLocatorBasedConnectable,
   ISubscriber,
-  Scope
 } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import type { IPlatform } from '../platform';
 import { isArray, safeString } from '../utilities';
 import type { BindingMode, IBinding, IBindingController } from './interfaces-bindings';

--- a/packages/runtime-html/src/binding/interfaces-bindings.ts
+++ b/packages/runtime-html/src/binding/interfaces-bindings.ts
@@ -1,7 +1,7 @@
 import { IDisposable, IServiceLocator } from '@aurelia/kernel';
 import { State } from '../templating/controller';
 import { objectFreeze } from '../utilities';
-import { Scope } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import { TaskQueue } from '@aurelia/platform';
 
 // Note: the oneTime binding now has a non-zero value for 2 reasons:

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -19,8 +19,8 @@ import type {
   IObserverLocator,
   IObserverLocatorBasedConnectable,
   ISubscriber,
-  Scope
 } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import { atLayout, isArray } from '../utilities';
 import type { IBinding, BindingMode, IBindingController } from './interfaces-bindings';
 import { type Interpolation, IsExpression } from '@aurelia/expression-parser';

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -5,8 +5,8 @@ import {
   connectable,
   type IObservable,
   type IObserverLocator,
-  type Scope
 } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import {
   astBind,
   astEvaluate,

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -4,7 +4,8 @@ import { createInterface, singletonRegistration } from '../utilities-di';
 import { mixinAstEvaluator, mixinUseScope, mixingBindingLimited } from './binding-utils';
 
 import { resolve, type IServiceLocator, all, IContainer } from '@aurelia/kernel';
-import { ICollectionSubscriber, IObserverLocatorBasedConnectable, ISubscriber, Scope } from '@aurelia/runtime';
+import { ICollectionSubscriber, IObserverLocatorBasedConnectable, ISubscriber, } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import { astBind, astEvaluate, astUnbind, IAstEvaluator } from '../ast.eval';
 import { IBinding } from './interfaces-bindings';
 

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -12,8 +12,8 @@ import type {
   IObserver,
   IObserverLocator,
   IObserverLocatorBasedConnectable,
-  Scope,
 } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import type { BindingMode, IBindingController } from './interfaces-bindings';
 import { createMappedError, ErrorNames } from '../errors';
 import { atLayout } from '../utilities';

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -1,5 +1,6 @@
 import type { IServiceLocator } from '@aurelia/kernel';
-import { ICollectionSubscriber, IObserverLocatorBasedConnectable, ISubscriber, type Scope } from '@aurelia/runtime';
+import { ICollectionSubscriber, IObserverLocatorBasedConnectable, ISubscriber } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import { astAssign, astBind, astEvaluate, astUnbind, IAstEvaluator } from '../ast.eval';
 import { mixinAstEvaluator } from './binding-utils';
 import { type IsBindingBehavior } from '@aurelia/expression-parser';

--- a/packages/runtime-html/src/binding/scope.ts
+++ b/packages/runtime-html/src/binding/scope.ts
@@ -1,19 +1,13 @@
 import { ErrorNames, createMappedError } from '../errors';
-import type { IBindingContext, IOverrideContext } from '../observation';
 
-/**
- * A class for creating context in synthetic scope to keep the number of classes of context in scope small
- */
-export class BindingContext implements IBindingContext {
-  [key: PropertyKey]: unknown;
+export interface IBindingContext {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: PropertyKey]: any;
+}
 
-  public constructor();
-  public constructor(key: PropertyKey, value: unknown);
-  public constructor(key?: PropertyKey, value?: unknown) {
-    if (key !== void 0) {
-      this[key] = value;
-    }
-  }
+export interface IOverrideContext {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: PropertyKey]: any;
 }
 
 export class Scope {
@@ -113,6 +107,21 @@ export class Scope {
       throw createMappedError(ErrorNames.null_scope);
     }
     return new Scope(ps, bc as IBindingContext, new OverrideContext(), false);
+  }
+}
+
+/**
+ * A class for creating context in synthetic scope to keep the number of classes of context in scope small
+ */
+export class BindingContext implements IBindingContext {
+  [key: PropertyKey]: unknown;
+
+  public constructor();
+  public constructor(key: PropertyKey, value: unknown);
+  public constructor(key?: PropertyKey, value?: unknown) {
+    if (key !== void 0) {
+      this[key] = value;
+    }
   }
 }
 

--- a/packages/runtime-html/src/binding/spread-binding.ts
+++ b/packages/runtime-html/src/binding/spread-binding.ts
@@ -1,6 +1,7 @@
 import { IServiceLocator, Key, emptyArray } from '@aurelia/kernel';
 import { IExpressionParser } from '@aurelia/expression-parser';
-import { IObserverLocator, Scope } from '@aurelia/runtime';
+import { IObserverLocator } from '@aurelia/runtime';
+import { type Scope } from './scope';
 import { createMappedError, ErrorNames } from '../errors';
 import { CustomElementDefinition, findElementControllerFor } from '../resources/custom-element';
 import { ICustomElementController, IHydrationContext, IController, IHydratableController, vmkCa } from '../templating/controller';

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -33,6 +33,9 @@ export const enum ErrorNames {
   binding_behavior_existed = 156,
   binding_command_existed = 157,
 
+  null_scope = 203,
+  create_scope_with_null_context = 204,
+
   invalid_bindable_decorator_usage_symbol = 227,
   invalid_bindable_decorator_usage_class_without_configuration = 228,
   invalid_bindable_decorator_usage_class_without_property_name_configuration = 229,
@@ -159,6 +162,9 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.value_converter_existed]: `Value converter {{0}} has already been registered.`,
   [ErrorNames.binding_behavior_existed]: `Binding behavior {{0}} has already been registered.`,
   [ErrorNames.binding_command_existed]: `Binding command {{0}} has already been registered.`,
+
+  [ErrorNames.null_scope]: `Trying to retrieve a property or build a scope from a null/undefined scope`,
+  [ErrorNames.create_scope_with_null_context]: 'Trying to create a scope with null/undefined binding context',
 
   [ErrorNames.invalid_bindable_decorator_usage_symbol]: `@bindable is not supported for properties that uses a symbol for name. Use a string for the property name instead.`,
   [ErrorNames.invalid_bindable_decorator_usage_class_without_configuration]: `@bindable cannot be used as a class decorator when no configuration object is supplied.`,

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -151,6 +151,12 @@ export {
 export {
   RefBinding,
 } from './binding/ref-binding';
+export {
+  Scope,
+  BindingContext,
+  type IBindingContext,
+  type IOverrideContext
+} from './binding/scope';
 
 export {
   IRenderer,

--- a/packages/runtime-html/src/resources/binding-behavior.ts
+++ b/packages/runtime-html/src/resources/binding-behavior.ts
@@ -1,5 +1,5 @@
 import { firstDefined, getResourceKeyFor, mergeArrays, resource, resourceBaseName, ResourceType } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
+import { type Scope } from '../binding/scope';
 import { isFunction, isString, objectFreeze } from '../utilities';
 import { aliasRegistration, singletonRegistration } from '../utilities-di';
 import { defineMetadata, getAnnotationKeyFor, getMetadata, hasMetadata } from '../utilities-metadata';

--- a/packages/runtime-html/src/resources/binding-behaviors/attr.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/attr.ts
@@ -1,7 +1,7 @@
 import { IBinding } from '../../binding/interfaces-bindings';
 import { attrAccessor } from '../../observation/data-attribute-accessor';
 
-import type { Scope } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { PropertyBinding } from '../../binding/property-binding';
 import { ErrorNames, createMappedError } from '../../errors';
 import { type BindingBehaviorInstance, type BindingBehaviorStaticAuDefinition, behaviorTypeName } from '../binding-behavior';

--- a/packages/runtime-html/src/resources/binding-behaviors/binding-mode.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/binding-mode.ts
@@ -1,7 +1,7 @@
 import { type IBinding, fromView, oneTime, toView, twoWay, type BindingMode } from '../../binding/interfaces-bindings';
 import { BindingBehaviorInstance, behaviorTypeName, type BindingBehaviorStaticAuDefinition } from '../binding-behavior';
 
-import type { Scope } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 
 const originalModesMap = new Map<IBinding & { mode: BindingMode }, BindingMode>();
 const createConfig = (name: string): BindingBehaviorStaticAuDefinition => ({ type: behaviorTypeName, name });

--- a/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/debounce.ts
@@ -1,7 +1,7 @@
 import { IDisposable, IPlatform, emptyArray, resolve } from '@aurelia/kernel';
 import { type BindingBehaviorInstance, BindingBehaviorStaticAuDefinition, behaviorTypeName } from '../binding-behavior';
 
-import { type Scope } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { isString } from '../../utilities';
 import { type IBinding, type IRateLimitOptions } from '../../binding/interfaces-bindings';
 

--- a/packages/runtime-html/src/resources/binding-behaviors/self.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/self.ts
@@ -1,4 +1,4 @@
-import { type Scope } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { ListenerBinding } from '../../binding/listener-binding';
 import { type BindingBehaviorInstance, BindingBehaviorStaticAuDefinition, behaviorTypeName } from '../binding-behavior';
 

--- a/packages/runtime-html/src/resources/binding-behaviors/signals.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/signals.ts
@@ -1,8 +1,9 @@
 import { ISignaler } from '../../signaler';
 import { type BindingBehaviorInstance, type BindingBehaviorStaticAuDefinition, behaviorTypeName } from '../binding-behavior';
 import { addSignalListener, removeSignalListener } from '../../utilities';
-import { type ISubscriber, type Scope } from '@aurelia/runtime';
+import { type ISubscriber } from '@aurelia/runtime';
 import { resolve } from '@aurelia/kernel';
+import { type Scope } from '../../binding/scope';
 import { ErrorNames, createMappedError } from '../../errors';
 import { IBinding } from '../../binding/interfaces-bindings';
 

--- a/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/throttle.ts
@@ -1,6 +1,6 @@
 import { IPlatform, type IDisposable, emptyArray, resolve } from '@aurelia/kernel';
 import { TaskQueue } from '@aurelia/platform';
-import { type Scope } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { type BindingBehaviorInstance, BindingBehaviorStaticAuDefinition, behaviorTypeName } from '../binding-behavior';
 import { isString } from '../../utilities';
 import { type IBinding, type IRateLimitOptions } from '../../binding/interfaces-bindings';

--- a/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
+++ b/packages/runtime-html/src/resources/binding-behaviors/update-trigger.ts
@@ -1,4 +1,5 @@
-import { INodeObserverLocator, IObserverLocator, type Scope } from '@aurelia/runtime';
+import { INodeObserverLocator, IObserverLocator } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { type IBinding, fromView } from '../../binding/interfaces-bindings';
 import { NodeObserverLocator } from '../../observation/observer-locator';
 import { behaviorTypeName, type BindingBehaviorInstance, type BindingBehaviorStaticAuDefinition } from '../binding-behavior';

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -1,5 +1,6 @@
 import { Constructable, IContainer, InstanceProvider, MaybePromise, emptyArray, onResolve, resolve, transient } from '@aurelia/kernel';
-import { IObserverLocator, Scope } from '@aurelia/runtime';
+import { IObserverLocator } from '@aurelia/runtime';
+import { Scope } from '../../binding/scope';
 import { INode, IRenderLocation, convertToRenderLocation, registerHostNode } from '../../dom';
 import { IPlatform } from '../../platform';
 import { HydrateElementInstruction, IInstruction, ITemplateCompiler } from '../../renderer';

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -1,4 +1,4 @@
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '../../binding/scope';
 import { IRenderLocation } from '../../dom';
 import { CustomElementDefinition, CustomElementStaticAuDefinition, elementTypeName } from '../custom-element';
 import { IInstruction } from '../../renderer';

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,6 +1,6 @@
 import { Task, TaskAbortError } from '@aurelia/platform';
 import { ILogger, onResolve, onResolveAll, resolve } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '../../binding/scope';
 import { INode, IRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
 import { IInstruction } from '../../renderer';

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -7,19 +7,21 @@ import {
   ValueConverterExpression,
 } from '@aurelia/expression-parser';
 import {
-  BindingContext,
   type Collection,
   CollectionObserver,
   getCollectionObserver,
   type IndexMap,
-  type IOverrideContext,
-  Scope,
   createIndexMap,
 } from '@aurelia/runtime';
 import {
   astEvaluate,
   astAssign,
 } from '../../ast.eval';
+import {
+  Scope,
+  BindingContext,
+  type IOverrideContext,
+} from '../../binding/scope';
 import { IExpressionParser } from '@aurelia/expression-parser';
 import { IRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';

--- a/packages/runtime-html/src/resources/template-controllers/switch.ts
+++ b/packages/runtime-html/src/resources/template-controllers/switch.ts
@@ -8,8 +8,8 @@ import {
 import {
   type ICollectionObserver,
   IObserverLocator,
-  type Scope,
 } from '@aurelia/runtime';
+import { type Scope } from '../../binding/scope';
 import { IRenderLocation } from '../../dom';
 import { attrTypeName, CustomAttributeStaticAuDefinition, defineAttribute } from '../custom-attribute';
 import { IViewFactory } from '../../templating/view';

--- a/packages/runtime-html/src/resources/template-controllers/with.ts
+++ b/packages/runtime-html/src/resources/template-controllers/with.ts
@@ -1,4 +1,4 @@
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '../../binding/scope';
 import { IRenderLocation } from '../../dom';
 import { IViewFactory } from '../../templating/view';
 import { CustomAttributeStaticAuDefinition, attrTypeName } from '../custom-attribute';

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -16,8 +16,8 @@ import { IExpressionParser, IsBindingBehavior, AccessScopeExpression } from '@au
 import {
   ICoercionConfiguration,
   IObserverLocator,
-  Scope,
 } from '@aurelia/runtime';
+import { Scope } from '../binding/scope';
 import { convertToRenderLocation, setRef } from '../dom';
 import { IPlatform } from '../platform';
 import { CustomAttributeDefinition, getAttributeDefinition } from '../resources/custom-attribute';
@@ -125,11 +125,11 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   public _vmHooks: HooksDefinition;
 
   /** @internal */
-  public _vm: BindingContext<C> | null;
-  public get viewModel(): BindingContext<C> | null {
+  public _vm: ControllerBindingContext<C> | null;
+  public get viewModel(): ControllerBindingContext<C> | null {
     return this._vm;
   }
-  public set viewModel(v: BindingContext<C> | null) {
+  public set viewModel(v: ControllerBindingContext<C> | null) {
     this._vm = v;
     this._vmHooks = v == null || this.vmKind === vmkSynth ? HooksDefinition.none : new HooksDefinition(v);
   }
@@ -147,7 +147,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     /**
      * The backing viewModel. Only present for custom attributes and elements.
      */
-    viewModel: BindingContext<C> | null,
+    viewModel: ControllerBindingContext<C> | null,
     /**
      * The physical host dom node.
      *
@@ -230,7 +230,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       /* vmKind         */vmkCe,
       /* definition     */definition,
       /* viewFactory    */null,
-      /* viewModel      */viewModel as BindingContext<C>,
+      /* viewModel      */viewModel as ControllerBindingContext<C>,
       /* host           */host,
       /* location       */location,
     );
@@ -291,7 +291,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       /* vmKind         */vmkCa,
       /* definition     */definition,
       /* viewFactory    */null,
-      /* viewModel      */viewModel as BindingContext<C>,
+      /* viewModel      */viewModel as ControllerBindingContext<C>,
       /* host           */host,
       /* location       */null
     );
@@ -1214,7 +1214,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
 const controllerLookup: WeakMap<object, Controller> = new WeakMap();
 
-export type BindingContext<C extends IViewModel> = Required<ICompileHooks> & Required<IActivationHooks<IHydratedController | null>> & C;
+export type ControllerBindingContext<C extends IViewModel> = Required<ICompileHooks> & Required<IActivationHooks<IHydratedController | null>> & C;
 
 const targetNone = 0;
 const targetHost = 1;

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -7,6 +7,7 @@ import {
   astEvaluate,
 } from '../ast.eval';
 import { mixinAstEvaluator } from '../binding/binding-utils';
+import { type Scope } from '../binding/scope';
 
 import type { IServiceLocator } from '@aurelia/kernel';
 import type {
@@ -16,7 +17,6 @@ import type {
   IObserverLocator,
   IObserverLocatorBasedConnectable,
   ISubscriber,
-  Scope,
 } from '@aurelia/runtime';
 import type { IWatcherCallback } from '../watch';
 import { areEqual } from '../utilities';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -22,10 +22,6 @@ export {
   disableSetObservation
 } from './observation/set-observer';
 export {
-  BindingContext,
-  Scope,
-} from './observation/scope';
-export {
   CollectionLengthObserver,
   CollectionSizeObserver,
 } from './observation/collection-length-observer';
@@ -53,6 +49,7 @@ export {
   type IObjectObservationAdapter,
   IObserverLocator,
   INodeObserverLocator,
+  IComputedObserverLocator,
   getCollectionObserver,
   ObserverLocator,
   getObserverLookup,
@@ -91,7 +88,6 @@ export {
   type Collection,
   type CollectionKind,
   type IAccessor,
-  type IBindingContext,
   type ICollectionChangeTracker,
   type ICollectionObserver,
   type IConnectable,
@@ -99,7 +95,6 @@ export {
   type IndexMap,
   type IObserver,
   type IObservable,
-  type IOverrideContext,
   type InterceptorFunc,
   type ISubscribable,
   type ISubscriberCollection,

--- a/packages/runtime/src/observation.ts
+++ b/packages/runtime/src/observation.ts
@@ -236,16 +236,6 @@ export interface ICollectionObserver<T extends CollectionKind> extends
 }
 export type CollectionObserver = ICollectionObserver<CollectionKind>;
 
-export interface IBindingContext {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: PropertyKey]: any;
-}
-
-export interface IOverrideContext {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: PropertyKey]: any;
-}
-
 export type IObservable<T = IIndexable> = T & {
   $observers?: IIndexable<{}, AccessorOrObserver>;
 };

--- a/packages/runtime/src/observation/observable.ts
+++ b/packages/runtime/src/observation/observable.ts
@@ -1,9 +1,9 @@
-import { AccessorType, IAccessor, IObserver, ISubscriberCollection, atObserver } from '../observation';
+import { AccessorType, IAccessor, ISubscriberCollection, atObserver } from '../observation';
 import { safeString, def, isFunction, areEqual } from '../utilities';
 import { currentConnectable } from './connectable-switcher';
 
 import { emptyObject, type Constructable, type IIndexable } from '@aurelia/kernel';
-import type { IBindingContext, InterceptorFunc, IObservable } from '../observation';
+import type { InterceptorFunc, IObservable } from '../observation';
 import type { ObservableGetter } from './observer-locator';
 import type { SetterObserver } from './setter-observer';
 import { subscriberCollection } from './subscriber-collection';
@@ -15,207 +15,209 @@ export interface IObservableDefinition {
   set?: InterceptorFunc;
 }
 
-function getObserversLookup(obj: IObservable): IIndexable<{}, SetterObserver | SetterNotifier> {
-  if (obj.$observers === void 0) {
-    def(obj, '$observers', { value: {} });
-    // todo: define in a weakmap
-  }
-  return obj.$observers as IIndexable<{}, SetterObserver | SetterNotifier>;
-}
-
-const noValue: unknown = {};
-
-type SetterObserverOwningObject = IIndexable<IBindingContext, IObserver>;
-
 type FieldInitializer<TFThis, TValue> = (this: TFThis, initialValue: TValue) => TValue;
 type ObservableFieldDecorator<TFThis, TValue> = (target: undefined, context: ClassFieldDecoratorContext<TFThis, TValue>) => FieldInitializer<TFThis, TValue>;
 type ObservableClassDecorator<TCThis extends Constructable> = (target: TCThis, context: ClassDecoratorContext<TCThis>) => void;
 
-// for
-//    class {
-//      @observable prop
-//    }
-export function observable<TFThis, TValue>(target: undefined, context: ClassFieldDecoratorContext<TFThis, TValue>): FieldInitializer<TFThis, TValue>;
-// for
-//    @observable({...})
-//    class {}
-// and
-//    class {
-//      @observable({...}) prop
-//    }
-export function observable<TCThis extends Constructable, TFThis, TValue>(config: IObservableDefinition): (target: TCThis | undefined, context: ClassDecoratorContext<TCThis> | ClassFieldDecoratorContext<TFThis, TValue>) => FieldInitializer<TFThis, TValue> | void;
-// for
-//    @observable('') class {}
-//    @observable(5) class {}
-//    @observable(Symbol()) class {}
-export function observable<TCThis extends Constructable>(key: PropertyKey): ObservableClassDecorator<TCThis>;
-// for:
-//    class {
-//      @observable() prop
-//    }
-export function observable<TFThis, TValue>(): ObservableFieldDecorator<TFThis, TValue>;
-// impl, wont be seen
-export function observable<TCThis extends Constructable, TFThis, TValue>(targetOrConfig?: undefined | IObservableDefinition | PropertyKey, context?: ClassFieldDecoratorContext): ObservableClassDecorator<TCThis> | ObservableFieldDecorator<TFThis, TValue> | FieldInitializer<TFThis, TValue> {
-  if (!SetterNotifier.mixed) {
-    SetterNotifier.mixed = true;
-    subscriberCollection(SetterNotifier);
-  }
+export const observable = /*@__PURE__*/(() => {
 
-  let isClassDecorator = false;
-  let config: IObservableDefinition;
-  if (typeof targetOrConfig === 'object') {
-    config = targetOrConfig;
-  } else if (targetOrConfig != null) {
-    config = { name: targetOrConfig };
-    isClassDecorator = true;
-  } else {
-    config = emptyObject;
-  }
-
-  // case: @observable() prop
-  if (arguments.length === 0) {
-    return function (target: unknown, context: DecoratorContext) {
-      if (context.kind !== 'field') throw createMappedError(ErrorNames.invalid_observable_decorator_usage);
-      return createFieldInitializer(context);
-    };
-  }
-
-  // case: @observable prop
-  if (context?.kind === 'field') return createFieldInitializer(context);
-
-  // case:  @observable(PropertyKey) class
-  if (isClassDecorator) {
-    return function (target: TCThis, _context: ClassDecoratorContext<TCThis>) {
-      createDescriptor(target, config.name!, () => noValue, true);
-    };
-  }
-
-  // case: @observable({...}) class | @observable({...}) prop
-  return function (target: Constructable | undefined, context: ClassFieldDecoratorContext | ClassDecoratorContext) {
-    switch (context.kind) {
-      case 'field': return createFieldInitializer(context);
-      case 'class': return createDescriptor(target, config.name!, () => noValue, true);
-      default: throw createMappedError(ErrorNames.invalid_observable_decorator_usage);
+  function getObserversLookup(obj: IObservable): IIndexable<{}, SetterObserver | SetterNotifier> {
+    if (obj.$observers === void 0) {
+      def(obj, '$observers', { value: {} });
+      // todo: define in a weakmap
     }
-  };
-
-  function createFieldInitializer(context: ClassFieldDecoratorContext): FieldInitializer<TFThis, TValue> {
-    let $initialValue: TValue;
-    context.addInitializer(function (this: unknown) {
-      createDescriptor(this, context.name, () => $initialValue, false);
-    });
-    return function (this: TFThis, initialValue: TValue) {
-      return $initialValue = initialValue;
-    };
+    return obj.$observers as IIndexable<{}, SetterObserver | SetterNotifier>;
   }
-  function createDescriptor(target: unknown, property: PropertyKey, initialValue: () => unknown, targetIsClass: boolean): void {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/strict-boolean-expressions
-    const callback = config.callback || `${safeString(property)}Changed`;
-    const $set = config.set;
-    const observableGetter: ObservableGetter = function (this: SetterObserverOwningObject) {
-      const notifier = getNotifier(this, property, callback, initialValue, $set);
-      currentConnectable()?.subscribeTo(notifier);
-      return notifier.getValue();
-    };
-    observableGetter.getObserver = function (obj: SetterObserverOwningObject) {
-      return getNotifier(obj, property, callback, initialValue, $set);
-    };
 
-    const descriptor = {
-      enumerable: true,
-      configurable: true,
-      get: observableGetter,
-      set(this: SetterObserverOwningObject, newValue: TValue) {
-        getNotifier(this, property, callback, initialValue, $set).setValue(newValue);
+  const noValue: unknown = {};
+  // for
+  //    class {
+  //      @observable prop
+  //    }
+  function observable<TFThis, TValue>(target: undefined, context: ClassFieldDecoratorContext<TFThis, TValue>): FieldInitializer<TFThis, TValue>;
+  // for
+  //    @observable({...})
+  //    class {}
+  // and
+  //    class {
+  //      @observable({...}) prop
+  //    }
+  function observable<TCThis extends Constructable, TFThis, TValue>(config: IObservableDefinition): (target: TCThis | undefined, context: ClassDecoratorContext<TCThis> | ClassFieldDecoratorContext<TFThis, TValue>) => FieldInitializer<TFThis, TValue> | void;
+  // for
+  //    @observable('') class {}
+  //    @observable(5) class {}
+  //    @observable(Symbol()) class {}
+  function observable<TCThis extends Constructable>(key: PropertyKey): ObservableClassDecorator<TCThis>;
+  // for:
+  //    class {
+  //      @observable() prop
+  //    }
+  function observable<TFThis, TValue>(): ObservableFieldDecorator<TFThis, TValue>;
+  // impl, wont be seen
+  function observable<TCThis extends Constructable, TFThis, TValue>(targetOrConfig?: undefined | IObservableDefinition | PropertyKey, context?: ClassFieldDecoratorContext): ObservableClassDecorator<TCThis> | ObservableFieldDecorator<TFThis, TValue> | FieldInitializer<TFThis, TValue> {
+    if (!SetterNotifier.mixed) {
+      SetterNotifier.mixed = true;
+      subscriberCollection(SetterNotifier);
+    }
+
+    let isClassDecorator = false;
+    let config: IObservableDefinition;
+    if (typeof targetOrConfig === 'object') {
+      config = targetOrConfig;
+    } else if (targetOrConfig != null) {
+      config = { name: targetOrConfig };
+      isClassDecorator = true;
+    } else {
+      config = emptyObject;
+    }
+
+    // case: @observable() prop
+    if (arguments.length === 0) {
+      return function (target: unknown, context: DecoratorContext) {
+        if (context.kind !== 'field') throw createMappedError(ErrorNames.invalid_observable_decorator_usage);
+        return createFieldInitializer(context);
+      };
+    }
+
+    // case: @observable prop
+    if (context?.kind === 'field') return createFieldInitializer(context);
+
+    // case:  @observable(PropertyKey) class
+    if (isClassDecorator) {
+      return function (target: TCThis, _context: ClassDecoratorContext<TCThis>) {
+        createDescriptor(target, config.name!, () => noValue, true);
+      };
+    }
+
+    // case: @observable({...}) class | @observable({...}) prop
+    return function (target: Constructable | undefined, context: ClassFieldDecoratorContext | ClassDecoratorContext) {
+      switch (context.kind) {
+        case 'field': return createFieldInitializer(context);
+        case 'class': return createDescriptor(target, config.name!, () => noValue, true);
+        default: throw createMappedError(ErrorNames.invalid_observable_decorator_usage);
       }
     };
-    if (targetIsClass) def((target as Constructable).prototype as object, property, descriptor);
-    else def(target as object, property, descriptor);
+
+    function createFieldInitializer(context: ClassFieldDecoratorContext): FieldInitializer<TFThis, TValue> {
+      let $initialValue: TValue;
+      context.addInitializer(function (this: unknown) {
+        createDescriptor(this, context.name, () => $initialValue, false);
+      });
+      return function (this: TFThis, initialValue: TValue) {
+        return $initialValue = initialValue;
+      };
+    }
+    function createDescriptor(target: unknown, property: PropertyKey, initialValue: () => unknown, targetIsClass: boolean): void {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/strict-boolean-expressions
+      const callback = config.callback || `${safeString(property)}Changed`;
+      const $set = config.set;
+      const observableGetter: ObservableGetter = function (this: IObservable) {
+        const notifier = getNotifier(this, property, callback, initialValue, $set);
+        currentConnectable()?.subscribeTo(notifier);
+        return notifier.getValue();
+      };
+      observableGetter.getObserver = function (obj: IObservable) {
+        return getNotifier(obj, property, callback, initialValue, $set);
+      };
+
+      const descriptor = {
+        enumerable: true,
+        configurable: true,
+        get: observableGetter,
+        set(this: IObservable, newValue: TValue) {
+          getNotifier(this, property, callback, initialValue, $set).setValue(newValue);
+        }
+      };
+      if (targetIsClass) def((target as Constructable).prototype as object, property, descriptor);
+      else def(target as object, property, descriptor);
+    }
   }
-}
 
-function getNotifier(
-  obj: SetterObserverOwningObject,
-  key: PropertyKey,
-  callbackKey: PropertyKey,
-  initialValue: () => unknown,
-  set: InterceptorFunc | undefined,
-): SetterNotifier {
-  const lookup = getObserversLookup(obj) as unknown as Record<PropertyKey, SetterObserver | SetterNotifier>;
-  let notifier = lookup[key as string] as SetterNotifier;
-  if (notifier == null) {
-    const $initialValue = initialValue();
-    notifier = new SetterNotifier(obj, callbackKey, set, $initialValue === noValue ? void 0 : $initialValue);
-    lookup[key as string] = notifier;
-  }
-  return notifier;
-}
-
-type ChangeHandlerCallback = (this: object, value: unknown, oldValue: unknown) => void;
-
-export interface SetterNotifier extends IAccessor, ISubscriberCollection {}
-
-export class SetterNotifier implements IAccessor {
-  public static mixed = false;
-  public readonly type: AccessorType = atObserver;
-
-  /** @internal */
-  private _value: unknown = void 0;
-  /** @internal */
-  private _oldValue: unknown = void 0;
-  /** @internal */
-  private readonly cb?: ChangeHandlerCallback;
-  /** @internal */
-  private readonly _obj: object;
-  /** @internal */
-  private readonly _setter: InterceptorFunc | undefined;
-  /** @internal */
-  private readonly _hasSetter: boolean;
-
-  public constructor(
-    obj: object,
+  function getNotifier(
+    obj: IObservable,
+    key: PropertyKey,
     callbackKey: PropertyKey,
+    initialValue: () => unknown,
     set: InterceptorFunc | undefined,
-    initialValue: unknown,
-  ) {
-    this._obj = obj;
-    this._setter = set;
-    this._hasSetter = isFunction(set);
-    const callback = (obj as IIndexable)[callbackKey as string];
-    this.cb = isFunction(callback) ? callback as ChangeHandlerCallback : void 0;
-    this._value = initialValue;
-  }
-
-  public getValue(): unknown {
-    return this._value;
-  }
-
-  public setValue(value: unknown): void {
-    if (this._hasSetter) {
-      value = this._setter!(value);
+  ): SetterNotifier {
+    const lookup = getObserversLookup(obj) as unknown as Record<PropertyKey, SetterObserver | SetterNotifier>;
+    let notifier = lookup[key as string] as SetterNotifier;
+    if (notifier == null) {
+      const $initialValue = initialValue();
+      notifier = new SetterNotifier(obj, callbackKey, set, $initialValue === noValue ? void 0 : $initialValue);
+      lookup[key as string] = notifier;
     }
-    if (!areEqual(value, this._value)) {
-      this._oldValue = this._value;
-      this._value = value;
-      this.cb?.call(this._obj, this._value, this._oldValue);
-      // this._value might have been updated during the callback
-      // we only want to notify subscribers with the latest values
-      value = this._oldValue;
-      this._oldValue = this._value;
-      this.subs.notify(this._value, value);
+    return notifier;
+  }
+
+  type ChangeHandlerCallback = (this: object, value: unknown, oldValue: unknown) => void;
+
+  interface SetterNotifier extends IAccessor, ISubscriberCollection { }
+
+  class SetterNotifier implements IAccessor {
+    public static mixed = false;
+    public readonly type: AccessorType = atObserver;
+
+    /** @internal */
+    private _value: unknown = void 0;
+    /** @internal */
+    private _oldValue: unknown = void 0;
+    /** @internal */
+    private readonly cb?: ChangeHandlerCallback;
+    /** @internal */
+    private readonly _obj: object;
+    /** @internal */
+    private readonly _setter: InterceptorFunc | undefined;
+    /** @internal */
+    private readonly _hasSetter: boolean;
+
+    public constructor(
+      obj: object,
+      callbackKey: PropertyKey,
+      set: InterceptorFunc | undefined,
+      initialValue: unknown,
+    ) {
+      this._obj = obj;
+      this._setter = set;
+      this._hasSetter = isFunction(set);
+      const callback = (obj as IIndexable)[callbackKey as string];
+      this.cb = isFunction(callback) ? callback as ChangeHandlerCallback : void 0;
+      this._value = initialValue;
+    }
+
+    public getValue(): unknown {
+      return this._value;
+    }
+
+    public setValue(value: unknown): void {
+      if (this._hasSetter) {
+        value = this._setter!(value);
+      }
+      if (!areEqual(value, this._value)) {
+        this._oldValue = this._value;
+        this._value = value;
+        this.cb?.call(this._obj, this._value, this._oldValue);
+        // this._value might have been updated during the callback
+        // we only want to notify subscribers with the latest values
+        value = this._oldValue;
+        this._oldValue = this._value;
+        this.subs.notify(this._value, value);
+      }
     }
   }
-}
 
-/*
-          | typescript       | babel
-----------|------------------|-------------------------
-property  | config           | config
-w/parens  | target, key      | target, key, descriptor
-----------|------------------|-------------------------
-property  | target, key      | target, key, descriptor
-no parens | n/a              | n/a
-----------|------------------|-------------------------
-class     | config           | config
-          | target           | target
-*/
+  /*
+            | typescript       | babel
+  ----------|------------------|-------------------------
+  property  | config           | config
+  w/parens  | target, key      | target, key, descriptor
+  ----------|------------------|-------------------------
+  property  | target, key      | target, key, descriptor
+  no parens | n/a              | n/a
+  ----------|------------------|-------------------------
+  class     | config           | config
+            | target           | target
+  */
+
+  return observable;
+})();

--- a/packages/state/src/state-binding-behavior.ts
+++ b/packages/state/src/state-binding-behavior.ts
@@ -1,7 +1,7 @@
-import { Writable, resolve } from '@aurelia/kernel';
-import { IOverrideContext, ISubscriber } from '@aurelia/runtime';
-import { IBinding, BindingBehavior, Scope } from '@aurelia/runtime-html';
-import { IStore, IStoreSubscriber } from './interfaces';
+import { type Writable, resolve } from '@aurelia/kernel';
+import { type ISubscriber } from '@aurelia/runtime';
+import { type IBinding, BindingBehavior, type IOverrideContext, Scope } from '@aurelia/runtime-html';
+import { IStore, type IStoreSubscriber } from './interfaces';
 import { StateBinding } from './state-binding';
 import { createStateBindingScope } from './state-utilities';
 

--- a/packages/state/src/state-binding-behavior.ts
+++ b/packages/state/src/state-binding-behavior.ts
@@ -1,6 +1,6 @@
 import { Writable, resolve } from '@aurelia/kernel';
-import { IOverrideContext, ISubscriber, Scope } from '@aurelia/runtime';
-import { IBinding, BindingBehavior } from '@aurelia/runtime-html';
+import { IOverrideContext, ISubscriber } from '@aurelia/runtime';
+import { IBinding, BindingBehavior, Scope } from '@aurelia/runtime-html';
 import { IStore, IStoreSubscriber } from './interfaces';
 import { StateBinding } from './state-binding';
 import { createStateBindingScope } from './state-utilities';

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -3,7 +3,6 @@ import { IDisposable, type IServiceLocator, type Writable } from '@aurelia/kerne
 import { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import {
   connectable,
-  type Scope,
   type IAccessor,
   type IObserverLocator,
   type IOverrideContext,
@@ -13,6 +12,7 @@ import {
 } from '@aurelia/runtime';
 import {
   BindingMode,
+  type Scope,
   type IBindingController,
   mixinAstEvaluator,
   mixingBindingLimited,

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -5,7 +5,6 @@ import {
   connectable,
   type IAccessor,
   type IObserverLocator,
-  type IOverrideContext,
   AccessorType,
   type IObserverLocatorBasedConnectable,
   ISubscriber
@@ -13,6 +12,7 @@ import {
 import {
   BindingMode,
   type Scope,
+  type IOverrideContext,
   type IBindingController,
   mixinAstEvaluator,
   mixingBindingLimited,

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -2,7 +2,6 @@
 import { type Writable, type IServiceLocator } from '@aurelia/kernel';
 import {
   type IOverrideContext,
-  Scope,
   connectable,
   IObserverLocatorBasedConnectable,
 } from '@aurelia/runtime';
@@ -14,6 +13,7 @@ import {
   astUnbind,
   IBinding,
   IAstEvaluator,
+  type Scope,
 } from '@aurelia/runtime-html';
 import {
   IStoreSubscriber,

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -1,7 +1,6 @@
 
 import { type Writable, type IServiceLocator } from '@aurelia/kernel';
 import {
-  type IOverrideContext,
   connectable,
   IObserverLocatorBasedConnectable,
 } from '@aurelia/runtime';
@@ -14,6 +13,7 @@ import {
   IBinding,
   IAstEvaluator,
   type Scope,
+  type IOverrideContext,
 } from '@aurelia/runtime-html';
 import {
   IStoreSubscriber,

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -3,7 +3,6 @@ import { IDisposable, IIndexable, IServiceLocator, type Writable } from '@aureli
 import {
   connectable,
   IObserverLocatorBasedConnectable,
-  Scope,
   type IOverrideContext,
 } from '@aurelia/runtime';
 import {
@@ -12,7 +11,7 @@ import {
   type IStoreSubscriber
 } from './interfaces';
 import { createStateBindingScope, isSubscribable } from './state-utilities';
-import { IBinding } from '@aurelia/runtime-html';
+import { IBinding, Scope } from '@aurelia/runtime-html';
 
 /**
  * A binding that handles the connection of the global state to a property of a target object

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -3,7 +3,6 @@ import { IDisposable, IIndexable, IServiceLocator, type Writable } from '@aureli
 import {
   connectable,
   IObserverLocatorBasedConnectable,
-  type IOverrideContext,
 } from '@aurelia/runtime';
 import {
   IStore,
@@ -11,7 +10,7 @@ import {
   type IStoreSubscriber
 } from './interfaces';
 import { createStateBindingScope, isSubscribable } from './state-utilities';
-import { IBinding, Scope } from '@aurelia/runtime-html';
+import { IBinding, Scope, type IOverrideContext, } from '@aurelia/runtime-html';
 
 /**
  * A binding that handles the connection of the global state to a property of a target object

--- a/packages/state/src/state-utilities.ts
+++ b/packages/state/src/state-utilities.ts
@@ -1,4 +1,4 @@
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '@aurelia/runtime-html';
 import { type SubscribableValue } from './interfaces';
 import { DI } from '@aurelia/kernel';
 

--- a/packages/testing/src/mocks.ts
+++ b/packages/testing/src/mocks.ts
@@ -9,6 +9,7 @@ import {
   type ISignaler,
   type IRateLimitOptions,
   type IBinding,
+  type Scope,
 } from '@aurelia/runtime-html';
 
 import type {
@@ -18,7 +19,6 @@ import type {
   IServiceLocator,
 } from '@aurelia/kernel';
 import type {
-  Scope,
   IndexMap,
   IObserverLocator,
   BindingObserverRecord,

--- a/packages/testing/src/test-builder.ts
+++ b/packages/testing/src/test-builder.ts
@@ -5,9 +5,9 @@ import {
 import {
   IDirtyChecker,
   IObserverLocator,
-  Scope,
   INodeObserverLocator,
 } from '@aurelia/runtime';
+import { Scope } from '@aurelia/runtime-html';
 import { createContainer } from './test-context';
 // import {
 //   IInstruction,

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -4,11 +4,11 @@ import {
   Collection,
   getCollectionObserver,
   IndexMap,
-  type IOverrideContext,
 } from '@aurelia/runtime';
 import {
   astEvaluate,
   Scope,
+  type IOverrideContext,
   BindingContext,
   IInstruction,
   IController,

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -1,15 +1,15 @@
 import { resolve } from "@aurelia/kernel";
 import type { ITask } from '@aurelia/platform';
 import {
-  Scope,
   Collection,
   getCollectionObserver,
   IndexMap,
-  BindingContext,
   type IOverrideContext,
 } from '@aurelia/runtime';
 import {
   astEvaluate,
+  Scope,
+  BindingContext,
   IInstruction,
   IController,
   IViewFactory,

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -5,13 +5,13 @@ import {
   IConnectable,
   IObserverLocator,
   IObserverLocatorBasedConnectable,
-  Scope
 } from '@aurelia/runtime';
 import {
   type IAstEvaluator,
   type IBinding,
   astEvaluate,
   type BindingBehaviorInstance,
+  Scope,
   BindingBehavior,
   BindingTargetSubscriber,
   IFlushQueue,

--- a/packages/validation-html/src/validation-controller.ts
+++ b/packages/validation-html/src/validation-controller.ts
@@ -16,6 +16,7 @@ import {
   astEvaluate,
   IPlatform,
   PropertyBinding,
+  type Scope,
 } from '@aurelia/runtime-html';
 import {
   parsePropertyName,
@@ -27,8 +28,6 @@ import {
   type IValidationRule,
   type IValidateable,
 } from '@aurelia/validation';
-
-import type { Scope } from '@aurelia/runtime';
 
 export type BindingWithBehavior = PropertyBinding & {
   ast: BindingBehaviorExpression;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -8,8 +8,6 @@ import {
 } from '@aurelia/expression-parser';
 import {
   Scope,
-} from '@aurelia/runtime';
-import {
   type IAstEvaluator,
   astEvaluate,
   mixinAstEvaluator,

--- a/packages/validation/src/serialization.ts
+++ b/packages/validation/src/serialization.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { IContainer, IServiceLocator, resolve } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
 import { IExpressionParser } from '@aurelia/expression-parser';
-import { mixinAstEvaluator, type IAstEvaluator, astEvaluate } from '@aurelia/runtime-html';
+import { mixinAstEvaluator, type IAstEvaluator, astEvaluate, Scope } from '@aurelia/runtime-html';
 import { Deserializer, serializePrimitive, Serializer } from './ast-serialization';
 import {
   IPropertyRule,

--- a/packages/validation/src/validator.ts
+++ b/packages/validation/src/validator.ts
@@ -1,5 +1,5 @@
 import { DI } from '@aurelia/kernel';
-import { Scope } from '@aurelia/runtime';
+import { Scope } from '@aurelia/runtime-html';
 import { ValidationResult, validationRulesRegistrar, PropertyRule, rootObjectSymbol } from './rule-provider';
 import { IValidateable } from './rule-interfaces';
 


### PR DESCRIPTION
## 📖 Description

As part of cleanup and reogranising exports, move `Scope` and related infra to binding areas in runtime html, where it should belong.