### PR TITLE
refactor(compiler): simplify definition creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test/benchmarking-apps/runner/cosmos.config.json
 
 .turbo
 .parcel-cache
+.tsconfig.dev.json

--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -39,6 +39,7 @@
     "build": "tsc --build",
     "postbuild": "rimraf dist/**/.tsbuildinfo",
     "dev": "cross-env DEV_MODE=true node esbuild.dev.cjs",
+    "dev:tsc": "node tsc.dev.cjs",
     "rollup": "npm run build",
     "build:packages": "node esbuild.dev.cjs",
     "verify": "tsc --noEmit"

--- a/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
@@ -15,6 +15,7 @@ import {
   IRendering,
   PropertyBinding,
   HydrateTemplateController,
+  ITemplateCompiler,
 } from '@aurelia/runtime-html';
 import {
   eachCartesianJoin,
@@ -22,7 +23,7 @@ import {
   PLATFORM,
   createContainer,
 } from '@aurelia/testing';
-import { Writable } from '@aurelia/kernel';
+import { Registration, Writable } from '@aurelia/kernel';
 
 describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
   function runActivateLifecycle(sut: Repeat, scope: Scope): void {
@@ -503,6 +504,7 @@ describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
     NodeObserverLocator,
     PropertyBindingRenderer,
     TextBindingRenderer,
+    Registration.instance(ITemplateCompiler, { compile: (d) => d }),
   );
 
   const createStartLocation = () => PLATFORM.document.createComment('au-start');

--- a/packages/__tests__/src/3-runtime-html/template-compiler.local-templates.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.local-templates.spec.ts
@@ -218,7 +218,7 @@ function $$createFixture() {
       ctx.templateCompiler.resolveResources = v;
     },
     compile(def: PartialCustomElementDefinition, container: IContainer, instruction: ICompliationInstruction) {
-      return ctx.templateCompiler.compile(CustomElementDefinition.create(def), container, instruction);
+      return CustomElementDefinition.getOrCreate(ctx.templateCompiler.compile(CustomElementDefinition.create(def), container, instruction));
     }
   };
   return { ctx, container, sut };

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -1283,7 +1283,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         ] as ((ctx: TestContext) => BindingMode | undefined)[],
         [
           (ctx, [, , to], [attr, value]) => [`${attr}`, value.length > 0 ? { type: TT.setProperty, to, value } : null],
-          (ctx, [, mode, to], [attr, value], defaultMode) => [`${attr}.bind`, { type: TT.propertyBinding, from: value.length > 0 ? new AccessScopeExpression(value) : new PrimitiveLiteralExpression(value), to, mode: (mode && mode !== BindingMode.default) ? mode : (defaultMode || BindingMode.toView) }],
+          (ctx, [, mode, to], [attr, value], defaultMode) => [`${attr}.bind`, { type: TT.propertyBinding, from: value.length > 0 ? new AccessScopeExpression(value) : new PrimitiveLiteralExpression(value), to, mode: (mode && mode !== BindingMode.default as any) ? mode : (defaultMode || BindingMode.toView) }],
           (ctx, [, , to], [attr, value]) => [`${attr}.to-view`, { type: TT.propertyBinding, from: value.length > 0 ? new AccessScopeExpression(value) : new PrimitiveLiteralExpression(value), to, mode: BindingMode.toView }],
           (ctx, [, , to], [attr, value]) => [`${attr}.one-time`, { type: TT.propertyBinding, from: value.length > 0 ? new AccessScopeExpression(value) : new PrimitiveLiteralExpression(value), to, mode: BindingMode.oneTime }],
           (ctx, [, , to], [attr, value]) => [`${attr}.from-view`, { type: TT.propertyBinding, from: value.length > 0 ? new AccessScopeExpression(value) : new PrimitiveLiteralExpression(value), to, mode: BindingMode.fromView }],
@@ -2149,7 +2149,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
       get debug() { return compiler.debug; },
       set debug(value: boolean) { compiler.debug = value; },
       compile(definition: PartialCustomElementDefinition, container: IContainer, instruction: any) {
-        return compiler.compile(CustomElementDefinition.create(definition), container, instruction);
+        return CustomElementDefinition.getOrCreate(compiler.compile(CustomElementDefinition.create(definition), container, instruction));
       },
       compileSpread(...args: any[]) {
         // eslint-disable-next-line prefer-spread

--- a/packages/__tests__/tsc.dev.cjs
+++ b/packages/__tests__/tsc.dev.cjs
@@ -1,0 +1,36 @@
+/* eslint-disable */
+const { existsSync, writeFileSync, unlinkSync } = require('fs');
+const { resolve } = require('path');
+const { execSync } = require('child_process');
+
+const testPatterns = process.argv.slice(2);
+const baseConfig = require('./tsconfig.json');
+const config = {
+  ...baseConfig,
+  compilerOptions: {
+    ...baseConfig.compilerOptions,
+    composite: false,
+    tsBuildInfoFile: null,
+  },
+  include: [
+    'src/*.ts',
+    ...testPatterns.flatMap(pattern => {
+      pattern = pattern.replace(/\.ts$/, '');
+      return [
+        `src/*/*${pattern}*.ts`,
+        `src/*/${pattern}/**/*.ts`,
+      ]
+    })
+  ]
+};
+
+if (existsSync(resolve(__dirname, './dist/.tsbuildinfo'))) {
+  unlinkSync(resolve(__dirname, './dist/.tsbuildinfo'));
+}
+
+writeFileSync(
+  resolve(__dirname, '.tsconfig.dev.json'),
+  JSON.stringify(config, null, 2)
+);
+
+execSync('tsc -p .tsconfig.dev.json --watch', { stdio: 'inherit' });

--- a/packages/rollup-utils.mjs
+++ b/packages/rollup-utils.mjs
@@ -180,7 +180,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           rollupReplace({ '_START_CONST_ENUM': '(() => {})', '_END_CONST_ENUM': '(() => {})' }),
           esbuild({
             minify: false,
-            target: 'es2022',
+            target: 'es2021',
             define: { ...envVars, __DEV__: 'true' },
             sourceMap: true,
           }),
@@ -230,7 +230,7 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           rollupReplace({ '_START_CONST_ENUM': '(() => {})', '_END_CONST_ENUM': '(() => {})' }),
           esbuild({
             minify: false,
-            target: 'es2022',
+            target: 'es2021',
             define: { ...envVars, __DEV__: 'false' },
             sourceMap: true,
           }),

--- a/packages/runtime-html/src/binding/interfaces-bindings.ts
+++ b/packages/runtime-html/src/binding/interfaces-bindings.ts
@@ -10,18 +10,18 @@ import { TaskQueue } from '@aurelia/platform';
 //
 // Furthermore, the "default" mode would be for simple ".bind" expressions to make it explicit for our logic that the default is being used.
 // This essentially adds extra information which binding could use to do smarter things and allows bindingBehaviors that add a mode instead of simply overwriting it
+/** @internal */ export const defaultMode = 0b0000;
 /** @internal */ export const oneTime     = 0b0001;
 /** @internal */ export const toView      = 0b0010;
 /** @internal */ export const fromView    = 0b0100;
 /** @internal */ export const twoWay      = 0b0110;
-/** @internal */ export const defaultMode = 0b1000;
 /**
  * Mode of a binding to operate
  * - 1 / one time - bindings should only update the target once
  * - 2 / to view - bindings should update the target and observe the source for changes to update again
  * - 3 / from view - bindings should update the source and observe the target for changes to update again
  * - 6 / two way - bindings should observe both target and source for changes to update the other side
- * - 8 / default - undecided mode, bindings, depends on the circumstance, may decide what to do accordingly
+ * - 0 / default - undecided mode, bindings, depends on the circumstance, may decide what to do accordingly
  */
 export const BindingMode = /*@__PURE__*/ objectFreeze({
   oneTime,

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -95,7 +95,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     this._compileLocalElement(content, context);
     this._compileNode(content, context);
 
-    const compiledDef: PartialCustomElementDefinition = {
+    const compiledDef: PartialCustomElementDefinition = CustomElementDefinition.create({
       ...definition,
       name: definition.name || generateElementName(),
       dependencies: (definition.dependencies ?? emptyArray).concat(context.deps ?? emptyArray),
@@ -106,7 +106,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       template,
       hasSlots: context.hasSlot,
       needsCompile: false,
-    };
+    });
 
     if (context.deps != null) {
       // if we have a template like this

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -28,7 +28,7 @@ import { IPlatform } from '../platform';
 import { BindableDefinition, PartialBindableDefinition } from '../bindable';
 import { AttrSyntax, IAttributeParser } from '../resources/attribute-pattern';
 import { CustomAttribute } from '../resources/custom-attribute';
-import { CustomElement, CustomElementDefinition, CustomElementType, defineElement, generateElementName, getElementDefinition } from '../resources/custom-element';
+import { CustomElement, CustomElementDefinition, CustomElementType, PartialCustomElementDefinition, defineElement, generateElementName, getElementDefinition } from '../resources/custom-element';
 import { BindingCommandInstance, ICommandBuildInfo, BindingCommand, BindingCommandDefinition } from '../resources/binding-command';
 import { createLookup, def, etInterpolation, etIsProperty, isString, objectAssign, objectFreeze } from '../utilities';
 import { aliasRegistration, createInterface, singletonRegistration } from '../utilities-di';
@@ -64,10 +64,10 @@ export class TemplateCompiler implements ITemplateCompiler {
   public resolveResources: boolean = true;
 
   public compile(
-    definition: CustomElementDefinition,
+    definition: PartialCustomElementDefinition,
     container: IContainer,
     compilationInstruction: ICompliationInstruction | null,
-  ): CustomElementDefinition {
+  ): PartialCustomElementDefinition {
     if (definition.template == null || definition.needsCompile === false) {
       return definition;
     }
@@ -1090,12 +1090,12 @@ export class TemplateCompiler implements ITemplateCompiler {
           // also, it wouldn't have any real uses
           projectionCompilationContext = context._createChild();
           this._compileNode(template.content, projectionCompilationContext);
-          projections[targetSlot] = CustomElementDefinition.create({
+          projections[targetSlot] = {
             name: generateElementName(),
             template,
             instructions: projectionCompilationContext.rows,
             needsCompile: false,
-          });
+          };
         }
         elementInstruction!.projections = projections;
       }
@@ -1125,12 +1125,12 @@ export class TemplateCompiler implements ITemplateCompiler {
           }
         }
       }
-      tcInstruction.def = CustomElementDefinition.create({
+      tcInstruction.def = {
         name: generateElementName(),
         template: mostInnerTemplate,
         instructions: childContext.rows,
         needsCompile: false,
-      });
+      };
 
       // 4.1.2.
       //  Start processing other Template controllers by walking the TC list (list 1) RIGHT -> LEFT
@@ -1158,12 +1158,12 @@ export class TemplateCompiler implements ITemplateCompiler {
           context._comment(auEndComment),
         ]);
 
-        tcInstruction.def = CustomElementDefinition.create({
+        tcInstruction.def = {
           name: generateElementName(),
           template,
           needsCompile: false,
           instructions: [[tcInstructions[i + 1]]],
-        });
+        };
       }
       // the most outer template controller should be
       // the only instruction for peek instruction of the current context
@@ -1277,12 +1277,12 @@ export class TemplateCompiler implements ITemplateCompiler {
           // compile it
           projectionCompilationContext = context._createChild();
           this._compileNode(template.content, projectionCompilationContext);
-          projections[targetSlot] = CustomElementDefinition.create({
+          projections[targetSlot] = {
             name: generateElementName(),
             template,
             instructions: projectionCompilationContext.rows,
             needsCompile: false,
-          });
+          };
         }
         elementInstruction!.projections = projections;
       }
@@ -1631,7 +1631,7 @@ const isMarker = (el: Node): el is Comment =>
 class CompilationContext {
   public readonly root: CompilationContext;
   public readonly parent: CompilationContext | null;
-  public readonly def: CustomElementDefinition;
+  public readonly def: PartialCustomElementDefinition;
   public readonly ci: ICompliationInstruction;
   public readonly _resourceResolver: IResourceResolver;
   public readonly _templateFactory: ITemplateElementFactory;
@@ -1650,7 +1650,7 @@ class CompilationContext {
   private readonly c: IContainer;
 
   public constructor(
-    def: CustomElementDefinition,
+    def: PartialCustomElementDefinition,
     container: IContainer,
     compilationInstruction: ICompliationInstruction,
     parent: CompilationContext | null,

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -95,7 +95,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     this._compileLocalElement(content, context);
     this._compileNode(content, context);
 
-    const compiledDef = CustomElementDefinition.create({
+    const compiledDef: PartialCustomElementDefinition = {
       ...definition,
       name: definition.name || generateElementName(),
       dependencies: (definition.dependencies ?? emptyArray).concat(context.deps ?? emptyArray),
@@ -106,7 +106,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       template,
       hasSlots: context.hasSlot,
       needsCompile: false,
-    });
+    };
 
     if (context.deps != null) {
       // if we have a template like this
@@ -118,9 +118,9 @@ export class TemplateCompiler implements ITemplateCompiler {
       // <template as-custom-element="le-2">...</template>
       //
       // without registering dependencies properly, <le-1> will not see <le-2> as a custom element
-      const allDepsForLocalElements = [compiledDef.Type, ...compiledDef.dependencies, ...context.deps];
+      const allDepsForLocalElements = [compiledDef.Type, ...compiledDef.dependencies ?? [], ...context.deps].filter(d => d);
       for (const localElementType of context.deps) {
-        (getElementDefinition(localElementType).dependencies as Key[]).push(...allDepsForLocalElements.filter(d => d !== localElementType));
+        (getElementDefinition(localElementType).dependencies as Key[]).push(...allDepsForLocalElements.filter(d => d !== localElementType) as Key[]);
       }
     }
 

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -95,7 +95,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     this._compileLocalElement(content, context);
     this._compileNode(content, context);
 
-    const compiledDef: PartialCustomElementDefinition = CustomElementDefinition.create({
+    const compiledDef: PartialCustomElementDefinition = {
       ...definition,
       name: definition.name || generateElementName(),
       dependencies: (definition.dependencies ?? emptyArray).concat(context.deps ?? emptyArray),
@@ -106,7 +106,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       template,
       hasSlots: context.hasSlot,
       needsCompile: false,
-    });
+    };
 
     if (context.deps != null) {
       // if we have a template like this

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -334,10 +334,10 @@ export interface ITemplateCompiler {
    */
   resolveResources: boolean;
   compile(
-    partialDefinition: CustomElementDefinition,
+    partialDefinition: PartialCustomElementDefinition,
     context: IContainer,
     compilationInstruction: ICompliationInstruction | null,
-  ): CustomElementDefinition;
+  ): PartialCustomElementDefinition;
 
   /**
    * Compile a list of captured attributes as if they are declared in a template

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -55,6 +55,7 @@ export type PartialCustomElementDefinition<TBindables extends string = string> =
   readonly enhance?: boolean;
   readonly watches?: IWatchDefinition[];
   readonly processContent?: ProcessContentHook | null;
+  readonly Type?: Constructable;
 }>;
 
 export type CustomElementStaticAuDefinition<TBindables extends string = string> = PartialCustomElementDefinition<TBindables> & {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -492,7 +492,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
   /** @internal */
   private _hydrateSynthetic(): void {
-    this._compiledDef = this._rendering.compile(this.viewFactory!.def!, this.container, null);
+    this._compiledDef = this._rendering.compile(this.viewFactory!.def, this.container, null);
     this._rendering.render(
       /* controller */this as ISyntheticView,
       /* targets    */(this.nodes = this._rendering.createNodes(this._compiledDef)).findTargets(),

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -13,9 +13,28 @@ import { createInterface } from '../utilities-di';
 import { ErrorNames, createMappedError } from '../errors';
 
 export const IRendering = /*@__PURE__*/createInterface<IRendering>('IRendering', x => x.singleton(Rendering));
-export interface IRendering extends Rendering { }
+export interface IRendering {
+  get renderers(): Record<string, IRenderer>;
 
-export class Rendering {
+  compile(
+    definition: CustomElementDefinition,
+    container: IContainer,
+    compilationInstruction: ICompliationInstruction | null,
+  ): CustomElementDefinition;
+
+  getViewFactory(definition: PartialCustomElementDefinition, container: IContainer): IViewFactory;
+
+  createNodes(definition: CustomElementDefinition): INodeSequence;
+
+  render(
+    controller: IHydratableController,
+    targets: ArrayLike<INode>,
+    definition: CustomElementDefinition,
+    host: INode | null | undefined,
+  ): void;
+}
+
+export class Rendering implements IRendering {
   /** @internal */
   private readonly _ctn: IContainer;
   /** @internal */
@@ -49,18 +68,17 @@ export class Rendering {
   }
 
   public compile(
-    definition: PartialCustomElementDefinition,
+    definition: CustomElementDefinition,
     container: IContainer,
     compilationInstruction: ICompliationInstruction | null,
   ): CustomElementDefinition {
+    const compiler = container.get(ITemplateCompiler);
+    const compiledMap = this._compilationCache;
+    let compiled = compiledMap.get(definition);
     if (definition.needsCompile !== false) {
-      const compiledMap = this._compilationCache;
-      const compiler = container.get(ITemplateCompiler);
-      let compiled = compiledMap.get(definition);
       if (compiled == null) {
-        // const fullDefinition = CustomElementDefinition.getOrCreate(definition);
-        compiledMap.set(definition, compiled = CustomElementDefinition.getOrCreate(compiler.compile(
-          CustomElementDefinition.getOrCreate(definition),
+        compiledMap.set(definition, compiled = CustomElementDefinition.create(compiler.compile(
+          definition,
           container,
           compilationInstruction
         )));
@@ -73,7 +91,7 @@ export class Rendering {
       return compiled;
     }
 
-    return definition as CustomElementDefinition;
+    return definition;
   }
 
   public getViewFactory(definition: PartialCustomElementDefinition, container: IContainer): IViewFactory {
@@ -94,7 +112,7 @@ export class Rendering {
     } else {
       const template = definition.template;
       let tpl: HTMLTemplateElement;
-      if (template === null) {
+      if (template == null) {
         fragment = null;
       } else if (template instanceof p.Node) {
         if (template.nodeName === 'TEMPLATE') {

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -59,11 +59,11 @@ export class Rendering {
       let compiled = compiledMap.get(definition);
       if (compiled == null) {
         // const fullDefinition = CustomElementDefinition.getOrCreate(definition);
-        compiledMap.set(definition, compiled = compiler.compile(
+        compiledMap.set(definition, compiled = CustomElementDefinition.getOrCreate(compiler.compile(
           CustomElementDefinition.getOrCreate(definition),
           container,
           compilationInstruction
-        ));
+        )));
       } else {
         // todo:
         // should only register if the compiled def resolution is string

--- a/packages/runtime-html/src/templating/view.ts
+++ b/packages/runtime-html/src/templating/view.ts
@@ -4,17 +4,30 @@ import { createInterface } from '../utilities-di';
 import { Controller } from './controller';
 
 import type { IContainer } from '@aurelia/kernel';
-import type { PartialCustomElementDefinition } from '../resources/custom-element';
 import type { ICustomAttributeController, ICustomElementController, ISyntheticView } from './controller';
 
-export interface IViewFactory extends ViewFactory {}
+export interface IViewFactory {
+  name: string;
+  readonly container: IContainer;
+  def: CustomElementDefinition;
+  isCaching: boolean;
+
+  setCacheSize(size: number | '*', doNotOverrideIfAlreadySet: boolean): void;
+
+  canReturnToCache(_controller: ISyntheticView): boolean;
+
+  tryReturnToCache(controller: ISyntheticView): boolean;
+
+  create(parentController?: ISyntheticView | ICustomElementController | ICustomAttributeController | undefined): ISyntheticView;
+}
 export const IViewFactory = /*@__PURE__*/createInterface<IViewFactory>('IViewFactory');
+
 export class ViewFactory implements IViewFactory {
   public static maxCacheSize: number = 0xFFFF;
 
   public name: string;
   public readonly container: IContainer;
-  public def: PartialCustomElementDefinition;
+  public def: CustomElementDefinition;
   public isCaching: boolean = false;
 
   /** @internal */

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -36,7 +36,7 @@ const args = yargs
   })
   .parseSync();
 
-const envVars = { DEV_MODE: true };
+const envVars = { DEV_MODE: false };
 const testPatterns = (args.t ?? []).join(' ');
 const hasValidTestPatterns = testPatterns !== '';
 
@@ -150,7 +150,7 @@ const baseAppPort = 9000;
 concurrently([
   { command: devCmd, cwd: 'packages/runtime', name: 'runtime', env: envVars },
   { command: devCmd, cwd: 'packages/runtime-html', name: 'runtime-html', env: envVars },
-  { command: devCmd, cwd: 'packages/__tests__', name: '__tests__(build)', env: envVars },
+  { command: 'tsc --watch --isolatedModules true', cwd: 'packages/__tests__', name: '__tests__(build)', env: envVars },
   ...devPackages.map((folder: string) => ({
     command: devCmd,
     cwd: `packages/${folder}`,

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -150,7 +150,14 @@ const baseAppPort = 9000;
 concurrently([
   { command: devCmd, cwd: 'packages/runtime', name: 'runtime', env: envVars },
   { command: devCmd, cwd: 'packages/runtime-html', name: 'runtime-html', env: envVars },
-  { command: 'tsc --watch --isolatedModules true', cwd: 'packages/__tests__', name: '__tests__(build)', env: envVars },
+  hasValidTestPatterns
+    ? {
+      command: `npm run dev:tsc ${testPatterns === '*' ? '*' : testPatterns}`,
+      cwd: 'packages/__tests__',
+      name: '__tests__(build)',
+      env: envVars
+    }
+    : null,
   ...devPackages.map((folder: string) => ({
     command: devCmd,
     cwd: `packages/${folder}`,
@@ -158,7 +165,12 @@ concurrently([
     env: envVars
   })),
   hasValidTestPatterns
-    ? { command: `npm run test-chrome:debugger ${testPatterns === '*' ? '' : testPatterns}`, cwd: 'packages/__tests__', name: '__tests__(run)', env: envVars }
+    ? {
+      command: `node -e "new Promise(r => setTimeout(r, 6000))" && npm run test-chrome:debugger ${testPatterns === '*' ? '' : testPatterns}`,
+      cwd: 'packages/__tests__',
+      name: '__tests__(run)',
+      env: envVars
+    }
     : null,
   ...(e2e ?? []).map(e => ({ command: 'npm run test:watch', cwd: `packages/__e2e__/${e}`, env: envVars, name: `__e2e__(${e})` })),
   ...apps.map((appFolder, i) => ({

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -175,7 +175,7 @@ concurrently([
   }))
 ].filter(Boolean), {
   prefix: '[{name}]',
-  killOthers: 'failure',
+  killOthers: ['failure', 'success'],
   prefixColors: [
     'green',
     'blue',


### PR DESCRIPTION
## 📖 Description

To prepare for the extraction of template compiler extraction, the direct usage of resources APIs first need to be simplified. Instead of using full element definition, only use partial. It turns out to be a pretty good change, template compiler emits just enough information about what it sees in the template.

cc @Sayan751 