### PR TITLE
fix(au-slot): ensure passthrough slot get the right host value

### DIFF
--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -55,13 +55,13 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   }
 
   it('compiles default <au-slot> as the only child', function () {
-    const { template, instructions } = compileWith('<au-slot></au-slot>');
+    const { template, instructions } = compileTemplate('<au-slot></au-slot>');
     assertTemplateEqual(template, '<!--au*--><!--au-start--><!--au-end-->');
     assertAuSlotFallback(instructions[0][0], null);
   });
 
   it('compiles 2 default <au-slot>s', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<au-slot></au-slot><au-slot></au-slot>'
     );
     assertTemplateEqual(
@@ -73,7 +73,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles default <au-slot> with fallback', function () {
-    const { template, instructions, createProp } = compileWith(
+    const { template, instructions, createProp } = compileTemplate(
       '<au-slot><div a.bind="b"></div></au-slot>'
     );
     assertTemplateEqual(
@@ -89,7 +89,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles default <au-slot> with [interpolation] fallback', function () {
-    const { template, instructions, createTextInterpolation } = compileWith(
+    const { template, instructions, createTextInterpolation } = compileTemplate(
       '<au-slot>${message}</au-slot>'
     );
     assertTemplateEqual(
@@ -105,26 +105,26 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles together with slot', function () {
-    const { template, instructions } = compileWith('<slot></slot><au-slot></au-slot>');
+    const { template, instructions } = compileTemplate('<slot></slot><au-slot></au-slot>');
     assertTemplateEqual(template, '<slot></slot><!--au*--><!--au-start--><!--au-end-->');
     assertAuSlotFallback(instructions[0][0], null);
   });
 
   it('compiles named <au-slot>', function () {
-    const { template, instructions } = compileWith('<au-slot name="s1"></au-slot>');
+    const { template, instructions } = compileTemplate('<au-slot name="s1"></au-slot>');
     assertTemplateEqual(template, '<!--au*--><!--au-start--><!--au-end-->');
     assertAuSlotFallback(instructions[0][0], null);
   });
 
   it('compiles default <au-slot> mixed with named <au-slot>', function () {
-    const { template, instructions } = compileWith('<au-slot name="s1"></au-slot><au-slot></au-slot>');
+    const { template, instructions } = compileTemplate('<au-slot name="s1"></au-slot><au-slot></au-slot>');
     assertTemplateEqual(template, '<!--au*--><!--au-start--><!--au-end--><!--au*--><!--au-start--><!--au-end-->');
     assertAuSlotFallback(instructions[0][0], null);
     assertAuSlotFallback(instructions[1][0], null);
   });
 
   it('compiles projection with default [au-slot]', function () {
-    const { template, instructions, createProp } = compileWith(
+    const { template, instructions, createProp } = compileTemplate(
       '<el><div au-slot a.bind="b">',
       $createCustomElement('', 'el')
     );
@@ -135,7 +135,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles content without the need of [au-slot]', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<el><div>',
       $createCustomElement('', 'el')
     );
@@ -146,7 +146,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles projection with default [au-slot] as empty string', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<el><div au-slot="">',
       $createCustomElement('', 'el')
     );
@@ -157,7 +157,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('does not get confused when theres a slot with the same name with project in the template', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<au-slot></au-slot><el><div au-slot="">',
       $createCustomElement('', 'el')
     );
@@ -169,7 +169,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles projection with specific [au-slot] name', function () {
-    const { template, instructions, createProp } = compileWith(
+    const { template, instructions, createProp } = compileTemplate(
       '<el><div au-slot="s1" a.bind="b">',
       $createCustomElement('', 'el')
     );
@@ -180,7 +180,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles auto projection with named projection', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<el><div></div><div au-slot="s1">',
       $createCustomElement('', 'el')
     );
@@ -192,7 +192,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles projection that has <au-slot>', function () {
-    const { template, instructions } = compileWith(
+    const { template, instructions } = compileTemplate(
       '<el><au-slot au-slot>',
       $createCustomElement('', 'el')
     );
@@ -207,7 +207,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles default <au-slot> in projection with fallback', function () {
-    const { template, instructions, createProp } = compileWith(
+    const { template, instructions, createProp } = compileTemplate(
       '<el><au-slot au-slot"><div a.bind="b">',
       $createCustomElement('', 'el')
     );
@@ -222,7 +222,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   });
 
   it('compiles multiple <au-slot>s in projection with fallback', function () {
-    const { template, instructions, createProp } = compileWith(
+    const { template, instructions, createProp } = compileTemplate(
       ['<el>',
         '<au-slot au-slot">',
           '<div a.bind="b"></div>',
@@ -365,7 +365,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
     });
   }
 
-  function compileWith(template: string, ...registrations: unknown[]) {
+  function compileTemplate(template: string, ...registrations: unknown[]) {
     const { container, sut } = createFixture();
     container.register(DefaultBindingSyntax, ...registrations);
 

--- a/packages/__tests__/tsc.dev.cjs
+++ b/packages/__tests__/tsc.dev.cjs
@@ -18,7 +18,9 @@ const config = {
       pattern = pattern.replace(/\.ts$/, '');
       return [
         `src/**/*${pattern}*.ts`,
+        `src/**/*${pattern}*.tsx`,
         `src/**/${pattern}/**/*.ts`,
+        `src/**/${pattern}/**/*.tsx`,
       ]
     })
   ]

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -164,9 +164,20 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
 
   public binding(
     _initiator: IHydratedController,
-    _parent: IHydratedParentController,
+    parent: IHydratedParentController,
   ): void | Promise<void> {
-    this._parentScope = this.$controller.scope.parent!;
+    // if this <au-slot> was created by another au slot, the controller hierarchy will be like this:
+    // C(au-slot)#1 --> C(synthetic)#1 --> C(au-slot)#2 --> C(synthetic)#2
+    //
+    // C(synthetic)#2 is what will provide the content for C(au-slot)#1
+    // but C(au-slot)#1 is what will provide the $host value for the content of C(au-slot)#2
+    //
+    // because of this structure, walk 2 level of controller at once to find the right parent scope for $host value
+    while (parent.vmKind === 'synthetic' && parent.parent?.viewModel instanceof AuSlot) {
+      parent = parent.parent.parent as IHydratedParentController;
+    }
+    this._parentScope = parent.scope;
+
     let outerScope: Scope;
     if (this._hasProjection) {
       // if there is a projection,


### PR DESCRIPTION
## 📖 Description

Currently if `$host` is used in the content of a custom element and that content happens to be passed through another layer of `<au-slot>`, it will end up getting wrong `$host` value. This PR fixes this.

Original thread on Discord https://discord.com/channels/448698263508615178/448699089513611266/1234665951467929666

Thanks @MaximBalaganskiy 

cc @Sayan751 