### PR TITLE
feat(convention): rewrite runtime-html decorators

### DIFF
--- a/packages-tooling/__tests__/src/babel-jest/index.spec.ts
+++ b/packages-tooling/__tests__/src/babel-jest/index.spec.ts
@@ -40,10 +40,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -63,10 +64,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ shadowCSS(d0) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -89,10 +91,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ cssModules(d0) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -10,10 +10,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -34,10 +35,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -59,10 +61,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -85,10 +88,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -110,10 +114,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -137,10 +142,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1 ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -163,10 +169,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1 ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -190,10 +197,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1 ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -217,10 +225,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1 ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -246,10 +255,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -280,10 +290,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2, d3) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -312,10 +323,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'closed' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -345,10 +357,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -378,10 +391,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -410,10 +424,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -739,10 +754,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, cssModules(d2) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -769,10 +785,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
 export const capture = true;
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, capture });
+    _e = CustomElement.define({ name, template, dependencies, capture, bindables });
   }
   container.register(_e);
 }
@@ -795,10 +812,11 @@ export const template = "<template ></template>";
 export default template;
 export const dependencies = [  ];
 export const capture = true;
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, capture });
+    _e = CustomElement.define({ name, template, dependencies, capture, bindables });
   }
   container.register(_e);
 }
@@ -824,10 +842,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, cssModules(d2, d3) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -851,10 +870,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -875,10 +895,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -900,10 +921,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -927,10 +949,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(d0, "x") ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -953,10 +976,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(d0, null, {"y":"x"}) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -980,10 +1004,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(d0, "x"), $$arr(d1, "k") ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -1012,10 +1037,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(d0, "x", {"a":"b"}), $$arr(d1, "k", {"c":"d"}) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -1044,10 +1070,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(d0, "x", {"a":"b"}), d1 ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -1075,10 +1102,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ $$arr(__get_el__(d0), "text") ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1093,6 +1093,8 @@ CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au
   // #region bindables
   it(`rewrites bindables - field decorator`, function () {
     const code = `import { bindable } from '@aurelia/runtime-html'
+@bindable('b')
+@bindable('c')
 export class FooBar {
   @bindable x;
   @bindable() y;
@@ -1102,13 +1104,15 @@ export class FooBar {
 `;
     const expected = `import * as __au2ViewDef from './foo-bar.html';
 import { bindable, CustomElement } from '@aurelia/runtime-html';
+
+
 export class FooBar {
    x;
    y;
    z;
    a;
 }
-CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 'x', 'y', { name: 'z', ...{ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } } }, { name: 'a', ...opts } ] }, FooBar);
+CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 'b', 'c', 'x', 'y', { name: 'z', ...{ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } } }, { name: 'a', ...opts } ] }, FooBar);
 
 `;
     const result = preprocessResource(
@@ -1121,7 +1125,6 @@ CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 
     );
     assert.equal(result.code, expected);
   });
-  // TODO: class decorators
   // #endregion
 });
 

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1499,11 +1499,18 @@ Reflect.defineProperty(FooBindingCommand, 'inject', { value: [A, B], writable: t
     const code = `import { inject } from '@aurelia/kernel';
 @inject(A, B)
 export class Foo {}
+
+@inject(C, D)
+export class Bar {}
 `;
     const expected = `import { inject } from '@aurelia/kernel';
 
 export class Foo {}
 Reflect.defineProperty(Foo, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+
+
+export class Bar {}
+Reflect.defineProperty(Bar, 'inject', { value: [C, D], writable: true, configurable: true, enumerable: true });
 `;
     const result = preprocessResource(
       {

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1352,6 +1352,169 @@ CustomAttribute.define({ name: 'foo-bar', isTemplateController: true, bindables:
     assert.equal(result.code, expected);
   });
   // #endregion
+
+  // #region inject
+  it(`rewrites @inject - custom element`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooBar {}
+`;
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import * as __au2ViewDef from './foo-bar.html';
+import { inject } from '@aurelia/kernel';
+
+export class FooBar {}
+CustomElement.define(__au2ViewDef, FooBar);
+Reflect.defineProperty(FooBar, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - custom attribute`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooCustomAttribute {}
+`;
+    const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+
+export class FooCustomAttribute {}
+CustomAttribute.define('foo', FooCustomAttribute);
+
+Reflect.defineProperty(FooCustomAttribute, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - template controller`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooTemplateController {}
+`;
+    const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+
+export class FooTemplateController {}
+CustomAttribute.define({ name: 'foo', isTemplateController: true }, FooTemplateController);
+
+Reflect.defineProperty(FooTemplateController, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - value converter`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooValueConverter {}
+`;
+    const expected = `import { ValueConverter } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+
+export class FooValueConverter {}
+ValueConverter.define('foo', FooValueConverter);
+
+Reflect.defineProperty(FooValueConverter, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - binding behavior`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooBindingBehavior {}
+`;
+    const expected = `import { BindingBehavior } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+
+export class FooBindingBehavior {}
+BindingBehavior.define('foo', FooBindingBehavior);
+
+Reflect.defineProperty(FooBindingBehavior, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - binding command`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class FooBindingCommand {}
+`;
+    const expected = `import { BindingCommand } from '@aurelia/runtime-html';
+import { inject } from '@aurelia/kernel';
+
+export class FooBindingCommand {}
+BindingCommand.define('foo', FooBindingCommand);
+
+Reflect.defineProperty(FooBindingCommand, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites @inject - general class`, function () {
+    const code = `import { inject } from '@aurelia/kernel';
+@inject(A, B)
+export class Foo {}
+`;
+    const expected = `import { inject } from '@aurelia/kernel';
+
+export class Foo {}
+Reflect.defineProperty(Foo, 'inject', { value: [A, B], writable: true, configurable: true, enumerable: true });
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+  // #endregion
 });
 
 describe('preprocessResource for complex resource', function () {

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -855,6 +855,119 @@ CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au
   }
   // #endregion
 
+  // #region capture
+  for (const [deco, options] of [['@capture()', 'true'], ['@capture(() => true)', '() => true'], ['@capture(filter)', 'filter']]) {
+    it(`rewrites ${deco} to CustomElement.define`, function () {
+      const code = `import { capture } from '@aurelia/runtime-html'
+${deco}
+export class FooBar {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { capture, CustomElement } from '@aurelia/runtime-html';
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, capture: ${options} }, FooBar);
+
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with @customElement`, function () {
+      const code = `import { capture, customElement } from '@aurelia/runtime-html'
+${deco}
+@customElement('foo-bar')
+export class FooBar {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { capture, customElement, CustomElement } from '@aurelia/runtime-html';
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', capture: ${options} }, FooBar);
+
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with local deps`, function () {
+      const code = `import { capture } from '@aurelia/runtime-html'
+${deco}
+export class FooBar {}
+
+export class BarCustomAttribute {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { capture, CustomElement, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class BarCustomAttribute {}
+CustomAttribute.define('bar', BarCustomAttribute);
+
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependencies, BarCustomAttribute ], capture: ${options} }, FooBar);
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with local deps - with @customElement`, function () {
+      const code = `import { capture, customElement } from '@aurelia/runtime-html'
+${deco}
+@customElement('foo-bar')
+export class FooBar {}
+
+export class BarCustomAttribute {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { capture, customElement, CustomElement, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class BarCustomAttribute {}
+CustomAttribute.define('bar', BarCustomAttribute);
+
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au2ViewDef.dependencies, BarCustomAttribute ], capture: ${options} }, FooBar);
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+  }
+  // #endregion
 });
 
 describe('preprocessResource for complex resource', function () {

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1283,6 +1283,74 @@ export class BarCustomAttribute {}
       preprocessOptions({ hmr: false })
     ), /@bindable decorators on fields.+not supported.+local dependencies.*BarCustomAttribute/);
   });
+
+  it(`rewrites bindables - custom attribute`, function () {
+    const code = `import { bindable } from '@aurelia/runtime-html'
+@bindable('b')
+@bindable('c')
+export class FooBarCustomAttribute {
+  @bindable x;
+  @bindable() y;
+  @bindable({ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } }) z;
+  @bindable(opts) a;
+}
+`;
+    const expected = `import { bindable, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class FooBarCustomAttribute {
+   x;
+   y;
+   z;
+   a;
+}
+CustomAttribute.define({ name: 'foo-bar', bindables: [ 'b', 'c', 'x', 'y', { name: 'z', ...{ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } } }, { name: 'a', ...opts } ] }, FooBarCustomAttribute);
+
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it(`rewrites bindables - template controller`, function () {
+    const code = `import { bindable } from '@aurelia/runtime-html'
+@bindable('b')
+@bindable('c')
+export class FooBarTemplateController {
+  @bindable x;
+  @bindable() y;
+  @bindable({ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } }) z;
+  @bindable(opts) a;
+}
+`;
+    const expected = `import { bindable, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class FooBarTemplateController {
+   x;
+   y;
+   z;
+   a;
+}
+CustomAttribute.define({ name: 'foo-bar', isTemplateController: true, bindables: [ 'b', 'c', 'x', 'y', { name: 'z', ...{ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } } }, { name: 'a', ...opts } ] }, FooBarTemplateController);
+
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
   // #endregion
 });
 

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1096,6 +1096,8 @@ CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au
 export class FooBar {
   @bindable x;
   @bindable() y;
+  @bindable({ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } }) z;
+  @bindable(opts) a;
 }
 `;
     const expected = `import * as __au2ViewDef from './foo-bar.html';
@@ -1103,8 +1105,10 @@ import { bindable, CustomElement } from '@aurelia/runtime-html';
 export class FooBar {
    x;
    y;
+   z;
+   a;
 }
-CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 'x', 'y' ] }, FooBar);
+CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 'x', 'y', { name: 'z', ...{ attribute: 'z-z', mode: 'fromView', primary: true, set(v) { return Boolean(v); } } }, { name: 'a', ...opts } ] }, FooBar);
 
 `;
     const result = preprocessResource(

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -1088,7 +1088,37 @@ CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au
     });
 
   }
-  // #region
+  // #endregion
+
+  // #region bindables
+  it(`rewrites bindables - field decorator`, function () {
+    const code = `import { bindable } from '@aurelia/runtime-html'
+export class FooBar {
+  @bindable x;
+  @bindable() y;
+}
+`;
+    const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { bindable, CustomElement } from '@aurelia/runtime-html';
+export class FooBar {
+   x;
+   y;
+}
+CustomElement.define({ ...__au2ViewDef, bindables: [ ...__au2ViewDef.bindables, 'x', 'y' ] }, FooBar);
+
+`;
+    const result = preprocessResource(
+      {
+        path: path.join('bar', 'foo-bar.js'),
+        contents: code,
+        filePair: 'foo-bar.html'
+      },
+      preprocessOptions({ hmr: false })
+    );
+    assert.equal(result.code, expected);
+  });
+  // TODO: class decorators
+  // #endregion
 });
 
 describe('preprocessResource for complex resource', function () {

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-resource.spec.ts
@@ -28,7 +28,7 @@ describe('preprocessResource', function () {
     assert.equal(result.code, code);
   });
 
-  it('injects customElement decorator', function () {
+  it('injects custom element definition', function () {
     const code = `\nexport class FooBar {}\n`;
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import * as __au2ViewDef from './foo-bar.html';
@@ -48,7 +48,7 @@ CustomElement.define(__au2ViewDef, FooBar);
     assert.equal(result.code, expected);
   });
 
-  it('injects customElement decorator for loosely equal class name', function () {
+  it('injects custom element definition for loosely equal class name', function () {
     const code = `export class UAFooBarCustomElement {}\n`;
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import * as __au2ViewDef from './ua-foo-bar.html';
@@ -67,7 +67,7 @@ CustomElement.define(__au2ViewDef, UAFooBarCustomElement);
     assert.equal(result.code, expected);
   });
 
-  it('injects customElement decorator for non-kebab case file name', function () {
+  it('injects custom element definition for non-kebab case file name', function () {
     const code = `export class FooBar {}\n`;
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import * as __au2ViewDef from './FooBar.html';
@@ -86,7 +86,7 @@ CustomElement.define(__au2ViewDef, FooBar);
     assert.equal(result.code, expected);
   });
 
-  it('injects customElement decorator with existing runtime import', function () {
+  it('injects custom element definition with existing runtime import', function () {
     const code = `import { containerless } from '@aurelia/runtime-html';
 
 const A = 0;
@@ -99,9 +99,9 @@ function b() {}
 import { containerless, CustomElement } from '@aurelia/runtime-html';
 
 const A = 0;
-@containerless()
+
 export class FooBar {}
-CustomElement.define(__au2ViewDef, FooBar);
+CustomElement.define({ ...__au2ViewDef, containerless: true }, FooBar);
 
 
 function b() {}
@@ -117,7 +117,7 @@ function b() {}
     assert.equal(result.code, expected);
   });
 
-  it('does not inject customElement decorator for decorated resource', function () {
+  it('does not inject custom element definition for decorated resource', function () {
     const code = `import { customElement } from '@aurelia/runtime-html';
 import * as lorem from './lorem.html';
 
@@ -141,7 +141,7 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
-  it('supports customized name in customElement decorator when there is html file pair', function () {
+  it('supports customized name in custom element definition when there is html file pair', function () {
     const code = `import { customElement } from '@aurelia/runtime-html';
 
 @customElement('lorem')
@@ -166,7 +166,7 @@ CustomElement.define({ ...__au2ViewDef, name: 'lorem' }, FooBar);
     assert.equal(result.code, expected);
   });
 
-  it('ignores customized name in customElement decorator when there is no html file pair. This default behaviour is like @noView in Aurelia 1.', function () {
+  it('ignores customized name in custom element definition when there is no html file pair. This default behaviour is like @noView in Aurelia 1.', function () {
     const code = `import { customElement } from '@aurelia/runtime-html';
 
 @customElement('lorem')
@@ -187,7 +187,7 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
-  it('injects customAttribute decorator', function () {
+  it('injects custom attribute definition', function () {
     const code = `export class FooBarCustomAttribute {}\n`;
     const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
 export class FooBarCustomAttribute {}
@@ -204,7 +204,7 @@ CustomAttribute.define('foo-bar', FooBarCustomAttribute);
     assert.equal(result.code, expected);
   });
 
-  it('injects customAttribute decorator for non-kebab case file name', function () {
+  it('injects custom attribute definition for non-kebab case file name', function () {
     const code = `export class FooBarCustomAttribute {}\n`;
     const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
 export class FooBarCustomAttribute {}
@@ -222,7 +222,7 @@ CustomAttribute.define('foo-bar', FooBarCustomAttribute);
     assert.equal(result.code, expected);
   });
 
-  it('skips existing customAttribute decorator', function () {
+  it('skips existing custom attribute definition', function () {
     const code = `import { customAttribute } from 'aurelia';
 @customAttribute('some-thing')
 export class FooBar {}
@@ -242,7 +242,7 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
-  it('injects templateController decorator', function () {
+  it('injects template controller definition', function () {
     const code = `export class FooBarTemplateController {}\n`;
     const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
 export class FooBarTemplateController {}
@@ -259,9 +259,9 @@ CustomAttribute.define({ name: 'foo-bar', isTemplateController: true }, FooBarTe
     assert.equal(result.code, expected);
   });
 
-  it('injects templateController decorator for non-kebab case file name', function () {
+  it('injects template controller definition for non-kebab case file name', function () {
     const code = `export class FooBarTemplateController {}\n`;
-    const expected =  `import { CustomAttribute } from '@aurelia/runtime-html';
+    const expected = `import { CustomAttribute } from '@aurelia/runtime-html';
 export class FooBarTemplateController {}
 CustomAttribute.define({ name: 'foo-bar', isTemplateController: true }, FooBarTemplateController);
 
@@ -277,7 +277,7 @@ CustomAttribute.define({ name: 'foo-bar', isTemplateController: true }, FooBarTe
     assert.equal(result.code, expected);
   });
 
-  it('skips existing templateController decorator', function () {
+  it('skips existing template controller definition', function () {
     const code = `import { templateController } from '@aurelia/runtime-html';
 @templateController('some-thing')
 export class FooBarCustomAttribute {}
@@ -297,7 +297,7 @@ export class FooBarCustomAttribute {}
     assert.equal(result.code, expected);
   });
 
-  it('injects valueConverter decorator', function () {
+  it('injects value converter definition', function () {
     const code = `export class FooBarValueConverter {}\n`;
     const expected = `import { ValueConverter } from '@aurelia/runtime-html';
 export class FooBarValueConverter {}
@@ -314,7 +314,7 @@ ValueConverter.define('fooBar', FooBarValueConverter);
     assert.equal(result.code, expected);
   });
 
-  it('injects valueConverter decorator for non-kebab case file name', function () {
+  it('injects value converter definition for non-kebab case file name', function () {
     const code = `export class FooBarValueConverter {}\n`;
     const expected = `import { ValueConverter } from '@aurelia/runtime-html';
 export class FooBarValueConverter {}
@@ -332,7 +332,7 @@ ValueConverter.define('fooBar', FooBarValueConverter);
     assert.equal(result.code, expected);
   });
 
-  it('skips existing valueConverter decorator', function () {
+  it('skips existing value converter definition', function () {
     const code = `import { valueConverter } from '@aurelia/runtime-html';
 @valueConverter('fooBar')
 export class FooBar {}
@@ -352,7 +352,7 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
-  it('injects bindingBehavior decorator', function () {
+  it('injects binding behavior definition', function () {
     const code = `export class FooBarBindingBehavior {}\n`;
     const expected = `import { BindingBehavior } from '@aurelia/runtime-html';
 export class FooBarBindingBehavior {}
@@ -369,7 +369,7 @@ BindingBehavior.define('fooBar', FooBarBindingBehavior);
     assert.equal(result.code, expected);
   });
 
-  it('injects bindingBehavior decorator for non-kebab case file name', function () {
+  it('injects binding behavior definition for non-kebab case file name', function () {
     const code = `export class FooBarBindingBehavior {}\n`;
     const expected = `import { BindingBehavior } from '@aurelia/runtime-html';
 export class FooBarBindingBehavior {}
@@ -387,7 +387,7 @@ BindingBehavior.define('fooBar', FooBarBindingBehavior);
     assert.equal(result.code, expected);
   });
 
-  it('skips existing bindingBehavior decorator', function () {
+  it('skips existing binding behavior definition', function () {
     const code = `import { bindingBehavior } from 'aurelia';
 @bindingBehavior('fooBar')
 export class FooBar {}
@@ -407,7 +407,7 @@ export class FooBar {}
     assert.equal(result.code, expected);
   });
 
-  it('injects bindingCommand decorator', function () {
+  it('injects binding command definition', function () {
     const code = `export class FooBarBindingCommand {}\n`;
     const expected = `import { BindingCommand } from '@aurelia/runtime-html';
 export class FooBarBindingCommand {}
@@ -424,7 +424,7 @@ BindingCommand.define('foo-bar', FooBarBindingCommand);
     assert.equal(result.code, expected);
   });
 
-  it('injects bindingCommand decorator for non-kebab case file name', function () {
+  it('injects binding command definition for non-kebab case file name', function () {
     const code = `export class FooBarBindingCommand {}\n`;
     const expected = `import { BindingCommand } from '@aurelia/runtime-html';
 export class FooBarBindingCommand {}
@@ -442,7 +442,7 @@ BindingCommand.define('foo-bar', FooBarBindingCommand);
     assert.equal(result.code, expected);
   });
 
-  it('skips existing bindingCommand decorator', function () {
+  it('skips existing binding command definition', function () {
     const code = `import { bindingCommand } from '@aurelia/runtime-html';
 @bindingCommand('lorem')
 export class FooBarBindingCommand {}
@@ -510,6 +510,119 @@ export class FooBar {
     );
     assert.equal(result.code, expected);
   });
+
+  for (const isCall of [true, false]) {
+    const deco = `@containerless${isCall ? '()' : ''}`;
+
+    it(`rewrites ${deco} to CustomElement.define`, function () {
+      const code = `import { containerless } from '@aurelia/runtime-html'
+${deco}
+export class FooBar {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { containerless, CustomElement } from '@aurelia/runtime-html';
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, containerless: true }, FooBar);
+
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with @customElement`, function () {
+      const code = `import { containerless, customElement } from '@aurelia/runtime-html'
+${deco}
+@customElement('foo-bar')
+export class FooBar {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { containerless, customElement, CustomElement } from '@aurelia/runtime-html';
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', containerless: true }, FooBar);
+
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with local deps`, function () {
+      const code = `import { containerless } from '@aurelia/runtime-html'
+${deco}
+export class FooBar {}
+
+export class BarCustomAttribute {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { containerless, CustomElement, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class BarCustomAttribute {}
+CustomAttribute.define('bar', BarCustomAttribute);
+
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependencies, BarCustomAttribute ], containerless: true }, FooBar);
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+
+    it(`rewrites ${deco} to CustomElement.define - with local deps - with @customElement`, function () {
+      const code = `import { containerless , customElement } from '@aurelia/runtime-html'
+${deco}
+@customElement('foo-bar')
+export class FooBar {}
+
+export class BarCustomAttribute {}
+`;
+      const expected = `import * as __au2ViewDef from './foo-bar.html';
+import { containerless, customElement, CustomElement, CustomAttribute } from '@aurelia/runtime-html';
+
+
+export class BarCustomAttribute {}
+CustomAttribute.define('bar', BarCustomAttribute);
+
+
+
+export class FooBar {}
+CustomElement.define({ ...__au2ViewDef, name: 'foo-bar', dependencies: [ ...__au2ViewDef.dependencies, BarCustomAttribute ], containerless: true }, FooBar);
+`;
+      const result = preprocessResource(
+        {
+          path: path.join('bar', 'foo-bar.js'),
+          contents: code,
+          filePair: 'foo-bar.html'
+        },
+        preprocessOptions({ hmr: false })
+      );
+      assert.equal(result.code, expected);
+    });
+  }
 });
 
 describe('preprocessResource for complex resource', function () {
@@ -545,7 +658,7 @@ export class AbcBindingCommand {
 
 }
 `;
-const expected = `import { CustomAttribute, ValueConverter, BindingBehavior, BindingCommand } from '@aurelia/runtime-html';
+    const expected = `import { CustomAttribute, ValueConverter, BindingBehavior, BindingCommand } from '@aurelia/runtime-html';
 import {Foo} from './foo.js';
 import Aurelia, { valueConverter } from 'aurelia';
 
@@ -797,7 +910,7 @@ CustomElement.define({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependen
     assert.equal(result.code, expected);
   });
 
-  it('injects new decorator before existing decorator', function () {
+  it('injects new definition after existing decorator', function () {
     const code = `import { something } from '@aurelia/runtime-html';
 @something
 export class FooBar {}
@@ -837,7 +950,7 @@ CustomElement.define({ ...__au2ViewDef, dependencies: [ ...__au2ViewDef.dependen
     assert.equal(result.code, expected);
   });
 
-  it('injects customElement decorator with index file', function () {
+  it('injects custom element definition with index file', function () {
     const code = `\nexport class FooBar {}\n`;
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import * as __au2ViewDef from './index.html';
@@ -857,7 +970,7 @@ CustomElement.define(__au2ViewDef, FooBar);
     assert.equal(result.code, expected);
   });
 
-  it('injects customElement decorator for loosely equal class name with index file', function () {
+  it('injects custom element definition for loosely equal class name with index file', function () {
     const code = `export class UAFooBarCustomElement {}\n`;
     const expected = `import { CustomElement } from '@aurelia/runtime-html';
 import * as __au2ViewDef from './index.html';

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
@@ -10,10 +10,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -31,10 +32,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -67,10 +69,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -101,10 +104,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ d0, d1, shadowCSS(d2) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }

--- a/packages-tooling/__tests__/src/ts-jest/index.spec.ts
+++ b/packages-tooling/__tests__/src/ts-jest/index.spec.ts
@@ -41,10 +41,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [  ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }
@@ -65,10 +66,11 @@ export const template = "<template></template>";
 export default template;
 export const dependencies = [ shadowCSS(d0) ];
 export const shadowOptions = { mode: 'open' };
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies, shadowOptions });
+    _e = CustomElement.define({ name, template, dependencies, shadowOptions, bindables });
   }
   container.register(_e);
 }
@@ -92,10 +94,11 @@ export const name = "foo-bar";
 export const template = "<template></template>";
 export default template;
 export const dependencies = [ cssModules(d0) ];
+export const bindables = [];
 let _e;
 export function register(container) {
   if (!_e) {
-    _e = CustomElement.define({ name, template, dependencies });
+    _e = CustomElement.define({ name, template, dependencies, bindables });
   }
   container.register(_e);
 }

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -155,9 +155,7 @@ export const dependencies = [ ${viewDeps.join(', ')} ];
     m.append(`export const capture = true;\n`);
   }
 
-  if (Object.keys(bindables).length > 0) {
-    m.append(`export const bindables = ${JSON.stringify(bindables)};\n`);
-  }
+  m.append(`export const bindables = ${(Object.keys(bindables).length > 0 ? JSON.stringify(bindables) : '[]')};\n`);
 
   if (aliases.length > 0) {
     m.append(`export const aliases = ${JSON.stringify(aliases)};\n`);
@@ -170,7 +168,7 @@ export const dependencies = [ ${viewDeps.join(', ')} ];
     shadowMode !== null ? 'shadowOptions' : '',
     containerless ? 'containerless' : '',
     capture ? 'capture' : '',
-    Object.keys(bindables).length > 0 ? 'bindables' : '',
+    'bindables',
     aliases.length > 0 ? 'aliases' : '',
   ].filter(Boolean);
   const definition = `{ ${definitionProperties.join(', ')} }`;

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -252,6 +252,10 @@ function modifyResource(unit: IFileUnit, m: ReturnType<typeof modifyCode>, optio
         const modified = createPrinter().printFile(result.transformed[0]);
         m.replace(implicitElement.pos, implicitElement.end, modified);
       } else if (localDeps.length) {
+        // this is needed to avoid conflicting code modification
+        if (ceBindables?.find((ceb) => !ceb.isClassDecorator) != null) throw new Error(
+`@bindable decorators on fields are not supported by the convention plugin, when there are local dependencies (${localDeps.join(',')}) found.
+Either move the dependencies to another source file, or consider using @bindable(string) decorator on class level.`);
         // eslint-disable-next-line prefer-const
         let { statement: decoratorStatements, effectivePos: pos } = createDecoratorStatement(ceDecorators, implicitElement.pos, m);
         let bindableStatements = '';

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -695,6 +695,15 @@ function collectBindables(node: ClassDeclaration, code: string): BindableDecorat
             position: getPosition(decorator, code),
             modifiedContent: `'${getText(member.name, code)}'`
           });
+        } else if (args.length === 1) {
+          // case 3: @bindable({...}) x
+          const definition = getText(args[0], code);
+          const name = getText(member.name, code);
+          bindables.push({
+            isClassDecorator: false,
+            position: getPosition(decorator, code),
+            modifiedContent: `{ name: '${name}', ...${definition} }`
+          });
         }
       }
     }

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -458,10 +458,23 @@ function findResource(node: Node, expectedResourceName: string, filePair: string
       }
 
       let auDecorator: ReplaceableDecorators | undefined;
+      const position = { pos: ensureTokenStart(d.pos, code), end: d.end };
       switch (name) {
         case 'containerless':
-          auDecorator = { position: {pos: ensureTokenStart(d.pos, code), end: d.end}, modifiedContent: 'containerless: true' };
+          auDecorator = { position, modifiedContent: 'containerless: true' };
           break;
+
+        case 'useShadowDOM': {
+          // early termination
+          if (!isCallExpression(d.expression) || d.expression.arguments.length === 0) {
+            auDecorator = { position, modifiedContent: 'shadowOptions: { mode: \'open\' }'};
+          } else {
+            const argument = d.expression.arguments[0];
+            const options = code.slice(ensureTokenStart(argument.pos, code), argument.end);
+            auDecorator = { position, modifiedContent: `shadowOptions: ${options}`};
+          }
+          break;
+        }
       }
       if (auDecorator != null) {
         ceDecorators.push(auDecorator);

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -665,8 +665,28 @@ function collectClassDecorators(node: ClassDeclaration, code: string): Decorator
 
 function collectBindables(node: ClassDeclaration, code: string): BindableDecorator[] {
   const bindables: BindableDecorator[] = [];
-  // TODO: class level decos
 
+  // class-level decorators
+  if (canHaveDecorators(node)) {
+    for (const decorator of (getDecorators(node) ?? [])) {
+      const de = decorator.expression;
+      if (!isCallExpression(de)) continue;
+
+      const decoratorName = getText(de.expression, code);
+      if (decoratorName !== 'bindable') continue;
+
+      const args = de.arguments;
+      if (args.length !== 1) continue;
+
+      bindables.push({
+        isClassDecorator: true,
+        position: getPosition(decorator, code),
+        modifiedContent: getText(args[0], code)
+      });
+    }
+  }
+
+  // field-level decorators
   for (const member of node.members) {
     if (!isPropertyDeclaration(member) || !canHaveDecorators(member)) continue;
     const decorators = getDecorators(member);

--- a/packages/__e2e__/3-hmr-webpack/playwright/app.spec.ts
+++ b/packages/__e2e__/3-hmr-webpack/playwright/app.spec.ts
@@ -13,6 +13,7 @@ test.describe.serial('examples/hmr-webpack-e2e/app.spec.ts', function () {
 
     test('import aliasing with [as] works', async function ({ page }) {
       await expect(page.locator('text=42')).toBeVisible();
+      await expect(page.locator('text=a - b')).toBeVisible(); // injects works correctly
     });
   });
 

--- a/packages/__e2e__/3-hmr-webpack/src/components/my-input.html
+++ b/packages/__e2e__/3-hmr-webpack/src/components/my-input.html
@@ -2,3 +2,4 @@
 <textarea value.bind="value"></textarea>
 <p>${value}</p>
 <the-text text.bind="value"></the-text>
+<div>${b.doComplex()}</div>

--- a/packages/__e2e__/3-hmr-webpack/src/components/my-input.ts
+++ b/packages/__e2e__/3-hmr-webpack/src/components/my-input.ts
@@ -1,5 +1,8 @@
-import { bindable } from 'aurelia';
+import { bindable, inject } from 'aurelia';
+import { ServiceB } from '../services';
 
+@inject(ServiceB)
 export class MyInput {
     @bindable value = '';
+    public constructor(private readonly b: ServiceB) {}
 }

--- a/packages/__e2e__/3-hmr-webpack/src/services.ts
+++ b/packages/__e2e__/3-hmr-webpack/src/services.ts
@@ -1,0 +1,11 @@
+import { inject } from 'aurelia';
+
+export class ServiceA {
+  public doSimple() { return 'a'; }
+}
+
+@inject(ServiceA)
+export class ServiceB {
+  public constructor(private readonly a: ServiceA) { }
+  public doComplex() { return `${this.a.doSimple()} - b`; }
+}

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -392,7 +392,6 @@ const defaultForOpts: ForOpts = {
   searchParents: false,
   optional: false,
 };
-const returnZero = () => 0;
 const returnNull = <T>(): T | null => null;
 const returnFalse = () => false;
 const returnTrue = () => true;

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -36,7 +36,6 @@ import { ErrorNames, createMappedError } from '../errors';
 import { dtElement, getDefinitionFromStaticAu, type IResourceKind } from './resources-shared';
 
 export type PartialCustomElementDefinition<TBindables extends string = string> = PartialResourceDefinition<Omit<IElementComponentDefinition<TBindables>, 'type'> & {
-  readonly cache?: number | '*';
   /**
    * An semi internal property used to signal the rendering process not to try to compile the template again
    */
@@ -207,7 +206,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly name: string,
     public readonly aliases: string[],
     public readonly key: string,
-    public readonly cache: '*' | number,
     public readonly capture: boolean | ((attr: string) => boolean),
     public readonly template: null | string | Node,
     public readonly instructions: readonly IInstruction[][],
@@ -243,7 +241,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     nameOrDef: string | PartialCustomElementDefinition,
     Type: CustomElementType | null = null,
   ): CustomElementDefinition {
-    // TODO(Sayan): aggregate the info from decorator metadata instead of using the Reflect API
     if (Type === null) {
       const def = nameOrDef;
       if (isString(def)) {
@@ -266,7 +263,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         name,
         mergeArrays(def.aliases),
         fromDefinitionOrDefault('key', def as CustomElementDefinition, () => getElementKeyFrom(name)),
-        fromDefinitionOrDefault('cache', def, returnZero),
         fromAnnotationOrDefinitionOrTypeOrDefault('capture', def, Type, returnFalse),
         fromDefinitionOrDefault('template', def, returnNull),
         mergeArrays(def.instructions),
@@ -293,7 +289,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         nameOrDef,
         mergeArrays(getElementAnnotation(Type, 'aliases'), Type.aliases),
         getElementKeyFrom(nameOrDef),
-        fromAnnotationOrTypeOrDefault('cache', Type, returnZero),
         fromAnnotationOrTypeOrDefault('capture', Type, returnFalse),
         fromAnnotationOrTypeOrDefault('template', Type, returnNull as () => string | Node | null),
         mergeArrays(getElementAnnotation(Type, 'instructions'), Type.instructions),
@@ -326,7 +321,6 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       name,
       mergeArrays(getElementAnnotation(Type, 'aliases'), nameOrDef.aliases, Type.aliases),
       getElementKeyFrom(name),
-      fromAnnotationOrDefinitionOrTypeOrDefault('cache', nameOrDef, Type, returnZero),
       fromAnnotationOrDefinitionOrTypeOrDefault('capture', nameOrDef, Type, returnFalse),
       fromAnnotationOrDefinitionOrTypeOrDefault('template', nameOrDef, Type, returnNull),
       mergeArrays(getElementAnnotation(Type, 'instructions'), nameOrDef.instructions, Type.instructions),

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -51,7 +51,7 @@ export function createFixture<T extends object>(
       } as unknown as Constructable<K>;
 
   const annotations: (Exclude<keyof CustomElementDefinition, 'Type' | 'key' | 'kind' | 'register' | 'type' | 'toString'>)[] =
-    ['aliases', 'bindables', 'cache', 'capture', 'containerless', 'dependencies', 'enhance'];
+    ['aliases', 'bindables', /* 'cache',  */'capture', 'containerless', 'dependencies', 'enhance'];
   if ($$class !== $class as any && $class != null) {
     annotations.forEach(anno => {
       Metadata.define(CustomElement.getAnnotation($class as Constructable<T>, anno, null), $$class, anno);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

As the wide support for TC39 decorators are still lacking, this PR refactors the convention-plugin to rewrite the following decorators:

- bindable
- containerless
- useShadowDOM
- capture
- alias 
- inject

Discord thread: https://discord.com/channels/448698263508615178/1230047298084409464

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
