### PR TITLE
fix(au-slot): separate parent scope selection from host scope selection

### DIFF
--- a/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
+++ b/packages/__tests__/src/3-runtime-html/au-slot.spec.tsx
@@ -2083,6 +2083,30 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
     assertHtml('p > a', 'hello');
   });
 
+  // bug reported by @MaxB on Discord
+  // https://discord.com/channels/448698263508615178/1236855768058302526
+  it('rightly chooses the scope for projected content', function () {
+    @customElement({
+      name: 'mdc-lookup',
+      template:
+      '<div repeat.for="option of options">' +
+        '<mdc-option>' +
+          '<au-slot>${$parent.option} -- ${option}</au-slot>' +
+        '</mdc-option>' +
+      '</div>',
+    })
+    class MdcLookup {
+      options = ['option1'];
+    }
+
+    @customElement({ name: 'mdc-option', template: '<au-slot></au-slot>' })
+    class MdcOption {}
+
+    const { assertHtml } = createFixture('<mdc-lookup></mdc-lookup>', class {}, [MdcLookup, MdcOption]);
+
+    assertHtml('<mdc-lookup><div><mdc-option>option1 -- option1</mdc-option></div></mdc-lookup>', { compact: true });
+  });
+
   describe('with multi layers of repeaters', function () {
     // au-slot creates a layer of scope
     // making $parent from the inner repeater not reaching to the outer repeater
@@ -2137,7 +2161,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
     });
   });
 
-  // bug discorverd by @MaxB on Discord
+  // bug discorvered by @MaxB on Discord
   // https://discord.com/channels/448698263508615178/448699089513611266/1234665951467929666
   it('passes $host value through 1 layer of <au-slot>', function () {
 
@@ -2170,7 +2194,7 @@ describe('3-runtime-html/au-slot.spec.tsx', function () {
       class MyApp {},
       [MdcLookup, MdcFilter, MdcOption, class {
         static $au = { type: 'value-converter', name: 'json' };
-        toView = (v: unknown, tag = '') => { console.log({ ctor: `${tag}:${v?.constructor.name ?? '<undefined>'}` }); return v; };
+        toView = (v: unknown) => v;
       }]
     );
 

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -15,7 +15,6 @@ import {
   type BindingCommandInstance,
   type IAttributeBindablesInfo,
   type IElementBindablesInfo,
-  IBindablesInfoResolver,
   IResourceResolver,
   TemplateCompiler,
 } from '@aurelia/template-compiler';
@@ -31,21 +30,71 @@ export const RuntimeTemplateCompilerImplementation: IRegistry = {
     container.register(
       TemplateCompiler,
       AttrMapper,
-      BindablesInfoResolver,
       ResourceResolver,
     );
   }
 };
 
-class BindablesInfoResolver implements IBindablesInfoResolver<CustomElementDefinition, CustomAttributeDefinition> {
-  public static register = /*@__PURE__*/ createImplementationRegister(IBindablesInfoResolver);
-  /** @internal */
-  private readonly _cache = new WeakMap<CustomElementDefinition | CustomAttributeDefinition, BindablesInfo>();
+class BindablesInfo {
+  public constructor(
+    public readonly attrs: Record<string, BindableDefinition>,
+    public readonly bindables: Record<string, BindableDefinition>,
+    public readonly primary: BindableDefinition | null,
+  ) {}
+}
 
-  public get(def: CustomAttributeDefinition): IAttributeBindablesInfo;
-  public get(def: CustomElementDefinition): IElementBindablesInfo;
-  public get(def: CustomAttributeDefinition | CustomElementDefinition): IAttributeBindablesInfo | IElementBindablesInfo {
-    let info = this._cache.get(def);
+class ResourceResolver implements IResourceResolver<CustomElementDefinition, CustomAttributeDefinition> {
+  public static register = /*@__PURE__*/ createImplementationRegister(IResourceResolver);
+
+  /** @internal */
+  private readonly _resourceCache = new WeakMap<IContainer, RecordCache>();
+  /** @internal */
+  private readonly _commandCache = new WeakMap<IContainer, Record<string, BindingCommandInstance | null>>();
+
+  public el(c: IContainer, name: string): CustomElementDefinition | null {
+    let record = this._resourceCache.get(c);
+    if (record == null) {
+      this._resourceCache.set(c, record = new RecordCache());
+    }
+    return name in record._element ? record._element[name] : (record._element[name] = CustomElement.find(c, name));
+  }
+
+  public attr(c: IContainer, name: string): CustomAttributeDefinition | null {
+    let record = this._resourceCache.get(c);
+    if (record == null) {
+      this._resourceCache.set(c, record = new RecordCache());
+    }
+    return name in record._attr ? record._attr[name] : (record._attr[name] = CustomAttribute.find(c, name));
+  }
+
+  public command(c: IContainer, name: string): BindingCommandInstance | null {
+    let commandInstanceCache = this._commandCache.get(c);
+    if (commandInstanceCache == null) {
+      this._commandCache.set(c, commandInstanceCache = createLookup());
+    }
+    let result = commandInstanceCache[name];
+    if (result === void 0) {
+      let record = this._resourceCache.get(c);
+      if (record == null) {
+        this._resourceCache.set(c, record = new RecordCache());
+      }
+
+      const commandDef = name in record._command ? record._command[name] : (record._command[name] = BindingCommand.find(c, name));
+      if (commandDef == null) {
+        throw createMappedError(ErrorNames.compiler_unknown_binding_command, name);
+      }
+      commandInstanceCache[name] = result = BindingCommand.get(c, name);
+    }
+    return result;
+  }
+
+  /** @internal */
+  private readonly _bindableCache = new WeakMap<CustomElementDefinition | CustomAttributeDefinition, BindablesInfo>();
+
+  public bindables(def: CustomAttributeDefinition): IAttributeBindablesInfo;
+  public bindables(def: CustomElementDefinition): IElementBindablesInfo;
+  public bindables(def: CustomAttributeDefinition | CustomElementDefinition): IAttributeBindablesInfo | IElementBindablesInfo {
+    let info = this._bindableCache.get(def);
     if (info == null) {
       const bindables = def.bindables;
       const attrs = createLookup<BindableDefinition>();
@@ -81,66 +130,14 @@ class BindablesInfoResolver implements IBindablesInfoResolver<CustomElementDefin
         );
       }
 
-      this._cache.set(def, info = new BindablesInfo(attrs, bindables, primary ?? null));
+      this._bindableCache.set(def, info = new BindablesInfo(attrs, bindables, primary ?? null));
     }
     return info;
   }
 }
 
-class BindablesInfo {
-  public constructor(
-    public readonly attrs: Record<string, BindableDefinition>,
-    public readonly bindables: Record<string, BindableDefinition>,
-    public readonly primary: BindableDefinition | null,
-  ) {}
-}
-
-class ResourceResolver implements IResourceResolver<CustomElementDefinition, CustomAttributeDefinition> {
-  public static register = /*@__PURE__*/ createImplementationRegister(IResourceResolver);
-
-  private readonly _resourceCache = new WeakMap<IContainer, RecordCache>();
-  private readonly _commandCache = new WeakMap<IContainer, Record<string, BindingCommandInstance | null>>();
-
-  public el(c: IContainer, name: string): CustomElementDefinition | null {
-    let record = this._resourceCache.get(c);
-    if (record == null) {
-      this._resourceCache.set(c, record = new RecordCache());
-    }
-    return name in record.element ? record.element[name] : (record.element[name] = CustomElement.find(c, name));
-  }
-
-  public attr(c: IContainer, name: string): CustomAttributeDefinition | null {
-    let record = this._resourceCache.get(c);
-    if (record == null) {
-      this._resourceCache.set(c, record = new RecordCache());
-    }
-    return name in record.attr ? record.attr[name] : (record.attr[name] = CustomAttribute.find(c, name));
-  }
-
-  public command(c: IContainer, name: string): BindingCommandInstance | null {
-    let commandInstanceCache = this._commandCache.get(c);
-    if (commandInstanceCache == null) {
-      this._commandCache.set(c, commandInstanceCache = createLookup());
-    }
-    let result = commandInstanceCache[name];
-    if (result === void 0) {
-      let record = this._resourceCache.get(c);
-      if (record == null) {
-        this._resourceCache.set(c, record = new RecordCache());
-      }
-
-      const commandDef = name in record.command ? record.command[name] : (record.command[name] = BindingCommand.find(c, name));
-      if (commandDef == null) {
-        throw createMappedError(ErrorNames.compiler_unknown_binding_command, name);
-      }
-      commandInstanceCache[name] = result = BindingCommand.get(c, name);
-    }
-    return result;
-  }
-}
-
 class RecordCache {
-  public element = createLookup<CustomElementDefinition | null>();
-  public attr = createLookup<CustomAttributeDefinition | null>();
-  public command = createLookup<BindingCommandDefinition | null>();
+  public _element = createLookup<CustomElementDefinition | null>();
+  public _attr = createLookup<CustomAttributeDefinition | null>();
+  public _command = createLookup<BindingCommandDefinition | null>();
 }

--- a/packages/runtime-html/src/compiler/template-compiler.ts
+++ b/packages/runtime-html/src/compiler/template-compiler.ts
@@ -10,9 +10,6 @@ import {
   type IRegistry
 } from '@aurelia/kernel';
 import {
-  BindingCommand,
-  BindingCommandDefinition,
-  type BindingCommandInstance,
   type IAttributeBindablesInfo,
   type IElementBindablesInfo,
   IResourceResolver,
@@ -48,8 +45,6 @@ class ResourceResolver implements IResourceResolver<CustomElementDefinition, Cus
 
   /** @internal */
   private readonly _resourceCache = new WeakMap<IContainer, RecordCache>();
-  /** @internal */
-  private readonly _commandCache = new WeakMap<IContainer, Record<string, BindingCommandInstance | null>>();
 
   public el(c: IContainer, name: string): CustomElementDefinition | null {
     let record = this._resourceCache.get(c);
@@ -65,27 +60,6 @@ class ResourceResolver implements IResourceResolver<CustomElementDefinition, Cus
       this._resourceCache.set(c, record = new RecordCache());
     }
     return name in record._attr ? record._attr[name] : (record._attr[name] = CustomAttribute.find(c, name));
-  }
-
-  public command(c: IContainer, name: string): BindingCommandInstance | null {
-    let commandInstanceCache = this._commandCache.get(c);
-    if (commandInstanceCache == null) {
-      this._commandCache.set(c, commandInstanceCache = createLookup());
-    }
-    let result = commandInstanceCache[name];
-    if (result === void 0) {
-      let record = this._resourceCache.get(c);
-      if (record == null) {
-        this._resourceCache.set(c, record = new RecordCache());
-      }
-
-      const commandDef = name in record._command ? record._command[name] : (record._command[name] = BindingCommand.find(c, name));
-      if (commandDef == null) {
-        throw createMappedError(ErrorNames.compiler_unknown_binding_command, name);
-      }
-      commandInstanceCache[name] = result = BindingCommand.get(c, name);
-    }
-    return result;
   }
 
   /** @internal */
@@ -139,5 +113,4 @@ class ResourceResolver implements IResourceResolver<CustomElementDefinition, Cus
 class RecordCache {
   public _element = createLookup<CustomElementDefinition | null>();
   public _attr = createLookup<CustomAttributeDefinition | null>();
-  public _command = createLookup<BindingCommandDefinition | null>();
 }

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -102,7 +102,7 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       // we won't find the information in the hydration context hierarchy <MyApp>/<S3>
       // as it's a flat wysiwyg structure based on the template html
       //
-      // since we are construction the projection (2) view based on the
+      // since we are constructing the projection (2) view based on the
       // container of <my-app>, we need to pre-register all information stored
       // in projection (1) into the container created for the projection (2) view
       // =============================
@@ -166,6 +166,10 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
     _initiator: IHydratedController,
     parent: IHydratedParentController,
   ): void | Promise<void> {
+    this._parentScope = parent.scope;
+
+    // The following block finds the real host scope for the content of this <au-slot>
+    //
     // if this <au-slot> was created by another au slot, the controller hierarchy will be like this:
     // C(au-slot)#1 --> C(synthetic)#1 --> C(au-slot)#2 --> C(synthetic)#2
     //
@@ -176,7 +180,7 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
     while (parent.vmKind === 'synthetic' && parent.parent?.viewModel instanceof AuSlot) {
       parent = parent.parent.parent as IHydratedParentController;
     }
-    this._parentScope = parent.scope;
+    const host = parent.scope.bindingContext;
 
     let outerScope: Scope;
     if (this._hasProjection) {
@@ -187,7 +191,7 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       // - override context has the $host pointing to inner scope binding context
       outerScope = this._hdrContext.controller.scope.parent!;
       (this._outerScope = Scope.fromParent(outerScope, outerScope.bindingContext))
-        .overrideContext.$host = this.expose ?? this._parentScope.bindingContext;
+        .overrideContext.$host = this.expose ?? host;
     }
   }
 

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -208,8 +208,10 @@ export class Rendering implements IRendering {
     }
     return fragment;
     // below is a homemade "comment query selector that seems to be as efficient as the TreeWalker
-    // leaving it here just in case we need it again
-    // TreeWalker is slightly less code
+    // also it works with very minimal set of APIs (.nextSibling, .parentNode, .insertBefore, .removeChild)
+    // while TreeWalker maynot be always available in platform that we may potentially support
+    //
+    // so leaving it here just in case we need it again, TreeWalker is slightly less code
 
     // let parent: Node = fragment;
     // let current: Node | null | undefined = parent.firstChild;

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -51,6 +51,8 @@ export class Rendering implements IRendering {
   private readonly _fragmentCache: WeakMap<CustomElementDefinition, DocumentFragment | null> = new WeakMap();
   /** @internal */
   private readonly _empty: INodeSequence;
+  /** @internal */
+  private readonly _marker: Node;
 
   public get renderers(): Record<string, IRenderer> {
     return this._renderers ??= this._ctn.getAll(IRenderer, false).reduce((all, r) => {
@@ -67,10 +69,11 @@ export class Rendering implements IRendering {
 
   public constructor() {
     const ctn = this._ctn = resolve(IContainer).root;
-    this._platform = ctn.get(IPlatform);
+    const p = this._platform = ctn.get(IPlatform);
     this._exprParser= ctn.get(IExpressionParser);
     this._observerLocator = ctn.get(IObserverLocator);
-    this._empty = new FragmentNodeSequence(this._platform, this._platform.document.createDocumentFragment());
+    this._marker = p.document.createElement('au-m');
+    this._empty = new FragmentNodeSequence(p, p.document.createDocumentFragment());
   }
 
   public compile(
@@ -192,51 +195,58 @@ export class Rendering implements IRendering {
   }
 
   /** @internal */
-  private _marker() {
-    return this._platform.document.createElement('au-m');
-  }
-
-  /** @internal */
   private _transformMarker(fragment: Node | null) {
     if (fragment == null) {
       return null;
     }
-    let parent: Node = fragment;
-    let current: Node | null | undefined = parent.firstChild;
-    let next: Node | null | undefined = null;
-
-    while (current != null) {
-      if (current.nodeType === 8 && current.nodeValue === 'au*') {
-        next = current.nextSibling!;
-        parent.removeChild(current);
-        parent.insertBefore(this._marker(), next);
-        if (next.nodeType === 8) {
-          current = next.nextSibling;
-          // todo: maybe validate?
-        } else {
-          current = next;
-        }
-      }
-
-      next = current?.firstChild;
-      if (next == null) {
-        next = current?.nextSibling;
-        if (next == null) {
-          current = parent.nextSibling;
-          parent = parent.parentNode!;
-          // needs to keep walking up all the way til a valid next node
-          while (current == null && parent != null) {
-            current = parent.nextSibling;
-            parent = parent.parentNode!;
-          }
-        } else {
-          current = next;
-        }
-      } else {
-        parent = current!;
-        current = next;
+    const walker = this._platform.document.createTreeWalker(fragment, /* NodeFilter.SHOW_COMMENT */ 128);
+    let currentNode: Node | null;
+    while ((currentNode = walker.nextNode()) != null) {
+      if (currentNode.nodeValue === 'au*') {
+        currentNode.parentNode!.replaceChild(walker.currentNode = this._marker.cloneNode(), currentNode);
       }
     }
     return fragment;
+    // below is a homemade "comment query selector that seems to be as efficient as the TreeWalker
+    // leaving it here just in case we need it again
+    // TreeWalker is slightly less code
+
+    // let parent: Node = fragment;
+    // let current: Node | null | undefined = parent.firstChild;
+    // let next: Node | null | undefined = null;
+
+    // while (current != null) {
+    //   if (current.nodeType === 8 && current.nodeValue === 'au*') {
+    //     next = current.nextSibling!;
+    //     parent.removeChild(current);
+    //     parent.insertBefore(this._marker(), next);
+    //     if (next.nodeType === 8) {
+    //       current = next.nextSibling;
+    //       // todo: maybe validate?
+    //     } else {
+    //       current = next;
+    //     }
+    //   }
+
+    //   next = current?.firstChild;
+    //   if (next == null) {
+    //     next = current?.nextSibling;
+    //     if (next == null) {
+    //       current = parent.nextSibling;
+    //       parent = parent.parentNode!;
+    //       // needs to keep walking up all the way til a valid next node
+    //       while (current == null && parent != null) {
+    //         current = parent.nextSibling;
+    //         parent = parent.parentNode!;
+    //       }
+    //     } else {
+    //       current = next;
+    //     }
+    //   } else {
+    //     parent = current!;
+    //     current = next;
+    //   }
+    // }
+    // return fragment;
   }
 }

--- a/packages/runtime-html/src/utilities-dom.ts
+++ b/packages/runtime-html/src/utilities-dom.ts
@@ -1,35 +1,16 @@
 import { type IRenderLocation } from './dom';
-import { ErrorNames, createMappedError } from './errors';
 import { type IPlatform } from './platform';
 
 /** @internal */
-export const auLocationStart = 'au-start';
-/** @internal */
-export const auLocationEnd = 'au-end';
+export const createLocation = /*@__PURE__*/ (() => {
+  const createComment = (p: IPlatform, text: string) => p.document.createComment(text);
+  return (p: IPlatform) => {
+    const locationEnd = createComment(p, 'au-end') as IRenderLocation;
+    locationEnd.$start = createComment(p, 'au-start') as IRenderLocation;
 
-/** @internal */
-export const createElement
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  = <K extends string>(p: IPlatform, name: K): K extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[K] : HTMLElement => p.document.createElement(name) as any;
-
-/** @internal */
-export const createComment = (p: IPlatform, text: string) => p.document.createComment(text);
-
-/** @internal */
-export const createLocation = (p: IPlatform) => {
-  const locationEnd = createComment(p, auLocationEnd) as IRenderLocation;
-  locationEnd.$start = createComment(p, auLocationStart) as IRenderLocation;
-
-  return locationEnd;
-};
-
-/** @internal */
-export const createText = (p: IPlatform, text: string) => p.document.createTextNode(text);
-
-/** @internal */
-export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, target: Node | null) => {
-  return parent.insertBefore(newChildNode, target);
-};
+    return locationEnd;
+  };
+})();
 
 /** @internal */
 export const insertManyBefore = (parent: Node | null, target: Node | null, newChildNodes: ArrayLike<Node>) => {
@@ -45,61 +26,7 @@ export const insertManyBefore = (parent: Node | null, target: Node | null, newCh
 };
 
 /** @internal */
-export const getPreviousSibling = (node: Node) => node.previousSibling;
-
-/** @internal */
-export const appendChild = <T extends Node>(parent: Node, child: T) => {
-  return parent.appendChild(child);
-};
-
-/** @internal */
-export const appendToTemplate = <T extends Node>(parent: HTMLTemplateElement, child: T) => {
-  return parent.content.appendChild(child);
-};
-
-/** @internal */
-export const appendManyToTemplate = (parent: HTMLTemplateElement, children: ArrayLike<Node>) => {
-  const ii = children.length;
-  let i = 0;
-  while (ii > i) {
-    parent.content.appendChild(children[i]);
-    ++i;
-  }
-};
-
-/** @internal */
-export const markerToTarget = (el: Element) => {
-  const nextSibling = el.nextSibling;
-  let locationStart: Comment;
-  let locationEnd: IRenderLocation;
-
-  if (nextSibling == null) {
-    throw createMappedError(ErrorNames.marker_malformed);
-  }
-
-  if (nextSibling.nodeType === /* Comment */8) {
-    if (nextSibling.textContent === 'au-start') {
-      locationStart = nextSibling as Comment;
-      if ((locationEnd = locationStart.nextSibling! as IRenderLocation) == null) {
-        throw createMappedError(ErrorNames.marker_malformed);
-      }
-      el.remove();
-      locationEnd.$start = locationStart;
-      return locationEnd;
-    } else {
-      throw createMappedError(ErrorNames.marker_malformed);
-    }
-  }
-
-  el.remove();
-  return nextSibling;
-};
-
-/** @internal */
 export const createMutationObserver = (node: Node, callback: MutationCallback) => new node.ownerDocument!.defaultView!.MutationObserver(callback);
 
 /** @internal */
 export const isElement = (node: Node): node is Element => node.nodeType === 1;
-
-/** @internal */
-export const isTextNode = (node: Node): node is Text => node.nodeType === 3;

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -68,6 +68,7 @@ export {
 
 export {
   IResourceResolver,
+  IBindingCommandResolver,
   type IElementBindablesInfo,
   type IAttributeBindablesInfo,
   ITemplateCompilerHooks,

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -68,7 +68,6 @@ export {
 
 export {
   IResourceResolver,
-  IBindablesInfoResolver,
   type IElementBindablesInfo,
   type IAttributeBindablesInfo,
   ITemplateCompilerHooks,

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -1822,7 +1822,6 @@ export interface IResourceResolver<
 > {
   el(c: IContainer, name: string): TElementDef | null;
   attr(c: IContainer, name: string): TAttrDef | null;
-  command(c: IContainer, name: string): BindingCommandInstance | null;
   bindables(def: TAttrDef): IAttributeBindablesInfo;
   bindables(def: TElementDef): IElementBindablesInfo;
   bindables(def: TAttrDef | TElementDef): IAttributeBindablesInfo | IElementBindablesInfo;

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { emptyArray, toArray, ILogger, camelCase, noop, Registrable, getResourceKeyFor, allResources, resolve, IPlatform, pascalCase, createImplementationRegister } from '@aurelia/kernel';
+import { emptyArray, toArray, ILogger, camelCase, noop, Registrable, getResourceKeyFor, allResources, IPlatform, pascalCase, createImplementationRegister } from '@aurelia/kernel';
 import {
   IExpressionParser,
   PrimitiveLiteralExpression,
@@ -25,9 +25,9 @@ import {
   IInstruction,
 } from './instructions';
 import { AttrSyntax, IAttributeParser } from './attribute-pattern';
-import { BindingCommandInstance, ICommandBuildInfo } from './binding-command';
+import { BindingCommand, BindingCommandInstance, ICommandBuildInfo } from './binding-command';
 import { etInterpolation, etIsProperty, isString, objectFreeze, createInterface, singletonRegistration, definitionTypeElement } from './utilities';
-import { appendManyToTemplate, appendToTemplate, createComment, createElement, createText, insertBefore, insertManyBefore, isElement, isTextNode } from './utilities-dom';
+import { auLocationStart, auLocationEnd, appendManyToTemplate, appendToTemplate, insertBefore, insertManyBefore, isElement, isTextNode } from './utilities-dom';
 
 import type {
   IContainer,
@@ -56,9 +56,6 @@ const generateElementName = ((id) => () => `anonymous-${++id}`)(0);
 
 export class TemplateCompiler implements ITemplateCompiler {
   public static register = /*@__PURE__*/ createImplementationRegister(ITemplateCompiler);
-
-  /** @internal */
-  private readonly _bindableResolver = resolve(IBindablesInfoResolver);
 
   public debug: boolean = false;
   public resolveResources: boolean = true;
@@ -142,7 +139,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       attrTarget = attrSyntax.target;
       attrValue = attrSyntax.rawValue;
 
-      bindingCommand = context._createCommand(attrSyntax);
+      bindingCommand = context._getCommand(attrSyntax);
       if (bindingCommand !== null && bindingCommand.ignoreAttr) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
@@ -165,7 +162,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (attrDef.isTemplateController) {
           throw createMappedError(ErrorNames.no_spread_template_controller, attrTarget);
         }
-        bindablesInfo = this._bindableResolver.get(attrDef);
+        bindablesInfo = context._getBindables(attrDef);
         // Custom attributes are always in multiple binding mode,
         // except when they can't be
         // When they cannot be:
@@ -224,7 +221,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         // + maybe a plain attribute with interpolation
         // + maybe a plain attribute
         if (isCustomElement) {
-          bindablesInfo = this._bindableResolver.get(elDef);
+          bindablesInfo = context._getBindables(elDef);
           bindable = bindablesInfo.attrs[attrTarget];
           if (bindable !== void 0) {
             expr = exprParser.parse(attrValue, etInterpolation);
@@ -267,7 +264,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (isCustomElement) {
           // if the element is a custom element
           // - prioritize bindables on a custom element before plain attributes
-          bindablesInfo = this._bindableResolver.get(elDef);
+          bindablesInfo = context._getBindables(elDef);
           bindable = bindablesInfo.attrs[attrTarget];
           if (bindable !== void 0) {
             commandBuildInfo.node = target;
@@ -335,7 +332,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         throw createMappedError(ErrorNames.compiler_invalid_surrogate_attr, attrName);
       }
 
-      bindingCommand = context._createCommand(attrSyntax);
+      bindingCommand = context._getCommand(attrSyntax);
       if (bindingCommand !== null && bindingCommand.ignoreAttr) {
         // when the binding command overrides everything
         // just pass the target as is to the binding command, and treat it as a normal attribute:
@@ -358,7 +355,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         if (attrDef.isTemplateController) {
           throw createMappedError(ErrorNames.compiler_no_tc_on_surrogate, realAttrTarget);
         }
-        bindableInfo = this._bindableResolver.get(attrDef);
+        bindableInfo = context._getBindables(attrDef);
         // Custom attributes are always in multiple binding mode,
         // except when they can't be
         // When they cannot be:
@@ -528,7 +525,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       realAttrTarget = attrSyntax.target;
       realAttrValue = attrSyntax.rawValue;
 
-      bindingCommand = context._createCommand(attrSyntax);
+      bindingCommand = context._getCommand(attrSyntax);
       if (bindingCommand !== null) {
         if (attrSyntax.command === 'bind') {
           letInstructions.push(new LetBindingInstruction(
@@ -698,7 +695,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       }
 
       attrSyntax = context._attrParser.parse(attrName, attrValue);
-      bindingCommand = context._createCommand(attrSyntax);
+      bindingCommand = context._getCommand(attrSyntax);
 
       realAttrTarget = attrSyntax.target;
       realAttrValue = attrSyntax.rawValue;
@@ -712,7 +709,7 @@ export class TemplateCompiler implements ITemplateCompiler {
 
         canCapture = realAttrTarget !== auslotAttr && realAttrTarget !== 'slot';
         if (canCapture) {
-          bindablesInfo = this._bindableResolver.get(elDef);
+          bindablesInfo = context._getBindables(elDef);
           // if capture is on, capture everything except:
           // - as-element
           // - containerless
@@ -751,7 +748,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       if (isCustomElement) {
         // if the element is a custom element
         // - prioritize bindables on a custom element before plain attributes
-        bindablesInfo = this._bindableResolver.get(elDef);
+        bindablesInfo = context._getBindables(elDef);
         bindable = bindablesInfo.attrs[realAttrTarget];
         if (bindable !== void 0) {
           if (bindingCommand === null) {
@@ -798,7 +795,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       // check for custom attributes before plain attributes
       attrDef = context._findAttr(realAttrTarget);
       if (attrDef !== null) {
-        bindablesInfo = this._bindableResolver.get(attrDef);
+        bindablesInfo = context._getBindables(attrDef);
         // Custom attributes are always in multiple binding mode,
         // except when they can't be
         // When they cannot be:
@@ -959,8 +956,8 @@ export class TemplateCompiler implements ITemplateCompiler {
         appendManyToTemplate(template, [
           // context.h(MARKER_NODE_NAME),
           context._marker(),
-          context._comment(auStartComment),
-          context._comment(auEndComment),
+          context._comment(auLocationStart),
+          context._comment(auLocationEnd),
         ]);
       } else {
         // assumption: el.parentNode is not null
@@ -1138,8 +1135,8 @@ export class TemplateCompiler implements ITemplateCompiler {
         marker = context._marker();
         appendManyToTemplate(template, [
           marker,
-          context._comment(auStartComment),
-          context._comment(auEndComment),
+          context._comment(auLocationStart),
+          context._comment(auLocationEnd),
         ]);
 
         tcInstruction.def = {
@@ -1345,7 +1342,7 @@ export class TemplateCompiler implements ITemplateCompiler {
     // my-attr="prop1: literal1 prop2.bind: ...; prop3: literal3"
     // my-attr="prop1.bind: ...; prop2.bind: ..."
     // my-attr="prop1: ${}; prop2.bind: ...; prop3: ${}"
-    const bindableAttrsInfo = this._bindableResolver.get(attrDef);
+    const bindableAttrsInfo = context._getBindables(attrDef);
     const valueLength = attrRawValue.length;
     const instructions: IInstruction[] = [];
 
@@ -1394,7 +1391,7 @@ export class TemplateCompiler implements ITemplateCompiler {
         // todo: should it always camel case???
         // const attrTarget = camelCase(attrSyntax.target);
         // ================================================
-        command = context._createCommand(attrSyntax);
+        command = context._getCommand(attrSyntax);
         bindable = bindableAttrsInfo.attrs[attrSyntax.target];
         if (bindable == null) {
           throw createMappedError(ErrorNames.compiler_binding_to_non_bindable, attrSyntax.target, attrDef.name);
@@ -1618,19 +1615,15 @@ export class TemplateCompiler implements ITemplateCompiler {
     // insertBefore(parent, marker, node);
     insertManyBefore(parent, node, [
       marker,
-      context._comment(auStartComment),
-      context._comment(auEndComment),
+      context._comment(auLocationStart),
+      context._comment(auLocationEnd),
     ]);
     parent.removeChild(node);
     return marker;
   }
 }
 
-// let nextSibling: Node | null;
-// const MARKER_NODE_NAME = 'AU-M';
 const TEMPLATE_NODE_NAME = 'TEMPLATE';
-const auStartComment = 'au-start';
-const auEndComment = 'au-end';
 const isMarker = (el: Node): el is Comment =>
   el.nodeValue === 'au*';
     // && isComment(nextSibling = el.nextSibling) && nextSibling.textContent === auStartComment
@@ -1648,6 +1641,7 @@ class CompilationContext {
   public readonly parent: CompilationContext | null;
   public readonly def: IElementComponentDefinition;
   public readonly _resourceResolver: IResourceResolver;
+  public readonly _commandResolver: IBindingCommandResolver;
   public readonly _templateFactory: ITemplateElementFactory;
   public readonly _logger: ILogger;
   public readonly _attrParser: IAttributeParser;
@@ -1676,6 +1670,7 @@ class CompilationContext {
     this.def = def;
     this.parent = parent;
     this._resourceResolver = hasParent ? parent._resourceResolver : container.get(IResourceResolver);
+    this._commandResolver = hasParent ? parent._commandResolver : container.get(IBindingCommandResolver);
     this._templateFactory = hasParent ? parent._templateFactory : container.get(ITemplateElementFactory);
     // todo: attr parser should be retrieved based in resource semantic (current leaf + root + ignore parent)
     this._attrParser = hasParent ? parent._attrParser : container.get(IAttributeParser);
@@ -1696,11 +1691,11 @@ class CompilationContext {
   }
 
   public _text(text: string) {
-    return createText(this.p, text);
+    return this.p.document.createTextNode(text);
   }
 
   public _comment(text: string) {
-    return createComment(this.p, text);
+    return this.p.document.createComment(text);
   }
 
   public _marker() {
@@ -1710,7 +1705,7 @@ class CompilationContext {
   public h<K extends keyof HTMLElementTagNameMap>(name: K): HTMLElementTagNameMap[K];
   public h(name: string): HTMLElement;
   public h(name: string): HTMLElement {
-    const el = createElement(this.p, name);
+    const el = this.p.document.createElement(name);
     if (name === 'template') {
       this.p.document.adoptNode((el as HTMLTemplateElement).content);
     }
@@ -1735,6 +1730,12 @@ class CompilationContext {
     return this._resourceResolver.attr(this.c, name);
   }
 
+  public _getBindables(def: IAttributeComponentDefinition): IAttributeBindablesInfo;
+  public _getBindables(def: IElementComponentDefinition): IElementBindablesInfo;
+  public _getBindables(def: IAttributeComponentDefinition | IElementComponentDefinition): IAttributeBindablesInfo | IElementBindablesInfo {
+    return this._resourceResolver.bindables(def);
+  }
+
   /**
    * Create a new child compilation context
    */
@@ -1749,12 +1750,12 @@ class CompilationContext {
    *
    * @returns An instance of the command if it exists, or `null` if it does not exist.
    */
-  public _createCommand(syntax: AttrSyntax): BindingCommandInstance | null {
+  public _getCommand(syntax: AttrSyntax): BindingCommandInstance | null {
     const name = syntax.command;
     if (name === null) {
       return null;
     }
-    return this._resourceResolver.command(this.c, name);
+    return this._commandResolver.get(this.c, name);
   }
 }
 
@@ -1815,16 +1816,6 @@ export interface IElementBindablesInfo {
   readonly primary: null;
 }
 
-export interface IBindablesInfoResolver<
-  TElementDef extends IElementComponentDefinition = IElementComponentDefinition,
-  TAttrDef extends IAttributeComponentDefinition = IAttributeComponentDefinition,
-> {
-  get(def: TAttrDef): IAttributeBindablesInfo;
-  get(def: TElementDef): IElementBindablesInfo;
-}
-
-export const IBindablesInfoResolver = /*@__PURE__*/createInterface<IBindablesInfoResolver>('IBindablesInfoResolver');
-
 export interface IResourceResolver<
   TElementDef extends IElementComponentDefinition = IElementComponentDefinition,
   TAttrDef extends IAttributeComponentDefinition = IAttributeComponentDefinition,
@@ -1832,9 +1823,30 @@ export interface IResourceResolver<
   el(c: IContainer, name: string): TElementDef | null;
   attr(c: IContainer, name: string): TAttrDef | null;
   command(c: IContainer, name: string): BindingCommandInstance | null;
+  bindables(def: TAttrDef): IAttributeBindablesInfo;
+  bindables(def: TElementDef): IElementBindablesInfo;
+  bindables(def: TAttrDef | TElementDef): IAttributeBindablesInfo | IElementBindablesInfo;
 }
 
-export const IResourceResolver = /*@__PURE__*/createInterface<IResourceResolver>('IResourceResolver');
+export const IResourceResolver = /*@__PURE__*/ createInterface<IResourceResolver>('IResourceResolver');
+
+export interface IBindingCommandResolver {
+  get(c: IContainer, name: string): BindingCommandInstance | null;
+}
+export const IBindingCommandResolver = /*@__PURE__*/ createInterface<IBindingCommandResolver>('IBindingCommandResolver', x => {
+  class DefaultBindingCommandResolver implements IBindingCommandResolver {
+    private readonly _cache = new WeakMap<IContainer, Record<string, BindingCommandInstance>>();
+    public get(c: IContainer, name: string): BindingCommandInstance | null {
+      let record = this._cache.get(c);
+      if (!record) {
+        this._cache.set(c, record = {});
+      }
+      return name in record ? record[name] : (record[name] = BindingCommand.get(c, name));
+    }
+  }
+
+  return x.singleton(DefaultBindingCommandResolver);
+});
 
 _START_CONST_ENUM();
 const enum LocalTemplateBindableAttributes {

--- a/packages/template-compiler/src/utilities-dom.ts
+++ b/packages/template-compiler/src/utilities-dom.ts
@@ -1,5 +1,3 @@
-import { IDomPlatform } from './interfaces-template-compiler';
-
 export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
 };
@@ -8,24 +6,6 @@ export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
 export const auLocationStart = 'au-start';
 /** @internal */
 export const auLocationEnd = 'au-end';
-
-/** @internal */
-export const createElement
-  = <K extends string>(p: IDomPlatform, name: K): K extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[K] : HTMLElement => p.document.createElement(name) as any;
-
-/** @internal */
-export const createComment = (p: IDomPlatform, text: string) => p.document.createComment(text);
-
-/** @internal */
-export const createLocation = (p: IDomPlatform) => {
-  const locationEnd = createComment(p, auLocationEnd) as IRenderLocation;
-  locationEnd.$start = createComment(p, auLocationStart) as IRenderLocation;
-
-  return locationEnd;
-};
-
-/** @internal */
-export const createText = (p: IDomPlatform, text: string) => p.document.createTextNode(text);
 
 /** @internal */
 export const insertBefore = <T extends Node>(parent: Node, newChildNode: T, target: Node | null) => {
@@ -43,14 +23,6 @@ export const insertManyBefore = (parent: Node | null, target: Node | null, newCh
     parent.insertBefore(newChildNodes[i], target);
     ++i;
   }
-};
-
-/** @internal */
-export const getPreviousSibling = (node: Node) => node.previousSibling;
-
-/** @internal */
-export const appendChild = <T extends Node>(parent: Node, child: T) => {
-  return parent.appendChild(child);
 };
 
 /** @internal */


### PR DESCRIPTION
## 📖 Description

In a previous at #1959 , parent scope of a projection content is set to be always the same with the scope that provides `$host` value, which is wrong. Reported by @MaximBalaganskiy at https://discord.com/channels/448698263508615178/1236855768058302526 . This PR fixes it.
Also:
- Separate binding command resolver from other resources resolver, so it makes more sense
- use standard treewalker API instead of our own tree walker for finding target comments
- cleanup leftover unused code in #1959

cc @Sayan751 