### PR TITLE
feat(template): auto infer binding expression when empty

### DIFF
--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -149,10 +149,19 @@ Read more about dynamic composition in v2 in this [dynamic composition doc](../.
 * Templates no longer need to have `<template>` tags as the start and ending tags. Templates can be pure HTML with enhanced Aurelia markup but `<template>` doesn't need to be explicitly defined.
 * `PLATFORM.moduleName` is gone. This was to address a limitation in Aurelia 1. Aurelia 2 now works well with all bundlers and does not require the addition of this code to use code splitting or tell the bundler where template code is.
 * Better intellisense support for TypeScript applications. Using the new injection interfaces, you can now inject strongly typed Aurelia packages such as Fetch Client, Router or Internationalization. These packages are prefixed with an "I" such as `IHttpClient`, `IRouter` and so on.
+* empty binding expressions are automatically inferred based on the target of the binding, like the following example:
+    ```html
+    <input value.bind>
+    <input value.bind="">
+    ```
+    means:
+    ```html
+    <input value.bind="value">
+    ```
 
 ## Plugins:
 
 ### Web-Components plugin
 
-* Remove automatic au- prefix
+* Remove automatic `au-` prefix
 * Remove auto-conversion of Aurelia element -> WC element. Applications need to explicitly define this. This should make mix-matching & controlling things easier.

--- a/docs/user-docs/templates/template-syntax/attribute-binding.md
+++ b/docs/user-docs/templates/template-syntax/attribute-binding.md
@@ -18,7 +18,12 @@ The basic syntax for binding to attributes in Aurelia is straightforward:
 You can bind to almost any attribute listed in the comprehensive HTML attributes list, which can be found [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).
 
 {% hint style="info" %}
-In a binding with empty expression, i.e `attribute-name.bind` or `attribute-name.bind=""`, the `expression` is automatically inferred based on the `target`: it'll have the value of the camel-case version of the `target`, so `attribute-name.bind=""` would mean `attribute-name.bind="attributeName"`
+In a binding with empty expression, i.e `attribute-name.bind` or `attribute-name.bind=""`, the `expression` is automatically inferred based on the `target`: it'll have the value of the camel-case version of the `target`, so `attribute-name.bind=""` would mean `attribute-name.bind="attributeName"`. This behavior is also present in other commands:
+- `.one-time`
+- `.to-view`
+- `.from-view`
+- `.two-way`
+- `.attr`
 {% endhint %}
 
 ## Binding Techniques and Syntax

--- a/docs/user-docs/templates/template-syntax/attribute-binding.md
+++ b/docs/user-docs/templates/template-syntax/attribute-binding.md
@@ -10,7 +10,16 @@ The basic syntax for binding to attributes in Aurelia is straightforward:
 <div attribute-name.bind="value"></div>
 ```
 
+- `attribute-name.bind="value"` is a binding
+- `attribute-name` is the target of the binding
+- `bind` is the command of the binding
+- `value` is the expression of the binding
+
 You can bind to almost any attribute listed in the comprehensive HTML attributes list, which can be found [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes).
+
+{% hint style="info" %}
+In a binding with empty expression, i.e `attribute-name.bind` or `attribute-name.bind=""`, the `expression` is automatically inferred based on the `target`: it'll have the value of the camel-case version of the `target`, so `attribute-name.bind=""` would mean `attribute-name.bind="attributeName"`
+{% endhint %}
 
 ## Binding Techniques and Syntax
 

--- a/packages/__tests__/src/3-runtime-html/custom-elements.harmony.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.harmony.spec.ts
@@ -355,7 +355,7 @@ describe('3-runtime-html/custom-elements.harmony.spec.ts', function () {
   });
 
   it('gives priority to custom element bindable over custom attribute with the same name', function () {
-    const { assertStyles, printHtml } = createFixture(
+    const { assertStyles } = createFixture(
       `<square size.bind="width"></square>`,
       { width: 10 },
       [
@@ -376,7 +376,6 @@ describe('3-runtime-html/custom-elements.harmony.spec.ts', function () {
       ]
     );
 
-    printHtml();
     assertStyles('square', { width: '10px' });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/custom-elements.infer-expression.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.infer-expression.spec.ts
@@ -1,0 +1,95 @@
+import { resolve } from '@aurelia/kernel';
+import { CustomAttribute, INode } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/custom-elements.infer-expression.spec.ts', function () {
+  it('auto infers binding expression with .bind', function () {
+    const { assertHtml, component, flush } = createFixture('<div textcontent.bind>', {
+      textcontent: 'hey'
+    });
+    assertHtml('<div>hey</div>');
+    component.textcontent = 'ahh';
+    flush();
+    assertHtml('<div>ahh</div>');
+  });
+
+  it('auto infers binding expression with .one-time', function () {
+    const { assertHtml, component, flush } = createFixture('<div textcontent.one-time>', {
+      textcontent: 'hey'
+    });
+    assertHtml('<div>hey</div>');
+    component.textcontent = 'ahh';
+    flush();
+    assertHtml('<div>hey</div>');
+  });
+
+  it('auto infers binding expression with .to-view', function () {
+    const { assertHtml, component, flush } = createFixture('<div textcontent.to-view>', {
+      textcontent: 'hey'
+    });
+    assertHtml('<div>hey</div>');
+    component.textcontent = 'ahh';
+    flush();
+    assertHtml('<div>ahh</div>');
+  });
+
+  it('auto infers binding expression with .two-way', function () {
+    const { assertValue, type, component } = createFixture('<input value.two-way>', {
+      value: 'hey'
+    });
+    assertValue('input', 'hey');
+    type('input', 'you');
+    assert.strictEqual(component.value, 'you');
+  });
+
+  it('auto infers binding expression with .from-view', function () {
+    const { assertValue, type, component, flush } = createFixture('<input value.from-view>', {
+      value: 'hey'
+    });
+    assertValue('input', '');
+    type('input', 'you');
+    assert.strictEqual(component.value, 'you');
+    component.value = 'ahh';
+    flush();
+    assertValue('input', 'you');
+  });
+
+  it('auto infers binding expression with .attr', function () {
+    const { assertHtml } = createFixture('<div hey-there.attr>', {
+      'hey-there': 1,
+      'heyThere': 2,
+    });
+    assertHtml('<div hey-there="2"></div>');
+  });
+
+  it('does not use mapped attribute name when inferring binding expression', function () {
+    const { assertHtml } = createFixture('<input minlength.bind>', {
+      minLength: 0,
+      minlength: 1,
+    });
+    assertHtml('<input minlength="1">');
+  });
+
+  it('infers expression with custom attribute', function () {
+    const { assertHtml } = createFixture('<div square.bind foo-bar.bind>', {
+      square: 2,
+      fooBar: 3,
+    }, [
+      CustomAttribute.define('square', class {
+        host = resolve(INode) as HTMLElement;
+        value: any;
+        binding() {
+          this.host.setAttribute('square', String(Number(this.value) * Number(this.value)));
+        }
+      }),
+      CustomAttribute.define('foo-bar', class {
+        host = resolve(INode) as HTMLElement;
+        value: any;
+        binding() {
+          this.host.setAttribute('random', String(this.value * 10));
+        }
+      }),
+    ]);
+    assertHtml('<div square="4" random="30"></div>');
+  });
+});

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -1635,7 +1635,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
 
         assert.deepStrictEqual(
           result.instructions[0],
-          [new PropertyBindingInstruction(new PrimitiveLiteralExpression(''), 'id', BindingMode.toView)]
+          [new PropertyBindingInstruction(new AccessScopeExpression('id'), 'id', BindingMode.toView)]
         );
       });
 

--- a/packages/template-compiler/src/binding-command.ts
+++ b/packages/template-compiler/src/binding-command.ts
@@ -11,7 +11,7 @@ import {
   RefBindingInstruction,
   SpreadBindingInstruction,
 } from './instructions';
-import { aliasRegistration, definitionTypeElement, etIsFunction, etIsProperty, isString, objectFreeze, singletonRegistration } from './utilities';
+import { aliasRegistration, etIsFunction, etIsProperty, isString, objectFreeze, singletonRegistration } from './utilities';
 
 import type {
   Constructable,
@@ -214,17 +214,13 @@ export class OneTimeBindingCommand implements BindingCommandInstance {
     const attr = info.attr;
     let target = attr.target;
     let value = info.attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (info.bindable == null) {
       target = attrMapper.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === definitionTypeElement) {
-        value = camelCase(target);
-      }
       target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, etIsProperty), target, InternalBindingMode.oneTime);
@@ -242,17 +238,13 @@ export class ToViewBindingCommand implements BindingCommandInstance {
     const attr = info.attr;
     let target = attr.target;
     let value = info.attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (info.bindable == null) {
       target = attrMapper.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === definitionTypeElement) {
-        value = camelCase(target);
-      }
       target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, etIsProperty), target, InternalBindingMode.toView);
@@ -270,17 +262,13 @@ export class FromViewBindingCommand implements BindingCommandInstance {
     const attr = info.attr;
     let target = attr.target;
     let value = attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (info.bindable == null) {
       target = attrMapper.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === definitionTypeElement) {
-        value = camelCase(target);
-      }
       target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, etIsProperty), target, InternalBindingMode.fromView);
@@ -298,17 +286,13 @@ export class TwoWayBindingCommand implements BindingCommandInstance {
     const attr = info.attr;
     let target = attr.target;
     let value = attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (info.bindable == null) {
       target = attrMapper.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === definitionTypeElement) {
-        value = camelCase(target);
-      }
       target = info.bindable.name;
     }
     return new PropertyBindingInstruction(exprParser.parse(value, etIsProperty), target, InternalBindingMode.twoWay);
@@ -325,10 +309,11 @@ export class DefaultBindingCommand implements BindingCommandInstance {
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser, attrMapper: IAttrMapper): PropertyBindingInstruction {
     const attr = info.attr;
     const bindable = info.bindable;
+    let value = attr.rawValue;
+    let target = attr.target;
     let defDefaultMode: string | number;
     let mode: string | number;
-    let target = attr.target;
-    let value = attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (bindable == null) {
       mode = attrMapper.isTwoWay(info.node, target) ? InternalBindingMode.twoWay : InternalBindingMode.toView;
       target = attrMapper.map(info.node, target)
@@ -336,11 +321,6 @@ export class DefaultBindingCommand implements BindingCommandInstance {
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === definitionTypeElement) {
-        value = camelCase(target);
-      }
       defDefaultMode = (info.def as IAttributeComponentDefinition).defaultBindingMode ?? 0;
       mode = bindable.mode === 0 || bindable.mode == null
         ? defDefaultMode == null || defDefaultMode === 0
@@ -435,7 +415,11 @@ export class AttrBindingCommand implements BindingCommandInstance {
   public get ignoreAttr() { return true; }
 
   public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IInstruction {
-    return new AttributeBindingInstruction(info.attr.target, exprParser.parse(info.attr.rawValue, etIsProperty), info.attr.target);
+    const attr = info.attr;
+    const target = attr.target;
+    let value = attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
+    return new AttributeBindingInstruction(target, exprParser.parse(value, etIsProperty), target);
   }
 }
 


### PR DESCRIPTION
## 📖 Description

Our binding syntax comprises of 3 parts: target, command and expression as per the following formular:
```
target.command="expression"
```
Currently, when `expression` is absent, or empty, like the following examples:
```html
<input value.bind="">
or
<input value.bind>
```
it's treated as an empty string, which means the template above works like this:
```html
<input value.bind="``">
```

This is a missed-opportunity in v1, where we could have better dev experience, like suggested in #1259 . When the `expression` is either empty or absent, we can infer the expression based on the `target`. so for the above example, it should be understood as:
```html
<input value.bind="value">
```

All binding commands that will share this behavior are:
- `.bind`
- `.one-time`
- `.to-view`
- `.from-view`
- `.two-way`
- `.attr`

This is technically a breaking change, but no-one would write anything meaningful with empty expression so the effect of this should be small, or none. Though it's still safer to have this done in beta so we don't cause unnecessary discomfort.

### 🎫 Issues

Close #1259 

cc @fkleuver @Sayan751 @brandonseydel 