### PR TITLE
feat(template): support spread syntax ...

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -98,7 +98,7 @@ module.exports = {
     '@typescript-eslint/prefer-includes': 'error',
     '@typescript-eslint/prefer-readonly': 'error',
     '@typescript-eslint/prefer-regexp-exec': 'error',
-    '@typescript-eslint/prefer-string-starts-ends-with': 'error',
+    '@typescript-eslint/prefer-string-starts-ends-with': 'off',
     '@typescript-eslint/return-await': 'error',
     '@typescript-eslint/semi': 'error',
     '@typescript-eslint/space-before-function-paren': ['error', {

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -597,8 +597,24 @@ Sometimes when the expression of the spread binding is simple, we can simplify t
 
 {% hint style="warning" %}
 - Remember that HTML is case insensitive, so `...firstName` actually will be seen as `...firstname`, for example
-- If the expression contains space, it will result into multiple attributes and thus won't work as intended with spread syntax `...`
+- If the expression contains space, it will result into multiple attributes and thus won't work as intended with spread syntax `...`.
+For example `...a + b` will be actually turned into 3 attributes: `...a`, `+` and `b`
 {% endhint %}
+
+### Binding orders
+
+The order of the bindings created will be the same with the order declared in the template. For example, for the `NameTag` component above, if we have a usage
+
+```html
+<name-tag id="1" first="John" ...$bindables="{ first: 'Jane' }">
+<name-tag id="2" ...$bindables="{ first: 'Jane' }" first="John">
+```
+Then the value of the `first` property in `NameTag` with `id=1` will be `Jane`, and the value of `first` property in `NameTag` with `id=2` will be `John`.
+
+{% hint style="warning" %}
+- An exception of this order is when bindables spreading is used together with [`...$attrs`](#attributes-transferring), `...$attrs` will always result in bindings after `...$bindables`/`$bindables.spread`/`...expression`.
+{% endhint %}
+
 
 ## Attributes Transferring
 

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -615,6 +615,37 @@ Then the value of the `first` property in `NameTag` with `id=1` will be `Jane`, 
 - An exception of this order is when bindables spreading is used together with [`...$attrs`](#attributes-transferring), `...$attrs` will always result in bindings after `...$bindables`/`$bindables.spread`/`...expression`.
 {% endhint %}
 
+### Observation behavior
+
+Bindings will be created based on the keys available in the object evaluated from the `expression` of a spread binding. The following example illustrate the behavior:
+
+For the `NameTag` component above:
+```html
+<let item.bind="{ first: 'John' }">
+<name-tag ...item></name-tag>
+<button click.trigger="item.last = 'Doe'">Change last name</button>
+```
+
+The rendered HTML of `<name-tag>` will be
+```html
+<b>JOHN</b>
+```
+
+When clicking on the button with text `Change last name`, the rendered html of `<name-tag>` won't be changed,
+as the original object given to `<name-tag>` doesn't contain `last`, hence it wasn't observed, which ignore our new value set from the button click.
+If it's desirable to reset the observation, give a new object to the spread binding, like the following example:
+
+```html
+<let item.bind="{ first: 'John' }">
+<name-tag ...item></name-tag>
+<button click.trigger="item = { first: item.name, last: 'Doe' }">Change last name</button>
+```
+
+{% hint style="success" %}
+With the above behavior of non-eager binding, applications can have the opportunity to leave some bindable properties alone,
+while with the opposite of always observing all properties on the given object based on the number of bindable properties,
+missing value (`null`/`undefined`) will start flowing in in an unwanted way.
+{% endhint %}
 
 ## Attributes Transferring
 

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -583,6 +583,9 @@ The `...$bindables="..."` syntax will only connect properties that are matching 
 <name-tag $bindables.spread="customer1">
 <name-tag $bindables.spread="customer.details">
 <name-tag $bindables.spread="customer[this_that]">
+<name-tag $bindables="customer1 | mapDetails">
+<name-tag $bindables="customer.details | simplify">
+<name-tag $bindables="customer[this_that] | addDetails">
 ```
 
 ### Shorthand syntax
@@ -593,10 +596,16 @@ Sometimes when the expression of the spread binding is simple, we can simplify t
 <name-tag ...customer1>
 <name-tag ...customer.details>
 <name-tag ...customer[this_that]>
+
+or if you need space in the expression:
+<name-tag ...$bindables="customer1 | mapDetails">
+<name-tag ...$bindables="customer.details | simplify">
+<name-tag ...$bindables="customer[this_that] | addDetails">
 ```
 
 {% hint style="warning" %}
 - Remember that HTML is case insensitive, so `...firstName` actually will be seen as `...firstname`, for example
+- Bindables properties will be tried to matched as is, which means a `firstName` bindable property will match an object `firstName` property, but not `first-name`
 - If the expression contains space, it will result into multiple attributes and thus won't work as intended with spread syntax `...`.
 For example `...a + b` will be actually turned into 3 attributes: `...a`, `+` and `b`
 {% endhint %}
@@ -642,9 +651,11 @@ If it's desirable to reset the observation, give a new object to the spread bind
 ```
 
 {% hint style="success" %}
-With the above behavior of non-eager binding, applications can have the opportunity to leave some bindable properties alone,
-while with the opposite of always observing all properties on the given object based on the number of bindable properties,
+- With the above behavior of non-eager binding, applications can have the opportunity to leave some bindable properties untouched,
+while with the opposite behavior of always observing all properties on the given object based on the number of bindable properties,
 missing value (`null`/`undefined`) will start flowing in in an unwanted way.
+- All bindings created with `$bindables.spread` or `...` syntax will have binding mode equivalent to `to-view`, binding behavior cannot alter this.
+Though other binding behavior like `throttle`/`debounce` can still work.
 {% endhint %}
 
 ## Attributes Transferring

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -574,7 +574,7 @@ The rendered html will be:
 <b>JOHN</b> Doe
 ```
 
-Here we are using `...$bindables` to express we want to bind all properties in the object `{ first: 'John', last: 'Doe' }` to bindable properties on `<name-tag>` component.
+Here we are using `...$bindables` to express that we want to bind all properties in the object `{ first: 'John', last: 'Doe' }` to bindable properties on `<name-tag>` component.
 The `...$bindables="..."` syntax will only connect properties that are matching with bindable properties on `<name-tag>`, so even if an object with hundreds of properties are given to a `...$bindables` binding, it will still resulted in 2 bindings for `first` and `last`.
 
 `...$bindables` also work with any expression, rather than literal object, per the following examples:

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -654,9 +654,13 @@ If it's desirable to reset the observation, give a new object to the spread bind
 - With the above behavior of non-eager binding, applications can have the opportunity to leave some bindable properties untouched,
 while with the opposite behavior of always observing all properties on the given object based on the number of bindable properties,
 missing value (`null`/`undefined`) will start flowing in in an unwanted way.
+{% endhint %}
+
+There are some other behaviors of the spread binding that are worth noting:
+
 - All bindings created with `$bindables.spread` or `...` syntax will have binding mode equivalent to `to-view`, binding behavior cannot alter this.
 Though other binding behavior like `throttle`/`debounce` can still work.
-{% endhint %}
+- If the same object is returned from evaluating the expression, the spread binding won't try to rebind its inner bindings. This means mutating and then reassigning won't result in new binding, instead, give the spread binding a new object.
 
 ## Attributes Transferring
 

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -566,7 +566,7 @@ with template:
 and its usage template:
 
 ```html
-<name-tag ...bindables="{ first: 'John', last: 'Doe' }"></name-tag>
+<name-tag ...$bindables="{ first: 'John', last: 'Doe' }"></name-tag>
 ```
 
 The rendered html will be:
@@ -574,15 +574,15 @@ The rendered html will be:
 <b>JOHN</b> Doe
 ```
 
-Here we are using `...bindables` to express we want to bind all properties in the object `{ first: 'John', last: 'Doe' }` to bindable properties on `<name-tag>` component.
-The `...bindables="..."` syntax will only connect properties that are matching with bindable properties on `<name-tag>`, so even if an object with hundreds of properties are given to a `...bindables` binding, it will still resulted in 2 bindings for `first` and `last`.
+Here we are using `...$bindables` to express we want to bind all properties in the object `{ first: 'John', last: 'Doe' }` to bindable properties on `<name-tag>` component.
+The `...$bindables="..."` syntax will only connect properties that are matching with bindable properties on `<name-tag>`, so even if an object with hundreds of properties are given to a `...$bindables` binding, it will still resulted in 2 bindings for `first` and `last`.
 
-`...bindables` also work with any expression, rather than literal object, per the following examples:
+`...$bindables` also work with any expression, rather than literal object, per the following examples:
 
 ```html
-<name-tag bindables.spread="customer1">
-<name-tag bindables.spread="customer.details">
-<name-tag bindables.spread="customer[this_that]">
+<name-tag $bindables.spread="customer1">
+<name-tag $bindables.spread="customer.details">
+<name-tag $bindables.spread="customer[this_that]">
 ```
 
 ### Shorthand syntax
@@ -591,15 +591,14 @@ Sometimes when the expression of the spread binding is simple, we can simplify t
 
 ```html
 <name-tag ...customer1>
-<name-tag bindables.spread="customer1">
-```
-These bindings would behave the same.
-
-The following template won't work:
-```html
 <name-tag ...customer.details>
 <name-tag ...customer[this_that]>
 ```
+
+{% hint style="warning" %}
+- Remember that HTML is case insensitive, so `...firstName` actually will be seen as `...firstname`, for example
+- If the expression contains space, it will result into multiple attributes and thus won't work as intended with spread syntax `...`
+{% endhint %}
 
 ## Attributes Transferring
 

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -547,6 +547,60 @@ export class MyEl {
 Even though using a `noop` function for `set` function is a straightforward choice, `Object` can also be used for `type` in the bindable definition to disable the auto-coercion for selective `@bindable`s (that is when the automatic type-coercion is enabled).
 {% endhint %}
 
+## Bindables spreading
+
+Spreading syntaxes are supported for simpler binding of multiple bindable properties.
+
+Given the following component:
+```typescript
+export class NameTag {
+  @bindable first
+  @bindable last
+}
+```
+with template:
+
+```html
+<b>${fist.toUpperCase()}</b> ${last}
+```
+and its usage template:
+
+```html
+<name-tag ...bindables="{ first: 'John', last: 'Doe' }"></name-tag>
+```
+
+The rendered html will be:
+```html
+<b>JOHN</b> Doe
+```
+
+Here we are using `...bindables` to express we want to bind all properties in the object `{ first: 'John', last: 'Doe' }` to bindable properties on `<name-tag>` component.
+The `...bindables="..."` syntax will only connect properties that are matching with bindable properties on `<name-tag>`, so even if an object with hundreds of properties are given to a `...bindables` binding, it will still resulted in 2 bindings for `first` and `last`.
+
+`...bindables` also work with any expression, rather than literal object, per the following examples:
+
+```html
+<name-tag bindables.spread="customer1">
+<name-tag bindables.spread="customer.details">
+<name-tag bindables.spread="customer[this_that]">
+```
+
+### Shorthand syntax
+
+Sometimes when the expression of the spread binding is simple, we can simplify the binding even further. Default templating syntax of Aurelia supports a shorter version of the above examples:
+
+```html
+<name-tag ...customer1>
+<name-tag bindables.spread="customer1">
+```
+These bindings would behave the same.
+
+The following template won't work:
+```html
+<name-tag ...customer.details>
+<name-tag ...customer[this_that]>
+```
+
 ## Attributes Transferring
 
 Attribute transferring is a way to relay the binding(s) on a custom element to its child element(s).

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "codecov": "^3.8.3",
         "concurrently": "7.6.0",
         "cross-env": "7.0.3",
-        "esbuild": "0.20.0",
+        "esbuild": "0.21.1",
         "eslint": "8.53.0",
         "eslint-plugin-import": "2.29.0",
         "eslint-plugin-jsdoc": "46.9.0",
@@ -1523,9 +1523,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
-      "integrity": "sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.1.tgz",
+      "integrity": "sha512-hh3jKWikdnTtHCglDAeVO3Oyh8MaH8xZUaWMiCCvJ9/c3NtPqZq+CACOlGTxhddypXhl+8B45SeceYBfB/e8Ow==",
       "cpu": [
         "arm"
       ],
@@ -1539,9 +1539,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
-      "integrity": "sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.1.tgz",
+      "integrity": "sha512-jXhccq6es+onw7x8MxoFnm820mz7sGa9J14kLADclmiEUH4fyj+FjR6t0M93RgtlI/awHWhtF0Wgfhqgf9gDZA==",
       "cpu": [
         "arm64"
       ],
@@ -1555,9 +1555,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.0.tgz",
-      "integrity": "sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.1.tgz",
+      "integrity": "sha512-NPObtlBh4jQHE01gJeucqEhdoD/4ya2owSIS8lZYS58aR0x7oZo9lB2lVFxgTANSa5MGCBeoQtr+yA9oKCGPvA==",
       "cpu": [
         "x64"
       ],
@@ -1571,9 +1571,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
-      "integrity": "sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.1.tgz",
+      "integrity": "sha512-BLT7TDzqsVlQRmJfO/FirzKlzmDpBWwmCUlyggfzUwg1cAxVxeA4O6b1XkMInlxISdfPAOunV9zXjvh5x99Heg==",
       "cpu": [
         "arm64"
       ],
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz",
-      "integrity": "sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.1.tgz",
+      "integrity": "sha512-D3h3wBQmeS/vp93O4B+SWsXB8HvRDwMyhTNhBd8yMbh5wN/2pPWRW5o/hM3EKgk9bdKd9594lMGoTCTiglQGRQ==",
       "cpu": [
         "x64"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz",
-      "integrity": "sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.1.tgz",
+      "integrity": "sha512-/uVdqqpNKXIxT6TyS/oSK4XE4xWOqp6fh4B5tgAwozkyWdylcX+W4YF2v6SKsL4wCQ5h1bnaSNjWPXG/2hp8AQ==",
       "cpu": [
         "arm64"
       ],
@@ -1619,9 +1619,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz",
-      "integrity": "sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.1.tgz",
+      "integrity": "sha512-paAkKN1n1jJitw+dAoR27TdCzxRl1FOEITx3h201R6NoXUojpMzgMLdkXVgCvaCSCqwYkeGLoe9UVNRDKSvQgw==",
       "cpu": [
         "x64"
       ],
@@ -1635,9 +1635,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz",
-      "integrity": "sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.1.tgz",
+      "integrity": "sha512-tRHnxWJnvNnDpNVnsyDhr1DIQZUfCXlHSCDohbXFqmg9W4kKR7g8LmA3kzcwbuxbRMKeit8ladnCabU5f2traA==",
       "cpu": [
         "arm"
       ],
@@ -1651,9 +1651,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz",
-      "integrity": "sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.1.tgz",
+      "integrity": "sha512-G65d08YoH00TL7Xg4LaL3gLV21bpoAhQ+r31NUu013YB7KK0fyXIt05VbsJtpqh/6wWxoLJZOvQHYnodRrnbUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1667,9 +1667,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz",
-      "integrity": "sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.1.tgz",
+      "integrity": "sha512-tt/54LqNNAqCz++QhxoqB9+XqdsaZOtFD/srEhHYwBd3ZUOepmR1Eeot8bS+Q7BiEvy9vvKbtpHf+r6q8hF5UA==",
       "cpu": [
         "ia32"
       ],
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz",
-      "integrity": "sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.1.tgz",
+      "integrity": "sha512-MhNalK6r0nZD0q8VzUBPwheHzXPr9wronqmZrewLfP7ui9Fv1tdPmg6e7A8lmg0ziQCziSDHxh3cyRt4YMhGnQ==",
       "cpu": [
         "loong64"
       ],
@@ -1699,9 +1699,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz",
-      "integrity": "sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.1.tgz",
+      "integrity": "sha512-YCKVY7Zen5rwZV+nZczOhFmHaeIxR4Zn3jcmNH53LbgF6IKRwmrMywqDrg4SiSNApEefkAbPSIzN39FC8VsxPg==",
       "cpu": [
         "mips64el"
       ],
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz",
-      "integrity": "sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.1.tgz",
+      "integrity": "sha512-bw7bcQ+270IOzDV4mcsKAnDtAFqKO0jVv3IgRSd8iM0ac3L8amvCrujRVt1ajBTJcpDaFhIX+lCNRKteoDSLig==",
       "cpu": [
         "ppc64"
       ],
@@ -1731,9 +1731,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz",
-      "integrity": "sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.1.tgz",
+      "integrity": "sha512-ARmDRNkcOGOm1AqUBSwRVDfDeD9hGYRfkudP2QdoonBz1ucWVnfBPfy7H4JPI14eYtZruRSczJxyu7SRYDVOcg==",
       "cpu": [
         "riscv64"
       ],
@@ -1747,9 +1747,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz",
-      "integrity": "sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.1.tgz",
+      "integrity": "sha512-o73TcUNMuoTZlhwFdsgr8SfQtmMV58sbgq6gQq9G1xUiYnHMTmJbwq65RzMx89l0iya69lR4bxBgtWiiOyDQZA==",
       "cpu": [
         "s390x"
       ],
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz",
-      "integrity": "sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.1.tgz",
+      "integrity": "sha512-da4/1mBJwwgJkbj4fMH7SOXq2zapgTo0LKXX1VUZ0Dxr+e8N0WbS80nSZ5+zf3lvpf8qxrkZdqkOqFfm57gXwA==",
       "cpu": [
         "x64"
       ],
@@ -1779,9 +1779,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.1.tgz",
+      "integrity": "sha512-CPWs0HTFe5woTJN5eKPvgraUoRHrCtzlYIAv9wBC+FAyagBSaf+UdZrjwYyTGnwPGkThV4OCI7XibZOnPvONVw==",
       "cpu": [
         "x64"
       ],
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.1.tgz",
+      "integrity": "sha512-xxhTm5QtzNLc24R0hEkcH+zCx/o49AsdFZ0Cy5zSd/5tOj4X2g3/2AJB625NoadUuc4A8B3TenLJoYdWYOYCew==",
       "cpu": [
         "x64"
       ],
@@ -1811,9 +1811,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz",
-      "integrity": "sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.1.tgz",
+      "integrity": "sha512-CWibXszpWys1pYmbr9UiKAkX6x+Sxw8HWtw1dRESK1dLW5fFJ6rMDVw0o8MbadusvVQx1a8xuOxnHXT941Hp1A==",
       "cpu": [
         "x64"
       ],
@@ -1827,9 +1827,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz",
-      "integrity": "sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.1.tgz",
+      "integrity": "sha512-jb5B4k+xkytGbGUS4T+Z89cQJ9DJ4lozGRSV+hhfmCPpfJ3880O31Q1srPCimm+V6UCbnigqD10EgDNgjvjerQ==",
       "cpu": [
         "arm64"
       ],
@@ -1843,9 +1843,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz",
-      "integrity": "sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.1.tgz",
+      "integrity": "sha512-PgyFvjJhXqHn1uxPhyN1wZ6dIomKjiLUQh1LjFvjiV1JmnkZ/oMPrfeEAZg5R/1ftz4LZWZr02kefNIQ5SKREQ==",
       "cpu": [
         "ia32"
       ],
@@ -1859,9 +1859,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz",
-      "integrity": "sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.1.tgz",
+      "integrity": "sha512-W9NttRZQR5ehAiqHGDnvfDaGmQOm6Fi4vSlce8mjM75x//XKuVAByohlEX6N17yZnVXxQFuh4fDRunP8ca6bfA==",
       "cpu": [
         "x64"
       ],
@@ -7722,9 +7722,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.0.tgz",
-      "integrity": "sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.1.tgz",
+      "integrity": "sha512-GPqx+FX7mdqulCeQ4TsGZQ3djBJkx5k7zBGtqt9ycVlWNg8llJ4RO9n2vciu8BN2zAEs6lPbPl0asZsAh7oWzg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -7734,35 +7734,35 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.0",
-        "@esbuild/android-arm": "0.20.0",
-        "@esbuild/android-arm64": "0.20.0",
-        "@esbuild/android-x64": "0.20.0",
-        "@esbuild/darwin-arm64": "0.20.0",
-        "@esbuild/darwin-x64": "0.20.0",
-        "@esbuild/freebsd-arm64": "0.20.0",
-        "@esbuild/freebsd-x64": "0.20.0",
-        "@esbuild/linux-arm": "0.20.0",
-        "@esbuild/linux-arm64": "0.20.0",
-        "@esbuild/linux-ia32": "0.20.0",
-        "@esbuild/linux-loong64": "0.20.0",
-        "@esbuild/linux-mips64el": "0.20.0",
-        "@esbuild/linux-ppc64": "0.20.0",
-        "@esbuild/linux-riscv64": "0.20.0",
-        "@esbuild/linux-s390x": "0.20.0",
-        "@esbuild/linux-x64": "0.20.0",
-        "@esbuild/netbsd-x64": "0.20.0",
-        "@esbuild/openbsd-x64": "0.20.0",
-        "@esbuild/sunos-x64": "0.20.0",
-        "@esbuild/win32-arm64": "0.20.0",
-        "@esbuild/win32-ia32": "0.20.0",
-        "@esbuild/win32-x64": "0.20.0"
+        "@esbuild/aix-ppc64": "0.21.1",
+        "@esbuild/android-arm": "0.21.1",
+        "@esbuild/android-arm64": "0.21.1",
+        "@esbuild/android-x64": "0.21.1",
+        "@esbuild/darwin-arm64": "0.21.1",
+        "@esbuild/darwin-x64": "0.21.1",
+        "@esbuild/freebsd-arm64": "0.21.1",
+        "@esbuild/freebsd-x64": "0.21.1",
+        "@esbuild/linux-arm": "0.21.1",
+        "@esbuild/linux-arm64": "0.21.1",
+        "@esbuild/linux-ia32": "0.21.1",
+        "@esbuild/linux-loong64": "0.21.1",
+        "@esbuild/linux-mips64el": "0.21.1",
+        "@esbuild/linux-ppc64": "0.21.1",
+        "@esbuild/linux-riscv64": "0.21.1",
+        "@esbuild/linux-s390x": "0.21.1",
+        "@esbuild/linux-x64": "0.21.1",
+        "@esbuild/netbsd-x64": "0.21.1",
+        "@esbuild/openbsd-x64": "0.21.1",
+        "@esbuild/sunos-x64": "0.21.1",
+        "@esbuild/win32-arm64": "0.21.1",
+        "@esbuild/win32-ia32": "0.21.1",
+        "@esbuild/win32-x64": "0.21.1"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz",
-      "integrity": "sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.1.tgz",
+      "integrity": "sha512-O7yppwipkXvnEPjzkSXJRk2g4bS8sUx9p9oXHq9MU/U7lxUzZVsnFZMDTmeeX9bfQxrFcvOacl/ENgOh0WP9pA==",
       "cpu": [
         "ppc64"
       ],
@@ -21452,156 +21452,156 @@
       "optional": true
     },
     "@esbuild/android-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.0.tgz",
-      "integrity": "sha512-3bMAfInvByLHfJwYPJRlpTeaQA75n8C/QKpEaiS4HrFWFiJlNI0vzq/zCjBrhAYcPyVPG7Eo9dMrcQXuqmNk5g==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.1.tgz",
+      "integrity": "sha512-hh3jKWikdnTtHCglDAeVO3Oyh8MaH8xZUaWMiCCvJ9/c3NtPqZq+CACOlGTxhddypXhl+8B45SeceYBfB/e8Ow==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.0.tgz",
-      "integrity": "sha512-aVpnM4lURNkp0D3qPoAzSG92VXStYmoVPOgXveAUoQBWRSuQzt51yvSju29J6AHPmwY1BjH49uR29oyfH1ra8Q==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.1.tgz",
+      "integrity": "sha512-jXhccq6es+onw7x8MxoFnm820mz7sGa9J14kLADclmiEUH4fyj+FjR6t0M93RgtlI/awHWhtF0Wgfhqgf9gDZA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.0.tgz",
-      "integrity": "sha512-uK7wAnlRvjkCPzh8jJ+QejFyrP8ObKuR5cBIsQZ+qbMunwR8sbd8krmMbxTLSrDhiPZaJYKQAU5Y3iMDcZPhyQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.1.tgz",
+      "integrity": "sha512-NPObtlBh4jQHE01gJeucqEhdoD/4ya2owSIS8lZYS58aR0x7oZo9lB2lVFxgTANSa5MGCBeoQtr+yA9oKCGPvA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
-      "integrity": "sha512-AjEcivGAlPs3UAcJedMa9qYg9eSfU6FnGHJjT8s346HSKkrcWlYezGE8VaO2xKfvvlZkgAhyvl06OJOxiMgOYQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.1.tgz",
+      "integrity": "sha512-BLT7TDzqsVlQRmJfO/FirzKlzmDpBWwmCUlyggfzUwg1cAxVxeA4O6b1XkMInlxISdfPAOunV9zXjvh5x99Heg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.0.tgz",
-      "integrity": "sha512-bsgTPoyYDnPv8ER0HqnJggXK6RyFy4PH4rtsId0V7Efa90u2+EifxytE9pZnsDgExgkARy24WUQGv9irVbTvIw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.1.tgz",
+      "integrity": "sha512-D3h3wBQmeS/vp93O4B+SWsXB8HvRDwMyhTNhBd8yMbh5wN/2pPWRW5o/hM3EKgk9bdKd9594lMGoTCTiglQGRQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.0.tgz",
-      "integrity": "sha512-kQ7jYdlKS335mpGbMW5tEe3IrQFIok9r84EM3PXB8qBFJPSc6dpWfrtsC/y1pyrz82xfUIn5ZrnSHQQsd6jebQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.1.tgz",
+      "integrity": "sha512-/uVdqqpNKXIxT6TyS/oSK4XE4xWOqp6fh4B5tgAwozkyWdylcX+W4YF2v6SKsL4wCQ5h1bnaSNjWPXG/2hp8AQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.0.tgz",
-      "integrity": "sha512-uG8B0WSepMRsBNVXAQcHf9+Ko/Tr+XqmK7Ptel9HVmnykupXdS4J7ovSQUIi0tQGIndhbqWLaIL/qO/cWhXKyQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.1.tgz",
+      "integrity": "sha512-paAkKN1n1jJitw+dAoR27TdCzxRl1FOEITx3h201R6NoXUojpMzgMLdkXVgCvaCSCqwYkeGLoe9UVNRDKSvQgw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.0.tgz",
-      "integrity": "sha512-2ezuhdiZw8vuHf1HKSf4TIk80naTbP9At7sOqZmdVwvvMyuoDiZB49YZKLsLOfKIr77+I40dWpHVeY5JHpIEIg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.1.tgz",
+      "integrity": "sha512-tRHnxWJnvNnDpNVnsyDhr1DIQZUfCXlHSCDohbXFqmg9W4kKR7g8LmA3kzcwbuxbRMKeit8ladnCabU5f2traA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.0.tgz",
-      "integrity": "sha512-uTtyYAP5veqi2z9b6Gr0NUoNv9F/rOzI8tOD5jKcCvRUn7T60Bb+42NDBCWNhMjkQzI0qqwXkQGo1SY41G52nw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.1.tgz",
+      "integrity": "sha512-G65d08YoH00TL7Xg4LaL3gLV21bpoAhQ+r31NUu013YB7KK0fyXIt05VbsJtpqh/6wWxoLJZOvQHYnodRrnbUQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.0.tgz",
-      "integrity": "sha512-c88wwtfs8tTffPaoJ+SQn3y+lKtgTzyjkD8NgsyCtCmtoIC8RDL7PrJU05an/e9VuAke6eJqGkoMhJK1RY6z4w==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.1.tgz",
+      "integrity": "sha512-tt/54LqNNAqCz++QhxoqB9+XqdsaZOtFD/srEhHYwBd3ZUOepmR1Eeot8bS+Q7BiEvy9vvKbtpHf+r6q8hF5UA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.0.tgz",
-      "integrity": "sha512-lR2rr/128/6svngnVta6JN4gxSXle/yZEZL3o4XZ6esOqhyR4wsKyfu6qXAL04S4S5CgGfG+GYZnjFd4YiG3Aw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.1.tgz",
+      "integrity": "sha512-MhNalK6r0nZD0q8VzUBPwheHzXPr9wronqmZrewLfP7ui9Fv1tdPmg6e7A8lmg0ziQCziSDHxh3cyRt4YMhGnQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.0.tgz",
-      "integrity": "sha512-9Sycc+1uUsDnJCelDf6ZNqgZQoK1mJvFtqf2MUz4ujTxGhvCWw+4chYfDLPepMEvVL9PDwn6HrXad5yOrNzIsQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.1.tgz",
+      "integrity": "sha512-YCKVY7Zen5rwZV+nZczOhFmHaeIxR4Zn3jcmNH53LbgF6IKRwmrMywqDrg4SiSNApEefkAbPSIzN39FC8VsxPg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.0.tgz",
-      "integrity": "sha512-CoWSaaAXOZd+CjbUTdXIJE/t7Oz+4g90A3VBCHLbfuc5yUQU/nFDLOzQsN0cdxgXd97lYW/psIIBdjzQIwTBGw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.1.tgz",
+      "integrity": "sha512-bw7bcQ+270IOzDV4mcsKAnDtAFqKO0jVv3IgRSd8iM0ac3L8amvCrujRVt1ajBTJcpDaFhIX+lCNRKteoDSLig==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.0.tgz",
-      "integrity": "sha512-mlb1hg/eYRJUpv8h/x+4ShgoNLL8wgZ64SUr26KwglTYnwAWjkhR2GpoKftDbPOCnodA9t4Y/b68H4J9XmmPzA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.1.tgz",
+      "integrity": "sha512-ARmDRNkcOGOm1AqUBSwRVDfDeD9hGYRfkudP2QdoonBz1ucWVnfBPfy7H4JPI14eYtZruRSczJxyu7SRYDVOcg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.0.tgz",
-      "integrity": "sha512-fgf9ubb53xSnOBqyvWEY6ukBNRl1mVX1srPNu06B6mNsNK20JfH6xV6jECzrQ69/VMiTLvHMicQR/PgTOgqJUQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.1.tgz",
+      "integrity": "sha512-o73TcUNMuoTZlhwFdsgr8SfQtmMV58sbgq6gQq9G1xUiYnHMTmJbwq65RzMx89l0iya69lR4bxBgtWiiOyDQZA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.0.tgz",
-      "integrity": "sha512-H9Eu6MGse++204XZcYsse1yFHmRXEWgadk2N58O/xd50P9EvFMLJTQLg+lB4E1cF2xhLZU5luSWtGTb0l9UeSg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.1.tgz",
+      "integrity": "sha512-da4/1mBJwwgJkbj4fMH7SOXq2zapgTo0LKXX1VUZ0Dxr+e8N0WbS80nSZ5+zf3lvpf8qxrkZdqkOqFfm57gXwA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-lCT675rTN1v8Fo+RGrE5KjSnfY0x9Og4RN7t7lVrN3vMSjy34/+3na0q7RIfWDAj0e0rCh0OL+P88lu3Rt21MQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.1.tgz",
+      "integrity": "sha512-CPWs0HTFe5woTJN5eKPvgraUoRHrCtzlYIAv9wBC+FAyagBSaf+UdZrjwYyTGnwPGkThV4OCI7XibZOnPvONVw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.0.tgz",
-      "integrity": "sha512-HKoUGXz/TOVXKQ+67NhxyHv+aDSZf44QpWLa3I1lLvAwGq8x1k0T+e2HHSRvxWhfJrFxaaqre1+YyzQ99KixoA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.1.tgz",
+      "integrity": "sha512-xxhTm5QtzNLc24R0hEkcH+zCx/o49AsdFZ0Cy5zSd/5tOj4X2g3/2AJB625NoadUuc4A8B3TenLJoYdWYOYCew==",
       "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.0.tgz",
-      "integrity": "sha512-GDwAqgHQm1mVoPppGsoq4WJwT3vhnz/2N62CzhvApFD1eJyTroob30FPpOZabN+FgCjhG+AgcZyOPIkR8dfD7g==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.1.tgz",
+      "integrity": "sha512-CWibXszpWys1pYmbr9UiKAkX6x+Sxw8HWtw1dRESK1dLW5fFJ6rMDVw0o8MbadusvVQx1a8xuOxnHXT941Hp1A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.0.tgz",
-      "integrity": "sha512-0vYsP8aC4TvMlOQYozoksiaxjlvUcQrac+muDqj1Fxy6jh9l9CZJzj7zmh8JGfiV49cYLTorFLxg7593pGldwQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.1.tgz",
+      "integrity": "sha512-jb5B4k+xkytGbGUS4T+Z89cQJ9DJ4lozGRSV+hhfmCPpfJ3880O31Q1srPCimm+V6UCbnigqD10EgDNgjvjerQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.0.tgz",
-      "integrity": "sha512-p98u4rIgfh4gdpV00IqknBD5pC84LCub+4a3MO+zjqvU5MVXOc3hqR2UgT2jI2nh3h8s9EQxmOsVI3tyzv1iFg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.1.tgz",
+      "integrity": "sha512-PgyFvjJhXqHn1uxPhyN1wZ6dIomKjiLUQh1LjFvjiV1JmnkZ/oMPrfeEAZg5R/1ftz4LZWZr02kefNIQ5SKREQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz",
-      "integrity": "sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.1.tgz",
+      "integrity": "sha512-W9NttRZQR5ehAiqHGDnvfDaGmQOm6Fi4vSlce8mjM75x//XKuVAByohlEX6N17yZnVXxQFuh4fDRunP8ca6bfA==",
       "dev": true,
       "optional": true
     },
@@ -25744,40 +25744,40 @@
       }
     },
     "esbuild": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.0.tgz",
-      "integrity": "sha512-6iwE3Y2RVYCME1jLpBqq7LQWK3MW6vjV2bZy6gt/WrqkY+WE74Spyc0ThAOYpMtITvnjX09CrC6ym7A/m9mebA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.1.tgz",
+      "integrity": "sha512-GPqx+FX7mdqulCeQ4TsGZQ3djBJkx5k7zBGtqt9ycVlWNg8llJ4RO9n2vciu8BN2zAEs6lPbPl0asZsAh7oWzg==",
       "dev": true,
       "requires": {
-        "@esbuild/aix-ppc64": "0.20.0",
-        "@esbuild/android-arm": "0.20.0",
-        "@esbuild/android-arm64": "0.20.0",
-        "@esbuild/android-x64": "0.20.0",
-        "@esbuild/darwin-arm64": "0.20.0",
-        "@esbuild/darwin-x64": "0.20.0",
-        "@esbuild/freebsd-arm64": "0.20.0",
-        "@esbuild/freebsd-x64": "0.20.0",
-        "@esbuild/linux-arm": "0.20.0",
-        "@esbuild/linux-arm64": "0.20.0",
-        "@esbuild/linux-ia32": "0.20.0",
-        "@esbuild/linux-loong64": "0.20.0",
-        "@esbuild/linux-mips64el": "0.20.0",
-        "@esbuild/linux-ppc64": "0.20.0",
-        "@esbuild/linux-riscv64": "0.20.0",
-        "@esbuild/linux-s390x": "0.20.0",
-        "@esbuild/linux-x64": "0.20.0",
-        "@esbuild/netbsd-x64": "0.20.0",
-        "@esbuild/openbsd-x64": "0.20.0",
-        "@esbuild/sunos-x64": "0.20.0",
-        "@esbuild/win32-arm64": "0.20.0",
-        "@esbuild/win32-ia32": "0.20.0",
-        "@esbuild/win32-x64": "0.20.0"
+        "@esbuild/aix-ppc64": "0.21.1",
+        "@esbuild/android-arm": "0.21.1",
+        "@esbuild/android-arm64": "0.21.1",
+        "@esbuild/android-x64": "0.21.1",
+        "@esbuild/darwin-arm64": "0.21.1",
+        "@esbuild/darwin-x64": "0.21.1",
+        "@esbuild/freebsd-arm64": "0.21.1",
+        "@esbuild/freebsd-x64": "0.21.1",
+        "@esbuild/linux-arm": "0.21.1",
+        "@esbuild/linux-arm64": "0.21.1",
+        "@esbuild/linux-ia32": "0.21.1",
+        "@esbuild/linux-loong64": "0.21.1",
+        "@esbuild/linux-mips64el": "0.21.1",
+        "@esbuild/linux-ppc64": "0.21.1",
+        "@esbuild/linux-riscv64": "0.21.1",
+        "@esbuild/linux-s390x": "0.21.1",
+        "@esbuild/linux-x64": "0.21.1",
+        "@esbuild/netbsd-x64": "0.21.1",
+        "@esbuild/openbsd-x64": "0.21.1",
+        "@esbuild/sunos-x64": "0.21.1",
+        "@esbuild/win32-arm64": "0.21.1",
+        "@esbuild/win32-ia32": "0.21.1",
+        "@esbuild/win32-x64": "0.21.1"
       },
       "dependencies": {
         "@esbuild/aix-ppc64": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.0.tgz",
-          "integrity": "sha512-fGFDEctNh0CcSwsiRPxiaqX0P5rq+AqE0SRhYGZ4PX46Lg1FNR6oCxJghf8YgY0WQEgQuh3lErUFE4KxLeRmmw==",
+          "version": "0.21.1",
+          "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.1.tgz",
+          "integrity": "sha512-O7yppwipkXvnEPjzkSXJRk2g4bS8sUx9p9oXHq9MU/U7lxUzZVsnFZMDTmeeX9bfQxrFcvOacl/ENgOh0WP9pA==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "codecov": "^3.8.3",
     "concurrently": "7.6.0",
     "cross-env": "7.0.3",
-    "esbuild": "0.20.0",
+    "esbuild": "0.21.1",
     "eslint": "8.53.0",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-jsdoc": "46.9.0",

--- a/packages-tooling/rollup-utils.mjs
+++ b/packages-tooling/rollup-utils.mjs
@@ -94,12 +94,8 @@ export function runPostbuildScript(...scripts) {
 /**
  * @param {PackageJson} pkg
  * @param {ConfigCallback} [configure]
- * @param {(env: NormalizedEnvVars) => import('terser').MinifyOptions} [configureTerser]
- * a callback that takes a record of env variables, and returns overrides for terser plugin config
- * @param {{ name: string; script: string }[]} [postBuildScript]
  */
-// eslint-disable-next-line default-param-last
-export function getRollupConfig(pkg, configure = identity, configureTerser, postBuildScript = [{ name: 'build dts', script: 'postrollup'}]) {
+export function getRollupConfig(pkg, configure = identity) {
   /** @type {NormalizedEnvVars} */
   const envVars = {
     __DEV__: process.env.__DEV__,
@@ -109,8 +105,8 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
   const inputFile = 'src/index.ts';
   // const esmDevDist = 'dist/esm/index.dev.mjs';
   // const cjsDevDist = 'dist/cjs/index.dev.cjs';
-  const esmDist = 'dist/esm/index.mjs';
-  const cjsDist = 'dist/cjs/index.cjs';
+  // const esmDist = 'dist/esm/index.mjs';
+  // const cjsDist = 'dist/cjs/index.cjs';
   // const typingsDist = 'dist/types/index.d.ts';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
@@ -127,12 +123,16 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
       .concat('node:module', 'node:path'),
     output: [
       {
-        file: esmDist,
+        dir: 'dist',
+        entryFileNames: 'esm/index.mjs',
+        // file: esmDist,
         format: 'es',
         sourcemap: true,
       },
       {
-        file: cjsDist,
+        dir: 'dist',
+        entryFileNames: 'cjs/index.cjs',
+        // file: cjsDist,
         format: 'cjs',
         sourcemap: true,
         externalLiveBindings: false,
@@ -141,8 +141,14 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     ],
     plugins: [
       rollupReplace({ ...envVars, __DEV__: false }),
-      rollupTypeScript(),
-      runPostbuildScript(...postBuildScript),
+      rollupTypeScript({
+        compilerOptions: {
+          declaration: true,
+          declarationDir: 'dist/types',
+          declarationMap: true,
+        }
+      }),
+      // runPostbuildScript(...postBuildScript),
     ],
     onwarn: onWarn,
   }, false, envVars);

--- a/packages-tooling/rollup-utils.mjs
+++ b/packages-tooling/rollup-utils.mjs
@@ -103,11 +103,6 @@ export function getRollupConfig(pkg, configure = identity) {
   };
   // const isDevMode = /^true$/.test(process.env.DEV_MODE);
   const inputFile = 'src/index.ts';
-  // const esmDevDist = 'dist/esm/index.dev.mjs';
-  // const cjsDevDist = 'dist/cjs/index.dev.cjs';
-  // const esmDist = 'dist/esm/index.mjs';
-  // const cjsDist = 'dist/cjs/index.cjs';
-  // const typingsDist = 'dist/types/index.d.ts';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
     if (warning.code === 'CIRCULAR_DEPENDENCY') return;
@@ -125,14 +120,12 @@ export function getRollupConfig(pkg, configure = identity) {
       {
         dir: 'dist',
         entryFileNames: 'esm/index.mjs',
-        // file: esmDist,
         format: 'es',
         sourcemap: true,
       },
       {
         dir: 'dist',
         entryFileNames: 'cjs/index.cjs',
-        // file: cjsDist,
         format: 'cjs',
         sourcemap: true,
         externalLiveBindings: false,
@@ -148,7 +141,6 @@ export function getRollupConfig(pkg, configure = identity) {
           declarationMap: true,
         }
       }),
-      // runPostbuildScript(...postBuildScript),
     ],
     onwarn: onWarn,
   }, false, envVars);

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -39,6 +39,7 @@ module.exports = {
     'no-inner-declarations': 'off',
     'no-await-in-loop': 'off',
     'require-atomic-updates': 'off',
+    'quote-props': ['error', 'as-needed'],
 
     // can only allow 1, to produce proper junit test format for later consumption
     "mocha/max-top-level-suites": ['error', {limit: 1}],

--- a/packages/__tests__/.eslintrc.cjs
+++ b/packages/__tests__/.eslintrc.cjs
@@ -39,7 +39,7 @@ module.exports = {
     'no-inner-declarations': 'off',
     'no-await-in-loop': 'off',
     'require-atomic-updates': 'off',
-    'quote-props': ['error', 'as-needed'],
+    'quote-props': 'off',
 
     // can only allow 1, to produce proper junit test format for later consumption
     "mocha/max-top-level-suites": ['error', {limit: 1}],

--- a/packages/__tests__/assets-modules.d.ts
+++ b/packages/__tests__/assets-modules.d.ts
@@ -1,0 +1,9 @@
+declare module '*.html' {
+    const value: string;
+    export default value;
+}
+
+declare module '*.css' {
+    const value: string;
+    export default value;
+}

--- a/packages/__tests__/src/3-runtime-html/generated/static.if-else.double.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/generated/static.if-else.double.spec.ts
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElement } from "@aurelia/runtime-html";
 import { TestContext, assert } from "@aurelia/testing";
 
-describe("3-runtime-html/generated/template-compiler.static.if-else.double.spec.ts", function () {
+describe("3-runtime-html/generated/static.if-else.double.spec.ts", function () {
     function createFixture() {
         const ctx = TestContext.create();
         const au = new Aurelia(ctx.container);

--- a/packages/__tests__/src/3-runtime-html/generated/static.if-else.repeat.double.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/generated/static.if-else.repeat.double.spec.ts
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElement } from "@aurelia/runtime-html";
 import { TestContext, assert } from "@aurelia/testing";
 
-describe("3-runtime-html/generated/template-compiler.static.if-else.repeat.double.spec.ts", function () {
+describe("3-runtime-html/generated/static.if-else.repeat.double.spec.ts", function () {
     function createFixture() {
         const ctx = TestContext.create();
         const au = new Aurelia(ctx.container);

--- a/packages/__tests__/src/3-runtime-html/generated/static.if-else.repeat.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/generated/static.if-else.repeat.spec.ts
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElement } from "@aurelia/runtime-html";
 import { TestContext, assert } from "@aurelia/testing";
 
-describe("3-runtime-html/generated/template-compiler.static.if-else.repeat.spec.ts", function () {
+describe("3-runtime-html/generated/static.if-else.repeat.spec.ts", function () {
     function createFixture() {
         const ctx = TestContext.create();
         const au = new Aurelia(ctx.container);

--- a/packages/__tests__/src/3-runtime-html/generated/static.if-else.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/generated/static.if-else.spec.ts
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElement } from "@aurelia/runtime-html";
 import { TestContext, assert } from "@aurelia/testing";
 
-describe("3-runtime-html/generated/template-compiler.static.if-else.spec.ts", function () {
+describe("3-runtime-html/generated/static.if-else.spec.ts", function () {
     function createFixture() {
         const ctx = TestContext.create();
         const au = new Aurelia(ctx.container);

--- a/packages/__tests__/src/3-runtime-html/generated/static.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/generated/static.spec.ts
@@ -1,7 +1,7 @@
 import { Aurelia, CustomElement } from "@aurelia/runtime-html";
 import { TestContext, assert } from "@aurelia/testing";
 
-describe("3-runtime-html/generated/template-compiler.static.spec.ts", function () {
+describe("3-runtime-html/generated/static.spec.ts", function () {
     function createFixture() {
         const ctx = TestContext.create();
         const au = new Aurelia(ctx.container);

--- a/packages/__tests__/src/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/spread.spec.ts
@@ -327,10 +327,35 @@ describe('3-runtime-html/spread.spec.ts', function () {
     });
 
     it('throws when trying to using invalid spread', function () {
-      assert.throws(() => createFixture('<div ...bindables="">'));
-      assert.throws(() => createFixture('<div bindables.spread="">'));
-      assert.throws(() => createFixture('<div ...element="">'));
-      assert.throws(() => createFixture('<div element.spread="">'));
+      assert.throws(() => createFixture('<div ...$bindables="">'));
+      assert.throws(() => createFixture('<div $bindables.spread="">'));
+      assert.throws(() => createFixture('<div ...$element="">'));
+      assert.throws(() => createFixture('<div $element.spread="">'));
+      assert.throws(() => createFixture('<div ...$blabla="">'));
+      assert.throws(() => createFixture('<div $bindables="">'));
+    });
+
+    it('spreads with ... syntax', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...item>', {
+        items: [
+          { id: 1, class: 'a' },
+          { id: 2, class: 'b' },
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+
+      component.items[0].id = 3;
+      flush();
+      assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
+    });
+
+    it('does not throw when expression returns null/undefined', function () {
+      assert.doesNotThrow(() => createFixture('<el repeat.for="item of items" ...$bindables="null">', {}, [El]));
+    });
+
+    it('does not throw when expression returns a primitive', function () {
+      assert.doesNotThrow(() => createFixture('<el repeat.for="item of items" ...$bindables="1">', {}, [El]));
     });
 
     it('does not affect non bindable properties', function () {
@@ -363,28 +388,28 @@ describe('3-runtime-html/spread.spec.ts', function () {
     });
 
     it('does not create more binding than what is available in the object', function () {
-      const { assertHtml, component, flush } = createFixture('<el ...bindables="item">', {
+      const { assertHtml, component, flush } = createFixture('<el ...$bindables="item">', {
         item: { id: 1 } as any,
       }, [El]);
 
-      assertHtml('<el>1--</el>', { compact: true });
+      assertHtml('<el>1--</el>');
 
       component.item.class = 'a';
       flush();
-      assertHtml('<el>1--</el>', { compact: true });
+      assertHtml('<el>1--</el>');
 
       component.item = { id: 1, class: 'a' };
-      assertHtml('<el>1--</el>', { compact: true });
+      assertHtml('<el>1--</el>');
       flush();
-      assertHtml('<el>1--a</el>', { compact: true });
+      assertHtml('<el>1--a</el>');
     });
 
     it('stops observing when unbound', function () {
-      const { assertHtml, component, stop, flush, getBy } = createFixture('<el ...bindables="item">', {
+      const { assertHtml, component, stop, flush, getBy } = createFixture('<el ...$bindables="item">', {
         item: { id: 1 } as any,
       }, [El]);
 
-      assertHtml('<el>1--</el>', { compact: true });
+      assertHtml('<el>1--</el>');
       const el = getBy('el');
       void stop();
       component.item.id = 2;
@@ -392,8 +417,32 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assert.html.innerEqual(el, '');
     });
 
+    it('stops observing when given a new object with fewer properties', function () {
+      const { assertHtml, component, flush } = createFixture('<el ...item>', {
+        item: { id: 1, class: 'a' } as any,
+      }, [El]);
+
+      assertHtml('<el>1--a</el>');
+      component.item = { id: 2 };
+      flush();
+      // --a is because content binding does not remove the old value
+      // but the next assertion will make sure this is not observed
+      assertHtml('<el>2--a</el>');
+      component.item.class = 'b';
+      flush();
+      assertHtml('<el>2--a</el>');
+    });
+
+    it('ignores usage of $bindables without command', function () {
+      const { assertHtml } = createFixture('<el $bindables="item">', {
+        item: { id: 1, class: 'a' },
+      }, [El]);
+
+      assertHtml('<el>--</el>');
+    });
+
     it('spreads with literal object expression', function () {
-      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...bindables="{ id: item.id, class: item.class }">', {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...$bindables="{ id: item.id, class: item.class }">', {
         items: [
           { id: 1, class: 'a' },
           { id: 2, class: 'b' }
@@ -407,23 +456,8 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
     });
 
-    it('spreads with ... syntax', function () {
-      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...item>', {
-        items: [
-          { id: 1, class: 'a', 'data-id': 'ohh' },
-          { id: 2, class: 'b', 'data-id': 'dataId' }
-        ]
-      }, [El]);
-
-      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
-
-      component.items[0].id = 3;
-      flush();
-      assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
-    });
-
-    it('spreads with ...bindables= syntax', function () {
-      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...bindables="item">', {
+    it('spreads with ...$bindables= syntax', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...$bindables="item">', {
         items: [
           { id: 1, class: 'a' },
           { id: 2, class: 'b' },
@@ -437,8 +471,8 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
     });
 
-    it('spreads with bindables.spread= syntax', function () {
-      const { assertHtml } = createFixture('<el repeat.for="item of items" bindables.spread="item">', {
+    it('spreads with $bindables.spread= syntax', function () {
+      const { assertHtml } = createFixture('<el repeat.for="item of items" $bindables.spread="item">', {
         items: [
           { id: 1, class: 'a' },
           { id: 2, class: 'b' },
@@ -448,9 +482,23 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
     });
 
-    // todo: improve the attr parser to support this
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('spreads with member access expression using shorthand syntax', function () {
+    it('creates binding in the order in the template (before)', function () {
+      const { assertHtml } = createFixture('<el id.bind="3" ...item>', {
+        item: { id: 1, class: 'a' },
+      }, [El]);
+
+      assertHtml('<el>1--a</el>');
+    });
+
+    it('creates binding in the order in the template (after)', function () {
+      const { assertHtml } = createFixture('<el ...item id.bind="3">', {
+        item: { id: 1, class: 'a' },
+      }, [El]);
+
+      assertHtml('<el>3--a</el>');
+    });
+
+    it('spreads with member access expression using shorthand syntax', function () {
       const { assertHtml } = createFixture('<el repeat.for="item of items" ...item.details>', {
         items: [
           { details: { id: 1, class: 'a' } },
@@ -461,7 +509,18 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
     });
 
-    it('works with $attrs', function () {
+    it('spreads with keyed access expression using shorthand syntax', function () {
+      const { assertHtml } = createFixture('<el ...items[0].details>', {
+        items: [
+          { details: { id: 1, class: 'a' } },
+          { details: { id: 2, class: 'b' } },
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el>');
+    });
+
+    it('cannot be transferred by ...$attrs', function () {
       const ElWithAttrs = CustomElement.define({
         name: 'el-with-attrs',
         template: '<el ...$attrs>',
@@ -470,8 +529,37 @@ describe('3-runtime-html/spread.spec.ts', function () {
       });
 
       const { assertHtml } = createFixture('<el-with-attrs ...item>', { item: { id: 1, class: 'a' } }, [El, ElWithAttrs]);
+      assertHtml('<el-with-attrs><el>--</el></el-with-attrs>');
+    });
 
-      assertHtml('<el-with-attrs><el>1--a</el></el-with-attrs>', { compact: true });
+    it('works with $attr when used before ...$attrs on the same element', function () {
+      const ElWithAttrs = CustomElement.define({
+        name: 'el-with-attrs',
+        template: '<el ...item ...$attrs>',
+        capture: true,
+      }, class {
+        item = { id: 4, class: 'b' };
+      });
+
+      const { assertHtml } = createFixture('<el-with-attrs id.bind="item.id">', { item: { id: 1, class: 'a' } }, [El, ElWithAttrs]);
+      // note: it's 1-- not because ...item is used before ...$attrs
+      // but it's actually a limitation, as ...item is processed before ...$attrs
+      assertHtml('<el-with-attrs><el>1--b</el></el-with-attrs>');
+    });
+
+    it('works with $attr when used after $attrs on the same element', function () {
+      const ElWithAttrs = CustomElement.define({
+        name: 'el-with-attrs',
+        template: '<el ...$attrs ...item>',
+        capture: true,
+      }, class {
+        item = { id: 4, class: 'b' };
+      });
+
+      const { assertHtml } = createFixture('<el-with-attrs id.bind="item.id">', { item: { id: 1, class: 'a' } }, [El, ElWithAttrs]);
+      // note: it's not the id from item, but from the transferred ...$attrs instead
+      // this is a limitation as ...item is processed before ...$attrs
+      assertHtml('<el-with-attrs><el>1--b</el></el-with-attrs>');
     });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/spread.spec.ts
@@ -2,251 +2,208 @@ import { Constructable } from '@aurelia/kernel';
 import { BindingMode, CustomAttribute, CustomElement, ICustomElementViewModel, INode } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
-// all the tests are using a common <my-input/> with a spreat on its internal <input/>
 describe('3-runtime-html/spread.spec.ts', function () {
-  const $it = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, false);
-  $it.only = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, true);
-  // eslint-disable-next-line mocha/no-skipped-tests
-  $it.todo = <T>(title: string, _args: ISpreadTestCase<T>) => it.skip(title);
+  // all the tests are using a common <my-input/> with a spreat on its internal <input/>
+  describe('...$attrs', function () {
+    const $it = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, false);
+    $it.only = <T>(title: string, args: ISpreadTestCase<T>) => runTest(title, args, true);
+    // eslint-disable-next-line mocha/no-skipped-tests
+    $it.todo = <T>(title: string, _args: ISpreadTestCase<T>) => it.skip(title);
 
-  $it('works single layer of ...attrs', {
-    template: '<my-input value.bind="message">',
-    component: { message: 'Aurelia' },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-    },
-  });
-
-  $it('preserves attr syntaxes', {
-    template: '<my-input value.bind="message">',
-    component: { message: 'Aurelia' },
-    assertFn: ({ ctx, component, appHost }) => {
-      ctx.type(appHost, 'input', 'hello');
-      assert.strictEqual(component.message, 'hello');
-      component.message = 'Aurelia';
-      ctx.platform.domWriteQueue.flush();
-      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-    },
-  });
-
-  $it('does not throw when capture: false', {
-    template: '<no-capture-input value.bind="message">',
-    component: { message: 'Aurelia' },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, '');
-    },
-  });
-
-  $it('does not throw when there are nothing to capture', {
-    template: '<my-input>',
-    component: { message: 'Aurelia' },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, '');
-    },
-  });
-
-  $it('works with pass-through ...$attrs', {
-    template: '<input-field value.bind="message">',
-    component: { message: 'Aurelia' },
-    registrations: [
-      CustomElement.define({
-        name: 'input-field',
-        template: '<my-input ...$attrs>',
-        capture: true,
-      }),
-    ],
-    assertFn: ({ platform, component, appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-      component.message = 'hello';
-      platform.domWriteQueue.flush();
-      assert.strictEqual(appHost.querySelector('input').value, 'hello');
-    },
-  });
-
-  $it('does not capture template controller', {
-    template: '<my-input value.bind="message" if.bind="hasInput">',
-    component: { hasInput: false, message: 'Aurelia' },
-    assertFn: ({ appHost }) => {
-      assert.html.innerEqual(appHost, '');
-    },
-  });
-
-  $it('does not apture slot', {
-    template: '<my-input slot="a" value.bind="message">',
-    component: { hasInput: false, message: 'Aurelia' },
-    assertFn: ({ appHost }) => {
-      assert.notEqual(appHost.querySelector('my-input[slot="a"]'), null);
-    },
-  });
-
-  $it('only captures attr based on filter function', {
-    template: '<filter-capture-input class="abc">',
-    component: { message: 'hello' },
-    assertFn: ({ appHost }) => {
-      assert.includes(appHost.querySelector('filter-capture-input').className, 'abc');
-    }
-  });
-
-  // away to support this is to change `.class` binding command to an attr pattern
-  // PART.class pattern -> class.bind="expression ? PART : ''"
-  // this would make it work maybe more consistently with the rest of the class binding
-  // same for style binding command
-  $it.todo('works with binding command that results in filtered out attr', {
-    template: '<filter-capture-input abc.class="hasClass">',
-    component: { hasClass: true },
-    assertFn: ({ appHost }) => {
-      assert.includes(appHost.querySelector('filter-capture-input').className, 'abc');
-    }
-  });
-
-  $it('spreads event bindings', {
-    template: '<my-input value.to-view="message" change.trigger="message = $event.target.value" focus.trigger="focused = true">',
-    component: { message: 'Aurelia', focused: false },
-    assertFn: ({ ctx, component, appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-      ctx.type(appHost, 'input', 'hello');
-      assert.strictEqual(component.message, 'hello');
-      appHost.querySelector('input').dispatchEvent(new ctx.CustomEvent('focus'));
-      assert.strictEqual(component.focused, true);
-    },
-  });
-
-  $it('spreads interpolation', {
-    template: `<my-input value="\${message}">`,
-    component: { message: 'Aurelia', focused: false },
-    assertFn: ({ ctx, component, appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-      ctx.type(appHost, 'input', 'hello');
-      assert.strictEqual(component.message, 'Aurelia');
-    },
-  });
-
-  $it('spreads plain class attribute', {
-    template: '<my-input class="abc">',
-    component: { message: 'Aurelia', focused: false },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').className, 'abc');
-    },
-  });
-
-  $it('spreads plain style attribute', {
-    template: '<my-input style="display: block;">',
-    component: { message: 'Aurelia', focused: false },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').style.display, 'block');
-    },
-  });
-
-  $it('spreads plain attributes', {
-    template: '<my-input size="20" aria-label="input">',
-    component: { message: 'Aurelia', focused: false },
-    assertFn: ({ appHost }) => {
-      assert.strictEqual(appHost.querySelector('input').size, 20);
-      assert.strictEqual(appHost.querySelector('input').getAttribute('aria-label'), 'input');
-    },
-  });
-
-  describe('custom attribute', function () {
-    const MyAttr = CustomAttribute.define({ name: 'my-attr', bindables: ['value'] }, class {
-      public static inject = [INode];
-      public value: any;
-      public constructor(private readonly host: HTMLElement) { }
-      public binding() {
-        this.host.setAttribute('size', this.value);
-      }
+    it('throws when using spread at the root level (no scope)', function () {
+      assert.throws(() => createFixture('<div ...$attrs>'));
     });
 
-    $it('spreads custom attribute (with literal value)', {
-      template: '<my-input my-attr="20">',
-      component: { },
-      registrations: [MyAttr],
-      assertFn: ({ appHost }) => {
-        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
-        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
-      }
-    });
-
-    $it('spreads custom attribute (with interpolation)', {
-      template: `<my-input my-attr="\${size}">`,
-      component: { size: 20 },
-      registrations: [MyAttr],
-      assertFn: ({ appHost }) => {
-        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
-        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
-      }
-    });
-
-    $it('spreads custom attribute (primary binding syntax)', {
-      template: '<my-input my-attr.bind="size">',
-      component: { size: 20 },
-      registrations: [MyAttr],
-      assertFn: ({ appHost }) => {
-        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
-        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
-      }
-    });
-
-    $it('spreads custom attribute (multi binding syntax)', {
-      template: '<my-input my-attr="value.bind: size">',
-      component: { size: 20 },
-      registrations: [MyAttr],
-      assertFn: ({ appHost }) => {
-        assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
-        assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
-      }
-    });
-  });
-
-  describe('custom element', function () {
-    const testElements = [
-      CustomElement.define({
-        name: 'form-field',
-        template: '<form-input ...$attrs>',
-        capture: true,
-      }),
-      CustomElement.define({
-        name: 'form-input',
-        template: '<input value.bind="value">',
-        bindables: {
-          value: { mode: BindingMode.twoWay }
-        }
-      }),
-    ];
-
-    $it('spreads plain binding to custom element bindable', {
-      template: '<form-field value="Aurelia">',
-      component: {},
-      registrations: testElements,
-      assertFn: ({ appHost }) => {
-        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
-        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
-      },
-    });
-
-    $it('spreads binding to custom element bindables', {
-      template: '<form-field value.bind="message">',
+    $it('works single layer of ...attrs', {
+      template: '<my-input value.bind="message">',
       component: { message: 'Aurelia' },
-      registrations: testElements,
       assertFn: ({ appHost }) => {
-        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
         assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
       },
     });
 
-    $it('spreads interpolation to custom element bindables', {
-      template: `<form-field value="\${message}">`,
+    $it('preserves attr syntaxes', {
+      template: '<my-input value.bind="message">',
       component: { message: 'Aurelia' },
-      registrations: testElements,
-      assertFn: ({ appHost }) => {
-        assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+      assertFn: ({ ctx, component, appHost }) => {
+        ctx.type(appHost, 'input', 'hello');
+        assert.strictEqual(component.message, 'hello');
+        component.message = 'Aurelia';
+        ctx.platform.domWriteQueue.flush();
         assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
       },
     });
 
-    $it('spreads shorthand element bindable props', {
-      template: '<form-field prop1.bind prop2.one-time prop3.to-view prop4.from-view>',
-      component: { prop1: 'prop 1', prop2: 'prop 2', prop3: 'prop 3', prop4: 'prop 4' },
+    $it('does not throw when capture: false', {
+      template: '<no-capture-input value.bind="message">',
+      component: { message: 'Aurelia' },
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').value, '');
+      },
+    });
+
+    $it('does not throw when there are nothing to capture', {
+      template: '<my-input>',
+      component: { message: 'Aurelia' },
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').value, '');
+      },
+    });
+
+    $it('works with pass-through ...$attrs', {
+      template: '<input-field value.bind="message">',
+      component: { message: 'Aurelia' },
       registrations: [
+        CustomElement.define({
+          name: 'input-field',
+          template: '<my-input ...$attrs>',
+          capture: true,
+        }),
+      ],
+      assertFn: ({ platform, component, appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        component.message = 'hello';
+        platform.domWriteQueue.flush();
+        assert.strictEqual(appHost.querySelector('input').value, 'hello');
+      },
+    });
+
+    $it('does not capture template controller', {
+      template: '<my-input value.bind="message" if.bind="hasInput">',
+      component: { hasInput: false, message: 'Aurelia' },
+      assertFn: ({ appHost }) => {
+        assert.html.innerEqual(appHost, '');
+      },
+    });
+
+    $it('does not apture slot', {
+      template: '<my-input slot="a" value.bind="message">',
+      component: { hasInput: false, message: 'Aurelia' },
+      assertFn: ({ appHost }) => {
+        assert.notEqual(appHost.querySelector('my-input[slot="a"]'), null);
+      },
+    });
+
+    $it('only captures attr based on filter function', {
+      template: '<filter-capture-input class="abc">',
+      component: { message: 'hello' },
+      assertFn: ({ appHost }) => {
+        assert.includes(appHost.querySelector('filter-capture-input').className, 'abc');
+      }
+    });
+
+    // away to support this is to change `.class` binding command to an attr pattern
+    // PART.class pattern -> class.bind="expression ? PART : ''"
+    // this would make it work maybe more consistently with the rest of the class binding
+    // same for style binding command
+    $it.todo('works with binding command that results in filtered out attr', {
+      template: '<filter-capture-input abc.class="hasClass">',
+      component: { hasClass: true },
+      assertFn: ({ appHost }) => {
+        assert.includes(appHost.querySelector('filter-capture-input').className, 'abc');
+      }
+    });
+
+    $it('spreads event bindings', {
+      template: '<my-input value.to-view="message" change.trigger="message = $event.target.value" focus.trigger="focused = true">',
+      component: { message: 'Aurelia', focused: false },
+      assertFn: ({ ctx, component, appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        ctx.type(appHost, 'input', 'hello');
+        assert.strictEqual(component.message, 'hello');
+        appHost.querySelector('input').dispatchEvent(new ctx.CustomEvent('focus'));
+        assert.strictEqual(component.focused, true);
+      },
+    });
+
+    $it('spreads interpolation', {
+      template: `<my-input value="\${message}">`,
+      component: { message: 'Aurelia', focused: false },
+      assertFn: ({ ctx, component, appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        ctx.type(appHost, 'input', 'hello');
+        assert.strictEqual(component.message, 'Aurelia');
+      },
+    });
+
+    $it('spreads plain class attribute', {
+      template: '<my-input class="abc">',
+      component: { message: 'Aurelia', focused: false },
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').className, 'abc');
+      },
+    });
+
+    $it('spreads plain style attribute', {
+      template: '<my-input style="display: block;">',
+      component: { message: 'Aurelia', focused: false },
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').style.display, 'block');
+      },
+    });
+
+    $it('spreads plain attributes', {
+      template: '<my-input size="20" aria-label="input">',
+      component: { message: 'Aurelia', focused: false },
+      assertFn: ({ appHost }) => {
+        assert.strictEqual(appHost.querySelector('input').size, 20);
+        assert.strictEqual(appHost.querySelector('input').getAttribute('aria-label'), 'input');
+      },
+    });
+
+    describe('custom attribute', function () {
+      const MyAttr = CustomAttribute.define({ name: 'my-attr', bindables: ['value'] }, class {
+        public static inject = [INode];
+        public value: any;
+        public constructor(private readonly host: HTMLElement) { }
+        public binding() {
+          this.host.setAttribute('size', this.value);
+        }
+      });
+
+      $it('spreads custom attribute (with literal value)', {
+        template: '<my-input my-attr="20">',
+        component: { },
+        registrations: [MyAttr],
+        assertFn: ({ appHost }) => {
+          assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+          assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+        }
+      });
+
+      $it('spreads custom attribute (with interpolation)', {
+        template: `<my-input my-attr="\${size}">`,
+        component: { size: 20 },
+        registrations: [MyAttr],
+        assertFn: ({ appHost }) => {
+          assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+          assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+        }
+      });
+
+      $it('spreads custom attribute (primary binding syntax)', {
+        template: '<my-input my-attr.bind="size">',
+        component: { size: 20 },
+        registrations: [MyAttr],
+        assertFn: ({ appHost }) => {
+          assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+          assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+        }
+      });
+
+      $it('spreads custom attribute (multi binding syntax)', {
+        template: '<my-input my-attr="value.bind: size">',
+        component: { size: 20 },
+        registrations: [MyAttr],
+        assertFn: ({ appHost }) => {
+          assert.strictEqual(appHost.querySelector('input').getAttribute('size'), '20');
+          assert.strictEqual(appHost.querySelector('my-input').getAttribute('size'), null);
+        }
+      });
+    });
+
+    describe('custom element', function () {
+      const testElements = [
         CustomElement.define({
           name: 'form-field',
           template: '<form-input ...$attrs>',
@@ -254,63 +211,225 @@ describe('3-runtime-html/spread.spec.ts', function () {
         }),
         CustomElement.define({
           name: 'form-input',
-          template: '<input value.bind="prop1">',
-          bindables: ['prop1', 'prop2', 'prop3', 'prop4']
+          template: '<input value.bind="value">',
+          bindables: {
+            value: { mode: BindingMode.twoWay }
+          }
         }),
-      ],
-      assertFn: ({ component, appHost }) => {
-        const formInput = CustomElement.for(appHost.querySelector('form-input')).viewModel as typeof component;
-        assert.strictEqual(formInput.prop1, 'prop 1');
-        assert.strictEqual(formInput.prop2, 'prop 2');
-        assert.strictEqual(formInput.prop3, 'prop 3');
-        assert.strictEqual(formInput.prop4, undefined);
-        formInput.prop4 = 'prop 5';
-        assert.strictEqual(component.prop4, 'prop 5');
-      },
+      ];
+
+      $it('spreads plain binding to custom element bindable', {
+        template: '<form-field value="Aurelia">',
+        component: {},
+        registrations: testElements,
+        assertFn: ({ appHost }) => {
+          assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+          assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        },
+      });
+
+      $it('spreads binding to custom element bindables', {
+        template: '<form-field value.bind="message">',
+        component: { message: 'Aurelia' },
+        registrations: testElements,
+        assertFn: ({ appHost }) => {
+          assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+          assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        },
+      });
+
+      $it('spreads interpolation to custom element bindables', {
+        template: `<form-field value="\${message}">`,
+        component: { message: 'Aurelia' },
+        registrations: testElements,
+        assertFn: ({ appHost }) => {
+          assert.notStrictEqual((appHost.querySelector('form-input') as any).value, 'Aurelia');
+          assert.strictEqual(appHost.querySelector('input').value, 'Aurelia');
+        },
+      });
+
+      $it('spreads shorthand element bindable props', {
+        template: '<form-field prop1.bind prop2.one-time prop3.to-view prop4.from-view>',
+        component: { prop1: 'prop 1', prop2: 'prop 2', prop3: 'prop 3', prop4: 'prop 4' },
+        registrations: [
+          CustomElement.define({
+            name: 'form-field',
+            template: '<form-input ...$attrs>',
+            capture: true,
+          }),
+          CustomElement.define({
+            name: 'form-input',
+            template: '<input value.bind="prop1">',
+            bindables: ['prop1', 'prop2', 'prop3', 'prop4']
+          }),
+        ],
+        assertFn: ({ component, appHost }) => {
+          const formInput = CustomElement.for(appHost.querySelector('form-input')).viewModel as typeof component;
+          assert.strictEqual(formInput.prop1, 'prop 1');
+          assert.strictEqual(formInput.prop2, 'prop 2');
+          assert.strictEqual(formInput.prop3, 'prop 3');
+          assert.strictEqual(formInput.prop4, undefined);
+          formInput.prop4 = 'prop 5';
+          assert.strictEqual(component.prop4, 'prop 5');
+        },
+      });
     });
+
+    function runTest<T>(title: string, { template, assertFn, component, registrations }: ISpreadTestCase<T>, only?: boolean) {
+      return (only ? it.only : it)(title, async function () {
+        const fixture = createFixture(
+          template,
+          (typeof component === 'object'
+            ? class { public constructor() { Object.assign(this, component); } }
+            : component
+          ) as Constructable<T extends Constructable<infer O> ? Constructable<O> : Constructable<T>>,
+          [
+            ...(registrations ?? []),
+            CustomElement.define({
+              name: 'my-input',
+              template: '<input ...$attrs>',
+              capture: true,
+            }, class MyInput { }),
+            CustomElement.define({
+              name: 'no-capture-input',
+              template: '<input ...$attrs>',
+              capture: false,
+            }, class NoCaptureInput { }),
+            CustomElement.define({
+              name: 'filter-capture-input',
+              template: '<input ...$attrs>',
+              capture: (attr) => attr !== 'class'
+            }, class FilterCaptureInput {}),
+          ],
+        );
+        const { startPromise, tearDown } = fixture;
+
+        await startPromise;
+
+        await assertFn(fixture as any);
+
+        await tearDown();
+      });
+    }
+    interface ISpreadTestCase<T> {
+      component: Constructable<T> | T;
+      template: string;
+      registrations?: any[];
+      assertFn(arg: ReturnType<typeof createFixture> & { component: ICustomElementViewModel & T }): void | Promise<void>;
+    }
   });
 
-  function runTest<T>(title: string, { template, assertFn, component, registrations }: ISpreadTestCase<T>, only?: boolean) {
-    return (only ? it.only : it)(title, async function () {
-      const fixture = createFixture(
-        template,
-        (typeof component === 'object'
-          ? class { public constructor() { Object.assign(this, component); } }
-          : component
-        ) as Constructable<T extends Constructable<infer O> ? Constructable<O> : Constructable<T>>,
-        [
-          ...(registrations ?? []),
-          CustomElement.define({
-            name: 'my-input',
-            template: '<input ...$attrs>',
-            capture: true,
-          }, class MyInput { }),
-          CustomElement.define({
-            name: 'no-capture-input',
-            template: '<input ...$attrs>',
-            capture: false,
-          }, class NoCaptureInput { }),
-          CustomElement.define({
-            name: 'filter-capture-input',
-            template: '<input ...$attrs>',
-            capture: (attr) => attr !== 'class'
-          }, class FilterCaptureInput {}),
-        ],
-      );
-      const { startPromise, tearDown } = fixture;
-
-      await startPromise;
-
-      await assertFn(fixture as any);
-
-      await tearDown();
+  describe('...[any]', function () {
+    const El = CustomElement.define({
+      name: 'el',
+      template: '${id}--${class}',
+      bindables: ['id', 'class'],
     });
-  }
 
-  interface ISpreadTestCase<T> {
-    component: Constructable<T> | T;
-    template: string;
-    registrations?: any[];
-    assertFn(arg: ReturnType<typeof createFixture> & { component: ICustomElementViewModel & T }): void | Promise<void>;
-  }
+    it('throws when trying to using invalid spread', function () {
+      assert.throws(() => createFixture('<div ...bindables="">'));
+      assert.throws(() => createFixture('<div bindables.spread="">'));
+      assert.throws(() => createFixture('<div ...element="">'));
+      assert.throws(() => createFixture('<div element.spread="">'));
+    });
+
+    it('does not create more binding than what is available in the object', function () {
+      const { assertHtml, component, flush } = createFixture('<el ...bindables="item">', {
+        item: { id: 1 } as any,
+      }, [El]);
+
+      assertHtml('<el>1--</el>', { compact: true });
+
+      component.item.class = 'a';
+      flush();
+      assertHtml('<el>1--</el>', { compact: true });
+
+      component.item = { id: 1, class: 'a' };
+      assertHtml('<el>1--</el>', { compact: true });
+      flush();
+      assertHtml('<el>1--a</el>', { compact: true });
+    });
+
+    it('stops observing when unbound', function () {
+      const { assertHtml, component, stop, flush, getBy } = createFixture('<el ...bindables="item">', {
+        item: { id: 1 } as any,
+      }, [El]);
+
+      assertHtml('<el>1--</el>', { compact: true });
+      const el = getBy('el');
+      void stop();
+      component.item.id = 2;
+      flush();
+      assert.html.innerEqual(el, '');
+    });
+
+    it('spreads with literal object expression', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...bindables="{ id: item.id, class: item.class }">', {
+        items: [
+          { id: 1, class: 'a' },
+          { id: 2, class: 'b' }
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+
+      component.items[0].id = 3;
+      flush();
+      assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
+    });
+
+    it('spreads with ... syntax', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...item>', {
+        items: [
+          { id: 1, class: 'a', 'data-id': 'ohh' },
+          { id: 2, class: 'b', 'data-id': 'dataId' }
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+
+      component.items[0].id = 3;
+      flush();
+      assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
+    });
+
+    it('spreads with ...bindables= syntax', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...bindables="item">', {
+        items: [
+          { id: 1, class: 'a' },
+          { id: 2, class: 'b' },
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+
+      component.items[0].id = 3;
+      flush();
+      assertHtml('<el>3--a</el><el>2--b</el>', { compact: true });
+    });
+
+    it('spreads with bindables.spread= syntax', function () {
+      const { assertHtml } = createFixture('<el repeat.for="item of items" bindables.spread="item">', {
+        items: [
+          { id: 1, class: 'a' },
+          { id: 2, class: 'b' },
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+    });
+
+    it('works with $attrs', function () {
+      const ElWithAttrs = CustomElement.define({
+        name: 'el-with-attrs',
+        template: '<el ...$attrs>',
+        bindables: ['id', 'class'],
+        capture: true,
+      });
+
+      const { assertHtml } = createFixture('<el-with-attrs ...item>', { item: { id: 1, class: 'a' } }, [El, ElWithAttrs]);
+
+      assertHtml('<el-with-attrs><el>1--a</el></el-with-attrs>', { compact: true });
+    });
+  });
 });

--- a/packages/__tests__/src/3-runtime-html/spread.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/spread.spec.ts
@@ -333,6 +333,35 @@ describe('3-runtime-html/spread.spec.ts', function () {
       assert.throws(() => createFixture('<div element.spread="">'));
     });
 
+    it('does not affect non bindable properties', function () {
+      const { assertHtml, component, flush } = createFixture('<el repeat.for="item of items" ...item>', {
+        items: [
+          { id: 1, class: 'a', prop: 'alien' },
+          { id: 2, class: 'b', prop: 'alien' },
+        ]
+      }, [CustomElement.define({ name: 'el', template: '${id}--${class}--${prop}', bindables: ['id', 'class'] }, class { prop = '1'; })]);
+
+      assertHtml('<el>1--a--1</el><el>2--b--1</el>', { compact: true });
+
+      component.items[0].id = 3;
+      flush();
+      assertHtml('<el>3--a--1</el><el>2--b--1</el>', { compact: true });
+    });
+
+    it('does not try to match attribute config of a bindable', function () {
+      const { assertHtml } = createFixture('<el repeat.for="item of items" ...item>', {
+        items: [
+          { 'my-id': 1, class: 'a' },
+          { 'my-id': 2, class: 'b' },
+        ]
+      }, [CustomElement.define({
+        name: 'el',
+        template: '${id}--${class}',
+        bindables: [ { name: 'id', attribute: 'my-id' }, 'class'] })]);
+
+      assertHtml('<el>--a</el><el>--b</el>', { compact: true });
+    });
+
     it('does not create more binding than what is available in the object', function () {
       const { assertHtml, component, flush } = createFixture('<el ...bindables="item">', {
         item: { id: 1 } as any,
@@ -413,6 +442,19 @@ describe('3-runtime-html/spread.spec.ts', function () {
         items: [
           { id: 1, class: 'a' },
           { id: 2, class: 'b' },
+        ]
+      }, [El]);
+
+      assertHtml('<el>1--a</el><el>2--b</el>', { compact: true });
+    });
+
+    // todo: improve the attr parser to support this
+    // eslint-disable-next-line mocha/no-skipped-tests
+    it.skip('spreads with member access expression using shorthand syntax', function () {
+      const { assertHtml } = createFixture('<el repeat.for="item of items" ...item.details>', {
+        items: [
+          { details: { id: 1, class: 'a' } },
+          { details: { id: 2, class: 'b' } },
         ]
       }, [El]);
 

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -191,7 +191,6 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
 
           it('does not create a prop binding when attribute value is an empty string', function () {
             const { instructions, surrogates } = compileWith(`<template foo>hello</template>`);
-            console.log(surrogates);
             verifyInstructions(instructions, [], 'normal');
             verifyInstructions(surrogates, [
               { toVerify: ['type', 'to', 'res', 'props'], type: TT.hydrateAttribute, res: 'foo', props: [] }
@@ -1596,7 +1595,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
 
         assert.deepStrictEqual(
           (definition.instructions[0][0] as any).captures,
-          [new AttrSyntax('...$attrs', '', '$attrs', 'spread')]
+          [new AttrSyntax('...$attrs', '', '...$attrs', null)]
         );
       });
 
@@ -1618,8 +1617,16 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         sut.resolveResources = false;
         const definition = sut.compile({ name: 'rando', template: '<my-element ...item>' }, container);
         verifyBindingInstructionsEqual(definition.instructions[0], [
-          new HydrateElementInstruction('my-element', [], null, false, [], {}),
-          new SpreadValueBindingInstruction('bindables', 'item')
+          new HydrateElementInstruction('my-element', [new SpreadValueBindingInstruction('$bindables', 'item')], null, false, [], {}),
+        ]);
+      });
+
+      it('compiles shorthand $bindables syntax', function () {
+        const { sut, container } = createFixture(TestContext.create(), CustomElement.define({ name: 'my-element', bindables: ['item'] }));
+        sut.resolveResources = false;
+        const definition = sut.compile({ name: 'rando', template: '<my-element ...$bindables="item">' }, container);
+        verifyBindingInstructionsEqual(definition.instructions[0], [
+          new HydrateElementInstruction('my-element', [new SpreadValueBindingInstruction('$bindables', 'item')], null, false, [], {}),
         ]);
       });
     });

--- a/packages/__tests__/src/state/state.spec.ts
+++ b/packages/__tests__/src/state/state.spec.ts
@@ -25,6 +25,16 @@ describe('state/state.spec.ts', function () {
     assert.strictEqual(getBy('input').value, '123');
   });
 
+  it('understands shorthand syntax', function () {
+    const state = { value: '1' };
+    const { assertValue } = createFixture
+      .html`<input value.state>`
+      .deps(StateDefaultConfiguration.init(state))
+      .build();
+
+    assertValue('input', '1');
+  });
+
   it('works with value converter', async function () {
     const state = { text: 'aaa' };
     const { getBy } = await createFixture

--- a/packages/__tests__/tsc.dev.cjs
+++ b/packages/__tests__/tsc.dev.cjs
@@ -13,6 +13,7 @@ const config = {
     tsBuildInfoFile: null,
   },
   include: [
+    'assets-modules.d.ts',
     'src/*.ts',
     ...testPatterns.flatMap(pattern => {
       pattern = pattern.replace(/\.ts$/, '');

--- a/packages/rollup-utils.mjs
+++ b/packages/rollup-utils.mjs
@@ -142,10 +142,10 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
   // @ts-ignore
   const isDevMode = /^true$/.test(process.env.DEV_MODE);
   const inputFile = 'src/index.ts';
-  const esmDevDist = 'dist/esm/index.dev.mjs';
-  const cjsDevDist = 'dist/cjs/index.dev.cjs';
-  const esmDist = 'dist/esm/index.mjs';
-  const cjsDist = 'dist/cjs/index.cjs';
+  // const esmDevDist = 'dist/esm/index.dev.mjs';
+  // const cjsDevDist = 'dist/cjs/index.dev.cjs';
+  // const esmDist = 'dist/esm/index.mjs';
+  // const cjsDist = 'dist/cjs/index.cjs';
   // const typingsDist = 'dist/types/index.d.ts';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
@@ -160,12 +160,16 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     external: Object.keys(pkg.dependencies),
     output: [
       {
-        file: esmDevDist,
+        dir: 'dist',
+        entryFileNames: 'esm/index.dev.mjs',
+        // file: esmDevDist,
         format: 'es',
         sourcemap: isDevMode ? 'inline' : true,
       },
       {
-        file: cjsDevDist,
+        dir: 'dist',
+        entryFileNames: 'cjs/index.dev.cjs',
+        // file: cjsDevDist,
         format: 'cjs',
         sourcemap: isDevMode ? 'inline' : true,
         esModule: true,
@@ -201,7 +205,9 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
     external: Object.keys(pkg.dependencies),
     output: [
       {
-        file: esmDist,
+        dir: 'dist',
+        entryFileNames: 'esm/index.mjs',
+        // file: esmDist,
         format: 'es',
         sourcemap: isDevMode ? 'inline' : true,
         plugins: isDevMode
@@ -211,7 +217,9 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
           ],
       },
       {
-        file: cjsDist,
+        dir: 'dist',
+        entryFileNames: 'cjs/index.cjs',
+        // file: cjsDist,
         format: 'cjs',
         sourcemap: isDevMode ? 'inline' : true,
         externalLiveBindings: false,
@@ -234,14 +242,20 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
             define: { ...envVars, __DEV__: 'false' },
             sourceMap: true,
           }),
+          runPostbuildScript(...postBuildScript)
         ]
         : [
           rollupReplace({ ...envVars, __DEV__: false }),
-          rollupTypeScript({}, isDevMode),
+          rollupTypeScript({
+            compilerOptions: {
+              declaration: true,
+              declarationDir: 'dist/types',
+              declarationMap: true,
+            },
+          }, isDevMode),
           stripInternalConstEnum(),
         ]
       ),
-      runPostbuildScript(...postBuildScript),
       generateNativeModulePlugin(cwd, 'index.mjs', isReleaseBuild),
     ],
     onwarn: onWarn,

--- a/packages/rollup-utils.mjs
+++ b/packages/rollup-utils.mjs
@@ -142,11 +142,6 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
   // @ts-ignore
   const isDevMode = /^true$/.test(process.env.DEV_MODE);
   const inputFile = 'src/index.ts';
-  // const esmDevDist = 'dist/esm/index.dev.mjs';
-  // const cjsDevDist = 'dist/cjs/index.dev.cjs';
-  // const esmDist = 'dist/esm/index.mjs';
-  // const cjsDist = 'dist/cjs/index.cjs';
-  // const typingsDist = 'dist/types/index.d.ts';
   /** @type {import('rollup').WarningHandlerWithDefault} */
   const onWarn = (warning, warn) => {
     if (warning.code === 'CIRCULAR_DEPENDENCY' || warning.code === 'MIXED_EXPORTS') return;
@@ -162,14 +157,12 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
       {
         dir: 'dist',
         entryFileNames: 'esm/index.dev.mjs',
-        // file: esmDevDist,
         format: 'es',
         sourcemap: isDevMode ? 'inline' : true,
       },
       {
         dir: 'dist',
         entryFileNames: 'cjs/index.dev.cjs',
-        // file: cjsDevDist,
         format: 'cjs',
         sourcemap: isDevMode ? 'inline' : true,
         esModule: true,
@@ -207,7 +200,6 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
       {
         dir: 'dist',
         entryFileNames: 'esm/index.mjs',
-        // file: esmDist,
         format: 'es',
         sourcemap: isDevMode ? 'inline' : true,
         plugins: isDevMode
@@ -219,7 +211,6 @@ export function getRollupConfig(pkg, configure = identity, configureTerser, post
       {
         dir: 'dist',
         entryFileNames: 'cjs/index.cjs',
-        // file: cjsDist,
         format: 'cjs',
         sourcemap: isDevMode ? 'inline' : true,
         externalLiveBindings: false,

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -294,8 +294,7 @@ export const mixingBindingLimited = /*@__PURE__*/ (() => {
   };
 })();
 
-export const createPrototypeMixer = (() => {
-  const mixed = new WeakSet<Constructable<IBinding>>();
+export const createPrototypeMixer = ((mixed = new WeakSet<Constructable<IBinding>>()) => {
   return (mixer: () => void) => {
     return function<T extends Constructable<IBinding>>(this: T) {
       if (!mixed.has(this)) {

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -114,7 +114,7 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
 
   public handleChange(): void {
     if (!this.isBound) {
-      /* istanbul-ignore-next */
+      /* istanbul ignore next */
       return;
     }
     this.obs.version++;

--- a/packages/runtime-html/src/binding/spread-binding.ts
+++ b/packages/runtime-html/src/binding/spread-binding.ts
@@ -69,7 +69,7 @@ export class SpreadBinding implements IBinding, IHasController {
       let inst: IInstruction;
       for (inst of instructions) {
         switch (inst.type) {
-          case InstructionType.spreadBinding:
+          case InstructionType.spreadTransferedBinding:
             renderSpreadInstruction(ancestor + 1);
             break;
           case InstructionType.spreadElementProp:
@@ -126,11 +126,11 @@ export class SpreadBinding implements IBinding, IHasController {
   public bind(_scope: Scope): void {
     /* istanbul ignore if */
     if (this.isBound) {
+      /* istanbul ignore next */
       return;
     }
     this.isBound = true;
     const innerScope = this.scope = this._hydrationContext.controller.scope.parent ?? void 0;
-    /* istanbul ignore if */
     if (innerScope == null) {
       throw createMappedError(ErrorNames.no_spread_scope_context_found);
     }
@@ -231,6 +231,7 @@ export class SpreadValueBinding implements IBinding {
   public handleChange(): void {
       /* istanbul ignore if */
     if (!this.isBound) {
+      /* istanbul ignore next */
       return;
     }
     this.updateTarget();
@@ -239,6 +240,7 @@ export class SpreadValueBinding implements IBinding {
   public handleCollectionChange(): void {
       /* istanbul ignore if */
     if (!this.isBound) {
+      /* istanbul ignore next */
       return;
     }
     this.updateTarget();
@@ -247,7 +249,9 @@ export class SpreadValueBinding implements IBinding {
   public bind(scope: Scope) {
       /* istanbul ignore if */
     if (this.isBound) {
+      /* istanbul ignore if */
       if (scope === this._scope) {
+      /* istanbul ignore next */
         return;
       }
     }
@@ -264,6 +268,7 @@ export class SpreadValueBinding implements IBinding {
   public unbind(): void {
       /* istanbul ignore if */
     if (!this.isBound) {
+      /* istanbul ignore next */
       return;
     }
     this.isBound = false;

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -40,6 +40,7 @@ import {
   SetClassAttributeRenderer,
   SetStyleAttributeRenderer,
   SpreadRenderer,
+  SpreadValueRenderer,
 } from './renderer';
 import {
   FromViewBindingBehavior,
@@ -212,6 +213,7 @@ export const DefaultRenderers = [
   StylePropertyBindingRenderer,
   TextBindingRenderer,
   SpreadRenderer,
+  SpreadValueRenderer,
 ];
 
 export const StandardConfiguration = /*@__PURE__*/createConfiguration(noop);

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -3,7 +3,6 @@ import { DirtyChecker, ICoercionConfiguration } from '@aurelia/runtime';
 import {
   AtPrefixedTriggerAttributePattern,
   ColonPrefixedBindAttributePattern,
-  SpreadAttributePattern,
   DotSeparatedAttributePattern,
   RefAttributePattern,
   EventAttributePattern,
@@ -20,7 +19,7 @@ import {
   RefBindingCommand,
   StyleBindingCommand,
   TriggerBindingCommand,
-  SpreadBindingCommand,
+  SpreadValueBindingCommand,
 } from '@aurelia/template-compiler';
 import {
   CustomAttributeRenderer,
@@ -99,7 +98,6 @@ export const DefaultComponents = [
 export const DefaultBindingSyntax = [
   RefAttributePattern,
   DotSeparatedAttributePattern,
-  SpreadAttributePattern,
   EventAttributePattern,
   EventModifierRegistration,
 ];
@@ -133,7 +131,7 @@ export const DefaultBindingLanguage = [
   ClassBindingCommand,
   StyleBindingCommand,
   AttrBindingCommand,
-  SpreadBindingCommand,
+  SpreadValueBindingCommand,
 ];
 
 /**

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -54,25 +54,8 @@ export const enum ErrorNames {
   node_observer_mapping_existed = 653,
   select_observer_array_on_non_multi_select = 654,
 
-  compiler_root_is_local = 701,
-  compiler_invalid_surrogate_attr = 702,
-  compiler_no_tc_on_surrogate = 703,
-  compiler_invalid_let_command = 704,
-  compiler_au_slot_on_non_element = 706,
-  compiler_binding_to_non_bindable = 707,
-  compiler_template_only_local_template = 708,
-  compiler_local_el_not_under_root = 709,
-  compiler_local_el_bindable_not_under_root = 710,
-  compiler_local_el_bindable_name_missing = 711,
-  compiler_local_el_bindable_duplicate = 712,
-  compiler_unknown_binding_command = 713,
   compiler_primary_already_existed = 714,
-  compiler_local_name_empty = 715,
-  compiler_duplicate_local_name = 716,
-  compiler_slot_without_shadowdom = 717,
-  compiler_no_spread_tc = 718,
   compiler_attr_mapper_duplicate_mapping = 719,
-
   root_not_found = 767,
   aurelia_instance_existed_in_container = 768,
   invalid_platform_impl = 769,
@@ -109,6 +92,8 @@ export const enum ErrorNames {
   repeat_non_countable = 778,
   repeat_mismatch_length = 814,
 
+  portal_invalid_insert_position = 779,
+
   self_behavior_invalid_usage = 801,
   update_trigger_behavior_no_triggers = 802,
   update_trigger_invalid_usage = 803,
@@ -125,6 +110,9 @@ export const enum ErrorNames {
 
   signal_behavior_invalid_usage = 817,
   signal_behavior_no_signals = 818,
+
+  spreading_bindable_onto_non_component = 819,
+  spreading_invalid_target = 820,
 
   no_spread_scope_context_found = 9999,
   no_spread_template_controller = 9998,
@@ -197,24 +185,8 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.node_observer_mapping_existed]: `Mapping for property {{0}} of <{{1}} /> already exists`,
   [ErrorNames.select_observer_array_on_non_multi_select]: `Array values can only be bound to a multi-select.`,
 
-  [ErrorNames.compiler_root_is_local]: `Template compilation error in element "{{0:name}}": the root <template> cannot be a local element template.`,
-  [ErrorNames.compiler_invalid_surrogate_attr]: `Template compilation error: attribute "{{0}}" is invalid on element surrogate.`,
-  [ErrorNames.compiler_no_tc_on_surrogate]: `Template compilation error: template controller "{{0}}" is invalid on element surrogate.`,
-  [ErrorNames.compiler_invalid_let_command]: `Template compilation error: Invalid command "{{0:.command}}" for <let>. Only to-view/bind supported.`,
-  [ErrorNames.compiler_au_slot_on_non_element]: `Template compilation error: detected projection with [au-slot="{{0}}"] attempted on a non custom element {{1}}.`,
-  [ErrorNames.compiler_binding_to_non_bindable]: `Template compilation error: creating binding to non-bindable property {{0}} on {{1}}.`,
-  [ErrorNames.compiler_template_only_local_template]: `Template compilation error: the custom element "{{0}}" does not have any content other than local template(s).`,
-  [ErrorNames.compiler_local_el_not_under_root]: `Template compilation error: local element template needs to be defined directly under root of element "{{0}}".`,
-  [ErrorNames.compiler_local_el_bindable_not_under_root]: `Template compilation error: bindable properties of local element "{{0}}" template needs to be defined directly under <template>.`,
-  [ErrorNames.compiler_local_el_bindable_name_missing]: `Template compilation error: the attribute 'property' is missing in {{0:outerHTML}} in local element "{{1}}"`,
-  [ErrorNames.compiler_local_el_bindable_duplicate]: `Template compilation error: Bindable property and attribute needs to be unique; found property: {{0}}, attribute: {{1}}`,
-  [ErrorNames.compiler_unknown_binding_command]: `Template compilation error: unknown binding command: "{{0}}".{{0:bindingCommandHelp}}`,
   [ErrorNames.compiler_primary_already_existed]: `Template compilation error: primary already exists on element/attribute "{{0}}"`,
-  [ErrorNames.compiler_local_name_empty]: `Template compilation error: the value of "as-custom-element" attribute cannot be empty for local element in element "{{0}}"`,
-  [ErrorNames.compiler_duplicate_local_name]: `Template compilation error: duplicate definition of the local template named "{{0}} in element {{1}}"`,
-  [ErrorNames.compiler_slot_without_shadowdom]: `Template compilation error: detected a usage of "<slot>" element without specifying shadow DOM options in element: {{0}}`,
   [ErrorNames.compiler_attr_mapper_duplicate_mapping]: `Attribute {{0}} has been already registered for {{1:element}}`,
-  [ErrorNames.compiler_no_spread_tc]: `Spreading template controller "{{0}}" is not supported.`,
 
   [ErrorNames.root_not_found]: `Aurelia.root was accessed without a valid root.`,
   [ErrorNames.aurelia_instance_existed_in_container]: `An instance of Aurelia is already registered with the container or an ancestor of it.`,
@@ -242,6 +214,8 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.repeat_non_countable]: `Unsupported: [repeat] cannot count {{0:toString}}`,
   [ErrorNames.repeat_mismatch_length]: `[repeat] encountered an error: number of views != number of items {{0:join(!=)}}`,
 
+  [ErrorNames.portal_invalid_insert_position]: 'Invalid portal insertion position: {{0}}',
+
   [ErrorNames.self_behavior_invalid_usage]: `"& self" binding behavior only supports listener binding via trigger/capture command.`,
   [ErrorNames.update_trigger_behavior_no_triggers]: `"& updateTrigger" invalid usage. This binding behavior requires at least one event name argument: eg <input value.bind="firstName & updateTrigger:'blur'">`,
   [ErrorNames.update_trigger_invalid_usage]: `"& updateTrigger" invalid usage. This binding behavior can only be applied to two-way/ from-view bindings.`,
@@ -258,6 +232,9 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.switch_no_multiple_default]: `Invalid [default-case] usage. Multiple 'default-case's are not allowed.`,
   [ErrorNames.signal_behavior_invalid_usage]: `"& signal" binding behavior can only be used with bindings that have a "handleChange" method`,
   [ErrorNames.signal_behavior_no_signals]: `"& signal" invalid usage. At least one signal name must be passed to the signal behavior, e.g. "expr & signal:'my-signal'"`,
+
+  [ErrorNames.spreading_bindable_onto_non_component]: 'Spreading to bindables onto non custom element',
+  [ErrorNames.spreading_invalid_target]: `Invalid spread target {{0}}`,
 
   [ErrorNames.no_spread_scope_context_found]: 'No scope context for spread binding.',
   [ErrorNames.no_spread_template_controller]: 'Spread binding does not support spreading custom attributes/template controllers. Did you build the spread instruction manually?',

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -765,7 +765,7 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
     const instructionTarget = instruction.target;
     if (instructionTarget === '$bindables') {
       if ('nodeType' in target) {
-        throw new Error('Spreading to bindables onto non custom element');
+        throw createMappedError(ErrorNames.spreading_bindable_onto_non_component);
       }
       renderingCtrl.addBinding(new SpreadValueBinding(
         renderingCtrl,
@@ -777,7 +777,7 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
         platform.domWriteQueue
       ));
     } else {
-      throw new Error(`Invalid spread target ${instructionTarget}`);
+      throw createMappedError(ErrorNames.spreading_invalid_target, instructionTarget);
     }
   }
 }, null!);

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -38,7 +38,30 @@ import { IAuSlotsInfo, AuSlotsInfo } from './templating/controller.projection';
 import type { IHydratableController } from './templating/controller';
 import { ErrorNames, createMappedError } from './errors';
 import { SpreadBinding, SpreadValueBinding } from './binding/spread-binding';
-import { AttributeBindingInstruction, HydrateAttributeInstruction, HydrateElementInstruction, HydrateLetElementInstruction, HydrateTemplateController, IInstruction, ITemplateCompiler, InstructionType, InterpolationInstruction, IteratorBindingInstruction, LetBindingInstruction, ListenerBindingInstruction, PropertyBindingInstruction, RefBindingInstruction, SetAttributeInstruction, SetClassAttributeInstruction, SetPropertyInstruction, SetStyleAttributeInstruction, SpreadBindingInstruction, SpreadValueBindingInstruction, StylePropertyBindingInstruction, TextBindingInstruction } from '@aurelia/template-compiler';
+import {
+  AttributeBindingInstruction,
+  HydrateAttributeInstruction,
+  HydrateElementInstruction,
+  HydrateLetElementInstruction,
+  HydrateTemplateController,
+  IInstruction,
+  ITemplateCompiler,
+  InstructionType,
+  InterpolationInstruction,
+  IteratorBindingInstruction,
+  LetBindingInstruction,
+  ListenerBindingInstruction,
+  PropertyBindingInstruction,
+  RefBindingInstruction,
+  SetAttributeInstruction,
+  SetClassAttributeInstruction,
+  SetPropertyInstruction,
+  SetStyleAttributeInstruction,
+  SpreadTransferedBindingInstruction,
+  SpreadValueBindingInstruction,
+  StylePropertyBindingInstruction,
+  TextBindingInstruction
+} from '@aurelia/template-compiler';
 
 /**
  * An interface describing an instruction renderer
@@ -706,7 +729,7 @@ export const SpreadRenderer = /*@__PURE__*/ renderer(class SpreadRenderer implem
   public render(
     renderingCtrl: IHydratableController,
     target: HTMLElement,
-    instruction: SpreadBindingInstruction,
+    instruction: SpreadTransferedBindingInstruction,
     platform: IPlatform,
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -756,7 +756,7 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
 
   public render(
     renderingCtrl: IHydratableController,
-    target: ICustomElementController | HTMLElement,
+    target: ICustomElementController,
     instruction: SpreadValueBindingInstruction,
     platform: IPlatform,
     exprParser: IExpressionParser,
@@ -764,9 +764,6 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
   ): void {
     const instructionTarget = instruction.target;
     if (instructionTarget === '$bindables') {
-      if ('nodeType' in target) {
-        throw createMappedError(ErrorNames.spreading_bindable_onto_non_component);
-      }
       renderingCtrl.addBinding(new SpreadValueBinding(
         renderingCtrl,
         target.viewModel,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -724,7 +724,7 @@ export const SpreadRenderer = /*@__PURE__*/ renderer(class SpreadRenderer implem
   /** @internal */ public readonly _compiler = resolve(ITemplateCompiler);
   /** @internal */ public readonly _rendering = resolve(IRendering);
 
-  public readonly target = InstructionType.spreadBinding;
+  public readonly target = InstructionType.spreadTransferedBinding;
 
   public render(
     renderingCtrl: IHydratableController,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -726,9 +726,6 @@ export const SpreadRenderer = /*@__PURE__*/ renderer(class SpreadRenderer implem
 }, null!);
 
 export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRenderer implements IRenderer {
-  /** @internal */ public readonly _compiler = resolve(ITemplateCompiler);
-  /** @internal */ public readonly _rendering = resolve(IRendering);
-
   public readonly target = InstructionType.spreadValueBinding;
   public constructor() {
     SpreadValueBinding.mix();
@@ -736,26 +733,22 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
 
   public render(
     renderingCtrl: IHydratableController,
-    target: HTMLElement,
+    target: ICustomElementController | HTMLElement,
     instruction: SpreadValueBindingInstruction,
     platform: IPlatform,
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
   ): void {
     const instructionTarget = instruction.target;
-    if (instructionTarget === 'bindables') {
-      const targetController = CustomElement.for(target, { optional: true });
-      const isCustomElement = targetController != null;
-
-      if (!isCustomElement) {
-        throw new Error('Spreading to bindables on not a csutom element');
+    if (instructionTarget === '$bindables') {
+      if ('nodeType' in target) {
+        throw new Error('Spreading to bindables onto non custom element');
       }
-
       renderingCtrl.addBinding(new SpreadValueBinding(
         renderingCtrl,
-        targetController.viewModel,
-        Object.keys(targetController.definition.bindables),
-        exprParser.parse(instruction.from, 'IsProperty'),
+        target.viewModel,
+        objectKeys(target.definition.bindables),
+        exprParser.parse(instruction.from, etIsProperty),
         observerLocator,
         renderingCtrl.container,
         platform.domWriteQueue

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -298,7 +298,7 @@ export class Portal implements ICustomAttributeViewModel {
         insertManyBefore(parent, target.nextSibling, nodes);
         break;
       default:
-        throw new Error('Invalid portal insertion position');
+        throw createMappedError(ErrorNames.portal_invalid_insert_position, position);
     }
   }
 

--- a/packages/runtime-html/src/resources/template-controllers/portal.ts
+++ b/packages/runtime-html/src/resources/template-controllers/portal.ts
@@ -297,6 +297,7 @@ export class Portal implements ICustomAttributeViewModel {
       case 'afterend':
         insertManyBefore(parent, target.nextSibling, nodes);
         break;
+      /* istanbul ignore next */
       default:
         throw createMappedError(ErrorNames.portal_invalid_insert_position, position);
     }

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -45,17 +45,13 @@ export class StateBindingCommand implements BindingCommandInstance {
     const attr = info.attr;
     let target = attr.target;
     let value = attr.rawValue;
+    value = value === '' ? camelCase(target) : value;
     if (info.bindable == null) {
       target = attrMapper.map(info.node, target)
         // if the mapper doesn't know how to map it
         // use the default behavior, which is camel-casing
         ?? camelCase(target);
     } else {
-      // if it looks like: <my-el value.bind>
-      // it means        : <my-el value.bind="value">
-      if (value === '' && info.def.type === 'custom-element') {
-        value = camelCase(target);
-      }
       target = info.bindable.name;
     }
     return new StateBindingInstruction(value, target);

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -612,10 +612,27 @@ export const AtPrefixedTriggerAttributePattern = /*@__PURE__*/ AttributePattern.
 );
 
 export const SpreadAttributePattern = /*@__PURE__*/ AttributePattern.define(
-  [{ pattern: '...$attrs', symbols: '' }],
+  [
+    { pattern: '...$attrs', symbols: '' },
+    { pattern: '...PART', symbols: '.' },
+    { pattern: '...bindables', symbols: '' },
+    { pattern: '...element', symbols: '' },
+  ],
   class SpreadAttributePattern {
     public '...$attrs'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, '', '...$attrs');
+      return new AttrSyntax(rawName, rawValue, '$attrs', 'spread');
+    }
+
+    public '...PART'(rawName: string, _rawValue: string, _parts: readonly string[]): AttrSyntax {
+      return new AttrSyntax(rawName, rawName.slice(3), 'bindables', 'spread');
+    }
+
+    public '...bindables'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
+      return new AttrSyntax(rawName, rawValue, 'bindables', 'spread');
+    }
+
+    public '...element'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
+      return new AttrSyntax(rawName, rawValue, 'element', 'spread');
     }
   }
 );

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -611,32 +611,6 @@ export const AtPrefixedTriggerAttributePattern = /*@__PURE__*/ AttributePattern.
   }
 );
 
-export const SpreadAttributePattern = /*@__PURE__*/ AttributePattern.define(
-  [
-    { pattern: '...$attrs', symbols: '' },
-    { pattern: '...PART', symbols: '.' },
-    { pattern: '...bindables', symbols: '' },
-    { pattern: '...element', symbols: '' },
-  ],
-  class SpreadAttributePattern {
-    public '...$attrs'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, '$attrs', 'spread');
-    }
-
-    public '...PART'(rawName: string, _rawValue: string, _parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawName.slice(3), 'bindables', 'spread');
-    }
-
-    public '...bindables'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, 'bindables', 'spread');
-    }
-
-    public '...element'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, 'element', 'spread');
-    }
-  }
-);
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 /* istanbul ignore next */function testAttributePatternDeco() {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/template-compiler/src/binding-command.ts
+++ b/packages/template-compiler/src/binding-command.ts
@@ -9,7 +9,6 @@ import {
   MultiAttrInstruction,
   PropertyBindingInstruction,
   RefBindingInstruction,
-  SpreadBindingInstruction,
   SpreadValueBindingInstruction,
 } from './instructions';
 import { aliasRegistration, etIsFunction, etIsProperty, isString, objectFreeze, singletonRegistration } from './utilities';
@@ -469,19 +468,14 @@ export class RefBindingCommand implements BindingCommandInstance {
   }
 }
 
-export class SpreadBindingCommand implements BindingCommandInstance {
+export class SpreadValueBindingCommand implements BindingCommandInstance {
   public static readonly $au: BindingCommandStaticAuDefinition = {
     type: bindingCommandTypeName,
     name: 'spread',
   };
-  public get ignoreAttr() { return true; }
+  public get ignoreAttr() { return false; }
 
   public build(info: ICommandBuildInfo): IInstruction {
-    const attr = info.attr;
-    if (attr.target === '$attrs') {
-      return new SpreadBindingInstruction();
-    } else {
-      return new SpreadValueBindingInstruction(attr.target, attr.rawValue);
-    }
+    return new SpreadValueBindingInstruction(info.attr.target as '$bindables' | '$element', info.attr.rawValue);
   }
 }

--- a/packages/template-compiler/src/binding-command.ts
+++ b/packages/template-compiler/src/binding-command.ts
@@ -10,6 +10,7 @@ import {
   PropertyBindingInstruction,
   RefBindingInstruction,
   SpreadBindingInstruction,
+  SpreadValueBindingInstruction,
 } from './instructions';
 import { aliasRegistration, etIsFunction, etIsProperty, isString, objectFreeze, singletonRegistration } from './utilities';
 
@@ -471,11 +472,16 @@ export class RefBindingCommand implements BindingCommandInstance {
 export class SpreadBindingCommand implements BindingCommandInstance {
   public static readonly $au: BindingCommandStaticAuDefinition = {
     type: bindingCommandTypeName,
-    name: '...$attrs',
+    name: 'spread',
   };
   public get ignoreAttr() { return true; }
 
-  public build(_info: ICommandBuildInfo): IInstruction {
-    return new SpreadBindingInstruction();
+  public build(info: ICommandBuildInfo): IInstruction {
+    const attr = info.attr;
+    if (attr.target === '$attrs') {
+      return new SpreadBindingInstruction();
+    } else {
+      return new SpreadValueBindingInstruction(attr.target, attr.rawValue);
+    }
   }
 }

--- a/packages/template-compiler/src/errors.ts
+++ b/packages/template-compiler/src/errors.ts
@@ -31,6 +31,9 @@ export const enum ErrorNames {
   compiler_slot_without_shadowdom = 717,
   compiler_no_spread_tc = 718,
   compiler_attr_mapper_duplicate_mapping = 719,
+  compiler_no_reserved_spread_syntax = 720,
+  compiler_no_reserved_$bindable = 721,
+  compiler_no_dom_api = 722,
   no_spread_template_controller = 9998,
 }
 _END_CONST_ENUM();
@@ -56,8 +59,11 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.compiler_local_name_empty]: `Template compilation error: the value of "as-custom-element" attribute cannot be empty for local element in element "{{0}}"`,
   [ErrorNames.compiler_duplicate_local_name]: `Template compilation error: duplicate definition of the local template named "{{0}} in element {{1}}"`,
   [ErrorNames.compiler_slot_without_shadowdom]: `Template compilation error: detected a usage of "<slot>" element without specifying shadow DOM options in element: {{0}}`,
-  [ErrorNames.compiler_attr_mapper_duplicate_mapping]: `Attribute {{0}} has been already registered for {{1:element}}`,
   [ErrorNames.compiler_no_spread_tc]: `Spreading template controller "{{0}}" is not supported.`,
+  [ErrorNames.compiler_attr_mapper_duplicate_mapping]: `Attribute {{0}} has been already registered for {{1:element}}`,
+  [ErrorNames.compiler_no_reserved_spread_syntax]: `Spreading syntax "...xxx" is reserved. Encountered "...{{0}}"`,
+  [ErrorNames.compiler_no_reserved_$bindable]: `Usage of $bindables is only allowed on custom element. Encountered: <{{0}} {{1}}="{{2}}">`,
+  [ErrorNames.compiler_no_dom_api]: 'Invalid platform object provided to the compilation, no DOM API found.',
 
   [ErrorNames.no_spread_template_controller]: 'Spread binding does not support spreading custom attributes/template controllers. Did you build the spread instruction manually?',
 };

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -102,6 +102,7 @@ export {
   SetStyleAttributeInstruction,
   SpreadBindingInstruction,
   SpreadElementPropBindingInstruction,
+  SpreadValueBindingInstruction,
   StylePropertyBindingInstruction,
   TextBindingInstruction
 } from './instructions';

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -34,7 +34,6 @@ export {
   DotSeparatedAttributePattern,
   EventAttributePattern,
   RefAttributePattern,
-  SpreadAttributePattern,
   attributePattern,
 } from './attribute-pattern';
 
@@ -58,7 +57,7 @@ export {
   FromViewBindingCommand,
   OneTimeBindingCommand,
   RefBindingCommand,
-  SpreadBindingCommand,
+  SpreadValueBindingCommand,
   StyleBindingCommand,
   ToViewBindingCommand,
   TriggerBindingCommand,
@@ -75,6 +74,7 @@ export {
   TemplateCompiler,
   TemplateCompilerHooks,
   templateCompilerHooks,
+  generateElementName,
 } from './template-compiler';
 
 export {

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -100,7 +100,7 @@ export {
   SetClassAttributeInstruction,
   SetPropertyInstruction,
   SetStyleAttributeInstruction,
-  SpreadBindingInstruction,
+  SpreadTransferedBindingInstruction,
   SpreadElementPropBindingInstruction,
   SpreadValueBindingInstruction,
   StylePropertyBindingInstruction,

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -278,7 +278,7 @@ export class AttributeBindingInstruction {
   ) {}
 }
 
-export class SpreadBindingInstruction {
+export class SpreadTransferedBindingInstruction {
   public readonly type = spreadBinding;
 }
 

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -297,7 +297,7 @@ export class SpreadElementPropBindingInstruction {
 export class SpreadValueBindingInstruction {
   public readonly type = spreadValueBinding;
   public constructor(
-    public target: string,
+    public target: '$bindables' | '$element',
     public from: string,
   ) {}
 }

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -28,6 +28,7 @@ import { BindingMode } from './binding-mode';
 /** @internal */ export const setStyleAttribute = 'hg';
 /** @internal */ export const spreadBinding = 'hs';
 /** @internal */ export const spreadElementProp = 'hp';
+/** @internal */ export const spreadValueBinding = 'svb';
 
 export const InstructionType = /*@__PURE__*/ objectFreeze({
   hydrateElement,
@@ -50,6 +51,7 @@ export const InstructionType = /*@__PURE__*/ objectFreeze({
   setStyleAttribute,
   spreadBinding,
   spreadElementProp,
+  spreadValueBinding,
 });
 export type InstructionType = typeof InstructionType[keyof typeof InstructionType];
 
@@ -288,6 +290,14 @@ export class SpreadBindingInstruction {
 export class SpreadElementPropBindingInstruction {
   public readonly type = spreadElementProp;
   public constructor(
-    public readonly instructions: IInstruction,
+    public readonly instruction: IInstruction,
+  ) {}
+}
+
+export class SpreadValueBindingInstruction {
+  public readonly type = spreadValueBinding;
+  public constructor(
+    public target: string,
+    public from: string,
   ) {}
 }

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -26,7 +26,7 @@ import { BindingMode } from './binding-mode';
 /** @internal */ export const setAttribute = 'he';
 /** @internal */ export const setClassAttribute = 'hf';
 /** @internal */ export const setStyleAttribute = 'hg';
-/** @internal */ export const spreadBinding = 'hs';
+/** @internal */ export const spreadTransferedBinding = 'hs';
 /** @internal */ export const spreadElementProp = 'hp';
 /** @internal */ export const spreadValueBinding = 'svb';
 
@@ -49,7 +49,7 @@ export const InstructionType = /*@__PURE__*/ objectFreeze({
   setAttribute,
   setClassAttribute,
   setStyleAttribute,
-  spreadBinding,
+  spreadTransferedBinding,
   spreadElementProp,
   spreadValueBinding,
 });
@@ -279,7 +279,7 @@ export class AttributeBindingInstruction {
 }
 
 export class SpreadTransferedBindingInstruction {
-  public readonly type = spreadBinding;
+  public readonly type = spreadTransferedBinding;
 }
 
 /**

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -766,7 +766,7 @@ export class TemplateCompiler implements ITemplateCompiler {
           continue;
         }
 
-        throw new Error(`Spreading syntax "...xxx" is reserved. Encountered "...${realAttrTarget}"`);
+        throw createMappedError(ErrorNames.compiler_no_reserved_spread_syntax, realAttrTarget);
       }
 
       // reaching here means:
@@ -849,7 +849,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       }
 
       if (realAttrTarget === '$bindables') {
-        throw new Error(`Usage of $bindables is only allowed on custom element. Encountered: <${el.nodeName} ${realAttrTarget}="${realAttrValue}">`);
+        throw createMappedError(ErrorNames.compiler_no_reserved_$bindable, el.nodeName, realAttrTarget, realAttrValue);
       }
 
       // reaching here means:
@@ -1745,7 +1745,7 @@ class CompilationContext {
     this._attrMapper = hasParent ? parent._attrMapper : container.get(IAttrMapper);
     this._logger = hasParent ? parent._logger : container.get(ILogger);
     if (typeof (this.p = hasParent ? parent.p : container.get(IPlatform) as unknown as IDomPlatform).document?.nodeType !== 'number') {
-      throw new Error('Invalid platform');
+      throw createMappedError(ErrorNames.compiler_no_dom_api);
     }
     this.localEls = hasParent ? parent.localEls : new Set();
     this.rows = instructions ?? [];

--- a/scripts/generate-tests/template-compiler.mutations.ts
+++ b/scripts/generate-tests/template-compiler.mutations.ts
@@ -23,7 +23,7 @@ import {
 } from './util';
 
 function outFile(suffix: string): string {
-  return join(`${project.path}`, 'packages', 'jit-html', 'test', 'generated', `template-compiler.${suffix}.spec.ts`);
+  return join(`${project.path}`, 'packages', 'jit-html', 'test', 'generated', `${suffix}.spec.ts`);
 }
 
 function $hook(name: string, mutation: Statement | Statement[], flush?: boolean, expectedBeforeFlush?: [any, any], expectedAfterFlush?: [any, any]): MethodDeclaration {
@@ -235,7 +235,7 @@ function generateAndEmit(): void {
       $$import('../util', 'TestContext'),
       null,
       $$functionExpr('describe', [
-        $expression(`generated.template-compiler.${suffix}`),
+        $expression(`${suffix}`),
         $functionExpr([
           $$functionDecl(
             'setup',

--- a/scripts/generate-tests/template-compiler.static.ts
+++ b/scripts/generate-tests/template-compiler.static.ts
@@ -127,7 +127,7 @@ const kebabCase = (function () {
 })();
 
 function outFile(suffix: string): string {
-  return join(`${project.path}`, 'packages', '__tests__', '5-jit-html', 'generated', `template-compiler.${suffix}.spec.ts`);
+  return join(`${project.path}`, 'packages', '__tests__', '5-jit-html', 'generated', `${suffix}.spec.ts`);
 }
 
 interface Identifiable {
@@ -1127,7 +1127,7 @@ function generateAndEmit(): void {
       $$import('@aurelia/testing', 'TestContext', 'writeProfilerReport', 'assert'),
       null,
       $$functionExpr('describe', [
-        $expression(`generated.template-compiler.${suffix}`),
+        $expression(`${suffix}`),
         $functionExpr([
           $$functionExpr('before', [
             $functionExpr([


### PR DESCRIPTION
## 📖 Description

When the number of bindable properties grows bigger, and the binding are repetitive, it's quite a boilerplate having to specify everything, as per the examples in #1477 #1258 :

Desirable:

```html
  <k-button  repeat.for="action of actions" ...action>${action.content}</k-button>
  <k-button  repeat.for="action of actions" ...$bindables="action">${action.content}</k-button>
  <k-button  repeat.for="action of actions" $bindables.spread="action">${action.content}</k-button>
```

Not desirable
```html
  <k-button color.bind="action.color"
            size.bind="action.size"
            type.bind="action.type" 
            repeat.for="action of actions">${action.content}</k-button>  
```

This PR adds support for spread syntaxes:
- full: `$bindables.spread="expression"`
- short: `...$bindables="expression"` 
- shorter: `...expresion`

Note:
- binding created via `$bindables` will have mode `to-view`, ignoring any default mode of the target bindable properties
- If the same object is returned from evaluating the expression, the spread binding won't try to rebind its inner bindings. This means mutating and then reassigning won't result in new binding, instead, give the spread binding a new object.
- fix an issue with spreading `...$attrs` not consider element bindable properties before custom attribute

### 🎫 Issues

Close #1477
Close #1258

cc @fkleuver @Sayan751 @brandonseydel @Vheissu 