### PR TITLE
fix(convention): use array for bindables isntead of object

### DIFF
--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -454,7 +454,7 @@ export const template = "<template ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 let _e;
 export function register(container) {
   if (!_e) {
@@ -483,7 +483,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 let _e;
 export function register(container) {
   if (!_e) {
@@ -512,7 +512,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test","test2"];
 let _e;
 export function register(container) {
@@ -542,7 +542,7 @@ export const template = "<template ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test","test2"];
 let _e;
 export function register(container) {
@@ -572,7 +572,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test","test2","test3","test4"];
 let _e;
 export function register(container) {
@@ -602,7 +602,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test3","test4"];
 let _e;
 export function register(container) {
@@ -632,7 +632,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test","test2"];
 let _e;
 export function register(container) {
@@ -662,7 +662,7 @@ export const template = "<template  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 let _e;
 export function register(container) {
   if (!_e) {
@@ -691,7 +691,7 @@ export const template = "<template id=\\"my-template\\"  ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test3","test4"];
 let _e;
 export function register(container) {
@@ -721,7 +721,7 @@ export const template = "<template id=\\"my-template\\" ></template>";
 export default template;
 export const dependencies = [  ];
 export const containerless = true;
-export const bindables = {"age":{"mode":2},"firstName":{},"lastName":{}};
+export const bindables = [{"name":"age","mode":2},{"name":"firstName"},{"name":"lastName"}];
 export const aliases = ["test3","test4"];
 let _e;
 export function register(container) {

--- a/packages-tooling/plugin-conventions/.eslintrc.cjs
+++ b/packages-tooling/plugin-conventions/.eslintrc.cjs
@@ -16,5 +16,10 @@ module.exports = {
     'import/no-nodejs-modules': 'off',
     '@typescript-eslint/strict-boolean-expressions': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/prefer-nullish-coalescing': ['error', {
+      ignorePrimitives: {
+        boolean: true,
+      }
+    }]
   }
 };

--- a/packages-tooling/plugin-conventions/src/hmr.ts
+++ b/packages-tooling/plugin-conventions/src/hmr.ts
@@ -5,7 +5,8 @@
  * @param moduleText -  Usually module but Vite uses import instead
  * @returns Generated HMR code
  */
-export const getHmrCode = (className: string, moduleText: string = 'module', moduleNames?: string[]): string => {
+export const getHmrCode = (className: string, moduleText?: string, moduleNames?: string[]): string => {
+  moduleText ??= 'module';
 
   const code = `
     import { Metadata as $$M } from '@aurelia/metadata';

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -155,7 +155,9 @@ export const dependencies = [ ${viewDeps.join(', ')} ];
     m.append(`export const capture = true;\n`);
   }
 
-  m.append(`export const bindables = ${(Object.keys(bindables).length > 0 ? JSON.stringify(bindables) : '[]')};\n`);
+  m.append(`export const bindables = ${(Object.keys(bindables).length > 0
+    ? JSON.stringify(Object.keys(bindables).map(b => ({ name: b, ...bindables[b] })))
+    : '[]')};\n`);
 
   if (aliases.length > 0) {
     m.append(`export const aliases = ${JSON.stringify(aliases)};\n`);

--- a/packages-tooling/plugin-conventions/src/preprocess-resource.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-resource.ts
@@ -362,8 +362,7 @@ function captureImport(s: Statement, lib: string, code: string): ICapturedImport
   if (isImportDeclaration(s) &&
     isStringLiteral(s.moduleSpecifier) &&
     s.moduleSpecifier.text === lib &&
-    s.importClause &&
-    s.importClause.namedBindings &&
+    s.importClause?.namedBindings &&
     isNamedImports(s.importClause.namedBindings)) {
     return {
       names: s.importClause.namedBindings.elements.map(e => e.name.text),

--- a/packages-tooling/plugin-conventions/src/strip-meta-data.ts
+++ b/packages-tooling/plugin-conventions/src/strip-meta-data.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from '@aurelia/kernel';
-import { BindingMode, PartialBindableDefinition } from '@aurelia/runtime-html';
+import { type PartialBindableDefinition } from '@aurelia/runtime-html';
 import { DefaultTreeElement, ElementLocation, parseFragment } from 'parse5';
 
 interface IStrippedHtml {
@@ -243,12 +243,22 @@ function stripCapture(node: DefaultTreeElement, cb: (ranges: [number, number][])
   });
 }
 
-function toBindingMode(mode?: string): BindingMode | undefined {
+function toBindingMode(mode?: string): number | undefined {
   if (mode) {
     const normalizedMode = kebabCase(mode);
-    if (normalizedMode === 'one-time') return BindingMode.oneTime;
-    if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return BindingMode.toView;
-    if (normalizedMode === 'from-view') return BindingMode.fromView;
-    if (normalizedMode === 'two-way') return BindingMode.twoWay;
+    if (normalizedMode === 'one-time') return 1;
+    if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return 2;
+    if (normalizedMode === 'from-view') return 4;
+    if (normalizedMode === 'two-way') return 6;
   }
 }
+
+// function toBindingMode(mode?: string): BindingMode | undefined {
+//   if (mode) {
+//     const normalizedMode = kebabCase(mode);
+//     if (normalizedMode === 'one-time') return BindingMode.oneTime;
+//     if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return BindingMode.toView;
+//     if (normalizedMode === 'from-view') return BindingMode.fromView;
+//     if (normalizedMode === 'two-way') return BindingMode.twoWay;
+//   }
+// }

--- a/packages-tooling/plugin-conventions/src/strip-meta-data.ts
+++ b/packages-tooling/plugin-conventions/src/strip-meta-data.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from '@aurelia/kernel';
-import { type PartialBindableDefinition } from '@aurelia/runtime-html';
+import { BindingMode, type PartialBindableDefinition } from '@aurelia/runtime-html';
 import { DefaultTreeElement, ElementLocation, parseFragment } from 'parse5';
 
 interface IStrippedHtml {
@@ -243,22 +243,12 @@ function stripCapture(node: DefaultTreeElement, cb: (ranges: [number, number][])
   });
 }
 
-function toBindingMode(mode?: string): number | undefined {
+function toBindingMode(mode?: string): BindingMode | undefined {
   if (mode) {
     const normalizedMode = kebabCase(mode);
-    if (normalizedMode === 'one-time') return 1;
-    if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return 2;
-    if (normalizedMode === 'from-view') return 4;
-    if (normalizedMode === 'two-way') return 6;
+    if (normalizedMode === 'one-time') return BindingMode.oneTime;
+    if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return BindingMode.toView;
+    if (normalizedMode === 'from-view') return BindingMode.fromView;
+    if (normalizedMode === 'two-way') return BindingMode.twoWay;
   }
 }
-
-// function toBindingMode(mode?: string): BindingMode | undefined {
-//   if (mode) {
-//     const normalizedMode = kebabCase(mode);
-//     if (normalizedMode === 'one-time') return BindingMode.oneTime;
-//     if (normalizedMode === 'one-way' || normalizedMode === 'to-view') return BindingMode.toView;
-//     if (normalizedMode === 'from-view') return BindingMode.fromView;
-//     if (normalizedMode === 'two-way') return BindingMode.twoWay;
-//   }
-// }

--- a/packages/__e2e__/3-hmr-webpack/src/components/my-input.html
+++ b/packages/__e2e__/3-hmr-webpack/src/components/my-input.html
@@ -1,4 +1,5 @@
 <import from="./my-text.html" as="the-text"></import>
+<bindable name="notUsed"></bindable>
 <textarea value.bind="value"></textarea>
 <p>${value}</p>
 <the-text text.bind="value"></the-text>

--- a/packages/__e2e__/3-hmr-webpack/src/resource.d.ts
+++ b/packages/__e2e__/3-hmr-webpack/src/resource.d.ts
@@ -1,9 +1,13 @@
+
 declare module '*.html' {
+  import { PartialBindableDefinition } from '@aurelia/runtime-html';
+
   export const name: string;
   export const template: string;
   export default template;
   export const dependencies: string[];
   export const containerless: boolean | undefined;
+  export const bindables: (string | PartialBindableDefinition & { name: string })[];
   export const shadowOptions: { mode: 'open' | 'closed'} | undefined;
 }
 

--- a/packages/__e2e__/3-hmr-webpack/webpack.config.js
+++ b/packages/__e2e__/3-hmr-webpack/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = function (env, { mode }) {
           {
             loader: 'ts-loader',
             options: {
-              transpileOnly: true
+              transpileOnly: false
             }
           },
           '@aurelia/webpack-loader'

--- a/packages/template-compiler/src/interfaces-template-compiler.ts
+++ b/packages/template-compiler/src/interfaces-template-compiler.ts
@@ -40,7 +40,7 @@ export interface IAttributeComponentDefinition<TBindables extends string = strin
   isTemplateController?: boolean;
   aliases?: readonly string[];
   defaultBindingMode?: StringBindingMode | number;
-  bindables?: (TBindables | IComponentBindablePropDefinition)[] | Record<TBindables, Omit<IComponentBindablePropDefinition, 'name'> | true> | null;
+  bindables?: (TBindables | IComponentBindablePropDefinition)[] | Record<TBindables, Omit<IComponentBindablePropDefinition, 'name'> | true>;
 }
 
 export interface IComponentBindablePropDefinition {


### PR DESCRIPTION
## 📖 Description

In the previous PR at #1960 , because of the presence of `transpileOnly: true` config in our webpack e2e, we accidentally introduced broken bindables code when the html template of a component has `<bindable>` tag. The following scenario will break:
```html
<bindable name="prop1">
```
```ts
class MyEl {
  @bindable value
}
```
as the generated code will be something like this:
```ts
...
CustomElement.define({ ...au2ViewDef, bindables: [...{prop1:{}}, 'value'] }, ...)
```
 This PR fixes this.

Thanks @ghiscoding for reporting this at https://github.com/aurelia/aurelia/pull/1963#issuecomment-2106112004

cc @Sayan751 @3cp 
Should we change the bindable generation code to use object syntax instead of array? like the following code for the above example:
```ts
...
CustomElement.define({ ...au2ViewDef, bindables: {...{prop1:{}}, value: {} }, ...)
```