### PR TITLE
Updated ISignaler documentation example

### DIFF
--- a/docs/user-docs/templates/binding-behaviors.md
+++ b/docs/user-docs/templates/binding-behaviors.md
@@ -143,7 +143,7 @@ import { ISignaler, resolve} from 'aurelia';
 
 export class MyApp {
   constructor(readonly signaler: ISignaler = resolve(ISignaler)) {
-    setInterval(() => signaler.signal('my-signal'), 5000);
+    setInterval(() => signaler.dispatchSignal('my-signal'), 5000);
   }
 }
 ```


### PR DESCRIPTION
Based on this: https://discourse.aurelia.io/t/signaler-signal-is-not-a-funcion-aurelia-2-esnext/5104

updated `signaler.signal` to `signaler.dispatchSignal`