### PR TITLE
feat(kernel): add last resolver

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
@@ -186,6 +186,63 @@ export class MyClass {
 }
 ```
 
+### `last` Resolver
+
+The last resolver is used to inject the last instance registered under a particular key. This can be useful when you need the most recently registered instance among multiple registrations of the same key.
+
+#### Using `@inject` Decorator
+
+```typescript
+import { last, inject } from 'aurelia';
+
+@inject(last(MyService))
+export class MyClass {
+  constructor(private service: MyService) {
+    // service is the last registered instance of MyService
+  }
+}
+```
+
+#### Using Static `inject` Property
+
+```typescript
+import { last } from 'aurelia';
+
+export class MyClass {
+  static inject = [last(MyService)];
+  constructor(private service: MyService) {
+    // service is the last registered instance of MyService
+  }
+}
+```
+
+#### Example
+
+If you have multiple instances of a service registered under the same key, last will ensure that you get the most recently registered instance:
+
+```typescript
+import { DI, IContainer, last, Registration } from 'aurelia';
+
+const container = DI.createContainer();
+container.register(Registration.instance(MyService, new MyService('instance1')));
+container.register(Registration.instance(MyService, new MyService('instance2')));
+container.register(Registration.instance(MyService, new MyService('instance3')));
+
+const myClass = container.get(MyClass);
+console.log(myClass.service); // Outputs: instance3
+```
+
+In this example, `myClass.service` will be the instance of MyService registered last (i.e., `instance3`).
+
+If no instances are registered under the specified key, the last resolver will return undefined:
+
+```typescript
+const container = DI.createContainer();
+
+const myClass = container.get(MyClass);
+console.log(myClass.service); // Outputs: undefined
+```
+
 ## Custom Resolvers
 
 You can create custom resolvers by implementing the `IResolver` interface. Custom resolvers give you the flexibility to implement complex resolution logic that may not be covered by the built-in resolvers.

--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
@@ -228,7 +228,7 @@ container.register(Registration.instance(MyService, new MyService('instance1')))
 container.register(Registration.instance(MyService, new MyService('instance2')));
 container.register(Registration.instance(MyService, new MyService('instance3')));
 
-const myClass = container.get(MyClass);
+const myClass = container.get(last(MyService));
 console.log(myClass.service); // Outputs: instance3
 ```
 
@@ -239,7 +239,7 @@ If no instances are registered under the specified key, the last resolver will r
 ```typescript
 const container = DI.createContainer();
 
-const myClass = container.get(MyClass);
+const myClass = container.get(last(MyClass));
 console.log(myClass.service); // Outputs: undefined
 ```
 

--- a/packages/__tests__/src/1-kernel/di.last.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.last.spec.ts
@@ -44,6 +44,6 @@ describe('1-kernel/di.last.spec.ts', function () {
 
   it('should return undefined if the key is not registered', function () {
     const result = container.get(last('key'));
-    assert.equal(result);
+    assert.strictEqual(result, undefined);
   });
 });

--- a/packages/__tests__/src/1-kernel/di.last.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.last.spec.ts
@@ -16,12 +16,12 @@ describe('1-kernel/di.last.spec.ts', function () {
     assert.equal(result, 'value3');
   });
 
-  it('should return the last registered instance in a parent container', function () {
-    const parent = container.createChild();
-    parent.register(Registration.instance('key', 'parentValue1'));
-    parent.register(Registration.instance('key', 'parentValue2'));
-    const result = parent.get(last('key'));
-    assert.equal(result, 'parentValue2');
+  it('should return the last registered instance in a child container', function () {
+    const child = container.createChild();
+    child.register(Registration.instance('key', 'childValue1'));
+    child.register(Registration.instance('key', 'childValue2'));
+    const result = child.get(last('key'));
+    assert.equal(result, 'childValue2');
   });
 
   it('should return the last registered instance in both parent and child containers', function () {

--- a/packages/__tests__/src/1-kernel/di.last.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.last.spec.ts
@@ -1,0 +1,49 @@
+import { DI, IContainer, last, Registration } from '@aurelia/kernel';
+import { assert } from '@aurelia/testing';
+
+describe('1-kernel/di.last.spec.ts', function () {
+  let container: IContainer;
+
+  beforeEach(function () {
+    container = DI.createContainer();
+  });
+
+  it('should return the last registered instance of a key', function () {
+    container.register(Registration.instance('key', 'value1'));
+    container.register(Registration.instance('key', 'value2'));
+    container.register(Registration.instance('key', 'value3'));
+    const result = container.get(last('key'));
+    assert.equal(result, 'value3');
+  });
+
+  it('should return the last registered instance in a parent container', function () {
+    const parent = container.createChild();
+    parent.register(Registration.instance('key', 'parentValue1'));
+    parent.register(Registration.instance('key', 'parentValue2'));
+    const result = parent.get(last('key'));
+    assert.equal(result, 'parentValue2');
+  });
+
+  it('should return the last registered instance in both parent and child containers', function () {
+    container.register(Registration.instance('key', 'parentValue1'));
+    const child = container.createChild();
+    child.register(Registration.instance('key', 'childValue1'));
+    const result = child.get(last('key'));
+    assert.equal(result, 'childValue1');
+  });
+
+  it('should handle different types of registrations', function () {
+    const instance1 = { name: 'instance1' };
+    const instance2 = { name: 'instance2' };
+    container.register(Registration.instance('key', instance1));
+    container.register(Registration.singleton('key', class { name = 'instance3'; }));
+    container.register(Registration.instance('key', instance2));
+    const result = container.get(last('key'));
+    assert.deepEqual(result, instance2);
+  });
+
+  it('should return undefined if the key is not registered', function () {
+    const result = container.get(last('key'));
+    assert.e(result);
+  });
+});

--- a/packages/__tests__/src/1-kernel/di.last.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.last.spec.ts
@@ -44,6 +44,6 @@ describe('1-kernel/di.last.spec.ts', function () {
 
   it('should return undefined if the key is not registered', function () {
     const result = container.get(last('key'));
-    assert.e(result);
+    assert.equal(result);
   });
 });

--- a/packages/kernel/src/di.resolvers.ts
+++ b/packages/kernel/src/di.resolvers.ts
@@ -45,6 +45,19 @@ export type IAllResolver<T> = IResolver<readonly Resolved<T>[]> &
   ((decorated: unknown, context: DecoratorContext) => any);
 
 /**
+ * Create a resolver that will resolve the last instance of a key from the resolving container
+ *
+ * - @param key [[`Key`]]
+ */
+export const last = <T extends Key>(key: T): IResolver<T | undefined> => ({
+  $isResolver: true,
+  resolve: handler => {
+    const allInstances = handler.getAll(key);
+    return allInstances.length > 0 ? allInstances[allInstances.length - 1] : undefined;
+  }
+});
+
+/**
  * Lazily inject a dependency depending on whether the [[`Key`]] is present at the time of function call.
  *
  * You need to make your argument a function that returns the type, for example

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -47,6 +47,7 @@ export {
   type IOptionalResolver,
   type IResolvedFactory,
   type INewInstanceResolver,
+  last,
   lazy,
   type ILazyResolver,
   type IResolvedLazy,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This pull request introduces support for retrieving the last registered value from the Aurelia DI (Dependency Injection) container. In scenarios where multiple values are registered under the same key, the new last resolver ensures that the most recently registered value is always returned.

In the Aurelia DI system, it's possible to register multiple values under the same key. This feature can be useful for various purposes, such as overriding previously registered values without losing them. However, when retrieving these values, the container typically returns all instances associated with the key. There are cases where it's desirable to get only the most recent value, such as when the latest configuration or instance should take precedence.

The implementation of the last resolver involves creating a new resolver that:

- Checks for the presence of multiple values under a specified key.
- Retrieves and returns the last (most recently registered) value among them.

This approach leverages the existing functionality of the getAll method to fetch all instances associated with a key and then accesses the last element in the array.

- **Single Call to getAll**: The last resolver optimises performance by making a single call to the getAll method and storing the result.

- **Direct Element Access**: It accesses the last element directly using array indexing, ensuring no modifications are made to the array, which preserves immutability.

- **Graceful Handling of Empty Arrays**: The resolver includes checks to handle cases where no values are registered under the key, returning undefined in such situations.

### Usage

The following example demonstrates what happens when you register three different values under the same key. 

```typescript
container.register(Registration.instance('key', 'value1'));
container.register(Registration.instance('key', 'value2'));
container.register(Registration.instance('key', 'value3'));

const myValue = container.get(last('key'));
console.log(myValue); // Outputs: value3
```