### PR TITLE
fix: container specific registrables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -299,6 +299,32 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Launch mocha i18n tests",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceRoot}/packages/__tests__/tsconfig.json"
+      },
+      "args": [
+       "--ui",
+       "bdd",
+       "--reporter",
+       "min",
+       "--colors",
+       "--recursive",
+       "--timeout",
+       "0",
+       "--watch-extensions",
+       "js",
+       "--bail",
+       "${workspaceRoot}/packages/__tests__/dist/setup-node.js",
+       "${workspaceRoot}/packages/__tests__/dist/i18n/**/*.spec.js",
+      ],
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch mocha state tests",
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
       "env": {

--- a/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
@@ -230,52 +230,53 @@ describe('3-runtime-html/attribute-pattern.spec.ts', function () {
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
     describe(`[UNIT] parse [${defs.map(d => d.pattern)}]`, function () {
       for (const [value, match, parts] of tests) {
-        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
-          let receivedRawName: string;
-          let receivedRawValue: string;
-          let receivedParts: string[];
+        // TODO(Sayan): fix
+        // it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
+        //   let receivedRawName: string;
+        //   let receivedRawValue: string;
+        //   let receivedParts: string[];
 
-          // disabling ts error since we are ensuring that the class has all the pattern methods
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error
-          @attributePattern(...defs)
-          class ThePattern {}
-          for (const { pattern } of defs) {
-            ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
-              receivedRawName = rawName;
-              receivedRawValue = rawValue;
-              receivedParts = parts;
-            };
-          }
-          const container = DI.createContainer();
-          container.register(ThePattern as any);
-          const interpreter = container.get(ISyntaxInterpreter);
-          const attrPattern = container.get(IAttributePattern);
-          const patternDefs = AttributePattern.getPatternDefinitions(attrPattern.constructor as Constructable);
-          interpreter.add(patternDefs);
+        //   // disabling ts error since we are ensuring that the class has all the pattern methods
+        //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //   // @ts-expect-error
+        //   @attributePattern(...defs)
+        //   class ThePattern {}
+        //   for (const { pattern } of defs) {
+        //     ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
+        //       receivedRawName = rawName;
+        //       receivedRawValue = rawValue;
+        //       receivedParts = parts;
+        //     };
+        //   }
+        //   const container = DI.createContainer();
+        //   container.register(ThePattern as any);
+        //   const interpreter = container.get(ISyntaxInterpreter);
+        //   const attrPattern = container.get(IAttributePattern);
+        //   const patternDefs = AttributePattern.getPatternDefinitions(attrPattern.constructor as Constructable);
+        //   interpreter.add(patternDefs);
 
-          const result = interpreter.interpret(value);
-          if (match != null) {
-            assert.strictEqual(result.pattern, match);
-            assert.strictEqual(
-              patternDefs.map(d => d.pattern).includes(result.pattern),
-              true,
-              `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0\n  result: ${result.pattern}`
-            );
-            attrPattern[result.pattern](value, 'foo', result.parts);
-            assert.strictEqual(receivedRawName, value, `receivedRawName`);
-            assert.strictEqual(receivedRawValue, 'foo', `receivedRawValue`);
-            assert.deepStrictEqual(receivedParts, result.parts, `receivedParts`);
-          } else {
-            assert.strictEqual(
-              !patternDefs.map(d => d.pattern).includes(result.pattern),
-              true,
-              `patternDefs.map(d => d.pattern).indexOf(result.pattern) === -1`
-            );
-          }
+        //   const result = interpreter.interpret(value);
+        //   if (match != null) {
+        //     assert.strictEqual(result.pattern, match);
+        //     assert.strictEqual(
+        //       patternDefs.map(d => d.pattern).includes(result.pattern),
+        //       true,
+        //       `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0\n  result: ${result.pattern}`
+        //     );
+        //     attrPattern[result.pattern](value, 'foo', result.parts);
+        //     assert.strictEqual(receivedRawName, value, `receivedRawName`);
+        //     assert.strictEqual(receivedRawValue, 'foo', `receivedRawValue`);
+        //     assert.deepStrictEqual(receivedParts, result.parts, `receivedParts`);
+        //   } else {
+        //     assert.strictEqual(
+        //       !patternDefs.map(d => d.pattern).includes(result.pattern),
+        //       true,
+        //       `patternDefs.map(d => d.pattern).indexOf(result.pattern) === -1`
+        //     );
+        //   }
 
-          assert.deepStrictEqual(result.parts, parts, `result.parts`);
-        });
+        //   assert.deepStrictEqual(result.parts, parts, `result.parts`);
+        // });
       }
     });
   }

--- a/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
@@ -230,53 +230,51 @@ describe('3-runtime-html/attribute-pattern.spec.ts', function () {
   ] as [AttributePatternDefinition[], [string, string, string[]][]][]) {
     describe(`[UNIT] parse [${defs.map(d => d.pattern)}]`, function () {
       for (const [value, match, parts] of tests) {
-        // TODO(Sayan): fix
-        // it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
-        //   let receivedRawName: string;
-        //   let receivedRawValue: string;
-        //   let receivedParts: string[];
+        it(`parse [${defs.map(d => d.pattern)}] -> interpret [${value}] -> match=[${match}]`, function () {
+          let receivedRawName: string;
+          let receivedRawValue: string;
+          let receivedParts: string[];
 
-        //   // disabling ts error since we are ensuring that the class has all the pattern methods
-        //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //   // @ts-expect-error
-        //   @attributePattern(...defs)
-        //   class ThePattern {}
-        //   for (const { pattern } of defs) {
-        //     ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
-        //       receivedRawName = rawName;
-        //       receivedRawValue = rawValue;
-        //       receivedParts = parts;
-        //     };
-        //   }
-        //   const container = DI.createContainer();
-        //   container.register(ThePattern as any);
-        //   const interpreter = container.get(ISyntaxInterpreter);
-        //   const attrPattern = container.get(IAttributePattern);
-        //   const patternDefs = AttributePattern.getPatternDefinitions(attrPattern.constructor as Constructable);
-        //   interpreter.add(patternDefs);
+          // disabling ts error since we are ensuring that the class has all the pattern methods
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-expect-error
+          @attributePattern(...defs)
+          class ThePattern {}
+          for (const { pattern } of defs) {
+            ThePattern.prototype[pattern] = (rawName, rawValue, parts) => {
+              receivedRawName = rawName;
+              receivedRawValue = rawValue;
+              receivedParts = parts;
+            };
+          }
+          const container = DI.createContainer();
+          container.register(ThePattern as any);
+          const interpreter = container.get(ISyntaxInterpreter);
+          const attrPattern = container.get(IAttributePattern);
+          interpreter.add(defs);
 
-        //   const result = interpreter.interpret(value);
-        //   if (match != null) {
-        //     assert.strictEqual(result.pattern, match);
-        //     assert.strictEqual(
-        //       patternDefs.map(d => d.pattern).includes(result.pattern),
-        //       true,
-        //       `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0\n  result: ${result.pattern}`
-        //     );
-        //     attrPattern[result.pattern](value, 'foo', result.parts);
-        //     assert.strictEqual(receivedRawName, value, `receivedRawName`);
-        //     assert.strictEqual(receivedRawValue, 'foo', `receivedRawValue`);
-        //     assert.deepStrictEqual(receivedParts, result.parts, `receivedParts`);
-        //   } else {
-        //     assert.strictEqual(
-        //       !patternDefs.map(d => d.pattern).includes(result.pattern),
-        //       true,
-        //       `patternDefs.map(d => d.pattern).indexOf(result.pattern) === -1`
-        //     );
-        //   }
+          const result = interpreter.interpret(value);
+          if (match != null) {
+            assert.strictEqual(result.pattern, match);
+            assert.strictEqual(
+              defs.map(d => d.pattern).includes(result.pattern),
+              true,
+              `patternDefs.map(d => d.pattern).indexOf(result.pattern) >= 0\n  result: ${result.pattern}`
+            );
+            attrPattern[result.pattern](value, 'foo', result.parts);
+            assert.strictEqual(receivedRawName, value, `receivedRawName`);
+            assert.strictEqual(receivedRawValue, 'foo', `receivedRawValue`);
+            assert.deepStrictEqual(receivedParts, result.parts, `receivedParts`);
+          } else {
+            assert.strictEqual(
+              !defs.map(d => d.pattern).includes(result.pattern),
+              true,
+              `patternDefs.map(d => d.pattern).indexOf(result.pattern) === -1`
+            );
+          }
 
-        //   assert.deepStrictEqual(result.parts, parts, `result.parts`);
-        // });
+          assert.deepStrictEqual(result.parts, parts, `result.parts`);
+        });
       }
     });
   }

--- a/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/attribute-pattern.spec.ts
@@ -1,10 +1,9 @@
-import { DI, Constructable } from '@aurelia/kernel';
+import { DI } from '@aurelia/kernel';
 import {
   attributePattern,
   AttributePatternDefinition,
   IAttributePattern,
   ISyntaxInterpreter,
-  AttributePattern
 } from '@aurelia/template-compiler';
 import { assert } from '@aurelia/testing';
 

--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -5,7 +5,6 @@ import {
   CustomElement,
   CustomElementDefinition,
   CustomElementType,
-  DefaultBindingSyntax,
 } from '@aurelia/runtime-html';
 import {
   HydrateElementInstruction,

--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -367,7 +367,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
 
   function compileTemplate(template: string, ...registrations: unknown[]) {
     const { container, sut } = createFixture();
-    container.register(DefaultBindingSyntax, ...registrations);
+    container.register(...registrations);
 
     const templateDefinition = CustomElementDefinition.create({
       name: 'ano',

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -21,7 +21,6 @@ import {
   PartialCustomElementDefinition,
   CustomElementDefinition,
   CustomAttributeDefinition,
-  DefaultBindingSyntax,
 } from '@aurelia/runtime-html';
 import {
   TemplateCompilerHooks,
@@ -331,7 +330,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
         it('enables binding commands to override custom attribute', function () {
           const { template, instructions } = compileWith(
             `<el foo.trigger="1">`,
-            [DefaultBindingSyntax, CustomAttribute.define('foo', class {})]
+            [CustomAttribute.define('foo', class {})]
           );
 
           assertTemplateHtml(template, '<!--au*--><el></el>');

--- a/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
@@ -12,7 +12,7 @@ import {
   TranslationBindInstructionType,
   TranslationInstructionType,
 } from '@aurelia/i18n';
-import { Constructable, Registration } from '@aurelia/kernel';
+import { Registration } from '@aurelia/kernel';
 import { IExpressionParser } from '@aurelia/expression-parser';
 import {
   IObserverLocator,

--- a/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
@@ -1,7 +1,5 @@
 import {
   I18nConfiguration,
-  TranslationAttributePattern,
-  TranslationBindAttributePattern,
   TranslationBindBindingCommand,
   TranslationBindBindingInstruction,
   TranslationBindBindingRenderer,
@@ -27,11 +25,8 @@ import {
   AttrMapper,
 } from '@aurelia/runtime-html';
 import {
-  AttributePattern,
-  AttributePatternDefinition,
   AttrSyntax,
   BindingCommand,
-  IAttributePattern,
   IAttrMapper,
   PropertyBindingInstruction,
   InstructionType,
@@ -41,29 +36,6 @@ import { assert, PLATFORM, createContainer } from '@aurelia/testing';
 const noopLocator = {} as unknown as IObserverLocator;
 
 describe('i18n/t/translation-renderer.spec.ts', function () {
-  describe('TranslationAttributePattern', function () {
-    function createFixture(aliases: string[] = ['t']) {
-      const patterns: AttributePatternDefinition[] = [];
-      for (const pattern of aliases) {
-        patterns.push({ pattern, symbols: '' });
-        TranslationAttributePattern.registerAlias(pattern);
-      }
-      const container = createContainer().register(AttributePattern.define(patterns, TranslationAttributePattern));
-      return container.get(IAttributePattern);
-    }
-
-    it('creates attribute syntax without `to` part when `T="expr"` is used', function () {
-      const sut = createFixture();
-      const pattern = 't';
-      const value = 'simple.key';
-
-      const actual: AttrSyntax = sut[pattern](pattern, value, []);
-      assert.equal(actual.command, pattern);
-      assert.equal(actual.rawName, pattern);
-      assert.equal(actual.rawValue, value);
-      assert.equal(actual.target, '');
-    });
-  });
 
   describe('TranslationBindingCommand', function () {
     function createFixture(aliases?: string[]) {
@@ -159,32 +131,6 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       );
 
       assert.equal(binding.ast, from);
-    });
-  });
-
-  describe('TranslationBindAttributePattern', function () {
-    function createFixture(aliases: string[] = ['t']) {
-      const patterns: AttributePatternDefinition[] = [];
-      for (const pattern of aliases) {
-        patterns.push({ pattern: `${pattern}.bind`, symbols: '.' });
-        TranslationBindAttributePattern.registerAlias(pattern);
-      }
-      const container = createContainer().register(
-        AttributePattern.define(patterns, TranslationBindAttributePattern)
-      );
-      return container.get(IAttributePattern);
-    }
-
-    it('creates attribute syntax with `to` part when `T.bind="expr"` is used', function () {
-      const sut = createFixture();
-      const pattern = 't.bind';
-      const value = 'simple.key';
-
-      const actual: AttrSyntax = sut[pattern](pattern, value, ['t', 'bind']);
-      assert.equal(actual.command, pattern);
-      assert.equal(actual.rawName, pattern);
-      assert.equal(actual.rawValue, value);
-      assert.equal(actual.target, 'bind');
     });
   });
 

--- a/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
@@ -52,22 +52,6 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       return container.get(IAttributePattern);
     }
 
-    // TODO(Sayan): fix
-    // it('registers alias attribute patterns when provided', function () {
-    //   const aliases = ['t', 'i18n'];
-    //   const sut = createFixture(aliases);
-
-    //   assert.instanceOf(sut, TranslationAttributePattern);
-
-    //   const patternDefs = [];
-    //   for (const alias of aliases) {
-    //     assert.typeOf(sut[alias], 'function');
-    //     patternDefs.push({ pattern: alias, symbols: '' });
-    //   }
-
-    //   assert.deepEqual(AttributePattern.getPatternDefinitions(sut.constructor as Constructable), patternDefs);
-    // });
-
     it('creates attribute syntax without `to` part when `T="expr"` is used', function () {
       const sut = createFixture();
       const pattern = 't';
@@ -190,26 +174,6 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       );
       return container.get(IAttributePattern);
     }
-
-    // TODO(Sayan): fix
-    // it('registers alias attribute patterns when provided', function () {
-    //   const aliases = ['t', 'i18n'];
-    //   const sut = createFixture(aliases);
-
-    //   assert.instanceOf(sut, TranslationBindAttributePattern);
-    //   assert.deepEqual(
-    //     AttributePattern.getPatternDefinitions(sut.constructor as Constructable),
-    //     aliases.reduce(
-    //       (acc, alias) => {
-    //         acc.push({ pattern: `${alias}.bind`, symbols: '.' });
-    //         return acc;
-    //       },
-    //       []));
-
-    //   aliases.forEach((alias) => {
-    //     assert.typeOf(sut[`${alias}.bind`], 'function', `${alias}.bind`);
-    //   });
-    // });
 
     it('creates attribute syntax with `to` part when `T.bind="expr"` is used', function () {
       const sut = createFixture();

--- a/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
@@ -52,20 +52,21 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       return container.get(IAttributePattern);
     }
 
-    it('registers alias attribute patterns when provided', function () {
-      const aliases = ['t', 'i18n'];
-      const sut = createFixture(aliases);
+    // TODO(Sayan): fix
+    // it('registers alias attribute patterns when provided', function () {
+    //   const aliases = ['t', 'i18n'];
+    //   const sut = createFixture(aliases);
 
-      assert.instanceOf(sut, TranslationAttributePattern);
+    //   assert.instanceOf(sut, TranslationAttributePattern);
 
-      const patternDefs = [];
-      for (const alias of aliases) {
-        assert.typeOf(sut[alias], 'function');
-        patternDefs.push({ pattern: alias, symbols: '' });
-      }
+    //   const patternDefs = [];
+    //   for (const alias of aliases) {
+    //     assert.typeOf(sut[alias], 'function');
+    //     patternDefs.push({ pattern: alias, symbols: '' });
+    //   }
 
-      assert.deepEqual(AttributePattern.getPatternDefinitions(sut.constructor as Constructable), patternDefs);
-    });
+    //   assert.deepEqual(AttributePattern.getPatternDefinitions(sut.constructor as Constructable), patternDefs);
+    // });
 
     it('creates attribute syntax without `to` part when `T="expr"` is used', function () {
       const sut = createFixture();
@@ -190,24 +191,25 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       return container.get(IAttributePattern);
     }
 
-    it('registers alias attribute patterns when provided', function () {
-      const aliases = ['t', 'i18n'];
-      const sut = createFixture(aliases);
+    // TODO(Sayan): fix
+    // it('registers alias attribute patterns when provided', function () {
+    //   const aliases = ['t', 'i18n'];
+    //   const sut = createFixture(aliases);
 
-      assert.instanceOf(sut, TranslationBindAttributePattern);
-      assert.deepEqual(
-        AttributePattern.getPatternDefinitions(sut.constructor as Constructable),
-        aliases.reduce(
-          (acc, alias) => {
-            acc.push({ pattern: `${alias}.bind`, symbols: '.' });
-            return acc;
-          },
-          []));
+    //   assert.instanceOf(sut, TranslationBindAttributePattern);
+    //   assert.deepEqual(
+    //     AttributePattern.getPatternDefinitions(sut.constructor as Constructable),
+    //     aliases.reduce(
+    //       (acc, alias) => {
+    //         acc.push({ pattern: `${alias}.bind`, symbols: '.' });
+    //         return acc;
+    //       },
+    //       []));
 
-      aliases.forEach((alias) => {
-        assert.typeOf(sut[`${alias}.bind`], 'function', `${alias}.bind`);
-      });
-    });
+    //   aliases.forEach((alias) => {
+    //     assert.typeOf(sut[`${alias}.bind`], 'function', `${alias}.bind`);
+    //   });
+    // });
 
     it('creates attribute syntax with `to` part when `T.bind="expr"` is used', function () {
       const sut = createFixture();

--- a/packages/i18n/src/configuration.ts
+++ b/packages/i18n/src/configuration.ts
@@ -64,10 +64,10 @@ function coreComponents(options: I18nConfigurationOptions) {
     }
   }
   const renderers = [
-    AttributePattern.define(patterns, TranslationAttributePattern),
+    AttributePattern.create(patterns, TranslationAttributePattern),
     BindingCommand.define({name:'t', aliases: commandAliases}, TranslationBindingCommand),
     TranslationBindingRenderer,
-    AttributePattern.define(bindPatterns, TranslationBindAttributePattern),
+    AttributePattern.create(bindPatterns, TranslationBindAttributePattern),
     BindingCommand.define({name:'t.bind', aliases: bindCommandAliases}, TranslationBindBindingCommand),
     TranslationBindBindingRenderer,
     TranslationParametersAttributePattern,

--- a/packages/i18n/src/configuration.ts
+++ b/packages/i18n/src/configuration.ts
@@ -1,6 +1,6 @@
 import { IContainer, Registration } from '@aurelia/kernel';
 import { AppTask } from '@aurelia/runtime-html';
-import { AttributePatternDefinition, BindingCommand, AttributePattern } from '@aurelia/template-compiler';
+import { AttributePatternDefinition, BindingCommand, AttributePattern, AttrSyntax } from '@aurelia/template-compiler';
 import { DateFormatBindingBehavior } from './df/date-format-binding-behavior';
 import { DateFormatValueConverter } from './df/date-format-value-converter';
 import { I18N, I18nService } from './i18n';
@@ -17,8 +17,6 @@ import {
   TranslationParametersBindingRenderer
 } from './t/translation-parameters-renderer';
 import {
-  TranslationAttributePattern,
-  TranslationBindAttributePattern,
   TranslationBindBindingCommand,
   TranslationBindBindingRenderer,
   TranslationBindingCommand,
@@ -41,14 +39,24 @@ function coreComponents(options: I18nConfigurationOptions) {
   const bindPatterns: AttributePatternDefinition[] = [];
   const commandAliases: string[] = [];
   const bindCommandAliases: string[] = [];
+  class TranslationAttributePattern {
+    [key: string]: ((rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax);
+  }
+  class TranslationBindAttributePattern {
+    [key: string]: ((rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax);
+  }
   for (const alias of aliases) {
-    const bindAlias = `${alias}.bind`;
 
     patterns.push({ pattern: alias, symbols: '' });
-    TranslationAttributePattern.registerAlias(alias);
+    TranslationAttributePattern.prototype[alias] = function (rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
+      return new AttrSyntax(rawName, rawValue, '', alias);
+    };
 
+    const bindAlias = `${alias}.bind`;
     bindPatterns.push({ pattern: bindAlias, symbols: '.' });
-    TranslationBindAttributePattern.registerAlias(alias);
+    TranslationBindAttributePattern.prototype[bindAlias] = function (rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
+      return new AttrSyntax(rawName, rawValue, parts[1], bindAlias);
+    };
 
     if (alias !== 't') {
       commandAliases.push(alias);

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -1,4 +1,4 @@
-import { camelCase } from '@aurelia/kernel';
+import { camelCase, registrableMetadataKey } from '@aurelia/kernel';
 import { TranslationBinding } from './translation-binding';
 import {
   IObserverLocator,
@@ -30,12 +30,12 @@ export const TranslationParametersInstructionType = 'tpt';
 const attribute = 't-params.bind';
 
 export class TranslationParametersAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define(
       [{ pattern: attribute, symbols: '' }],
-      this
-    );
-  }
+      TranslationParametersAttributePattern
+    )
+  };
   public [attribute](rawName: string, rawValue: string): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, '', attribute);
   }

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -29,14 +29,17 @@ export const TranslationParametersInstructionType = 'tpt';
 // `.bind` part is needed here only for vCurrent compliance
 const attribute = 't-params.bind';
 
-export const TranslationParametersAttributePattern = AttributePattern.define(
-  [{ pattern: attribute, symbols: '' }],
-  class TranslationParametersAttributePattern {
-    public [attribute](rawName: string, rawValue: string): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, '', attribute);
-    }
+export class TranslationParametersAttributePattern {
+  public static getRegistrable() {
+    return AttributePattern.define(
+      [{ pattern: attribute, symbols: '' }],
+      this
+    );
   }
-);
+  public [attribute](rawName: string, rawValue: string): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, '', attribute);
+  }
+}
 
 export class TranslationParametersBindingInstruction {
   public readonly type: string = TranslationParametersInstructionType;

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -1,4 +1,4 @@
-import { camelCase } from '@aurelia/kernel';
+import { IContainer, camelCase } from '@aurelia/kernel';
 import { TranslationBinding } from './translation-binding';
 import {
   IObserverLocator,
@@ -30,11 +30,11 @@ export const TranslationParametersInstructionType = 'tpt';
 const attribute = 't-params.bind';
 
 export class TranslationParametersAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static register(container: IContainer): void {
+    container.register(AttributePattern.define(
       [{ pattern: attribute, symbols: '' }],
       this
-    );
+    ));
   }
   public [attribute](rawName: string, rawValue: string): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, '', attribute);

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -31,7 +31,7 @@ const attribute = 't-params.bind';
 
 export class TranslationParametersAttributePattern {
   public static [Symbol.metadata] = {
-    [registrableMetadataKey]: AttributePattern.define(
+    [registrableMetadataKey]: AttributePattern.create(
       [{ pattern: attribute, symbols: '' }],
       TranslationParametersAttributePattern
     )

--- a/packages/i18n/src/t/translation-parameters-renderer.ts
+++ b/packages/i18n/src/t/translation-parameters-renderer.ts
@@ -1,4 +1,4 @@
-import { IContainer, camelCase } from '@aurelia/kernel';
+import { camelCase } from '@aurelia/kernel';
 import { TranslationBinding } from './translation-binding';
 import {
   IObserverLocator,
@@ -30,11 +30,11 @@ export const TranslationParametersInstructionType = 'tpt';
 const attribute = 't-params.bind';
 
 export class TranslationParametersAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(AttributePattern.define(
+  public static getRegistrable() {
+    return AttributePattern.define(
       [{ pattern: attribute, symbols: '' }],
       this
-    ));
+    );
   }
   public [attribute](rawName: string, rawValue: string): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, '', attribute);

--- a/packages/i18n/src/t/translation-renderer.ts
+++ b/packages/i18n/src/t/translation-renderer.ts
@@ -10,11 +10,10 @@ import {
   IHydratableController,
   IPlatform,
 } from '@aurelia/runtime-html';
-import {
-  AttrSyntax,
-  type IAttrMapper,
-  type ICommandBuildInfo,
-  type BindingCommandInstance,
+import type {
+  IAttrMapper,
+  ICommandBuildInfo,
+  BindingCommandInstance,
 } from '@aurelia/template-compiler';
 
 import type {
@@ -23,17 +22,6 @@ import type {
 import { etIsProperty, bmToView } from '../utils';
 
 export const TranslationInstructionType = 'tt';
-
-export class TranslationAttributePattern {
-  [key: string]: ((rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax);
-
-  public static registerAlias(alias: string) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    this.prototype[alias] = function (rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, '', alias);
-    };
-  }
-}
 
 export class TranslationBindingInstruction {
   public readonly type: string = TranslationInstructionType;
@@ -85,17 +73,6 @@ export const TranslationBindingRenderer = /*@__PURE__*/ renderer(class Translati
 }, null!);
 
 export const TranslationBindInstructionType = 'tbt';
-
-export class TranslationBindAttributePattern {
-  [key: string]: ((rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax);
-
-  public static registerAlias(alias: string) {
-    const bindPattern = `${alias}.bind`;
-    this.prototype[bindPattern] = function (rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
-      return new AttrSyntax(rawName, rawValue, parts[1], bindPattern);
-    };
-  }
-}
 
 export class TranslationBindBindingInstruction {
   public readonly type: string = TranslationBindInstructionType;

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -171,6 +171,10 @@ export class Container implements IContainer {
       } else if ((def = getMetadata(resourceBaseName, current)!) != null) {
         def.register(this);
       } else if (isClass<StaticResourceType>(current)) {
+        if (hasRegistrable(current)) {
+          current.getRegistrable().register(this);
+          continue;
+        }
         const registrable = current[Symbol.metadata]?.[registrableMetadataKey] as IRegistry;
         if (isRegistry(registrable)) {
           registrable.register(this);
@@ -749,3 +753,7 @@ const isClass = <T>(obj: unknown): obj is Class<any, T> =>
 
 const isResourceKey = (key: Key): key is string =>
   isString(key) && key.indexOf(':') > 0;
+
+// Limit this method for now only to classes
+const hasRegistrable = (obj: Class<any, unknown>): obj is Class<any, unknown> & { getRegistrable(): IRegistry } =>
+  isFunction((obj as Class<any, unknown> & { getRegistrable(): IRegistry }).getRegistrable);

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -171,10 +171,6 @@ export class Container implements IContainer {
       } else if ((def = getMetadata(resourceBaseName, current)!) != null) {
         def.register(this);
       } else if (isClass<StaticResourceType>(current)) {
-        if (hasRegistrable(current)) {
-          current.getRegistrable().register(this);
-          continue;
-        }
         const registrable = current[Symbol.metadata]?.[registrableMetadataKey] as IRegistry;
         if (isRegistry(registrable)) {
           registrable.register(this);
@@ -753,7 +749,3 @@ const isClass = <T>(obj: unknown): obj is Class<any, T> =>
 
 const isResourceKey = (key: Key): key is string =>
   isString(key) && key.indexOf(':') > 0;
-
-// Limit this method for now only to classes
-const hasRegistrable = (obj: Class<any, unknown>): obj is Class<any, unknown> & { getRegistrable(): IRegistry } =>
-  isFunction((obj as Class<any, unknown> & { getRegistrable(): IRegistry }).getRegistrable);

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -176,7 +176,7 @@ export class Container implements IContainer {
           continue;
         }
         const registrable = current[Symbol.metadata]?.[registrableMetadataKey] as IRegistry;
-        if (registrable != null && isRegistry(registrable)) {
+        if (isRegistry(registrable)) {
           registrable.register(this);
         } else if (isString((current).$au?.type)) {
           const $au = current.$au;

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -740,7 +740,7 @@ const containerResolver: IResolver = {
 };
 
 const isRegistry = (obj: IRegistry | Record<string, IRegistry>): obj is IRegistry =>
-  isFunction(obj.register);
+  isFunction(obj?.register);
 
 const isSelfRegistry = <T extends Constructable>(obj: RegisterSelf<T>): obj is RegisterSelf<T> =>
   isRegistry(obj) && typeof obj.registerInRequestor === 'boolean';

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -28,7 +28,6 @@ export {
 export {
   resolve,
   type IResolvedInjection,
-  Registrable,
   ContainerConfiguration,
   DefaultResolver,
   registrableMetadataKey,

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -31,6 +31,7 @@ export {
   Registrable,
   ContainerConfiguration,
   DefaultResolver,
+  registrableMetadataKey,
 } from './di.container';
 
 export {

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -96,8 +96,8 @@ export const DefaultComponents = [
  * - `target.command` (dot-separated)
  */
 export const DefaultBindingSyntax = [
-  DotSeparatedAttributePattern,
   RefAttributePattern,
+  DotSeparatedAttributePattern,
   EventAttributePattern,
   EventModifierRegistration,
 ];
@@ -108,8 +108,8 @@ export const DefaultBindingSyntax = [
  * - `:target` (short-hand for `target.bind`)
  */
 export const ShortHandBindingSyntax = [
-  ColonPrefixedBindAttributePattern,
   AtPrefixedTriggerAttributePattern,
+  ColonPrefixedBindAttributePattern,
 ];
 
 /**
@@ -240,11 +240,11 @@ function createConfiguration(optionsProvider: ConfigurationOptionsProvider) {
        * - `DefaultRenderers`
        */
       return container.register(
-        ...DefaultBindingSyntax,
-        ...DefaultBindingLanguage,
         instanceRegistration(ICoercionConfiguration, runtimeConfigurationOptions.coercingOptions),
         ...DefaultComponents,
         ...DefaultResources,
+        ...DefaultBindingSyntax,
+        ...DefaultBindingLanguage,
         ...DefaultRenderers,
       );
     },

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -65,7 +65,6 @@ import {
   PendingTemplateController,
   FulfilledTemplateController,
   RejectedTemplateController,
-  // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
   PromiseAttributePattern,
   FulfilledAttributePattern,
   RejectedAttributePattern,
@@ -162,7 +161,6 @@ export const DefaultResources = [
   PendingTemplateController,
   FulfilledTemplateController,
   RejectedTemplateController,
-  // TODO: activate after the attribute parser and/or interpreter such that for `t`, `then` is not picked up.
   PromiseAttributePattern,
   FulfilledAttributePattern,
   RejectedAttributePattern,

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -96,8 +96,8 @@ export const DefaultComponents = [
  * - `target.command` (dot-separated)
  */
 export const DefaultBindingSyntax = [
-  RefAttributePattern,
   DotSeparatedAttributePattern,
+  RefAttributePattern,
   EventAttributePattern,
   EventModifierRegistration,
 ];
@@ -108,8 +108,8 @@ export const DefaultBindingSyntax = [
  * - `:target` (short-hand for `target.bind`)
  */
 export const ShortHandBindingSyntax = [
+  ColonPrefixedBindAttributePattern,
   AtPrefixedTriggerAttributePattern,
-  ColonPrefixedBindAttributePattern
 ];
 
 /**
@@ -240,11 +240,11 @@ function createConfiguration(optionsProvider: ConfigurationOptionsProvider) {
        * - `DefaultRenderers`
        */
       return container.register(
+        ...DefaultBindingSyntax,
+        ...DefaultBindingLanguage,
         instanceRegistration(ICoercionConfiguration, runtimeConfigurationOptions.coercingOptions),
         ...DefaultComponents,
         ...DefaultResources,
-        ...DefaultBindingSyntax,
-        ...DefaultBindingLanguage,
         ...DefaultRenderers,
       );
     },

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -5,8 +5,8 @@ import {
   type Constructable,
   type IResolver,
   resolve,
-  Registrable,
   isString,
+  registrableMetadataKey,
 } from '@aurelia/kernel';
 import {
   IExpressionParser,
@@ -86,9 +86,13 @@ export interface IRenderer {
 export const IRenderer = /*@__PURE__*/createInterface<IRenderer>('IRenderer');
 
 export function renderer<T extends IRenderer, C extends Constructable<T>>(target: C, context: ClassDecoratorContext): C {
-  return Registrable.define(target, function (this: typeof target, container: IContainer): void {
-    singletonRegistration(IRenderer, this).register(container);
-  });
+  const metadata = context?.metadata ?? (target[Symbol.metadata] ??= Object.create(null));
+  metadata[registrableMetadataKey] = {
+    register(container: IContainer): void {
+      singletonRegistration(IRenderer, target).register(container);
+    }
+  };
+  return target;
 }
 
 function ensureExpression<TFrom>(parser: IExpressionParser, srcOrExpr: TFrom | string, expressionType: ExpressionType): TFrom {

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -336,7 +336,7 @@ function getPromiseController(controller: IHydratableController) {
 
 export class PromiseAttributePattern {
   public static [Symbol.metadata] = {
-    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern)
+    [registrableMetadataKey]: AttributePattern.create([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern)
   };
   public 'promise.resolve'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'promise', 'bind');
@@ -345,7 +345,7 @@ export class PromiseAttributePattern {
 
 export class FulfilledAttributePattern {
   public static [Symbol.metadata] = {
-    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern)
+    [registrableMetadataKey]: AttributePattern.create([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern)
   };
   public 'then'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'then', 'from-view');
@@ -354,7 +354,7 @@ export class FulfilledAttributePattern {
 
 export class RejectedAttributePattern {
   public static [Symbol.metadata] = {
-    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern)
+    [registrableMetadataKey]: AttributePattern.create([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern)
   };
   public 'catch'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'catch', 'from-view');

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,5 +1,5 @@
 import { Task, TaskAbortError } from '@aurelia/platform';
-import { ILogger, onResolve, onResolveAll, resolve, isPromise } from '@aurelia/kernel';
+import { ILogger, onResolve, onResolveAll, resolve, isPromise, registrableMetadataKey } from '@aurelia/kernel';
 import { Scope } from '../../binding/scope';
 import { INode, IRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
@@ -335,27 +335,27 @@ function getPromiseController(controller: IHydratableController) {
 }
 
 export class PromiseAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern);
-  }
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern)
+  };
   public 'promise.resolve'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'promise', 'bind');
   }
 }
 
 export class FulfilledAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern);
-  }
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern)
+  };
   public 'then'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'then', 'from-view');
   }
 }
 
 export class RejectedAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern);
-  }
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern)
+  };
   public 'catch'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'catch', 'from-view');
   }

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,5 +1,5 @@
 import { Task, TaskAbortError } from '@aurelia/platform';
-import { ILogger, onResolve, onResolveAll, resolve, isPromise } from '@aurelia/kernel';
+import { ILogger, onResolve, onResolveAll, resolve, isPromise, IContainer } from '@aurelia/kernel';
 import { Scope } from '../../binding/scope';
 import { INode, IRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
@@ -335,8 +335,8 @@ function getPromiseController(controller: IHydratableController) {
 }
 
 export class PromiseAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern);
+  public static register(container: IContainer): void {
+    container.register(AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern));
   }
   public 'promise.resolve'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'promise', 'bind');
@@ -344,8 +344,8 @@ export class PromiseAttributePattern {
 }
 
 export class FulfilledAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern);
+  public static register(container: IContainer): void {
+    container.register(AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern));
   }
   public 'then'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'then', 'from-view');
@@ -353,8 +353,8 @@ export class FulfilledAttributePattern {
 }
 
 export class RejectedAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern);
+  public static register(container: IContainer): void {
+    container.register(AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern));
   }
   public 'catch'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'catch', 'from-view');

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -335,22 +335,28 @@ function getPromiseController(controller: IHydratableController) {
 }
 
 export class PromiseAttributePattern {
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern);
+  }
   public 'promise.resolve'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'promise', 'bind');
   }
 }
-AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern);
 
 export class FulfilledAttributePattern {
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern);
+  }
   public 'then'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'then', 'from-view');
   }
 }
-AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern);
 
 export class RejectedAttributePattern {
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern);
+  }
   public 'catch'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'catch', 'from-view');
   }
 }
-AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern);

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -1,5 +1,5 @@
 import { Task, TaskAbortError } from '@aurelia/platform';
-import { ILogger, onResolve, onResolveAll, resolve, isPromise, IContainer } from '@aurelia/kernel';
+import { ILogger, onResolve, onResolveAll, resolve, isPromise } from '@aurelia/kernel';
 import { Scope } from '../../binding/scope';
 import { INode, IRenderLocation } from '../../dom';
 import { IPlatform } from '../../platform';
@@ -335,8 +335,8 @@ function getPromiseController(controller: IHydratableController) {
 }
 
 export class PromiseAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern));
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'promise.resolve', symbols: '' }], PromiseAttributePattern);
   }
   public 'promise.resolve'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'promise', 'bind');
@@ -344,8 +344,8 @@ export class PromiseAttributePattern {
 }
 
 export class FulfilledAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern));
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'then', symbols: '' }], FulfilledAttributePattern);
   }
   public 'then'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'then', 'from-view');
@@ -353,8 +353,8 @@ export class FulfilledAttributePattern {
 }
 
 export class RejectedAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern));
+  public static getRegistrable() {
+    return AttributePattern.define([{ pattern: 'catch', symbols: '' }], RejectedAttributePattern);
   }
   public 'catch'(name: string, value: string): AttrSyntax {
     return new AttrSyntax(name, value, 'catch', 'from-view');

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -543,6 +543,7 @@ export interface AttributePatternKind {
 export function attributePattern<const K extends AttributePatternDefinition>(...patternDefs: K[]): <T extends Constructable<IAttributePattern<K['pattern']>>>(target: T, context: ClassDecoratorContext<T>) => T {
   return function decorator<T extends Constructable<IAttributePattern<K['pattern']>>>(target: T, context: ClassDecoratorContext<T>): T {
     const registrable = AttributePattern.define(patternDefs, target);
+    // Decorators are by nature static, so we need to store the metadata on the class itself, assuming only one set of patterns per class.
     context.metadata[registrableMetadataKey] = registrable;
     return target;
   };

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -557,7 +557,7 @@ export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>
     // patterns.set(Type, patternDefs);
     return Registrable.define(Type, (container: IContainer) => {
       container.get(IAttributeParser).registerPattern(patternDefs, Type);
-      // singletonRegistration(IAttributePattern, Type).register(container);
+      singletonRegistration(IAttributePattern, Type).register(container);
     });
   },
   // getPatternDefinitions: getAllPatternDefinitions,

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -549,15 +549,14 @@ export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>
 });
 
 export class DotSeparatedAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(AttributePattern
-      .define(
-        [
-          { pattern: 'PART.PART', symbols: '.' },
-          { pattern: 'PART.PART.PART', symbols: '.' }
-        ],
-        this
-      ));
+  public static getRegistrable() {
+    return AttributePattern.define(
+      [
+        { pattern: 'PART.PART', symbols: '.' },
+        { pattern: 'PART.PART.PART', symbols: '.' }
+      ],
+      this
+    );
   }
 
   public 'PART.PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
@@ -570,15 +569,14 @@ export class DotSeparatedAttributePattern {
 }
 
 export class RefAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(
-      AttributePattern.define(
-        [
-          { pattern: 'ref', symbols: '' },
-          { pattern: 'PART.ref', symbols: '.' }
-        ],
-        this
-      ));
+  public static getRegistrable() {
+    return AttributePattern.define(
+      [
+        { pattern: 'ref', symbols: '' },
+        { pattern: 'PART.ref', symbols: '.' }
+      ],
+      this
+    );
   }
   public 'ref'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, 'element', 'ref');
@@ -599,15 +597,14 @@ export class RefAttributePattern {
 }
 
 export class EventAttributePattern {
-  public static register(container: IContainer): void {
-    container.register(
-     AttributePattern.define(
+  public static getRegistrable() {
+    return AttributePattern.define(
       [
         { pattern: 'PART.trigger:PART', symbols: '.:' },
         { pattern: 'PART.capture:PART', symbols: '.:' },
       ],
       this
-    ));
+    );
   }
   public 'PART.trigger:PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], 'trigger', parts);
@@ -619,12 +616,11 @@ export class EventAttributePattern {
 
 export class ColonPrefixedBindAttributePattern {
 
-  public static register(container: IContainer): void {
-    container.register(
-      AttributePattern.define(
-        [{ pattern: ':PART', symbols: ':' }],
-        this
-      ));
+  public static getRegistrable() {
+    return AttributePattern.define(
+      [{ pattern: ':PART', symbols: ':' }],
+      this
+    );
   }
 
   public ':PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
@@ -634,13 +630,13 @@ export class ColonPrefixedBindAttributePattern {
 
 export class AtPrefixedTriggerAttributePattern {
 
-  public static register(container: IContainer): void {
-    container.register(AttributePattern.define(
+  public static getRegistrable() {
+    return AttributePattern.define(
       [
         { pattern: '@PART', symbols: '@' },
         { pattern: '@PART:PART', symbols: '@:' },
       ], this
-    ));
+    );
   }
 
   public '@PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -549,16 +549,15 @@ export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>
 });
 
 export class DotSeparatedAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define(
       [
         { pattern: 'PART.PART', symbols: '.' },
         { pattern: 'PART.PART.PART', symbols: '.' }
       ],
-      this
-    );
-  }
-
+      DotSeparatedAttributePattern
+    )
+  };
   public 'PART.PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], parts[1]);
   }
@@ -569,15 +568,15 @@ export class DotSeparatedAttributePattern {
 }
 
 export class RefAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]:  AttributePattern.define(
       [
         { pattern: 'ref', symbols: '' },
         { pattern: 'PART.ref', symbols: '.' }
       ],
-      this
-    );
-  }
+      RefAttributePattern
+    )
+  };
   public 'ref'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, 'element', 'ref');
   }
@@ -597,15 +596,15 @@ export class RefAttributePattern {
 }
 
 export class EventAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define(
       [
         { pattern: 'PART.trigger:PART', symbols: '.:' },
         { pattern: 'PART.capture:PART', symbols: '.:' },
       ],
-      this
-    );
-  }
+      EventAttributePattern
+    )
+  };
   public 'PART.trigger:PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], 'trigger', parts);
   }
@@ -616,12 +615,12 @@ export class EventAttributePattern {
 
 export class ColonPrefixedBindAttributePattern {
 
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.define(
       [{ pattern: ':PART', symbols: ':' }],
-      this
-    );
-  }
+      ColonPrefixedBindAttributePattern
+    )
+  };
 
   public ':PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], 'bind');
@@ -630,14 +629,14 @@ export class ColonPrefixedBindAttributePattern {
 
 export class AtPrefixedTriggerAttributePattern {
 
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]:  AttributePattern.define(
       [
         { pattern: '@PART', symbols: '@' },
         { pattern: '@PART:PART', symbols: '@:' },
-      ], this
-    );
-  }
+      ], AtPrefixedTriggerAttributePattern
+    )
+  };
 
   public '@PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], 'trigger');

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -1,4 +1,4 @@
-import type { Constructable, } from '@aurelia/kernel';
+import type { Constructable, IRegistry, } from '@aurelia/kernel';
 import { IContainer, registrableMetadataKey, emptyArray, getResourceKeyFor, resolve } from '@aurelia/kernel';
 import { createInterface, objectFreeze, singletonRegistration } from './utilities';
 
@@ -521,7 +521,7 @@ export class AttributeParser implements IAttributeParser {
 
 export interface AttributePatternKind {
   readonly name: string;
-  define<const K extends AttributePatternDefinition, P extends Constructable<IAttributePattern<K['pattern']>> = Constructable<IAttributePattern<K['pattern']>>>(patternDefs: K[], Type: P): { register(container: IContainer): void };
+  define<const K extends AttributePatternDefinition, P extends Constructable<IAttributePattern<K['pattern']>> = Constructable<IAttributePattern<K['pattern']>>>(patternDefs: K[], Type: P): IRegistry;
 }
 
 /**

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -475,19 +475,8 @@ export class AttributeParser implements IAttributeParser {
   private readonly _container: IContainer;
 
   public constructor() {
-    /* const interpreter =  */this._interpreter = resolve(ISyntaxInterpreter);
+    this._interpreter = resolve(ISyntaxInterpreter);
     this._container = resolve(IContainer);
-    // const attrPatterns = AttributePattern.findAll(resolve(IContainer));
-    // const patterns: AttributeParser['_patterns'] = this._patterns = {};
-    // const allDefs = attrPatterns.reduce<AttributePatternDefinition[]>(
-    //   (allDefs, attrPattern) => {
-    //     const patternDefs = getAllPatternDefinitions(attrPattern.constructor as Constructable);
-    //     patternDefs.forEach(def => patterns[def.pattern] = attrPattern);
-    //     return allDefs.concat(patternDefs);
-    //   },
-    //   emptyArray as AttributePatternDefinition[]
-    // );
-    // interpreter.add(allDefs);
   }
 
   public registerPattern(patterns: AttributePatternDefinition[], Type: Constructable<IAttributePattern>): void {
@@ -533,8 +522,6 @@ export class AttributeParser implements IAttributeParser {
 export interface AttributePatternKind {
   readonly name: string;
   define<const K extends AttributePatternDefinition, P extends Constructable<IAttributePattern<K['pattern']>> = Constructable<IAttributePattern<K['pattern']>>>(patternDefs: K[], Type: P): { register(container: IContainer): void };
-  // getPatternDefinitions(Type: Constructable): AttributePatternDefinition[];
-  // findAll(container: IContainer): readonly IAttributePattern[];
 }
 
 /**
@@ -549,11 +536,6 @@ export function attributePattern<const K extends AttributePatternDefinition>(...
   };
 }
 
-// const getAllPatternDefinitions = <P extends Constructable>(Type: P): AttributePatternDefinition[] =>
-//   patterns.get(Type as Constructable<IAttributePattern>) ?? emptyArray;
-
-// const patterns = new WeakMap<Constructable<IAttributePattern>, AttributePatternDefinition[]>();
-
 export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>({
   name: getResourceKeyFor('attribute-pattern'),
   define(patternDefs, Type) {
@@ -563,14 +545,7 @@ export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>
         singletonRegistration(IAttributePattern, Type).register(container);
       }
     };
-    // patterns.set(Type, patternDefs);
-    // return Registrable.define(Type, (container: IContainer) => {
-    //   container.get(IAttributeParser).registerPattern(patternDefs, Type);
-    //   singletonRegistration(IAttributePattern, Type).register(container);
-    // });
   },
-  // getPatternDefinitions: getAllPatternDefinitions,
-  // findAll: (container) => container.root.getAll(IAttributePattern),
 });
 
 export class DotSeparatedAttributePattern {
@@ -682,6 +657,4 @@ export class AtPrefixedTriggerAttributePattern {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error
   AttributePattern.define([{ pattern: 'abc', symbols: '.' }], class Def {});
-
-  // AttributePattern.getPatternDefinitions(DotSeparatedAttributePattern).map(c => c.pattern);
 }

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -1,6 +1,7 @@
 import type { Constructable, IRegistry, } from '@aurelia/kernel';
 import { IContainer, registrableMetadataKey, emptyArray, getResourceKeyFor, resolve } from '@aurelia/kernel';
 import { createInterface, objectFreeze, singletonRegistration } from './utilities';
+import { ErrorNames, createMappedError } from './errors';
 
 export interface AttributePatternDefinition<T extends string = string> {
   pattern: T;
@@ -480,12 +481,11 @@ export class AttributeParser implements IAttributeParser {
   }
 
   public registerPattern(patterns: AttributePatternDefinition[], Type: Constructable<IAttributePattern>): void {
-    // TODO(Sayan): optimize the errors for production build.
-    if (this._initialized) throw new Error('Cannot add patterns after initialization');
+    if (this._initialized) throw createMappedError(ErrorNames.attribute_pattern_already_initialized);
 
     const $patterns = this._patterns;
     for (const { pattern } of patterns) {
-      if ($patterns[pattern] != null) throw new Error(`Pattern ${pattern} is already registered`);
+      if ($patterns[pattern] != null) throw createMappedError(ErrorNames.attribute_pattern_duplicate, pattern);
       $patterns[pattern] = { factory: container => container.get(Type) };
     }
     this._allDefinitions.push(...patterns);

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -549,14 +549,15 @@ export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>
 });
 
 export class DotSeparatedAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
-      [
-        { pattern: 'PART.PART', symbols: '.' },
-        { pattern: 'PART.PART.PART', symbols: '.' }
-      ],
-      this
-    );
+  public static register(container: IContainer): void {
+    container.register(AttributePattern
+      .define(
+        [
+          { pattern: 'PART.PART', symbols: '.' },
+          { pattern: 'PART.PART.PART', symbols: '.' }
+        ],
+        this
+      ));
   }
 
   public 'PART.PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
@@ -569,14 +570,15 @@ export class DotSeparatedAttributePattern {
 }
 
 export class RefAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
-      [
-        { pattern: 'ref', symbols: '' },
-        { pattern: 'PART.ref', symbols: '.' }
-      ],
-      this
-    );
+  public static register(container: IContainer): void {
+    container.register(
+      AttributePattern.define(
+        [
+          { pattern: 'ref', symbols: '' },
+          { pattern: 'PART.ref', symbols: '.' }
+        ],
+        this
+      ));
   }
   public 'ref'(rawName: string, rawValue: string, _parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, 'element', 'ref');
@@ -597,14 +599,15 @@ export class RefAttributePattern {
 }
 
 export class EventAttributePattern {
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static register(container: IContainer): void {
+    container.register(
+     AttributePattern.define(
       [
         { pattern: 'PART.trigger:PART', symbols: '.:' },
         { pattern: 'PART.capture:PART', symbols: '.:' },
       ],
       this
-    );
+    ));
   }
   public 'PART.trigger:PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
     return new AttrSyntax(rawName, rawValue, parts[0], 'trigger', parts);
@@ -616,11 +619,12 @@ export class EventAttributePattern {
 
 export class ColonPrefixedBindAttributePattern {
 
-  public static getRegistrable() {
-    return AttributePattern.define(
-      [{ pattern: ':PART', symbols: ':' }],
-      this
-    );
+  public static register(container: IContainer): void {
+    container.register(
+      AttributePattern.define(
+        [{ pattern: ':PART', symbols: ':' }],
+        this
+      ));
   }
 
   public ':PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {
@@ -630,13 +634,13 @@ export class ColonPrefixedBindAttributePattern {
 
 export class AtPrefixedTriggerAttributePattern {
 
-  public static getRegistrable() {
-    return AttributePattern.define(
+  public static register(container: IContainer): void {
+    container.register(AttributePattern.define(
       [
         { pattern: '@PART', symbols: '@' },
         { pattern: '@PART:PART', symbols: '@:' },
       ], this
-    );
+    ));
   }
 
   public '@PART'(rawName: string, rawValue: string, parts: readonly string[]): AttrSyntax {

--- a/packages/template-compiler/src/errors.ts
+++ b/packages/template-compiler/src/errors.ts
@@ -9,6 +9,9 @@ export const createMappedError: CreateError = __DEV__
 _START_CONST_ENUM();
 /** @internal */
 export const enum ErrorNames {
+  attribute_pattern_already_initialized = 88,
+  attribute_pattern_duplicate = 89,
+
   method_not_implemented = 99,
 
   binding_command_existed = 157,
@@ -39,6 +42,9 @@ export const enum ErrorNames {
 _END_CONST_ENUM();
 
 const errorsMap: Record<ErrorNames, string> = {
+  [ErrorNames.attribute_pattern_already_initialized]: 'AttributeParser is already initialized; cannot add patterns after initialization.',
+  [ErrorNames.attribute_pattern_duplicate]: 'Attribute pattern "{{0}}" has already been registered.',
+
   [ErrorNames.method_not_implemented]: 'Method {{0}} not implemented',
 
   [ErrorNames.binding_command_existed]: `Binding command {{0}} has already been registered.`,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR fixes the problem demonstrated in this [SB project](https://stackblitz.com/edit/au2-registrable-issue?file=src%2Fmain.ts). In short, some resources were registered globally, which can cause problem when dealing with multi-app setup. For example, app1 uses the `t` as translation attribute, and app2 uses `i18n` for the same purpose. As the patterns were registered globally, the configuration from one app overwrites the configuration from the another app. This can cause unwanted surprises.

This PR changes that behaviour by lazily registering the formerly globally registered resources (Registrables) to the container.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
