### PR TITLE
fix(router-lite): replace transition plan for same component with different paths

### DIFF
--- a/packages/__tests__/src/router-lite/current-route.spec.ts
+++ b/packages/__tests__/src/router-lite/current-route.spec.ts
@@ -43,7 +43,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r1', path: ['c-1', 'c-1/:id1'], component: C1, title: 'C1' },
+        { id: 'r1', path: ['', 'c-1', 'c-1/:id1'], component: C1, title: 'C1' },
         { id: 'r2', path: ['c-2', 'c-2/:id2'], component: C2, title: 'C2' },
       ]
     })
@@ -54,6 +54,21 @@ describe('router-lite/current-route.spec.ts', function () {
 
     const { au, container, rootVm } = await start({ appRoot: App });
     const router = container.get(IRouter);
+
+    assertCurrentRoute(rootVm.currentRoute, {
+      path: '',
+      url: '',
+      title: 'C1',
+      query: new URLSearchParams(),
+      parameterInformation: [
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'default',
+          params: emptyParams,
+          children: [],
+        }
+      ]
+    }, 'round#0');
 
     await router.load('c-1');
     assertCurrentRoute(rootVm.currentRoute, {
@@ -166,7 +181,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r11', path: ['c-11', 'c-11/:id1'], component: C11, title: 'C11' },
+        { id: 'r11', path: ['', 'c-11', 'c-11/:id1'], component: C11, title: 'C11' },
         { id: 'r12', path: ['c-12', 'c-12/:id2'], component: C12, title: 'C12' },
       ]
     })
@@ -175,7 +190,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r21', path: ['c-21', 'c-21/:id1'], component: C21, title: 'C21' },
+        { id: 'r21', path: ['', 'c-21', 'c-21/:id1'], component: C21, title: 'C21' },
         { id: 'r22', path: ['c-22', 'c-22/:id2'], component: C22, title: 'C22' },
       ]
     })
@@ -184,7 +199,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r1', path: ['c-1'], component: C1, title: 'C1' },
+        { id: 'r1', path: ['', 'c-1'], component: C1, title: 'C1' },
         { id: 'r2', path: ['c-2'], component: C2, title: 'C2' },
       ]
     })
@@ -195,6 +210,28 @@ describe('router-lite/current-route.spec.ts', function () {
 
     const { au, container, rootVm } = await start({ appRoot: App, registrations: [C11, C12, C21, C22] });
     const router = container.get(IRouter);
+
+    assertCurrentRoute(rootVm.currentRoute, {
+      path: '',
+      url: '',
+      title: 'C11 | C1',
+      query: new URLSearchParams(),
+      parameterInformation: [
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'default',
+          params: emptyParams,
+          children: [
+            {
+              config: { id: 'r11' } as RouteConfig,
+          viewport: 'default',
+          params: emptyParams,
+              children: [],
+            }
+          ],
+        }
+      ]
+    }, 'round#0');
 
     await router.load('c-1/c-11');
     assertCurrentRoute(rootVm.currentRoute, {
@@ -415,7 +452,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r1', path: ['c-1', 'c-1/:id1'], component: C1, title: 'C1' },
+        { id: 'r1', path: ['', 'c-1', 'c-1/:id1'], component: C1, title: 'C1' },
         { id: 'r2', path: ['c-2', 'c-2/:id2'], component: C2, title: 'C2' },
       ]
     })
@@ -426,6 +463,27 @@ describe('router-lite/current-route.spec.ts', function () {
 
     const { au, container, rootVm } = await start({ appRoot: App });
     const router = container.get(IRouter);
+
+    assertCurrentRoute(rootVm.currentRoute, {
+      path: '+',
+      url: '',
+      title: 'C1 | C1',
+      query: new URLSearchParams(),
+      parameterInformation: [
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'vp1',
+          params: emptyParams,
+          children: [],
+        },
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'vp2',
+          params: emptyParams,
+          children: [],
+        },
+      ]
+    }, 'round#0');
 
     await router.load('c-1+c-2');
     assertCurrentRoute(rootVm.currentRoute, {
@@ -574,7 +632,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r11', path: ['c-11', 'c-11/:id1'], component: C11, title: 'C11' },
+        { id: 'r11', path: ['', 'c-11', 'c-11/:id1'], component: C11, title: 'C11' },
         { id: 'r12', path: ['c-12', 'c-12/:id2'], component: C12, title: 'C12' },
       ]
     })
@@ -583,7 +641,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r21', path: ['c-21', 'c-21/:id1'], component: C21, title: 'C21' },
+        { id: 'r21', path: ['', 'c-21', 'c-21/:id1'], component: C21, title: 'C21' },
         { id: 'r22', path: ['c-22', 'c-22/:id2'], component: C22, title: 'C22' },
       ]
     })
@@ -592,7 +650,7 @@ describe('router-lite/current-route.spec.ts', function () {
 
     @route({
       routes: [
-        { id: 'r1', path: ['c-1'], component: C1, title: 'C1' },
+        { id: 'r1', path: ['', 'c-1'], component: C1, title: 'C1' },
         { id: 'r2', path: ['c-2'], component: C2, title: 'C2' },
       ]
     })
@@ -603,6 +661,41 @@ describe('router-lite/current-route.spec.ts', function () {
 
     const { au, container, rootVm } = await start({ appRoot: App });
     const router = container.get(IRouter);
+
+    assertCurrentRoute(rootVm.currentRoute, {
+      path: '+',
+      url: '',
+      title: 'C11 | C1 | C11 | C1',
+      query: new URLSearchParams(),
+      parameterInformation: [
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'vp1',
+          params: emptyParams,
+          children: [
+            {
+              config: { id: 'r11' } as RouteConfig,
+              viewport: 'default',
+              params: emptyParams,
+              children: [],
+            }
+          ],
+        },
+        {
+          config: { id: 'r1' } as RouteConfig,
+          viewport: 'vp2',
+          params: emptyParams,
+          children: [
+            {
+              config: { id: 'r11' } as RouteConfig,
+              viewport: 'default',
+              params: emptyParams,
+              children: [],
+            }
+          ],
+        },
+      ]
+    }, 'round#0');
 
     await router.load('c-1/c-11+c-2/c-21');
     assertCurrentRoute(rootVm.currentRoute, {

--- a/packages/router-lite/src/route.ts
+++ b/packages/router-lite/src/route.ts
@@ -10,8 +10,12 @@ import { IRouteViewModel } from './component-agent';
 import { ensureArrayOfStrings, ensureString } from './util';
 import type { FallbackFunction, IChildRouteConfig, IRedirectRouteConfig, IRouteConfig, Routeable, TransitionPlan, TransitionPlanOrFunc } from './options';
 import { Events, getMessage } from './events';
+import { RESIDUE } from '@aurelia/route-recognizer';
 
 export const noRoutes = emptyArray as RouteConfig['routes'];
+
+function cleanPath(path: string): string { return path.replace(`/*${RESIDUE}`, ''); }
+function hasSamePath(nodeA: RouteNode, nodeB: RouteNode): boolean { return cleanPath(nodeA.finalPath) === cleanPath(nodeB.finalPath); }
 
 // Every kind of route configurations are normalized to this `RouteConfig` class.
 export class RouteConfig implements IRouteConfig, IChildRouteConfig {
@@ -136,8 +140,7 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
 
   /** @internal */
   public _getTransitionPlan(cur: RouteNode, next: RouteNode, overridingTransitionPlan: TransitionPlan | null) {
-    const hasSameParameters = shallowEquals(cur.params, next.params);
-    if (hasSameParameters) return 'none';
+    if (hasSamePath(cur, next) && shallowEquals(cur.params, next.params)) return 'none';
 
     if (overridingTransitionPlan != null) return overridingTransitionPlan;
 

--- a/packages/router-lite/src/route.ts
+++ b/packages/router-lite/src/route.ts
@@ -14,9 +14,6 @@ import { RESIDUE } from '@aurelia/route-recognizer';
 
 export const noRoutes = emptyArray as RouteConfig['routes'];
 
-function cleanPath(path: string): string { return path.replace(`/*${RESIDUE}`, ''); }
-function hasSamePath(nodeA: RouteNode, nodeB: RouteNode): boolean { return cleanPath(nodeA.finalPath) === cleanPath(nodeB.finalPath); }
-
 // Every kind of route configurations are normalized to this `RouteConfig` class.
 export class RouteConfig implements IRouteConfig, IChildRouteConfig {
   /** @internal */
@@ -146,6 +143,15 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
 
     const plan = this.transitionPlan ?? 'replace';
     return typeof plan === 'function' ? plan(cur, next) : plan;
+
+    function cleanPath(path: string): string { return path.replace(`/*${RESIDUE}`, ''); }
+    function hasSamePath(nodeA: RouteNode, nodeB: RouteNode): boolean {
+      const pathA = nodeA.finalPath;
+      const pathB = nodeB.finalPath;
+      // As this function is invoked when the components are same, we are giving a benefit of doubt for empty paths.
+      // It is seems like a sensible assumption that a transition from '' to '/p1' (assuming p1 is same as the empty path) does not require a non-none transition.
+      return pathA.length === 0 || pathB.length === 0 || cleanPath(pathA) === cleanPath(pathB);
+    }
   }
 
   /** @internal */


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This fixes the issue reported in this [discourse post](https://discourse.aurelia.io/t/transition-plan-for-routes-when-parameters-do-not-change/5431) by @ivanbacher.

Additionally, it add some assertions to some existing tests.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
