### PR TITLE
feat(validation): state rule

### DIFF
--- a/docs/user-docs/aurelia-packages/validation/defining-rules.md
+++ b/docs/user-docs/aurelia-packages/validation/defining-rules.md
@@ -362,6 +362,44 @@ Let us look at one last example before moving to next section. The following exa
 
 > In the light of using rule _instance_, note that the the lambda in `satisfies` is actually wrapped in an instance of anonymous subclass of `BaseValidationRule`.
 
+**State rule using `satisfiesState`**
+
+Typically a validation rule has two states, valid and invalid.
+Although it is generally true that a rule has a single valid state, it is possible for a rule to have multiple invalid states.
+Consider a certificate validation rule.
+In that case, it is possible to have [multiple invalid states](https://x509errors.org/), such as "expired", "revoked", "not yet valid", etc.
+Naturally, we would like to provide a custom message for each invalid state.
+
+This can be done using the `.satisfiesState` method.
+An example will look like as follows.
+
+```typescript
+type certificateErrors = 'ok' | 'expired' | 'revoked' | 'not-yet-valid';
+function validateCertificate(x509Certificate): certificateErrors {
+  // some logic to determine the state of the certificate
+}
+
+validationRules
+  .on(this)
+  .ensure('certificate')
+    .satisfiesState(
+      /* valid state                 */'ok',
+      /* state (validation) function */ (value) => validateCertificate(value),
+      /* state to message mapper     */ (state) => {
+        switch (state) {
+          case 'expired': return 'The certificate was expired.';
+          case 'revoked': return 'The certificate was revoked.';
+          case 'not-yet-valid': return 'The certificate is not yet valid.';
+          // no message for 'ok' state, as it is the valid state
+        }
+      }
+    );
+```
+
+{% hint style="info" %}
+When using `@aurelia/validation-i18n` to localize the messages, the message mapper function can return the key of the localized message instead of the message itself.
+{% endhint %}
+
 **Defining rules for multiple objects**
 
 Rules on multiple objects can be defined by simply using the API in sequence for multiple objects. An example is shown below.

--- a/packages/__tests__/src/validation-i18n/localization.spec.ts
+++ b/packages/__tests__/src/validation-i18n/localization.spec.ts
@@ -33,13 +33,16 @@ describe('validation-i18n/localization.spec.ts', function () {
       public constructor(public name: string, public age: number) { }
     }
 
+    type StateError = 'none' | 'foo' | 'bar';
     class App {
       public person1: Person = new Person((void 0)!, (void 0)!);
       public person2: Person = new Person((void 0)!, (void 0)!);
+      public person3: Person = new Person((void 0)!, (void 0)!);
       public factory: LocalizedValidationControllerFactory;
       public controller: IValidationController;
       public controllerSpy: Spy;
       public readonly validationRules: IValidationRules;
+      public stateError: StateError = 'none';
 
       public constructor(container: IContainer) {
         const factory = this.factory = new LocalizedValidationControllerFactory();
@@ -66,6 +69,11 @@ describe('validation-i18n/localization.spec.ts', function () {
           .ensure('name')
           .required()
           .withMessageKey('errorMessages:required');
+
+        validationRules
+          .on(this.person3)
+          .ensure('name')
+          .satisfiesState<StateError, string>('none', (_v, _o) => this.stateError, (state) => `stateError.${state}`);
       }
 
       public unbinding() {
@@ -107,6 +115,10 @@ describe('validation-i18n/localization.spec.ts', function () {
                   nameRequired: 'Name is mandatory',
                   errorMessages: {
                     required: 'The value is required'
+                  },
+                  stateError: {
+                    foo: 'Foo Error',
+                    bar: 'Bar Error'
                   }
                 },
                 errorMessages: {
@@ -127,6 +139,10 @@ describe('validation-i18n/localization.spec.ts', function () {
                   nameRequired: 'Name ist notwendig',
                   errorMessages: {
                     required: 'Der Wert ist notwendig'
+                  },
+                  stateError: {
+                    foo: 'Foo Fehler',
+                    bar: 'Bar Fehler'
                   }
                 },
                 errorMessages: {
@@ -193,9 +209,9 @@ describe('validation-i18n/localization.spec.ts', function () {
       controllerSpy.methodCalledTimes('validate', callCount);
     }
 
-    async function changeLocale(container: IContainer, platform: IPlatform, controllerSpy: Spy) {
+    async function changeLocale(container: IContainer, platform: IPlatform, controllerSpy: Spy, locale: string = 'de') {
       const i18n = container.get(I18N);
-      await i18n.setLocale('de');
+      await i18n.setLocale(locale);
       await platform.domQueue.yield();
       controllerSpy.methodCalledTimes('validate', 1);
     }
@@ -394,6 +410,54 @@ describe('validation-i18n/localization.spec.ts', function () {
         template: `<input type="text" value.two-way="person1.age & validate">`,
         defaultNS: 'foo',
         defaultKeyPrefix: 'errorMessages'
+      }
+    );
+
+    $it('supports translating state rule',
+      async function ({ app, container, host, platform, ctx }) {
+        const controller = app.controller;
+        const controllerSpy = app.controllerSpy;
+
+        const target = host.querySelector('input');
+        assertControllerBinding(controller as ValidationController, 'person3.name', target, controllerSpy);
+
+        app.stateError = 'foo';
+        await assertEventHandler(target, 'focusout', 1, platform, controllerSpy, ctx);
+        assert.deepStrictEqual(
+          controller.results.filter(r => !r.valid).map((r) => r.toString()),
+          ['Foo Error']
+        );
+
+        await changeLocale(container, platform, controllerSpy);
+
+        assert.deepStrictEqual(
+          controller.results.filter(r => !r.valid).map((r) => r.toString()),
+          ['Foo Fehler']
+        );
+
+        app.stateError = 'bar';
+        await assertEventHandler(target, 'focusout', 1, platform, controllerSpy, ctx);
+        assert.deepStrictEqual(
+          controller.results.filter(r => !r.valid).map((r) => r.toString()),
+          ['Bar Fehler']
+        );
+
+        await changeLocale(container, platform, controllerSpy, 'en');
+
+        assert.deepStrictEqual(
+          controller.results.filter(r => !r.valid).map((r) => r.toString()),
+          ['Bar Error']
+        );
+
+        app.stateError = 'none';
+        await assertEventHandler(target, 'focusout', 1, platform, controllerSpy, ctx);
+        assert.deepStrictEqual(
+          controller.results.filter(r => !r.valid),
+          []
+        );
+      },
+      {
+        template: `<input type="text" value.two-way="person3.name & validate">`
       }
     );
   });

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -1178,5 +1178,117 @@ describe('validation/rule-provider.spec.ts', function () {
 
       validationRules.off();
     });
+
+    // The state rule is tested here as the individual unit tests are somewhat pointless.
+    describe('StateRule', function () {
+      it('stateful message - sync state function', async function () {
+        type error = 'none' | 'fooError' | 'barError';
+
+        const { validationRules } = setup();
+        const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
+        let state: error = 'none';
+        const rule = validationRules
+          .on(obj)
+          .ensure('name')
+          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .rules[0];
+
+        state = 'fooError';
+        let result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'foo');
+
+        state = 'barError';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'bar');
+
+        state = 'none';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, true);
+      });
+
+      it('stateful message - async state function', async function () {
+        type error = 'none' | 'fooError' | 'barError';
+
+        const { validationRules } = setup();
+        const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
+        let state: error = 'none';
+        const rule = validationRules
+          .on(obj)
+          .ensure('name')
+          .satisfiesState<error, string>('none', (_value, _object) => new Promise((res) => setTimeout(() => res(state), 1)), ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .rules[0];
+
+        state = 'fooError';
+        let result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'foo');
+
+        state = 'barError';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'bar');
+
+        state = 'none';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, true);
+      });
+
+      it('stateful message - interpolated message', async function () {
+        type error = 'none' | 'fooError' | 'barError';
+
+        const { validationRules } = setup();
+        const obj: Person = new Person('awesome possum', (void 0)!, (void 0)!);
+        let state: error = 'none';
+        const rule = validationRules
+          .on(obj)
+          .ensure('name')
+          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => `\${$displayName} is ${$state === 'fooError' ? 'foo' : 'bar'} (value: \${$value}).`)
+          .rules[0];
+
+        state = 'fooError';
+        let result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'Name is foo (value: awesome possum).');
+
+        state = 'barError';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'Name is bar (value: awesome possum).');
+
+        state = 'none';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, true);
+      });
+
+      it('overridden message', async function () {
+        type error = 'none' | 'fooError' | 'barError';
+
+        const { validationRules } = setup();
+        const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
+        let state: error = 'none';
+        const rule = validationRules
+          .on(obj)
+          .ensure('name')
+          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .withMessage('baz')
+          .rules[0];
+
+        state = 'fooError';
+        let result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'baz');
+
+        state = 'barError';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, false);
+        assert.equal(result[0].message, 'baz');
+
+        state = 'none';
+        result = await rule.validate(obj);
+        assert.equal(result[0].valid, true);
+      });
+    });
   });
 });

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -1182,15 +1182,15 @@ describe('validation/rule-provider.spec.ts', function () {
     // The state rule is tested here as the individual unit tests are somewhat pointless.
     describe('StateRule', function () {
       it('stateful message - sync state function', async function () {
-        type error = 'none' | 'fooError' | 'barError';
+        type Error = 'none' | 'fooError' | 'barError';
 
         const { validationRules } = setup();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
-        let state: error = 'none';
+        let state: Error = 'none';
         const rule = validationRules
           .on(obj)
           .ensure('name')
-          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .satisfiesState<Error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
           .rules[0];
 
         state = 'fooError';
@@ -1209,15 +1209,15 @@ describe('validation/rule-provider.spec.ts', function () {
       });
 
       it('stateful message - async state function', async function () {
-        type error = 'none' | 'fooError' | 'barError';
+        type Error = 'none' | 'fooError' | 'barError';
 
         const { validationRules } = setup();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
-        let state: error = 'none';
+        let state: Error = 'none';
         const rule = validationRules
           .on(obj)
           .ensure('name')
-          .satisfiesState<error, string>('none', (_value, _object) => new Promise((res) => setTimeout(() => res(state), 1)), ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .satisfiesState<Error, string>('none', (_value, _object) => new Promise((res) => setTimeout(() => res(state), 1)), ($state) => $state === 'fooError' ? 'foo' : 'bar')
           .rules[0];
 
         state = 'fooError';
@@ -1236,15 +1236,15 @@ describe('validation/rule-provider.spec.ts', function () {
       });
 
       it('stateful message - interpolated message', async function () {
-        type error = 'none' | 'fooError' | 'barError';
+        type Error = 'none' | 'fooError' | 'barError';
 
         const { validationRules } = setup();
         const obj: Person = new Person('awesome possum', (void 0)!, (void 0)!);
-        let state: error = 'none';
+        let state: Error = 'none';
         const rule = validationRules
           .on(obj)
           .ensure('name')
-          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => `\${$displayName} is ${$state === 'fooError' ? 'foo' : 'bar'} (value: \${$value}).`)
+          .satisfiesState<Error, string>('none', (_value, _object) => state, ($state) => `\${$displayName} is ${$state === 'fooError' ? 'foo' : 'bar'} (value: \${$value}).`)
           .rules[0];
 
         state = 'fooError';
@@ -1263,15 +1263,15 @@ describe('validation/rule-provider.spec.ts', function () {
       });
 
       it('overridden message', async function () {
-        type error = 'none' | 'fooError' | 'barError';
+        type Error = 'none' | 'fooError' | 'barError';
 
         const { validationRules } = setup();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
-        let state: error = 'none';
+        let state: Error = 'none';
         const rule = validationRules
           .on(obj)
           .ensure('name')
-          .satisfiesState<error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
+          .satisfiesState<Error, string>('none', (_value, _object) => state, ($state) => $state === 'fooError' ? 'foo' : 'bar')
           .withMessage('baz')
           .rules[0];
 

--- a/packages/validation-i18n/src/localization.ts
+++ b/packages/validation-i18n/src/localization.ts
@@ -1,7 +1,5 @@
 import { I18N, Signals } from '@aurelia/i18n';
-// import { DI, EventAggregator, IContainer, IDisposable, IEventAggregator, ILogger, IServiceLocator, Key } from '@aurelia/kernel';
 import { DI, EventAggregator, IContainer, IDisposable, IEventAggregator, Key, resolve } from '@aurelia/kernel';
-// import { Interpolation, PrimitiveLiteralExpression } from '@aurelia/runtime';
 import { Interpolation, PrimitiveLiteralExpression } from '@aurelia/expression-parser';
 import { IPlatform } from '@aurelia/runtime-html';
 import { IValidationRule, ValidationMessageProvider } from '@aurelia/validation';
@@ -37,6 +35,7 @@ export class LocalizedValidationControllerFactory extends ValidationControllerFa
   }
 }
 
+const explicitMessageKey: unique symbol = Symbol.for('au:validation:explicit-message-key');
 export class LocalizedValidationMessageProvider extends ValidationMessageProvider {
   private readonly keyPrefix?: string;
 
@@ -64,10 +63,14 @@ export class LocalizedValidationMessageProvider extends ValidationMessageProvide
   }
 
   public getMessage(rule: IValidationRule): PrimitiveLiteralExpression | Interpolation {
-    const parsedMessage = this.registeredMessages.get(rule);
-    if (parsedMessage !== void 0) { return parsedMessage; }
+    const messageKey = rule.messageKey;
+    const lookup = this.registeredMessages.get(rule);
+    if (lookup != null) {
+      const parsedMessage = lookup.get(explicitMessageKey) ?? lookup.get(messageKey);
+      if (parsedMessage !== void 0) { return parsedMessage; }
+    }
 
-    return this.setMessage(rule, this.i18n.tr(this.getKey(rule.messageKey)));
+    return this.setMessage(rule, this.i18n.tr(this.getKey(messageKey)));
   }
 
   public getDisplayName(propertyName: string | number | undefined, displayName?: string | null | (() => string)): string | undefined {

--- a/packages/validation-i18n/src/localization.ts
+++ b/packages/validation-i18n/src/localization.ts
@@ -1,5 +1,5 @@
 import { I18N, Signals } from '@aurelia/i18n';
-import { DI, EventAggregator, IContainer, IDisposable, IEventAggregator, Key, resolve } from '@aurelia/kernel';
+import { DI, EventAggregator, IContainer, IDisposable, IEventAggregator, Key, isFunction, resolve } from '@aurelia/kernel';
 import { Interpolation, PrimitiveLiteralExpression } from '@aurelia/expression-parser';
 import { IPlatform } from '@aurelia/runtime-html';
 import { IValidationRule, ValidationMessageProvider } from '@aurelia/validation';
@@ -63,14 +63,14 @@ export class LocalizedValidationMessageProvider extends ValidationMessageProvide
   }
 
   public getMessage(rule: IValidationRule): PrimitiveLiteralExpression | Interpolation {
-    const messageKey = rule.messageKey;
+    const messageKey = isFunction(rule.getMessage) ? rule.getMessage() : rule.messageKey;
     const lookup = this.registeredMessages.get(rule);
     if (lookup != null) {
       const parsedMessage = lookup.get(explicitMessageKey) ?? lookup.get(messageKey);
       if (parsedMessage !== void 0) { return parsedMessage; }
     }
 
-    return this.setMessage(rule, this.i18n.tr(this.getKey(messageKey)));
+    return this.setMessage(rule, this.i18n.tr(this.getKey(rule.getMessage?.() ?? messageKey)));
   }
 
   public getDisplayName(propertyName: string | number | undefined, displayName?: string | null | (() => string)): string | undefined {

--- a/packages/validation-i18n/src/localization.ts
+++ b/packages/validation-i18n/src/localization.ts
@@ -70,7 +70,7 @@ export class LocalizedValidationMessageProvider extends ValidationMessageProvide
       if (parsedMessage !== void 0) { return parsedMessage; }
     }
 
-    return this.setMessage(rule, this.i18n.tr(this.getKey(rule.getMessage?.() ?? messageKey)));
+    return this.setMessage(rule, this.i18n.tr(this.getKey(messageKey)));
   }
 
   public getDisplayName(propertyName: string | number | undefined, displayName?: string | null | (() => string)): string | undefined {

--- a/packages/validation/src/rule-interfaces.ts
+++ b/packages/validation/src/rule-interfaces.ts
@@ -11,8 +11,10 @@ export type ValidationRuleExecutionPredicate<TObject extends IValidateable = IVa
 export interface IValidationRule<TValue = any, TObject extends IValidateable = IValidateable, TState = unknown> {
   tag?: string;
   messageKey: string;
-  state?: TState;
-  isStateful: boolean;
+  /** @internal */
+  _state?: TState;
+  /** @internal */
+  _isStateful: boolean;
   canExecute(object?: IValidateable): boolean;
 
   /**

--- a/packages/validation/src/rule-interfaces.ts
+++ b/packages/validation/src/rule-interfaces.ts
@@ -8,9 +8,11 @@ import { IValidationMessageProvider } from './rules';
 export type IValidateable<T = any> = (Class<T> | object) & { [key in PropertyKey]: any };
 export type ValidationRuleExecutionPredicate<TObject extends IValidateable = IValidateable> = (object?: TObject) => boolean;
 
-export interface IValidationRule<TValue = any, TObject extends IValidateable = IValidateable> {
+export interface IValidationRule<TValue = any, TObject extends IValidateable = IValidateable, TState = unknown> {
   tag?: string;
   messageKey: string;
+  state?: TState;
+  isStateful: boolean;
   canExecute(object?: IValidateable): boolean;
 
   /**

--- a/packages/validation/src/rule-interfaces.ts
+++ b/packages/validation/src/rule-interfaces.ts
@@ -22,7 +22,7 @@ export interface IValidationRule<TValue = any, TObject extends IValidateable = I
    */
   execute(value: TValue, object?: TObject): boolean | Promise<boolean>;
   accept(visitor: IValidationVisitor): any;
-  getStateMessage?(): string;
+  getMessage?(): string;
 }
 
 export interface IRequiredRule extends IValidationRule { }

--- a/packages/validation/src/rule-interfaces.ts
+++ b/packages/validation/src/rule-interfaces.ts
@@ -8,13 +8,9 @@ import { IValidationMessageProvider } from './rules';
 export type IValidateable<T = any> = (Class<T> | object) & { [key in PropertyKey]: any };
 export type ValidationRuleExecutionPredicate<TObject extends IValidateable = IValidateable> = (object?: TObject) => boolean;
 
-export interface IValidationRule<TValue = any, TObject extends IValidateable = IValidateable, TState = unknown> {
+export interface IValidationRule<TValue = any, TObject extends IValidateable = IValidateable> {
   tag?: string;
   messageKey: string;
-  /** @internal */
-  _state?: TState;
-  /** @internal */
-  _isStateful: boolean;
   canExecute(object?: IValidateable): boolean;
 
   /**
@@ -26,6 +22,7 @@ export interface IValidationRule<TValue = any, TObject extends IValidateable = I
    */
   execute(value: TValue, object?: TObject): boolean | Promise<boolean>;
   accept(visitor: IValidationVisitor): any;
+  getStateMessage?(): string;
 }
 
 export interface IRequiredRule extends IValidationRule { }

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -25,6 +25,7 @@ import {
   BaseValidationRule,
   StateRule,
   explicitMessageKey,
+  isStatefulRule,
 } from './rules';
 import {
   IValidateable,
@@ -237,7 +238,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
     const rule = this.latestRule;
     this.assertLatestRule(rule);
     // eslint-disable-next-line no-console
-    if (__DEV__ && rule._isStateful) { console.debug('Setting message to stateful rule will override the message mapper set to the rule.'); }
+    if (__DEV__ && isStatefulRule(rule)) { console.debug('Setting message to stateful rule will override the message mapper set to the rule.'); }
     this.messageProvider.setMessage(rule, message, explicitMessageKey);
     return this;
   }
@@ -643,8 +644,7 @@ export class ValidationMessageProvider implements IValidationMessageProvider {
       if (parsedMessage !== void 0) { return parsedMessage; }
     }
 
-    // In case of stateful rule, the message key is the message itself.
-    if (rule._isStateful) return this.setMessage(rule, messageKey);
+    if (isStatefulRule(rule)) return this.setMessage(rule, rule.getStateMessage());
 
     const validationMessages = ValidationRuleAliasMessage.getDefaultMessages(rule);
     let message: string | undefined;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -25,7 +25,6 @@ import {
   BaseValidationRule,
   StateRule,
   explicitMessageKey,
-  providesMessage,
 } from './rules';
 import {
   IValidateable,

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -642,7 +642,7 @@ export class ValidationMessageProvider implements IValidationMessageProvider {
       if (parsedMessage !== void 0) { return parsedMessage; }
     }
 
-    if ($providesMessage) return this.setMessage(rule, rule.getMessage!());
+    if ($providesMessage) return this.setMessage(rule, messageKey);
 
     const validationMessages = ValidationRuleAliasMessage.getDefaultMessages(rule);
     let message: string | undefined;

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -23,6 +23,7 @@ import {
   IValidationMessageProvider,
   ValidationRuleAliasMessage,
   BaseValidationRule,
+  StateRule,
 } from './rules';
 import {
   IValidateable,
@@ -273,6 +274,10 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
   public displayName(name: string | ValidationDisplayNameAccessor) {
     this.property.displayName = name;
     return this;
+  }
+
+  public satisfiesState<TState, TVal>(this: PropertyRule<TObject, TVal>, validState: TState, stateFunction: (value: TVal, object?: TObject) => TState | Promise<TState>, messageMapper: (state: TState) => string) {
+    return this.addRule(new StateRule(validState, stateFunction, messageMapper));
   }
 
   /**

--- a/packages/validation/src/rules.ts
+++ b/packages/validation/src/rules.ts
@@ -248,8 +248,8 @@ export class EqualsRule extends BaseValidationRule implements IEqualsRule {
 
 const statefulFlag: unique symbol = Symbol.for('au:validation:rule:isStateful');
 export function isStatefulRule(rule: IValidationRule): rule is IValidationRule & { getStateMessage(): string } {
-  return (rule as IValidateable & {[statefulFlag]?: boolean})[statefulFlag] === true  // this for short-circuiting the most common case
-    || 'getStateMessage' in rule;                                                     // this is just for better DX
+  return (rule as IValidateable & {[statefulFlag]?: boolean})[statefulFlag]  // this for short-circuiting the most common case
+    ?? 'getStateMessage' in rule;                                            // this is just for better DX
 }
 export class StateRule<TValue = any, TObject extends IValidateable = IValidateable, TState = unknown> extends BaseValidationRule<TValue, TObject> {
   public static readonly $TYPE: string = 'StateRule';

--- a/packages/validation/src/rules.ts
+++ b/packages/validation/src/rules.ts
@@ -246,10 +246,15 @@ export class EqualsRule extends BaseValidationRule implements IEqualsRule {
   }
 }
 
-export function isStatefulRule(rule: IValidationRule): rule is IValidationRule & { getStateMessage(): string } { return 'getStateMessage' in rule; }
+const statefulFlag: unique symbol = Symbol.for('au:validation:rule:isStateful');
+export function isStatefulRule(rule: IValidationRule): rule is IValidationRule & { getStateMessage(): string } {
+  return (rule as IValidateable & {[statefulFlag]?: boolean})[statefulFlag] === true  // this for short-circuiting the most common case
+    || 'getStateMessage' in rule;                                                     // this is just for better DX
+}
 export class StateRule<TValue = any, TObject extends IValidateable = IValidateable, TState = unknown> extends BaseValidationRule<TValue, TObject> {
   public static readonly $TYPE: string = 'StateRule';
 
+  private readonly [statefulFlag]: boolean = true;
   public _state: TState;
   public constructor(
     private readonly validState: TState,

--- a/packages/validation/src/rules.ts
+++ b/packages/validation/src/rules.ts
@@ -273,7 +273,7 @@ export class StateRule<TValue = any, TObject extends IValidateable = IValidateab
     }
   }
 
-  public getMessage(): string { return this.messageMapper(this._state); }
+  public getMessage(): string { return this.messageKey = this.messageMapper(this._state); }
 }
 
 // #region definitions

--- a/packages/validation/src/rules.ts
+++ b/packages/validation/src/rules.ts
@@ -1,4 +1,4 @@
-import { Constructable, Class, DI, toArray, onResolve, isFunction } from '@aurelia/kernel';
+import { Constructable, Class, DI, toArray, onResolve } from '@aurelia/kernel';
 import { Interpolation, PrimitiveLiteralExpression } from '@aurelia/expression-parser';
 import {
   IValidateable,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR adds a new feature to the validation packages. So far, it was assumed that a validation rule can have 2 states, valid or invalid. Even though it is generally true that a rule has a single valid state, there are instances where a rule can have several invalid states. A classic example might be [certificate validation errors](https://x509errors.org/). 

The Aurelia validation has not yet supported a validation rule with multiple invalid states and state-specific error messages. This PR introduces the support for that. An example looks like as follows.

```ts
type Error = 'none' | 'fooError' | 'barError';

let state: Error = 'none';
validationRules
  .on(obj)
  .ensure('name')
  .satisfiesState<Error, string>(
    /* valid state                 */ 'none',
    /* state (validation) function */ (_value, _object) => state, 
    /* state -> message mapper     */ ($state) => $state === 'fooError' ? 'foo' : 'bar');
```

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
