### PR TITLE
refactor(projection): use $all instead of * to include all node types

### DIFF
--- a/docs/user-docs/components/shadow-dom-and-slots.md
+++ b/docs/user-docs/components/shadow-dom-and-slots.md
@@ -106,7 +106,7 @@ export class MyDetails {
 }
 ```
 {% endcode %}
-{% code title="my-app.html" overflow="wrap" lineNumbers="true" }
+{% code title="my-app.html" overflow="wrap" lineNumbers="true" %}
 ```html
 <my-details>
   <div>@children decorator is a good way to listen to node changes without having to deal with boilerplate yourself</div>
@@ -125,11 +125,62 @@ the property being decorated, example: `divs` -> `divsChanged`
 | - | - |
 | `@children() prop` | Use default options, observe mutation, and select all elements |
 | `@children('div') prop` | Observe mutation, and select only `div` elements |
+| `@children({ query: 'my-child' })` | Observe mutation, and select only `my-child` elements, get the component instance if available and fallback to the element itself |
+| `@children({ query: 'my-child', map: (node, viewModel) => viewModel ?? node })` | Observe mutation, and select only `my-child` elements, get the component instance if available and fallback to the element itself |
 
 {% hint style="info" %}
-
 Note: the `@children` decorator wont update if the children of a slotted node change — only if you change (e.g. add or delete) the actual nodes themselves.
 {% endhint %}
+
+### Retrieving component view models
+
+When using `@children` to target projected element components, it's often desirable to get the underlying component instances rather than the host elements of those.
+The `@children` decorator by default automatically retrieves those instances, like the following examples:
+
+{% code title="my-item.ts" overflow="wrap" lineNumbers="true" %}
+```typescript
+export class MyItem {
+  ...
+}
+```
+{% endcode %}
+{% code title="my-list.ts" overflow="wrap" lineNumbers="true" %}
+```typescript
+import { MyItem } from './my-item';
+
+export class MyList {
+  @children('my-item') items: MyItem[]
+}
+```
+{% endcode %}
+
+{% code title="my-app.html" overflow="wrap" lineNumbers="true" %}
+```html
+<import from="my-list">
+
+<my-list>
+  <my-item repeat.for="option of options" value.bind="option.value"></my-item>
+</my-list>
+```
+{% endcode %}
+
+As `items` property is decorated with `@children('my-item')`, its values is always a list of `MyItem` instances instead of `<my-item>` elements. You can alter this behavior by specifying a map option, like the following example:
+
+{% code title="my-list.ts" overflow="wrap" lineNumbers="true" %}
+```typescript
+import { MyItem } from './my-item';
+
+export class MyList {
+  @children({
+    query: 'my-item',
+    map: (node, component) => node
+  })
+  items: MyItem[]
+}
+```
+{% endcode %}
+
+In the above example, we give `map` option a function to decide that we want to take the host element instead of the component instance.
 
 ## Au-slot
 
@@ -243,7 +294,7 @@ Another important point to note is that the usage of `[au-slot]` attribute is su
 
 **Inject the projected slot information**
 
-It is possible to inject an instance of `IAuSlotsInfo` in a custom element view model. This provides information related to the slots inside a custom element. The information includes only the slot names for which content has been projected. Let's consider the following example.
+It is possible to inject an instance of `IAuSlotsInfo` in a element component view model. This provides information related to the slots inside a custom element. The information includes only the slot names for which content has been projected. Let's consider the following example.
 
 {% tabs %}
 {% tab title="my-element.html" %}
@@ -400,7 +451,7 @@ export class FooBar {
 {% endtab %}
 {% endtabs %}
 
-#### **Fallback uses the inner scope by default**
+#### Fallback uses the inner scope by default
 
 Let's consider the following example with interpolation. This is the same example as before, but this time without projection.
 
@@ -494,7 +545,7 @@ export class FooBar {
 {% endtab %}
 {% endtabs %}
 
-#### **Access the inner scope with `$host`**
+#### Access the inner scope with `$host`
 
 The outer custom element can access the inner custom element's scope using the `$host` keyword, as shown in the following example.
 
@@ -841,8 +892,10 @@ The `@slotted` decorator can be used in multiple forms:
 | `@slotted() prop` | Use default options, observe projection on the `default` slot, and select all elements |
 | `@slotted('div') prop` | Observe projection on the `default` slot, and select only `div` elements |
 | `@slotted('div', 'footer') prop` | Observe projection on the `footer` slot and select only `div` elements |
-| `@slotted('*')` | Observe projection on the `default` slot, and select all nodes, including text |
+| `@slotted('$all')` | Observe projection on the `default` slot, and select all nodes, including text |
+| `@slotted('*')` | Observe projection on the `default` slot, and select all elements |
 | `@slotted('div', '*')` | Observe projection on all slots, and select only `div` elements |
+| `@slotted('*', '*')` | Observe projection on all slots, and select all elements |
 | `@slotted({ query: 'div' })` | Observe projection on the `default` slot, and select only `div` elements |
 | `@slotted({ slotName: 'footer' })` | Observe projection on `footer` slot, and select all elements |
 | `@slotted({ callback: 'nodeChanged' })` | Observe projection on `default` slot, and select all elements, and call `nodeChanged` method on projection change |

--- a/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
@@ -240,7 +240,26 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       assertText('Count: 3 6');
     });
 
-    it('assigns all node with *', function () {
+    it('assigns all nodes with $all', function () {
+      @customElement({
+        name: 'el',
+        template: 'Count: ${nodes.length} <au-slot>'
+      })
+      class El {
+        @slotted('$all') nodes;
+      }
+
+      const { assertText } = createFixture(
+        '<el>text<div></div><p></p><!--ha-->',
+        class App { },
+        [El,]
+      );
+
+      // comments are filtered out by projection slot change notifier
+      assertText('Count: 3 text');
+    });
+
+    it('assigns all elements with *', function () {
       @customElement({
         name: 'el',
         template: 'Count: ${nodes.length} <au-slot>'
@@ -255,7 +274,7 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
         [El,]
       );
 
-      assertText('Count: 3 text');
+      assertText('Count: 2 text');
     });
 
     it('works with slots when there are elements in between', async function () {

--- a/packages/__tests__/src/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/children-observer.spec.ts
@@ -34,7 +34,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
     it('children array with by custom query', async function () {
       const { au, viewModel, ChildOne } = createAppAndStart({
-        query: p => p.host.querySelectorAll('.child-one')
+        query: '.child-one'
       });
 
       await Promise.resolve();
@@ -48,7 +48,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
     it('children array with by custom query, filter, and map', async function () {
       const { au, viewModel, ChildOne } = createAppAndStart({
-        query: p => p.host.querySelectorAll('.child-one'),
+        query: '.child-one',
         filter: (node) => !!node,
         map: (node) => node
       });
@@ -60,6 +60,16 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
       await au.stop();
       au.dispose();
+    });
+
+    it('queries all nodes when using "$all"', async function () {
+      const { component } = createFixture('<e-l component.ref="el">hi<div>hey</div><span></span><p></p><!--hah-->', { el: { children: [] } }, [
+        CustomElement.define({ name: 'e-l', template: '<slot>', shadowOptions: { mode: 'open' } }, class El {
+          @children('$all') public children: any[];
+        })
+      ]);
+
+      assert.strictEqual(component.el.children.length, 5 /* #text + div + span + p + #comment */);
     });
   });
 
@@ -90,7 +100,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
     it('children array with by custom query', async function () {
       const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
-        query: p => p.host.querySelectorAll('.child-two')
+        query: '.child-two'
       });
 
       await Promise.resolve();
@@ -116,7 +126,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
 
     it('children array with by custom query, filter, and map', async function () {
       const { au, viewModel, ChildTwo, hostViewModel } = createAppAndStart({
-        query: p => p.host.querySelectorAll('.child-two'),
+        query: '.child-two',
         filter: (node) => !!node,
         map: (node) => node
       });
@@ -153,7 +163,7 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
       class El {
         @children('div') nodes: any[];
       }
-      const { assertText } = createFixture(
+      const { flush, assertText } = createFixture(
         '<e-l ref=el><div repeat.for="i of items">',
         class App {
           items = 3;
@@ -161,7 +171,8 @@ describe('3-runtime-html/children-observer.spec.ts', function () {
         [El]
       );
 
-      await new Promise(r => setTimeout(r, 50));
+      await Promise.resolve();
+      flush();
 
       assertText('child count: 3');
     });

--- a/packages/__tests__/src/3-runtime-html/children-observer.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/children-observer.spec.ts
@@ -3,6 +3,18 @@ import { TestContext, assert, createFixture } from '@aurelia/testing';
 import { IContainer } from '@aurelia/kernel';
 
 describe('3-runtime-html/children-observer.spec.ts', function () {
+
+  it('throws on invalid query', function () {
+    @customElement({
+      name: 'el',
+      template: '<au-slot>'
+    })
+    class El {
+      @children('div div') divs;
+    }
+    assert.throws(() => createFixture('', El));
+  });
+
   describe('populates', function () {
     it('[without shadow DOM] static plain elements', async function () {
       @customElement({ name: 'my-el', template: '<slot>', shadowOptions: { mode: 'open' } })

--- a/packages/kernel/src/functions.ts
+++ b/packages/kernel/src/functions.ts
@@ -1,6 +1,6 @@
 import { ErrorNames, createMappedError } from './errors';
 import { Constructable, Overwrite } from './interfaces';
-import { createLookup, objectAssign } from './utilities';
+import { createLookup, isPromise, objectAssign } from './utilities';
 
 /**
  * Efficiently determine whether the provided property key is numeric
@@ -34,7 +34,7 @@ export const isArrayIndex = (() => {
         ch = 0;
         i = 0;
         for (; i < length; ++i) {
-          ch = charCodeAt(value, i);
+          ch = value.charCodeAt(i);
           if (i === 0 && ch === 0x30 && length > 1 /* must not start with 0 */ || ch < 0x30 /* 0 */ || ch > 0x39/* 9 */) {
             return isNumericLookup[value] = false;
           }
@@ -381,7 +381,7 @@ export function toLookup(...objs: {}[]): Readonly<{}> {
  * @param fn - The function to check.
  * @returns `true` is the function is a native function, otherwise `false`
  */
-export const isNativeFunction = /*@__PURE__*/(function () {
+export const isNativeFunction = /*@__PURE__*/(() => {
   // eslint-disable-next-line @typescript-eslint/ban-types
   const lookup: WeakMap<Function, boolean> = new WeakMap();
   let isNative = false as boolean | undefined;
@@ -391,34 +391,9 @@ export const isNativeFunction = /*@__PURE__*/(function () {
   // eslint-disable-next-line @typescript-eslint/ban-types
   return (fn: Function) => {
     isNative = lookup.get(fn);
-    if (isNative === void 0) {
-      sourceText = fn.toString();
-      i = sourceText.length;
-
-      // http://www.ecma-international.org/ecma-262/#prod-NativeFunction
-      isNative = (
-        // 29 is the length of 'function () { [native code] }' which is the smallest length of a native function string
-        i >= 29 &&
-        // 100 seems to be a safe upper bound of the max length of a native function. In Chrome and FF it's 56, in Edge it's 61.
-        i <= 100 &&
-        // This whole heuristic *could* be tricked by a comment. Do we need to care about that?
-        charCodeAt(sourceText, i -  1) === 0x7D && // }
-        // TODO: the spec is a little vague about the precise constraints, so we do need to test this across various browsers to make sure just one whitespace is a safe assumption.
-        charCodeAt(sourceText, i -  2)  <= 0x20 && // whitespace
-        charCodeAt(sourceText, i -  3) === 0x5D && // ]
-        charCodeAt(sourceText, i -  4) === 0x65 && // e
-        charCodeAt(sourceText, i -  5) === 0x64 && // d
-        charCodeAt(sourceText, i -  6) === 0x6F && // o
-        charCodeAt(sourceText, i -  7) === 0x63 && // c
-        charCodeAt(sourceText, i -  8) === 0x20 && //
-        charCodeAt(sourceText, i -  9) === 0x65 && // e
-        charCodeAt(sourceText, i - 10) === 0x76 && // v
-        charCodeAt(sourceText, i - 11) === 0x69 && // i
-        charCodeAt(sourceText, i - 12) === 0x74 && // t
-        charCodeAt(sourceText, i - 13) === 0x61 && // a
-        charCodeAt(sourceText, i - 14) === 0x6E && // n
-        charCodeAt(sourceText, i - 15) === 0x5B    // [
-      );
+    if (isNative == null) {
+      i = (sourceText = fn.toString()).length;
+      isNative = i > 28 && sourceText.indexOf('[native code] }') === i - 15;
       lookup.set(fn, isNative);
     }
     return isNative;
@@ -452,18 +427,16 @@ export const onResolve = <TValue, TRet>(
  *
  * If none of the values is a promise, nothing is returned, to indicate that things can stay synchronous.
  */
-export const onResolveAll = (
-  ...maybePromises: (void | Promise<void>)[]
-): void | Promise<void> => {
-  let maybePromise: Promise<void> | void = void 0;
-  let firstPromise: Promise<void> | void = void 0;
-  let promises: Promise<void>[] | undefined = void 0;
+export const onResolveAll = (...maybePromises: unknown[]): void | Promise<void> => {
+  let maybePromise: unknown = void 0;
+  let firstPromise: unknown = void 0;
+  let promises: unknown[] | undefined = void 0;
   let i = 0;
   // eslint-disable-next-line
   let ii = maybePromises.length;
   for (; i < ii; ++i) {
     maybePromise = maybePromises[i];
-    if ((maybePromise = maybePromises[i]) instanceof Promise) {
+    if (isPromise(maybePromise = maybePromises[i])) {
       if (firstPromise === void 0) {
         firstPromise = maybePromise;
       } else if (promises === void 0) {
@@ -475,9 +448,7 @@ export const onResolveAll = (
   }
 
   if (promises === void 0) {
-    return firstPromise;
+    return firstPromise as void | Promise<void>;
   }
   return Promise.all(promises) as unknown as Promise<void>;
 };
-
-const charCodeAt = (str: string, index: number) => str.charCodeAt(index);

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -125,6 +125,7 @@ export const enum ErrorNames {
 
   children_decorator_invalid_usage = 9991,
   slotted_decorator_invalid_usage = 9990,
+  children_invalid_query = 9989,
 }
 _END_CONST_ENUM();
 
@@ -248,6 +249,7 @@ const errorsMap: Record<ErrorNames, string> = {
 
   [ErrorNames.children_decorator_invalid_usage]: `Invalid @children usage. @children decorator can only be used on a field`,
   [ErrorNames.slotted_decorator_invalid_usage]: `Invalid @slotted usage. @slotted decorator can only be used on a field`,
+  [ErrorNames.children_invalid_query]: `Invalid query selector. Only selectors with alpha-numeric characters, or $all are allowed. Got {{0}} instead.`
 };
 
 const getMessageByCode = (name: ErrorNames, ...details: unknown[]) => {

--- a/packages/runtime-html/src/index.ts
+++ b/packages/runtime-html/src/index.ts
@@ -166,7 +166,7 @@ export {
 export {
   NodeObserverLocator,
   type INodeObserverConfig,
-  type INodeObserverConstructor as IHtmlObserverConstructor,
+  type INodeObserverConstructor,
 } from './observation/observer-locator';
 export {
   type ISelectElement,

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -176,6 +176,15 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
     // C(synthetic)#2 is what will provide the content for C(au-slot)#1
     // but C(au-slot)#1 is what will provide the $host value for the content of C(au-slot)#2
     //
+    // example:
+    // <template as-custom-element="parent">
+    //   <child>
+    //    <au-slot> #2
+    //   </child>
+    // ...
+    // <template as-custom-element="child">
+    //  <au-slot> #1
+    //
     // because of this structure, walk 2 level of controller at once to find the right parent scope for $host value
     while (parent.vmKind === 'synthetic' && parent.parent?.viewModel instanceof AuSlot) {
       parent = parent.parent.parent as IHydratedParentController;

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -215,7 +215,7 @@ class ChildrenLifecycleHooks {
       $def.filter as PartialChildrenDefinition<'$all'>['filter'],
       $def.map as PartialChildrenDefinition<'$all'>['map'],
     );
-    if (/[^a-z0-9_-$]/.test(query)) {
+    if (/[\s>]/.test(query)) {
       throw createMappedError(ErrorNames.children_invalid_query, query);
     }
     def(vm, $def.name, {

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -5,20 +5,21 @@ import { ILifecycleHooks, lifecycleHooks } from './lifecycle-hooks';
 import { def, objectAssign, safeString } from '../utilities';
 import { instanceRegistration } from '../utilities-di';
 import { type ICustomElementViewModel, type ICustomElementController } from './controller';
-import { createMutationObserver, isElement } from '../utilities-dom';
+import { createMutationObserver } from '../utilities-dom';
 
-import type { INode } from '../dom';
 import { ErrorNames, createMappedError } from '../errors';
 import { getAnnotationKeyFor } from '../utilities-metadata';
 import { IBinding } from '../binding/interfaces-bindings';
 
-export type PartialChildrenDefinition = {
+/**
+ * An interface describing options to observe the children elements of a custom element host
+ */
+export type PartialChildrenDefinition<TQuery extends string = string> = {
+  query?: TQuery;
   callback?: PropertyKey;
   name?: PropertyKey;
-  options?: MutationObserverInit;
-  query?: (controller: ICustomElementController) => ArrayLike<Node>;
-  filter?: (node: Node, controller?: ICustomElementController | null, viewModel?: ICustomElementViewModel) => boolean;
-  map?: (node: Node, controller?: ICustomElementController | null, viewModel?: ICustomElementViewModel) => unknown;
+  filter?: (node: TQuery extends '$all' ? Node : HTMLElement, viewModel: ICustomElementViewModel | null) => boolean;
+  map?: (node: TQuery extends '$all' ? Node : HTMLElement, viewModel: ICustomElementViewModel | null) => unknown;
 };
 
 /**
@@ -26,23 +27,24 @@ export type PartialChildrenDefinition = {
  *
  * @param config - The overrides
  */
-export function children<TThis,TValue>(config?: PartialChildrenDefinition): (target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void;
+export function children<TThis, TValue, TQuery extends string>(config?: PartialChildrenDefinition<TQuery>): (target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void;
 /**
  * Decorator: Specifies an array property on a class that synchronizes its items with child content nodes of the element.
  *
- * @param selector - The CSS element selector for filtering children
+ * @param selector - The CSS element selector for filtering children. Use `$all` to select everything including non element nodes.
+ * If nothing is provided, it defaults to `*`, which means all elements
  */
-export function children<TThis,TValue>(selector: string): (target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void;
+export function children<TThis, TValue>(selector: string): (target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void;
 /**
  * Decorator: Decorator: Specifies an array property that synchronizes its items with child content nodes of the element.
  *
  * @param target - The class
  * @param prop - The property name
  */
-export function children<TThis,TValue>(target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>): void;
-export function children<TThis,TValue>(configOrTarget?: PartialChildrenDefinition | string | undefined, context?: ClassFieldDecoratorContext<TThis,TValue>): void | ((target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void) {
-  if (!mixed) {
-    mixed = true;
+export function children<TThis, TValue>(target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>): void;
+export function children<TThis, TValue, TQuery extends string>(configOrTarget?: PartialChildrenDefinition<TQuery> | string | undefined, context?: ClassFieldDecoratorContext<TThis,TValue>): void | ((target: undefined, context: ClassFieldDecoratorContext<TThis,TValue>) => void) {
+  if (!children.mixed) {
+    children.mixed = true;
     subscriberCollection(ChildrenBinding, null!);
     lifecycleHooks()(ChildrenLifecycleHooks, null!);
   }
@@ -57,7 +59,7 @@ export function children<TThis,TValue>(configOrTarget?: PartialChildrenDefinitio
     }
 
     const dependencies = (context.metadata[dependenciesKey] ??= []) as Key[];
-    dependencies.push(new ChildrenLifecycleHooks(config as PartialChildrenDefinition & { name: PropertyKey }));
+    dependencies.push(new ChildrenLifecycleHooks(config as PartialChildrenDefinition & { name: PropertyKey } ?? {}));
   }
 
   if (arguments.length > 1) {
@@ -70,8 +72,9 @@ export function children<TThis,TValue>(configOrTarget?: PartialChildrenDefinitio
     // Direct call:
     // - @children('div')(Foo)
     config = {
-      filter: (node: Node) => isElement(node) && node.matches(configOrTarget),
-      map: el => el
+      query: configOrTarget,
+      // filter: (node: Node) => isElement(node) && node.matches(configOrTarget),
+      // map: el => el
     };
     return decorator;
   }
@@ -82,6 +85,7 @@ export function children<TThis,TValue>(configOrTarget?: PartialChildrenDefinitio
   config = configOrTarget === void 0 ? {} : configOrTarget;
   return decorator;
 }
+children.mixed = false;
 
 export interface ChildrenBinding extends ISubscriberCollection { }
 
@@ -98,36 +102,29 @@ export class ChildrenBinding implements IBinding {
   /** @internal */
   private readonly _host: HTMLElement;
   /** @internal */
-  private readonly _controller: ICustomElementController;
+  private readonly _query: string;
   /** @internal */
-  private readonly _query = defaultChildQuery;
+  private readonly _filter?: (node: Node, viewModel: ICustomElementViewModel | null) => boolean;
   /** @internal */
-  private readonly _filter = defaultChildFilter;
-  /** @internal */
-  private readonly _map = defaultChildMap;
-  /** @internal */
-  private readonly _options?: MutationObserverInit;
+  private readonly _map?: (node: Node, viewModel: ICustomElementViewModel | null) => unknown;
 
   public isBound = false;
   public readonly obj: ICustomElementViewModel;
 
   public constructor(
-    controller: ICustomElementController,
+    host: HTMLElement,
     obj: ICustomElementViewModel,
     callback: undefined | (() => void),
-    query = defaultChildQuery,
-    filter = defaultChildFilter,
-    map = defaultChildMap,
-    options = childObserverOptions,
+    query: string,
+    filter?: (node: Node, viewModel: ICustomElementViewModel | null) => boolean,
+    map?: (node: Node, viewModel: ICustomElementViewModel | null) => unknown,
   ) {
-    this._controller = controller;
     this.obj = obj;
     this._callback = callback;
     this._query = query;
     this._filter = filter;
     this._map = map;
-    this._options = options;
-    this._observer = createMutationObserver(this._host = controller.host, () => {
+    this._observer = createMutationObserver(this._host = host, () => {
       this._onChildrenChanged();
     });
   }
@@ -143,7 +140,7 @@ export class ChildrenBinding implements IBinding {
       return;
     }
     this.isBound = true;
-    this._observer.observe(this._host, this._options);
+    this._observer.observe(this._host, { childList: true });
     this._children = this._getNodes();
   }
 
@@ -152,6 +149,8 @@ export class ChildrenBinding implements IBinding {
       return;
     }
     this.isBound = false;
+    // prevent memory leaks
+    this._observer.takeRecords();
     this._observer.disconnect();
     this._children = emptyArray;
   }
@@ -172,51 +171,29 @@ export class ChildrenBinding implements IBinding {
   // freshly retrieve the children everytime
   // in case this observer is not observing
   private _getNodes() {
-    return filterChildren(this._controller, this._query, this._filter, this._map);
+    const query = this._query;
+    const filter = this._filter;
+    const map = this._map;
+    const nodes = query === '$all' ? this._host.childNodes : this._host.querySelectorAll(`:scope > ${query}`);
+    const ii = nodes.length;
+    const results: unknown[] = [];
+    const findControllerOptions = { optional: true };
+    let $controller: ICustomElementController | null;
+    let viewModel: ICustomElementViewModel | null;
+    let i = 0;
+    let node: Node;
+    while (ii > i) {
+      node = nodes[i];
+      $controller = findElementControllerFor(node, findControllerOptions);
+      viewModel = $controller?.viewModel ?? null;
+      if (filter == null ? true : filter(node, viewModel)) {
+        results.push(map == null ? viewModel ?? node : map(node, viewModel));
+      }
+      ++i;
+    }
+    return results;
   }
 }
-
-const childObserverOptions: MutationObserverInit = { childList: true };
-
-const defaultChildQuery = (controller: ICustomElementController): ArrayLike<INode> => controller.host.childNodes;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultChildFilter = (node: INode, controller?: ICustomElementController | null, viewModel?: any): boolean =>
-  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-  !!viewModel;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const defaultChildMap = (node: INode, controller?: ICustomElementController | null, viewModel?: any): any => viewModel;
-
-const forOpts = { optional: true } as const;
-
-const filterChildren = (
-  controller: ICustomElementController,
-  query: typeof defaultChildQuery,
-  filter: typeof defaultChildFilter,
-  map: typeof defaultChildMap
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-): any[] => {
-  const nodes = query(controller);
-  const ii = nodes.length;
-  const children: unknown[] = [];
-
-  let node: INode;
-  let $controller: ICustomElementController | null;
-  let viewModel: ICustomElementViewModel | null;
-  let i = 0;
-  for (; i < ii; ++i) {
-    node = nodes[i];
-    $controller = findElementControllerFor(node, forOpts);
-    viewModel = $controller?.viewModel ?? null;
-
-    if (filter(node, $controller, viewModel)) {
-      children.push(map(node, $controller, viewModel));
-    }
-  }
-
-  return children;
-};
 
 class ChildrenLifecycleHooks {
   public constructor(
@@ -230,13 +207,12 @@ class ChildrenLifecycleHooks {
   public hydrating(vm: IIndexable, controller: ICustomElementController) {
     const $def = this._def;
     const childrenObserver = new ChildrenBinding(
-      controller,
+      controller.host,
       vm,
       vm[$def.callback ?? `${safeString($def.name)}Changed`] as () => void,
-      $def.query ?? defaultChildQuery,
-      $def.filter ?? defaultChildFilter,
-      $def.map ?? defaultChildMap,
-      $def.options ?? childObserverOptions,
+      $def.query ?? '*',
+      $def.filter as PartialChildrenDefinition<'$all'>['filter'],
+      $def.map as PartialChildrenDefinition<'$all'>['map'],
     );
     def(vm, $def.name, {
       enumerable: true,
@@ -253,4 +229,21 @@ class ChildrenLifecycleHooks {
   }
 }
 
-let mixed = false;
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment */
+function testChildrenDecorator() {
+  class MyEl {
+    @children({
+      filter: (element) => element.getAttribute('hey') == null,
+      map: el => el.style
+    })
+    @children({
+      map: node => node.style
+    })
+    @children({
+      query: '$all',
+      // @ts-expect-error
+      map: node => node.style
+    })
+    public nodes: unknown[] = [];
+  }
+}

--- a/packages/runtime-html/src/templating/children.ts
+++ b/packages/runtime-html/src/templating/children.ts
@@ -206,14 +206,18 @@ class ChildrenLifecycleHooks {
 
   public hydrating(vm: IIndexable, controller: ICustomElementController) {
     const $def = this._def;
+    const query = $def.query ?? '*';
     const childrenObserver = new ChildrenBinding(
       controller.host,
       vm,
       vm[$def.callback ?? `${safeString($def.name)}Changed`] as () => void,
-      $def.query ?? '*',
+      query,
       $def.filter as PartialChildrenDefinition<'$all'>['filter'],
       $def.map as PartialChildrenDefinition<'$all'>['map'],
     );
+    if (/[^a-z0-9_-$]/.test(query)) {
+      throw createMappedError(ErrorNames.children_invalid_query, query);
+    }
     def(vm, $def.name, {
       enumerable: true,
       configurable: true,

--- a/packages/runtime-html/src/templating/controller.projection.ts
+++ b/packages/runtime-html/src/templating/controller.projection.ts
@@ -141,11 +141,12 @@ class AuSlotWatcherBinding implements IAuSlotWatcher, IAuSlotSubscriber, ISubscr
     }
     const oldNodes = this._nodes;
     const $nodes: Node[] = [];
+    const query = this._query;
     let $slot: IAuSlot;
     let node: Node;
     for ($slot of this._slots) {
       for (node of $slot === slot ? nodes : $slot.nodes) {
-        if (this._query === '*' || (isElement(node) && node.matches(this._query))) {
+        if (query === '$all' || (isElement(node) && (query === '*' || node.matches(query)))) {
           $nodes[$nodes.length] = node;
         }
       }


### PR DESCRIPTION
## 📖 Description

BREAKING CHANGE: currently `@children` and `@slotted` decorators use `*` to express "select all nodes", but this is not what it means as a selector in CSS. Change `*` to `$all` to express select all.

- Cleanup & improve doc for `@children`