### PR TITLE
feat(plugin-conventions): support foo.module.css CSS module convention

### DIFF
--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -764,9 +764,106 @@ export function register(container) {
 }
 `;
     const result = preprocessHtmlTemplate(
-      { path: path.join('lo', 'FooBar.html'), contents: html },
+      { path: path.join('lo', 'FooBar.html'), filePair: 'foo-bar.scss', contents: html },
       preprocessOptions({
         useCSSModule: true,
+        hmr: false,
+        stringModuleWrap: (id: string) => `text!${id}`
+      }),
+      false,
+      () => false
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('processes template with implicit css dependencies in cssModule mode', function () {
+    const html = '<import from="./hello-world.html" /><template><import from="foo"></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import { cssModules } from '@aurelia/runtime-html';
+import d0 from "./foo-bar.module.scss";
+import * as d1 from "./hello-world.html";
+import * as d2 from "foo";
+export const name = "foo-bar";
+export const template = "<template></template>";
+export default template;
+export const dependencies = [ d1, d2, cssModules(d0) ];
+export const bindables = [];
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocessHtmlTemplate(
+      { path: path.join('lo', 'FooBar.html'), filePair: 'foo-bar.module.scss', contents: html },
+      preprocessOptions({
+        useCSSModule: true,
+        hmr: false,
+        stringModuleWrap: (id: string) => `text!${id}`
+      }),
+      false,
+      () => false
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('processes template with css dependencies with module.css convention', function () {
+    const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.module.scss"></require></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import { cssModules } from '@aurelia/runtime-html';
+import * as d0 from "./hello-world.html";
+import * as d1 from "foo";
+import d2 from "./foo-bar.module.scss";
+export const name = "foo-bar";
+export const template = "<template></template>";
+export default template;
+export const dependencies = [ d0, d1, cssModules(d2) ];
+export const bindables = [];
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocessHtmlTemplate(
+      { path: path.join('lo', 'FooBar.html'), filePair: 'foo-bar.module.scss', contents: html },
+      preprocessOptions({
+        hmr: false,
+        stringModuleWrap: (id: string) => `text!${id}`
+      }),
+      false,
+      () => false
+    );
+    assert.equal(result.code, expected);
+  });
+
+  it('processes template with implicit css dependencies with module.css convention', function () {
+    const html = '<import from="./hello-world.html" /><template><import from="foo"></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import { cssModules } from '@aurelia/runtime-html';
+import d0 from "./foo-bar.module.scss";
+import * as d1 from "./hello-world.html";
+import * as d2 from "foo";
+export const name = "foo-bar";
+export const template = "<template></template>";
+export default template;
+export const dependencies = [ d1, d2, cssModules(d0) ];
+export const bindables = [];
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocessHtmlTemplate(
+      { path: path.join('lo', 'FooBar.html'), filePair: 'foo-bar.module.scss', contents: html },
+      preprocessOptions({
         hmr: false,
         stringModuleWrap: (id: string) => `text!${id}`
       }),

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess.spec.ts
@@ -57,6 +57,40 @@ export function register(container) {
     assert.equal(result.map.version, 3);
   });
 
+  it('transforms html file with paired css module file', function () {
+    const html = '<template></template>';
+    const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import { cssModules } from '@aurelia/runtime-html';
+import d0 from "./foo-bar.module.css";
+export const name = "foo-bar";
+export const template = "<template></template>";
+export default template;
+export const dependencies = [ cssModules(d0) ];
+export const bindables = [];
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+    const result = preprocess(
+      {
+        path: path.join('src', 'foo-bar.html'),
+        contents: html
+      },
+      {
+        useProcessedFilePairFilename: true,
+        hmr: false,
+        enableConventions: true
+      },
+      (unit: IFileUnit, filePath: string) => filePath === './foo-bar.module.less'
+    )!;
+    assert.equal(result.code, expected);
+    assert.equal(result.map.version, 3);
+  });
+
   it('transforms html file with shadowOptions', function () {
     const html = '<import from="./hello-world.html" /><template><import from="foo"><require from="./foo-bar.scss"></require></template>';
     const expected = `import { CustomElement } from '@aurelia/runtime-html';

--- a/packages-tooling/plugin-conventions/src/preprocess.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess.ts
@@ -15,14 +15,17 @@ export function preprocess(
   const allOptions = preprocessOptions(options);
 
   if (allOptions.enableConventions && allOptions.templateExtensions.includes(ext)) {
-    const possibleFilePair = allOptions.cssExtensions.map(e =>
-      `${basename}${e}`
-    );
+    const possibleFilePair: string[] = [];
+    allOptions.cssExtensions.forEach(e => {
+      // foo.css or foo.module.css
+      possibleFilePair.push(`${basename}.module${e}`, `${basename}${e}`);
+    });
 
     const filePair = possibleFilePair.find(p => _fileExists(unit, `./${p}`));
     if (filePair) {
       if (allOptions.useProcessedFilePairFilename) {
-        unit.filePair = `${basename}.css`;
+        // Replace foo.scss with transpiled file name foo.css
+        unit.filePair = `${path.basename(filePair, path.extname(filePair))}.css`;
       } else {
         unit.filePair = filePair;
       }


### PR DESCRIPTION
Related to #1948

This enables foo.module.css file to be processed with CSS module.