### PR TITLE
fix(css-modules): avoid duplicate registrations

### DIFF
--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/README.md
@@ -138,6 +138,11 @@ composition, so `component.ref` (`view-model.ref` in v1) no longer means getting
 
 Read more about dynamic composition in v2 in this [dynamic composition doc](../../getting-to-know-aurelia/dynamic-composition.md) and [dynamic ui composition doc](../../app-basics/dynamic-ui-composition.md).
 
+## Replaceable & replaceable part
+
+If you are using `replaceable`/`part`/`repaceable-part` combo in your v1 applications, you'll need to replace them with `<au-slot>` elements and `au-slot` attributes.
+Refer to the [au slot doc](../../components/shadow-dom-and-slots.md#au-slot) for more information.
+
 ## General changes
 
 * Custom attributes are no longer considered to have a binding to the primary bindable when their template usage is with an empty string, like the following examples:
@@ -158,6 +163,7 @@ Read more about dynamic composition in v2 in this [dynamic composition doc](../.
     ```html
     <input value.bind="value">
     ```
+    This is automatically applied to `.bind`/`.one-time`/`.to-view`/`.from-view`/`.two-way`/`.attr` binding commands.
 
 ## Plugins:
 

--- a/packages/__tests__/src/3-runtime-html/styles.integration.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/styles.integration.spec.ts
@@ -1,5 +1,5 @@
-import { CustomElement, Aurelia, cssModules } from '@aurelia/runtime-html';
-import { assert, createFixture, TestContext } from '@aurelia/testing';
+import { CustomElement, Aurelia, cssModules, customElement, ICustomElementViewModel } from '@aurelia/runtime-html';
+import { assert, createFixture, createSink, TestContext } from '@aurelia/testing';
 
 describe('3-runtime-html/styles.integration.spec.ts', function () {
 
@@ -107,6 +107,67 @@ I am green if I am selected and red if I am not
       );
 
       assertClass('p:nth-child(1)', 'a_', 'strike');
+    });
+
+    it('works with class on surrogate elements', function () {
+      @customElement({
+        name: 'el',
+        template: '<template class="b">Hey',
+        dependencies: [cssModules({ 'a': 'a_' }), cssModules({ 'b': 'b_' })]
+      })
+      class El {}
+
+      let i = 0;
+
+      const { assertClass } = createFixture(
+        '<el class="a" component.ref="el">',
+        class { el: ICustomElementViewModel & El; },
+        [El, createSink.warn(() => i = 1)]);
+
+      assert.strictEqual(i, 0);
+      assertClass('el', 'b_', 'a');
+    });
+
+    it('works with class with interpolation', function () {
+      const { assertClass } = createFixture('<my-el>', undefined, [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<div class="some ${myClass}">',
+          dependencies: [cssModules({ 'hey': 'abc' })]
+        }, class MyEl {
+          myClass = "hey";
+        })
+      ]);
+
+      assertClass('div', 'abc', 'some');
+    });
+
+    it('works with bind command and an expression returning string value', function () {
+      const { assertClass } = createFixture('<my-el>', undefined, [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<div class.bind="myClass">',
+          dependencies: [cssModules({ 'hey': 'abc' })]
+        }, class MyEl {
+          myClass = "hey";
+        })
+      ]);
+
+      assertClass('div', 'abc');
+    });
+
+    it('works with bind command and an expression returning an object', function () {
+      const { assertClass } = createFixture('<my-el>', undefined, [
+        CustomElement.define({
+          name: 'my-el',
+          template: '<div class.bind="myClass">',
+          dependencies: [cssModules({ 'hey': 'abc' })]
+        }, class MyEl {
+          myClass = { "hey": true };
+        })
+      ]);
+
+      assertClass('div', 'abc');
     });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/styles.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/styles.spec.ts
@@ -1,20 +1,15 @@
-import { DI, Registration } from '@aurelia/kernel';
+import { Registration } from '@aurelia/kernel';
 import {
-  CustomAttribute,
-  CustomElement,
-  INode,
-  CustomAttributeType,
-  Controller,
-  Aurelia,
   AdoptedStyleSheetsStyles,
-  CSSModulesProcessorRegistry,
-  StyleConfiguration,
-  StyleElementStyles,
-  cssModules,
+  Aurelia,
+  Controller,
+  CustomElement,
   IShadowDOMGlobalStyles,
   IShadowDOMStyles,
+  StyleConfiguration,
+  StyleElementStyles
 } from '@aurelia/runtime-html';
-import { assert, PLATFORM, TestContext } from '@aurelia/testing';
+import { PLATFORM, TestContext, assert } from '@aurelia/testing';
 
 describe('3-runtime-html/styles.spec.ts', function () {
   async function startApp(configure: (au: Aurelia) => void) {
@@ -30,76 +25,6 @@ describe('3-runtime-html/styles.spec.ts', function () {
   }
 
   describe('CSS Modules Processor', function () {
-    it('registry overrides class attribute', function () {
-      const element = { className: '' };
-      const container = DI.createContainer();
-      container.register(Registration.instance(INode, element));
-      const cssModulesLookup = {};
-      const registry = new CSSModulesProcessorRegistry([cssModulesLookup]);
-
-      registry.register(container);
-
-      const attr = container.get<CustomAttributeType>(
-        CustomAttribute.keyFrom('class')
-      );
-
-      assert.equal(CustomAttribute.isType(attr.constructor), true);
-    });
-
-    it('class attribute maps class names', function () {
-      const element = PLATFORM.document.createElement('div');
-      const container = DI.createContainer();
-      container.register(Registration.instance(INode, element));
-      const cssModulesLookup = {
-        'foo': 'bar',
-        'baz': 'qux'
-      };
-
-      const registry = new CSSModulesProcessorRegistry([cssModulesLookup]);
-      registry.register(container);
-
-      const attr = container.get(CustomAttribute.keyFrom('class')) as any;
-      attr.value = 'foo baz';
-      attr.valueChanged();
-
-      assert.equal(element.className, 'bar qux');
-    });
-
-    it('style function uses correct registry', function () {
-      const element = PLATFORM.document.createElement('div');
-      const container = DI.createContainer();
-      const childContainer = container.createChild();
-      const cssModulesLookup = {
-        'foo': 'bar',
-        'baz': 'qux'
-      };
-
-      childContainer.register(Registration.instance(INode, element));
-      cssModules(cssModulesLookup).register(childContainer);
-
-      const attr = childContainer.get(CustomAttribute.keyFrom('class')) as any;
-      attr.value = 'foo baz';
-      attr.valueChanged();
-
-      assert.equal(element.className, 'bar qux');
-    });
-
-    // TODO(fkleuver): Reactivate this test
-    // it('components do not inherit parent component styles', function () {
-    //   const rootContainer = DI.createContainer();
-    //   const parentContainer = rootContainer.createChild();
-    //   const cssModulesLookup = {};
-    //   const registry = new CSSModulesProcessorRegistry([cssModulesLookup]);
-    //   registry.register(parentContainer);
-
-    //   const childContainer = parentContainer.createChild();
-
-    //   const fromParent = parentContainer.findResource(CustomAttribute, 'class');
-    //   const fromChild = childContainer.findResource(CustomAttribute, 'class');
-
-    //   assert.equal(fromParent.name, 'class');
-    //   assert.equal(fromChild, null);
-    // });
   });
 
   describe('Shadow DOM', function () {

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -15,6 +15,7 @@ import { toView } from './interfaces-bindings';
 import type { ITask, QueueTaskOptions, TaskQueue } from '@aurelia/platform';
 import type {
   AccessorOrObserver,
+  IAccessor,
   ICollectionSubscriber,
   IObserverLocator,
   IObserverLocatorBasedConnectable,
@@ -34,8 +35,8 @@ const queueTaskOptions: QueueTaskOptions = {
 // ========
 // Note: the child expressions of an Interpolation expression are full Aurelia expressions, meaning they may include
 // value converters and binding behaviors.
-// Each expression represents one ${interpolation}, and for each we create a child TextBinding unless there is only one,
-// in which case the renderer will create the TextBinding directly
+// Each expression represents one ${interpolation}, and for each we create a child InterpolationPartBinding
+
 export interface InterpolationBinding extends IObserverLocatorBasedConnectable, IAstEvaluator, IServiceLocator {}
 export class InterpolationBinding implements IBinding, ISubscriber, ICollectionSubscriber {
   public isBound: boolean = false;
@@ -46,7 +47,7 @@ export class InterpolationBinding implements IBinding, ISubscriber, ICollectionS
   public partBindings: InterpolationPartBinding[];
 
   /** @internal */
-  private readonly _targetObserver: AccessorOrObserver;
+  private _targetObserver: AccessorOrObserver;
 
   /** @internal */
   private _task: ITask | null = null;
@@ -165,6 +166,13 @@ export class InterpolationBinding implements IBinding, ISubscriber, ICollectionS
     }
     this._task?.cancel();
     this._task = null;
+  }
+
+  /**
+   * Start using a given observer to update the target
+   */
+  public useAccessor(accessor: IAccessor): void {
+    this._targetObserver = accessor;
   }
 }
 

--- a/packages/runtime-html/src/dom.ts
+++ b/packages/runtime-html/src/dom.ts
@@ -1,4 +1,4 @@
-import { IContainer, InstanceProvider, type Writable } from '@aurelia/kernel';
+import { IContainer, IResolver, InstanceProvider, emptyArray, type Writable } from '@aurelia/kernel';
 import { IAppRoot } from './app-root';
 import { IPlatform } from './platform';
 import { findElementControllerFor } from './resources/custom-element';
@@ -31,15 +31,33 @@ export const IEventTarget = /*@__PURE__*/createInterface<IEventTarget>('IEventTa
   return handler.get(IPlatform).document;
 }));
 
+/**
+ * An interface describing a marker.
+ * Components can use this to anchor where their content should be rendered in place of a host element.
+ */
 export const IRenderLocation = /*@__PURE__*/createInterface<IRenderLocation>('IRenderLocation');
 export type IRenderLocation<T extends ChildNode = ChildNode> = T & {
   $start?: IRenderLocation<T>;
 };
 
-export const ICssModulesMapping = /*@__PURE__*/createInterface<Record<string, string>>('CssModules');
+/** @internal */
+export const ICssClassMapping = /*@__PURE__*/createInterface<Record<string, string>>('ICssClassMapping');
+/** @internal */
+export const cssMappings: IResolver<Record<string, string>[]> = {
+  $isResolver: true,
+  resolve(_, requestor) {
+    if (requestor.has(ICssClassMapping, false)) {
+      return requestor.getAll(ICssClassMapping);
+    }
+    return emptyArray;
+  }
+};
 
 /**
- * Represents a DocumentFragment
+ * Represents a DocumentFragment with a memory of what it has.
+ * This is known as many names, a live fragment for example.
+ *
+ * Relevant discussion at https://github.com/whatwg/dom/issues/736
  */
 export interface INodeSequence<T extends INode = INode> {
   readonly platform: IPlatform;

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -146,8 +146,8 @@ const errorsMap: Record<ErrorNames, string> = {
 
   [ErrorNames.binding_behavior_def_not_found]: `No binding behavior definition found for type {{0:name}}`,
   [ErrorNames.value_converter_def_not_found]: `No value converter definition found for type {{0:name}}`,
-  [ErrorNames.element_existed]: `Element {{0}} has already been registered.`,
-  [ErrorNames.attribute_existed]: `Attribute {{0}} has already been registered.`,
+  [ErrorNames.element_existed]: `Element "{{0}}" has already been registered.`,
+  [ErrorNames.attribute_existed]: `Attribute "{{0}}" has already been registered.`,
   [ErrorNames.value_converter_existed]: `Value converter {{0}} has already been registered.`,
   [ErrorNames.binding_behavior_existed]: `Binding behavior {{0}} has already been registered.`,
   [ErrorNames.binding_command_existed]: `Binding command {{0}} has already been registered.`,

--- a/packages/runtime-html/src/observation/class-attribute-accessor.ts
+++ b/packages/runtime-html/src/observation/class-attribute-accessor.ts
@@ -1,9 +1,10 @@
 import { emptyArray, isArray, isString } from '@aurelia/kernel';
 import { atLayout, atNode } from '../utilities';
 
-import type { AccessorType, IAccessor } from '@aurelia/runtime';
+import type { AccessorType, IAccessor, IObserver } from '@aurelia/runtime';
 import { mixinNoopSubscribable } from './observation-utils';
 
+export interface ClassAttributeAccessor extends IObserver {}
 export class ClassAttributeAccessor implements IAccessor {
   static {
     mixinNoopSubscribable(ClassAttributeAccessor);
@@ -22,6 +23,7 @@ export class ClassAttributeAccessor implements IAccessor {
 
   public constructor(
     public readonly obj: HTMLElement,
+    public readonly mapping: Record<string, string> = {}
   ) {
   }
 
@@ -50,6 +52,8 @@ export class ClassAttributeAccessor implements IAccessor {
     if (ii > 0) {
       for (; i < ii; i++) {
         name = classesToAdd[i];
+        name = this.mapping[name] || name;
+
         if (name.length === 0) {
           continue;
         }
@@ -64,6 +68,7 @@ export class ClassAttributeAccessor implements IAccessor {
     }
 
     for (name in nameIndex) {
+      name = this.mapping[name] || name;
       if (nameIndex[name] === version) {
         continue;
       }

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -27,7 +27,7 @@ import { RefBinding } from './binding/ref-binding';
 import { IEventModifier, ListenerBinding, ListenerBindingOptions } from './binding/listener-binding';
 import { CustomElement, CustomElementDefinition, findElementControllerFor } from './resources/custom-element';
 import { CustomAttribute, CustomAttributeDefinition, findAttributeControllerFor } from './resources/custom-attribute';
-import { convertToRenderLocation, IRenderLocation, INode, setRef, ICssModulesMapping, registerHostNode } from './dom';
+import { convertToRenderLocation, IRenderLocation, INode, setRef, ICssClassMapping, registerHostNode } from './dom';
 import { Controller, ICustomElementController, ICustomElementViewModel, IController, ICustomAttributeViewModel, IHydrationContext } from './templating/controller';
 import { IPlatform } from './platform';
 import { IViewFactory } from './templating/view';
@@ -63,6 +63,8 @@ import {
   StylePropertyBindingInstruction,
   TextBindingInstruction
 } from '@aurelia/template-compiler';
+import { ClassAttributeAccessor } from './observation/class-attribute-accessor';
+import { fromHydrationContext } from './resources/resolvers';
 
 /**
  * An interface describing an instruction renderer
@@ -441,22 +443,28 @@ export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class Interpo
   }
   public render(
     renderingCtrl: IHydratableController,
-    target: IController,
+    target: IController | HTMLElement,
     instruction: InterpolationInstruction,
     platform: IPlatform,
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
   ): void {
-    renderingCtrl.addBinding(new InterpolationBinding(
+    const container = renderingCtrl.container;
+    const binding = new InterpolationBinding(
       renderingCtrl,
-      renderingCtrl.container,
+      container,
       observerLocator,
       platform.domQueue,
       ensureExpression(exprParser, instruction.from, etInterpolation),
       getTarget(target),
       instruction.to,
-      toView,
-    ));
+      toView
+    );
+    if (instruction.to === 'class' && (binding.target as Node).nodeType > 0) {
+      const cssMapping = container.get(fromHydrationContext(ICssClassMapping));
+      binding.useAccessor(new ClassAttributeAccessor(binding.target as HTMLElement, cssMapping));
+    }
+    renderingCtrl.addBinding(binding);
   }
 }, null!);
 
@@ -473,16 +481,22 @@ export const PropertyBindingRenderer = /*@__PURE__*/ renderer(class PropertyBind
     exprParser: IExpressionParser,
     observerLocator: IObserverLocator,
   ): void {
-    renderingCtrl.addBinding(new PropertyBinding(
+    const container = renderingCtrl.container;
+    const binding = new PropertyBinding(
       renderingCtrl,
-      renderingCtrl.container,
+      container,
       observerLocator,
       platform.domQueue,
       ensureExpression(exprParser, instruction.from, etIsProperty),
       getTarget(target),
       instruction.to,
-      instruction.mode,
-    ));
+      instruction.mode
+    );
+    if (instruction.to === 'class' && (binding.target as Node).nodeType > 0) {
+      const cssMapping = container.get(fromHydrationContext(ICssClassMapping));
+      binding.useTargetObserver(new ClassAttributeAccessor(binding.target as HTMLElement, cssMapping));
+    }
+    renderingCtrl.addBinding(binding);
   }
 }, null!);
 
@@ -706,8 +720,8 @@ export const AttributeBindingRenderer = /*@__PURE__*/ renderer(class AttributeBi
   ): void {
     const container = renderingCtrl.container;
     const classMapping =
-      container.has(ICssModulesMapping, false)
-        ? container.get(ICssModulesMapping)
+      container.has(ICssClassMapping, false)
+        ? container.get(ICssClassMapping)
         : null;
     renderingCtrl.addBinding(new AttributeBinding(
       renderingCtrl,

--- a/packages/runtime-html/src/resources/custom-attribute.ts
+++ b/packages/runtime-html/src/resources/custom-attribute.ts
@@ -1,4 +1,4 @@
-import { mergeArrays, firstDefined, Key, resourceBaseName, getResourceKeyFor, isFunction, isString } from '@aurelia/kernel';
+import { mergeArrays, firstDefined, Key, resourceBaseName, getResourceKeyFor, isFunction, isString, ILogger } from '@aurelia/kernel';
 import { Bindable } from '../bindable';
 import { Watch } from '../watch';
 import { INode, getEffectiveParentNode, getRef } from '../dom';
@@ -116,6 +116,7 @@ export function templateController(nameOrDef: string | Omit<PartialCustomAttribu
 }
 
 export class CustomAttributeDefinition<T extends Constructable = Constructable> implements ResourceDefinition<T, ICustomAttributeViewModel, PartialCustomAttributeDefinition> {
+  public static warnDuplicate = true;
   // a simple marker to distinguish between Custom Element definition & Custom attribute definition
   public get type(): 'custom-attribute' { return dtAttribute; }
 
@@ -175,9 +176,15 @@ export class CustomAttributeDefinition<T extends Constructable = Constructable> 
         aliasRegistration($Type, key),
         ...aliases.map(alias => aliasRegistration($Type, getAttributeKeyFrom(alias)))
       );
-    } /* istanbul ignore next */ else if (__DEV__) {
-      // eslint-disable-next-line no-console
-      console.warn(`[DEV:aurelia] ${createMappedError(ErrorNames.attribute_existed, this.name)}`);
+    } /* istanbul ignore next */ else {
+      if (CustomAttributeDefinition.warnDuplicate) {
+        container.get(ILogger).warn(createMappedError(ErrorNames.attribute_existed, this.name));
+      }
+      /* istanbul ignore if */
+      if (__DEV__) {
+        // eslint-disable-next-line no-console
+        console.warn(`[DEV:aurelia] ${createMappedError(ErrorNames.attribute_existed, this.name)}`);
+      }
     }
   }
 

--- a/packages/runtime-html/src/resources/resolvers.ts
+++ b/packages/runtime-html/src/resources/resolvers.ts
@@ -1,0 +1,12 @@
+import { Key, IResolver, own } from '@aurelia/kernel';
+import { IHydrationContext } from '../templating/controller';
+
+/**
+ * Create a resolver for a given key that will only resolve from the nearest hydration context.
+ */
+export const fromHydrationContext = <T extends Key>(key: T): IResolver<T | undefined> => ({
+  $isResolver: true,
+  resolve(_, requestor) {
+    return requestor.get(IHydrationContext).controller.container.get(own(key));
+  }
+});

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -11,10 +11,10 @@ import { objectAssign } from '../utilities';
 /**
  * There are 2 implementations of CSS registry: css module registry and shadow dom registry.
  *
- * CSS registry alters the way class attribute works instead.
+ * - CSS registry alters the way class bindings work via altering templates and register interfaces that will alter bindings to class attribute.
  *
- * Shadow dom registry regisiters some interfaces with the custom element container to handle shadow dom styles.
- * abtraction summary:
+ * - Shadow dom registry regisiters some interfaces with the custom element container to handle shadow dom styles.
+ * Shadow DOM abtraction summary:
  * CSS registry ---(register)---> IShadowDOMStyleFactory ---(createStyles)---> IShadowDOMStyles ---(applyTo)---> ShadowRoot
  */
 

--- a/packages/runtime-html/src/templating/styles.ts
+++ b/packages/runtime-html/src/templating/styles.ts
@@ -1,12 +1,11 @@
-import { IContainer, noop, resolve } from '@aurelia/kernel';
+import { IContainer, createLookup, noop, own, resolve, toArray } from '@aurelia/kernel';
 import { AppTask } from '../app-task';
-import { ICssModulesMapping, INode } from '../dom';
-import { ClassAttributeAccessor } from '../observation/class-attribute-accessor';
+import { ICssClassMapping } from '../dom';
 import { IPlatform } from '../platform';
-import { defineAttribute } from '../resources/custom-attribute';
 import { createInterface, instanceRegistration } from '../utilities-di';
 
 import type { IRegistry } from '@aurelia/kernel';
+import { ITemplateCompilerHooks, TemplateCompilerHooks } from '@aurelia/template-compiler';
 import { objectAssign } from '../utilities';
 
 /**
@@ -33,35 +32,47 @@ export class CSSModulesProcessorRegistry implements IRegistry {
   ) {}
 
   public register(container: IContainer): void {
-    // it'd be nice to be able to register a template compiler hook instead
-    // so that it's lighter weight on the creation of a custom element with css module
-    // also it'll be more consitent in terms as CSS class output
-    // if custom attribute is used, the class controlled by custom attribute may come after
-    // other bindings, regardless what their declaration order is in the template
-    const classLookup = objectAssign({}, ...this.modules) as Record<string, string>;
-    const ClassCustomAttribute = defineAttribute({
-      name: 'class',
-      bindables: ['value'],
-      noMultiBindings: true,
-    }, class CustomAttributeClass {
-      /** @internal */
-      private readonly _accessor = new ClassAttributeAccessor(resolve(INode) as HTMLElement);
-
-      public value: string = '';
-
-      public binding() {
-        this.valueChanged();
+    let existingMapping = container.get(own(ICssClassMapping));
+    if (existingMapping == null) {
+      container.register(
+        instanceRegistration(ICssClassMapping, existingMapping = createLookup()),
+      );
+    }
+    /* istanbul ignore if */
+    if (__DEV__) {
+      for (const mapping of this.modules) {
+        for (const originalClass in mapping) {
+          if (originalClass in existingMapping) {
+            // eslint-disable-next-line no-console
+            console.warn(`[DEV:aurelia] CSS class mapping for class "${originalClass}": "${mapping[originalClass]}" is overridden by "${existingMapping[originalClass]}"`);
+          }
+          existingMapping[originalClass] = mapping[originalClass];
+        }
       }
+    } else {
+      objectAssign(existingMapping, ...this.modules);
+    }
 
-      public valueChanged() {
-        this._accessor.setValue(this.value?.split(/\s+/g).map(x => classLookup[x] || x) ?? '');
+    class CompilingHook implements ITemplateCompilerHooks {
+      public compiling(template: HTMLElement): void {
+        const isTemplate = template.tagName === 'TEMPLATE';
+        const container = isTemplate
+          ? (template as HTMLTemplateElement).content
+          : template;
+        const plainClasses = [template, ...toArray(container.querySelectorAll('[class]'))];
+        for (const element of plainClasses) {
+          const classes = element.getAttributeNode('class')!;
+          // we always include container, so there's a case where classes is null
+          if (classes == null) {
+            continue;
+          }
+          const newClasses = classes.value.split(/\s+/g).map(x => existingMapping![x] || x).join(' ');
+          classes.value = newClasses;
+        }
       }
-    });
+    }
 
-    container.register(
-      ClassCustomAttribute,
-      instanceRegistration(ICssModulesMapping, classLookup),
-    );
+    container.register(TemplateCompilerHooks.define(CompilingHook));
   }
 }
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -34,6 +34,9 @@ export {
   inspect,
 } from './inspect';
 export {
+  createSink,
+} from './logger-sinks';
+export {
   MockBinding,
   MockBindingBehavior,
   MockBrowserHistoryLocation,

--- a/packages/testing/src/logger-sinks.ts
+++ b/packages/testing/src/logger-sinks.ts
@@ -1,0 +1,21 @@
+import { IContainer, ILogEvent, ISink, LogLevel, Registration } from '@aurelia/kernel';
+
+export const createSink = Object.assign((callback: (message: any) => any, level?: LogLevel) => {
+  return class TargetedConsoleSink implements ISink {
+    public static register(container: IContainer) {
+      container.register(Registration.singleton(ISink, this));
+    }
+
+    public handleEvent(event: ILogEvent): void {
+      if (level == null || event.severity === level) {
+        callback(event.message);
+      }
+    }
+  };
+}, {
+  error: (callback: (message: any) => any) => createSink(callback, LogLevel.error),
+  warn: (callback: (message: any) => any) => createSink(callback, LogLevel.warn),
+  info: (callback: (message: any) => any) => createSink(callback, LogLevel.info),
+  debug: (callback: (message: any) => any) => createSink(callback, LogLevel.debug),
+  trace: (callback: (message: any) => any) => createSink(callback, LogLevel.trace),
+});


### PR DESCRIPTION
## 📖 Description

Currently CSS module registration works by altering how class attribute is compiled: it registers a class custom attribute to map the classes value before setting it on the element. This sometimes causes duplicate registration warning, as reported at https://discord.com/channels/448698263508615178/1244638420274384946

- Additional warn with `ILogger` for duplicate attribute registration, which can be turned off via `CustomAttributeDefinition.warnDuplicate`, we will keep this for now to monitor the duplicate registration issue.