### PR TITLE
fix(router): fix redirect issue

### DIFF
--- a/packages/router/src/endpoints/viewport.ts
+++ b/packages/router/src/endpoints/viewport.ts
@@ -526,7 +526,7 @@ export class Viewport extends Endpoint {
             return Runner.run(step,
               (innerStep: Step<void>) => this.cancelContentChange(coordinator, innerStep),
               (innerStep: Step<void>) => {
-                void this.router.load(canLoadResult, { append: true });
+                void this.router.load(canLoadResult); //, { append: true }); // TODO: Add the append back with iteration
                 return innerStep.exit();
               },
             );

--- a/packages/router/src/instructions/instruction-component.ts
+++ b/packages/router/src/instructions/instruction-component.ts
@@ -231,9 +231,11 @@ export class InstructionComponent {
       ? this.type!
       : container.getResolver<RouteableComponentType>(CustomElement.keyFrom(this.name!))!.getFactory!(container)!.Type;
     const instance = container.invoke(Type);
+    // TODO: Investigate this!
     // const instance: IRouteableComponent = this.isType()
     //   ? container.invoke(this.type!)
     //   : container.get(routerComponentResolver(this.name!));
+
     // TODO: Implement non-traversing lookup (below) based on router configuration
     // let instance;
     // if (this.isType()) {
@@ -275,6 +277,7 @@ export class InstructionComponent {
   }
 }
 
+// TODO: Investigate this (should probably be added back)
 // function routerComponentResolver(name: string): IResolver<IRouteableComponent> {
 //   const key = CustomElement.keyFrom(name);
 //   return {

--- a/packages/router/src/resources/viewport.ts
+++ b/packages/router/src/resources/viewport.ts
@@ -119,6 +119,8 @@ export class ViewportCustomElement implements ICustomElementViewModel {
 
   public hydrated(controller: ICompiledCustomElementController): void | Promise<void> {
     this.controller = controller as ICustomElementController;
+    // TODO: Below was here for a reason, investigate if no longer necessary
+    // this.container = controller.container;
 
     // eslint-disable-next-line
     const hasDefault = this.instruction.props.filter((instr: any) => instr.to === 'default').length > 0;

--- a/packages/router/src/router-options.ts
+++ b/packages/router/src/router-options.ts
@@ -353,7 +353,7 @@ export class RouterOptions implements INavigatorOptions {
      * synced,`guardedLoad`, `unload` and `load` should be added to default.
      * Default: `guardedUnload`, `swapped`, `completed`
      */
-    public navigationSyncStates: NavigationState[] = ['guardedUnload', 'swapped', 'completed'],
+    public navigationSyncStates: NavigationState[] = ['guardedUnload', 'guardedLoad', 'swapped', 'completed'],
 
     /**
      * How contents are swapped in a viewport when transitioning. Default: `attach-next-detach-current`
@@ -364,15 +364,15 @@ export class RouterOptions implements INavigatorOptions {
      * The component to be loaded if a specified can't be loaded.
      * The unloadable component is passed as a parameter to the fallback.
      */
-     public fallback: ComponentAppellation = '',
+    public fallback: ComponentAppellation = '',
 
-     /**
-      * Whether the fallback action is to load the fallback component in
-      * place of the unloadable component and continue with any child
-      * instructions or if the fallback is to be called and the processing
-      * of the children to be aborted.
-      */
-     public fallbackAction: FallbackAction = 'abort',
+    /**
+     * Whether the fallback action is to load the fallback component in
+     * place of the unloadable component and continue with any child
+     * instructions or if the fallback is to be called and the processing
+     * of the children to be aborted.
+     */
+    public fallbackAction: FallbackAction = 'abort',
   ) { }
 
   public static create(input: IRouterOptions = {}): RouterOptions {

--- a/packages/router/src/routing-scope.ts
+++ b/packages/router/src/routing-scope.ts
@@ -555,7 +555,6 @@ export class RoutingScope {
     const options = this.router.configuration.options;
     const route = RoutingInstruction.stringify(this.router, instructions);
     // TODO: Add missing/unknown route handling
-    //       shouldn't this check all routes, instead of only the first one?
     if (instructions[0].route != null) {
       if (!options.useConfiguredRoutes) {
         return new Error("Can not match '" + route + "' since the router is configured to not use configured routes.");


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue with redirect from `canLoad` when there are multiple `canLoad` hooks. It also adds `guardedLoad` to the default sync states to behave more like v1 router out of the box.
