### PR TITLE
feat(event): support common event modifier on all events

### DIFF
--- a/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
@@ -388,6 +388,25 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
       assert.strictEqual(stopped, true);
     });
 
+    it('allows prevent modifier on events that are not mouse or key', function () {
+      let prevented = false;
+      let stopped = false;
+      const { trigger } = createFixture(
+        '<form submit.capture="modifyEvent($event)" submit.trigger:prevent+stop="">',
+        {
+          modifyEvent: (e: SubmitEvent) => {
+            Object.defineProperty(e, 'preventDefault', { value: () => prevented = true });
+            Object.defineProperty(e, 'stopPropagation', { value: () => stopped = true });
+          }
+        },
+        [AppTask.creating(IAppRoot, root => root.config.allowActionlessForm = true)]
+      );
+
+      trigger('form', 'submit');
+      assert.strictEqual(prevented, true);
+      assert.strictEqual(stopped, true);
+    });
+
     it('does not alter dispatchEvent working', function () {
       const { ctx, getBy } = createFixture(
         '<div some-event.trigger="handleEvent($event)"><center>',

--- a/packages/__tests__/src/3-runtime-html/dialog/dialog-service.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/dialog/dialog-service.spec.ts
@@ -1,5 +1,5 @@
 import { delegateSyntax } from '@aurelia/compat-v1';
-import { Registration, noop } from '@aurelia/kernel';
+import { Registration, noop, resolve } from '@aurelia/kernel';
 import {
   INode,
   customElement,
@@ -1017,6 +1017,28 @@ describe('3-runtime-html/dialog/dialog-service.spec.ts', function () {
           assert.deepEqual(calls, ['deactivate', 'hide']);
         }
       },
+      {
+        title: 'calls prevent default on form submit event',
+        async afterStarted(appCreationResult, dialogService) {
+          let submit: () => void;
+          let e: SubmitEvent;
+          await dialogService.open({
+            template: '<form submit.trigger="onSubmit($event)"><button>Submit</button></form>',
+            component: () => class {
+              dom = resolve(IDialogDom);
+              activate() {
+                submit = () => this.dom.contentHost.querySelector('button').click();
+              }
+              onSubmit(event: Event) {
+                e = event as SubmitEvent;
+              }
+            }
+          });
+
+          submit();
+          assert.strictEqual(e?.defaultPrevented, true);
+        },
+      }
     ];
 
     // #region test run

--- a/packages/dialog/src/dialog-event-manager.ts
+++ b/packages/dialog/src/dialog-event-manager.ts
@@ -26,10 +26,21 @@ export class DefaultDialogEventManager implements IDialogEventManager {
     };
     dom.overlay.addEventListener(mouseEvent, handleClick);
 
+    const handleSubmit = (e: SubmitEvent) => {
+      const target = e.target as HTMLFormElement;
+      const noAction = !target.getAttribute('action');
+
+      if (target.tagName === 'FORM' && noAction) {
+        e.preventDefault();
+      }
+    };
+    dom.contentHost.addEventListener('submit', handleSubmit);
+
     return {
       dispose: () => {
         this._remove(controller);
         dom.overlay.removeEventListener(mouseEvent, handleClick);
+        dom.contentHost.removeEventListener('submit', handleSubmit);
       }
     };
   }

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -258,6 +258,42 @@ class ModifiedKeyboardEventHandler implements IModifiedEventHandlerCreator {
   }
 }
 
+/**
+ * A generic event handler that can be used for any event type
+ */
+class ModifiedEventHandler implements IModifiedEventHandlerCreator {
+  public static register(c: IContainer) {
+    c.register(singletonRegistration(IModifiedEventHandlerCreator, ModifiedEventHandler));
+  }
+
+  public readonly type = ['$ALL'];
+  public getHandler(modifier: string): IModifiedEventHandler {
+    const modifiers = modifier.split(/[:+.]/);
+    return ((event: Event) => {
+      let prevent = false;
+      let stop = false;
+      let mod: string;
+
+      for (mod of modifiers) {
+        switch (mod) {
+          case 'prevent': prevent = true; continue;
+          case 'stop': stop = true; continue;
+        }
+
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn(`Modifier '${mod}' is not supported for event "${event.type}".`);
+        }
+      }
+
+      if (prevent) event.preventDefault();
+      if (stop) event.stopPropagation();
+
+      return true;
+    }) as IModifiedEventHandler;
+  }
+}
+
 export interface IEventModifier {
   getHandler(type: string, modifier: string | null): IModifiedEventHandler | null;
 }
@@ -285,7 +321,7 @@ export class EventModifier implements IEventModifier {
     }, {});
 
   public getHandler(type: string, modifier: string | null): IModifiedEventHandler | null {
-    return isString(modifier) ? this._reg[type]?.getHandler(modifier) ?? null : null;
+    return isString(modifier) ? (this._reg[type] ?? this._reg.$ALL)?.getHandler(modifier) ?? null : null;
   }
 }
 
@@ -295,6 +331,7 @@ export const EventModifierRegistration = {
       EventModifier,
       ModifiedMouseEventHandler,
       ModifiedKeyboardEventHandler,
+      ModifiedEventHandler,
     );
   }
 };


### PR DESCRIPTION
## 📖 Description

In a previous PR #1891 , event modifier was introduce to help remove boilerplate from mouse & keyboard events. This PR expands the modifier support to all event, for `prevent` and `stop`

- Also automatically call `preventDefault` on form actionless submit event