### PR TITLE
refactor(router-lite): can* hook semantics

### DIFF
--- a/docs/user-docs/router-lite/routing-lifecycle.md
+++ b/docs/user-docs/router-lite/routing-lifecycle.md
@@ -53,14 +53,9 @@ The `canLoad` method is called upon attempting to load the component.
 It allows you to determine if the component should be loaded or not.
 If your component relies on some precondition being fulfilled before being allowed to render, this is the method you would use.
 
-The component would be loaded if `true` (it has to be `boolean` `true` ) is returned from this method.
-To disallow loading the component you can return `false`.
+To disallow loading the component you can return a `boolean` `false`.
 You can also return a navigation instruction to navigate the user to a different view.
 These are discussed in the following sections.
-
-{% hint style="warning" %}
-Returning any value other than `boolean true`, from within the `canLoad` function will [cancel](./router-events.md#emitted-events) the router navigation.
-{% endhint %}
 
 ### Allow or disallowed loading components
 
@@ -259,12 +254,7 @@ The `canUnload` method is called when a user attempts to leave a routed view.
 The first argument (`next`) of this hook is a `RouteNode` which provides information about the next route.
 
 This hook is like the `canLoad` method but inverse.
-You can return a `boolean true` from this method, allowing the router-lite to navigate away from the current component.
-Returning any other value from this method will disallow the router-lite to unload this component.
-
-{% hint style="warning" %}
-Returning any value other than `boolean true`, from within the `canUnload` function will [cancel](./router-events.md#emitted-events) the router navigation.
-{% endhint %}
+You can return a `boolean false` from this method, to disallow the router-lite to navigate away from the current component.
 
 The following example shows that before navigating away, the user is shown a confirmation prompt.
 If the user agrees to navigate way, then the navigation is performed.

--- a/packages/__tests__/src/router-lite/hook-tests.spec.ts
+++ b/packages/__tests__/src/router-lite/hook-tests.spec.ts
@@ -4819,4 +4819,111 @@ describe('router-lite/hook-tests.spec.ts', function () {
       });
     });
   });
+
+  it('canUnload returns null/undefined -> unloading works', async function () {
+
+    @customElement({ name: 'ce-a', template: 'a' })
+    class A implements IRouteViewModel {
+      public canUnload(_next: RN, _current: RN): boolean | Promise<boolean> { return null!; }
+    }
+    @customElement({ name: 'ce-b', template: 'b' })
+    class B implements IRouteViewModel {
+      public canUnload(_next: RN, _current: RN): boolean | Promise<boolean> { return undefined!; }
+    }
+
+    @route({
+      routes: [
+        { path: ['', 'a'], component: A, title: 'A' },
+        { path: 'b', component: B, title: 'B' },
+      ]
+    })
+    @customElement({
+      name: 'my-app',
+      template: `<au-viewport></au-viewport>`
+    })
+    class Root { }
+
+    const { router, tearDown, host } = await createFixture(Root, [A, B]/* , LogLevel.trace */);
+
+    assert.html.textContent(host, 'a', 'round#0');
+
+    await router.load('b');
+    assert.html.textContent(host, 'b', 'round#1');
+
+    await router.load('a');
+    assert.html.textContent(host, 'a', 'round#2');
+
+    await tearDown();
+  });
+
+  it('canLoad returns null/undefined -> loading works', async function () {
+
+    @customElement({ name: 'ce-a', template: 'a' })
+    class A implements IRouteViewModel {
+      public canLoad(_params: P, _next: RN, _current: RN): boolean | NI | NI[] | Promise<boolean | NI | NI[]> { return null!; }
+    }
+    @customElement({ name: 'ce-b', template: 'b' })
+    class B implements IRouteViewModel {
+      public canLoad(_params: P, _next: RN, _current: RN): boolean | NI | NI[] | Promise<boolean | NI | NI[]> { return undefined!; }
+    }
+
+    @route({
+      routes: [
+        { path: ['', 'a'], component: A, title: 'A' },
+        { path: 'b', component: B, title: 'B' },
+      ]
+    })
+    @customElement({
+      name: 'my-app',
+      template: `<au-viewport></au-viewport>`
+    })
+    class Root { }
+
+    const { router, tearDown, host } = await createFixture(Root, [A, B]/* , LogLevel.trace */);
+
+    assert.html.textContent(host, 'a', 'round#0');
+
+    await router.load('b');
+    assert.html.textContent(host, 'b', 'round#1');
+
+    await router.load('a');
+    assert.html.textContent(host, 'a', 'round#2');
+
+    await tearDown();
+  });
+
+  it('canLoad returns routing instruction -> redirects', async function () {
+
+    @customElement({ name: 'ce-a', template: 'a' })
+    class A implements IRouteViewModel { }
+    @customElement({ name: 'ce-b', template: 'b' })
+    class B { }
+
+    @customElement({ name: 'ce-c', template: 'c' })
+    class C implements IRouteViewModel {
+      public canLoad(_params: P, _next: RN, _current: RN): boolean | NI | NI[] | Promise<boolean | NI | NI[]> { return 'b'; }
+    }
+
+    @route({
+      routes: [
+        { path: ['', 'a'], component: A, title: 'A' },
+        { path: 'b', component: B, title: 'B' },
+        { path: 'c', component: C, title: 'C' },
+      ]
+    })
+    @customElement({
+      name: 'my-app',
+      template: `<au-viewport></au-viewport>`
+    })
+    class Root { }
+
+    const { router, tearDown, host } = await createFixture(Root, [A, B, C]/* , LogLevel.trace */);
+
+    assert.html.textContent(host, 'a', 'round#0');
+
+    await router.load('c');
+    assert.html.textContent(host, 'b', 'round#1');
+
+    await tearDown();
+  });
 });

--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -245,10 +245,9 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
       public canLoad(_vm: IRouteViewModel, _params: Params, next: RouteNode, _current: RouteNode): boolean | NavigationInstruction | NavigationInstruction[] | Promise<boolean | NavigationInstruction | NavigationInstruction[]> {
         this.logger.trace(`canLoad ${(next.instruction as IViewportInstruction).component}`);
         const claim = (next.data as { claim: { type: string; value: string } }).claim ?? null;
-        if (claim === null) return true;
-        return this.authService.hasClaim(claim.type, claim.value)
-          ? true
-          : 'forbidden';
+        if (claim === null) return;
+        if (this.authService.hasClaim(claim.type, claim.value)) return;
+        return 'forbidden';
       }
     }
 

--- a/packages/router-lite/src/component-agent.ts
+++ b/packages/router-lite/src/component-agent.ts
@@ -109,7 +109,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
         tr._run(() => {
           return hook.canUnload(this._instance, next, this._routeNode);
         }, ret => {
-          if (tr.guardsResult === true && ret !== true) {
+          if (tr.guardsResult === true && ret === false) {
             tr.guardsResult = false;
           }
           b._pop();
@@ -174,7 +174,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
         tr._run(() => {
           return this._instance.canLoad!(next.params, next, this._routeNode);
         }, ret => {
-          if (tr.guardsResult === true && ret !== true) {
+          if (tr.guardsResult === true && ret != null && ret !== true) {
             tr.guardsResult = ret === false ? false : ViewportInstructionTree.create(ret, this._routerOptions, void 0, rootCtx);
           }
           b._pop();

--- a/packages/router-lite/src/component-agent.ts
+++ b/packages/router-lite/src/component-agent.ts
@@ -128,7 +128,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
         tr._run(() => {
           return this._instance.canUnload!(next, this._routeNode);
         }, ret => {
-          if (tr.guardsResult === true && ret !== true) {
+          if (tr.guardsResult === true && ret === false) {
             tr.guardsResult = false;
           }
           b._pop();
@@ -155,7 +155,7 @@ export class ComponentAgent<T extends IRouteViewModel = IRouteViewModel> {
         tr._run(() => {
           return hook.canLoad(this._instance, next.params, next, this._routeNode);
         }, ret => {
-          if (tr.guardsResult === true && ret !== true) {
+          if (tr.guardsResult === true && ret != null && ret !== true) {
             tr.guardsResult = ret === false ? false : ViewportInstructionTree.create(ret, this._routerOptions, void 0, rootCtx);
           }
           b._pop();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR changes the semantics of `canLoad` and `canUnload` hooks.

If `canLoad` returns no value, `null`, or en explicit `undfined`, the component will be loaded. Returning a routing instruction to perform redirect instead is still supported. To prevent loading altogether, the return of an explicit `boolean` `false` is required.

Similarly, if the `canUnload` returns no value, `null`, or en explicit `undfined`, the component will be unloaded. To prevent unload, the return of an explicit `boolean` `false` is required.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
