### PR TITLE
fix(task-queue): fix timing issue

### DIFF
--- a/packages/__tests__/src/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/src/2-runtime/scheduler.spec.ts
@@ -1526,7 +1526,7 @@ describe('2-runtime/scheduler.spec.ts', function () {
     });
   });
 
-  it('multiple persistent delayed tasks with different delays retain correct timing', async function () {
+  it('2 persistent delayed tasks with different delays retain correct timing', async function () {
     let counter10 = 0;
     let counter20 = 0;
 
@@ -1561,11 +1561,68 @@ describe('2-runtime/scheduler.spec.ts', function () {
     await task.result;
 
     if (Math.abs(counter10  - counter20 * 2) > 2) {
-      assert.fail('too far apart')
+      assert.fail('too far apart');
     }
 
     task10.cancel();
     task20.cancel();
+    task.cancel();
+
+    assert.areTaskQueuesEmpty();
+  });
+
+  it('3 persistent delayed tasks with different delays retain correct timing', async function () {
+    let counter10 = 0;
+    let counter20 = 0;
+    let counter40 = 0;
+
+    const task10 = platform.taskQueue.queueTask(
+      function () {
+        ++counter10;
+      },
+      {
+        persistent: true,
+        delay: 10,
+      }
+    );
+
+    const task20 = platform.taskQueue.queueTask(
+      function () {
+        ++counter20;
+      },
+      {
+        persistent: true,
+        delay: 20,
+      }
+    );
+
+    const task40 =platform.taskQueue.queueTask(
+      function () {
+        ++counter40;
+      },
+      {
+        persistent: true,
+        delay: 40,
+      }
+    );
+
+    const task = platform.taskQueue.queueTask(
+      noop,
+      {
+        persistent: true,
+        delay: 200,
+      }
+    );
+
+    await task.result;
+
+    if (Math.abs(counter10  - counter20 * 2) > 2 || Math.abs(counter20  - counter40 * 2) > 2) {
+      assert.fail('too far apart');
+    }
+
+    task10.cancel();
+    task20.cancel();
+    task40.cancel();
     task.cancel();
 
     assert.areTaskQueuesEmpty();

--- a/packages/__tests__/src/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/src/2-runtime/scheduler.spec.ts
@@ -1530,7 +1530,7 @@ describe('2-runtime/scheduler.spec.ts', function () {
     let counter10 = 0;
     let counter20 = 0;
 
-    platform.taskQueue.queueTask(
+    const task10 = platform.taskQueue.queueTask(
       function () {
         ++counter10;
       },
@@ -1540,7 +1540,7 @@ describe('2-runtime/scheduler.spec.ts', function () {
       }
     );
 
-    platform.taskQueue.queueTask(
+    const task20 =platform.taskQueue.queueTask(
       function () {
         ++counter20;
       },
@@ -1574,5 +1574,11 @@ describe('2-runtime/scheduler.spec.ts', function () {
     } else {
       assert.fail(`counter10: ${counter10}, counter20: ${counter20}`);
     }
+
+    task10.cancel();
+    task20.cancel();
+    task.cancel();
+
+    assert.areTaskQueuesEmpty();
   });
 });

--- a/packages/__tests__/src/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/src/2-runtime/scheduler.spec.ts
@@ -1560,19 +1560,8 @@ describe('2-runtime/scheduler.spec.ts', function () {
 
     await task.result;
 
-    if (counter10 === counter20 * 2) {
-      assert.ok(true, `exact match`);
-    } else if (counter10 - 1 === counter20 * 2) {
-      // a little bit of drift can happen at these low delays
-      assert.ok(true, `counter10 - 1`);
-    } else if (counter10 - 2 === counter20 * 2) {
-      // this might happen rarely, we don't want to fail the whole test suite for this
-      assert.ok(true, `counter10 - 2`);
-    } else if (counter10 + 1 === counter20 * 2) {
-      // a little bit of drift the other direction can also happen
-      assert.ok(true, `counter10 + 1`);
-    } else {
-      assert.fail(`counter10: ${counter10}, counter20: ${counter20}`);
+    if (Math.abs(counter10  - counter20 * 2) > 2) {
+      assert.fail('too far apart')
     }
 
     task10.cancel();

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -178,11 +178,11 @@ export class TaskQueue {
     this._tracer = new Tracer(platform.console);
   }
 
-  public flush(time: number = this._now()): void {
+  public flush(now: number = this._now()): void {
     if (__DEV__ && this._tracer.enabled) { this._tracer.enter(this, 'flush'); }
 
     this._flushRequested = false;
-    this._lastFlush = time;
+    this._lastFlush = now;
 
     // Only process normally if we are *not* currently waiting for an async task to finish
     if (this._suspenderTask === void 0) {
@@ -194,7 +194,7 @@ export class TaskQueue {
       if (this._delayed.length > 0) {
         for (let i = 0; i < this._delayed.length; ++i) {
           curr = this._delayed[i];
-          if (curr.queueTime <= time) {
+          if (curr.queueTime <= now) {
             this._processing.push(curr);
             this._delayed.splice(i--, 1);
           }
@@ -226,7 +226,7 @@ export class TaskQueue {
       if (this._delayed.length > 0) {
         for (let i = 0; i < this._delayed.length; ++i) {
           curr = this._delayed[i];
-          if (curr.queueTime <= time) {
+          if (curr.queueTime <= now) {
             this._processing.push(curr);
             this._delayed.splice(i--, 1);
           }

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -186,14 +186,19 @@ export class TaskQueue {
 
     // Only process normally if we are *not* currently waiting for an async task to finish
     if (this._suspenderTask === void 0) {
+      let curr: Task;
       if (this._pending.length > 0) {
         this._processing.push(...this._pending);
         this._pending.length = 0;
       }
       if (this._delayed.length > 0) {
-        let i = -1;
-        while (++i < this._delayed.length && this._delayed[i].queueTime <= time) { /* do nothing */ }
-        this._processing.push(...this._delayed.splice(0, i));
+        for (let i = 0; i < this._delayed.length; ++i) {
+          curr = this._delayed[i];
+          if (curr.queueTime <= time) {
+            this._processing.push(curr);
+            this._delayed.splice(i--, 1);
+          }
+        }
       }
 
       let cur: Task;
@@ -219,9 +224,13 @@ export class TaskQueue {
         this._pending.length = 0;
       }
       if (this._delayed.length > 0) {
-        let i = -1;
-        while (++i < this._delayed.length && this._delayed[i].queueTime <= time) { /* do nothing */ }
-        this._processing.push(...this._delayed.splice(0, i));
+        for (let i = 0; i < this._delayed.length; ++i) {
+          curr = this._delayed[i];
+          if (curr.queueTime <= time) {
+            this._processing.push(curr);
+            this._delayed.splice(i--, 1);
+          }
+        }
       }
 
       if (this._processing.length > 0 || this._delayed.length > 0 || this._pendingAsyncCount > 0) {


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes an issue in the task queue when using multiple persistent delayed tasks with different timings.


<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

- close https://github.com/aurelia/aurelia/issues/1542
- resolve https://discourse.aurelia.io/t/platform-taskqueue-does-not-run-concurrent-tasks/5379
- resolve https://discord.com/channels/448698263508615178/448699089513611266
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

There was a small oversight in the queue processing loop where it assumed the smallest delay task to be in the front of the queue. It now checks all tasks in the delayed task list.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

A single test covers this bug properly. Without the fix, it fails with `counter10` and `counter20` being equal. Now it's doubled (though I added some leeway in there to account for flakiness)
<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
