### PR TITLE
refactor(task-queue): remove 'reusable' param

### DIFF
--- a/packages/__tests__/src/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/src/2-runtime/scheduler.spec.ts
@@ -1483,13 +1483,13 @@ describe('2-runtime/scheduler.spec.ts', function () {
 
     await task.result;
 
-    if (Math.abs(counter10  - counter20 * 2) > 2) {
-      assert.fail('too far apart');
-    }
-
     task10.cancel();
     task20.cancel();
     task.cancel();
+
+    if (Math.abs(counter10  - counter20 * 2) > 2) {
+      assert.fail('too far apart');
+    }
 
     assert.areTaskQueuesEmpty();
   });
@@ -1539,14 +1539,14 @@ describe('2-runtime/scheduler.spec.ts', function () {
 
     await task.result;
 
-    if (Math.abs(counter10  - counter20 * 2) > 2 || Math.abs(counter20  - counter40 * 2) > 2) {
-      assert.fail('too far apart');
-    }
-
     task10.cancel();
     task20.cancel();
     task40.cancel();
     task.cancel();
+
+    if (Math.abs(counter10  - counter20 * 2) > 4 || Math.abs(counter20  - counter40 * 2) > 4) {
+      assert.fail('too far apart');
+    }
 
     assert.areTaskQueuesEmpty();
   });

--- a/packages/__tests__/src/2-runtime/scheduler.spec.ts
+++ b/packages/__tests__/src/2-runtime/scheduler.spec.ts
@@ -27,11 +27,10 @@ function reportTask(task: any) {
   const created = round(task.createdTime);
   const queue = round(task.queueTime);
   const preempt = task.preempt;
-  const reusable = task.reusable;
   const persistent = task.persistent;
   const status = task._status;
 
-  return `id=${id} createdTime=${created} queueTime=${queue} preempt=${preempt} reusable=${reusable} persistent=${persistent} status=${status}`;
+  return `id=${id} createdTime=${created} queueTime=${queue} preempt=${preempt} persistent=${persistent} status=${status}`;
 }
 
 describe('2-runtime/scheduler.spec.ts', function () {
@@ -97,248 +96,869 @@ describe('2-runtime/scheduler.spec.ts', function () {
     },
   ];
 
-  for (const reusable of [true, false]) {
+  for (const { sut, name } of prioritySpecs) {
+    describe(`can queue ${name}`, function () {
+      it('x1, {preempt: false, delay: 0}', function (done) {
+        sut.queueTask(
+          function () {
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            preempt: false,
+            delay: 0,
+          },
+        );
+      });
+
+      it('x1, {preempt: true, delay: 0}', function (done) {
+        sut.queueTask(
+          function () {
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            preempt: true,
+            delay: 0,
+          },
+        );
+      });
+
+      it('x1, {delay: 5}', function (done) {
+        sut.queueTask(
+          function () {
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            delay: 5,
+          },
+        );
+      });
+
+      it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', function (done) {
+        const calls: number[] = [];
+
+        sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            delay: 5,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            delay: 0,
+          },
+        );
+      });
+
+      it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', function (done) {
+        const calls: number[] = [];
+
+        sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            preempt: false,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            preempt: true,
+          },
+        );
+      });
+
+      it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', function (done) {
+        const calls: number[] = [];
+
+        sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+
+            done();
+          },
+          {
+            delay: 5,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            preempt: false,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(3);
+          },
+          {
+            preempt: true,
+          },
+        );
+      });
+
+      for (const delay of [1, 5]) {
+        for (const expected of [2, 4]) {
+          it(`${name} x${expected} sequential, {delay: ${delay}}`, function (done) {
+            let actual = 0;
+            function increment() {
+              if (++actual === expected) {
+                assert.areTaskQueuesEmpty();
+
+                done();
+              }
+            }
+            queueSequential(
+              sut,
+              {
+                delay,
+              },
+              expected,
+              increment,
+            );
+          });
+
+          it(`${name} x${expected} recursive, {delay: ${delay}}`, function (done) {
+            let actual = 0;
+            function increment() {
+              if (++actual === expected) {
+                assert.areTaskQueuesEmpty();
+
+                done();
+              }
+            }
+            queueRecursive(
+              sut,
+              {
+                delay,
+              },
+              expected,
+              increment,
+            );
+          });
+        }
+      }
+    });
+
+    describe(`can await ${name}`, function () {
+      it('x1, {preempt: false, delay: 0}', function () {
+        const task = sut.queueTask(
+          function () {
+            /* */
+          },
+          {
+            preempt: false,
+            delay: 0,
+          },
+        );
+
+        return task.result;
+      });
+
+      it('x1, {preempt: true, delay: 0}', function () {
+        const task = sut.queueTask(
+          function () {
+            /* */
+          },
+          {
+            preempt: true,
+            delay: 0,
+          },
+        );
+
+        return task.result;
+      });
+
+      it('x1, {delay: 5}', function () {
+        const task = sut.queueTask(
+          function () {
+            /* */
+          },
+          {
+            delay: 5,
+          },
+        );
+
+        return task.result;
+      });
+
+      it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', function () {
+        const calls: number[] = [];
+
+        const task = sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+          },
+          {
+            delay: 5,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            delay: 0,
+          },
+        );
+
+        return task.result;
+      });
+
+      it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', function () {
+        const calls: number[] = [];
+
+        const task = sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+          },
+          {
+            preempt: false,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            preempt: true,
+          },
+        );
+
+        return task.result;
+      });
+
+      it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', function () {
+        const calls: number[] = [];
+
+        const task = sut.queueTask(
+          function () {
+            calls.push(1);
+
+            assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
+
+            assert.areTaskQueuesEmpty();
+          },
+          {
+            delay: 5,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(2);
+          },
+          {
+            preempt: false,
+          },
+        );
+
+        sut.queueTask(
+          function () {
+            calls.push(3);
+          },
+          {
+            preempt: true,
+          },
+        );
+
+        return task.result;
+      });
+
+      for (const delay of [1, 5]) {
+        for (const expected of [2, 4]) {
+          it(`x${expected} sequential, {delay: ${delay}}`, async function () {
+            let actual = 0;
+            queueSequential(
+              sut,
+              {
+                delay,
+              },
+              expected,
+              function () {
+                ++actual;
+              },
+            );
+
+            await sut.yield();
+
+            assert.strictEqual(actual, expected, 'callCount');
+
+            assert.areTaskQueuesEmpty();
+          });
+
+          it(`x${expected} recursive, {delay: ${delay}}`, async function () {
+            let actual = 0;
+            queueRecursive(
+              sut,
+              {
+                delay,
+              },
+              expected,
+              function () {
+                ++actual;
+              },
+            );
+
+            await sut.yield();
+
+            assert.strictEqual(actual, expected, 'callCount');
+
+            assert.areTaskQueuesEmpty();
+          });
+        }
+      }
+    });
+
+    describe(`can persist ${name}`, function () {
+      for (const iterations of [1, 2, 3]) {
+        describe(`runs until canceled after ${iterations} iterations`, function () {
+          it(`from within the running task`, function (done) {
+            let count = 0;
+
+            const task = sut.queueTask(
+              function () {
+                if (++count === iterations) {
+                  assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+
+                  task.cancel();
+
+                  assert.areTaskQueuesEmpty();
+                }
+              },
+              {
+                persistent: true,
+              },
+            );
+
+            let thenCount = 0;
+            function callback() {
+              if (++thenCount === iterations) {
+                assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                assert.areTaskQueuesEmpty();
+
+                done();
+              } else {
+                assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                task.result.then(callback).catch((error) => { throw error; });
+              }
+            }
+
+            task.result.then(callback).catch((error) => { throw error; });
+          });
+
+          it(`from within a followup task`, function (done) {
+            let count = 0;
+
+            const task = sut.queueTask(
+              function () {
+                assert.strictEqual(nextTask.status, 'pending', `nextTask.status in task at count=${count} ${reportTask(nextTask)}`);
+                assert.strictEqual(task.status, 'running', `task.status in task at count=${count} ${reportTask(task)}`);
+
+                ++count;
+              },
+              {
+                persistent: true,
+              },
+            );
+
+            let nextTask: ITask;
+            function createNextTask() {
+              return sut.queueTask(
+                function () {
+                  assert.strictEqual(nextTask.status, 'running', `nextTask.status in nextTask at count=${count} ${reportTask(nextTask)}`);
+                  assert.strictEqual(task.status, 'pending', `task.status in nextTask at count=${count} ${reportTask(task)}`);
+
+                  if (count === iterations) {
+                    task.cancel();
+
+                    assert.areTaskQueuesEmpty();
+                  } else {
+                    nextTask = createNextTask();
+                  }
+                },
+                {
+                },
+              );
+            }
+
+            nextTask = createNextTask();
+
+            let thenCount = 0;
+            function callback() {
+              if (++thenCount === iterations) {
+                assert.strictEqual(nextTask.status, 'completed', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
+                assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                assert.areTaskQueuesEmpty();
+
+                done();
+              } else {
+                assert.strictEqual(nextTask.status, 'pending', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
+                assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
+
+                nextTask.result.then(callback).catch((error) => { throw error; });
+              }
+            }
+
+            nextTask.result.then(callback).catch((error) => { throw error; });
+          });
+
+          it(`yields after the first iteration with no other tasks`, function (done) {
+            let count = 0;
+            let yieldCount = 0;
+
+            const task = sut.queueTask(
+              function () {
+                assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+
+                assert.strictEqual(++count, yieldCount + 1, '++count === yieldCount + 1');
+              },
+              {
+                persistent: true,
+              },
+            );
+
+            function yieldAndVerify() {
+              sut.yield().then(() => {
+                assert.strictEqual(count, ++yieldCount, 'count === ++yieldCount');
+
+                if (yieldCount < iterations) {
+                  yieldAndVerify();
+                } else {
+                  task.cancel();
+
+                  assert.areTaskQueuesEmpty();
+
+                  done();
+                }
+              }).catch((error) => { throw error; });
+            }
+
+            yieldAndVerify();
+          });
+
+          it(`yields after the first iteration with several other tasks`, function (done) {
+            let count = 0;
+
+            const task = sut.queueTask(
+              function () {
+                assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
+
+                ++count;
+              },
+              {
+                persistent: true,
+              },
+            );
+
+            let otherCount = 0;
+            sut.queueTask(
+              function () {
+                ++otherCount;
+              },
+              {
+                preempt: true,
+              },
+            );
+
+            sut.queueTask(
+              function () {
+                ++otherCount;
+              },
+              {
+                preempt: false,
+              },
+            );
+
+            sut.queueTask(
+              function () {
+                ++otherCount;
+              },
+              {
+                preempt: true,
+              },
+            );
+
+            sut.queueTask(
+              function () {
+                ++otherCount;
+              },
+              {
+                preempt: false,
+              },
+            );
+
+            sut.yield().then(() => {
+              assert.strictEqual(count, 1, 'count');
+              assert.strictEqual(otherCount, 4, 'otherCount');
+
+              task.cancel();
+
+              assert.areTaskQueuesEmpty();
+
+              done();
+            }).catch((error) => { throw error; });
+          });
+        });
+      }
+    });
+  }
+
+  // TODO(fkleuver): we need async tests with suspend: false.
+  // This is indirectly tested by various integration tests but we need at least a couple of thorough platform-specific tests as well.
+  describe('async', function () {
     for (const { sut, name } of prioritySpecs) {
       describe(`can queue ${name}`, function () {
-        it('x1, {preempt: false, delay: 0}', function (done) {
+        it('x1, {preempt: false, delay: 0}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           sut.queueTask(
-            function () {
+            async function () {
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               preempt: false,
               delay: 0,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
-        it('x1, {preempt: true, delay: 0}', function (done) {
+        it('x1, {preempt: true, delay: 0}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           sut.queueTask(
-            function () {
+            async function () {
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               preempt: true,
               delay: 0,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
-        it('x1, {delay: 5}', function (done) {
+        it('x1, {delay: 5}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           sut.queueTask(
-            function () {
+            async function () {
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
-        it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', function (done) {
+        it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           const calls: number[] = [];
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [2, 1], 'calls');
 
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               delay: 0,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
-        it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', function (done) {
+        it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           const calls: number[] = [];
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [2, 1], 'calls');
 
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               preempt: false,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               preempt: true,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
-        it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', function (done) {
+        it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
+          const { promise, resolve } = createExposedPromise();
+
           const calls: number[] = [];
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
 
               assert.areTaskQueuesEmpty();
 
-              done();
+              resolve();
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               preempt: false,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(3);
             },
             {
-              reusable,
               preempt: true,
+              suspend: true,
             },
           );
+
+          await promise;
         });
 
         for (const delay of [1, 5]) {
           for (const expected of [2, 4]) {
-            it(`${name} x${expected} sequential, {delay: ${delay}}`, function (done) {
+            it(`${name} x${expected} sequential, {delay: ${delay}}`, async function () {
+              const { promise, resolve } = createExposedPromise();
+
               let actual = 0;
-              function increment() {
+              async function increment() {
                 if (++actual === expected) {
                   assert.areTaskQueuesEmpty();
 
-                  done();
+                  resolve();
                 }
               }
-              queueSequential(
+              queueSequentialAsync(
                 sut,
                 {
-                  reusable,
                   delay,
+                  suspend: true,
                 },
                 expected,
                 increment,
               );
+
+              await promise;
             });
 
-            it(`${name} x${expected} recursive, {delay: ${delay}}`, function (done) {
+            it(`${name} x${expected} recursive, {delay: ${delay}}`, async function () {
+              const { promise, resolve } = createExposedPromise();
+
               let actual = 0;
-              function increment() {
+              async function increment() {
                 if (++actual === expected) {
                   assert.areTaskQueuesEmpty();
 
-                  done();
+                  resolve();
                 }
               }
-              queueRecursive(
+              queueRecursiveAsync(
                 sut,
                 {
-                  reusable,
                   delay,
+                  suspend: true,
                 },
                 expected,
                 increment,
               );
+
+              await promise;
             });
           }
         }
       });
 
       describe(`can await ${name}`, function () {
-        it('x1, {preempt: false, delay: 0}', function () {
+        it(`manual 2x recursive`, async function () {
+          const opts = {
+            preempt: false,
+            delay: 0,
+            suspend: true,
+          };
+
+          let count = 0;
+
+          sut.queueTask(
+            async function () {
+              await Promise.resolve();
+              ++count;
+
+              sut.queueTask(
+                async function () {
+                  ++count;
+                },
+                opts,
+              );
+            },
+            opts,
+          );
+
+          await sut.yield();
+
+          assert.strictEqual(count, 2);
+
+          assert.areTaskQueuesEmpty();
+        });
+
+        it('x1, {preempt: false, delay: 0}', async function () {
           const task = sut.queueTask(
-            function () {
+            async function () {
               /* */
             },
             {
-              reusable,
               preempt: false,
               delay: 0,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
-        it('x1, {preempt: true, delay: 0}', function () {
+        it('x1, {preempt: true, delay: 0}', async function () {
           const task = sut.queueTask(
-            function () {
+            async function () {
               /* */
             },
             {
-              reusable,
               preempt: true,
               delay: 0,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
-        it('x1, {delay: 5}', function () {
+        it('x1, {delay: 5}', async function () {
           const task = sut.queueTask(
-            function () {
+            async function () {
               /* */
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
-        it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', function () {
+        it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
           const calls: number[] = [];
 
           const task = sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [2, 1], 'calls');
@@ -346,29 +966,29 @@ describe('2-runtime/scheduler.spec.ts', function () {
               assert.areTaskQueuesEmpty();
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               delay: 0,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
-        it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', function () {
+        it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
           const calls: number[] = [];
 
           const task = sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [2, 1], 'calls');
@@ -376,29 +996,29 @@ describe('2-runtime/scheduler.spec.ts', function () {
               assert.areTaskQueuesEmpty();
             },
             {
-              reusable,
               preempt: false,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               preempt: true,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
-        it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', function () {
+        it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
           const calls: number[] = [];
 
           const task = sut.queueTask(
-            function () {
+            async function () {
               calls.push(1);
 
               assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
@@ -406,46 +1026,46 @@ describe('2-runtime/scheduler.spec.ts', function () {
               assert.areTaskQueuesEmpty();
             },
             {
-              reusable,
               delay: 5,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(2);
             },
             {
-              reusable,
               preempt: false,
+              suspend: true,
             },
           );
 
           sut.queueTask(
-            function () {
+            async function () {
               calls.push(3);
             },
             {
-              reusable,
               preempt: true,
+              suspend: true,
             },
           );
 
-          return task.result;
+          await task.result;
         });
 
         for (const delay of [1, 5]) {
           for (const expected of [2, 4]) {
             it(`x${expected} sequential, {delay: ${delay}}`, async function () {
               let actual = 0;
-              queueSequential(
+              queueSequentialAsync(
                 sut,
                 {
-                  reusable,
                   delay,
+                  suspend: true,
                 },
                 expected,
-                function () {
+                async function () {
                   ++actual;
                 },
               );
@@ -459,14 +1079,14 @@ describe('2-runtime/scheduler.spec.ts', function () {
 
             it(`x${expected} recursive, {delay: ${delay}}`, async function () {
               let actual = 0;
-              queueRecursive(
+              queueRecursiveAsync(
                 sut,
                 {
-                  reusable,
                   delay,
+                  suspend: true,
                 },
                 expected,
-                function () {
+                async function () {
                   ++actual;
                 },
               );
@@ -484,11 +1104,13 @@ describe('2-runtime/scheduler.spec.ts', function () {
       describe(`can persist ${name}`, function () {
         for (const iterations of [1, 2, 3]) {
           describe(`runs until canceled after ${iterations} iterations`, function () {
-            it(`from within the running task`, function (done) {
+            it(`from within the running task`, async function () {
+              const { promise, resolve } = createExposedPromise();
+
               let count = 0;
 
               const task = sut.queueTask(
-                function () {
+                async function () {
                   if (++count === iterations) {
                     assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
 
@@ -499,33 +1121,38 @@ describe('2-runtime/scheduler.spec.ts', function () {
                 },
                 {
                   persistent: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               let thenCount = 0;
-              function callback() {
+              async function callback() {
                 if (++thenCount === iterations) {
                   assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
 
                   assert.areTaskQueuesEmpty();
 
-                  done();
+                  resolve();
                 } else {
                   assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
 
-                  task.result.then(callback).catch((error) => { throw error; });
+                  await task.result;
+                  await callback();
                 }
               }
 
-              task.result.then(callback).catch((error) => { throw error; });
+              await task.result;
+              await callback();
+              await promise;
             });
 
-            it(`from within a followup task`, function (done) {
+            it(`from within a followup task`, async function () {
+              const { promise, resolve } = createExposedPromise();
+
               let count = 0;
 
               const task = sut.queueTask(
-                function () {
+                async function () {
                   assert.strictEqual(nextTask.status, 'pending', `nextTask.status in task at count=${count} ${reportTask(nextTask)}`);
                   assert.strictEqual(task.status, 'running', `task.status in task at count=${count} ${reportTask(task)}`);
 
@@ -533,14 +1160,14 @@ describe('2-runtime/scheduler.spec.ts', function () {
                 },
                 {
                   persistent: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               let nextTask: ITask;
               function createNextTask() {
                 return sut.queueTask(
-                  function () {
+                  async function () {
                     assert.strictEqual(nextTask.status, 'running', `nextTask.status in nextTask at count=${count} ${reportTask(nextTask)}`);
                     assert.strictEqual(task.status, 'pending', `task.status in nextTask at count=${count} ${reportTask(task)}`);
 
@@ -553,7 +1180,7 @@ describe('2-runtime/scheduler.spec.ts', function () {
                     }
                   },
                   {
-                    reusable,
+                    suspend: true,
                   },
                 );
               }
@@ -561,905 +1188,201 @@ describe('2-runtime/scheduler.spec.ts', function () {
               nextTask = createNextTask();
 
               let thenCount = 0;
-              function callback() {
+              async function callback() {
                 if (++thenCount === iterations) {
                   assert.strictEqual(nextTask.status, 'completed', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
                   assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
 
                   assert.areTaskQueuesEmpty();
 
-                  done();
+                  resolve();
                 } else {
                   assert.strictEqual(nextTask.status, 'pending', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
                   assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
 
-                  nextTask.result.then(callback).catch((error) => { throw error; });
+                  await nextTask.result;
+
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                  callback();
                 }
               }
 
-              nextTask.result.then(callback).catch((error) => { throw error; });
+              await task.result;
+              assert.strictEqual(nextTask.status, 'pending', `nextTask.status after awaiting task.result at thenCount=${thenCount} ${reportTask(nextTask)}`);
+              assert.strictEqual(task.status, 'pending', `task.status after awaiting task.result at thenCount=${thenCount} ${reportTask(task)}`);
+
+              await nextTask.result;
+
+              await callback();
+
+              await promise;
             });
 
-            it(`yields after the first iteration with no other tasks`, function (done) {
+            it(`yields after the first iteration with no other tasks`, async function () {
+              const { promise, resolve } = createExposedPromise();
+
               let count = 0;
               let yieldCount = 0;
 
               const task = sut.queueTask(
-                function () {
+                async function () {
                   assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
-
                   assert.strictEqual(++count, yieldCount + 1, '++count === yieldCount + 1');
                 },
                 {
                   persistent: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
-              function yieldAndVerify() {
-                sut.yield().then(() => {
-                  assert.strictEqual(count, ++yieldCount, 'count === ++yieldCount');
+              async function yieldAndVerify() {
+                await sut.yield();
 
-                  if (yieldCount < iterations) {
-                    yieldAndVerify();
-                  } else {
-                    task.cancel();
+                assert.strictEqual(count, ++yieldCount, 'count === ++yieldCount');
 
-                    assert.areTaskQueuesEmpty();
+                if (yieldCount < iterations) {
+                  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+                  yieldAndVerify();
+                } else {
+                  task.cancel();
 
-                    done();
-                  }
-                }).catch((error) => { throw error; });
+                  assert.areTaskQueuesEmpty();
+
+                  resolve();
+                }
               }
 
-              yieldAndVerify();
+              await yieldAndVerify();
+              await promise;
             });
 
-            it(`yields after the first iteration with several other tasks`, function (done) {
+            it(`yields after the first iteration with several other tasks`, async function () {
               let count = 0;
 
               const task = sut.queueTask(
-                function () {
+                async function () {
                   assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
 
                   ++count;
                 },
                 {
                   persistent: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               let otherCount = 0;
               sut.queueTask(
-                function () {
+                async function () {
                   ++otherCount;
                 },
                 {
                   preempt: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               sut.queueTask(
-                function () {
+                async function () {
                   ++otherCount;
                 },
                 {
                   preempt: false,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               sut.queueTask(
-                function () {
+                async function () {
                   ++otherCount;
                 },
                 {
                   preempt: true,
-                  reusable,
+                  suspend: true,
                 },
               );
 
               sut.queueTask(
-                function () {
+                async function () {
                   ++otherCount;
                 },
                 {
                   preempt: false,
-                  reusable,
+                  suspend: true,
                 },
               );
 
-              sut.yield().then(() => {
-                assert.strictEqual(count, 1, 'count');
-                assert.strictEqual(otherCount, 4, 'otherCount');
+              await sut.yield();
 
-                task.cancel();
+              assert.strictEqual(count, 1, 'count');
+              assert.strictEqual(otherCount, 4, 'otherCount');
 
-                assert.areTaskQueuesEmpty();
+              task.cancel();
 
-                done();
-              }).catch((error) => { throw error; });
+              assert.areTaskQueuesEmpty();
             });
           });
         }
-      });
-    }
-  }
 
-  // TODO(fkleuver): we need async tests with suspend: false.
-  // This is indirectly tested by various integration tests but we need at least a couple of thorough platform-specific tests as well.
-  describe('async', function () {
-    for (const reusable of [true, false]) {
-      const $reusable = reusable ? 'reusable' : 'non-reusable';
-
-      for (const { sut, name } of prioritySpecs) {
-        describe(`can queue ${$reusable} ${name}`, function () {
-          it('x1, {preempt: false, delay: 0}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            sut.queueTask(
-              async function () {
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                preempt: false,
-                delay: 0,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          it('x1, {preempt: true, delay: 0}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            sut.queueTask(
-              async function () {
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                preempt: true,
-                delay: 0,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          it('x1, {delay: 5}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            sut.queueTask(
-              async function () {
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            const calls: number[] = [];
-
-            sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                delay: 0,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            const calls: number[] = [];
-
-            sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                preempt: false,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                preempt: true,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
-            const { promise, resolve } = createExposedPromise();
-
-            const calls: number[] = [];
-
-            sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-
-                resolve();
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                preempt: false,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(3);
-              },
-              {
-                reusable,
-                preempt: true,
-                suspend: true,
-              },
-            );
-
-            await promise;
-          });
-
-          for (const delay of [1, 5]) {
-            for (const expected of [2, 4]) {
-              it(`${name} x${expected} sequential, {delay: ${delay}}`, async function () {
-                const { promise, resolve } = createExposedPromise();
-
-                let actual = 0;
-                async function increment() {
-                  if (++actual === expected) {
-                    assert.areTaskQueuesEmpty();
-
-                    resolve();
-                  }
-                }
-                queueSequentialAsync(
-                  sut,
-                  {
-                    reusable,
-                    delay,
-                    suspend: true,
-                  },
-                  expected,
-                  increment,
-                );
-
-                await promise;
-              });
-
-              it(`${name} x${expected} recursive, {delay: ${delay}}`, async function () {
-                const { promise, resolve } = createExposedPromise();
-
-                let actual = 0;
-                async function increment() {
-                  if (++actual === expected) {
-                    assert.areTaskQueuesEmpty();
-
-                    resolve();
-                  }
-                }
-                queueRecursiveAsync(
-                  sut,
-                  {
-                    reusable,
-                    delay,
-                    suspend: true,
-                  },
-                  expected,
-                  increment,
-                );
-
-                await promise;
-              });
-            }
-          }
-        });
-
-        describe(`can await ${$reusable} ${name}`, function () {
-          it(`manual 2x recursive`, async function () {
-            const opts = {
-              reusable,
-              preempt: false,
-              delay: 0,
+        it(`yields after the first iteration with no other tasks, after finishing a persistent task that was canceled from within a followup task`, async function () {
+          const primerTask = sut.queueTask(
+            async function () {
+              assert.strictEqual(primerTask.status, 'running', `primerTask.status in primerTask ${reportTask(primerTask)}`);
+              assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status in primerTask ${reportTask(primerCancelTask)}`);
+            },
+            {
+              persistent: true,
               suspend: true,
-            };
+            },
+          );
 
-            let count = 0;
+          const primerCancelTask = sut.queueTask(
+            async function () {
+              assert.strictEqual(primerTask.status, 'pending', `primerTask.status in primerCancelTask ${reportTask(primerTask)}`);
+              assert.strictEqual(primerCancelTask.status, 'running', `primerCancelTask.status in primerCancelTask ${reportTask(primerCancelTask)}`);
 
-            sut.queueTask(
-              async function () {
-                await Promise.resolve();
-                ++count;
+              primerTask.cancel();
 
-                sut.queueTask(
-                  async function () {
-                    ++count;
-                  },
-                  opts,
-                );
-              },
-              opts,
-            );
+              assert.areTaskQueuesEmpty();
+            },
+            {
+              suspend: true,
+            },
+          );
 
-            await sut.yield();
+          await primerTask.result;
+          assert.strictEqual(primerTask.status, 'pending', `primerTask.status after awaiting primerTask.result ${reportTask(primerTask)}`);
+          assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status after awaiting primerTask.result ${reportTask(primerCancelTask)}`);
 
-            assert.strictEqual(count, 2);
+          await primerCancelTask.result;
+          assert.strictEqual(primerTask.status, 'canceled', `primerTask.status after awaiting primerCancelTask.result ${reportTask(primerTask)}`);
+          assert.strictEqual(primerCancelTask.status, 'completed', `primerCancelTask.status after awaiting primerCancelTask.result ${reportTask(primerCancelTask)}`);
 
-            assert.areTaskQueuesEmpty();
-          });
+          assert.areTaskQueuesEmpty();
 
-          it('x1, {preempt: false, delay: 0}', async function () {
-            const task = sut.queueTask(
-              async function () {
-                /* */
-              },
-              {
-                reusable,
-                preempt: false,
-                delay: 0,
-                suspend: true,
-              },
-            );
+          let count = 0;
+          let yieldCount = 0;
 
-            await task.result;
-          });
+          const persistentTask = sut.queueTask(
+            async function () {
+              assert.strictEqual(persistentTask.status, 'running', `persistentTask.status in persistentTask ${reportTask(persistentTask)}`);
+              assert.strictEqual(++count, yieldCount + 1, `++count (${count}) === yieldCount + 1 (${yieldCount + 1}) in persistentTask`);
+            },
+            {
+              persistent: true,
+              suspend: true,
+            },
+          );
 
-          it('x1, {preempt: true, delay: 0}', async function () {
-            const task = sut.queueTask(
-              async function () {
-                /* */
-              },
-              {
-                reusable,
-                preempt: true,
-                delay: 0,
-                suspend: true,
-              },
-            );
+          await sut.yield();
 
-            await task.result;
-          });
+          assert.strictEqual(count, ++yieldCount, `count (${count}) === ++yieldCount (${yieldCount}) after awaiting sut.yield()`);
 
-          it('x1, {delay: 5}', async function () {
-            const task = sut.queueTask(
-              async function () {
-                /* */
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
+          persistentTask.cancel();
 
-            await task.result;
-          });
-
-          it('x1, queue {delay: 5} -> {delay: 0}, invoke {delay: 0} -> {delay: 5}', async function () {
-            const calls: number[] = [];
-
-            const task = sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                delay: 0,
-                suspend: true,
-              },
-            );
-
-            await task.result;
-          });
-
-          it('x1, queue {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false}', async function () {
-            const calls: number[] = [];
-
-            const task = sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-              },
-              {
-                reusable,
-                preempt: false,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                preempt: true,
-                suspend: true,
-              },
-            );
-
-            await task.result;
-          });
-
-          it('x1, queue {delay: 5} -> {preempt: false} -> {preempt: true}, invoke {preempt: true} -> {preempt: false} -> {delay: 5}', async function () {
-            const calls: number[] = [];
-
-            const task = sut.queueTask(
-              async function () {
-                calls.push(1);
-
-                assert.deepStrictEqual(calls, [3, 2, 1], 'calls');
-
-                assert.areTaskQueuesEmpty();
-              },
-              {
-                reusable,
-                delay: 5,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(2);
-              },
-              {
-                reusable,
-                preempt: false,
-                suspend: true,
-              },
-            );
-
-            sut.queueTask(
-              async function () {
-                calls.push(3);
-              },
-              {
-                reusable,
-                preempt: true,
-                suspend: true,
-              },
-            );
-
-            await task.result;
-          });
-
-          for (const delay of [1, 5]) {
-            for (const expected of [2, 4]) {
-              it(`x${expected} sequential, {delay: ${delay}}`, async function () {
-                let actual = 0;
-                queueSequentialAsync(
-                  sut,
-                  {
-                    reusable,
-                    delay,
-                    suspend: true,
-                  },
-                  expected,
-                  async function () {
-                    ++actual;
-                  },
-                );
-
-                await sut.yield();
-
-                assert.strictEqual(actual, expected, 'callCount');
-
-                assert.areTaskQueuesEmpty();
-              });
-
-              it(`x${expected} recursive, {delay: ${delay}}`, async function () {
-                let actual = 0;
-                queueRecursiveAsync(
-                  sut,
-                  {
-                    reusable,
-                    delay,
-                    suspend: true,
-                  },
-                  expected,
-                  async function () {
-                    ++actual;
-                  },
-                );
-
-                await sut.yield();
-
-                assert.strictEqual(actual, expected, 'callCount');
-
-                assert.areTaskQueuesEmpty();
-              });
-            }
-          }
+          assert.areTaskQueuesEmpty();
         });
-
-        describe(`can persist ${$reusable} ${name}`, function () {
-          for (const iterations of [1, 2, 3]) {
-            describe(`runs until canceled after ${iterations} iterations`, function () {
-              it(`from within the running task`, async function () {
-                const { promise, resolve } = createExposedPromise();
-
-                let count = 0;
-
-                const task = sut.queueTask(
-                  async function () {
-                    if (++count === iterations) {
-                      assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
-
-                      task.cancel();
-
-                      assert.areTaskQueuesEmpty();
-                    }
-                  },
-                  {
-                    persistent: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                let thenCount = 0;
-                async function callback() {
-                  if (++thenCount === iterations) {
-                    assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
-
-                    assert.areTaskQueuesEmpty();
-
-                    resolve();
-                  } else {
-                    assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
-
-                    await task.result;
-                    await callback();
-                  }
-                }
-
-                await task.result;
-                await callback();
-                await promise;
-              });
-
-              it(`from within a followup task`, async function () {
-                const { promise, resolve } = createExposedPromise();
-
-                let count = 0;
-
-                const task = sut.queueTask(
-                  async function () {
-                    assert.strictEqual(nextTask.status, 'pending', `nextTask.status in task at count=${count} ${reportTask(nextTask)}`);
-                    assert.strictEqual(task.status, 'running', `task.status in task at count=${count} ${reportTask(task)}`);
-
-                    ++count;
-                  },
-                  {
-                    persistent: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                let nextTask: ITask;
-                function createNextTask() {
-                  return sut.queueTask(
-                    async function () {
-                      assert.strictEqual(nextTask.status, 'running', `nextTask.status in nextTask at count=${count} ${reportTask(nextTask)}`);
-                      assert.strictEqual(task.status, 'pending', `task.status in nextTask at count=${count} ${reportTask(task)}`);
-
-                      if (count === iterations) {
-                        task.cancel();
-
-                        assert.areTaskQueuesEmpty();
-                      } else {
-                        nextTask = createNextTask();
-                      }
-                    },
-                    {
-                      reusable,
-                      suspend: true,
-                    },
-                  );
-                }
-
-                nextTask = createNextTask();
-
-                let thenCount = 0;
-                async function callback() {
-                  if (++thenCount === iterations) {
-                    assert.strictEqual(nextTask.status, 'completed', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
-                    assert.strictEqual(task.status, 'canceled', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
-
-                    assert.areTaskQueuesEmpty();
-
-                    resolve();
-                  } else {
-                    assert.strictEqual(nextTask.status, 'pending', `nextTask.status at thenCount=${thenCount} ${reportTask(nextTask)}`);
-                    assert.strictEqual(task.status, 'pending', `task.status at thenCount=${thenCount} ${reportTask(task)}`);
-
-                    await nextTask.result;
-
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    callback();
-                  }
-                }
-
-                await task.result;
-                assert.strictEqual(nextTask.status, 'pending', `nextTask.status after awaiting task.result at thenCount=${thenCount} ${reportTask(nextTask)}`);
-                assert.strictEqual(task.status, 'pending', `task.status after awaiting task.result at thenCount=${thenCount} ${reportTask(task)}`);
-
-                await nextTask.result;
-
-                await callback();
-
-                await promise;
-              });
-
-              it(`yields after the first iteration with no other tasks`, async function () {
-                const { promise, resolve } = createExposedPromise();
-
-                let count = 0;
-                let yieldCount = 0;
-
-                const task = sut.queueTask(
-                  async function () {
-                    assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
-                    assert.strictEqual(++count, yieldCount + 1, '++count === yieldCount + 1');
-                  },
-                  {
-                    persistent: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                async function yieldAndVerify() {
-                  await sut.yield();
-
-                  assert.strictEqual(count, ++yieldCount, 'count === ++yieldCount');
-
-                  if (yieldCount < iterations) {
-                    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                    yieldAndVerify();
-                  } else {
-                    task.cancel();
-
-                    assert.areTaskQueuesEmpty();
-
-                    resolve();
-                  }
-                }
-
-                await yieldAndVerify();
-                await promise;
-              });
-
-              it(`yields after the first iteration with several other tasks`, async function () {
-                let count = 0;
-
-                const task = sut.queueTask(
-                  async function () {
-                    assert.strictEqual(task.status, 'running', `task.status at count=${count} ${reportTask(task)}`);
-
-                    ++count;
-                  },
-                  {
-                    persistent: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                let otherCount = 0;
-                sut.queueTask(
-                  async function () {
-                    ++otherCount;
-                  },
-                  {
-                    preempt: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                sut.queueTask(
-                  async function () {
-                    ++otherCount;
-                  },
-                  {
-                    preempt: false,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                sut.queueTask(
-                  async function () {
-                    ++otherCount;
-                  },
-                  {
-                    preempt: true,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                sut.queueTask(
-                  async function () {
-                    ++otherCount;
-                  },
-                  {
-                    preempt: false,
-                    reusable,
-                    suspend: true,
-                  },
-                );
-
-                await sut.yield();
-
-                assert.strictEqual(count, 1, 'count');
-                assert.strictEqual(otherCount, 4, 'otherCount');
-
-                task.cancel();
-
-                assert.areTaskQueuesEmpty();
-              });
-            });
-          }
-
-          it(`yields after the first iteration with no other tasks, after finishing a persistent task that was canceled from within a followup task`, async function () {
-            const primerTask = sut.queueTask(
-              async function () {
-                assert.strictEqual(primerTask.status, 'running', `primerTask.status in primerTask ${reportTask(primerTask)}`);
-                assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status in primerTask ${reportTask(primerCancelTask)}`);
-              },
-              {
-                persistent: true,
-                reusable,
-                suspend: true,
-              },
-            );
-
-            const primerCancelTask = sut.queueTask(
-              async function () {
-                assert.strictEqual(primerTask.status, 'pending', `primerTask.status in primerCancelTask ${reportTask(primerTask)}`);
-                assert.strictEqual(primerCancelTask.status, 'running', `primerCancelTask.status in primerCancelTask ${reportTask(primerCancelTask)}`);
-
-                primerTask.cancel();
-
-                assert.areTaskQueuesEmpty();
-              },
-              {
-                reusable,
-                suspend: true,
-              },
-            );
-
-            await primerTask.result;
-            assert.strictEqual(primerTask.status, 'pending', `primerTask.status after awaiting primerTask.result ${reportTask(primerTask)}`);
-            assert.strictEqual(primerCancelTask.status, 'pending', `primerCancelTask.status after awaiting primerTask.result ${reportTask(primerCancelTask)}`);
-
-            await primerCancelTask.result;
-            assert.strictEqual(primerTask.status, 'canceled', `primerTask.status after awaiting primerCancelTask.result ${reportTask(primerTask)}`);
-            assert.strictEqual(primerCancelTask.status, 'completed', `primerCancelTask.status after awaiting primerCancelTask.result ${reportTask(primerCancelTask)}`);
-
-            assert.areTaskQueuesEmpty();
-
-            let count = 0;
-            let yieldCount = 0;
-
-            const persistentTask = sut.queueTask(
-              async function () {
-                assert.strictEqual(persistentTask.status, 'running', `persistentTask.status in persistentTask ${reportTask(persistentTask)}`);
-                assert.strictEqual(++count, yieldCount + 1, `++count (${count}) === yieldCount + 1 (${yieldCount + 1}) in persistentTask`);
-              },
-              {
-                persistent: true,
-                reusable,
-                suspend: true,
-              },
-            );
-
-            await sut.yield();
-
-            assert.strictEqual(count, ++yieldCount, `count (${count}) === ++yieldCount (${yieldCount}) after awaiting sut.yield()`);
-
-            persistentTask.cancel();
-
-            assert.areTaskQueuesEmpty();
-          });
-        });
-      }
+      });
     }
 
     const enum TaskState {

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -59,7 +59,6 @@ export interface TranslationBinding extends IAstEvaluator, IObserverLocatorBased
 
 const forOpts = { optional: true } as const;
 const taskQueueOpts: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };
 

--- a/packages/runtime-html/src/binding/attribute-binding.ts
+++ b/packages/runtime-html/src/binding/attribute-binding.ts
@@ -28,7 +28,6 @@ import { safeString } from '../utilities';
 import { ForOfStatement, IsBindingBehavior } from '@aurelia/expression-parser';
 
 const taskOptions: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };
 

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -182,7 +182,7 @@ export const mixingBindingLimited = /*@__PURE__*/ (() => {
       latestValue = v;
       if (binding.isBound) {
         task = limiterTask;
-        limiterTask = taskQueue.queueTask(callOriginalCallback, { delay: opts.delay, reusable: false });
+        limiterTask = taskQueue.queueTask(callOriginalCallback, { delay: opts.delay });
         task?.cancel();
       } else {
         callOriginalCallback();
@@ -231,7 +231,7 @@ export const mixingBindingLimited = /*@__PURE__*/ (() => {
           limiterTask = taskQueue.queueTask(() => {
             last = now();
             callOriginalCallback();
-          }, { delay: opts.delay - elapsed, reusable: false });
+          }, { delay: opts.delay - elapsed });
         }
         task?.cancel();
       } else {

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -25,7 +25,6 @@ import { mixinUseScope, mixingBindingLimited, mixinAstEvaluator, createPrototype
 import { IsExpression } from '@aurelia/expression-parser';
 
 const queueTaskOptions: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };
 

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -27,7 +27,6 @@ import type { IBinding, BindingMode, IBindingController } from './interfaces-bin
 import { type Interpolation, IsExpression } from '@aurelia/expression-parser';
 
 const queueTaskOptions: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };
 

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -211,6 +211,5 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
 let task: ITask | null = null;
 
 const updateTaskOpts: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };

--- a/packages/runtime-html/src/resources/template-controllers/promise.ts
+++ b/packages/runtime-html/src/resources/template-controllers/promise.ts
@@ -86,7 +86,6 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
     const s = this.viewScope;
 
     let preSettlePromise: Promise<void>;
-    const defaultQueuingOptions = { reusable: false };
     const $swap = () => {
       // Note that the whole thing is not wrapped in a q.queueTask intentionally.
       // Because that would block the app till the actual promise is resolved, which is not the goal anyway.
@@ -99,7 +98,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
             rejected?.deactivate(initiator),
             pending?.activate(initiator, s)
           );
-        }, defaultQueuingOptions)).result.catch((err) => { if (!(err instanceof TaskAbortError)) throw err; }),
+        })).result.catch((err) => { if (!(err instanceof TaskAbortError)) throw err; }),
         value
           .then(
             (data) => {
@@ -112,7 +111,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
                   pending?.deactivate(initiator),
                   rejected?.deactivate(initiator),
                   fulfilled?.activate(initiator, s, data),
-                ), defaultQueuingOptions)).result;
+                ))).result;
               };
               if (this.preSettledTask!.status === tsRunning) {
                 void preSettlePromise.then(fulfill);
@@ -131,7 +130,7 @@ export class PromiseTemplateController implements ICustomAttributeViewModel {
                   pending?.deactivate(initiator),
                   fulfilled?.deactivate(initiator),
                   rejected?.activate(initiator, s, err),
-                ), defaultQueuingOptions)).result;
+                ))).result;
               };
               if (this.preSettledTask!.status === tsRunning) {
                 void preSettlePromise.then(reject);

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -233,7 +233,6 @@ type Unsubscribable = {
 };
 
 const updateTaskOpts: QueueTaskOptions = {
-  reusable: false,
   preempt: true,
 };
 

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -776,11 +776,10 @@ const areTaskQueuesEmpty = (function () {
     const created = round(task.createdTime);
     const queue = round(task.queueTime);
     const preempt = task.preempt;
-    const reusable = task.reusable;
     const persistent = task.persistent;
     const status = task.status;
 
-    return `    task id=${id} createdTime=${created} queueTime=${queue} preempt=${preempt} reusable=${reusable} persistent=${persistent} status=${status}\n`
+    return `    task id=${id} createdTime=${created} queueTime=${queue} preempt=${preempt} persistent=${persistent} status=${status}\n`
       + `    task callback="${task.callback?.toString()}"`;
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Removes the `reusable` task queue option. This was originally intended as a performance optimization for animations but the mechanism for animations is going to be optimized separately.
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
