### PR TITLE
fix(binding): handle glitch

### DIFF
--- a/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
@@ -207,6 +207,38 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       assert.deepEqual([i1, i2, i3], [1, 2, 1]);
     });
 
+    it('handles array index related glitches', function () {
+      class NameTag {
+        firstName = '';
+        lastName = '';
+
+        constructor(readonly tags: string[] = []) {
+        }
+
+        get tag() {
+          return this.tags[0] === 'a' ? `[Badge] ${this.tags.join(',')}` : '[a]';
+        }
+      }
+
+      const tags: string[] = [];
+      const changeSnapshots: unknown[][] = [];
+      locator.getArrayObserver(tags).subscribe({
+        handleCollectionChange(collection: []) {
+          changeSnapshots.push([collection.length, obj.tag]);
+        }
+      });
+      const obj = new NameTag(tags);
+      const tagObserver = locator.getObserver(obj, 'tag');
+      tagObserver.subscribe({ handleChange: () => {
+        // only for triggering observation
+      } });
+
+      tags.push('a');
+      assert.deepEqual(changeSnapshots, [
+        [1, '[Badge] a']
+      ]);
+    });
+
     it('handles array length related glitches', function () {
       class NameTag {
         firstName = '';

--- a/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
@@ -1,6 +1,6 @@
 import { DI, IPlatform, Registration } from '@aurelia/kernel';
 import { BrowserPlatform } from '@aurelia/platform-browser';
-import { DirtyChecker, IObserverLocator, observable } from '@aurelia/runtime';
+import { batch, DirtyChecker, IObserverLocator, observable } from '@aurelia/runtime';
 import { assert } from '@aurelia/testing';
 
 describe('3-runtime-html/observation-glitches.spec.ts', function () {
@@ -229,9 +229,11 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       });
       const obj = new NameTag(tags);
       const tagObserver = locator.getObserver(obj, 'tag');
-      tagObserver.subscribe({ handleChange: () => {
-        // only for triggering observation
-      } });
+      tagObserver.subscribe({
+        handleChange: () => {
+          // only for triggering observation
+        }
+      });
 
       tags.push('a');
       assert.deepEqual(changeSnapshots, [
@@ -261,9 +263,11 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       });
       const obj = new NameTag(tags);
       const tagObserver = locator.getObserver(obj, 'tag');
-      tagObserver.subscribe({ handleChange: () => {
-        // only for triggering observation
-      } });
+      tagObserver.subscribe({
+        handleChange: () => {
+          // only for triggering observation
+        }
+      });
 
       tags.push('a');
       assert.deepEqual(changeSnapshots, [
@@ -293,9 +297,11 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       });
       const obj = new NameTag(tags);
       const tagObserver = locator.getObserver(obj, 'tag');
-      tagObserver.subscribe({ handleChange: () => {
-        // only for triggering observation
-      } });
+      tagObserver.subscribe({
+        handleChange: () => {
+          // only for triggering observation
+        }
+      });
 
       tags.set('a', 'b');
       assert.deepEqual(changeSnapshots, [
@@ -325,9 +331,11 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       });
       const obj = new NameTag(tags);
       const tagObserver = locator.getObserver(obj, 'tag');
-      tagObserver.subscribe({ handleChange: () => {
-        // only for triggering observation
-      } });
+      tagObserver.subscribe({
+        handleChange: () => {
+          // only for triggering observation
+        }
+      });
 
       tags.add('a');
       assert.deepEqual(changeSnapshots, [
@@ -337,6 +345,354 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
 
     // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('handles glitches in circular dependencies', function () { });
+
+    describe('with batch()', function () {
+
+      it('handles glitches', function () {
+        let i1 = 0;
+        let i2 = 0;
+        let i3 = 0;
+
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          get tag() {
+            if (!this.firstName && !this.lastName) {
+              i1++;
+              return '(Anonymous)';
+            }
+            if (this.fullName.includes('Sync')) {
+              i2++;
+              return '[Banned]';
+            }
+            i3++;
+            return `[Badge] ${this.fullName}`;
+          }
+
+          get fullName() {
+            return `${this.firstName} ${this.lastName}`;
+          }
+        }
+        const obj = new NameTag();
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({ handleChange: () => { /* only to trigger observation */ } });
+        assert.deepEqual([i1, i2, i3], [1, 0, 0]);
+
+        batch(() => {
+          obj.firstName = 'Sync';
+          obj.lastName = 'Last';
+        });
+        assert.strictEqual(obj.tag, '[Banned]');
+        assert.deepEqual([i1, i2, i3], [1, 1, 0]);
+
+        batch(() => {
+          obj.firstName = '';
+        });
+        // shouldn't go to 2 because fullName should no longer have 'Sync' in it
+        assert.deepEqual([i1, i2, i3], [1, 1, 1]);
+      });
+
+      it('handles nested dependencies glitches', function () {
+        // in this test, fullName depends on firstName, but is not directly a dependency of tag
+        // in other word, `fullName` is an indirect dependency of `tag`
+        // though it also depends on firstName, so this test is to ensure that regardless of the position of the dependency in the chain,
+        // it should still be able to get the notification
+        //
+        let i1 = 0;
+        let i2 = 0;
+        let i3 = 0;
+
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          get tag() {
+            if (!this.firstName && !this.lastName) {
+              i1++;
+              return '(Anonymous)';
+            }
+            if (this.trimmed.includes('Sync')) {
+              i2++;
+              return '[Banned]';
+            }
+            i3++;
+            return `[Badge] ${this.trimmed}`;
+          }
+
+          get fullName() {
+            return `${this.firstName} ${this.lastName}`;
+          }
+
+          get trimmed() {
+            return this.fullName.slice(0, 10);
+          }
+        }
+
+        const obj = new NameTag();
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({ handleChange: () => { /* only to trigger observation */ } });
+        assert.deepEqual([i1, i2, i3], [1, 0, 0]);
+
+        batch(() => {
+          obj.firstName = 'Sync';
+          obj.lastName = 'Last';
+        });
+        assert.strictEqual(obj.tag, '[Banned]');
+        assert.deepEqual([i1, i2, i3], [1, 1, 0]);
+
+        batch(() => {
+          obj.firstName = '';
+        });
+        assert.deepEqual([i1, i2, i3], [1, 1, 1]);
+      });
+
+      it('handles many layers of nested dependencies glitches', function () {
+        // in this test, fullName depends on firstName, but is not directly a dependency of tag
+        // in other word, `fullName` is an indirect dependency of `tag`
+        // though it also depends on firstName, so this test is to ensure that regardless of the position of the dependency in the chain,
+        // it should still be able to get the notification
+        //
+        let i1 = 0;
+        let i2 = 0;
+        let i3 = 0;
+
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          get tag() {
+            if (!this.firstName && !this.lastName) {
+              i1++;
+              return '(Anonymous)';
+            }
+            if (this.trimmed.includes('Sync')) {
+              i2++;
+              return '[Banned]';
+            }
+            i3++;
+            return `[Badge] ${this.trimmed}`;
+          }
+
+          get fullName() {
+            return `${this.firstName} ${this.lastName}`;
+          }
+
+          get trimmed() {
+            return this.trimmed1;
+          }
+          get trimmed1() {
+            return this.trimmed2.slice(0, 10);
+          }
+          get trimmed2() {
+            return this.trimmed3.slice(0, 10);
+          }
+          get trimmed3() {
+            return this.fullName.slice(0, 10);
+          }
+        }
+
+        const obj = new NameTag();
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({ handleChange: () => { /* only to trigger observation */ } });
+        assert.deepEqual([i1, i2, i3], [1, 0, 0]);
+
+        batch(() => {
+          obj.firstName = 'Sync';
+          obj.lastName = 'Last';
+        });
+        assert.strictEqual(obj.tag, '[Banned]');
+        assert.deepEqual([i1, i2, i3], [1, 1, 0]);
+
+        batch(() => {
+          obj.firstName = '';
+        });
+        assert.deepEqual([i1, i2, i3], [1, 1, 1]);
+      });
+
+      it('handles @observable decorator glitches', function () {
+        let i1 = 0;
+        let i2 = 0;
+        let i3 = 0;
+
+        class NameTag {
+          @observable firstName = '';
+          @observable lastName = '';
+
+          get tag() {
+            if (!this.firstName && !this.lastName) {
+              i1++;
+              return '(Anonymous)';
+            }
+            if (this.fullName.includes('Sync')) {
+              i2++;
+              return '[Banned]';
+            }
+            i3++;
+            return `[Badge] ${this.fullName}`;
+          }
+
+          get fullName() {
+            return `${this.firstName} ${this.lastName}`;
+          }
+        }
+
+        const obj = new NameTag();
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({ handleChange: () => { /* only to trigger observation */ } });
+        assert.deepEqual([i1, i2, i3], [1, 0, 0]);
+
+        batch(() => {
+          obj.firstName = 'Sync';
+          obj.lastName = 'Last';
+        });
+        assert.strictEqual(obj.tag, '[Banned]');
+        assert.deepEqual([i1, i2, i3], [1, 1, 0]);
+
+        batch(() => {
+          obj.firstName = '';
+        });
+        assert.deepEqual([i1, i2, i3], [1, 1, 1]);
+      });
+
+      it('handles array index related glitches', function () {
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          constructor(readonly tags: string[] = []) {
+          }
+
+          get tag() {
+            return this.tags[0] === 'a' ? `[Badge] ${this.tags.join(',')}` : '[a]';
+          }
+        }
+
+        const tags: string[] = [];
+        const changeSnapshots: unknown[][] = [];
+        locator.getArrayObserver(tags).subscribe({
+          handleCollectionChange(collection: []) {
+            changeSnapshots.push([collection.length, obj.tag]);
+          }
+        });
+        const obj = new NameTag(tags);
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({
+          handleChange: () => {
+            // only for triggering observation
+          }
+        });
+
+        batch(() => {
+          tags.push('a');
+        });
+        assert.deepEqual(changeSnapshots, [
+          [1, '[Badge] a']
+        ]);
+      });
+
+      it('handles array length related glitches', function () {
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          constructor(readonly tags: string[] = []) {
+          }
+
+          get tag() {
+            return this.tags.length > 0 ? `[Badge] ${this.tags.join(',')}` : '[a]';
+          }
+        }
+
+        const tags: string[] = [];
+        const changeSnapshots: unknown[][] = [];
+        locator.getArrayObserver(tags).subscribe({
+          handleCollectionChange(collection: []) {
+            changeSnapshots.push([collection.length, obj.tag]);
+          }
+        });
+        const obj = new NameTag(tags);
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({
+          handleChange: () => {
+            // only for triggering observation
+          }
+        });
+
+        tags.push('a');
+        assert.deepEqual(changeSnapshots, [
+          [1, '[Badge] a']
+        ]);
+      });
+
+      it('handles map size related glitches', function () {
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          constructor(readonly tags: Map<string, string>) {
+          }
+
+          get tag() {
+            return this.tags.size > 0 ? `[Badge] ${[...this.tags.values()].join(',')}` : '[a]';
+          }
+        }
+
+        const tags = new Map<string, string>();
+        const changeSnapshots: unknown[][] = [];
+        locator.getMapObserver(tags).subscribe({
+          handleCollectionChange(collection: Map<string, string>) {
+            changeSnapshots.push([collection.size, obj.tag]);
+          }
+        });
+        const obj = new NameTag(tags);
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({
+          handleChange: () => {
+            // only for triggering observation
+          }
+        });
+
+        tags.set('a', 'b');
+        assert.deepEqual(changeSnapshots, [
+          [1, '[Badge] b']
+        ]);
+      });
+
+      it('handles set size related glitches', function () {
+        class NameTag {
+          firstName = '';
+          lastName = '';
+
+          constructor(readonly tags: Set<string>) {
+          }
+
+          get tag() {
+            return this.tags.size > 0 ? `[Badge] ${[...this.tags.values()].join(',')}` : '[a]';
+          }
+        }
+
+        const tags = new Set<string>();
+        const changeSnapshots: unknown[][] = [];
+        locator.getSetObserver(tags).subscribe({
+          handleCollectionChange(collection: Set<string>) {
+            changeSnapshots.push([collection.size, obj.tag]);
+          }
+        });
+        const obj = new NameTag(tags);
+        const tagObserver = locator.getObserver(obj, 'tag');
+        tagObserver.subscribe({
+          handleChange: () => {
+            // only for triggering observation
+          }
+        });
+
+        tags.add('a');
+        assert.deepEqual(changeSnapshots, [
+          [1, '[Badge] a']
+        ]);
+      });
+    });
   });
 
   describe('app based', function () {

--- a/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/observation-glitches.spec.ts
@@ -1,6 +1,6 @@
 import { DI, IPlatform, Registration } from '@aurelia/kernel';
 import { BrowserPlatform } from '@aurelia/platform-browser';
-import { DirtyChecker, IObserverLocator } from '@aurelia/runtime';
+import { DirtyChecker, IObserverLocator, observable } from '@aurelia/runtime';
 import { assert } from '@aurelia/testing';
 
 describe('3-runtime-html/observation-glitches.spec.ts', function () {
@@ -54,10 +54,10 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       assert.deepEqual([i1, i2, i3], [1, 2, 0]);
 
       obj.firstName = '';
-      assert.throws(() => assert.deepEqual([i1, i2, i3], [1, 2, 1]));
+      assert.deepEqual([i1, i2, i3], [1, 2, 1]);
     });
 
-    it('handle nested dependencies glitches', function () {
+    it('handles nested dependencies glitches', function () {
       // in this test, fullName depends on firstName, but is not directly a dependency of tag
       // in other word, `fullName` is an indirect dependency of `tag`
       // though it also depends on firstName, so this test is to ensure that regardless of the position of the dependency in the chain,
@@ -104,10 +104,10 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       assert.deepEqual([i1, i2, i3], [1, 2, 0]);
 
       obj.firstName = '';
-      assert.throws(() => assert.deepEqual([i1, i2, i3], [1, 2, 1]));
+      assert.deepEqual([i1, i2, i3], [1, 2, 1]);
     });
 
-    it('handle many layers of nested dependencies glitches', function () {
+    it('handles many layers of nested dependencies glitches', function () {
       // in this test, fullName depends on firstName, but is not directly a dependency of tag
       // in other word, `fullName` is an indirect dependency of `tag`
       // though it also depends on firstName, so this test is to ensure that regardless of the position of the dependency in the chain,
@@ -163,7 +163,144 @@ describe('3-runtime-html/observation-glitches.spec.ts', function () {
       assert.deepEqual([i1, i2, i3], [1, 2, 0]);
 
       obj.firstName = '';
-      assert.throws(() => assert.deepEqual([i1, i2, i3], [1, 2, 1]));
+      assert.deepEqual([i1, i2, i3], [1, 2, 1]);
+    });
+
+    it('handles @observable decorator glitches', function () {
+      let i1 = 0;
+      let i2 = 0;
+      let i3 = 0;
+
+      class NameTag {
+        @observable firstName = '';
+        @observable lastName = '';
+
+        get tag() {
+          if (!this.firstName && !this.lastName) {
+            i1++;
+            return '(Anonymous)';
+          }
+          if (this.fullName.includes('Sync')) {
+            i2++;
+            return '[Banned]';
+          }
+          i3++;
+          return `[Badge] ${this.fullName}`;
+        }
+
+        get fullName() {
+          return `${this.firstName} ${this.lastName}`;
+        }
+      }
+
+      const obj = new NameTag();
+      const tagObserver = locator.getObserver(obj, 'tag');
+      tagObserver.subscribe({ handleChange: () => { /* only to trigger observation */ } });
+      assert.deepEqual([i1, i2, i3], [1, 0, 0]);
+
+      obj.firstName = 'Sync';
+      obj.lastName = 'Last';
+      assert.strictEqual(obj.tag, '[Banned]');
+      assert.deepEqual([i1, i2, i3], [1, 2, 0]);
+
+      obj.firstName = '';
+      assert.deepEqual([i1, i2, i3], [1, 2, 1]);
+    });
+
+    it('handles array length related glitches', function () {
+      class NameTag {
+        firstName = '';
+        lastName = '';
+
+        constructor(readonly tags: string[] = []) {
+        }
+
+        get tag() {
+          return this.tags.length > 0 ? `[Badge] ${this.tags.join(',')}` : '[a]';
+        }
+      }
+
+      const tags: string[] = [];
+      const changeSnapshots: unknown[][] = [];
+      locator.getArrayObserver(tags).subscribe({
+        handleCollectionChange(collection: []) {
+          changeSnapshots.push([collection.length, obj.tag]);
+        }
+      });
+      const obj = new NameTag(tags);
+      const tagObserver = locator.getObserver(obj, 'tag');
+      tagObserver.subscribe({ handleChange: () => {
+        // only for triggering observation
+      } });
+
+      tags.push('a');
+      assert.deepEqual(changeSnapshots, [
+        [1, '[Badge] a']
+      ]);
+    });
+
+    it('handles map size related glitches', function () {
+      class NameTag {
+        firstName = '';
+        lastName = '';
+
+        constructor(readonly tags: Map<string, string>) {
+        }
+
+        get tag() {
+          return this.tags.size > 0 ? `[Badge] ${[...this.tags.values()].join(',')}` : '[a]';
+        }
+      }
+
+      const tags = new Map<string, string>();
+      const changeSnapshots: unknown[][] = [];
+      locator.getMapObserver(tags).subscribe({
+        handleCollectionChange(collection: Map<string, string>) {
+          changeSnapshots.push([collection.size, obj.tag]);
+        }
+      });
+      const obj = new NameTag(tags);
+      const tagObserver = locator.getObserver(obj, 'tag');
+      tagObserver.subscribe({ handleChange: () => {
+        // only for triggering observation
+      } });
+
+      tags.set('a', 'b');
+      assert.deepEqual(changeSnapshots, [
+        [1, '[Badge] b']
+      ]);
+    });
+
+    it('handles set size related glitches', function () {
+      class NameTag {
+        firstName = '';
+        lastName = '';
+
+        constructor(readonly tags: Set<string>) {
+        }
+
+        get tag() {
+          return this.tags.size > 0 ? `[Badge] ${[...this.tags.values()].join(',')}` : '[a]';
+        }
+      }
+
+      const tags = new Set<string>();
+      const changeSnapshots: unknown[][] = [];
+      locator.getSetObserver(tags).subscribe({
+        handleCollectionChange(collection: Set<string>) {
+          changeSnapshots.push([collection.size, obj.tag]);
+        }
+      });
+      const obj = new NameTag(tags);
+      const tagObserver = locator.getObserver(obj, 'tag');
+      tagObserver.subscribe({ handleChange: () => {
+        // only for triggering observation
+      } });
+
+      tags.add('a');
+      assert.deepEqual(changeSnapshots, [
+        [1, '[Badge] a']
+      ]);
     });
 
     // eslint-disable-next-line mocha/no-skipped-tests

--- a/packages/aurelia/src/index.ts
+++ b/packages/aurelia/src/index.ts
@@ -670,4 +670,7 @@ export {
 
   Scope,
   ISignaler,
+
+  IWindow,
+  IHistory,
 } from '@aurelia/runtime-html';

--- a/packages/runtime/src/array-observer.ts
+++ b/packages/runtime/src/array-observer.ts
@@ -490,6 +490,12 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
       arrayObserver.notify();
     }
 
+    public handleDirty() {
+      if (this.value !== this.getValue()) {
+        this.subs.notifyDirty();
+      }
+    }
+
     /**
      * From interface `ICollectionSubscriber`
      */
@@ -501,7 +507,6 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
       }
       const prevValue = this.value;
       const currValue = this.value = this.getValue();
-      // hmm
       if (prevValue !== currValue) {
         this.subs.notify(currValue, prevValue);
       }

--- a/packages/runtime/src/array-observer.ts
+++ b/packages/runtime/src/array-observer.ts
@@ -426,6 +426,8 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
 
     public notify(): void {
       const subs = this.subs;
+      subs.notifyDirty();
+
       const indexMap = this.indexMap;
       if (batching) {
         addCollectionBatch(subs, this.collection, indexMap);
@@ -436,8 +438,7 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
       const length = arr.length;
 
       this.indexMap = createIndexMap(length);
-      this.subs.notifyDirty();
-      this.subs.notifyCollection(arr, indexMap);
+      subs.notifyCollection(arr, indexMap);
     }
 
     public getLengthObserver(): CollectionLengthObserver {

--- a/packages/runtime/src/array-observer.ts
+++ b/packages/runtime/src/array-observer.ts
@@ -436,6 +436,7 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
       const length = arr.length;
 
       this.indexMap = createIndexMap(length);
+      this.subs.notifyDirty();
       this.subs.notifyCollection(arr, indexMap);
     }
 

--- a/packages/runtime/src/collection-length-observer.ts
+++ b/packages/runtime/src/collection-length-observer.ts
@@ -57,10 +57,17 @@ export class CollectionLengthObserver implements IObserver, ICollectionSubscribe
     }
   }
 
+  public handleDirty() {
+    if (this._value !== this._obj.length) {
+      this.subs.notifyDirty();
+    }
+  }
+
   public handleCollectionChange(_arr: unknown[], _: IndexMap) {
     const oldValue = this._value;
     const value = this._obj.length;
     if ((this._value = value) !== oldValue) {
+      this.subs.notifyDirty();
       this.subs.notify(this._value, oldValue);
     }
   }
@@ -93,6 +100,12 @@ export class CollectionSizeObserver implements ICollectionSubscriber {
 
   public setValue(): void {
     throw createMappedError(ErrorNames.assign_readonly_size);
+  }
+
+  public handleDirty() {
+    if (this._value !== this._obj.size) {
+      this.subs.notifyDirty();
+    }
   }
 
   public handleCollectionChange(_collection: Collection,  _: IndexMap): void {

--- a/packages/runtime/src/computed-observer.ts
+++ b/packages/runtime/src/computed-observer.ts
@@ -140,6 +140,13 @@ export class ComputedObserver<T extends object> implements
     return true;
   }
 
+  public handleDirty(): void {
+    if (!this._isDirty) {
+      this._isDirty = true;
+      this.subs.notifyDirty();
+    }
+  }
+
   public handleChange(): void {
     this._isDirty = true;
     if (this.subs.count > 0) {

--- a/packages/runtime/src/interfaces.ts
+++ b/packages/runtime/src/interfaces.ts
@@ -23,7 +23,12 @@ export interface IConnectable {
  * Interface of a subscriber or property change handler
  */
 export interface ISubscriber<TValue = unknown> {
+  handleDirty?(): void;
   handleChange(newValue: TValue, previousValue: TValue): void;
+}
+
+export interface IDirtySubscriber {
+  handleDirty(): void;
 }
 
 /**
@@ -53,6 +58,7 @@ export interface ISubscriberRecord<T extends ISubscriber | ICollectionSubscriber
   remove(subscriber: T): boolean;
   notify(value: unknown, oldValue: unknown): void;
   notifyCollection(collection: Collection, indexMap: IndexMap): void;
+  notifyDirty(): void;
 }
 
 /**

--- a/packages/runtime/src/interfaces.ts
+++ b/packages/runtime/src/interfaces.ts
@@ -19,16 +19,15 @@ export interface IConnectable {
   subscribeTo(subscribable: ISubscribable | ICollectionSubscribable): void;
 }
 
+export interface IDirtySubscriber {
+  handleDirty(): void;
+}
+
 /**
  * Interface of a subscriber or property change handler
  */
-export interface ISubscriber<TValue = unknown> {
-  handleDirty?(): void;
+export interface ISubscriber<TValue = unknown> extends Partial<IDirtySubscriber> {
   handleChange(newValue: TValue, previousValue: TValue): void;
-}
-
-export interface IDirtySubscriber {
-  handleDirty(): void;
 }
 
 /**

--- a/packages/runtime/src/map-observer.ts
+++ b/packages/runtime/src/map-observer.ts
@@ -141,6 +141,8 @@ export const getMapObserver = /*@__PURE__*/ (() => {
 
     public notify(): void {
       const subs = this.subs;
+      subs.notifyDirty();
+
       const indexMap = this.indexMap;
       if (batching) {
         addCollectionBatch(subs, this.collection, indexMap);
@@ -151,7 +153,6 @@ export const getMapObserver = /*@__PURE__*/ (() => {
       const size = map.size;
 
       this.indexMap = createIndexMap(size);
-      subs.notifyDirty();
       subs.notifyCollection(map, indexMap);
     }
 

--- a/packages/runtime/src/map-observer.ts
+++ b/packages/runtime/src/map-observer.ts
@@ -151,6 +151,7 @@ export const getMapObserver = /*@__PURE__*/ (() => {
       const size = map.size;
 
       this.indexMap = createIndexMap(size);
+      subs.notifyDirty();
       subs.notifyCollection(map, indexMap);
     }
 

--- a/packages/runtime/src/observable.ts
+++ b/packages/runtime/src/observable.ts
@@ -201,6 +201,7 @@ export const observable = /*@__PURE__*/(() => {
         // we only want to notify subscribers with the latest values
         value = this._oldValue;
         this._oldValue = this._value;
+        this.subs.notifyDirty();
         this.subs.notify(this._value, value);
       }
     }

--- a/packages/runtime/src/set-observer.ts
+++ b/packages/runtime/src/set-observer.ts
@@ -101,14 +101,6 @@ export const getSetObserver = /*@__PURE__*/ (() => {
     }
   }
 
-  // function disableSetObservation(): void {
-  //   for (const method of methods) {
-  //     if (proto[method].observing === true) {
-  //       rtDef(proto, method, { ...descriptorProps, value: native[method] });
-  //     }
-  //   }
-  // }
-
   interface SetObserverImpl extends SetObserver {}
   class SetObserverImpl {
     public type: AccessorType = atObserver;
@@ -132,6 +124,7 @@ export const getSetObserver = /*@__PURE__*/ (() => {
       const size = set.size;
 
       this.indexMap = createIndexMap(size);
+      this.subs.notifyDirty();
       this.subs.notifyCollection(set, indexMap);
     }
 

--- a/packages/runtime/src/set-observer.ts
+++ b/packages/runtime/src/set-observer.ts
@@ -114,6 +114,8 @@ export const getSetObserver = /*@__PURE__*/ (() => {
 
     public notify(): void {
       const subs = this.subs;
+      subs.notifyDirty();
+
       const indexMap = this.indexMap;
       if (batching) {
         addCollectionBatch(subs, this.collection, indexMap);
@@ -124,8 +126,7 @@ export const getSetObserver = /*@__PURE__*/ (() => {
       const size = set.size;
 
       this.indexMap = createIndexMap(size);
-      this.subs.notifyDirty();
-      this.subs.notifyCollection(set, indexMap);
+      subs.notifyCollection(set, indexMap);
     }
 
     public getLengthObserver(): CollectionSizeObserver {

--- a/packages/runtime/src/setter-observer.ts
+++ b/packages/runtime/src/setter-observer.ts
@@ -61,6 +61,7 @@ export class SetterObserver implements IObserver, ISubscriberCollection {
       oV = this._value;
       this._value = newValue;
       this._callback?.(newValue, oV);
+      this.subs.notifyDirty();
       this.subs.notify(newValue, oV);
     } else {
       // If subscribe() has been called, the target property descriptor is replaced by these getter/setter methods,

--- a/packages/runtime/src/subscriber-collection.ts
+++ b/packages/runtime/src/subscriber-collection.ts
@@ -116,7 +116,7 @@ export const subscriberCollection = /*@__PURE__*/(() => {
     }
 
     public notifyDirty() {
-      if (!this._hasDirtySubs) {
+      if (this._hasDirtySubs) {
         for (const dirtySub of this._requestDirtySubs.slice(0)) {
           dirtySub.handleDirty();
         }

--- a/packages/runtime/src/subscriber-collection.ts
+++ b/packages/runtime/src/subscriber-collection.ts
@@ -85,13 +85,10 @@ export const subscriberCollection = /*@__PURE__*/(() => {
        * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
        * however this is accounted for via $isBound and similar flags on the subscriber objects)
        */
-      const _subs = this._subs.slice(0) as ISubscriber[];
-      const len = _subs.length;
-      let i = 0;
-      for (; i < len; ++i) {
-        _subs[i].handleChange(val, oldVal);
+      let sub: ISubscriber;
+      for (sub of this._subs.slice(0) as ISubscriber[]) {
+        sub.handleChange(val, oldVal);
       }
-      return;
     }
 
     public notifyCollection(collection: Collection, indexMap: IndexMap): void {

--- a/packages/runtime/src/subscriber-collection.ts
+++ b/packages/runtime/src/subscriber-collection.ts
@@ -3,6 +3,7 @@ import { rtDef, rtDefineHiddenProp, ensureProto } from './utilities';
 import type {
   Collection,
   ICollectionSubscriber,
+  IDirtySubscriber,
   IndexMap,
   ISubscriber,
   ISubscriberCollection,
@@ -53,20 +54,29 @@ export const subscriberCollection = /*@__PURE__*/(() => {
     public count: number = 0;
     /** @internal */
     private readonly _subs: T[] = [];
+    /** @internal */
+    private readonly _requestDirtySubs: IDirtySubscriber[] = [];
 
     public add(subscriber: T): boolean {
       if (this._subs.includes(subscriber)) {
         return false;
       }
       this._subs[this._subs.length] = subscriber;
+      if ('handleDirty' in subscriber) {
+        this._requestDirtySubs[this._requestDirtySubs.length] = subscriber as IDirtySubscriber;
+      }
       ++this.count;
       return true;
     }
 
     public remove(subscriber: T): boolean {
-      const idx = this._subs.indexOf(subscriber);
+      let idx = this._subs.indexOf(subscriber);
       if (idx !== -1) {
         this._subs.splice(idx, 1);
+        idx = this._requestDirtySubs.indexOf(subscriber as IDirtySubscriber);
+        if (idx !== -1) {
+          this._requestDirtySubs.splice(idx, 1);
+        }
         --this.count;
         return true;
       }
@@ -78,6 +88,7 @@ export const subscriberCollection = /*@__PURE__*/(() => {
         addValueBatch(this, val, oldVal);
         return;
       }
+
       /**
        * Note: change handlers may have the side-effect of adding/removing subscribers to this collection during this
        * callSubscribers invocation, so we're caching them all before invoking any.
@@ -85,7 +96,7 @@ export const subscriberCollection = /*@__PURE__*/(() => {
        * Subscribers removed during this invocation will still be invoked (and they also shouldn't be,
        * however this is accounted for via $isBound and similar flags on the subscriber objects)
        */
-      let sub: ISubscriber;
+      let sub: ISubscriber | IDirtySubscriber;
       for (sub of this._subs.slice(0) as ISubscriber[]) {
         sub.handleChange(val, oldVal);
       }
@@ -99,6 +110,13 @@ export const subscriberCollection = /*@__PURE__*/(() => {
         _subs[i].handleCollectionChange(collection, indexMap);
       }
       return;
+    }
+
+    public notifyDirty() {
+      let sub: IDirtySubscriber;
+      for (sub of this._requestDirtySubs.slice(0)) {
+        sub.handleDirty();
+      }
     }
   }
 


### PR DESCRIPTION
## 📖 Description

Currently, as described in #1957 , our binding system needs a way to ensure observer value caching doesn't result in impossible state - or glitch. This is handled through a pre-change notification - or dirty notification, before the actual change notification.

### 🎫 Issues

Resolves partially #1957 

cc @Sayan751 @fkleuver 