### PR TITLE
fix(state): ensure all actions queued are called

### DIFF
--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -208,7 +208,10 @@ module.exports =
                 jsCache = {};
                 htmlCache = {};
                 cssCache = {};
-                console.log("\u001b[2J\u001b[0;0H");
+                setCursor();
+                breakLine();
+                clearScreen();
+                console.clear();
                 console.log(`Watch run: ${runId}. ${new Date().toJSON()}`);
               };
             }]
@@ -468,3 +471,18 @@ const mimetypes = {
   js: "text/javascript",
   css: "text/css"
 };
+
+function clearScreen() {
+  'use strict';
+  try {
+    process.stdout.write('\x1Bc');
+  } catch {}
+}
+
+function breakLine() {
+  console.log('\x1b[2J');
+}
+
+function setCursor() {
+  console.log("\u001b[2J\u001b[0;0H");
+}

--- a/packages/__tests__/src/state/state.spec.ts
+++ b/packages/__tests__/src/state/state.spec.ts
@@ -481,7 +481,7 @@ describe('state/state.spec.ts', function () {
       trigger('input', 'input');
       trigger('button', 'click');
 
-      await resolveAfter(1);
+      await resolveAfter(10);
       assert.deepEqual(logs, [
         { text: '11', click: 0 },
         { text: '11', click: 1 },

--- a/packages/__tests__/src/state/state.spec.ts
+++ b/packages/__tests__/src/state/state.spec.ts
@@ -110,17 +110,6 @@ describe('state/state.spec.ts', function () {
     assert.strictEqual(getBy('input').value, '123');
   });
 
-  it('makes state immutable', async function () {
-    const state = { text: '123' };
-    const { trigger } = await createFixture
-      .html('<input value.state="text" input.trigger="$state.text = `456`">')
-      .deps(StateDefaultConfiguration.init(state))
-      .build().started;
-
-    trigger('input', 'input');
-    assert.strictEqual(state.text, '123');
-  });
-
   it('works with promise', async function () {
     const state = { data: () => resolveAfter(1, 'value-1-2') };
     const { getBy } = await createFixture
@@ -355,6 +344,150 @@ describe('state/state.spec.ts', function () {
       assert.strictEqual(actionCallCount, 2);
       flush();
       assert.strictEqual(getBy('input').value, '1111');
+    });
+
+    it('notifies changes only once for single synchronous dispatch', async function () {
+      let started = 0;
+      const logs = [];
+      const state = { text: '1', click: 0 };
+      const { trigger } = await createFixture
+        .html`
+          <input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value }">
+          <button click.dispatch="{ type: 'click' }">Change</button>
+        `
+        .deps(StateDefaultConfiguration.init(
+          state,
+          (s, { type, v }: { type: string; v: string }) => {
+            if (type === 'event') {
+              return { ...s, text: s.text + v };
+            }
+            if (type === 'click') {
+              return { ...s, click: s.click + 1 };
+            }
+            return s;
+          }
+        ))
+        .component(class {
+          @fromState<typeof state>(state => {
+            if (started > 0) {
+              logs.push({ ...state });
+            }
+            return state.text;
+          })
+          text: string;
+        })
+        .build().started;
+      started = 1;
+
+      trigger('input', 'input');
+      trigger('button', 'click');
+
+      assert.deepEqual(logs, [
+        { text: '11', click: 0 },
+        { text: '11', click: 1 }
+      ]);
+    });
+
+    it('notifies changes only once for single asynchronous dispatch', async function () {
+      let started = 0;
+      const logs = [];
+      const state = { text: '1', click: 0 };
+      const { trigger } = await createFixture
+        .html`
+          <input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value }">
+        `
+        .deps(StateDefaultConfiguration.init(
+          state,
+          (s, { type, v }: { type: string; v: string }) => {
+            return Promise.resolve().then(() => {
+              if (type === 'event') {
+                return { ...s, text: s.text + v };
+              }
+              if (type === 'click') {
+                return { ...s, click: s.click + 1 };
+              }
+              return s;
+            });
+          }
+        ))
+        .component(class {
+          @fromState<typeof state>(state => {
+            if (started > 0) {
+              logs.push({ ...state });
+            }
+            return state.text;
+          })
+          text: string;
+        })
+        .build().started;
+      started = 1;
+
+      trigger('input', 'input');
+      await resolveAfter(10);
+
+      assert.deepEqual(logs, [
+        { text: '11', click: 0 },
+      ]);
+    });
+
+    it('notifies change for every dispatch', async function () {
+      let started = 0;
+      const logs = [];
+      const state = { text: '1', click: 0 };
+      const { trigger } = await createFixture
+        .html`
+          <input value.state="text" input.dispatch="{ type: 'event', v: $event.target.value }">
+          <button click.dispatch="{ type: 'click' }">Change</button>
+        `
+        .deps(StateDefaultConfiguration.init(
+          state,
+          (s, { type, v }: { type: string; v: string }) => {
+            return Promise.resolve().then(() => {
+              if (type === 'event') {
+                return { ...s, text: s.text + v };
+              }
+              if (type === 'click') {
+                return { ...s, click: s.click + 1 };
+              }
+              return s;
+            });
+          }
+        ))
+        .component(class {
+          @fromState<typeof state>(state => {
+            if (started > 0) {
+              logs.push({ ...state });
+            }
+            return state.text;
+          })
+          text: string;
+        })
+        .build().started;
+      started = 1;
+
+      trigger('input', 'input');
+      trigger('button', 'click');
+
+      assert.deepEqual(logs, []);
+
+      await resolveAfter(10);
+      assert.deepEqual(logs, [
+        { text: '11', click: 0 },
+        { text: '11', click: 1 }
+      ]);
+
+      // ensure no stragglers
+      await resolveAfter(10);
+      trigger('input', 'input');
+      trigger('button', 'click');
+
+      await resolveAfter(1);
+      assert.deepEqual(logs, [
+        { text: '11', click: 0 },
+        { text: '11', click: 1 },
+        { text: '111', click: 1 },
+        { text: '111', click: 2 },
+      ]);
     });
   });
 

--- a/packages/dialog/src/dialog-interfaces.ts
+++ b/packages/dialog/src/dialog-interfaces.ts
@@ -100,8 +100,8 @@ export interface DialogOpenPromise extends Promise<DialogOpenResult> {
    * Add a callback that will be invoked when a dialog has been closed
    */
   whenClosed<TResult1, TResult2>(
-    onfulfilled?: (value: DialogCloseResult) => TResult1 | PromiseLike<TResult1>,
-    onrejected?: (reason: unknown) => TResult2 | PromiseLike<TResult2>
+    onfulfilled?: (value: DialogCloseResult) => TResult1 | Promise<TResult1>,
+    onrejected?: (reason: unknown) => TResult2 | Promise<TResult2>
   ): Promise<TResult1 | TResult2>;
 }
 /* tslint:enable:max-line-length */
@@ -281,7 +281,7 @@ export interface IDialogComponentCanActivate<T> {
    * To cancel the opening of the dialog return false or a promise that resolves to false.
    * Any other returned value is coerced to true.
    */
-  canActivate(model?: T): boolean | Promise<boolean> | PromiseLike<boolean>;
+  canActivate(model?: T): boolean | Promise<boolean>;
 }
 
 /**
@@ -291,7 +291,7 @@ export interface IDialogComponentActivate<T> {
   /**
    * Implement this hook if you want to perform custom logic just before the dialog is open.
    */
-  activate(model?: T): void | Promise<void> | PromiseLike<void>;
+  activate(model?: T): void | Promise<void>;
 }
 
 /**
@@ -303,7 +303,7 @@ export interface IDialogComponentCanDeactivate {
    * To cancel the closing of the dialog return false or a promise that resolves to false.
    * Any other returned value is coerced to true.
    */
-  canDeactivate(result: DialogCloseResult): boolean | Promise<boolean> | PromiseLike<boolean>;
+  canDeactivate(result: DialogCloseResult): boolean | Promise<boolean>;
 }
 
 /**
@@ -313,7 +313,7 @@ export interface IDialogComponentDeactivate {
   /**
    * Implement this hook if you want to perform custom logic when the dialog is being closed.
    */
-  deactivate(result: DialogCloseResult): void | Promise<void> | PromiseLike<void>;
+  deactivate(result: DialogCloseResult): void | Promise<void>;
 }
 
 // #endregion

--- a/packages/dialog/src/dialog-service.ts
+++ b/packages/dialog/src/dialog-service.ts
@@ -121,7 +121,7 @@ export class DialogService implements IDialogService {
         })
       )
       .then(unclosedControllers =>
-        unclosedControllers.filter(unclosed => !!unclosed) as IDialogController[]
+        unclosedControllers.filter(unclosed => !!unclosed)
       );
   }
 
@@ -182,8 +182,8 @@ class DialogSettings<T extends object = object> implements IDialogSettings<T> {
 
 function whenClosed<TResult1 = unknown, TResult2 = unknown>(
   this: Promise<DialogOpenResult>,
-  onfulfilled?: (r: DialogCloseResult) => TResult1 | PromiseLike<TResult1>,
-  onrejected?: (err: unknown) => TResult2 | PromiseLike<TResult2>
+  onfulfilled?: (r: DialogCloseResult) => TResult1 | Promise<TResult1>,
+  onrejected?: (err: unknown) => TResult2 | Promise<TResult2>
 ): Promise<TResult1 | TResult2> {
   return this.then(openResult => openResult.dialog.closed.then(onfulfilled, onrejected), onrejected);
 }

--- a/packages/state/src/interfaces.ts
+++ b/packages/state/src/interfaces.ts
@@ -1,9 +1,9 @@
-import { type MaybePromise, type IRegistry, type IDisposable } from '@aurelia/kernel';
+import { type IRegistry, type IDisposable } from '@aurelia/kernel';
 import { IDevToolsOptions } from './interfaces-devtools';
 import { createInterface } from './state-utilities';
 
 export const IActionHandler = /*@__PURE__*/createInterface<IActionHandler>('IActionHandler');
-export type IActionHandler<T = any> = (state: T, action: unknown) => MaybePromise<T>;
+export type IActionHandler<T = any> = (state: T, action: unknown) => T | Promise<T>;
 
 export const IStore = /*@__PURE__*/createInterface<IStore<object>>('IStore');
 export interface IStore<T extends object, TAction = unknown> {

--- a/packages/state/src/state-binding-behavior.ts
+++ b/packages/state/src/state-binding-behavior.ts
@@ -50,7 +50,7 @@ class StateSubscriber implements IStoreSubscriber<object> {
   public handleStateChange(state: object): void {
     const scope = this._wrappedScope;
     const overrideContext = scope.overrideContext as Writable<IOverrideContext>;
-    scope.bindingContext = overrideContext.bindingContext = overrideContext.$state = state;
+    scope.bindingContext = overrideContext.bindingContext = state;
     (this._binding as unknown as ISubscriber).handleChange?.(undefined, undefined);
   }
 }

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -181,7 +181,7 @@ export class StateBinding implements IBinding, ISubscriber, IStoreSubscriber<obj
     const state = this._store.getState();
     const _scope = this._scope!;
     const overrideContext = _scope.overrideContext as Writable<IOverrideContext>;
-    _scope.bindingContext = overrideContext.bindingContext = overrideContext.$state = state;
+    _scope.bindingContext = overrideContext.bindingContext = state;
     const value = astEvaluate(
       this.ast,
       _scope,

--- a/packages/state/src/state-getter-binding.ts
+++ b/packages/state/src/state-getter-binding.ts
@@ -97,7 +97,7 @@ export class StateGetterBinding implements IBinding, IStoreSubscriber<object> {
   public handleStateChange(state: object): void {
     const _scope = this._scope!;
     const overrideContext = _scope.overrideContext as Writable<IOverrideContext>;
-    _scope.bindingContext = overrideContext.bindingContext = overrideContext.$state = state;
+    _scope.bindingContext = overrideContext.bindingContext = state;
     const value = this.$get(this._store.getState());
 
     if (value === this._value) {

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -88,8 +88,6 @@ export const StateBindingInstructionRenderer = /*@__PURE__*/ renderer(class Stat
     observerLocator: IObserverLocator,
   ): void {
     const ast = ensureExpression(exprParser, instruction.from, 'IsFunction');
-    // todo: insert `$state` access scope into the expression when it does not start with `$this`/`$parent`/`$state`/`$host`
-    //    example: <input value.state="value"> means <input value.bind="$state.value">
 
     renderingCtrl.addBinding(new StateBinding(
       renderingCtrl,

--- a/packages/state/src/store.ts
+++ b/packages/state/src/store.ts
@@ -1,4 +1,4 @@
-import { all, IContainer, ILogger, lazy, MaybePromise, optional, Registration, resolve } from '@aurelia/kernel';
+import { all, IContainer, ILogger, isPromise, lazy, onResolve, optional, Registration, resolve } from '@aurelia/kernel';
 import { IActionHandler, IState, IStore, IStoreSubscriber } from './interfaces';
 import { IDevToolsExtension, IDevToolsOptions, IDevToolsPayload } from './interfaces-devtools';
 
@@ -15,7 +15,7 @@ export class Store<T extends object, TAction = unknown> implements IStore<T> {
   /** @internal */ private readonly _subs = new Set<IStoreSubscriber<T>>();
   /** @internal */ private readonly _logger: ILogger;
   /** @internal */ private readonly _handlers: readonly IActionHandler<T>[];
-  /** @internal */ private _dispatching = 0;
+  /** @internal */ private _dispatching = false;
   /** @internal */ private readonly _dispatchQueues: TAction[] = [];
   /** @internal */ private readonly _getDevTools: () => IDevToolsExtension;
 
@@ -61,48 +61,39 @@ export class Store<T extends object, TAction = unknown> implements IStore<T> {
   }
 
   public dispatch(action: TAction): void | Promise<void> {
-    if (this._dispatching > 0) {
+    if (this._dispatching) {
       this._dispatchQueues.push(action);
       return;
     }
 
-    this._dispatching++;
+    this._dispatching = true;
 
-    let $$action: TAction;
-    const reduce = ($state: T | Promise<T>, $action: unknown) =>
-      this._handlers.reduce(($state, handler) => {
-        if ($state instanceof Promise) {
-          return $state.then($ => handler($, $action));
-        }
-        return handler($state, $action) as T | Promise<T>;
-      }, $state);
-
-    const afterDispatch = ($state: MaybePromise<T>): void | Promise<void> => {
-      if (this._dispatchQueues.length > 0) {
-        $$action = this._dispatchQueues.shift()!;
-        const newState = reduce($state, $$action);
-        if (newState instanceof Promise) {
-          return newState.then($ => afterDispatch($));
+    const afterDispatch = ($state: T | Promise<T>): void | Promise<void> => {
+      return onResolve($state, s => {
+        const $$action = this._dispatchQueues.shift()!;
+        if ($$action != null) {
+          return onResolve(callStateHandlers<T>(this._handlers, s, $$action), state => {
+            this._setState(state);
+            return afterDispatch(state);
+          });
         } else {
-          return afterDispatch(newState);
+          this._dispatching = false;
         }
-      }
+      });
     };
-    const newState = reduce(this._state, action);
+    const newState = callStateHandlers<T>(this._handlers, this._state, action);
 
-    if (newState instanceof Promise) {
+    if (isPromise(newState)) {
       return newState.then($state => {
         this._setState($state);
-        this._dispatching--;
 
         return afterDispatch(this._state);
       }, ex => {
-        this._dispatching--;
+        this._dispatching = false;
         throw ex;
       });
     } else {
       this._setState(newState);
-      this._dispatching--;
 
       return afterDispatch(this._state);
     }
@@ -167,6 +158,14 @@ export class Store<T extends object, TAction = unknown> implements IStore<T> {
     });
   }
 }
+
+const callStateHandlers = <T>(handlers: readonly IActionHandler<T>[], $state: T | Promise<T>, $action: unknown): T | Promise<T> => {
+  for (const handler of handlers) {
+    $state = onResolve($state, $state => handler($state, $action));
+  }
+  return onResolve($state, s => s);
+};
+
 class State { }
 
 class StateProxyHandler<T extends object> implements ProxyHandler<T> {
@@ -177,7 +176,7 @@ class StateProxyHandler<T extends object> implements ProxyHandler<T> {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public set(target: T, prop: string | symbol, value: unknown, receiver: unknown): boolean {
-    this._logger.warn(`Setting State is immutable. Dispatch an action to create a new state`);
+    this._logger.warn(`State is immutable. Dispatch an action to create a new state`);
     return true;
   }
 }

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -1,4 +1,4 @@
-import { Constructable, EventAggregator, IContainer, ILogger, MaybePromise } from '@aurelia/kernel';
+import { Constructable, EventAggregator, IContainer, ILogger } from '@aurelia/kernel';
 import { Metadata } from '@aurelia/metadata';
 import { IObserverLocator } from '@aurelia/runtime';
 import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig } from '@aurelia/runtime-html';
@@ -287,7 +287,7 @@ export function createFixture<T extends object>(
   };
 
   const stop = (dispose: boolean = false): void | Promise<void> => {
-    let ret: MaybePromise<void> = void 0;
+    let ret: void | Promise<void> = void 0;
     try {
       ret = au.stop(dispose);
     } finally {


### PR DESCRIPTION
## 📖 Description

Fix a bug in the state plugin where it wouldn't call the last action if there's more than 1 action queued, and an action handler returns a promise that resolves after the 2nd action being dispatched.

### 🎫 Issues

Resolves #1871 

Thanks @gtroxler @Siddharth1605