### PR TITLE
refactor(parser): no longer provide default to exp parser interface

### DIFF
--- a/packages/__tests__/src/2-runtime/global-context.spec.ts
+++ b/packages/__tests__/src/2-runtime/global-context.spec.ts
@@ -1,4 +1,4 @@
-import { AccessGlobalExpression, IExpressionParser } from '@aurelia/expression-parser';
+import { AccessGlobalExpression, ExpressionParser } from '@aurelia/expression-parser';
 import { BindingBehavior, ValueConverter } from '@aurelia/runtime-html';
 import { assert, createFixture, TestContext } from '@aurelia/testing';
 
@@ -34,7 +34,7 @@ const globalNames = [
 const getParser = () => {
   const ctx = TestContext.create();
   const container = ctx.container;
-  const parser = container.get(IExpressionParser);
+  const parser = container.get(ExpressionParser);
   return parser;
 };
 

--- a/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeater.unit.spec.ts
@@ -1,4 +1,4 @@
-import { AccessScopeExpression, ForOfStatement, BindingIdentifier, IExpressionParser } from '@aurelia/expression-parser';
+import { AccessScopeExpression, ForOfStatement, BindingIdentifier, ExpressionParser } from '@aurelia/expression-parser';
 import { DirtyChecker } from '@aurelia/runtime';
 import {
   Scope,
@@ -509,6 +509,7 @@ describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
     NodeObserverLocator,
     PropertyBindingRenderer,
     TextBindingRenderer,
+    ExpressionParser,
     Registration.instance(ITemplateCompiler, { compile: (d) => d }),
   );
 
@@ -558,11 +559,12 @@ describe(`3-runtime-html/repeater.unit.spec.ts`, function () {
           props: [{ props: [] }]
         } as any;
         const child = container.createChild();
-        child.register(Registration.instance(IInstruction, instruction));
-        child.register(Registration.instance(IExpressionParser, null));
-        child.register(Registration.instance(IRenderLocation, loc));
-        child.register(Registration.instance(IController, hydratable));
-        child.register(Registration.instance(IViewFactory, itemFactory));
+        child.register(
+          Registration.instance(IInstruction, instruction),
+          Registration.instance(IRenderLocation, loc),
+          Registration.instance(IController, hydratable),
+          Registration.instance(IViewFactory, itemFactory),
+        );
         const sut = child.invoke(Repeat);
         (sut as Writable<Repeat>).$controller = Controller.$attr(container, sut, (void 0)!);
         binding.target = sut as any;

--- a/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.au-slot.spec.ts
@@ -1,4 +1,4 @@
-import { IExpressionParser } from '@aurelia/expression-parser';
+import { ExpressionParser, IExpressionParser } from '@aurelia/expression-parser';
 import {
   BindingMode,
   AuSlot,
@@ -28,7 +28,7 @@ describe('3-runtime-html/template-compiler.au-slot.spec.ts', function () {
   const anything = {} as any;
   function createFixture() {
     const ctx = TestContext.create();
-    const container = ctx.container;
+    const container = ctx.container.register(ExpressionParser);
     const sut = ctx.templateCompiler;
     return { ctx, container, sut };
   }

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -9,6 +9,7 @@ import {
   AccessScopeExpression,
   PrimitiveLiteralExpression,
   IExpressionParser,
+  ExpressionParser,
 } from '@aurelia/expression-parser';
 import {
   bindable,
@@ -1776,7 +1777,7 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
     const ctx = TestContext.create();
     const container = ctx.container;
     const sut = ctx.templateCompiler;
-    container.register(...extraResources);
+    container.register(ExpressionParser, ...extraResources);
     const markup = typeof markupOrOptions === 'string' || 'nodeType' in markupOrOptions
         ? markupOrOptions
         : markupOrOptions.template;

--- a/packages/__tests__/src/i18n/t/translation-parameters-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-parameters-renderer.spec.ts
@@ -1,6 +1,6 @@
 import { I18nConfiguration, TranslationBinding, TranslationParametersAttributePattern, TranslationParametersBindingCommand, TranslationParametersBindingInstruction, TranslationParametersBindingRenderer, TranslationParametersInstructionType } from '@aurelia/i18n';
 import { DI, Registration } from '@aurelia/kernel';
-import { IExpressionParser } from '@aurelia/expression-parser';
+import { ExpressionParser, IExpressionParser } from '@aurelia/expression-parser';
 import {
   IObserverLocator,
 } from '@aurelia/runtime';
@@ -50,6 +50,7 @@ describe('i18n/t/translation-parameters-renderer.spec.ts', function () {
     function createFixture() {
       const container = DI.createContainer();
       container.register(
+        ExpressionParser,
         TranslationParametersBindingCommand,
         Registration.singleton(IAttrMapper, AttrMapper)
       );
@@ -83,7 +84,7 @@ describe('i18n/t/translation-parameters-renderer.spec.ts', function () {
 
     function createFixture() {
       const { container } = TestContext.create();
-      container.register(I18nConfiguration);
+      container.register(ExpressionParser, I18nConfiguration);
       return container;
     }
 

--- a/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-renderer.spec.ts
@@ -11,7 +11,7 @@ import {
   TranslationInstructionType,
 } from '@aurelia/i18n';
 import { Registration } from '@aurelia/kernel';
-import { IExpressionParser } from '@aurelia/expression-parser';
+import { ExpressionParser, IExpressionParser } from '@aurelia/expression-parser';
 import {
   IObserverLocator,
 } from '@aurelia/runtime';
@@ -139,6 +139,7 @@ describe('i18n/t/translation-renderer.spec.ts', function () {
       aliases = aliases || [];
       aliases = aliases.map(alias => `${alias}.bind`);
       const container = createContainer().register(
+        ExpressionParser,
         BindingCommand.define({ name: 't.bind', aliases }, TranslationBindBindingCommand),
         Registration.singleton(IAttrMapper, AttrMapper),
       );

--- a/packages/__tests__/src/validation/expression-serialization.spec.ts
+++ b/packages/__tests__/src/validation/expression-serialization.spec.ts
@@ -1,6 +1,4 @@
-/* eslint-disable mocha/no-sibling-hooks */
 import {
-  IExpressionParser,
   type ExpressionType,
   Interpolation,
   PrimitiveLiteralExpression,
@@ -23,14 +21,15 @@ import {
   TaggedTemplateExpression,
   AssignExpression,
   AccessBoundaryExpression,
+  ExpressionParser,
 } from '@aurelia/expression-parser';
 import { TestContext, assert } from '@aurelia/testing';
 import { Deserializer, Serializer } from '@aurelia/validation';
 
 describe('validation/expression-serialization.spec.ts', function () {
-  function setup() {
+  function createParser() {
     const ctx = TestContext.create();
-    return ctx.container.get(IExpressionParser);
+    return ctx.container.get(ExpressionParser);
   }
   const list: { name: string; strExpr: string; expressionType: ExpressionType; exprType: any }[] = [
     { name: 'interpolation', strExpr: '${prop} static', expressionType: 'Interpolation', exprType: Interpolation },
@@ -91,7 +90,7 @@ describe('validation/expression-serialization.spec.ts', function () {
 
   for (const { strExpr, expressionType, exprType, name } of list) {
     it(`works for ${name} expression`, function () {
-      const parser = setup();
+      const parser = createParser();
       const expr = parser.parse(strExpr, expressionType);
       assert.instanceOf(expr, exprType);
       const serialized = Serializer.serialize(expr);
@@ -104,7 +103,7 @@ describe('validation/expression-serialization.spec.ts', function () {
 
   it(`works for for of with binding identifier expression`, function () {
     const exprType = TaggedTemplateExpression;
-    const parser = setup();
+    const parser = createParser();
     const expr: TaggedTemplateExpression = parser.parse('a`static${prop}`', 'None') as TaggedTemplateExpression;
     assert.instanceOf(expr, exprType);
     const serialized = Serializer.serialize(expr);

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -12,6 +12,7 @@ import {
   Interpolation,
   PrimitiveLiteralExpression,
   IExpressionParser,
+  ExpressionParser,
 } from '@aurelia/expression-parser';
 import {
   Scope,
@@ -844,7 +845,7 @@ describe('validation/rule-provider.spec.ts', function () {
 
     function setup() {
       const container = TestContext.create().container;
-      container.register(ValidationConfiguration);
+      container.register(ExpressionParser, ValidationConfiguration);
       return {
         parser: container.get(IExpressionParser),
         container,

--- a/packages/__tests__/src/validation/rule-provider.spec.ts
+++ b/packages/__tests__/src/validation/rule-provider.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-constant-condition, mocha/no-sibling-hooks */
+/* eslint-disable no-constant-condition */
 import { Metadata } from '@aurelia/metadata';
 import {
   DI,
@@ -43,20 +43,20 @@ import { Person } from './_test-resources.js';
 describe('validation/rule-provider.spec.ts', function () {
   describe('ValidationRules', function () {
 
-    function setup() {
+    function $createFixture() {
       const container = DI.createContainer();
-      container.register(ValidationConfiguration);
+      container.register(ExpressionParser, ValidationConfiguration);
       return { sut: container.get(IValidationRules), container };
     }
 
     it('is transient', function () {
-      const { sut: instance1, container } = setup();
+      const { sut: instance1, container } = $createFixture();
       const instance2 = container.get(IValidationRules);
       assert.notEqual(instance1, instance2);
     });
 
     it('can be used to define validation rules fluently on string properties', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const propName = 'name';
       const rules = sut
         .ensure(propName)
@@ -107,7 +107,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to define validation rules fluently on number properties', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const propName = 'age';
       const rules = sut
         .ensure(propName)
@@ -152,7 +152,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to define validation rules fluently on collection properties', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const propName = 'arrayProp';
       const rules = sut
         .ensure(propName)
@@ -184,7 +184,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to define validation rules fluently using lambda', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const propName = 'fooBar';
       let executed = false;
       const rules = sut
@@ -210,7 +210,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to define custom validation rules fluently', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const propName = 'fooBar';
       let executed = false;
       class CustomRule extends BaseValidationRule {
@@ -243,7 +243,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to define validation rules on different properties', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const rules = sut
 
         .ensure('name')
@@ -268,7 +268,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('consolidates the rule based on property name', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const rules = sut
 
         .ensure('name')
@@ -295,7 +295,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define metadata annotation for rules on an object', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!);
       const rules = sut
         .on(obj)
@@ -314,7 +314,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define metadata annotation for rules on a class', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const rules = sut
         .on(Person)
 
@@ -341,7 +341,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define rules on properties of an object using lambda expression', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const rules = sut
         .on(obj)
@@ -371,7 +371,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define rules on properties of a class using lambda expression', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
 
       const rules = sut
         .on(Person)
@@ -404,7 +404,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define rules on multiple objects', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj1: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const obj2: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       sut
@@ -448,7 +448,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('calling .off on an object without rules does not cause error', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       assert.equal(validationRulesRegistrar.get(obj), void 0);
       sut.off(obj);
@@ -456,7 +456,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can define multiple ruleset for the same object using tagging', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag1 = 'tag1', tag2 = 'tag2';
       sut
@@ -482,7 +482,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to delete the rules defined for an object', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       sut
         .on(obj)
@@ -499,7 +499,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to delete specific ruleset', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag1 = 'tag1', tag2 = 'tag2';
 
@@ -535,7 +535,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to delete all ruleset by default for a given object', function () {
-      const { sut } = setup();
+      const { sut } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag1 = 'tag1', tag2 = 'tag2';
 
@@ -563,7 +563,7 @@ describe('validation/rule-provider.spec.ts', function () {
         this.log.push(event);
       }
     }
-    function setup(customMessages?: ICustomMessage[]) {
+    function $createFixture(customMessages?: ICustomMessage[]) {
       const container = TestContext.create().container;
       const eventLog = new EventLog();
 
@@ -593,14 +593,14 @@ describe('validation/rule-provider.spec.ts', function () {
     ];
     for (const { message, expectedType } of messages1) {
       it(`#parseMessage parses message correctly - ${message}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
         assert.instanceOf(sut.parseMessage(message), expectedType);
       });
     }
     const specialPropertyNames = ['displayName', 'propertyName', 'value', 'object', 'config', 'getDisplayName'];
     for (const property of specialPropertyNames) {
       it(`#parseMessage logs warning if the message contains contextual property expression w/o preceeding '$' - ${property}`, function () {
-        const { sut, eventLog } = setup();
+        const { sut, eventLog } = $createFixture();
 
         const message = `\${${property}} foo bar`;
         sut.parseMessage(message);
@@ -620,7 +620,7 @@ describe('validation/rule-provider.spec.ts', function () {
     const invalidMessages = ['${$parent} foo bar', '${$parent.prop} foo bar'];
     for (const message of invalidMessages) {
       it(`#parseMessage throws error if the message contains '$parent' - ${message}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
 
         assert.throws(
           () => {
@@ -699,7 +699,7 @@ describe('validation/rule-provider.spec.ts', function () {
     for (let i = 0, ii = rules.length; i < ii; i++) {
       const { title, getRule } = rules[i];
       it(`rule.message returns the registered message for a rule instance - ${title}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
         const message = 'FooBar';
         const $rule = getRule();
         sut.setMessage($rule, message);
@@ -709,7 +709,7 @@ describe('validation/rule-provider.spec.ts', function () {
       });
 
       it(`rule.message returns the registered default message for a rule type when no message for the instance is registered - ${title}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
         const $rule = getRule();
         const scope = Scope.create({ $displayName: 'FooBar', $rule });
         const actual = astEvaluate(sut.getMessage($rule), scope, null, null);
@@ -717,7 +717,7 @@ describe('validation/rule-provider.spec.ts', function () {
       });
 
       it(`rule.message returns the default message if the registered key is not found - ${title}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
         const $rule = getRule();
         $rule.messageKey = 'foobar';
         const scope = Scope.create({ $displayName: 'FooBar', $rule });
@@ -772,7 +772,7 @@ describe('validation/rule-provider.spec.ts', function () {
           ],
         },
       ];
-      const { sut, originalMessages } = setup(customMessages);
+      const { sut, originalMessages } = $createFixture(customMessages);
       for (const { getRule } of rules) {
         const $rule = getRule();
         const scope = Scope.create({ $displayName: 'FooBar', $rule });
@@ -800,7 +800,7 @@ describe('validation/rule-provider.spec.ts', function () {
           ],
         }
       ];
-      const { sut, originalMessages } = setup(customMessages);
+      const { sut, originalMessages } = $createFixture(customMessages);
 
       const $rule1 = new RequiredRule();
       $rule1.messageKey = 'required';
@@ -835,7 +835,7 @@ describe('validation/rule-provider.spec.ts', function () {
     ];
     for (const { arg1, arg2, expected } of displayNames) {
       it(`#getDisplayName computes display name - (${arg1}, ${arg2?.toString() ?? Object.prototype.toString.call(arg2)}) => ${expected}`, function () {
-        const { sut } = setup();
+        const { sut } = $createFixture();
         assert.equal(sut.getDisplayName(arg1, arg2), expected);
       });
     }
@@ -843,7 +843,7 @@ describe('validation/rule-provider.spec.ts', function () {
 
   describe('parsePropertyName', function () {
 
-    function setup() {
+    function $createFixture() {
       const container = TestContext.create().container;
       container.register(ExpressionParser, ValidationConfiguration);
       return {
@@ -985,7 +985,7 @@ describe('validation/rule-provider.spec.ts', function () {
     ];
     for(const { property, expected } of positiveDataRows) {
       it(`parses ${property.toString()} to ${expected}`, function () {
-        const { parser } = setup();
+        const { parser } = $createFixture();
         assert.deepStrictEqual(parsePropertyName(property, parser), [expected, parser.parse(`${rootObjectSymbol}.${expected}`, 'None')]);
       });
     }
@@ -1002,7 +1002,7 @@ describe('validation/rule-provider.spec.ts', function () {
     ];
     for(const { property } of negativeDataRows) {
       it(`throws error when parsing ${property.toString()}`, function () {
-        const { parser } = setup();
+        const { parser } = $createFixture();
         assert.throws(
           () => {
             parsePropertyName(property as any, parser);
@@ -1014,14 +1014,14 @@ describe('validation/rule-provider.spec.ts', function () {
 
   describe('PropertyRule', function () {
 
-    function setup() {
+    function $createFixture() {
       const container = TestContext.create().container;
-      container.register(ValidationConfiguration);
+      container.register(ExpressionParser, ValidationConfiguration);
       return { validationRules: container.get(IValidationRules), container };
     }
 
     it('can validate async rules', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj1: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const rules = validationRules
         .on(obj1)
@@ -1048,7 +1048,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('respects a function for displayName', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       let i = 0;
       const rules = validationRules
@@ -1073,7 +1073,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('respects execution condition', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const rule = validationRules
         .on(obj)
@@ -1094,7 +1094,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('respects rule chaining', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person('test', (void 0)!, (void 0)!);
       const rule = validationRules
         .on(obj)
@@ -1119,7 +1119,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('can be used to tag the rules', function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag = 'foo';
       const rules = validationRules
@@ -1137,7 +1137,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('validates all rules by default despite some of those are tagged', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag = 'foo';
       const msg = 'not foobar';
@@ -1159,7 +1159,7 @@ describe('validation/rule-provider.spec.ts', function () {
     });
 
     it('validates only the tagged rules when provided', async function () {
-      const { validationRules } = setup();
+      const { validationRules } = $createFixture();
       const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
       const tag = 'foo';
       const msg = 'not foobar';
@@ -1185,7 +1185,7 @@ describe('validation/rule-provider.spec.ts', function () {
       it('stateful message - sync state function', async function () {
         type Error = 'none' | 'fooError' | 'barError';
 
-        const { validationRules } = setup();
+        const { validationRules } = $createFixture();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
         let state: Error = 'none';
         const rule = validationRules
@@ -1212,7 +1212,7 @@ describe('validation/rule-provider.spec.ts', function () {
       it('stateful message - async state function', async function () {
         type Error = 'none' | 'fooError' | 'barError';
 
-        const { validationRules } = setup();
+        const { validationRules } = $createFixture();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
         let state: Error = 'none';
         const rule = validationRules
@@ -1239,7 +1239,7 @@ describe('validation/rule-provider.spec.ts', function () {
       it('stateful message - interpolated message', async function () {
         type Error = 'none' | 'fooError' | 'barError';
 
-        const { validationRules } = setup();
+        const { validationRules } = $createFixture();
         const obj: Person = new Person('awesome possum', (void 0)!, (void 0)!);
         let state: Error = 'none';
         const rule = validationRules
@@ -1272,7 +1272,7 @@ describe('validation/rule-provider.spec.ts', function () {
       it('overridden message', async function () {
         type Error = 'none' | 'fooError' | 'barError';
 
-        const { validationRules } = setup();
+        const { validationRules } = $createFixture();
         const obj: Person = new Person((void 0)!, (void 0)!, (void 0)!);
         let state: Error = 'none';
         const rule = validationRules

--- a/packages/__tests__/src/validation/serialization.spec.ts
+++ b/packages/__tests__/src/validation/serialization.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable mocha/no-sibling-hooks */
-import { IExpressionParser } from '@aurelia/expression-parser';
+import { ExpressionParser, IExpressionParser } from '@aurelia/expression-parser';
 import { assert, TestContext } from '@aurelia/testing';
 import {
   EqualsRule,
@@ -29,7 +29,10 @@ describe('validation/serialization.spec.ts', function () {
   describe('validation de/serialization', function () {
     function setup() {
       const container = TestContext.create().container;
-      container.register(ValidationConfiguration.customize((options) => { options.HydratorType = ValidationDeserializer; }));
+      container.register(
+        ExpressionParser,
+        ValidationConfiguration.customize((options) => { options.HydratorType = ValidationDeserializer; })
+      );
       return {
         container,
         parser: container.get(IExpressionParser),
@@ -284,7 +287,7 @@ describe('validation/serialization.spec.ts', function () {
   describe('ModelValidationExpressionHydrator', function () {
     function setup() {
       const container = TestContext.create().container;
-      container.register(ValidationConfiguration);
+      container.register(ExpressionParser, ValidationConfiguration);
       return {
         container,
         expressionHydrator: container.get(IValidationExpressionHydrator),

--- a/packages/__tests__/src/validation/validator.spec.ts
+++ b/packages/__tests__/src/validation/validator.spec.ts
@@ -19,12 +19,14 @@ import {
 } from '@aurelia/validation';
 import { assert } from '@aurelia/testing';
 import { Person, Address, Organization } from './_test-resources.js';
+import { ExpressionParser } from '@aurelia/expression-parser';
 
 describe('validation/validator.spec.ts', function () {
   describe('IValidator', function () {
-    function setup(validator?: Class<IValidator>) {
+    function $createFixture(validator?: Class<IValidator>) {
       const container = DI.createContainer();
       container.register(
+        ExpressionParser,
         validator
           ? ValidationConfiguration.customize((options) => {
             options.ValidatorType = validator;
@@ -34,7 +36,7 @@ describe('validation/validator.spec.ts', function () {
     }
 
     it('registered to Singleton StandardValidator by default', function () {
-      const { sut: sut1, container } = setup();
+      const { sut: sut1, container } = $createFixture();
       const sut2 = container.get(IValidator);
 
       assert.instanceOf(sut1, StandardValidator);
@@ -48,7 +50,7 @@ describe('validation/validator.spec.ts', function () {
           throw new Error('Method not implemented.');
         }
       }
-      const { sut: sut1, container } = setup(CustomValidator);
+      const { sut: sut1, container } = $createFixture(CustomValidator);
       const sut2 = container.get(IValidator);
 
       assert.instanceOf(sut1, CustomValidator);
@@ -60,7 +62,7 @@ describe('validation/validator.spec.ts', function () {
   describe('StandardValidator', function () {
     function setup() {
       const container = DI.createContainer();
-      container.register(ValidationConfiguration);
+      container.register(ExpressionParser, ValidationConfiguration);
       return {
         sut: container.get(IValidator),
         validationRules: container.get(IValidationRules),

--- a/packages/expression-parser/src/expression-parser.ts
+++ b/packages/expression-parser/src/expression-parser.ts
@@ -55,7 +55,7 @@ import {
 } from './ast';
 import { createLookup } from './utilities';
 import { ErrorNames, createMappedError } from './errors';
-import { DI } from '@aurelia/kernel';
+import { createImplementationRegister, DI } from '@aurelia/kernel';
 
 export interface IExpressionParser<TCustom extends CustomExpression = CustomExpression> {
   parse(expression: string, expressionType: 'IsIterator'): ForOfStatement;
@@ -63,12 +63,14 @@ export interface IExpressionParser<TCustom extends CustomExpression = CustomExpr
   parse(expression: string, expressionType: Exclude<ExpressionType, 'IsIterator' | 'Interpolation'>): IsBindingBehavior;
   parse(expression: string, expressionType: ExpressionType): AnyBindingExpression<TCustom>;
 }
-export const IExpressionParser = /*@__PURE__*/DI.createInterface<IExpressionParser>('IExpressionParser', x => x.singleton(ExpressionParser));
+export const IExpressionParser = /*@__PURE__*/DI.createInterface<IExpressionParser>('IExpressionParser');
 
 /**
  * A default implementation of the IExpressionParser interface
  */
 export class ExpressionParser<TCustom extends CustomExpression = CustomExpression> implements IExpressionParser<TCustom> {
+  public static readonly register = createImplementationRegister(IExpressionParser);
+
   /** @internal */ private readonly _expressionLookup: Record<string, IsBindingBehavior> = createLookup();
   /** @internal */ private readonly _forOfLookup: Record<string, ForOfStatement> = createLookup();
   /** @internal */ private readonly _interpolationLookup: Record<string, Interpolation> = createLookup();

--- a/packages/runtime-html/src/configuration.ts
+++ b/packages/runtime-html/src/configuration.ts
@@ -1,4 +1,5 @@
 import { IContainer, noop } from '@aurelia/kernel';
+import { ExpressionParser } from '@aurelia/expression-parser';
 import { DirtyChecker, ICoercionConfiguration } from '@aurelia/runtime';
 import {
   AtPrefixedTriggerAttributePattern,
@@ -239,6 +240,7 @@ function createConfiguration(optionsProvider: ConfigurationOptionsProvider) {
        */
       return container.register(
         instanceRegistration(ICoercionConfiguration, runtimeConfigurationOptions.coercingOptions),
+        ExpressionParser,
         ...DefaultComponents,
         ...DefaultResources,
         ...DefaultBindingSyntax,


### PR DESCRIPTION
## 📖 Description

One possible optimization of build time template compilation is that template expression can be precompiled into AST. The fully benefit from the potential tree shaking that comes with this optimisation, the parser interface shouldn't be tied to the parser implementation. This PR removes that connection.

This shouldn't affect any application that uses standard `StandardConfiguration`, but if for some reason a minimal setup was used, then the container of that setup needs to register `ExpressionParser` from `@aurelia/expression-parser` to make `container.get(IExpressionParser)` work.

cc @fkleuver @Sayan751 