### PR TITLE
fix(radio): handle repeated start/stop correctly

### DIFF
--- a/packages/__tests__/src/3-runtime-html/input.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/input.spec.ts
@@ -217,4 +217,29 @@ describe('3-runtime-html/input.spec.ts', function () {
     assertAttr('input', 'popovertarget', 'a');
     assertAttr('input', 'popovertargetaction', 'auto');
   });
+
+  describe('gh issues', function () {
+    it('selects radio when radios are rendered inside an [if]', async function () {
+      const { assertChecked, trigger, flush } = createFixture(
+        `
+        <let show.bind="true" option.bind="'s'"></let>
+        <input if.bind="show"  id="blue"  type="radio" name="r1" checked.bind="option" value="s" />
+        <input if.bind="!show" id="green" type="radio" name="r1" checked.bind="option" value="s" />
+        <button click.trigger="show = !show">toggle</button>
+        `
+      );
+
+      trigger('button', 'click');
+      flush();
+      assertChecked('#green', true);
+
+      trigger('button', 'click');
+      flush();
+      assertChecked('#blue', true);
+
+      trigger('button', 'click');
+      flush();
+      assertChecked('#green', true);
+    });
+  });
 });

--- a/packages/runtime-html/src/observation/checked-observer.ts
+++ b/packages/runtime-html/src/observation/checked-observer.ts
@@ -275,6 +275,7 @@ export class CheckedObserver implements INodeObserver {
    * @internal
    */
   public _stop(): void {
+    this._value = this._oldValue = void 0;
     this._collectionObserver?.unsubscribe(this);
     this._valueObserver?.unsubscribe(this);
     this._collectionObserver = this._valueObserver = void 0;
@@ -285,6 +286,7 @@ export class CheckedObserver implements INodeObserver {
     oV = this._oldValue;
     this._oldValue = this._value;
     this.subs.notify(this._value, oV);
+    oV = void 0;
   }
 
   /** @internal */

--- a/packages/runtime-html/src/resources/template-controllers/if.ts
+++ b/packages/runtime-html/src/resources/template-controllers/if.ts
@@ -62,6 +62,7 @@ export class If implements ICustomAttributeViewModel {
     if (newValue !== oldValue) return this._swap(newValue);
   }
 
+  /** @internal */
   private _swap(value: unknown): void | Promise<void> {
     const currView = this.view;
     const ctrl = this.$controller;

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -236,6 +236,13 @@ export function createFixture<T extends object>(
     const el = strictQueryBy(selector, `to compare value against "${value}"`);
     assert.strictEqual((el as any).value, value);
   }
+  function assertChecked(selector: string, value: boolean) {
+    const el = strictQueryBy(selector, `to compare value against "${value}"`);
+    if (!('checked' in el)) {
+      throw new Error('Element does not have a checked property');
+    }
+    assert.strictEqual((el as any).checked, value, `Expected element (${selector}) to  have :checked state as ${value}, but received ${!value}`);
+  }
 
   function trigger(selector: string, event: string, init?: CustomEventInit, overrides?: Record<string, unknown>): void {
     const el = strictQueryBy(selector, `to fire event "${event}"`);
@@ -366,6 +373,7 @@ export function createFixture<T extends object>(
     public assertAttrNS = assertAttrNS;
     public assertStyles = assertStyles;
     public assertValue = assertValue;
+    public assertChecked = assertChecked;
     public createEvent = (name: string, init?: CustomEventInit) => new platform.CustomEvent(name, init);
     public trigger = trigger as ITrigger;
     public type = type;
@@ -498,6 +506,13 @@ export interface IFixture<T> {
    * Will throw if there' more than one elements with matching selector
    */
   assertValue(selector: string, value: unknown): void;
+  /**
+   * Assert whether an element matching the given selector has the :checked state.
+   *
+   * Will throw if there's no checked property on the element
+   * Will throw if there' more than one elements with matching selector
+   */
+  assertChecked(selector: string, value: boolean): void;
   /**
    * Create a custom event by the given name and init for the current platform
    */


### PR DESCRIPTION
## 📖 Description

Currently, as per described in #2030, when a radio is repeated started/stopped i.e in an if template, its subsequence activation may have invalid `:checked` state. This is due to the fact that upon stopped, the observer of the radio does not cleanup its internal cache value causing the next activation to be a noop. This PR fixes this.

### 🎫 Issues

Close #2030