### PR TITLE
feat(bindable): support aggregate callback

### DIFF
--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -99,6 +99,43 @@ export class NameComponent {
 }
 ```
 
+If you have multiple bindable properties like `firstName`/`lastName` in the above example, and want to use a single callback to react to those changes,
+you can use `propertyChanged` callback. `propertyChanged` callback will be called immediately after the targeted change callback.
+The parameters of this callback will be `key`/`newValue`/`oldValue`, similar like the following example:
+
+```ts
+export class NameComponent {
+    @bindable firstName = '';
+    @bindable lastName  = '';
+
+    propertyChanged(key, newVal, oldVal) {
+      if (key === 'firstName') {
+
+      } else if (key === 'lastName') {
+
+      }
+    }
+```
+
+In the above example, even though `propertyChanged` can be used for multiple properties (like `firstName` and `lastName`), it's only called individually for each of those properties.
+If you wish to act on a group of changes, like both `firstName` and `lastName` at once in the above example, `propertiesChanged` callback can used instead, like the following example:
+```ts
+propertiesChanged({ firstName, lastName }) {
+  if (firstName && lastName) {
+    // both firstName and lastName were changed at the same time
+    // apply first update strategy
+    const { newValue: newFirstName, oldValue: oldFirstName } = firstName;
+    const { newValue: newLastName, oldValue: oldLastName } = lastName;
+  } else if (firstName) {
+    // only firstName was changed - apply second update strategy
+    // ...
+  } else {
+    // only lastName was changed - apply third update strategy
+    // ...
+  }
+}
+```
+
 ## Configuring bindable properties
 
 Like almost everything in Aurelia, you can configure how bindable properties work.&#x20;

--- a/docs/user-docs/components/bindable-properties.md
+++ b/docs/user-docs/components/bindable-properties.md
@@ -136,6 +136,35 @@ propertiesChanged({ firstName, lastName }) {
 }
 ```
 
+For the order of callback when there' multiple callbacks involved, refer the following example:
+If we have a component class that looks like this:
+```ts
+class MyComponent {
+  @bindable prop = 0
+  
+  propChanged() { console.log('prop changed'); }
+
+  propertyChanged(name) { console.log(`property "${name}" changed`) }
+
+  propertiesChanged(changes) {
+    console.log('changes are:', changes)
+  }
+}
+```
+When we do
+```ts
+myComponent.prop = 1;
+console.log('after assign');
+```
+the console logs will look like the following:
+
+```
+propChanged
+property "prop" changed
+after assign
+changes are, { prop: { newValue: 1, oldValue: 0 } }
+```
+
 ## Configuring bindable properties
 
 Like almost everything in Aurelia, you can configure how bindable properties work.&#x20;

--- a/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
@@ -1,5 +1,8 @@
 import { DI, IContainer, Registration, resolve } from '@aurelia/kernel';
 import {
+  observable,
+} from '@aurelia/runtime';
+import {
   CustomAttribute,
   IAurelia,
   ICustomAttributeViewModel,
@@ -1221,6 +1224,309 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
       } catch (e) {
         assert.match(e.message, /714/, 'incorrect error code');
       }
+    });
+  });
+
+  describe('aggregated callback', function () {
+    it('calls aggregated callback', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+    });
+
+    it('calls aggregated callback only once for 2 changes', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop = 2;
+      component.prop = 3;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 3, oldValue: 2 } });
+    });
+
+    it('does not call aggregated callback again after first call if there is no new changes', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+
+      changes = void 0;
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, void 0);
+    });
+
+    it('calls aggregated callback again after first call if there are new changes during callback', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+            if (this.prop === 2) {
+              this.prop = 3;
+            }
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+
+      changes = void 0;
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 3, oldValue: 2 } });
+    });
+
+    it('does not call aggregated callback after unbind', async function () {
+      let changes = void 0;
+      const { component, stop } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      component.prop = 2;
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+
+      changes = void 0;
+      await stop(true);
+      component.prop = 3;
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, void 0);
+    });
+
+    it('does not call aggregated callback for @observable', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @observable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.strictEqual(changes, void 0);
+    });
+
+    it('calls both change handler and aggregated callback', async function () {
+      let changes = void 0;
+      let propChangedCallCount = 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propChanged() {
+            propChangedCallCount++;
+          }
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      assert.strictEqual(propChangedCallCount, 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      assert.strictEqual(propChangedCallCount, 1);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+    });
+
+    it('calls change handler, propertyChanged and aggregated callback', async function () {
+      let changes = void 0;
+      let propChangedCallCount = 0;
+      let propertyChangedCallCount = 0;
+      const { component } = createFixture(
+        `<div foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propChanged() {
+            propChangedCallCount++;
+          }
+
+          propertyChanged() {
+            propertyChangedCallCount++;
+          }
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      assert.strictEqual(propChangedCallCount, 0);
+      assert.strictEqual(propertyChangedCallCount, 0);
+      component.prop = 2;
+      assert.strictEqual(changes, void 0);
+      assert.strictEqual(propChangedCallCount, 1);
+      assert.strictEqual(propertyChangedCallCount, 1);
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, { prop: { newValue: 2, oldValue: 1 } });
+      assert.strictEqual(propChangedCallCount, 1);
+      assert.strictEqual(propertyChangedCallCount, 1);
+    });
+
+    it('aggregates changes for multiple properties', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo="prop1.bind: prop1; prop2.bind: prop2"></div>`,
+        class App {
+          prop1 = 1;
+          prop2 = 2;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop1 = 0;
+
+          @bindable
+          prop2 = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop1 = 2;
+      component.prop2 = 3;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(
+        changes,
+        {
+          prop1: { newValue: 2, oldValue: 1 },
+          prop2: { newValue: 3, oldValue: 2 }
+        }
+      );
+    });
+
+    it('calls aggregated callback for multiple properties with the right key', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div foo="prop1.bind: prop1; 5.bind: prop2"></div>`,
+        class App {
+          prop1 = 1;
+          prop2 = 2;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop1 = 0;
+
+          @bindable
+          5 = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      assert.strictEqual(changes, void 0);
+      component.prop1 = 2;
+      component.prop2 = 3;
+      assert.strictEqual(changes, void 0);
+      await Promise.resolve();
+      assert.deepStrictEqual(
+        changes,
+        {
+          prop1: { newValue: 2, oldValue: 1 },
+          5: { newValue: 3, oldValue: 2 }
+        }
+      );
     });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-attributes.spec.ts
@@ -1364,6 +1364,30 @@ describe('3-runtime-html/custom-attributes.spec.ts', function () {
       assert.deepStrictEqual(changes, void 0);
     });
 
+    it('does not call aggregated callback if the component is unbound before next tick', async function () {
+      let changes = void 0;
+      const { component } = createFixture(
+        `<div if.bind="show" foo.bind="prop"></div>`,
+        class App {
+          prop = 1;
+          show = true;
+        },
+        [@customAttribute('foo') class {
+          @bindable
+          prop = 0;
+
+          propertiesChanged($changes) {
+            changes = $changes;
+          }
+        }]
+      );
+
+      component.prop = 2;
+      component.show = false;
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, void 0);
+    });
+
     it('does not call aggregated callback for @observable', async function () {
       let changes = void 0;
       const { component } = createFixture(

--- a/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
@@ -825,6 +825,26 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
       assert.deepStrictEqual(changes, { a: { newValue: 3, oldValue: 2 } });
     });
 
+    it('does not call aggregated callback if component is unbound before next tick', async function () {
+      let changes = void 0;
+      const { component, stop } = createFixture(``, class App {
+        @bindable
+        a = 1;
+
+        propertiesChanged($changes: Record<string, { newValue: unknown; oldValue: unknown }>) {
+          changes = $changes;
+        }
+      });
+
+      assert.strictEqual(changes, void 0);
+      component.a = 2;
+      assert.strictEqual(changes, void 0);
+      void stop(true);
+
+      await Promise.resolve();
+      assert.deepStrictEqual(changes, void 0);
+    });
+
     it('does not call aggregated callback after unbind', async function () {
       let changes = void 0;
       const { component, stop } = createFixture(``, class App {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1251,59 +1251,63 @@ function createObservers(
   const locator = controller.container.get(IObserverLocator);
   const hasAggregatedCallbacks = 'propertiesChanged' in instance;
 
-  if (length > 0) {
-    let changes: Record<string, { newValue: unknown; oldValue: unknown }> = {};
-    let promise: Promise<void> | void = void 0;
-    let changeCount = 0;
-    const queueCallback = (key: string, newValue: unknown, oldValue: unknown) => {
-      changes[key] = { newValue, oldValue };
-      changeCount++;
-      callPropertiesChanged();
-    };
-    const callPropertiesChanged = () => {
-      if (promise == null) {
-        promise = Promise.resolve().then(() => {
-          const $changes = changes;
-          changes = {};
-          changeCount = 0;
-          promise = void 0;
-          if (controller.isBound) {
-            instance.propertiesChanged?.($changes);
-            if (changeCount > 0) {
-              callPropertiesChanged();
-            }
-          }
-        });
-      }
-    };
+  if (length === 0) return;
 
-    for (let i = 0; i < length; ++i) {
-      const name = observableNames[i];
-      const bindable = bindables[name];
-      const handler = bindable.callback;
-      const obs = locator.getObserver(instance, name);
-
-      if (bindable.set !== noop) {
-        if (obs.useCoercer?.(bindable.set, controller.coercion) !== true) {
-          throw createMappedError(ErrorNames.controller_property_not_coercible, name);
-        }
-      }
-      if (instance[handler] != null
-        || instance.propertyChanged != null
-        || hasAggregatedCallbacks
-      ) {
-        const callback = (newValue: unknown, oldValue: unknown) => {
-          if (controller.isBound) {
-            (instance[handler] as AnyFunction)?.(newValue, oldValue);
-            instance.propertyChanged?.(name, newValue, oldValue);
-            if (hasAggregatedCallbacks) {
-              queueCallback(name, newValue, oldValue);
-            }
+  const queueCallback = hasAggregatedCallbacks
+    ? (() => {
+        let changes: Record<string, { newValue: unknown; oldValue: unknown }> = {};
+        let promise: Promise<void> | void = void 0;
+        let changeCount = 0;
+        const resolvedPromise = Promise.resolve();
+        const callPropertiesChanged = () => {
+          if (promise == null) {
+            promise = resolvedPromise.then(() => {
+              const $changes = changes;
+              changes = {};
+              changeCount = 0;
+              promise = void 0;
+              if (controller.isBound) {
+                instance.propertiesChanged?.($changes);
+                if (changeCount > 0) {
+                  callPropertiesChanged();
+                }
+              }
+            });
           }
         };
-        if (obs.useCallback?.(callback) !== true) {
-          throw createMappedError(ErrorNames.controller_property_no_change_handler, name);
+
+        return (key: string, newValue: unknown, oldValue: unknown) => {
+          changes[key] = { newValue, oldValue };
+          changeCount++;
+          callPropertiesChanged();
+        };
+    })()
+    : noop;
+
+  for (let i = 0; i < length; ++i) {
+    const name = observableNames[i];
+    const bindable = bindables[name];
+    const handler = bindable.callback;
+    const obs = locator.getObserver(instance, name);
+
+    if (bindable.set !== noop) {
+      if (obs.useCoercer?.(bindable.set, controller.coercion) !== true) {
+        throw createMappedError(ErrorNames.controller_property_not_coercible, name);
+      }
+    }
+    if (instance[handler] != null
+      || instance.propertyChanged != null
+      || hasAggregatedCallbacks
+    ) {
+      const callback = (newValue: unknown, oldValue: unknown) => {
+        if (controller.isBound) {
+          (instance[handler] as AnyFunction)?.(newValue, oldValue);
+          instance.propertyChanged?.(name, newValue, oldValue);
+          queueCallback(name, newValue, oldValue);
         }
+      };
+      if (obs.useCallback?.(callback) !== true) {
+        throw createMappedError(ErrorNames.controller_property_no_change_handler, name);
       }
     }
   }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1840,7 +1840,7 @@ export interface ICustomElementViewModel extends IViewModel, IActivationHooks<IH
     controller: ICustomElementController<this>,
   ): void;
   propertyChanged?(key: PropertyKey, newValue: unknown, oldValue: unknown): void;
-  propertiesChanged?(changes: Record<string | symbol, { newValue: unknown; oldValue: unknown }>): void;
+  propertiesChanged?(changes: Record<string, { newValue: unknown; oldValue: unknown }>): void;
 }
 
 export interface ICustomAttributeViewModel extends IViewModel, IActivationHooks<IHydratedController> {
@@ -1855,7 +1855,7 @@ export interface ICustomAttributeViewModel extends IViewModel, IActivationHooks<
     controller: ICustomAttributeController<this>,
   ): void;
   propertyChanged?(key: PropertyKey, newValue: unknown, oldValue: unknown): void;
-  propertiesChanged?(changes: Record<string | symbol, { newValue: unknown; oldValue: unknown }>): void;
+  propertiesChanged?(changes: Record<string, { newValue: unknown; oldValue: unknown }>): void;
 }
 
 export interface IHydratedCustomElementViewModel extends ICustomElementViewModel {


### PR DESCRIPTION
## 📖 Description

Currently, as per noted in #2021 by @ekzobrain:

> There is no way to set a single change callback for multiple properties. In Angular there's an ngOnChanges() callback (https://angular.io/api/core/OnChanges) which fires once for all changed bindables. I would like to have something similar in Aurelia, for example "propertiesChanged()". There are cases when component update strategy heavily depends on wheather one or several related properties changed at once.

This is a missing feature of v1 where it was quite difficult to aggregate the changes during 1 flush cycle of a component. Thanks @ekzobrain for bringing this up.

This PR adds support for the ability to declare a aggregated callback on the component instances (attributes/elements) to receive all the changes at once, with the following signature:

```ts
export interface ICustomElementViewModel {
  ...
  propertiesChanged?(changes: Record<string, { newValue: unknown; oldValue: unknown }>): void;
}
```

- Note that if there' multiple writes to the same property, the changes record given to `propertiesChanged` will only have the latest values, i.e:
    ```ts
    class Component {
      prop = 0
    }
    ...
    component.prop = 1;
    ...
    component.prop = 2;
    ```
    Changes record will be:
    ```ts
    {
      prop: { newValue: 2, oldValue: 1 }
    }
    ```
    not:
    ```ts
    {
      prop: { newValue: 2, oldValue: 0 }
    }
    ```
- The timing of the aggregated changes callback will be the immediate next tick, queued via `Promise.resolve().then(...)` Though this may change if it's deemed unsuitable. We will test for a few versions before RC.

### 🎫 Issues

Close #2021

cc @Sayan751 @fkleuver @ekzobrain 

Note: about the timing, we can try to make it synchronous after a `batch`, but I'm not sure if that's desirable.

cc @3cp with this next tick group update, we kind of have a way to deal with state tearing.