### PR TITLE
chore(router-lite): removed IRouteNode implementation in RouteNode

### DIFF
--- a/packages/router-lite/src/index.ts
+++ b/packages/router-lite/src/index.ts
@@ -67,6 +67,7 @@ export {
 } from './route-expression';
 
 export {
+  IRouteNodeInitializationOptions,
   RouteNode,
   RouteTree,
 } from './route-tree';

--- a/packages/router-lite/src/route-tree.ts
+++ b/packages/router-lite/src/route-tree.ts
@@ -49,7 +49,7 @@ import { resolveCustomElementDefinition, resolveRouteConfiguration, RouteConfig,
 import { Events, getMessage } from './events';
 import { pathUrlParser } from './url-parser';
 
-export interface IRouteNode {
+export interface IRouteNodeInitializationOptions {
   path: string;
   finalPath: string;
   context: IRouteContext;
@@ -64,9 +64,10 @@ export interface IRouteNode {
   component: CustomElementDefinition;
   children?: RouteNode[];
   residue?: ViewportInstruction[];
+  originalInstruction?: ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent> | null;
 }
 
-export class RouteNode implements IRouteNode {
+export class RouteNode {
   /** @internal */ public _tree!: RouteTree;
   /** @internal */ public _version: number = 1;
 
@@ -132,7 +133,7 @@ export class RouteNode implements IRouteNode {
     this._originalInstruction ??= instruction;
   }
 
-  public static create(input: IRouteNode & { originalInstruction?: ViewportInstruction<ITypedNavigationInstruction_ResolvedComponent> | null }): RouteNode {
+  public static create(input: IRouteNodeInitializationOptions): RouteNode {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [RESIDUE]: _, ...params } = input.params ?? {};
     return new RouteNode(


### PR DESCRIPTION


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

The inheritance was relatively superfluous. The `IRouteNode` is also not a significant part of the public API. This commit corrects that by renaming the said interface to `IRouteNodeInitializationOptions` as the interface is merely used for creating a `RouteNode`. However, the interface is exported from the package as `RouteNode#create` is a part of the public API.

Thanks @ekzobrain for [reporting this](https://discord.com/channels/448698263508615178/1243519563283435520/1273318182798622936).

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
