### PR TITLE
feat(runtime-html): reuse host and hostController

### DIFF
--- a/packages/__tests__/src/3-runtime-html/controller.smoke-test.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/controller.smoke-test.spec.ts
@@ -1,0 +1,58 @@
+import { resolve } from '@aurelia/kernel';
+import { Controller, CustomElement, customElement, ICustomElementViewModel, IHydratedController, INode, registerHostNode } from '@aurelia/runtime-html';
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/controller.smoke-test.spec.ts', function () {
+
+  it('explicit hydration host and hostController can be provided', async function () {
+    @customElement({ name: 'c-1', template: 'c1' })
+    class CeOne { }
+
+    @customElement({ name: 'c-2', template: 'c2' })
+    class CeTwo implements ICustomElementViewModel {
+      public readonly ce2El: Element = resolve(INode) as Element;
+
+      public attached(_initiator: IHydratedController): void | Promise<void> {
+        // at this point, the element should be in the DOM
+        assert.strictEqual(this.ce2El.parentElement, ce1El);
+      }
+    }
+
+    const { appHost, stop, startPromise, platform } = createFixture(
+      `<c-1></c-1>`,
+      class { },
+      [CeOne, CeTwo],
+    );
+    await startPromise;
+
+    const ce1El = appHost.querySelector('c-1');
+    assert.html.innerEqual(ce1El, 'c1');
+
+    const ce1Ctrl = CustomElement.for(ce1El);
+
+    // activate c-2
+    const childCtn = ce1Ctrl.container.createChild({ inheritParentResources: true });
+    const ce2El = platform.document.createElement('c-2');
+    registerHostNode(childCtn, ce2El);
+    assert.html.innerEqual(ce2El, '');
+    const ce2Vm = childCtn.invoke(CeTwo);
+    assert.strictEqual(ce2Vm.ce2El, ce2El);
+    const ce2Ctrl = Controller.$el(childCtn, ce2Vm, ce2El, { hostController: ce1Ctrl as unknown as Controller, projections: null });
+    await ce2Ctrl.activate(ce2Ctrl, ce1Ctrl);
+
+    // post-activation assertion
+    assert.html.textContent(ce2El, 'c2');
+    assert.html.textContent(ce1El, 'c1c2');
+    assert.strictEqual(ce1El.contains(ce2El), true);
+
+    // deactivate c-2
+    await ce2Ctrl.deactivate(ce2Ctrl, ce1Ctrl);
+
+    // post-deactivation assertion
+    assert.html.textContent(ce2El, '');
+    assert.html.textContent(ce1El, 'c1');
+    assert.strictEqual(ce1El.contains(ce2El), false);
+
+    await stop(true);
+  });
+});

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -117,7 +117,7 @@ export class AppRoot<
         definition
       )) as Controller<K>;
 
-      controller._hydrateCustomElement(hydrationInst, /* root does not have hydration context */null);
+      controller._hydrateCustomElement(hydrationInst);
       return onResolve(this._runAppTasks('hydrating'), () => {
         controller._hydrate();
         return onResolve(this._runAppTasks('hydrated'), () => {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -253,7 +253,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     controllerLookup.set(viewModel, controller as Controller);
 
     if (hydrationInst == null || hydrationInst.hydrate !== false) {
-      controller._hydrateCustomElement(hydrationInst, hydrationContext);
+      controller._hydrateCustomElement(hydrationInst);
     }
 
     return controller as ICustomElementController<C>;
@@ -340,12 +340,6 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
   /** @internal */
   public _hydrateCustomElement(
     hydrationInst: IControllerElementHydrationInstruction | null,
-    /**
-     * The context where this custom element is hydrated.
-     *
-     * This is the context controller creating this this controller
-     */
-    _hydrationContext: IHydrationContext | null,
   ): void {
     if (__DEV__) {
       this.logger = this.container.get(ILogger).root;
@@ -387,13 +381,13 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     // - Controller.compileChildren
     // This keeps hydration synchronous while still allowing the composition root compile hooks to do async work.
     if (hydrationInst == null || hydrationInst.hydrate !== false) {
-      this._hydrate();
+      this._hydrate(hydrationInst?.hostController);
       this._hydrateChildren();
     }
   }
 
   /** @internal */
-  public _hydrate(): void {
+  public _hydrate(hostController?: Controller | null): void {
     if (this._lifecycleHooks!.hydrating != null) {
       this._lifecycleHooks!.hydrating.forEach(callHydratingHook, this);
     }
@@ -411,11 +405,17 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
     let host = this.host!;
     let location: IRenderLocation | null = this.location;
 
-    if ((this.hostController = findElementControllerFor(host, optionalCeFind) as Controller | null) !== null) {
+    let createLocation = false;
+    if (hostController != null) {
+      this.hostController = hostController;
+      createLocation = true;
+    } else if ((this.hostController = findElementControllerFor(host, optionalCeFind) as Controller | null) !== null) {
       host = this.host = this.container.root.get(IPlatform).document.createElement(definition.name);
-      if (containerless && location == null) {
-        location = this.location = convertToRenderLocation(host);
-      }
+      createLocation = true;
+    }
+
+    if (createLocation && containerless && location == null) {
+      location = this.location = convertToRenderLocation(host);
     }
 
     setRef(host, elementBaseName, this as IHydratedController);
@@ -1889,6 +1889,11 @@ export interface IControllerElementHydrationInstruction {
    * Indicates whether the custom element was used with "containerless" attribute
    */
   readonly containerless?: boolean;
+  /**
+   * When provided, the controller is used while hydrating the custom element.
+   * Otherwise, the host controller is resolved in the Controller; this is the default behavior.
+   */
+  readonly hostController?: Controller | null;
 }
 
 function callDispose(disposable: IDisposable): void {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This enables reusing the given host and hostController without trying to resolve the hostController again in the Controller. This fix is likely a predecessor for the fix for #2042.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
