### PR TITLE
chore: move utilities from metadata to kernel package

### DIFF
--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
-import { isObject } from '@aurelia/metadata';
 import {
   IContainer,
   InterfaceSymbol,
@@ -32,7 +31,7 @@ import { isNativeFunction } from './functions';
 import { type Class, type Constructable } from './interfaces';
 import { emptyArray } from './platform';
 import { ResourceDefinition, StaticResourceType, resourceBaseName, type ResourceType } from './resource';
-import { getMetadata, isFunction, isString } from './utilities';
+import { getMetadata, isFunction, isObjectOrFunction, isString } from './utilities';
 
 export const registrableMetadataKey = Symbol.for('au:registrable');
 export const DefaultResolver = {
@@ -166,7 +165,7 @@ export class Container implements IContainer {
 
     for (; i < ii; ++i) {
       current = params[i];
-      if (!isObject(current)) {
+      if (!isObjectOrFunction(current)) {
         continue;
       }
       if (isRegistry(current)) {
@@ -214,7 +213,7 @@ export class Container implements IContainer {
         jj = keys.length;
         for (; j < jj; ++j) {
           value = current[keys[j]];
-          if (!isObject(value)) {
+          if (!isObjectOrFunction(value)) {
             continue;
           }
           // note: we could remove this if-branch and call this.register directly

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -148,6 +148,7 @@ export {
   isSet,
   isPromise,
   isFunction,
+  isObjectOrFunction,
   isNumber,
   isString,
   isSymbol,

--- a/packages/kernel/src/utilities.ts
+++ b/packages/kernel/src/utilities.ts
@@ -38,9 +38,69 @@ export const isMap = <T, K>(v: unknown): v is Map<T, K> => v instanceof Map;
 /**
  * Returns true if the value is an object via checking if it's an instance of Object.
  * This does not work for objects across different realms (e.g., iframes).
- * An utility to be shared among core packages for better size optimization
+ * An utility to be shared among core packages only for better size optimization
+ *
+ * This is semi private to core packages and applications should not depend on this.
  */
 export const isObject = (v: unknown): v is object => v instanceof Object;
+
+/**
+ * IMPORTANT: This is semi private to core packages and applications should not depend on this.
+ *
+ * Determine whether a value is an object.
+ *
+ * Uses `typeof` to guarantee this works cross-realm, which is where `instanceof Object` might fail.
+ *
+ * Some environments where these issues are known to arise:
+ * - same-origin iframes (accessing the other realm via `window.top`)
+ * - `jest`.
+ *
+ * The exact test is:
+ * ```ts
+ * typeof value === 'object' && value !== null || typeof value === 'function'
+ * ```
+ *
+ * @param value - The value to test.
+ * @returns `true` if the value is an object, otherwise `false`.
+ * Also performs a type assertion that defaults to `value is Object | Function` which, if the input type is a union with an object type, will infer the correct type.
+ * This can be overridden with the generic type argument.
+ *
+ * @example
+ *
+ * ```ts
+ * class Foo {
+ *   bar = 42;
+ * }
+ *
+ * function doStuff(input?: Foo | null) {
+ *   input.bar; // Object is possibly 'null' or 'undefined'
+ *
+ *   // input has an object type in its union (Foo) so that type will be extracted for the 'true' condition
+ *   if (isObject(input)) {
+ *     input.bar; // OK (input is now typed as Foo)
+ *   }
+ * }
+ *
+ * function doOtherStuff(input: unknown) {
+ *   input.bar; // Object is of type 'unknown'
+ *
+ *   // input is 'unknown' so there is no union type to match and it will default to 'Object | Function'
+ *   if (isObject(input)) {
+ *     input.bar; // Property 'bar' does not exist on type 'Object | Function'
+ *   }
+ *
+ *   // if we know for sure that, if input is an object, it must be a specific type, we can explicitly tell the function to assert that for us
+ *   if (isObject<Foo>(input)) {
+ *    input.bar; // OK (input is now typed as Foo)
+ *   }
+ * }
+ * ```
+ *
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isObjectOrFunction<T extends object = Object | Function>(value: unknown): value is T {
+  return typeof value === 'object' && value !== null || typeof value === 'function';
+}
 
 /**
  * Returns true if the value is a function

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * TODO: add description.
  * References:
@@ -9,71 +11,6 @@ export function initializeTC39Metadata() {
   // And the symbol we are creating here is not assignable to the unique symbol.
   // More info: https://github.com/Microsoft/TypeScript/issues/23388
   (Symbol as any).metadata ??= Symbol.for("Symbol.metadata");
-}
-/**
- * Determine whether a value is an object.
- *
- * Uses `typeof` to guarantee this works cross-realm, which is where `instanceof Object` might fail.
- *
- * Some environments where these issues are known to arise:
- * - same-origin iframes (accessing the other realm via `window.top`)
- * - `jest`.
- *
- * The exact test is:
- * ```ts
- * typeof value === 'object' && value !== null || typeof value === 'function'
- * ```
- *
- * @param value - The value to test.
- * @returns `true` if the value is an object, otherwise `false`.
- * Also performs a type assertion that defaults to `value is Object | Function` which, if the input type is a union with an object type, will infer the correct type.
- * This can be overridden with the generic type argument.
- *
- * @example
- *
- * ```ts
- * class Foo {
- *   bar = 42;
- * }
- *
- * function doStuff(input?: Foo | null) {
- *   input.bar; // Object is possibly 'null' or 'undefined'
- *
- *   // input has an object type in its union (Foo) so that type will be extracted for the 'true' condition
- *   if (isObject(input)) {
- *     input.bar; // OK (input is now typed as Foo)
- *   }
- * }
- *
- * function doOtherStuff(input: unknown) {
- *   input.bar; // Object is of type 'unknown'
- *
- *   // input is 'unknown' so there is no union type to match and it will default to 'Object | Function'
- *   if (isObject(input)) {
- *     input.bar; // Property 'bar' does not exist on type 'Object | Function'
- *   }
- *
- *   // if we know for sure that, if input is an object, it must be a specific type, we can explicitly tell the function to assert that for us
- *   if (isObject<Foo>(input)) {
- *    input.bar; // OK (input is now typed as Foo)
- *   }
- * }
- * ```
- */
-// eslint-disable-next-line @typescript-eslint/ban-types
-export function isObject<T extends object = Object | Function>(value: unknown): value is T {
-  return typeof value === 'object' && value !== null || typeof value === 'function';
-}
-
-/**
- * Determine whether a value is `null` or `undefined`.
- *
- * @param value - The value to test.
- * @returns `true` if the value is `null` or `undefined`, otherwise `false`.
- * Also performs a type assertion that ensures TypeScript treats the value appropriately in the `if` and `else` branches after this check.
- */
-export function isNullOrUndefined(value: unknown): value is null | undefined {
-  return value === null || value === void 0;
 }
 
 export const Metadata = {

--- a/packages/router-lite/src/configuration.ts
+++ b/packages/router-lite/src/configuration.ts
@@ -1,5 +1,4 @@
-import { isObject } from '@aurelia/metadata';
-import { IContainer, IRegistry, Registration } from '@aurelia/kernel';
+import { IContainer, IRegistry, isObjectOrFunction, Registration } from '@aurelia/kernel';
 import { AppTask, IWindow } from '@aurelia/runtime-html';
 
 import { RouteContext } from './route-context';
@@ -52,7 +51,7 @@ export interface IRouterConfigurationOptions extends $IRouterOptions {
 
 function configure(container: IContainer, options?: IRouterConfigurationOptions): IContainer {
   let basePath: string | null = null;
-  if (isObject(options)) {
+  if (isObjectOrFunction(options)) {
     basePath = (options as IRouterConfigurationOptions).basePath ?? null;
   } else {
     options = {};

--- a/packages/router-lite/src/instructions.ts
+++ b/packages/router-lite/src/instructions.ts
@@ -1,9 +1,9 @@
-import { isObject } from '@aurelia/metadata';
 import {
   Constructable,
   emptyObject,
   IModule,
   isArrayIndex,
+  isObjectOrFunction,
   Writable,
 } from '@aurelia/kernel';
 import {
@@ -440,7 +440,7 @@ export class TypedNavigationInstruction<TInstruction extends NavigationInstructi
 
     if (typeof instruction === 'string') return new TypedNavigationInstruction(NavigationInstructionType.string, instruction);
     // Typings prevent this from happening, but guard it anyway due to `as any` and the sorts being a thing in userland code and tests.
-    if (!isObject(instruction)) expectType('function/class or object', '', instruction);
+    if (!isObjectOrFunction(instruction)) expectType('function/class or object', '', instruction);
     if (typeof instruction === 'function') {
       if (CustomElement.isType(instruction as Constructable)) {
         // This is the class itself

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -1,5 +1,4 @@
-import { isObject } from '@aurelia/metadata';
-import { IContainer, ILogger, DI, IDisposable, onResolve, Writable, onResolveAll, Registration, resolve } from '@aurelia/kernel';
+import { IContainer, ILogger, DI, IDisposable, onResolve, Writable, onResolveAll, Registration, resolve, isObjectOrFunction } from '@aurelia/kernel';
 import { CustomElement, CustomElementDefinition, IPlatform } from '@aurelia/runtime-html';
 
 import { IRouteContext, RouteContext } from './route-context';
@@ -19,7 +18,7 @@ import { Events, debug, error, getMessage, trace } from './events';
 export const emptyQuery = Object.freeze(new URLSearchParams());
 
 export function isManagedState(state: {} | null): state is ManagedState {
-  return isObject(state) && Object.prototype.hasOwnProperty.call(state, AuNavId) === true;
+  return isObjectOrFunction(state) && Object.prototype.hasOwnProperty.call(state, AuNavId) === true;
 }
 export function toManagedState(state: {} | null, navId: number): ManagedState {
   return { ...state, [AuNavId]: navId };

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -14,7 +14,6 @@ import {
   isPromise,
   isString,
 } from '@aurelia/kernel';
-import { isObject } from '@aurelia/metadata';
 import { IExpressionParser, IsBindingBehavior, AccessScopeExpression } from '@aurelia/expression-parser';
 import {
   ICoercionConfiguration,
@@ -1379,7 +1378,7 @@ export function isCustomElementController<C extends ICustomElementViewModel = IC
 }
 
 export function isCustomElementViewModel(value: unknown): value is ICustomElementViewModel {
-  return isObject(value) && isElementType(value.constructor);
+  return isElementType(value?.constructor);
 }
 
 class HooksDefinition {

--- a/packages/template-compiler/src/attribute-mapper.ts
+++ b/packages/template-compiler/src/attribute-mapper.ts
@@ -1,9 +1,9 @@
-import { createInterface } from './utilities';
+import { tcCreateInterface } from './utilities';
 
 /**
  * An interface describing the API for mapping attributes to properties
  */
-export const IAttrMapper = /*@__PURE__*/createInterface<IAttrMapper>('IAttrMapper');
+export const IAttrMapper = /*@__PURE__*/tcCreateInterface<IAttrMapper>('IAttrMapper');
 export interface IAttrMapper {
   /**
    * Allow application to teach Aurelia how to define how to map attributes to properties

--- a/packages/template-compiler/src/attribute-pattern.ts
+++ b/packages/template-compiler/src/attribute-pattern.ts
@@ -1,6 +1,6 @@
 import type { Constructable, IRegistry, } from '@aurelia/kernel';
 import { IContainer, registrableMetadataKey, emptyArray, getResourceKeyFor, resolve } from '@aurelia/kernel';
-import { createInterface, objectFreeze, singletonRegistration } from './utilities';
+import { tcCreateInterface, tcObjectFreeze, singletonRegistration } from './utilities';
 import { ErrorNames, createMappedError } from './errors';
 
 export interface AttributePatternDefinition<T extends string = string> {
@@ -286,7 +286,7 @@ export interface ISyntaxInterpreter {
   add(defs: AttributePatternDefinition[]): void;
   interpret(name: string): Interpretation;
 }
-export const ISyntaxInterpreter = /*@__PURE__*/createInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
+export const ISyntaxInterpreter = /*@__PURE__*/tcCreateInterface<ISyntaxInterpreter>('ISyntaxInterpreter', x => x.singleton(SyntaxInterpreter));
 
 /**
  * The default implementation of @see {ISyntaxInterpreter}.
@@ -444,13 +444,13 @@ export class AttrSyntax {
 
 export type IAttributePattern<T extends string = string> = Record<T, (rawName: string, rawValue: string, parts: readonly string[]) => AttrSyntax>;
 
-export const IAttributePattern = /*@__PURE__*/createInterface<IAttributePattern>('IAttributePattern');
+export const IAttributePattern = /*@__PURE__*/tcCreateInterface<IAttributePattern>('IAttributePattern');
 
 export interface IAttributeParser {
   registerPattern(patterns: AttributePatternDefinition[], Type: Constructable<IAttributePattern>): void;
   parse(name: string, value: string): AttrSyntax;
 }
-export const IAttributeParser = /*@__PURE__*/createInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
+export const IAttributeParser = /*@__PURE__*/tcCreateInterface<IAttributeParser>('IAttributeParser', x => x.singleton(AttributeParser));
 
 /**
  * The default implementation of the @see IAttributeParser interface
@@ -531,13 +531,12 @@ export function attributePattern<const K extends AttributePatternDefinition>(...
   return function decorator<T extends Constructable<IAttributePattern<K['pattern']>>>(target: T, context: ClassDecoratorContext<T>): T {
     const registrable = AttributePattern.create(patternDefs, target);
     // Decorators are by nature static, so we need to store the metadata on the class itself, assuming only one set of patterns per class.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     context.metadata[registrableMetadataKey] = registrable;
     return target;
   };
 }
 
-export const AttributePattern = /*@__PURE__*/ objectFreeze<AttributePatternKind>({
+export const AttributePattern = /*@__PURE__*/ tcObjectFreeze<AttributePatternKind>({
   name: getResourceKeyFor('attribute-pattern'),
   create(patternDefs, Type) {
     return {

--- a/packages/template-compiler/src/binding-command.ts
+++ b/packages/template-compiler/src/binding-command.ts
@@ -1,5 +1,5 @@
 import { IExpressionParser } from '@aurelia/expression-parser';
-import { Protocol, camelCase, emptyArray, firstDefined, getResourceKeyFor, mergeArrays, resolve, resource, resourceBaseName } from '@aurelia/kernel';
+import { Protocol, camelCase, emptyArray, firstDefined, getResourceKeyFor, mergeArrays, resolve, resource, resourceBaseName, isString } from '@aurelia/kernel';
 import { defineMetadata, getMetadata } from './utilities-metadata';
 import { IAttrMapper } from './attribute-mapper';
 import {
@@ -11,7 +11,7 @@ import {
   RefBindingInstruction,
   SpreadValueBindingInstruction,
 } from './instructions';
-import { aliasRegistration, etIsFunction, etIsProperty, isString, objectFreeze, singletonRegistration } from './utilities';
+import { aliasRegistration, etIsFunction, etIsProperty, tcObjectFreeze, singletonRegistration } from './utilities';
 
 import type {
   Constructable,
@@ -165,7 +165,7 @@ export const BindingCommand = /*@__PURE__*/ (() => {
     return def;
   };
 
-  return objectFreeze<BindingCommandKind>({
+  return tcObjectFreeze<BindingCommandKind>({
     name: cmdBaseName,
     keyFrom: getCommandKeyFrom,
     // isType<T>(value: T): value is (T extends Constructable ? BindingCommandType<T> : never) {

--- a/packages/template-compiler/src/binding-mode.ts
+++ b/packages/template-compiler/src/binding-mode.ts
@@ -1,4 +1,4 @@
-import { objectFreeze } from './utilities';
+import { tcObjectFreeze } from './utilities';
 
 // Note: the oneTime binding now has a non-zero value for 2 reasons:
 //  - plays nicer with bitwise operations (more consistent code, more explicit settings)
@@ -14,7 +14,7 @@ import { objectFreeze } from './utilities';
  * - 6 / two way - bindings should observe both target and source for changes to update the other side
  * - 0 / default - undecided mode, bindings, depends on the circumstance, may decide what to do accordingly
  */
-export const BindingMode = /*@__PURE__*/ objectFreeze({
+export const BindingMode = /*@__PURE__*/ tcObjectFreeze({
   /**
    * Unspecified mode, bindings may act differently with this mode
    */

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -1,10 +1,11 @@
+import { isString } from '@aurelia/kernel';
 import {
   type ForOfStatement,
   type Interpolation,
   type IsBindingBehavior,
 } from '@aurelia/expression-parser';
 import { IAttributeComponentDefinition, IElementComponentDefinition } from './interfaces-template-compiler';
-import { createInterface, isString, objectFreeze } from './utilities';
+import { tcCreateInterface, tcObjectFreeze } from './utilities';
 import { AttrSyntax } from './attribute-pattern';
 import { BindingMode } from './binding-mode';
 
@@ -30,7 +31,7 @@ import { BindingMode } from './binding-mode';
 /** @internal */ export const spreadElementProp = 'hp';
 /** @internal */ export const spreadValueBinding = 'svb';
 
-export const InstructionType = /*@__PURE__*/ objectFreeze({
+export const InstructionType = /*@__PURE__*/ tcObjectFreeze({
   hydrateElement,
   hydrateAttribute,
   hydrateTemplateController,
@@ -58,7 +59,7 @@ export type InstructionType = typeof InstructionType[keyof typeof InstructionTyp
 export interface IInstruction {
   readonly type: string;
 }
-export const IInstruction = /*@__PURE__*/createInterface<IInstruction>('Instruction');
+export const IInstruction = /*@__PURE__*/tcCreateInterface<IInstruction>('Instruction');
 
 export function isInstruction(value: unknown): value is IInstruction {
   const type = (value as { type?: string }).type;

--- a/packages/template-compiler/src/interfaces-template-compiler.ts
+++ b/packages/template-compiler/src/interfaces-template-compiler.ts
@@ -1,5 +1,5 @@
 import { Constructable, IContainer, IPlatform, Key } from '@aurelia/kernel';
-import { createInterface } from './utilities';
+import { tcCreateInterface } from './utilities';
 import { AttrSyntax } from './attribute-pattern';
 import { IInstruction } from './instructions';
 
@@ -60,7 +60,7 @@ export type ICompiledElementComponentDefinition = IElementComponentDefinition & 
 /**
  * An interface describing the template compiler used by Aurelia applicaitons
  */
-export const ITemplateCompiler = /*@__PURE__*/createInterface<ITemplateCompiler>('ITemplateCompiler');
+export const ITemplateCompiler = /*@__PURE__*/tcCreateInterface<ITemplateCompiler>('ITemplateCompiler');
 export interface ITemplateCompiler {
   /**
    * Indicates whether this compiler should compile template in debug mode

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -1,6 +1,19 @@
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-import { emptyArray, toArray, ILogger, camelCase, noop, getResourceKeyFor, allResources, IPlatform, pascalCase, createImplementationRegister, registrableMetadataKey } from '@aurelia/kernel';
+import {
+  emptyArray,
+  toArray,
+  ILogger,
+  camelCase,
+  noop,
+  getResourceKeyFor,
+  allResources,
+  IPlatform,
+  pascalCase,
+  createImplementationRegister,
+  registrableMetadataKey,
+  isString,
+} from '@aurelia/kernel';
 import {
   IExpressionParser,
   PrimitiveLiteralExpression,
@@ -28,7 +41,7 @@ import {
 } from './instructions';
 import { AttrSyntax, IAttributeParser } from './attribute-pattern';
 import { BindingCommand, BindingCommandInstance, ICommandBuildInfo } from './binding-command';
-import { etInterpolation, etIsProperty, isString, objectFreeze, createInterface, singletonRegistration, definitionTypeElement } from './utilities';
+import { etInterpolation, etIsProperty, tcObjectFreeze, tcCreateInterface, singletonRegistration, definitionTypeElement } from './utilities';
 import { auLocationStart, auLocationEnd, appendManyToTemplate, appendToTemplate, insertBefore, insertManyBefore, isElement, isTextNode } from './utilities-dom';
 
 import type {
@@ -1902,12 +1915,12 @@ export interface IResourceResolver<
   bindables(def: TAttrDef | TElementDef): IAttributeBindablesInfo | IElementBindablesInfo;
 }
 
-export const IResourceResolver = /*@__PURE__*/ createInterface<IResourceResolver>('IResourceResolver');
+export const IResourceResolver = /*@__PURE__*/ tcCreateInterface<IResourceResolver>('IResourceResolver');
 
 export interface IBindingCommandResolver {
   get(c: IContainer, name: string): BindingCommandInstance | null;
 }
-export const IBindingCommandResolver = /*@__PURE__*/ createInterface<IBindingCommandResolver>('IBindingCommandResolver', x => {
+export const IBindingCommandResolver = /*@__PURE__*/ tcCreateInterface<IBindingCommandResolver>('IBindingCommandResolver', x => {
   class DefaultBindingCommandResolver implements IBindingCommandResolver {
     private readonly _cache = new WeakMap<IContainer, Record<string, BindingCommandInstance>>();
     public get(c: IContainer, name: string): BindingCommandInstance | null {
@@ -1929,7 +1942,7 @@ const enum LocalTemplateBindableAttributes {
   mode = "mode",
 }
 _END_CONST_ENUM();
-const allowedLocalTemplateBindableAttributes: readonly string[] = objectFreeze([
+const allowedLocalTemplateBindableAttributes: readonly string[] = tcObjectFreeze([
   LocalTemplateBindableAttributes.name,
   LocalTemplateBindableAttributes.attribute,
   LocalTemplateBindableAttributes.mode
@@ -1955,7 +1968,7 @@ const processTemplateName = (owningElementName: string, localTemplate: HTMLTempl
  *
  * A feature available to the default template compiler.
  */
-export const ITemplateCompilerHooks = /*@__PURE__*/createInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
+export const ITemplateCompilerHooks = /*@__PURE__*/tcCreateInterface<ITemplateCompilerHooks>('ITemplateCompilerHooks');
 export interface ITemplateCompilerHooks {
   /**
    * Should be invoked immediately before a template gets compiled
@@ -1963,7 +1976,7 @@ export interface ITemplateCompilerHooks {
   compiling?(template: HTMLElement): void;
 }
 
-export const TemplateCompilerHooks = objectFreeze({
+export const TemplateCompilerHooks = tcObjectFreeze({
   name: /*@__PURE__*/getResourceKeyFor('compiler-hooks'),
   define<K extends ITemplateCompilerHooks, T extends Constructable<K>>(Type: T): IRegistry {
     return {

--- a/packages/template-compiler/src/template-element-factory.ts
+++ b/packages/template-compiler/src/template-element-factory.ts
@@ -1,5 +1,5 @@
-import { IPlatform, resolve } from '@aurelia/kernel';
-import { createInterface, isString } from './utilities';
+import { IPlatform, resolve, isString } from '@aurelia/kernel';
+import { tcCreateInterface } from './utilities';
 import { IDomPlatform } from './interfaces-template-compiler';
 
 /**
@@ -11,7 +11,7 @@ import { IDomPlatform } from './interfaces-template-compiler';
 export interface ITemplateElementFactory {
   createTemplate(input: string | Node): HTMLTemplateElement;
 }
-export const ITemplateElementFactory = /*@__PURE__*/createInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
+export const ITemplateElementFactory = /*@__PURE__*/tcCreateInterface<ITemplateElementFactory>('ITemplateElementFactory', x => x.singleton(TemplateElementFactory));
 
 const markupCache: Record<string, HTMLTemplateElement | undefined> = {};
 

--- a/packages/template-compiler/src/utilities.ts
+++ b/packages/template-compiler/src/utilities.ts
@@ -1,10 +1,8 @@
 import { DI, Registration } from '@aurelia/kernel';
 
-/** @internal */ export const isString = (v: unknown): v is string => typeof v === 'string';
+/** @internal */ export const tcCreateInterface = DI.createInterface;
 
-/** @internal */ export const createInterface = DI.createInterface;
-
-/** @internal */ export const objectFreeze = Object.freeze;
+/** @internal */ export const tcObjectFreeze = Object.freeze;
 
 /** @internal */ export const { aliasTo: aliasRegistration, singleton: singletonRegistration } = Registration;
 

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -38,7 +38,6 @@ import { getVisibleText } from './specialized-assertions';
 import {
   isError,
   isFunction,
-  isNullOrUndefined,
   isObject,
   isPrimitive,
   isRegExp,
@@ -107,7 +106,7 @@ class Comparison {
           !isUndefined(actual)
           && isString(actual[key])
           && isRegExp(obj[key])
-          && (obj[key] as RegExp).test(actual[key] as string)
+          && obj[key].test(actual[key])
         ) {
           this[key] = actual[key];
         } else {
@@ -320,7 +319,7 @@ export async function doesNotReject(
 }
 
 export function ifError(err?: Error): void {
-  if (!isNullOrUndefined(err)) {
+  if (err != null) {
     let message = 'ifError got unwanted exception: ';
     if (isObject(err) && isString(err.message)) {
       if (err.message.length === 0 && err.constructor) {

--- a/packages/testing/src/util.ts
+++ b/packages/testing/src/util.ts
@@ -103,10 +103,6 @@ export function isNull(arg: unknown): arg is null {
   return arg === null;
 }
 
-export function isNullOrUndefined(arg: unknown): arg is null | undefined {
-  return arg === null || arg === void 0;
-}
-
 export function isNumber(arg: unknown): arg is number {
   return typeof arg === 'number';
 }
@@ -123,6 +119,7 @@ export function isUndefined(arg: unknown): arg is undefined {
   return arg === void 0;
 }
 
+/** @internal */
 export function isObject(arg: unknown): arg is Object {
   return arg !== null && typeof arg === 'object';
 }


### PR DESCRIPTION
## 📖 Description

There's a `isObject` that is left over from the old metadata implementation, that now looks like a stray export, move it to kernel and rename so that it better reflects what it does.
We may add a new internal package to host all of our utilities, instead of leaving them on kernel.