### PR TITLE
fix(ast): correct null/undefined handling

### DIFF
--- a/packages/__tests__/src/2-runtime/ast.integration.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.integration.spec.ts
@@ -39,6 +39,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           target,
           'name',
           BindingMode.toView,
+          false,
         );
 
         binding.bind(createScopeForTest(source));
@@ -72,6 +73,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           target,
           'value',
           BindingMode.toView,
+          false,
         );
 
         let handleChangeCallCount = 0;
@@ -131,7 +133,8 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           observerLocator,
           accessScopeExpr,
           'value',
-          true
+          true,
+          false,
         );
 
         binding.bind(scope);
@@ -162,6 +165,7 @@ describe('2-runtime/ast.integration.spec.ts', function () {
           conditionalExpr,
           'value',
           true,
+          false,
         );
 
         let handleChangeCallCount = 0;

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -82,7 +82,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       });
 
       trigger.click('div');
-      assert.includes(String(error), 'AUR0107:');
+      assert.includes(String(error), 'AUR0111:');
     });
 
     it('[event] does not throw on handler missing - call keyed', function () {
@@ -154,7 +154,11 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createStrictFixture('${a[5]}'));
     });
 
-    it('[text] throws on call scope with function missing', function () {
+    it('[text] throws on call scope - prop missing', function () {
+      assert.throws(() => createStrictFixture('${a()}'));
+    });
+
+    it('[text] throws on call scope - prop nullish', function () {
       assert.throws(() => createStrictFixture('${a()}'));
     });
 
@@ -162,12 +166,16 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createStrictFixture('${a()}', { a: 5 }));
     });
 
-    it('[text] throws on call member with obj missing', function () {
-      assert.throws(() => createStrictFixture('${a.b()}'));
+    it('[text] does not throw on call scope - optional call + prop missing', function () {
+      assert.doesNotThrow(() => createStrictFixture('${a?.()}'));
     });
 
-    it('[text] does not throw on optional call scope with missing function', function () {
-      assert.doesNotThrow(() => createStrictFixture('${a?.()}'));
+    it('[text] throws on call scope - optional call + prop is not a fn', function () {
+      assert.throws(() => createStrictFixture('${a?.()}', { a: 5 }));
+    });
+
+    it('[text] throws on call member - obj missing', function () {
+      assert.throws(() => createStrictFixture('${a.b()}'));
     });
 
     it('[text] throws on call member - missing member', function () {
@@ -178,7 +186,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createStrictFixture('${a.b()}', { a: { b: 5 } }));
     });
 
-    it('[text] does not throw on optional call member with missing object', function () {
+    it('[text] does not throw on call member - optional call + object missing', function () {
       assert.doesNotThrow(() => createStrictFixture('${a.b?.()}', { a: {} }));
     });
 
@@ -236,7 +244,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       });
 
       trigger.click('div');
-      assert.includes(String(error), 'AUR0107:');
+      assert.includes(String(error), 'AUR0111:');
     });
 
     it('[trigger] throws on call member optional call - not a fn', function () {
@@ -250,7 +258,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       });
 
       trigger.click('div');
-      assert.includes(String(error), 'AUR0107:');
+      assert.includes(String(error), 'AUR0111:');
     });
 
   });

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -67,19 +67,19 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assertText('');
     });
 
-    it('[text] works with ?? on missing prop', function () {
+    it('[text] works with ?? on undefined prop - access scope', function () {
       const { assertText } = createFixture('${a ?? "b"}', { a: undefined });
 
       assertText('b');
     });
 
-    it('[text] works with ?? on missing prop from access member', function () {
+    it('[text] works with ?? on missing instance - access member', function () {
       const { assertText } = createFixture('${a.c ?? "b"}');
 
       assertText('b');
     });
 
-    it('[text] works with ?? on missing prop from access keyed', function () {
+    it('[text] works with ?? on missing instance - access keyed', function () {
       const { assertText } = createFixture('${a[c] ?? "b"}');
 
       assertText('b');

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -1,7 +1,137 @@
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('2-runtime/ast.optional.spec.ts', function () {
-  it('does not throw on optional call', function () {
-    assert.doesNotThrow(() => createFixture('${text?.()}'));
+
+  describe.only('non-strict mode', function () {
+    it('[text] does not throw on access member', function () {
+      assert.doesNotThrow(() => createFixture('${a.b}'));
+    });
+
+    it('[text] does not throw on access keyed', function () {
+      assert.doesNotThrow(() => createFixture('${a[b]}'));
+    });
+
+    it('[text] does not throw on access keyed with literal', function () {
+      assert.doesNotThrow(() => createFixture('${a[5]}'));
+    });
+
+    it('[text] does not throw on call scope with function missing', function () {
+      assert.doesNotThrow(() => createFixture('${a()}'));
+    });
+
+    it('[text] does not throw on call member with object missing', function () {
+      assert.doesNotThrow(() => createFixture('${a.b()}'));
+    });
+
+    it('[text] does not throw on optional call scope with missing function', function () {
+      assert.doesNotThrow(() => createFixture('${a?.()}'));
+    });
+
+    it('[text] does not throw on optional call member with missing object', function () {
+      assert.doesNotThrow(() => createFixture('${a.b?.()}', { a: {} }));
+    });
+
+    it('[event] does not throw on handler missing - call scope', function () {
+      const { trigger } = createFixture('<div click.trigger="a()"></div>');
+
+      assert.doesNotThrow(() => trigger.click('div'));
+    });
+
+    it('[event] does not throw on event handler missing - call member', function () {
+      const { trigger } = createFixture('<div click.trigger="a.b()"></div>');
+
+      assert.doesNotThrow(() => trigger.click('div'));
+    });
+
+    it('[event] does not throw on handler missing - call keyed', function () {
+      const { trigger } = createFixture('<div click.trigger="a[`b`]()"></div>');
+
+      assert.doesNotThrow(() => trigger.click('div'));
+    });
+
+    it('[event] does not throw on handler missing - complex expression', function () {
+      const { trigger } = createFixture('<div click.trigger="(a ? b : c)()"></div>');
+
+      assert.doesNotThrow(() => trigger.click('div'));
+    });
+
+    it('[text] renders empty string on undefined', function () {
+      const { assertText } = createFixture('${a}', { a: undefined });
+
+      assertText('');
+    });
+
+    it('[text] renders empty string on null', function () {
+      const { assertText } = createFixture('${a}', { a: null });
+
+      assertText('');
+    });
+
+    it('[text] works with ?? on missing prop', function () {
+      const { assertText } = createFixture('${a ?? "b"}', { a: undefined });
+
+      assertText('b');
+    });
+
+    it('[text] works with ?? on missing prop from access member', function () {
+      const { assertText } = createFixture('${a.c ?? "b"}');
+
+      assertText('b');
+    });
+
+    it('[text] works with ?? on missing prop from access keyed', function () {
+      const { assertText } = createFixture('${a[c] ?? "b"}');
+
+      assertText('b');
+    });
+
+    it('[text] works with ?? on null prop', function () {
+      const { assertText } = createFixture('${a ?? "b"}', { a: null });
+
+      assertText('b');
+    });
+  });
+
+  describe('strict mode', function () {
+    it('throws on access member', function () {
+      assert.throws(() => createFixture('${a.b}'));
+    });
+
+    it('does not throw on access keyed', function () {
+      assert.throws(() => createFixture('${a[b]}'));
+    });
+
+    it('does not throw on access keyed with literal', function () {
+      assert.throws(() => createFixture('${a[5]}'));
+    });
+
+    it('throws on call scope with function missing', function () {
+      assert.throws(() => createFixture('${a()}'));
+    });
+
+    it('throws on call member with obj missing', function () {
+      assert.throws(() => createFixture('${a.b()}'));
+    });
+
+    it('does not throw on optional call scope with missing function', function () {
+      assert.doesNotThrow(() => createFixture('${a?.()}'));
+    });
+
+    it('does not throw on optional call member with missing object', function () {
+      assert.doesNotThrow(() => createFixture('${a.b?.()}', { a: {} }));
+    });
+
+    it('[trigger] throws on missing call scope fn', function () {
+      const { trigger } = createFixture('<div click.trigger="a()"></div>');
+
+      assert.throws(() => trigger.click('div'));
+    });
+
+    it('[trigger] throws on missing call member fn', function () {
+      const { trigger } = createFixture('<div click.trigger="a.b()"></div>', { a: {} });
+
+      assert.throws(() => trigger.click('div'));
+    });
+
   });
 });

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -27,6 +27,10 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.doesNotThrow(() => createFixture('${a()}'));
     });
 
+    it('[text] throws on call scope - prop not a fn', function () {
+      assert.throws(() => createFixture('${a()}', { a: 5 }));
+    });
+
     it('[text] does not throw on call member with object missing', function () {
       assert.doesNotThrow(() => createFixture('${a.b()}'));
     });
@@ -37,6 +41,10 @@ describe('2-runtime/ast.optional.spec.ts', function () {
 
     it('[text] does not throw on optional call member with missing prop', function () {
       assert.doesNotThrow(() => createFixture('${a.b?.()}', { a: {} }));
+    });
+
+    it('[text] throws on optional call member - prop is not a fn', function () {
+      assert.throws(() => createFixture('${a.b?.()}', { a: { b: 5 } }));
     });
 
     it('[event] does not throw on handler missing - call scope', function () {
@@ -138,6 +146,10 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createStrictFixture('${a()}'));
     });
 
+    it('[text] throws on call scope - prop not a fn', function () {
+      assert.throws(() => createStrictFixture('${a()}', { a: 5 }));
+    });
+
     it('[text] throws on call member with obj missing', function () {
       assert.throws(() => createStrictFixture('${a.b()}'));
     });
@@ -146,12 +158,20 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.doesNotThrow(() => createStrictFixture('${a?.()}'));
     });
 
-    it('[text] throws on call member with missing member/not a function', function () {
+    it('[text] throws on call member - missing member', function () {
       assert.throws(() => createStrictFixture('${a.b()}', { a: {} }));
+    });
+
+    it('[text] throws on call member - member not a function', function () {
+      assert.throws(() => createStrictFixture('${a.b()}', { a: { b: 5 } }));
     });
 
     it('[text] does not throw on optional call member with missing object', function () {
       assert.doesNotThrow(() => createStrictFixture('${a.b?.()}', { a: {} }));
+    });
+
+    it('[text] throws on optional call member - member not a fn', function () {
+      assert.throws(() => createStrictFixture('${a.b?.()}', { a: { b: 5 } }));
     });
 
     it('[trigger] throws on missing call scope fn', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -146,8 +146,16 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createStrictFixture('${a.b}'));
     });
 
+    it('[text] does not throw on access member - object missing + optional', function () {
+      assert.doesNotThrow(() => createStrictFixture('${a?.b}'));
+    });
+
     it('[text] throws on access keyed - object missing', function () {
       assert.throws(() => createStrictFixture('${a[b]}'));
+    });
+
+    it('[text] does not throw on access keyed - object missing + optional', function () {
+      assert.doesNotThrow(() => createStrictFixture('${a?.[b]}'));
     });
 
     it('[text] throws on access keyed - literal key - object missing', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -159,7 +159,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
     });
 
     it('[text] throws on call scope - prop nullish', function () {
-      assert.throws(() => createStrictFixture('${a()}'));
+      assert.throws(() => createStrictFixture('${a()}', { a: null }));
     });
 
     it('[text] throws on call scope - prop not a fn', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -7,23 +7,23 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.doesNotThrow(() => createFixture('${a.b}'));
     });
 
-    it('[text] does not throw on optional access member', function () {
+    it('[text] does not throw on access member - missing object + optional access', function () {
       assert.doesNotThrow(() => createFixture('${a?.b}'));
     });
 
-    it('[text] does not throw on access keyed', function () {
+    it('[text] does not throw on access keyed - misssing object', function () {
       assert.doesNotThrow(() => createFixture('${a[b]}'));
     });
 
-    it('[text] does not throw on optional access keyed', function () {
+    it('[text] does not throw on access keyed - missing object + optional access', function () {
       assert.doesNotThrow(() => createFixture('${a?.[b]}'));
     });
 
-    it('[text] does not throw on access keyed with literal', function () {
+    it('[text] does not throw on access keyed - literal key', function () {
       assert.doesNotThrow(() => createFixture('${a[5]}'));
     });
 
-    it('[text] does not throw on call scope with function missing', function () {
+    it('[text] does not throw on call scope - prop missing', function () {
       assert.doesNotThrow(() => createFixture('${a()}'));
     });
 
@@ -31,20 +31,32 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.throws(() => createFixture('${a()}', { a: 5 }));
     });
 
-    it('[text] does not throw on call member with object missing', function () {
+    it('[text] does not throw on call member - object missing', function () {
       assert.doesNotThrow(() => createFixture('${a.b()}'));
     });
 
-    it('[text] does not throw on optional call scope with missing function', function () {
+    it('[text] does not throw on call scope - optional call + missing function', function () {
       assert.doesNotThrow(() => createFixture('${a?.()}'));
     });
 
-    it('[text] does not throw on optional call member with missing prop', function () {
+    it('[text] does not throw on call member - optional call + missing prop', function () {
       assert.doesNotThrow(() => createFixture('${a.b?.()}', { a: {} }));
     });
 
-    it('[text] throws on optional call member - prop is not a fn', function () {
+    it('[text] throws on optional call member - optional call + member is not a fn', function () {
       assert.throws(() => createFixture('${a.b?.()}', { a: { b: 5 } }));
+    });
+
+    it('[text] does not throw on call function - object missing', function () {
+      assert.doesNotThrow(() => createFixture('${a[5]?.()}'));
+    });
+
+    it('[text] does not throw on call function - value is nullish', function () {
+      assert.doesNotThrow(() => createFixture('${a[5]?.()}', { a: {} }));
+    });
+
+    it('[text] throws on call function - value is not a function', function () {
+      assert.throws(() => createFixture('${a[5]?.()}', { a: { 5: 5 } }));
     });
 
     it('[event] does not throw on handler missing - call scope', function () {
@@ -172,6 +184,18 @@ describe('2-runtime/ast.optional.spec.ts', function () {
 
     it('[text] throws on optional call member - member not a fn', function () {
       assert.throws(() => createStrictFixture('${a.b?.()}', { a: { b: 5 } }));
+    });
+
+    it('[text] throws on call function - nullish fn', function () {
+      assert.throws(() => createStrictFixture('${a[5]()}', { a: {  } }));
+    });
+
+    it('[text] does not throw on call function - optional call + nullish fn', function () {
+      assert.doesNotThrow(() => createStrictFixture('${a[5]?.()}', { a: { 5: null } }));
+    });
+
+    it('[text] throws on call function - optional call + fn not a function', function () {
+      assert.throws(() => createStrictFixture('${a[5]?.()}', { a: { 5: 5 } }));
     });
 
     it('[trigger] throws on missing call scope fn', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -147,6 +147,10 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assert.doesNotThrow(() => createFixture('<let id.bind="a.b">'));
     });
 
+    it('[attribute] does not throw on access member - missing object', function () {
+      assert.doesNotThrow(() => createFixture('<div selected.class="a.b">'));
+    });
+
     describe('assignment', function () {
       @customElement({ name: 'my-el', template: '', bindables: [{ name: 'value', mode: 'fromView' }] })
       class MyEl {
@@ -199,8 +203,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       createFixture
         .html(template)
         .deps(...registrations)
-        .component(component)
-        .config({ strictBinding: true })
+        .component(component, { strict: true })
         .build();
 
     it('[text] throws on access member - object missing', function () {
@@ -221,6 +224,10 @@ describe('2-runtime/ast.optional.spec.ts', function () {
 
     it('[let] throws on access member - missing object', function () {
       assert.throws(() => createStrictFixture('<let id.bind="a.b">'));
+    });
+
+    it('[attribute] throws on access member - missing object', function () {
+      assert.throws(() => createStrictFixture('<div selected.class="a.b">'));
     });
 
     it('[text] does not throw on access member - object missing + optional', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -135,6 +135,18 @@ describe('2-runtime/ast.optional.spec.ts', function () {
       assertText('b');
     });
 
+    it('[interpolation] does not throw on access member - missing object', function () {
+      assert.doesNotThrow(() => createFixture('<div id="${a.b}">'));
+    });
+
+    it('[ref] does not throw on access member - missing object', function () {
+      assert.doesNotThrow(() => createFixture('<div ref="a.b">'));
+    });
+
+    it('[let] does not throw on access member - missing object', function () {
+      assert.doesNotThrow(() => createFixture('<let id.bind="a.b">'));
+    });
+
     describe('assignment', function () {
       @customElement({ name: 'my-el', template: '', bindables: [{ name: 'value', mode: 'fromView' }] })
       class MyEl {
@@ -193,6 +205,22 @@ describe('2-runtime/ast.optional.spec.ts', function () {
 
     it('[text] throws on access member - object missing', function () {
       assert.throws(() => createStrictFixture('${a.b}'));
+    });
+
+    // only 1 to test demonstrate strict mode is applied for interpolation
+    // the rest of the tests are assumed to be similar to text binding
+    it('[interpolation] throws on access member - missing object', function () {
+      assert.throws(() => createStrictFixture('<div id="${a.b}">'));
+    });
+
+    // only 1 to test demonstrate strict mode is applied for ref
+    // the rest of the tests are assumed to be similar to text binding
+    it('[ref] throws on access member - missing object', function () {
+      assert.throws(() => createStrictFixture('<div ref="a.b">'));
+    });
+
+    it('[let] throws on access member - missing object', function () {
+      assert.throws(() => createStrictFixture('<let id.bind="a.b">'));
     });
 
     it('[text] does not throw on access member - object missing + optional', function () {

--- a/packages/__tests__/src/2-runtime/ast.optional.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.optional.spec.ts
@@ -42,25 +42,39 @@ describe('2-runtime/ast.optional.spec.ts', function () {
     it('[event] does not throw on handler missing - call scope', function () {
       const { trigger } = createFixture('<div click.trigger="a()"></div>');
 
-      assert.doesNotThrow(() => trigger.click('div'));
+      trigger.click('div');
     });
 
     it('[event] does not throw on event handler missing - call member', function () {
       const { trigger } = createFixture('<div click.trigger="a.b()"></div>');
 
-      assert.doesNotThrow(() => trigger.click('div'));
+      trigger.click('div');
+    });
+
+    it('[event] throws on event handler not a fn - call member', function () {
+      const { platform, trigger } = createFixture('<div click.trigger="a.b()"></div>', { a: { b: 5 } });
+
+      let error: unknown;
+      platform.window.addEventListener('au-event-error', function handler(e: CustomEvent<{ error: Error }>) {
+        e.preventDefault();
+        error = e.detail.error;
+        platform.window.removeEventListener('au-event-error', handler);
+      });
+
+      trigger.click('div');
+      assert.includes(String(error), 'AUR0107:');
     });
 
     it('[event] does not throw on handler missing - call keyed', function () {
       const { trigger } = createFixture('<div click.trigger="a[`b`]()"></div>');
 
-      assert.doesNotThrow(() => trigger.click('div'));
+      trigger.click('div');
     });
 
     it('[event] does not throw on handler missing - complex expression', function () {
       const { trigger } = createFixture('<div click.trigger="(a ? b : c)()"></div>');
 
-      assert.doesNotThrow(() => trigger.click('div'));
+      trigger.click('div');
     });
 
     it('[text] renders empty string on undefined', function () {
@@ -100,7 +114,7 @@ describe('2-runtime/ast.optional.spec.ts', function () {
     });
   });
 
-  describe.only('strict mode', function () {
+  describe('strict mode', function () {
     const createStrictFixture = (template: string, component?: unknown) =>
       createFixture
         .html(template)
@@ -169,6 +183,20 @@ describe('2-runtime/ast.optional.spec.ts', function () {
 
     it('[trigger] throws on call member fn not a fn', function () {
       const { platform, trigger } = createStrictFixture('<div click.trigger="a.b()"></div>', { a: { b: 5 } });
+
+      let error: unknown;
+      platform.window.addEventListener('au-event-error', function handler(e: CustomEvent<{ error: Error }>) {
+        e.preventDefault();
+        error = e.detail.error;
+        platform.window.removeEventListener('au-event-error', handler);
+      });
+
+      trigger.click('div');
+      assert.includes(String(error), 'AUR0107:');
+    });
+
+    it('[trigger] throws on call member optional call - not a fn', function () {
+      const { platform, trigger } = createStrictFixture('<div click.trigger="a.b?.()"></div>', { a: { b: 5 } });
 
       let error: unknown;
       platform.window.addEventListener('au-event-error', function handler(e: CustomEvent<{ error: Error }>) {

--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -673,8 +673,13 @@ describe('2-runtime/ast.spec.ts', function () {
         if (!(obj instanceof Object)) {
           assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
           astAssign(sut, scope, null, 42);
-          assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-          assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          if (obj == null) {
+            assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
+            assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          } else {
+            assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
+            assert.strictEqual((scope.bindingContext['foo'] as IIndexable), obj, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          }
         }
       });
 
@@ -699,13 +704,16 @@ describe('2-runtime/ast.spec.ts', function () {
         if (!(obj instanceof Object)) {
           assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
           astAssign(sut, scope, null, 42);
-          assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-          assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          if (obj == null) {
+            assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
+            assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          } else {
+            assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
+            assert.strictEqual((scope.bindingContext['foo'] as IIndexable), obj, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
+          }
         }
       });
-
-    })
-    );
+    }));
 
     it('evaluates member on bindingContext', function () {
       const scope = createScopeForTest({ foo: { bar: 'baz' } });

--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -666,20 +666,15 @@ describe('2-runtime/ast.spec.ts', function () {
         astEvaluate(sut, scope, dummyLocator, binding);
         assert.strictEqual(
           binding.calls.filter(c => c[0] === 'observe').length,
-          obj == null ? 1 : 2,
+          2,
           `binding.calls.filter(c => c[0] === 'observe').length`
         );
 
         if (!(obj instanceof Object)) {
           assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-          astAssign(sut, scope, null, 42);
-          if (obj == null) {
-            assert.instanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-            assert.strictEqual((scope.bindingContext['foo'] as IIndexable)[prop], 42, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
-          } else {
-            assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
-            assert.strictEqual((scope.bindingContext['foo'] as IIndexable), obj, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
-          }
+          astAssign(sut, scope, null, 42);// }
+          assert.notInstanceOf(scope.bindingContext['foo'], Object, `scope.bindingContext['foo']`);
+          assert.strictEqual((scope.bindingContext['foo'] as IIndexable), obj, `(scope.bindingContext['foo'] as IIndexable)[prop]`);
         }
       });
 
@@ -1035,19 +1030,19 @@ describe('2-runtime/ast.spec.ts', function () {
 
       expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $null);
       scope = createScopeForTest({});
-      assert.strictEqual(astEvaluate(expression, scope, null, null), 'a', `astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(astEvaluate(expression, scope, null, null), 'anull', `astEvaluate(expression, scope, null, null)`);
 
       expression = new BinaryExpression('+', $null, new PrimitiveLiteralExpression('b'));
       scope = createScopeForTest({});
-      assert.strictEqual(astEvaluate(expression, scope, null, null), 'b', `astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(astEvaluate(expression, scope, null, null), 'nullb', `astEvaluate(expression, scope, null, null)`);
 
       expression = new BinaryExpression('+', new PrimitiveLiteralExpression('a'), $undefined);
       scope = createScopeForTest({});
-      assert.strictEqual(astEvaluate(expression, scope, null, null), 'a', `astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(astEvaluate(expression, scope, null, null), 'aundefined', `astEvaluate(expression, scope, null, null)`);
 
       expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression('b'));
       scope = createScopeForTest({});
-      assert.strictEqual(astEvaluate(expression, scope, null, null), 'b', `astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(astEvaluate(expression, scope, null, null), 'undefinedb', `astEvaluate(expression, scope, null, null)`);
     });
 
     it(`adds numbers`, function () {

--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -1302,10 +1302,10 @@ describe('2-runtime/ast.spec.ts', function () {
       const s2 = createScopeForTest({ foo: {} });
       const s3 = createScopeForTest({ foo: { bar: undefined } });
       const s4 = createScopeForTest({ foo: { bar: null } });
-      assert.throws(() => astEvaluate(expression, s1, { strictFnCall: true }, null));
-      assert.throws(() => astEvaluate(expression, s2, { strictFnCall: true }, null));
-      assert.throws(() => astEvaluate(expression, s3, { strictFnCall: true }, null));
-      assert.throws(() => astEvaluate(expression, s4, { strictFnCall: true }, null));
+      assert.throws(() => astEvaluate(expression, s1, { strict: true }, null));
+      assert.throws(() => astEvaluate(expression, s2, { strict: true }, null));
+      assert.throws(() => astEvaluate(expression, s3, { strict: true }, null));
+      assert.throws(() => astEvaluate(expression, s4, { strict: true }, null));
     });
   });
 

--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -1058,11 +1058,11 @@ describe('2-runtime/ast.spec.ts', function () {
 
       expression = new BinaryExpression('+', new PrimitiveLiteralExpression(1), $undefined);
       scope = createScopeForTest({});
-      assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), false, `isNaN(astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), true, `isNaN(astEvaluate(expression, scope, null, null)`);
 
       expression = new BinaryExpression('+', $undefined, new PrimitiveLiteralExpression(2));
       scope = createScopeForTest({});
-      assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), false, `isNaN(astEvaluate(expression, scope, null, null)`);
+      assert.strictEqual(isNaN(astEvaluate(expression, scope, null, null) as number), true, `isNaN(astEvaluate(expression, scope, null, null)`);
     });
 
     it(`concats strings - STRICT`, function () {

--- a/packages/__tests__/src/2-runtime/ast.spec.ts
+++ b/packages/__tests__/src/2-runtime/ast.spec.ts
@@ -1,6 +1,5 @@
 import { IServiceLocator, Writable, IIndexable } from '@aurelia/kernel';
 import {
-  eachCartesianJoin,
   eachCartesianJoinFactory,
   createScopeForTest,
   MockTracingExpression,

--- a/packages/__tests__/src/2-runtime/binding-mode-behaviors.spec.ts
+++ b/packages/__tests__/src/2-runtime/binding-mode-behaviors.spec.ts
@@ -44,6 +44,7 @@ describe('2-runtime/binding-mode-behaviors.spec.ts', function () {
             undefined,
             undefined,
             initMode,
+            false,
           );
           sut.bind(undefined, binding);
         });

--- a/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
@@ -132,21 +132,21 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
-        interpolation: `$\{value}`, it: 'Date works and setDate triggers change properly'
+        interpolation: `$\{value}`, it: 'Date works and setDate triggers change properly',
       },
       {
-        expected: `undefined${testDateString}`,
+        expected: `${testDateString}`,
         expectedStrictMode: `undefined${testDateString}`,
-        expectedValueAfterChange: `undefined${ThreeDaysDateString}`,
+        expectedValueAfterChange: `${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
         interpolation: `$\{undefined + value}`, it: 'Date works with undefined expression and setDate triggers change properly',
       },
       {
-        expected: `null${testDateString}`,
+        expected: `${testDateString}`,
         expectedStrictMode: `null${testDateString}`,
-        expectedValueAfterChange: `null${ThreeDaysDateString}`,
+        expectedValueAfterChange: `${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
@@ -318,7 +318,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
       if (x.expectedStrictMode) {
         $it(`${x.it} STRICT MODE `, async function () {
           const strict = CustomElement.define({ name: 'strict', template: `${x.interpolation}` }, x.app);
-          const { tearDown, appHost } = createFixture(`<template><strict></strict></template>`, class { }, [strict]);
+          const { tearDown, appHost } = createFixture(`<template><strict></strict></template>`, class { }, [strict], void 0, void 0, { strictBinding: true });
           assert.strictEqual(appHost.textContent, x.expectedStrictMode.toString(), `host.textContent`);
           await tearDown();
         });

--- a/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
@@ -135,18 +135,18 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
         interpolation: `$\{value}`, it: 'Date works and setDate triggers change properly',
       },
       {
-        expected: `${testDateString}`,
+        expected: `undefined${testDateString}`,
         expectedStrictMode: `undefined${testDateString}`,
-        expectedValueAfterChange: `${ThreeDaysDateString}`,
+        expectedValueAfterChange: `undefined${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },
         interpolation: `$\{undefined + value}`, it: 'Date works with undefined expression and setDate triggers change properly',
       },
       {
-        expected: `${testDateString}`,
+        expected: `null${testDateString}`,
         expectedStrictMode: `null${testDateString}`,
-        expectedValueAfterChange: `${ThreeDaysDateString}`,
+        expectedValueAfterChange: `null${ThreeDaysDateString}`,
         changeFnc: (_val: Date) => {
           return new Date(ThreeDaysDateString);
         }, app: class { public value = new Date('Sat Feb 02 2002 00:00:00 GMT+0000 (Coordinated Universal Time)'); },

--- a/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/interpolation.spec.ts
@@ -317,8 +317,8 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
       });
       if (x.expectedStrictMode) {
         $it(`${x.it} STRICT MODE `, async function () {
-          const strict = CustomElement.define({ name: 'strict', template: `${x.interpolation}` }, x.app);
-          const { tearDown, appHost } = createFixture(`<template><strict></strict></template>`, class { }, [strict], void 0, void 0, { strictBinding: true });
+          const strict = CustomElement.define({ name: 'strict', template: `${x.interpolation}`, strict: true }, x.app);
+          const { tearDown, appHost } = createFixture(`<template><strict></strict></template>`, class { }, [strict], void 0, void 0);
           assert.strictEqual(appHost.textContent, x.expectedStrictMode.toString(), `host.textContent`);
           await tearDown();
         });
@@ -347,6 +347,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
           target,
           'value',
           BindingMode.toView,
+          false,
         );
         const source = { checked: false, yesMsg: 'yes', noMsg: 'no' };
 
@@ -431,6 +432,7 @@ describe('3-runtime-html/interpolation.spec.ts', function () {
           target,
           'value',
           BindingMode.toView,
+          false,
         );
         const source = {
           checked1: false,

--- a/packages/__tests__/src/compat-v1/call.spec.ts
+++ b/packages/__tests__/src/compat-v1/call.spec.ts
@@ -4,6 +4,23 @@ import { assert, createFixture } from '@aurelia/testing';
 
 describe('compat-v1/call.spec.ts', function () {
 
+  it('does not throw on missing function', function () {
+
+    @customElement({ name: 'my-ce', template: '<button click.trigger="action()"></button>' })
+    class MyCe {
+      @bindable public action: () => void;
+    }
+
+    const { trigger } = createFixture(
+      '<my-ce action.bind="a.b()"></my-ce>',
+      class App {
+      },
+      [MyCe, compatRegistration]
+    );
+
+    trigger.click('button');
+  });
+
   it('works with function call binding', async function () {
     @customElement({ name: 'my-ce', template: '<button click.trigger="action()"></button>' })
     class MyCe {

--- a/packages/__tests__/src/compat-v1/event.spec.ts
+++ b/packages/__tests__/src/compat-v1/event.spec.ts
@@ -3,6 +3,17 @@ import { assert, createFixture } from '@aurelia/testing';
 
 describe('compat-v1/event.spec.ts', function () {
 
+  it('does not throw when function is missing', function () {
+    const { trigger } = createFixture(
+      '<button click.delegate="a.b()">',
+      class App {
+      },
+      [compatRegistration]
+    );
+
+    trigger.click('button', { bubbles: true});
+  });
+
   it('works with delegate event binding', function () {
     const { trigger, component } = createFixture(
       '<button click.delegate="doSomething()"></my-ce>',

--- a/packages/__tests__/src/setup-shared.ts
+++ b/packages/__tests__/src/setup-shared.ts
@@ -18,7 +18,9 @@ export function $setup(platform: BrowserPlatform): void {
   setPlatform(platform);
   BrowserPlatform.set(globalThis, platform);
 
-  if (typeof window !== 'undefined') window.addEventListener('error', e => console.log(e));
+  if (typeof window !== 'undefined') window.addEventListener('error', e => {
+    console.log('Globally caught error:', String(e.error));
+  });
 
   const globalStart = platform.performanceNow();
   let firstTestStart = 0;

--- a/packages/__tests__/src/state/state.spec.ts
+++ b/packages/__tests__/src/state/state.spec.ts
@@ -35,6 +35,25 @@ describe('state/state.spec.ts', function () {
     assertValue('input', '1');
   });
 
+  it('does not throw in access member - object nullish', async function () {
+    const state = { a: null };
+    assert.doesNotThrow(() => createFixture
+      .html`<input value.state="a.b">`
+      .deps(StateDefaultConfiguration.init(state))
+      .build()
+    );
+  });
+
+  it('[strict] throws in access member - object nullish', async function () {
+    const state = { a: null };
+    assert.throws(() => createFixture
+      .html`<input value.state="a.b">`
+      .component(class { static strict = true; })
+      .deps(StateDefaultConfiguration.init(state))
+      .build()
+    );
+  });
+
   it('works with value converter', async function () {
     const state = { text: 'aaa' };
     const { getBy } = await createFixture

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -1229,7 +1229,7 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
 
         assert.equal(controller.results.filter((r) => !r.valid && r.propertyName === 'address.pin').length, 0, 'error1');
         await controller.validate();
-        assert.equal(controller.results.filter((r) => !r.valid && r.propertyName === 'address.pin').length, 0, 'error2');
+        assert.equal(controller.results.filter((r) => !r.valid && r.propertyName === 'address.pin').length, 1, 'error2');
 
         target.value = '123456';
         await assertEventHandler(target, 'change', 1, platform, app.controllerValidateBindingSpy, app.controllerValidateSpy, ctx);

--- a/packages/compat-v1/src/compat-call.ts
+++ b/packages/compat-v1/src/compat-call.ts
@@ -100,7 +100,7 @@ export class CallBinding implements IBinding {
   static {
     mixinUseScope(CallBinding);
     mixingBindingLimited(CallBinding, () => 'callSource');
-    mixinAstEvaluator(true)(CallBinding);
+    mixinAstEvaluator(CallBinding);
   }
 
   public isBound: boolean = false;

--- a/packages/compat-v1/src/compat-event.ts
+++ b/packages/compat-v1/src/compat-event.ts
@@ -123,7 +123,7 @@ export class DelegateListenerBinding implements IBinding {
   static {
     mixinUseScope(DelegateListenerBinding);
     mixingBindingLimited(DelegateListenerBinding, () => 'callSource');
-    mixinAstEvaluator(true, true)(DelegateListenerBinding);
+    mixinAstEvaluator(DelegateListenerBinding);
   }
 
   public isBound: boolean = false;

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -141,6 +141,8 @@ export class TranslationBinding implements IBinding {
   /** @internal */
   public readonly boundFn = false;
 
+  public strict = true;
+
   public constructor(
     controller: IBindingController,
     locator: IServiceLocator,
@@ -355,7 +357,7 @@ export class TranslationBinding implements IBinding {
   }
 }
 connectable(TranslationBinding, null!);
-mixinAstEvaluator(true)(TranslationBinding);
+mixinAstEvaluator(TranslationBinding);
 mixingBindingLimited(TranslationBinding, () => 'updateTranslations');
 
 class AccessorUpdateTask {
@@ -374,6 +376,11 @@ class AccessorUpdateTask {
 interface ParameterBinding extends IAstEvaluator, IObserverLocatorBasedConnectable, IServiceLocator {}
 
 class ParameterBinding implements IBinding {
+  static {
+    connectable(ParameterBinding, null!);
+    mixinAstEvaluator(ParameterBinding);
+  }
+
   public isBound: boolean = false;
   public value!: i18next.TOptions;
   /**
@@ -390,6 +397,8 @@ class ParameterBinding implements IBinding {
   // see Listener binding for explanation
   /** @internal */
   public readonly boundFn = false;
+
+  public strict = true;
 
   public constructor(
     public readonly owner: TranslationBinding,
@@ -436,5 +445,3 @@ class ParameterBinding implements IBinding {
   }
 }
 
-connectable(ParameterBinding, null!);
-mixinAstEvaluator(true)(ParameterBinding);

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -11,7 +11,6 @@ import type { ICustomElementViewModel, ICustomElementController } from './templa
 import { IPlatform } from './platform';
 import { IEventTarget, registerHostNode } from './dom';
 import { ErrorNames, createMappedError } from './errors';
-import { IBindingConfiguration } from './renderer';
 
 export interface IAppRootConfig<T extends object = object> {
   host: HTMLElement;
@@ -91,7 +90,6 @@ export class AppRoot<
 
     registerResolver(container, IEventTarget, new InstanceProvider<IEventTarget>('IEventTarget', host));
     registerHostNode(container, host, this.platform = this._createPlatform(container, host));
-    registerResolver(container, IBindingConfiguration, new InstanceProvider<IBindingConfiguration>('IBindingConfiguration', { strict: config.strictBinding ?? false }));
 
     this._hydratePromise = onResolve(this._runAppTasks('creating'), () => {
       if (!config.allowActionlessForm !== false) {
@@ -117,7 +115,7 @@ export class AppRoot<
 
       const hydrationInst: IControllerElementHydrationInstruction = { hydrate: false, projections: null };
       const definition = enhance
-        ? CustomElementDefinition.create({ name: generateElementName(), template: this.host, enhance: true })
+        ? CustomElementDefinition.create({ name: generateElementName(), template: this.host, enhance: true, strict: config.strictBinding })
         // leave the work of figuring out the definition to the controller
         // there's proper error messages in case of failure inside the $el() call
         : void 0;

--- a/packages/runtime-html/src/app-root.ts
+++ b/packages/runtime-html/src/app-root.ts
@@ -11,6 +11,7 @@ import type { ICustomElementViewModel, ICustomElementController } from './templa
 import { IPlatform } from './platform';
 import { IEventTarget, registerHostNode } from './dom';
 import { ErrorNames, createMappedError } from './errors';
+import { IBindingConfiguration } from './renderer';
 
 export interface IAppRootConfig<T extends object = object> {
   host: HTMLElement;
@@ -22,6 +23,16 @@ export interface IAppRootConfig<T extends object = object> {
    * This option re-enables the default behavior of HTML forms.
    */
   allowActionlessForm?: boolean;
+  /**
+   * Indicates strictness of expression evaluation.
+   *
+   * When strictBinding is true, standard JS behavior applies, which means accessing a property of undefined will throw an error.
+   * Use optional syntaxes (?./?.()/?.[]) to prevent errors.
+   *
+   * When strictBinding is false (default), the behavior is more lenient, which means accessing a property of undefined will return undefined.
+   * In this mode, calling an undefined function will return undefined as well.
+   */
+  strictBinding?: boolean;
 }
 
 export interface IAppRoot<C extends object = object> extends IDisposable {
@@ -80,6 +91,7 @@ export class AppRoot<
 
     registerResolver(container, IEventTarget, new InstanceProvider<IEventTarget>('IEventTarget', host));
     registerHostNode(container, host, this.platform = this._createPlatform(container, host));
+    registerResolver(container, IBindingConfiguration, new InstanceProvider<IBindingConfiguration>('IBindingConfiguration', { strict: config.strictBinding ?? false }));
 
     this._hydratePromise = onResolve(this._runAppTasks('creating'), () => {
       if (!config.allowActionlessForm !== false) {

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -178,25 +178,22 @@ export const {
         }
       }
       case ekCallScope: {
-        const args = ast.args.map(a => astEvaluate(a, s, e, c));
         const context = getContext(s, ast.name, ast.ancestor)!;
         // ideally, should observe property represents by ast.name as well
         // because it could be changed
         // todo: did it ever surprise anyone?
-        const func = getFunction(e?.strictFnCall, context, ast.name);
+        const func = getFunction(e?.strict, context, ast.name);
         if (func) {
-          return func.apply(context, args);
+          return func.apply(context, ast.args.map(a => astEvaluate(a, s, e, c)));
         }
         return void 0;
       }
       case ekCallMember: {
         const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
-
-        const args = ast.args.map(a => astEvaluate(a, s, e, c));
-        const func = getFunction(e?.strictFnCall, instance, ast.name);
+        const func = getFunction(e?.strict, instance, ast.name);
         let ret: unknown;
         if (func) {
-          ret = func.apply(instance, args);
+          ret = func.apply(instance, ast.args.map(a => astEvaluate(a, s, e, c)));
           // todo(doc): investigate & document in engineering doc the difference
           //            between observing before/after func.apply
           if (isArray(instance) && autoObserveArrayMethods.includes(ast.name)) {
@@ -210,7 +207,7 @@ export const {
         if (isFunction(func)) {
           return func(...ast.args.map(a => astEvaluate(a, s, e, c)));
         }
-        if (!e?.strictFnCall && func == null) {
+        if (!e?.strict) {
           return void 0;
         }
         throw createMappedError(ErrorNames.ast_not_a_function);

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -323,18 +323,8 @@ export const {
             }
             return false;
           }
-          case '+': {
-            const $left: unknown = astEvaluate(left, s, e, c);
-            const $right: unknown = astEvaluate(right, s, e, c);
-
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if ((!$left || !$right) && !e?.strict) {
-              if (isStringOrDate($left) || isStringOrDate($right)) {
-                return ($left as string || '') + ($right as string || '');
-              }
-            }
-            return ($left as number) + ($right as number);
-          }
+          case '+':
+            return (astEvaluate(left, s, e, c) as number) + (astEvaluate(right, s, e, c) as number);
           case '-':
             return (astEvaluate(left, s, e, c) as number) - (astEvaluate(right, s, e, c) as number);
           case '*':
@@ -679,22 +669,6 @@ export const {
       }
     }
   }
-
-  /**
-   * Determines if the value passed is a string or Date for parsing purposes
-   *
-   * @param value - Value to evaluate
-   */
-  const isStringOrDate = (value: unknown): value is string | Date => {
-    switch (typeof value) {
-      case 'string':
-        return true;
-      case 'object':
-        return value instanceof Date;
-      default:
-        return false;
-    }
-  };
 
   const autoObserveArrayMethods =
     'at map filter includes indexOf lastIndexOf findIndex find flat flatMap join reduce reduceRight slice every some sort'.split(' ');

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -251,14 +251,20 @@ export const {
       case ekAccessKeyed: {
         const instance = astEvaluate(ast.object, s, e, c) as IIndexable;
         const key = astEvaluate(ast.key, s, e, c) as string;
-        if (isObject(instance)) {
-          if (c !== null && !ast.accessGlobal) {
-            c.observe(instance, key);
+
+        if (instance == null) {
+          if (e?.strict) {
+            throw createMappedError(ErrorNames.ast_nullish_keyed_access, key, instance);
           }
-          return instance[key];
+          return instance;
         }
+
+        if (c !== null && !ast.accessGlobal) {
+          c.observe(instance, key);
+        }
+
         return instance == null
-          ? ''
+          ? instance
           : instance[key];
       }
       case ekTaggedTemplate: {

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -249,7 +249,7 @@ export const {
       case ekAccessMember: {
         const instance = astEvaluate(ast.object, s, e, c) as IIndexable | null;
         if (instance == null) {
-          if (e?.strict) {
+          if (e?.strict && !ast.optional) {
             throw createMappedError(ErrorNames.ast_nullish_member_access, ast.name, instance);
           }
           return void 0;
@@ -269,7 +269,7 @@ export const {
         const key = astEvaluate(ast.key, s, e, c) as string;
 
         if (instance == null) {
-          if (e?.strict) {
+          if (e?.strict && !ast.optional) {
             throw createMappedError(ErrorNames.ast_nullish_keyed_access, key, instance);
           }
           return void 0;

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -125,7 +125,7 @@ export const {
           return func(...ast.args.map(a => astEvaluate(a, s, e, c)));
         }
         /* istanbul ignore next */
-        if (!e?.strictFnCall && func == null) {
+        if (!e?.strict && func == null) {
           return void 0;
         }
         throw createMappedError(ErrorNames.ast_not_a_function);

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -203,10 +203,7 @@ export const {
           return void 0;
         }
         if (!isFunction(fn)) {
-          if (e?.strict) {
-            throw createMappedError(ErrorNames.ast_not_a_function);
-          }
-          return void 0;
+          throw createMappedError(ErrorNames.ast_not_a_function);
         }
         const ret = fn.apply(instance, ast.args.map(a => astEvaluate(a, s, e, c)));
         if (isArray(instance) && autoObserveArrayMethods.includes(ast.name)) {

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -107,20 +107,15 @@ export const {
           c.observe(obj, ast.name);
         }
         const evaluatedValue: unknown = obj[ast.name];
-        if (evaluatedValue == null && ast.name === '$host') {
-          throw createMappedError(ErrorNames.ast_$host_not_found);
+        if (evaluatedValue == null) {
+          if (ast.name === '$host') {
+            throw createMappedError(ErrorNames.ast_$host_not_found);
+          }
+          return evaluatedValue;
         }
-        if (e?.strict) {
-          // return evaluatedValue;
-          return e?.boundFn && isFunction(evaluatedValue)
-            ? evaluatedValue.bind(obj)
-            : evaluatedValue;
-        }
-        return evaluatedValue == null
-          ? null
-          : e?.boundFn && isFunction(evaluatedValue)
-            ? evaluatedValue.bind(obj)
-            : evaluatedValue;
+        return e?.boundFn && isFunction(evaluatedValue)
+          ? evaluatedValue.bind(obj)
+          : evaluatedValue;
       }
       case ekAccessGlobal:
         return globalThis[ast.name as keyof typeof globalThis];
@@ -284,9 +279,7 @@ export const {
           c.observe(instance, key);
         }
 
-        return instance == null
-          ? instance
-          : instance[key];
+        return instance[key];
       }
       case ekTaggedTemplate: {
         const results = ast.expressions.map(expr => astEvaluate(expr, s, e, c));

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -252,7 +252,7 @@ export const {
           if (e?.strict) {
             throw createMappedError(ErrorNames.ast_nullish_member_access, ast.name, instance);
           }
-          return instance;
+          return void 0;
         }
 
         if (c !== null && !ast.accessGlobal) {
@@ -272,7 +272,7 @@ export const {
           if (e?.strict) {
             throw createMappedError(ErrorNames.ast_nullish_keyed_access, key, instance);
           }
-          return instance;
+          return void 0;
         }
 
         if (c !== null && !ast.accessGlobal) {
@@ -340,7 +340,7 @@ export const {
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             if (!$left || !$right) {
               if (isNumberOrBigInt($left) || isNumberOrBigInt($right)) {
-                return ($left as number || 0) + ($right as number || 0);
+                return ($left as number) + ($right as number);
               }
               if (isStringOrDate($left) || isStringOrDate($right)) {
                 return ($left as string || '') + ($right as string || '');

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -28,8 +28,6 @@ export interface IAstEvaluator {
   strict?: boolean;
   /** describe whether the evaluator wants a bound function to be returned, in case the returned value is a function */
   boundFn?: boolean;
-  /** describe whether the evaluator wants to evaluate the function call in strict mode */
-  strictFnCall?: boolean;
   /** Allow an AST to retrieve a signaler instance for connecting/disconnecting */
   getSignaler?(): ISignaler;
   /** Allow an AST to retrieve a value converter that it needs */

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -323,23 +323,12 @@ export const {
             }
             return false;
           }
-          // note: autoConvertAdd (and the null check) is removed because the default spec behavior is already largely similar
-          // and where it isn't, you kind of want it to behave like the spec anyway (e.g. return NaN when adding a number to undefined)
-          // ast makes bugs in user code easier to track down for end users
-          // also, skipping these checks and leaving it to the runtime is a nice little perf boost and simplifies our code
           case '+': {
             const $left: unknown = astEvaluate(left, s, e, c);
             const $right: unknown = astEvaluate(right, s, e, c);
 
-            if (e?.strict) {
-              return ($left as number) + ($right as number);
-            }
-
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            if (!$left || !$right) {
-              if (isNumberOrBigInt($left) || isNumberOrBigInt($right)) {
-                return ($left as number) + ($right as number);
-              }
+            if ((!$left || !$right) && !e?.strict) {
               if (isStringOrDate($left) || isStringOrDate($right)) {
                 return ($left as string || '') + ($right as string || '');
               }
@@ -690,21 +679,6 @@ export const {
       }
     }
   }
-
-  /**
-   * Determines if the value passed is a number or bigint for parsing purposes
-   *
-   * @param value - Value to evaluate
-   */
-  const isNumberOrBigInt = (value: unknown): value is number | bigint => {
-    switch (typeof value) {
-      case 'number':
-      case 'bigint':
-        return true;
-      default:
-        return false;
-    }
-  };
 
   /**
    * Determines if the value passed is a string or Date for parsing purposes

--- a/packages/runtime-html/src/ast.eval.ts
+++ b/packages/runtime-html/src/ast.eval.ts
@@ -216,10 +216,13 @@ export const {
         if (isFunction(func)) {
           return func(...ast.args.map(a => astEvaluate(a, s, e, c)));
         }
-        if (e?.strict) {
-          throw createMappedError(ErrorNames.ast_not_a_function);
+        if (func == null) {
+          if (!ast.optional && e?.strict) {
+            throw createMappedError(ErrorNames.ast_not_a_function);
+          }
+          return void 0;
         }
-        return void 0;
+        throw createMappedError(ErrorNames.ast_not_a_function);
       }
       case ekArrowFunction: {
         const func = (...args: unknown[]) => {

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -1,5 +1,5 @@
 import { isPromise, DI, InstanceProvider, onResolve } from '@aurelia/kernel';
-import { AppRoot, IAppRoot } from './app-root';
+import { AppRoot, IAppRoot, IAppRootConfig } from './app-root';
 import { createInterface, registerResolver } from './utilities-di';
 
 import type {
@@ -62,7 +62,7 @@ export class Aurelia implements IDisposable {
     return this;
   }
 
-  public app(config: ISinglePageAppConfig<object>): Omit<this, 'register' | 'app' | 'enhance'> {
+  public app(config: ISinglePageAppConfig): Omit<this, 'register' | 'app' | 'enhance'> {
     this.next = new AppRoot(config, this.container, this._rootProvider);
     return this;
   }
@@ -152,25 +152,11 @@ export class Aurelia implements IDisposable {
   }
 }
 
-export interface ISinglePageAppConfig<T = unknown> {
-  /**
-   * The host element of the app
-   */
-  host: HTMLElement;
-  /**
-   * The root component of the app
-   */
-  component: T | Constructable<T>;
-  /**
-   * When a HTML form is submitted, the default behavior is to "redirect" the page to the action of the form
-   * This is not desirable for SPA applications, so by default, this behavior is prevented.
-   *
-   * This option re-enables the default behavior of HTML forms.
-   */
-  allowActionlessForm?: boolean;
-}
+export type ISinglePageAppConfig<T extends object = object> = IAppRootConfig<T> & {
+  host: Element;
+};
 
-export interface IEnhancementConfig<T> {
+export type IEnhancementConfig<T extends object = object> = IAppRootConfig<T> & {
   host: Element;
   /**
    * The binding context of the enhancement. Will be instantiate by DI if a constructor is given
@@ -180,11 +166,4 @@ export interface IEnhancementConfig<T> {
    * A predefined container for the enhanced view.
    */
   container?: IContainer;
-  /**
-   * When a HTML form is submitted, the default behavior is to "redirect" the page to the action of the form
-   * This is not desirable for SPA applications, so by default, this behavior is prevented.
-   *
-   * This option re-enables the default behavior of HTML forms.
-   */
-  allowActionlessForm?: boolean;
-}
+};

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -152,7 +152,7 @@ export class Aurelia implements IDisposable {
   }
 }
 
-export type ISinglePageAppConfig<T extends object = object> = IAppRootConfig<T> & {
+export type ISinglePageAppConfig<T extends object = object> = Omit<IAppRootConfig<T>, 'strictBinding'> & {
   host: Element;
 };
 

--- a/packages/runtime-html/src/binding/attribute-binding.ts
+++ b/packages/runtime-html/src/binding/attribute-binding.ts
@@ -43,7 +43,7 @@ export class AttributeBinding implements IBinding, ISubscriber, ICollectionSubsc
       mixinUseScope(AttributeBinding);
       mixingBindingLimited(AttributeBinding, () => 'updateTarget');
       connectable(AttributeBinding, null!);
-      mixinAstEvaluator(true)(AttributeBinding);
+      mixinAstEvaluator(AttributeBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/attribute-binding.ts
+++ b/packages/runtime-html/src/binding/attribute-binding.ts
@@ -95,6 +95,7 @@ export class AttributeBinding implements IBinding, ISubscriber, ICollectionSubsc
     public targetAttribute: string,
     public targetProperty: string,
     public mode: BindingMode,
+    public strict: boolean,
   ) {
     this.l = locator;
     this.ast = ast;

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -5,7 +5,7 @@ import { astEvaluate } from '../ast.eval';
 import { type IBinding, type IRateLimitOptions } from './interfaces-bindings';
 import { BindingBehavior, BindingBehaviorInstance } from '../resources/binding-behavior';
 import { ValueConverter, ValueConverterInstance } from '../resources/value-converter';
-import { addSignalListener, def, defineHiddenProp, removeSignalListener, tsPending } from '../utilities';
+import { addSignalListener, defineHiddenProp, removeSignalListener, tsPending } from '../utilities';
 import { createInterface } from '../utilities-di';
 import { PropertyBinding } from './property-binding';
 import { ErrorNames, createMappedError } from '../errors';
@@ -97,20 +97,12 @@ export const mixinAstEvaluator = /*@__PURE__*/(() => {
     return resourceLookup[name] ??= BindingBehavior.get(this.l, name);
   }
 
-  return (strict?: boolean | undefined, strictFnCall = true) => {
-    return <T extends { l: IServiceLocator }>(target: Constructable<T>) => {
-      const proto = target.prototype;
-      // some evaluator may have their strict configurable in some way
-      // undefined to leave the property alone
-      if (strict != null) {
-        def(proto, 'strict', { enumerable: true, get: function () { return strict; } });
-      }
-      def(proto, 'strictFnCall', { enumerable: true, get: function () { return strictFnCall; } });
-      defineHiddenProp(proto, 'get', evaluatorGet<T>);
-      defineHiddenProp(proto, 'getSignaler', evaluatorGetSignaler<T>);
-      defineHiddenProp(proto, 'getConverter', evaluatorGetConverter<T>);
-      defineHiddenProp(proto, 'getBehavior', evaluatorGetBehavior<T>);
-    };
+  return <T extends { l: IServiceLocator }>(target: Constructable<T>) => {
+    const proto = target.prototype;
+    defineHiddenProp(proto, 'get', evaluatorGet<T>);
+    defineHiddenProp(proto, 'getSignaler', evaluatorGetSignaler<T>);
+    defineHiddenProp(proto, 'getConverter', evaluatorGetConverter<T>);
+    defineHiddenProp(proto, 'getBehavior', evaluatorGetBehavior<T>);
   };
 })();
 class ResourceLookup {

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -77,7 +77,7 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
   /** @internal */
   public readonly boundFn = false;
 
-  public strict = true;
+  public strict = false;
 
   public constructor(
     controller: IBindingController,

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -40,7 +40,7 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
     mixinUseScope(ContentBinding);
     mixingBindingLimited(ContentBinding, () => 'updateTarget');
     connectable(ContentBinding, null!);
-    mixinAstEvaluator(void 0, false)(ContentBinding);
+    mixinAstEvaluator(ContentBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -77,8 +77,6 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
   /** @internal */
   public readonly boundFn = false;
 
-  public strict = false;
-
   public constructor(
     controller: IBindingController,
     locator: IServiceLocator,
@@ -87,6 +85,7 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
     private readonly p: IPlatform,
     public readonly ast: IsExpression,
     public readonly target: Text,
+    public strict = false,
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/content-binding.ts
+++ b/packages/runtime-html/src/binding/content-binding.ts
@@ -85,7 +85,7 @@ export class ContentBinding implements IBinding, ISubscriber, ICollectionSubscri
     private readonly p: IPlatform,
     public readonly ast: IsExpression,
     public readonly target: Text,
-    public strict = false,
+    public strict: boolean,
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -73,7 +73,7 @@ export class InterpolationBinding implements IBinding, ISubscriber, ICollectionS
     public target: object,
     public targetProperty: string,
     public mode: BindingMode,
-    public strict = false,
+    public strict: boolean,
   ) {
     this._controller = controller;
     this.oL = observerLocator;
@@ -217,7 +217,7 @@ export class InterpolationPartBinding implements IBinding, ICollectionSubscriber
     public readonly targetProperty: string,
     locator: IServiceLocator,
     observerLocator: IObserverLocator,
-    public strict = false,
+    public strict: boolean,
     public readonly owner: InterpolationBinding,
   ) {
     this.l = locator;

--- a/packages/runtime-html/src/binding/interpolation-binding.ts
+++ b/packages/runtime-html/src/binding/interpolation-binding.ts
@@ -72,7 +72,8 @@ export class InterpolationBinding implements IBinding, ISubscriber, ICollectionS
     public ast: Interpolation,
     public target: object,
     public targetProperty: string,
-    public mode: BindingMode
+    public mode: BindingMode,
+    public strict = false,
   ) {
     this._controller = controller;
     this.oL = observerLocator;
@@ -83,7 +84,7 @@ export class InterpolationBinding implements IBinding, ISubscriber, ICollectionS
     const ii = expressions.length;
     let i = 0;
     for (; ii > i; ++i) {
-      partBindings[i] = new InterpolationPartBinding(expressions[i], target, targetProperty, locator, observerLocator, this);
+      partBindings[i] = new InterpolationPartBinding(expressions[i], target, targetProperty, locator, observerLocator, strict, this);
     }
   }
 
@@ -185,7 +186,7 @@ export class InterpolationPartBinding implements IBinding, ICollectionSubscriber
     mixinUseScope(InterpolationPartBinding);
     mixingBindingLimited(InterpolationPartBinding, () => 'updateTarget');
     connectable(InterpolationPartBinding, null!);
-    mixinAstEvaluator(true)(InterpolationPartBinding);
+    mixinAstEvaluator(InterpolationPartBinding);
   });
 
   // at runtime, mode may be overriden by binding behavior
@@ -216,6 +217,7 @@ export class InterpolationPartBinding implements IBinding, ICollectionSubscriber
     public readonly targetProperty: string,
     locator: IServiceLocator,
     observerLocator: IObserverLocator,
+    public strict = false,
     public readonly owner: InterpolationBinding,
   ) {
     this.l = locator;

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -30,7 +30,7 @@ export class LetBinding implements IBinding, ISubscriber, ICollectionSubscriber 
     mixinUseScope(LetBinding);
     mixingBindingLimited(LetBinding, () => 'updateTarget');
     connectable(LetBinding, null!);
-    mixinAstEvaluator(true)(LetBinding);
+    mixinAstEvaluator()(LetBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -66,13 +66,13 @@ export class LetBinding implements IBinding, ISubscriber, ICollectionSubscriber 
     observerLocator: IObserverLocator,
     public ast: IsExpression,
     public targetProperty: string,
-    toBindingContext: boolean = false,
-    strict: boolean = false,
+    toBindingContext: boolean,
+    strict: boolean,
   ) {
     this.l = locator;
     this.oL = observerLocator;
-    this._toBindingContext = toBindingContext;
     this.strict = strict;
+    this._toBindingContext = toBindingContext;
   }
 
   public updateTarget() {

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -59,16 +59,20 @@ export class LetBinding implements IBinding, ISubscriber, ICollectionSubscriber 
   /** @internal */
   public readonly boundFn = false;
 
+  public strict: boolean;
+
   public constructor(
     locator: IServiceLocator,
     observerLocator: IObserverLocator,
     public ast: IsExpression,
     public targetProperty: string,
     toBindingContext: boolean = false,
+    strict: boolean = false,
   ) {
     this.l = locator;
     this.oL = observerLocator;
     this._toBindingContext = toBindingContext;
+    this.strict = strict;
   }
 
   public updateTarget() {

--- a/packages/runtime-html/src/binding/let-binding.ts
+++ b/packages/runtime-html/src/binding/let-binding.ts
@@ -30,7 +30,7 @@ export class LetBinding implements IBinding, ISubscriber, ICollectionSubscriber 
     mixinUseScope(LetBinding);
     mixingBindingLimited(LetBinding, () => 'updateTarget');
     connectable(LetBinding, null!);
-    mixinAstEvaluator()(LetBinding);
+    mixinAstEvaluator(LetBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -63,7 +63,7 @@ export class ListenerBinding implements IBinding, ISubscriber, ICollectionSubscr
     public targetEvent: string,
     options: ListenerBindingOptions,
     modifiedEventHandler: IModifiedEventHandler | null,
-    public strict = false,
+    public strict: boolean,
   ) {
     this.l = locator;
     this._options = options;

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -26,7 +26,7 @@ export class ListenerBinding implements IBinding, ISubscriber, ICollectionSubscr
   public static mix = createPrototypeMixer(function () {
     mixinUseScope(ListenerBinding);
     mixingBindingLimited(ListenerBinding, () => 'callSource');
-    mixinAstEvaluator(void 0, true)(ListenerBinding);
+    mixinAstEvaluator(ListenerBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -25,7 +25,7 @@ export class ListenerBinding implements IBinding, ISubscriber, ICollectionSubscr
   public static mix = createPrototypeMixer(function () {
     mixinUseScope(ListenerBinding);
     mixingBindingLimited(ListenerBinding, () => 'callSource');
-    mixinAstEvaluator(true, true)(ListenerBinding);
+    mixinAstEvaluator(void 0, true)(ListenerBinding);
   });
 
   public isBound: boolean = false;
@@ -54,6 +54,8 @@ export class ListenerBinding implements IBinding, ISubscriber, ICollectionSubscr
 
   /** @internal */
   private readonly _modifiedEventHandler: IModifiedEventHandler | null = null;
+
+  public strict = false;
 
   public constructor(
     locator: IServiceLocator,

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -73,7 +73,7 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     public target: object,
     public targetProperty: string,
     public mode: BindingMode,
-    public stict: boolean = false,
+    public strict: boolean = false,
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -27,7 +27,7 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     mixinUseScope(PropertyBinding);
     mixingBindingLimited(PropertyBinding, (propBinding: PropertyBinding) => (propBinding.mode & fromView) ? 'updateSource' : 'updateTarget');
     connectable(PropertyBinding, null!);
-    mixinAstEvaluator(true, false)(PropertyBinding);
+    mixinAstEvaluator(void 0, false)(PropertyBinding);
   });
 
   public isBound: boolean = false;
@@ -73,6 +73,7 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     public target: object,
     public targetProperty: string,
     public mode: BindingMode,
+    public stict: boolean = false,
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -27,7 +27,7 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     mixinUseScope(PropertyBinding);
     mixingBindingLimited(PropertyBinding, (propBinding: PropertyBinding) => (propBinding.mode & fromView) ? 'updateSource' : 'updateTarget');
     connectable(PropertyBinding, null!);
-    mixinAstEvaluator(void 0, false)(PropertyBinding);
+    mixinAstEvaluator(PropertyBinding);
   });
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -73,7 +73,7 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     public target: object,
     public targetProperty: string,
     public mode: BindingMode,
-    public strict: boolean = false,
+    public strict: boolean,
   ) {
     this.l = locator;
     this._controller = controller;

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -24,7 +24,7 @@ export class RefBinding implements IBinding, ISubscriber, ICollectionSubscriber 
     locator: IServiceLocator,
     public ast: IsBindingBehavior,
     public target: object,
-    public strict = false,
+    public strict: boolean,
   ) {
     this.l = locator;
   }

--- a/packages/runtime-html/src/binding/ref-binding.ts
+++ b/packages/runtime-html/src/binding/ref-binding.ts
@@ -9,7 +9,7 @@ import { IBinding } from './interfaces-bindings';
 export interface RefBinding extends IAstEvaluator, IObserverLocatorBasedConnectable, IServiceLocator { }
 export class RefBinding implements IBinding, ISubscriber, ICollectionSubscriber {
   public static mix = /*@__PURE__*/ createPrototypeMixer(() => {
-    mixinAstEvaluator(false)(RefBinding);
+    mixinAstEvaluator(RefBinding);
   });
 
   public isBound: boolean = false;
@@ -24,6 +24,7 @@ export class RefBinding implements IBinding, ISubscriber, ICollectionSubscriber 
     locator: IServiceLocator,
     public ast: IsBindingBehavior,
     public target: object,
+    public strict = false,
   ) {
     this.l = locator;
   }

--- a/packages/runtime-html/src/binding/spread-binding.ts
+++ b/packages/runtime-html/src/binding/spread-binding.ts
@@ -161,7 +161,7 @@ export class SpreadValueBinding implements IBinding {
     mixinUseScope(SpreadValueBinding);
     mixingBindingLimited(SpreadValueBinding, () => 'updateTarget');
     connectable(SpreadValueBinding, null!);
-    mixinAstEvaluator(true, false)(SpreadValueBinding);
+    mixinAstEvaluator(SpreadValueBinding);
   });
 
   /** @internal */

--- a/packages/runtime-html/src/binding/spread-binding.ts
+++ b/packages/runtime-html/src/binding/spread-binding.ts
@@ -207,6 +207,7 @@ export class SpreadValueBinding implements IBinding {
     ol: IObserverLocator,
     l: IServiceLocator,
     taskQueue: TaskQueue,
+    public strict: boolean,
   ) {
     this._controller = controller;
     this.oL = ol;
@@ -320,7 +321,8 @@ export class SpreadValueBinding implements IBinding {
             SpreadValueBinding._astCache[key] ??= new AccessScopeExpression(key, 0),
             this.target,
             key,
-            BindingMode.toView
+            BindingMode.toView,
+            this.strict,
           );
         }
         binding.bind(scope);

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -26,6 +26,7 @@ export const enum ErrorNames {
   ast_destruct_null = 112,
   ast_increment_infinite_loop = 113,
   ast_nullish_member_access = 114,
+  ast_nullish_keyed_access = 115,
 
   binding_behavior_def_not_found = 151,
   value_converter_def_not_found = 152,
@@ -147,6 +148,7 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.ast_destruct_null]: `Ast eval error: cannot use non-object value for destructuring assignment.`,
   [ErrorNames.ast_increment_infinite_loop]: `Ast eval error: infinite loop detected. Increment operators should only be used in event handlers.`,
   [ErrorNames.ast_nullish_member_access]: `Ast eval error: cannot access property "{{0}}" of {{1}}.`,
+  [ErrorNames.ast_nullish_keyed_access]: `Ast eval error: cannot access key "{{0}}" of {{1}}.`,
 
   [ErrorNames.binding_behavior_def_not_found]: `No binding behavior definition found for type {{0:name}}`,
   [ErrorNames.value_converter_def_not_found]: `No value converter definition found for type {{0:name}}`,

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -25,6 +25,7 @@ export const enum ErrorNames {
   ast_name_is_not_a_function = 111,
   ast_destruct_null = 112,
   ast_increment_infinite_loop = 113,
+  ast_nullish_member_access = 114,
 
   binding_behavior_def_not_found = 151,
   value_converter_def_not_found = 152,
@@ -145,6 +146,7 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.ast_name_is_not_a_function]: `Ast eval error: expected "{{0}}" to be a function`,
   [ErrorNames.ast_destruct_null]: `Ast eval error: cannot use non-object value for destructuring assignment.`,
   [ErrorNames.ast_increment_infinite_loop]: `Ast eval error: infinite loop detected. Increment operators should only be used in event handlers.`,
+  [ErrorNames.ast_nullish_member_access]: `Ast eval error: cannot access property "{{0}}" of {{1}}.`,
 
   [ErrorNames.binding_behavior_def_not_found]: `No binding behavior definition found for type {{0:name}}`,
   [ErrorNames.value_converter_def_not_found]: `No value converter definition found for type {{0:name}}`,

--- a/packages/runtime-html/src/errors.ts
+++ b/packages/runtime-html/src/errors.ts
@@ -27,6 +27,7 @@ export const enum ErrorNames {
   ast_increment_infinite_loop = 113,
   ast_nullish_member_access = 114,
   ast_nullish_keyed_access = 115,
+  ast_nullish_assignment = 116,
 
   binding_behavior_def_not_found = 151,
   value_converter_def_not_found = 152,
@@ -149,6 +150,7 @@ const errorsMap: Record<ErrorNames, string> = {
   [ErrorNames.ast_increment_infinite_loop]: `Ast eval error: infinite loop detected. Increment operators should only be used in event handlers.`,
   [ErrorNames.ast_nullish_member_access]: `Ast eval error: cannot access property "{{0}}" of {{1}}.`,
   [ErrorNames.ast_nullish_keyed_access]: `Ast eval error: cannot access key "{{0}}" of {{1}}.`,
+  [ErrorNames.ast_nullish_assignment]: `Ast eval error: cannot assign value to property "{{0}}" of null/undefined.`,
 
   [ErrorNames.binding_behavior_def_not_found]: `No binding behavior definition found for type {{0:name}}`,
   [ErrorNames.value_converter_def_not_found]: `No value converter definition found for type {{0:name}}`,

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -433,6 +433,8 @@ export const LetElementRenderer = /*@__PURE__*/ renderer(class LetElementRendere
 
 export const RefBindingRenderer = /*@__PURE__*/ renderer(class RefBindingRenderer implements IRenderer {
   public readonly target = InstructionType.refBinding;
+  /** @internal */
+  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public render(
     renderingCtrl: IHydratableController,
     target: INode,
@@ -443,13 +445,16 @@ export const RefBindingRenderer = /*@__PURE__*/ renderer(class RefBindingRendere
     renderingCtrl.addBinding(new RefBinding(
       renderingCtrl.container,
       ensureExpression(exprParser, instruction.from, etIsProperty),
-      getRefTarget(target, instruction.to)
+      getRefTarget(target, instruction.to),
+      this._defaultBindingConfig.strict,
     ));
   }
 }, null!);
 
 export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class InterpolationBindingRenderer implements IRenderer {
   public readonly target = InstructionType.interpolation;
+  /** @internal */
+  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     InterpolationPartBinding.mix();
   }
@@ -470,7 +475,8 @@ export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class Interpo
       ensureExpression(exprParser, instruction.from, etInterpolation),
       getTarget(target),
       instruction.to,
-      toView
+      toView,
+      this._defaultBindingConfig.strict
     );
     if (instruction.to === 'class' && (binding.target as Node).nodeType > 0) {
       const cssMapping = container.get(fromHydrationContext(ICssClassMapping));

--- a/packages/runtime-html/src/renderer.ts
+++ b/packages/runtime-html/src/renderer.ts
@@ -382,19 +382,8 @@ export const TemplateControllerRenderer = /*@__PURE__*/ renderer(class TemplateC
   }
 }, null!);
 
-/** @internal */
-export interface IBindingConfiguration {
-  strict: boolean;
-}
-/** @internal */
-export const IBindingConfiguration = createInterface<IBindingConfiguration>('IBindingConfiguration', x => x.instance({
-  strict: false,
-}));
-
 export const LetElementRenderer = /*@__PURE__*/ renderer(class LetElementRenderer implements IRenderer {
   public readonly target = InstructionType.hydrateLetElement;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     LetBinding.mix();
   }
@@ -424,7 +413,7 @@ export const LetElementRenderer = /*@__PURE__*/ renderer(class LetElementRendere
         expr,
         childInstruction.to,
         toBindingContext,
-        this._defaultBindingConfig.strict
+        renderingCtrl.strict ?? false,
       ));
       ++i;
     }
@@ -433,8 +422,6 @@ export const LetElementRenderer = /*@__PURE__*/ renderer(class LetElementRendere
 
 export const RefBindingRenderer = /*@__PURE__*/ renderer(class RefBindingRenderer implements IRenderer {
   public readonly target = InstructionType.refBinding;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public render(
     renderingCtrl: IHydratableController,
     target: INode,
@@ -446,15 +433,13 @@ export const RefBindingRenderer = /*@__PURE__*/ renderer(class RefBindingRendere
       renderingCtrl.container,
       ensureExpression(exprParser, instruction.from, etIsProperty),
       getRefTarget(target, instruction.to),
-      this._defaultBindingConfig.strict,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
 
 export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class InterpolationBindingRenderer implements IRenderer {
   public readonly target = InstructionType.interpolation;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     InterpolationPartBinding.mix();
   }
@@ -476,7 +461,7 @@ export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class Interpo
       getTarget(target),
       instruction.to,
       toView,
-      this._defaultBindingConfig.strict
+      renderingCtrl.strict ?? false,
     );
     if (instruction.to === 'class' && (binding.target as Node).nodeType > 0) {
       const cssMapping = container.get(fromHydrationContext(ICssClassMapping));
@@ -488,8 +473,6 @@ export const InterpolationBindingRenderer = /*@__PURE__*/ renderer(class Interpo
 
 export const PropertyBindingRenderer = /*@__PURE__*/ renderer(class PropertyBindingRenderer implements IRenderer {
   public readonly target = InstructionType.propertyBinding;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     PropertyBinding.mix();
   }
@@ -511,7 +494,7 @@ export const PropertyBindingRenderer = /*@__PURE__*/ renderer(class PropertyBind
       getTarget(target),
       instruction.to,
       instruction.mode,
-      this._defaultBindingConfig.strict
+      renderingCtrl.strict ?? false,
     );
     if (instruction.to === 'class' && (binding.target as Node).nodeType > 0) {
       const cssMapping = container.get(fromHydrationContext(ICssClassMapping));
@@ -523,8 +506,6 @@ export const PropertyBindingRenderer = /*@__PURE__*/ renderer(class PropertyBind
 
 export const IteratorBindingRenderer = /*@__PURE__*/ renderer(class IteratorBindingRenderer implements IRenderer {
   public readonly target = InstructionType.iteratorBinding;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     PropertyBinding.mix();
   }
@@ -545,15 +526,13 @@ export const IteratorBindingRenderer = /*@__PURE__*/ renderer(class IteratorBind
       getTarget(target),
       instruction.to,
       toView,
-      this._defaultBindingConfig.strict
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
 
 export const TextBindingRenderer = /*@__PURE__*/ renderer(class TextBindingRenderer implements IRenderer {
   public readonly target = InstructionType.textBinding;
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
   public constructor() {
     ContentBinding.mix();
   }
@@ -573,7 +552,7 @@ export const TextBindingRenderer = /*@__PURE__*/ renderer(class TextBindingRende
       platform,
       ensureExpression(exprParser, instruction.from, etIsProperty),
       target as Text,
-      this._defaultBindingConfig.strict
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
@@ -616,8 +595,6 @@ export const ListenerBindingRenderer = /*@__PURE__*/ renderer(class ListenerBind
   public readonly _modifierHandler = resolve(IEventModifier);
   /** @internal */
   public readonly _defaultOptions = resolve(IListenerBindingOptions);
-  /** @internal */
-  public readonly _defaultBindingConfig = resolve(IBindingConfiguration);
 
   public constructor() {
     ListenerBinding.mix();
@@ -637,7 +614,7 @@ export const ListenerBindingRenderer = /*@__PURE__*/ renderer(class ListenerBind
       instruction.to,
       new ListenerBindingOptions(this._defaultOptions.prevent, instruction.capture, this._defaultOptions.onError),
       this._modifierHandler.getHandler(instruction.to, instruction.modifier),
-      this._defaultBindingConfig.strict,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
@@ -725,6 +702,7 @@ export const StylePropertyBindingRenderer = /*@__PURE__*/ renderer(class StylePr
           target.style,
           instruction.to,
           toView,
+          renderingCtrl.strict ?? false,
         ));
         return;
       }
@@ -738,6 +716,7 @@ export const StylePropertyBindingRenderer = /*@__PURE__*/ renderer(class StylePr
       target.style,
       instruction.to,
       toView,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
@@ -783,6 +762,7 @@ export const AttributeBindingRenderer = /*@__PURE__*/ renderer(class AttributeBi
         ? instruction.to/* targetKey */
         : instruction.to.split(/\s/g).map(c => classMapping[c] ?? c).join(' '),
       toView,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
@@ -838,7 +818,8 @@ export const SpreadValueRenderer = /*@__PURE__*/ renderer(class SpreadValueRende
         exprParser.parse(instruction.from, etIsProperty),
         observerLocator,
         renderingCtrl.container,
-        platform.domQueue
+        platform.domQueue,
+        renderingCtrl.strict ?? false,
       ));
     } else {
       throw createMappedError(ErrorNames.spreading_invalid_target, instructionTarget);

--- a/packages/runtime-html/src/resources/custom-element.ts
+++ b/packages/runtime-html/src/resources/custom-element.ts
@@ -45,6 +45,7 @@ export type PartialCustomElementDefinition<TBindables extends string = string> =
   readonly injectable?: InterfaceSymbol | null;
   readonly enhance?: boolean;
   readonly watches?: IWatchDefinition[];
+  readonly strict?: boolean;
 }>;
 
 export type CustomElementStaticAuDefinition<TBindables extends string = string> = PartialCustomElementDefinition<TBindables> & {
@@ -225,6 +226,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
     public readonly hasSlots: boolean,
     public readonly enhance: boolean,
     public readonly watches: IWatchDefinition[],
+    public readonly strict: boolean | undefined,
     public readonly processContent: ProcessContentHook | null,
   ) { }
 
@@ -282,7 +284,10 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         fromDefinitionOrDefault('hasSlots', def, returnFalse),
         fromDefinitionOrDefault('enhance', def, returnFalse),
         fromDefinitionOrDefault('watches', def as CustomElementDefinition, returnEmptyArray),
+        // casting is incorrect, but it's good enough
+        fromDefinitionOrDefault('strict', def, returnUndefined as () => boolean),
         fromAnnotationOrTypeOrDefault('processContent', Type, returnNull as () => ProcessContentHook | null),
+
       );
     }
 
@@ -312,6 +317,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
         fromAnnotationOrTypeOrDefault('hasSlots', Type, returnFalse),
         fromAnnotationOrTypeOrDefault('enhance', Type, returnFalse),
         mergeArrays(Watch.getDefinitions(Type), Type.watches),
+        fromAnnotationOrTypeOrDefault('strict', Type, returnUndefined as () => boolean),
         fromAnnotationOrTypeOrDefault('processContent', Type, returnNull as () => ProcessContentHook | null),
       );
     }
@@ -349,6 +355,7 @@ export class CustomElementDefinition<C extends Constructable = Constructable> im
       fromAnnotationOrDefinitionOrTypeOrDefault('hasSlots', nameOrDef, Type, returnFalse),
       fromAnnotationOrDefinitionOrTypeOrDefault('enhance', nameOrDef, Type, returnFalse),
       mergeArrays(nameOrDef.watches, Watch.getDefinitions(Type), Type.watches),
+      fromAnnotationOrDefinitionOrTypeOrDefault('strict', nameOrDef, Type, returnUndefined as () => boolean),
       fromAnnotationOrDefinitionOrTypeOrDefault('processContent', nameOrDef, Type, returnNull),
     );
   }
@@ -403,6 +410,7 @@ const defaultForOpts: ForOpts = {
   optional: false,
 };
 const returnNull = <T>(): T | null => null;
+const returnUndefined = <T>(): T | undefined => void 0;
 const returnFalse = () => false;
 const returnTrue = () => true;
 const returnEmptyArray = () => emptyArray;

--- a/packages/runtime-html/src/resources/resolvers.ts
+++ b/packages/runtime-html/src/resources/resolvers.ts
@@ -3,6 +3,8 @@ import { IHydrationContext } from '../templating/controller';
 
 /**
  * Create a resolver for a given key that will only resolve from the nearest hydration context.
+ *
+ * @internal
  */
 export const fromHydrationContext = <T extends Key>(key: T): IResolver<T | undefined> => ({
   $isResolver: true,

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -136,6 +136,10 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
 
   public coercion: ICoercionConfiguration | undefined;
 
+  public get strict() {
+    return (this.definition as CustomElementDefinition)?.strict;
+  }
+
   public constructor(
     public container: IContainer,
     public readonly vmKind: ViewModelKind,
@@ -1529,6 +1533,7 @@ export interface IHydratableController<C extends IViewModel = IViewModel> extend
   readonly vmKind: 'customElement' | 'synthetic';
   readonly mountTarget: MountTarget;
   readonly definition: CustomElementDefinition | null;
+  readonly strict: boolean | undefined | null;
 
   readonly children: readonly IHydratedController[] | null;
 
@@ -1681,6 +1686,7 @@ export interface ICustomAttributeController<C extends ICustomAttributeViewModel 
 export interface IDryCustomElementController<C extends IViewModel = IViewModel> extends IComponentController<C>, IHydratableController<C> {
   readonly vmKind: 'customElement';
   readonly definition: CustomElementDefinition;
+  readonly strict: boolean | undefined | null;
   /**
    * The scope that belongs to this custom element. This property is set immediately after the controller is created and is always guaranteed to be available.
    *

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -123,7 +123,7 @@ export interface ExpressionWatcher extends IObserverLocatorBasedConnectable, /* 
 export class ExpressionWatcher implements IBinding, IObserverLocatorBasedConnectable {
   static {
     connectable(ExpressionWatcher, null!);
-    mixinAstEvaluator(void 0)(ExpressionWatcher);
+    mixinAstEvaluator(ExpressionWatcher);
   }
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/templating/watchers.ts
+++ b/packages/runtime-html/src/templating/watchers.ts
@@ -123,7 +123,7 @@ export interface ExpressionWatcher extends IObserverLocatorBasedConnectable, /* 
 export class ExpressionWatcher implements IBinding, IObserverLocatorBasedConnectable {
   static {
     connectable(ExpressionWatcher, null!);
-    mixinAstEvaluator(true)(ExpressionWatcher);
+    mixinAstEvaluator(void 0)(ExpressionWatcher);
   }
 
   public isBound: boolean = false;

--- a/packages/runtime-html/src/utilities-di.ts
+++ b/packages/runtime-html/src/utilities-di.ts
@@ -48,6 +48,6 @@ export function alias(...aliases: readonly string[]) {
 
 export function registerAliases(aliases: readonly string[], resource: IResourceKind, key: string, container: IContainer) {
   for (let i = 0, ii = aliases.length; i < ii; ++i) {
-    Registration.aliasTo(key, resource.keyFrom(aliases[i])).register(container);
+    aliasRegistration(key, resource.keyFrom(aliases[i])).register(container);
   }
 }

--- a/packages/state/src/state-binding.ts
+++ b/packages/state/src/state-binding.ts
@@ -35,6 +35,12 @@ const stateActivating = State.activating;
  */
 export interface StateBinding extends IAstEvaluator, IObserverLocatorBasedConnectable, IServiceLocator { }
 export class StateBinding implements IBinding, ISubscriber, IStoreSubscriber<object> {
+  static {
+    connectable(StateBinding, null!);
+    mixinAstEvaluator(StateBinding);
+    mixingBindingLimited(StateBinding, () => 'updateTarget');
+  }
+
   public isBound: boolean = false;
 
   /** @internal */
@@ -64,6 +70,8 @@ export class StateBinding implements IBinding, ISubscriber, IStoreSubscriber<obj
   /** @internal */
   public readonly boundFn = false;
 
+  public strict: boolean;
+
   public mode: BindingMode = BindingMode.toView;
 
   public constructor(
@@ -75,6 +83,7 @@ export class StateBinding implements IBinding, ISubscriber, IStoreSubscriber<obj
     target: object,
     prop: PropertyKey,
     store: IStore<object>,
+    strict: boolean,
   ) {
     this._controller = controller;
     this.l = locator;
@@ -84,6 +93,7 @@ export class StateBinding implements IBinding, ISubscriber, IStoreSubscriber<obj
     this.ast = ast;
     this.target = target;
     this.targetProperty = prop;
+    this.strict = strict;
   }
 
   public updateTarget(value: unknown) {
@@ -235,7 +245,3 @@ type Unsubscribable = {
 const updateTaskOpts: QueueTaskOptions = {
   preempt: true,
 };
-
-connectable(StateBinding, null!);
-mixinAstEvaluator(true)(StateBinding);
-mixingBindingLimited(StateBinding, () => 'updateTarget');

--- a/packages/state/src/state-dispatch-binding.ts
+++ b/packages/state/src/state-dispatch-binding.ts
@@ -17,16 +17,22 @@ import {
 } from '@aurelia/runtime-html';
 import {
   IStoreSubscriber,
-  type IStore
+  type IStore,
 } from './interfaces';
 import { createStateBindingScope } from './state-utilities';
-import { IsBindingBehavior } from '@aurelia/expression-parser';
+import type { IsBindingBehavior } from '@aurelia/expression-parser';
 
 /**
  * A binding that handles the connection of the global state to a property of a target object
  */
 export interface StateDispatchBinding extends IAstEvaluator, IObserverLocatorBasedConnectable, IServiceLocator { }
 export class StateDispatchBinding implements IBinding, IStoreSubscriber<object> {
+  static {
+    connectable(StateDispatchBinding, null!);
+    mixinAstEvaluator(StateDispatchBinding);
+    mixingBindingLimited(StateDispatchBinding, () => 'callSource');
+  }
+
   public isBound: boolean = false;
 
   /** @internal */
@@ -42,6 +48,9 @@ export class StateDispatchBinding implements IBinding, IStoreSubscriber<object> 
   // see Listener binding for explanation
   /** @internal */
   public readonly boundFn = false;
+
+  public strict: boolean;
+
   /** @internal */ private readonly _store: IStore<object>;
 
   public constructor(
@@ -50,12 +59,14 @@ export class StateDispatchBinding implements IBinding, IStoreSubscriber<object> 
     target: HTMLElement,
     prop: string,
     store: IStore<object>,
+    strict: boolean,
   ) {
     this.l = locator;
     this._store = store;
     this.ast = expr;
     this._target = target;
     this._targetProperty = prop;
+    this.strict = strict;
   }
 
   public callSource(e: Event) {
@@ -99,7 +110,3 @@ export class StateDispatchBinding implements IBinding, IStoreSubscriber<object> 
     scope.bindingContext = overrideContext.bindingContext = state;
   }
 }
-
-connectable(StateDispatchBinding, null!);
-mixinAstEvaluator(true)(StateDispatchBinding);
-mixingBindingLimited(StateDispatchBinding, () => 'callSource');

--- a/packages/state/src/state-templating.ts
+++ b/packages/state/src/state-templating.ts
@@ -98,6 +98,7 @@ export const StateBindingInstructionRenderer = /*@__PURE__*/ renderer(class Stat
       target,
       instruction.to,
       this._stateContainer,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);
@@ -120,6 +121,7 @@ export const DispatchBindingInstructionRenderer = /*@__PURE__*/ renderer(class D
       target,
       instruction.from,
       this._stateContainer,
+      renderingCtrl.strict ?? false,
     ));
   }
 }, null!);

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 // Significant portion of this code is copy-pasted from the node.js source
 // Modifications consist primarily of removing dependencies on v8 natives and adding typings
 
@@ -106,7 +107,6 @@ class Comparison {
           !isUndefined(actual)
           && isString(actual[key])
           && isRegExp(obj[key])
-          // eslint-disable-next-line
           && (obj[key] as RegExp).test(actual[key] as string)
         ) {
           this[key] = actual[key];

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 // Significant portion of this code is copy-pasted from the node.js source
 // Modifications consist primarily of removing dependencies on v8 natives and adding typings
 
@@ -105,9 +104,7 @@ class Comparison {
       if (key in obj) {
         if (
           !isUndefined(actual)
-          && isString(actual[key])
-          && isRegExp(obj[key])
-          && (obj[key] as RegExp).test(actual[key] as string)
+          && (isString(actual[key]) && isRegExp(obj[key]) && obj[key].test(actual[key]))
         ) {
           this[key] = actual[key];
         } else {

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -104,7 +104,7 @@ class Comparison {
       if (key in obj) {
         if (
           !isUndefined(actual)
-          && (isString(actual[key]) && isRegExp(obj[key]) && obj[key].test(actual[key]))
+          && (isString(actual[key]) && isRegExp(obj[key]) && (obj[key] as RegExp).test(actual[key] as string))
         ) {
           this[key] = actual[key];
         } else {

--- a/packages/testing/src/assert.ts
+++ b/packages/testing/src/assert.ts
@@ -106,7 +106,8 @@ class Comparison {
           !isUndefined(actual)
           && isString(actual[key])
           && isRegExp(obj[key])
-          && obj[key].test(actual[key])
+          // eslint-disable-next-line
+          && (obj[key] as RegExp).test(actual[key] as string)
         ) {
           this[key] = actual[key];
         } else {

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -280,7 +280,7 @@ export function createFixture<T extends object>(
       throw new Error(`No <input>/<textarea> element found for selector "${selector}" to emulate input for "${value}"`);
     }
     (el as HTMLInputElement).value = value;
-    el.dispatchEvent(new platform.window.Event('input'));
+    el.dispatchEvent(new platform.window.Event('input', { bubbles: true }));
   }
 
   const scrollBy = (selector: string, init: number | ScrollToOptions) => {

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -1,7 +1,7 @@
 import { Constructable, EventAggregator, IContainer, ILogger } from '@aurelia/kernel';
 import { Metadata } from '@aurelia/metadata';
 import { IObserverLocator } from '@aurelia/runtime';
-import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig } from '@aurelia/runtime-html';
+import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig, PartialCustomElementDefinition } from '@aurelia/runtime-html';
 import { assert } from './assert';
 import { hJsx } from './h';
 import { TestContext } from './test-context';
@@ -29,6 +29,7 @@ export function createFixture<T extends object>(
   autoStart: boolean = true,
   ctx: TestContext = TestContext.create(),
   appConfig: IFixtureConfig =  {},
+  rootElementDef?: Partial<PartialCustomElementDefinition>,
 ): IFixture<ICustomElementViewModel & ObjectType<T>> {
   type K = ObjectType<T>;
   const { container } = ctx;
@@ -51,7 +52,7 @@ export function createFixture<T extends object>(
       } as unknown as Constructable<K>;
 
   const annotations: (Exclude<keyof CustomElementDefinition, 'Type' | 'key' | 'kind' | 'register' | 'type' | 'toString'>)[] =
-    ['aliases', 'bindables', /* 'cache',  */'capture', 'containerless', 'dependencies', 'enhance'];
+    ['aliases', 'bindables', /* 'cache',  */'capture', 'containerless', 'dependencies', 'enhance', 'strict'];
   if ($$class !== $class as any && $class != null) {
     annotations.forEach(anno => {
       Metadata.define(CustomElement.getAnnotation($class as Constructable<T>, anno, null), $$class, anno);
@@ -61,6 +62,7 @@ export function createFixture<T extends object>(
   const existingDefs = (CustomElement.isType($$class) ? CustomElement.getDefinition($$class) : {}) as CustomElementDefinition;
   const App = CustomElement.define({
     ...existingDefs,
+    ...rootElementDef,
     name: existingDefs.name ?? 'app',
     template,
   }, $$class);
@@ -556,7 +558,7 @@ export type ITrigger = {
 export interface IFixtureBuilderBase<T, E = {}> {
   html(html: string): this & E;
   html<M>(html: TemplateStringsArray, ...values: TemplateValues<M>[]): this & E;
-  component(comp: T): this & E;
+  component(comp: T, def?: Partial<PartialCustomElementDefinition>): this & E;
   deps(...args: unknown[]): this & E;
   config(config: IFixtureConfig): this & E;
 }
@@ -570,19 +572,20 @@ type CreateBuilder<T, Availables extends BuilderMethodNames> = {
         (html: TemplateStringsArray, ...values: TemplateValues<T>[]): CreateBuilder<T, Exclude<Availables, 'html'>>;
       }
       : key extends 'component'
-        ? <K>(comp: Constructable<K> | K) => CreateBuilder<K, Exclude<Availables, 'component'>>
+        ? <K>(comp: Constructable<K> | K, def?: Partial<PartialCustomElementDefinition>) => CreateBuilder<K, Exclude<Availables, 'component'>>
         : (...args: Parameters<IFixtureBuilderBase<T>[key]>) => CreateBuilder<T, Exclude<Availables, key>>
 } & ('html' extends Availables ? {} : { build(): IFixture<T> });
 
 type TaggedTemplateLambda<M> = (vm: M) => unknown;
 type TemplateValues<M> = string | number | TaggedTemplateLambda<M>;
 
-export type IFixtureConfig = Pick<IAppRootConfig, 'allowActionlessForm' | 'strictBinding'>;
+export type IFixtureConfig = Pick<IAppRootConfig, 'allowActionlessForm'>;
 
 class FixtureBuilder<T> {
   private _html?: string | TemplateStringsArray;
   private _htmlArgs?: TemplateValues<T>[];
   private _comp?: T;
+  private _def?: Partial<PartialCustomElementDefinition>;
   private _args?: unknown[];
   private _config?: IFixtureConfig;
 
@@ -592,8 +595,9 @@ class FixtureBuilder<T> {
     return this as unknown as CreateBuilder<T, Exclude<BuilderMethodNames, 'html'>>;
   }
 
-  public component(comp: T): CreateBuilder<T, Exclude<BuilderMethodNames, 'component'>> {
+  public component(comp: T, def?: Partial<PartialCustomElementDefinition>): CreateBuilder<T, Exclude<BuilderMethodNames, 'component'>> {
     this._comp = comp;
+    this._def = def;
     return this;
   }
 
@@ -618,6 +622,7 @@ class FixtureBuilder<T> {
       void 0,
       void 0,
       this._config,
+      this._def,
     );
   }
 }

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -577,7 +577,7 @@ type CreateBuilder<T, Availables extends BuilderMethodNames> = {
 type TaggedTemplateLambda<M> = (vm: M) => unknown;
 type TemplateValues<M> = string | number | TaggedTemplateLambda<M>;
 
-export type IFixtureConfig = Pick<IAppRootConfig, 'allowActionlessForm'>;
+export type IFixtureConfig = Pick<IAppRootConfig, 'allowActionlessForm' | 'strictBinding'>;
 
 class FixtureBuilder<T> {
   private _html?: string | TemplateStringsArray;
@@ -614,7 +614,10 @@ class FixtureBuilder<T> {
     return createFixture<any>(
       typeof this._html === 'string' ? this._html : brokenProcessFastTemplate(this._html, ...this._htmlArgs ?? []),
       this._comp,
-      this._args
+      this._args,
+      void 0,
+      void 0,
+      this._config,
     );
   }
 }

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -362,7 +362,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
 }
 
 connectable(ValidationConnector, null!);
-mixinAstEvaluator(true)(ValidationConnector);
+mixinAstEvaluator(ValidationConnector);
 
 class WithValidationTargetSubscriber extends BindingTargetSubscriber {
   public constructor(
@@ -408,4 +408,4 @@ export class BindingMediator<K extends string> {
 }
 
 connectable(BindingMediator, null!);
-mixinAstEvaluator(true)(BindingMediator);
+mixinAstEvaluator(BindingMediator);

--- a/packages/validation/src/rule-provider.ts
+++ b/packages/validation/src/rule-provider.ts
@@ -436,7 +436,7 @@ export class PropertyRule<TObject extends IValidateable = IValidateable, TValue 
   }
   // #endregion
 }
-mixinAstEvaluator()(PropertyRule);
+mixinAstEvaluator(PropertyRule);
 
 export class ModelBasedRule {
   public constructor(

--- a/packages/validation/src/serialization.ts
+++ b/packages/validation/src/serialization.ts
@@ -322,4 +322,4 @@ export class ModelValidationExpressionHydrator implements IValidationExpressionH
   }
 }
 
-mixinAstEvaluator()(ModelValidationExpressionHydrator);
+mixinAstEvaluator(ModelValidationExpressionHydrator);


### PR DESCRIPTION
## 📖 Description

Most of the behaviors of template expression evaluation in v2 are from v1, which have both good and bad things. One of the most beneficial features is a non-standard "optional syntax": accessing property on null/undefined won't throw without having to use `?./?.[]/?.()`. Though because we developed this before an official language feature, it comes with a several unpredictable/ not well spec'd behaviors:

- In non strict mode, accessing a member on undefined/null will give an empty string
- In strict mode, accessing a member on undefined/null will return undefined
- In non strict mode, calling a function will not throw when the evaluated function is not a function (i.e a number/string...)
- In non strict mode, `a + b` sometimes coerces value of either a/b/both depends on the type of the value
- there's a difference between calling a non-existent function in normal binding vs listener binding. The former will return undefined while the later will throw
- optional syntaxes are not consistently applied in all scenarios
- assigning a value to a property of null/undefined will not always throw in strict mode

Besides that, there's not an easy way to configure strict/non strict mode.

This PR fixes the above issues by making our optional-by-default feature closely aligned with optional syntax of JS: 
- in non strict mode, accessing a property on null/undefined will yield undefined (throw in strict mode)
- in non strict mode, calling a null/undefined function will yield undefined (throw in strict mode)
- in non strict mode, calling a non-existent function (null/undefined) will no longer throw, regardless type of binding. (Used to throw in listener binding, and not in others)
- in all modes, doing `a + b` should behave like standard JS
- add a `strict` option (default false) for elements to evaluated in strict/non-strict mode

Now non-strict mode can be understood as optional by default:

1. Accessing properties on `null/undefined` does not throw, and returns undefined
2. Calling null/undefined function does not throw, and returns undefined
3. Assigning a value to `null/undefined` will automatically create an object with the corresponding property and assign to the root path (i.e for `a.b = 5` binding will turn an empty object `{ }` into `{ b: 5 }`)
4. The rest of the behaviors will be similar like JS

The above 4 principles probably should be the guideline for expression evaluation, so if there's a bug in the future, we can have something to rely on to align to.

### 🎫 Issues

Closes #1808

## 📑 Test Plan

- New suites of tests for optional ast in strict/non strict modes together with all types of binding

## Next step

- Add `<strict>` support for our convention plugin.

cc @fkleuver @Sayan751 