### PR TITLE
fix(watch): initialise only once

### DIFF
--- a/packages/__tests__/src/3-runtime-html/decorator-watch.computed.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/decorator-watch.computed.spec.ts
@@ -63,6 +63,13 @@ describe('3-runtime-html/decorator-watch.computed.spec.ts', function () {
     });
   }
 
+  it('throws on @watch usage on static method', function () {
+    assert.throws(() => class App {
+      @watch('')
+      static method() {}
+    }, /AUR0774/);
+  });
+
   it('works in basic scenario', function () {
     let callCount = 0;
     class App {
@@ -1518,4 +1525,26 @@ describe('3-runtime-html/decorator-watch.computed.spec.ts', function () {
   function json(d: any) {
     return JSON.stringify(d);
   }
+
+  it('initialises once for each instance', function () {
+    const logs = [];
+    @customElement({
+      name: 'my-button',
+      template: '<button click.trigger="count++">Count: ${count}</button>'
+    })
+    class MyButton {
+      count: number = 0;
+
+      @watch('count')
+      logCountChanged() {
+        logs.push(this.count);
+      }
+    }
+
+    const { getAllBy } = createFixture('<my-button repeat.for="i of 3">', {}, [MyButton]);
+    const buttons = getAllBy('button');
+    assert.strictEqual(buttons.length, 3);
+    buttons.forEach(button => button.click());
+    assert.deepStrictEqual(logs, [1, 1, 1]);
+  });
 });

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -73,7 +73,7 @@ export function watch<T extends object = object, TV extends AnyMethod = AnyMetho
       ) {
         throw createMappedError(ErrorNames.watch_invalid_change_handler, `${safeString(changeHandlerOrCallback)}@${target.name}}`);
       }
-    } else if (!isFunction(target)) {
+    } else if (!isFunction(target) || context.static) {
       throw createMappedError(ErrorNames.watch_non_method_decorator_usage, context.name);
     }
 
@@ -85,8 +85,13 @@ export function watch<T extends object = object, TV extends AnyMethod = AnyMetho
     if (isClassDecorator) {
       addDefinition(target as Constructable);
     } else {
+      // instance method decorator initializer is called for each instance
+      let added = false;
       context.addInitializer(function (this: T) {
-        addDefinition(this.constructor as Constructable);
+        if (!added) {
+          added = true;
+          addDefinition(this.constructor as Constructable);
+        }
       });
     }
 


### PR DESCRIPTION
## 📖 Description

In our previous work related to decorator, addInitialiser was used to add watch metadata for Aurelia to instantiate watcher, but we missed that method decorator is called for every instance so watch metadata is applied multiple times if a component is used more than once.

Thanks to Tordmulen for reporting this on discord: https://discord.com/channels/448698263508615178/448699158052864001/threads/1288414475137060936
