### PR TITLE
Fix repeater scope reuse issue

### DIFF
--- a/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
@@ -102,19 +102,93 @@ describe("3-runtime-html/repeat.duplicates.spec.ts", function () {
     });
 
     it('object duplication unshift (issue 2078)', function () {
-      const objA = { toString() { return 'a'; } };
-      const objB = { toString() { return 'b'; } };
+      const objA = { toString() { return 'A'; } };
+      const objB = { toString() { return 'B'; } };
 
       const { assertText, component, flush } = createFixture(
         `<div repeat.for="i of items">\${$index}-\${i} </div>`,
         class { items = [objA, objB]; }
       );
-      assertText('0-a 1-b ');
+      assertText('0-A 1-B ');
 
       component.items.unshift(objB);
       flush();
 
-      assertText('0-b 1-a 2-b ');
+      assertText('0-B 1-A 2-B ');
+    });
+
+    it('object duplication push with multiple references', function () {
+      const objA = { toString() { return 'A'; } };
+      const objB = { toString() { return 'B'; } };
+
+      const { assertText, component, flush } = createFixture(
+        `<div repeat.for="i of items">\${$index}-\${i} </div>`,
+        class { items = [objA, objB]; }
+      );
+      assertText('0-A 1-B ');
+
+      component.items.push(objA, objB);
+      flush();
+
+      assertText('0-A 1-B 2-A 3-B ');
+    });
+
+    it('object duplication splice in the middle', function () {
+      const objA = { toString() { return 'A'; } };
+      const objB = { toString() { return 'B'; } };
+      const objC = { toString() { return 'C'; } };
+
+      const { assertText, component, flush } = createFixture(
+        `<div repeat.for="i of items">\${$index}-\${i} </div>`,
+        class { items = [objA, objB, objC]; }
+      );
+      assertText('0-A 1-B 2-C ');
+
+      component.items.splice(1, 1, objA, objA);
+      flush();
+
+      assertText('0-A 1-A 2-A 3-C ');
+    });
+
+    it('object duplication sort (ascending vs. descending)', function () {
+      const obj1 = { id: 3, toString() { return `X${this.id}`; } };
+      const obj2 = { id: 1, toString() { return `X${this.id}`; } };
+      const obj3 = { id: 2, toString() { return `X${this.id}`; } };
+      const obj2Dup = obj2;
+
+      const { assertText, component, flush } = createFixture(
+        `<div repeat.for="i of items">\${$index}-\${i} </div>`,
+        class { items = [obj1, obj2, obj3, obj2Dup]; }
+      );
+      assertText('0-X3 1-X1 2-X2 3-X1 ');
+
+      component.items.sort((a, b) => a.id - b.id);
+      flush();
+
+      assertText('0-X1 1-X1 2-X2 3-X3 ');
+
+      component.items.sort((a, b) => b.id - a.id);
+      flush();
+
+      assertText('0-X3 1-X2 2-X1 3-X1 ');
+    });
+
+    it('unshift multiple duplicates', function () {
+      const objA = { toString() { return 'A'; } };
+
+      const { assertText, component, flush } = createFixture(
+        `<div repeat.for="i of items">\${$index}-\${i} </div>`,
+        class { items = [objA, objA]; }
+      );
+      assertText('0-A 1-A ');
+
+      component.items.unshift(objA);
+      flush();
+      assertText('0-A 1-A 2-A ');
+
+      component.items.unshift(objA);
+      flush();
+      assertText('0-A 1-A 2-A 3-A ');
     });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
@@ -100,5 +100,21 @@ describe("3-runtime-html/repeat.duplicates.spec.ts", function () {
 
       assertText('0-a 1-b 2-c ');
     });
+
+    it('object duplication unshift (issue 2078)', function () {
+      const objA = { toString() { return 'a'; } };
+      const objB = { toString() { return 'b'; } };
+
+      const { assertText, component, flush } = createFixture(
+        `<div repeat.for="i of items">\${$index}-\${i} </div>`,
+        class { items = [objA, objB]; }
+      );
+      assertText('0-a 1-b ');
+
+      component.items.unshift(objB);
+      flush();
+
+      assertText('0-b 1-a 2-b ');
+    });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/repeat.duplicates.spec.ts
@@ -101,7 +101,7 @@ describe("3-runtime-html/repeat.duplicates.spec.ts", function () {
       assertText('0-a 1-b 2-c ');
     });
 
-    it('object duplication unshift (issue 2078)', function () {
+    it('object duplication unshift (issue #2078)', function () {
       const objA = { toString() { return 'A'; } };
       const objB = { toString() { return 'B'; } };
 

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -75,7 +75,6 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
   /** @internal */ private _oldViews: ISyntheticView[] = [];
   /** @internal */ private _scopes: Scope[] = [];
   /** @internal */ private _oldScopes: Scope[] = [];
-  /** @internal */ private _scopeMap: Map<unknown, Scope | Scope[]> = new Map();
   /** @internal */ private _observer?: CollectionObserver = void 0;
   /** @internal */ private _innerItems: Items<C> | null;
   /** @internal */ private _forOfBinding!: PropertyBinding;
@@ -159,13 +158,6 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     this._refreshCollectionObserver();
 
     return this._deactivateAllViews(initiator);
-  }
-
-  public unbinding(
-    _initiator: IHydratedController,
-    _parent: IHydratedParentController,
-  ): void | Promise<void> {
-    this._scopeMap.clear();
   }
 
   // called by SetterObserver
@@ -332,8 +324,6 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     const len = items.length;
     const scopes = this._scopes = Array(items.length);
 
-    const oldScopeMap = this._scopeMap;
-    const newScopeMap = new Map<unknown, Scope | Scope[]>();
     const parentScope = this.$controller.scope;
     const binding = this._forOfBinding;
     const forOf = this.forOf;
@@ -342,7 +332,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
 
     if (indexMap === void 0) {
       for (let i = 0; i < len; ++i) {
-        scopes[i] = getScope(oldScopeMap, newScopeMap, items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
+        scopes[i] = getScope(items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
       }
     } else {
       const oldLen = oldScopes.length;
@@ -352,14 +342,10 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
         if (src >= 0 && src < oldLen) {
           scopes[i] = oldScopes[src];
         } else {
-          scopes[i] = createScope(items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
+          scopes[i] = getScope(items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
         }
-        setItem(hasDestructuredLocal, forOf.declaration, scopes[i], binding, local, items[i]);
       }
     }
-
-    oldScopeMap.clear();
-    this._scopeMap = newScopeMap;
   }
 
   /** @internal */
@@ -857,8 +843,6 @@ const getKeyValue = (
 };
 
 const getScope = (
-  oldScopeMap: Map<unknown, Scope | Scope[]>,
-  newScopeMap: Map<unknown, Scope | Scope[]>,
   item: unknown,
   forOf: ForOfStatement,
   parentScope: Scope,
@@ -866,29 +850,8 @@ const getScope = (
   local: string,
   hasDestructuredLocal: boolean,
 ) => {
-  // let scope = void 0 as Scope | Scope[] | undefined;
-  let scope = oldScopeMap.get(item);
-  if (scope === void 0) {
-    scope = createScope(item, forOf, parentScope, binding, local, hasDestructuredLocal);
-  } else if (scope instanceof Scope) {
-    oldScopeMap.delete(item);
-  } else if (scope.length === 1) {
-    scope = scope[0];
-    oldScopeMap.delete(item);
-  } else {
-    scope = scope.shift()!;
-  }
+  const scope = createScope(item, forOf, parentScope, binding, local, hasDestructuredLocal);
 
-  if (newScopeMap.has(item)) {
-    const entry = newScopeMap.get(item)!;
-    if (entry instanceof Scope) {
-      newScopeMap.set(item, [entry, scope]);
-    } else {
-      entry.push(scope);
-    }
-  } else {
-    newScopeMap.set(item, scope);
-  }
   setItem(hasDestructuredLocal, forOf.declaration, scope, binding, local, item);
   return scope;
 };

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -195,7 +195,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     }
 
     this._normalizeToArray();
-    this._createScopes(indexMap);
+    this._createScopes(this.key === null ? indexMap : void 0);
     this._applyIndexMap(indexMap);
   }
 
@@ -353,8 +353,8 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
           scopes[i] = oldScopes[src];
         } else {
           scopes[i] = createScope(items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
-          setItem(hasDestructuredLocal, forOf.declaration, scopes[i], binding, local, items[i]);
         }
+        setItem(hasDestructuredLocal, forOf.declaration, scopes[i], binding, local, items[i]);
       }
     }
 

--- a/packages/runtime-html/src/resources/template-controllers/repeat.ts
+++ b/packages/runtime-html/src/resources/template-controllers/repeat.ts
@@ -147,7 +147,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     _parent: IHydratedParentController,
   ): void | Promise<void> {
     this._normalizeToArray();
-    this._createScopes();
+    this._createScopes(void 0);
 
     return this._activateAllViews(initiator, this._normalizedItems ?? emptyArray);
   }
@@ -175,7 +175,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     }
     this._refreshCollectionObserver();
     this._normalizeToArray();
-    this._createScopes();
+    this._createScopes(void 0);
     this._applyIndexMap(void 0);
   }
 
@@ -195,7 +195,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     }
 
     this._normalizeToArray();
-    this._createScopes();
+    this._createScopes(indexMap);
     this._applyIndexMap(indexMap);
   }
 
@@ -324,7 +324,7 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
   }
 
   /** @internal */
-  private _createScopes(): void {
+  private _createScopes(indexMap: IndexMap | undefined): void {
     const oldScopes = this._scopes;
     this._oldScopes = oldScopes.slice();
 
@@ -340,8 +340,22 @@ export class Repeat<C extends Collection = unknown[]> implements ICustomAttribut
     const local = this.local;
     const hasDestructuredLocal = this._hasDestructuredLocal;
 
-    for (let i = 0; i < len; ++i) {
-      scopes[i] = getScope(oldScopeMap, newScopeMap, items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
+    if (indexMap === void 0) {
+      for (let i = 0; i < len; ++i) {
+        scopes[i] = getScope(oldScopeMap, newScopeMap, items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
+      }
+    } else {
+      const oldLen = oldScopes.length;
+      for (let i = 0; i < len; ++i) {
+        const src = indexMap[i];
+
+        if (src >= 0 && src < oldLen) {
+          scopes[i] = oldScopes[src];
+        } else {
+          scopes[i] = createScope(items[i], forOf, parentScope, binding, local, hasDestructuredLocal);
+        }
+        setItem(hasDestructuredLocal, forOf.declaration, scopes[i], binding, local, items[i]);
+      }
     }
 
     oldScopeMap.clear();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

Fixes an issue in the repeater where the scope cache can get misaligned in indexed mode with duplicate objects
<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

https://github.com/aurelia/aurelia/issues/2078
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

The `getScope` method and the way it was storing scopes associated with duplicate items in the scopeMap is not reliable when existing items are moved around. In that case the indexMap is now used to restore existing scopes from the correct source location instead of a naive FIFO item-based identity lookup.
<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
