### PR TITLE
docs(building-plugins): rewrite building plugin docs

### DIFF
--- a/docs/user-docs/developer-guides/building-plugins.md
+++ b/docs/user-docs/developer-guides/building-plugins.md
@@ -1,421 +1,269 @@
 ---
 description: >-
-  Aurelia makes it easy to create your own plugins. Learn how you can create
-  individual plugins, register them and work with tasks to run code at certain
+  Aurelia makes it easy to create your plugins. Learn how to create
+  individual plugins, register them, and work with tasks to run code during certain
   parts of the lifecycle process.
 ---
 
-# Building plugins
+# Building Plugins
 
-One of the most important needs of users is to design custom plugins. In the following, we want to get acquainted with how to design a plugin in the form of a mono-repository structure with configuration.
+Aurelia plugins allow you to encapsulate functionality that can be reused across multiple applications. They can include custom elements, value converters, and other resources. The goal is to create packaged, easily shared, ready-to-use functionalities that integrate seamlessly with Aurelia applications.
 
-### What is a mono-repository?
+## Minimal Plugin Example
 
-A monorepo (mono repository) is a single repository that stores all of your code and assets for every project. Using a monorepo is important for many reasons. It creates a single source of truth. It makes it easier to share code. It even makes it easier to refactor code.
+### What a Plugin Is
 
-### How NPM v7 helps us?
+At its core, a plugin in Aurelia is an object with a `register` method that configures dependencies and sets up your component or functionality for use in an Aurelia application.
 
-With `workspaces`. Workspaces are a set of features in the npm CLI that offer support for managing multiple packages within a single top-level, root package. NPM v7 has shipped with Node.js v15.
+### Simple Plugin Setup
 
-### What is the scenario?
-
-To move forward with a practical example. We want to implement Bootstrap components in a custom mono-repository with a configuration to make it customizable.
-
-### What is the library structure?
-
-We want to separate our plugin into three packages.
-
-* **bootstrap-v5-core**
-
-We will add the Bootstrap 5 configurations to this package.
-
-* **bootstrap-v5**
-
-Our Bootstrap 5 components will define in this package. `bootstrap-v5` depends on `bootstrap-v5-core` packages.
-
-* **demo**
-
-We will use our plugin in this package as a demo. `demo` depends on `bootstrap-v5-core` and `bootstrap-v5`.
-
-### How to configure NPM v7 workspaces?
-
-To configure your monorepo, you should do as following:
-
-Make sure you have installed NPM v7+
-
-```bash
-npm -v
-```
-
-Go to a folder that you want to make the project, for example `my-plugin`
-
-Create a `packages` folder and `package.json` inside it.
-
-```javascript
-// package.json content
-
-{
-  "name": "@my-plugin",
-  "workspaces": [
-    "packages/**"
-  ]
-}
-```
-
-The mono repository's name is `@my-plugin`. We defined our workspaces (projects) under `packages` folder.
-
-Open your `packages` folder and install the projects inside it.
-
-```bash
-npx makes aurelia bootstrap-v5-core -s typescript
-npx makes aurelia bootstrap-v5 -s typescript
-npx makes aurelia demo -s typescript
-```
-
-After creating, delete all files inside `src` folders of `bootstrap-v5-core` and `bootstrap-v5` but `resource.d.ts`. We will add our files there.
-
-![](../.gitbook/assets/1.png)
-
-## How to manage dependencies?
-
-As described in the structure section defined packages depend on each other. So, we link them together and add the other prerequisites for each. At the same time it is good to name them a bit better.
-
-* **bootstrap-v5-core**
-
-Go to its `package.json` and change the name to
-
-```javascript
-"name": "@my-plugin/bootstrap-v5-core"
-```
-
-As our core package, it has no dependency.
-
-* **bootstrap-v5**
-
-Go to its `package.json` and change the name to
-
-```javascript
-"name": "@my-plugin/bootstrap-v5"
-```
-
-Then, add the following dependencies:
-
-```javascript
-// bootstrap-v5/package.json
-"dependencies": {
-    "aurelia": "latest",
-    "bootstrap": "^5.0.0-beta2",
-    "@my-plugin/bootstrap-v5-core": "0.1.0"
-},
-```
-
-* **demo**
-
-Go to its `package.json` and change the name to
-
-```javascript
-"name": "@my-plugin/demo"
-```
-
-Then, add the following dependencies:
-
-```javascript
-// demo/package.json
-"dependencies": {
-    "aurelia": "latest",
-    "@my-plugin/bootstrap-v5-core": "0.1.0",
-    "@my-plugin/bootstrap-v5": "0.1.0"
-},
-```
-
-**Note**: All created packages have `0.1.0` version so pay attention if the version changes, update it correctly.
-
-Run the command below to install packages inside the `my-plugin` folder.
-
-```bash
-npm install
-```
-
-### How to define a plugin configuration?
-
-Go to the `src` folder of `bootstrap-v5-core` package and create each of the below files there.
-
-**Size**
-
-As I mentioned before, I want to write a configurable Bootstrap plugin so create `src/Size.ts` file.
-
-```javascript
-// Size.ts
-
-export enum Size {
-    ExtraSmall = 'xs',
-    Small = 'sm',
-    Medium = 'md',
-    Large = 'lg',
-    ExtraLarge = 'xl',
-}
-```
-
-I made a `Size` enum to handle all Bootstrap sizes. I want to make an option for those who use the plugin to define a global size for all Bootstrap components at first. Next, we manage our components according to size value.
-
-**Bootstrap 5 Options**
-
-Create `src/BootstrapV5Options.ts` file.
-
-```javascript
-// BootstrapV5Options.ts
-
-import { Size } from "./Size";
-
-export interface IBootstrapV5Options {
-    defaultSize?: Size;
-}
-const defaultOptions: IBootstrapV5Options = {
-    defaultSize: Size.Medium
-};
-```
-
-You need to define your configurations via an interface with its default values as a constant.
-
-**DI**
-
-To register it via DI, you need to add codes below too:
-
-```javascript
-// BootstrapV5Options.ts
-
+```typescript
+// my-simple-plugin.ts
 import { IContainer } from '@aurelia/kernel';
-import { AppTask, DI, Registration } from 'aurelia';
 
-function configure(container: IContainer, config: IBootstrapV5Options = defaultOptions) {
-    return container.register(
-        AppTask.hydrating(IContainer, async container => {
-            if (config.enableSpecificOption) {
-                const file = await import('file');
-                cfg.register(Registration.instance(ISpecificOption, file.do());
-            }
-            Registration.instance(IBootstrapV5Options, config).register(container);
-        })
-    );
-}
-
-export const IBootstrapV5Options = DI.createInterface<IBootstrapV5Options>('IBootstrapV5Options');
-
-export const BootstrapV5Configuration = {
-    register(container: IContainer) {
-        return configure(container);
-    },
-    customize(config: IBootstrapV5Options) {
-        return {
-            register(container: IContainer) {
-                return configure(container, config);
-            },
-        };
-    }
+export const MySimplePlugin = {
+  register(container: IContainer): void {
+    // Register your plugin resources here
+  }
 };
 ```
 
-`configure` helps us to set the initial options or loading special files based on a specific option to DI system. To load specific files, you need to do this via `AppTask`.
-
-The `AppTask` allows you to position when/where certain initialization should happen and also optionally block app rendering accordingly.
-
-If you no need this feature replace it with:
+### Integrating the Plugin into Your Application
 
 ```typescript
-function configure(container: IContainer, config: IBootstrapV5Options = defaultOptions) {
-    Registration.instance(IBootstrapV5Options, config).register(container);
-}
-```
-
-`Registration.instance` helps us to register our default option into the container.
-
-To use your option later inside your components, you should introduce it via `DI.createInterface`. The trick here is to create a resource name the same as what you want to inject. This is the reason I name it as `IBootstrapV5Options` constant.
-
-Finally, you need to make sure that the user can determine the settings. This is the task of `BootstrapV5Configuration`.
-
-`register` This method helps the user to use your plugin with default settings but `customize` is the method that allows the user to introduce their custom settings.
-
-**Exports**
-
-Create `src/index.ts` file.
-
-```javascript
-// index.ts
-
-export * from './BootstrapV5Configuration';
-export * from './Size';
-```
-
-Create new `index.ts` file inside `bootstrap-v5-core` package too.
-
-```javascript
-export * from './src';
-```
-
-### How to implement the custom plugin?
-
-Go to the `src` folder of `bootstrap-v5` package, create a `button` folder then create each of the below files there.
-
-* **View**
-
-Create `bs-button.html` file.
-
-```html
-<button class="btn btn-primary btn-${size}" ref="bsButtonTemplate">
-    Primary Button
-</button>
-```
-
-* **ViewModel**
-
-Create `bs-button.ts` file.
-
-```javascript
-import { customElement, containerless, BindingMode, bindable, resolve } from "aurelia";
-import template from "./bs-button.html";
-import { IBootstrapV5Options, Size } from "@my-plugin/bootstrap-v5-core";
-
-@customElement({ name: "bs-button", template })
-@containerless
-export class BootstrapButton {
-    private bsButtonTemplate: Element;
-    @bindable({ mode: BindingMode.toView }) public size?: Size = null;
-    constructor(
-        private options: IBootstrapV5Options = resolve(IBootstrapV5Options)
-    ) {
-    }
-    attached() {
-        this.applySize();
-    }
-    private applySize() {
-        if (this.options.defaultSize && !this.size) {
-            switch (this.options.defaultSize) {
-                case Size.ExtraSmall:
-                case Size.Small:
-                    this.resetSize();
-                    this.size = Size.Small;
-                    break;
-                case Size.Large:
-                case Size.ExtraLarge:
-                    this.resetSize();
-                    this.size = Size.Large;
-                    break;
-                default:
-                    this.resetSize();
-                    this.size = Size.Medium;
-            }
-        }
-    }
-    private resetSize() {
-        this.bsButtonTemplate.classList.remove("btn-sm", "btn-lg");
-    }
-}
-```
-
-As you can see we are able to access to plugin options easy via `ctor` (DI) and react appropriately to its values.
-
-```typescript
-private options: IBootstrapV5Options = resolve(IBootstrapV5Options)
-```
-
-In this example, I get the size from the user and apply it to the button component. If the user does not define a value, the default value will be used.
-
-**Exports**
-
-Create files below correctly:
-
-Create `src/button/index.ts` file.
-
-```javascript
-export * from './bs-button';
-```
-
-Create `src/index.ts` file.
-
-```javascript
-export * from './button';
-```
-
-Create new `index.ts` file inside `bootstrap-v5` package.
-
-```javascript
-import 'bootstrap/dist/css/bootstrap.min.css';
-export * from './src';
-```
-
-### How to use it?
-
-Open `demo` package and go to the `src` and update `main.ts`.
-
-```javascript
 // main.ts
-
 import Aurelia from 'aurelia';
-import { MyApp } from './my-app';
-import { BootstrapV5Configuration } from '@my-plugin/bootstrap-v5-core';
-import * as BsComponents from '@my-plugin/bootstrap-v5';
+import { MySimplePlugin } from './my-simple-plugin';
 
 Aurelia
-  .register(BsComponents, BootstrapV5Configuration)
+  .register(MySimplePlugin)
   .app(MyApp)
   .start();
 ```
 
-Importing is available for whole components
+## Adding Components
 
-```javascript
-import * as BsComponents from '@my-plugin/bootstrap-v5';
-```
+You often want to add custom components to make your plugin more useful.
 
-Or just a component
+```typescript
+// hello-world.ts
+import { customElement } from '@aurelia/runtime-html';
 
-```javascript
-import { BootstrapButton } from '@my-plugin/bootstrap-v5';
-```
+@customElement({
+  name: 'hello-world',
+  template: '<div>Hello, ${name}!</div>'
+})
+export class HelloWorld {
+  name = 'World';
+}
 
-To register your components you should add them to `register` method.
+// my-component-plugin.ts
+import { IContainer } from '@aurelia/kernel';
+import { HelloWorld } from './hello-world';
 
-```javascript
-.register(BsComponents) // For whole components
-// Or
-.register(BootstrapButton) // For a component
-```
-
-We support configuration so we should introduce it to `register` method too.
-
-```javascript
- // With default options
-.register(BootstrapV5Configuration)
-// Or with a custom option
-.register(BootstrapV5Configuration.customize({
-  defaultSize: Size.Small // Components loads with small size.
-}))
-```
-
-Now, You are able to use your `bs-button` inside `src/my-app.html`.
-
-```html
-<bs-button></bs-button>
-<bs-button size="lg"></bs-button>
-```
-
-To run the `demo` easily, go to the `my-plugin` root folder and add the following script section to the `package.json`.
-
-```bash
-{
-  "name": "@my-plugin",
-  "workspaces": [
-    "packages/**"
-  ],
-  "scripts": {
-    "start": "npm run --prefix packages/demo start"
+export const MyComponentPlugin = {
+  register(container: IContainer): void {
+    container.register(HelloWorld);
   }
+};
+```
+
+## Creating a Configurable Plugin
+
+### Define Configuration Interface
+
+```typescript
+// plugin-configuration.ts
+export interface MyPluginOptions {
+  greeting?: string;
+  debug?: boolean;
+}
+
+const defaultOptions: MyPluginOptions = {
+  greeting: 'Hello',
+  debug: false
+};
+```
+
+### Implement Configuration in Plugin
+
+```typescript
+// my-configurable-plugin.ts
+import { DI, IContainer, Registration } from '@aurelia/kernel';
+
+export const IMyPluginOptions = DI.createInterface<MyPluginOptions>('IMyPluginOptions');
+
+export const MyConfigurablePlugin = {
+  configure(options: Partial<MyPluginOptions> = {}) {
+    const finalOptions = { ...defaultOptions, ...options };
+
+    return {
+      register(container: IContainer): void {
+        container.register(
+          Registration.instance(IMyPluginOptions, finalOptions)
+        );
+      }
+    };
+  }
+};
+```
+
+### Using the Configurable Plugin
+
+```typescript
+// main.ts
+import Aurelia from 'aurelia';
+import { MyConfigurablePlugin } from './my-configurable-plugin';
+
+Aurelia
+  .register(
+    MyConfigurablePlugin.configure({
+      greeting: 'Bonjour',
+      debug: true
+    })
+  )
+  .app(MyApp)
+  .start();
+```
+
+### Accessing Configuration in a Component
+
+```typescript
+// greeting.ts
+import { customElement, inject } from '@aurelia/runtime-html';
+import { IMyPluginOptions } from './my-configurable-plugin';
+
+@customElement({
+  name: 'greeting',
+  template: '<div>${options.greeting}, ${name}!</div>'
+})
+export class Greeting {
+  name = 'World';
+  
+  constructor(@inject(IMyPluginOptions) private options: MyPluginOptions) {}
 }
 ```
 
-Then, call the command
+## Best Practices
 
-```shell
-npm run start
-npm start
+- **Use Clear Naming Conventions**: Prefix your plugin resources with your plugin name to avoid naming collisions.
+- **Provide Sensible Defaults**: Always have sensible default values when adding configuration options.
+- **Document Plugin Usage**: Write clear documentation on how to use your plugin and its configurations.
+
+## Advanced Features
+
+Once you’ve mastered the basics of creating plugins, you may find that your needs evolve to require more complex functionality. This section covers advanced features in plugin development, such as advanced configuration management, lifecycle tasks, and mono-repository structures.
+
+### Advanced Configuration Management
+
+When your plugin settings are more intricate, consider adding more comprehensive configuration handling:
+
+#### Dynamic Configuration
+
+Plugins can adjust settings dynamically based on user input or environment conditions.
+
+```typescript
+// dynamic-configuration-plugin.ts
+import { DI, IContainer, Registration } from '@aurelia/kernel';
+
+export interface DynamicPluginOptions {
+  mode: 'development' | 'production';
+}
+
+export const IDynamicPluginOptions = DI.createInterface<DynamicPluginOptions>('IDynamicPluginOptions');
+
+export const DynamicPlugin = {
+  configure(options: Partial<DynamicPluginOptions> = {}) {
+    const environment = process.env.NODE_ENV || 'development';
+    const finalOptions: DynamicPluginOptions = { 
+      mode: environment, 
+      ...options 
+    };
+
+    return {
+      register(container: IContainer): void {
+        container.register(
+          Registration.instance(IDynamicPluginOptions, finalOptions)
+        );
+      }
+    };
+  }
+};
+
+// Usage
+Aurelia
+  .register(
+    DynamicPlugin.configure({
+      mode: 'production'
+    })
+  )
+  .app(MyApp)
+  .start();
 ```
+
+### Plugin Lifecycle Management
+
+Aurelia provides lifecycle hooks that you can hook into within your plugins to perform operations at specific times during the app’s startup process.
+
+#### Using Lifecycle Tasks
+
+```typescript
+import { IContainer, AppTask } from '@aurelia/kernel';
+
+const MyLifecyclePlugin = {
+  register(container: IContainer): void {
+    // Add tasks to run before or after different app stages
+    container.register(
+      AppTask.beforeStart(IContainer, () => {
+        console.log('Plugin is initializing...');
+      }),
+      AppTask.afterStart(IContainer, () => {
+        console.log('Plugin has finished initializing.');
+      })
+    );
+  }
+};
+```
+
+This approach is beneficial when your plugin needs to load data, configure services, or perform actions that require awareness of the application’s runtime state.
+
+### Mono-Repository Structure
+
+For larger projects with multiple interrelated plugins, maintaining individual repositories may become cumbersome. A mono-repository can simplify this by organizing multiple packages in a single repository.
+
+#### Setting Up a Mono-Repository
+
+1. **Directory Structure**
+   ```
+   my-mono-repo/
+   ├── packages/
+   │   ├── my-plugin-a/
+   │   │   ├── src/
+   │   │   ├── package.json
+   │   │   └── ...
+   │   ├── my-plugin-b/
+   │   │   ├── src/
+   │   │   ├── package.json
+   │   │   └── ...
+   └── package.json
+   ```
+
+2. **Top-level `package.json` Setup**
+   ```json
+   {
+     "private": true,
+     "workspaces": [
+       "packages/*"
+     ]
+   }
+   ```
+
+3. **Link Dependencies**
+   Use tools like `lerna` or native `npm` workspaces (`npm install -g lerna`).
+
+   Initialize the repository:
+   ```bash
+   lerna init
+   ```
+
+   This setup helps maintain consistency, allows for easier inter-package dependencies, and simplifies testing across multiple plugins.


### PR DESCRIPTION
The existing docs were focusing too heavily on Monorepo and not on how to create plugins are their basic core. This makes the docs minimal first and then adds advanced later on.