### PR TITLE
docs(synthetic-view): modernize docs

### DIFF
--- a/docs/user-docs/tutorials/synthetic-view.md
+++ b/docs/user-docs/tutorials/synthetic-view.md
@@ -30,10 +30,11 @@ A synthetic view in Aurelia 2 consists of several key components:
 
 Before working with synthetic views, you should be familiar with:
 
-- Basic Aurelia 2 concepts and templating
-- JavaScript DOM APIs (particularly `createElement` and `appendChild`)
-- Aurelia's dependency injection system
-- Basic understanding of scopes and binding contexts
+* Creating a new Aurelia app. This tutorial won't cover this; you can look at the other tutorials.
+* You have familiarized yourself with the [Aurelia template syntax](../templates/template-syntax.md).
+* You have familiarized yourself with [components in Aurelia](../components/components.md).
+* You are familiar with [Dependency Injection](../getting-to-know-aurelia/dependency-injection-di/). You don't need to master it; you need to be familiar with its existence and why it matters in Aurelia.
+* Native Web APIs, such as [`createElement`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement).
 
 ## Getting Started
 

--- a/docs/user-docs/tutorials/synthetic-view.md
+++ b/docs/user-docs/tutorials/synthetic-view.md
@@ -4,512 +4,960 @@ description: >-
   runtime.
 ---
 
-# Synthetic view
+# Synthetic Views
 
-Synthetic views in Aurelia are a powerful feature that allows developers to generate and manage UI templates entirely through code dynamically. Unlike traditional views, which are pre-defined in HTML, synthetic views offer a higher degree of flexibility and control, making them ideal for scenarios where the UI needs to be constructed or altered on the fly based on various conditions or data sources.
+Synthetic views in Aurelia 2 are a powerful feature that allows developers to create and manage views programmatically at runtime. Unlike traditional views in HTML templates, synthetic views offer complete control over view creation, binding, and lifecycle management.
 
-In this tutorial, we'll explore creating and using synthetic views in Aurelia, utilizing lower-level APIs like ViewFactory and Controller. This approach provides a deeper understanding of how Aurelia manages views and offers more control over the view lifecycle and rendering process.
+## When to Use Synthetic Views
 
-While you can use the `enhance` API to hydrate dynamically (on runtime) generated templates, this tutorial shows some primitives to do the same with more controls.
+Synthetic views are particularly useful when:
+- Rendering server-generated HTML with Aurelia bindings
+- Dynamically creating templates based on runtime data
+- Integrating with CMS or third-party content that needs Aurelia binding capabilities
+- Creating complex, programmatically-generated UIs
 
-## What we will be building
+## Basic Concepts
 
-In this tutorial, we will build a simple application demonstrating the power of synthetic views. Our application will include:
+A synthetic view in Aurelia 2 consists of several key components:
 
-- **Two Custom Elements:** We'll start by writing two custom elements - `normal-text` and `value-text`. These elements will be simplistic, focusing on displaying bound values in different HTML tags (`<span>` and `<strong>`, respectively).
-- **Dynamic Template Construction:** We'll then dynamically construct a template at runtime using these custom elements. This step will showcase how to build a view from scratch using JavaScript.
-- **Utilizing Aurelia's Lower-Level APIs:** Finally, we will delve into lower-level Aurelia APIs like ViewFactory and Controller. This will demonstrate how to hydrate (or activate) the template, bringing our dynamic view to life.
-
-Through these steps, you'll learn not just how to create synthetic views, but also understand the scenarios where they are particularly beneficial.
-
-{% hint style="success" %}
-You can see a working example [here](https://stackblitz.com/edit/typescript-hh9a1e).
-{% endhint %}
+1. **Template Creation**: A programmatically created template element containing your dynamic HTML
+2. **Render Location**: A marker in the DOM where Aurelia will render your view
+3. **View Factory**: Creates view instances from your template
+4. **Scope**: Provides the binding context for your view
+5. **View Instance**: The actual view that gets rendered and managed
 
 ## Prerequisites
 
-Before going any further, you should be familiar with some basic Aurelia concepts and some fundamental Javascript ones. While these are not hard prerequisites, please know that some concepts used in this tutorial out of context might be confusing or difficult to understand.
+Before working with synthetic views, you should be familiar with:
 
-* Creating a new Aurelia app. This won't be covered in this tutorial; you can take a look at the other tutorials.
-* You have familiarized yourself with the [Aurelia template syntax](../templates/template-syntax.md).
-* You have familiarized yourself with [components in Aurelia](../components/components.md).
-* You are familiar with [Dependency Injection](../getting-to-know-aurelia/dependency-injection-di/). You don't need to be a master of it; you just need to be familiar with its existence and why it matters in Aurelia.
-* Native Web APIs, such as [`createElement`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElement).
+- Basic Aurelia 2 concepts and templating
+- JavaScript DOM APIs (particularly `createElement` and `appendChild`)
+- Aurelia's dependency injection system
+- Basic understanding of scopes and binding contexts
 
-## Why Use Synthetic Views
+## Getting Started
 
-Synthetic views are particularly useful in scenarios where the content of a view is not known at design time or needs to be dynamically constructed based on runtime data. This makes them a go-to solution for:
+Here's a basic example of creating a synthetic view:
 
-- **Dynamic Content Rendering:** Creating views on the fly based on user interactions, data changes, or dynamic content requirements.
-- **Complex UI Manipulations:** Constructing UIs with a level of complexity that isn't easily achievable with static templates.
-- **Performance Optimization:** Tailoring the view creation and rendering process for specific performance requirements, as synthetic views can be fine-tuned for optimal performance in dynamic UI scenarios.
-
-By the end of this tutorial, you'll have a clearer understanding of how and when to leverage synthetic views in your Aurelia applications, enhancing both flexibility and user experience.
-
-## Custom elements
-
-First, let us write some custom elements. These custom elements will be rather simplistic in nature so that we don't get tangled in the logic of complex custom elements too much. To this end, we will have two custom elements, namely `normal-text` and `value-text`. These custom elements display a bound `value` inside a `<span>` and a `<strong>` element, respectively, as shown in the following code fragment.
-
-{% tabs %}
-{% tab title="custom-elements.ts" %}
 ```typescript
-import { bindable, customElement } from '@aurelia/runtime-html';
+import { 
+    convertToRenderLocation, 
+    CustomElementDefinition, 
+    ICustomElementController, 
+    ISyntheticView 
+} from '@aurelia/runtime-html';
+import { Scope } from '@aurelia/runtime';
+import { 
+    customElement, 
+    IContainer, 
+    ViewFactory,
+    IPlatform, 
+    resolve 
+} from "aurelia";
 
 @customElement({
-  name: 'normal-text',
-
-  //the template is inlined for ease of demonstration; feel free to import the template from an external html file.
-  template: '<span>NT: ${value}</span>',
+    name: 'synthetic-example',
+    template: '<div ref="container"></div>'
 })
-export class NormalText {
-  @bindable value: unknown;
-}
-
-@customElement({
-  name: 'value-text',
-
-  //the template is inlined for ease of demonstration; feel free to import the template from an external html file.
-  template: '<strong>VT: ${value}</strong>',
-})
-export class ValueText {
-  @bindable value: unknown;
-}
-```
-{% endtab %}
-
-{% tab title="main.ts" %}
-```typescript
-import { Aurelia, StandardConfiguration } from '@aurelia/runtime-html';
-import { NormalText, ValueText } from './custom-elements';
-
-(async function () {
-  await new Aurelia()
-    .register(
-      StandardConfiguration,
-
-      /*--- Register the custom elements ---*/
-      NormalText,
-      ValueText,
-    )
-    //...
-    ;
-})().catch(console.error);
-```
-{% endtab %}
-{% endtabs %}
-
-Make sure that you have registered those custom elements.
-
-## Setup the `App`
-
-Let us assume that the starting point of our app is as follows.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import { ICustomElementViewModel } from '@aurelia/runtime-HTML';
-import { customElement } from 'aurelia';
-import template from './app.html';
-
-@customElement({ name: 'app', template })
-export class App {
-  private containerEl: HTMLDivElement;
-  private readonly bc = { value: 'Hello Aurelia!' };
-
-  private async add() {
-    // TODO add code here to compose dynamic template and hydrate
-  }
-
-  private async remove() {
-    // TODO add code here to remove the hydrated
-  }
-}
-```
-{% endtab %}
-
-{% tab title="app.html" %}
-```html
-${bc.message} <br>
-
-<!-- we would like to add the hydrated custom elements when this button is clicked -->
-<button click.delegate="add()">Add CEs</button>
-
-<!-- we would like to remove the hydrated custom elements when this button is clicked -->
-<button click.delegate="remove()">Remove CEs</button>
-
-<br>
-<!-- This is where we would like add our hydrated elements -->
-<div ref="containerEl"></div>
-```
-{% endtab %}
-{% endtabs %}
-
-The idea is to add the dynamically generated and hydrated nodes in the `div[ref=containerEl]` using the `add` method and remove those using the `remove` method.
-
-## Synthesize the view
-
-The process of dynamically adding the hydrated nodes can be broadly divided into the following steps:
-
-1. Create the DOM fragment under a single root node.
-2. Add the root node to the DOM.
-3. Convert the root node to a render location where Aurelia can add the hydrated nodes later.
-4. Create a `ViewFactory`.
-5. Activate an `ISyntheticView` using the view factory.
-
-We generate the DOM fragment in the first step using simple Web APIs. Our goal for this tutorial is to create the following DOM fragment.
-
-```html
-<normal-text value.bind></normal-text>
-<br>
-<value-text value.bind></value-text>
-```
-
-{% hint style="info" %}
-The dynamically generated nodes need not necessarily be only custom elements. Native elements can also be hydrated the same way.
-{% endhint %}
-
-To this end, we inject a `IPlatform` instance to our `App` instead of directly using the global Web APIs. This is recommended because it makes the testing easier.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import { resolve } from 'aurelia';
-import {
-  IPlatform,
-  //...
-} from '@aurelia/runtime-html';
-//...
-
-export class App {
-  private readonly platform: IPlatform = resolve(IPlatform);
-}
-```
-{% endtab %}
-{% endtabs %}
-
-Next we proceed to prepare the DOM fragment inside the `add` method.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-//...
-export class App {
-  //...
-  public async add() {
-
-    // Step#1: Create the template.
-    const doc = this.platform.document;
-    // synthetic view root
-    const template: HTMLTemplateElement = doc.createElement('template');
-    const content = template.content;
-
-    const normalText = doc.createElement('normal-text');
-    normalText.setAttribute('value.bind', '');
-
-    const valueText = doc.createElement('value-text');
-    valueText.setAttribute('value.bind', '');
-
-    content.append(
-      normalText,
-      doc.createElement('br'),
-      valueText
-    );
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-In the next step we need to add this fragment to the DOM and to this end we would like to use the `div[ref=containerEl]` to be the parent of the `template`.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-//...
-export class App {
-  //...
-  public async add() {
-    //...
-    // Step#2: Add the template to the DOM
-    this.containerEl.append(template);
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-Then we convert the `template` to a render location. This process adds a marker, as render location, in the DOM where the hydrated nodes will be attached later.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import {
-  convertToRenderLocation,
-  //...
-} from '@aurelia/runtime-html';
-//...
-export class App {
-  //...
-  public async add() {
-    //...
-    // Step#3: Convert the node to a render location so that Aurelia can attach the hydrated nodes back to correct location during activate
-    const loc = convertToRenderLocation(template);
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-After that we need to create a view factory from the template. The objective of creating a view factory is simply, as the name already suggests, to create a view later from it.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import {
-  CustomElementDefinition,
-  CustomElement,
-  ViewFactory,
-  //...
-} from '@aurelia/runtime-html';
-import {
-  IContainer,
-  resolve,
-  //...
-} from 'aurelia';
-//...
-export class App {
-  private readonly platform: IPlatform = resolve(IPlatform);
-
-  public async add() {
-    //...
-    // Step#4: Create view factory
-    // create a custom-element definition from the template.
-    // The view later will be created from this definition
-    const definition = CustomElementDefinition.create({
-      // we have used here a auto-generated name to avoid collision; you may choose an explicit name if you want to.
-      name: CustomElement.generateName(),
-      template,
-    });
-    const factory = new ViewFactory(this.container, definition);
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-Note that to create the view factory, we need a container, which is injected via the `App` constructor.
-
-With that, our preparation is almost done. The next step involves creating a view from the view factory and activating it.
-
-To activate the view, however, we need to use a "parent" controller. This is needed as a hierarchical structure is maintained on the controller level. Because we are creating the view from `App`, it makes sense to use the controller from the `App` to this end. Aurelia adds a controller to every view custom element view model (as well as custom attribute view model) once the view model is created.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import {
-  ICustomElementViewModel,
-  ICustomElementController,
-  //...
-} from '@aurelia/runtime-html';
-//...
-export class App implements ICustomElementViewModel {
-  //...
-  // This is set by the controller after this instance is constructed.
-  public readonly $controller!: ICustomElementController<this>;
-  //...
-}
-```
-{% endtab %}
-{% endtabs %}
-
-We use this controller to create the view from the view factory.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import {
-  ISyntheticView,
-  LifecycleFlags,
-  //...
-} from '@aurelia/runtime-html';
-import {
-  Scope,
-  //...
-} from '@aurelia/runtime';
-//...
-export class App implements ICustomElementViewModel {
-  private view: ISyntheticView | undefined;
-  private readonly bc = { value: 'Hello Aurelia!' };
-  //...
-
-  public async add() {
-    //...
-    // Step#5: Create and activate view
-    const view = this.view = factory
-      .create(controller)
-      .setLocation(loc); //<-- render location created in Step#2
-
-    // binds the view with the given scope and attaches it to the DOM
-    await view.activate(
-      view,
-      controller,
-      LifecycleFlags.none,
-      Scope.create(this.bc),
-    );
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-In this step, the view is created from the factory, and the render location is set. Subsequently, the view is activated, which involves mainly binding the view with the given scope and attaching the hydrated nodes to the render location.
-
-In this example, a new scope is created to bind the view for simplicity. However, if you want to avoid that, you may reuse the same scope from the `controller` itself (see [example](https://stackblitz.com/edit/typescript-pzef4n?file=app%2Fapp.ts)) or use that as parent scope depending on your need. To know more about scope and context, refer to the respective [documentation](../components/scope-and-binding-context.md). Once the activation is complete you can see the hydrated nodes in DOM.
-
-## Remove the view
-
-You may have noticed that we have stored the view in the `App#view` property. Removing involves simply deactivating the view.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-//...
-export class App implements ICustomElementViewModel {
-  //...
-  private async remove() {
-    await this.view.deactivate(view, this.$controller, LifecycleFlags.none);
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-{% hint style="info" %}
-Note that the `view` can be kept around, activated, or deactivated on-demand.
-{% endhint %}
-
-It also might be a good idea to dispose of the `view` from the `dispose` hook of the view model to ensure systematic disposal of the view and the associated resources.
-
-{% tabs %}
-{% tab title="app.ts" %}
-```typescript
-import {
-  Controller,
-  //...
-} from '@aurelia/runtime-html';
-//...
-export class App implements ICustomElementViewModel {
-  //...
-  public dispose() {
-    (this.view as Controller).dispose();
-    this.view = undefined;
-  }
-}
-```
-{% endtab %}
-{% endtabs %}
-
-### Live example
-
-You can see the live example below. It involves some trivial guard conditions; other than that, it is mostly the same.
-
-{% embed url="https://stackblitz.com/edit/typescript-hh9a1e?ctl=1&embed=1&file=app/app.ts" %}
-
-## Additional Examples
-
-### Dynamic Form Generation
-
-In an application where the form fields need to be generated based on user selections or data retrieved from an API, synthetic views can be used to dynamically create and render these forms.
-
-```typescript
-// app.ts
-import { customElement, ICustomElementViewModel, ICustomElementController, LifecycleFlags, Scope, ISyntheticView, ViewFactory, convertToRenderLocation, IPlatform } from '@aurelia/runtime-html';
-import { IContainer, resolve } from 'aurelia';
-
-@customElement({ name: 'app', template: '<div ref="containerEl"></div>' })
-export class App implements ICustomElementViewModel {
-  private containerEl: HTMLElement;
-  private view: ISyntheticView | undefined;
-
-  private readonly platform: IPlatform = resolve(IPlatform);
-  private readonly container: IContainer = resolve(IContainer);
-
-  public attached() {
-    this.addDynamicForm();
-  }
-
-  private async addDynamicForm() {
-    // Create a synthetic view for the form
-    const formTemplate = this.platform.document.createElement('template');
-    formTemplate.innerHTML = `
-      <input type="text" placeholder="Name">
-      <input type="email" placeholder="Email">
-      <button type="submit">Submit</button>
-    `;
-
-    // Convert to render location
-    this.containerEl.appendChild(formTemplate);
-    const renderLocation = convertToRenderLocation(formTemplate);
-
-    // Create and activate view
-    const factory = new ViewFactory(this.container, { name: 'dynamic-form', template: formTemplate });
-    const controller = this.container.get(ICustomElementController);
-    this.view = factory.create(controller).setLocation(renderLocation);
-    await this.view.activate(this.view, controller, LifecycleFlags.fromBind, Scope.create({}));
-  }
-}
-```
-
-### Real-Time Data Display
-
-This example illustrates a scenario where a component needs to display real-time data updates, such as a stock ticker or live feed. Synthetic views are ideal for this because they can efficiently update the UI in response to data changes without rerendering the entire view.
-
-```typescript
-// app.ts
-import { customElement, ICustomElementViewModel, ICustomElementController, LifecycleFlags, Scope, ISyntheticView, ViewFactory, convertToRenderLocation, IPlatform } from '@aurelia/runtime-html';
-import { IContainer, resolve } from 'aurelia';
-
-interface LiveData {
-  id: number;
-  value: string;
-}
-
-@customElement({ name: 'live-data-app', template: '<div ref="liveDataContainer"></div>' })
-export class LiveDataApp implements ICustomElementViewModel {
-  private liveDataContainer: HTMLElement;
-  private view: ISyntheticView | undefined;
-  private liveData: LiveData[] = [];
-
-  private readonly platform: IPlatform = resolve(IPlatform);
-  private readonly container: IContainer = resolve(IContainer);
-
-  constructor() {
-    // Simulate live data updates
-    setInterval(() => this.updateLiveData(), 1000);
-  }
-
-  private async updateLiveData() {
-    // Update live data
-    this.liveData.push({ id: this.liveData.length, value: `Data ${this.liveData.length}` });
-
-    // Create and update view with new data
-    if (!this.view) {
-      const template = this.platform.document.createElement('template');
-      template.innerHTML = this.liveData.map(data => `<div>Live Data: ${data.value}</div>`).join('');
-      this.liveDataContainer.appendChild(template);
-      const renderLocation = convertToRenderLocation(template);
-      const factory = new ViewFactory(this.container, { name: 'live-data-view', template });
-      const controller = this.container.get(ICustomElementController);
-      this.view = factory.create(controller).setLocation(renderLocation);
-      await this.view.activate(this.view, controller, LifecycleFlags.fromBind, Scope.create({}));
-    } else {
-      // Update existing view with new data
-      this.view.nodes.firstChild.textContent = this.liveData.map(data => `Live Data: ${data.value}`).join('');
+export class SyntheticExample {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async attached() {
+        // 1. Create template
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <div>
+                <h1>\${title}</h1>
+                <button click.trigger="handleClick()">Click Me</button>
+            </div>
+        `;
+
+        // 2. Add to DOM and create render location
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        // 3. Create view factory
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'dynamic-view',
+                template
+            })
+        );
+
+        // 4. Create view instance
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        // 5. Create scope and activate view
+        const viewModel = {
+            title: 'Dynamic View',
+            handleClick: () => console.log('Clicked!')
+        };
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(viewModel)
+        );
     }
-  }
+
+    async detaching() {
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+        }
+    }
 }
 ```
 
-In this example, the component LiveDataApp simulates receiving live data updates. It uses a synthetic view to render this data dynamically. When new data arrives, the view is efficiently updated without needing to rerender the entire component.
+This code demonstrates the basic pattern for creating and managing synthetic views in Aurelia 2. Each step is essential:
 
-These examples demonstrate two different, but common scenarios where synthetic views can be particularly useful: dynamically generating content based on data and updating content in real-time. They illustrate the flexibility and power of synthetic views in handling dynamic and changing content in an Aurelia application.
+1. **Template Creation**: Create a template element with your dynamic content
+2. **DOM Integration**: Add the template to the DOM and create a render location
+3. **Factory Creation**: Create a view factory from your template
+4. **View Creation**: Create a view instance and set its location
+5. **Activation**: Activate the view with a scope containing your view model
+6. **Cleanup**: Properly deactivate the view when done
+
+## Working with Scopes and Bindings
+
+Understanding how to handle scopes and bindings properly is crucial when creating synthetic views. The scope provides the context for all bindings within your dynamic template.
+
+### Basic Scope Handling
+
+Here's how to create and use scopes effectively:
+
+```typescript
+@customElement({
+    name: 'scope-example',
+    template: '<div ref="container"></div>'
+})
+export class ScopeExample {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async attached() {
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <div>
+                <!-- Basic property binding -->
+                <h1>\${title}</h1>
+                
+                <!-- Event binding -->
+                <button click.trigger="handleClick()">Click Me</button>
+                
+                <!-- Two-way binding -->
+                <input value.bind="inputValue">
+                <p>You typed: \${inputValue}</p>
+                
+                <!-- Repeater binding -->
+                <ul>
+                    <li repeat.for="item of items">\${item.name}</li>
+                </ul>
+            </div>
+        `;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'scope-example-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        // Create view model with reactive properties
+        const viewModel = {
+            title: 'Dynamic View with Bindings',
+            inputValue: '',
+            items: [
+                { name: 'Item 1' },
+                { name: 'Item 2' }
+            ],
+            handleClick: () => {
+                console.log('Current input:', viewModel.inputValue);
+            }
+        };
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(viewModel)
+        );
+    }
+}
+```
+
+### Working with Parent Scopes
+
+Sometimes, you need to access the parent component's scope in your synthetic view. Here's how to do that:
+
+```typescript
+@customElement({
+    name: 'parent-scope-example',
+    template: '<div ref="container"></div>'
+})
+export class ParentScopeExample {
+    // Parent component property
+    message = 'Hello from parent';
+
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async attached() {
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <div>
+                <!-- Access parent scope -->
+                <h2>\${parentMessage}</h2>
+                
+                <!-- Access local scope -->
+                <p>\${localMessage}</p>
+                
+                <button click.trigger="handleClick()">
+                    Update Messages
+                </button>
+            </div>
+        `;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'parent-scope-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        // Create child scope with parent scope access
+        const childScope = Scope.create(
+            {
+                localMessage: 'Hello from child',
+                handleClick: () => {
+                    // Can access both scopes
+                    childScope.localMessage = 'Updated child message';
+                    this.message = 'Updated parent message';
+                }
+            },
+            this.$controller.scope // Parent scope
+        );
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            childScope
+        );
+    }
+}
+```
+
+### Handling Dynamic Updates
+
+When your view model data changes, the bindings will automatically update. However, if you need to rebuild the view completely, you'll need to handle that manually:
+
+```typescript
+@customElement({
+    name: 'dynamic-update-example',
+    template: '<div ref="container"></div>'
+})
+export class DynamicUpdateExample {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async updateView(newData: any) {
+        // Deactivate existing view if it exists
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+            this.container.innerHTML = ''; // Clear container
+        }
+
+        // Create new view with updated data
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <div>
+                <h2>\${title}</h2>
+                <div repeat.for="item of items">
+                    \${item.name}
+                </div>
+            </div>
+        `;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'dynamic-update-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(newData)
+        );
+    }
+}
+```
+
+### Best Practices for Scope Management
+
+1. **Cleanup**: Always deactivate views when they're no longer needed
+2. **Scope Isolation**: Create isolated scopes when you don't need parent scope access
+3. **Parent Scope Access**: Use parent scopes judiciously to avoid tight coupling
+4. **Memory Management**: Clear references to views and scopes when disposing
+5. **Error Handling**: Wrap view creation and activation in try-catch blocks
+
+```typescript
+async createView(data: any) {
+    try {
+        // ... view creation code ...
+        
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(data)
+        );
+    } catch (error) {
+        console.error('Failed to create view:', error);
+        // Handle error appropriately
+    }
+}
+
+async detaching() {
+    try {
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+            this.view = null;
+        }
+    } catch (error) {
+        console.error('Failed to cleanup view:', error);
+    }
+}
+```
+
+## Real-World Examples
+
+### 1. Server-Rendered Content with Aurelia Bindings
+
+This example shows how to take HTML content from a server (like a CMS) and make it interactive with Aurelia bindings:
+
+```typescript
+@customElement({
+    name: 'cms-content',
+    template: '<div ref="container"></div>'
+})
+export class CmsContent {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async attached() {
+        try {
+            // Fetch content from CMS/server
+            const response = await fetch('/api/content/page-123');
+            const html = await response.text();
+            
+            await this.renderContent(html);
+        } catch (error) {
+            console.error('Failed to load content:', error);
+        }
+    }
+
+    private async renderContent(html: string) {
+        const template = this.platform.document.createElement('template');
+        
+        // Server returns HTML with Aurelia binding expressions
+        // Example: <button click.trigger="handleAction('${id}')">...</button>
+        template.innerHTML = html;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'cms-content-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        // Create view model with methods that the server-rendered content can bind to
+        const viewModel = {
+            handleAction: (id: string) => {
+                console.log('Action triggered:', id);
+            },
+            submitForm: async (formData: any) => {
+                const response = await fetch('/api/submit', {
+                    method: 'POST',
+                    body: JSON.stringify(formData)
+                });
+                return response.json();
+            }
+        };
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(viewModel)
+        );
+    }
+
+    async detaching() {
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+        }
+    }
+}
+```
+
+### 2. Dynamic Form Builder with Validation
+
+This example creates forms dynamically based on a schema, with validation:
+
+```typescript
+interface FormField {
+    type: 'text' | 'number' | 'select' | 'date';
+    name: string;
+    label: string;
+    required?: boolean;
+    options?: { value: string; label: string; }[];
+    validation?: {
+        pattern?: string;
+        min?: number;
+        max?: number;
+        message?: string;
+    };
+}
+
+@customElement({
+    name: 'dynamic-form',
+    template: '<div ref="container"></div>'
+})
+export class DynamicForm {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    @bindable() schema: FormField[] = [];
+    @bindable() onSubmit: (data: any) => Promise<void>;
+
+    $controller!: ICustomElementController<this>;
+
+    async schemaChanged() {
+        await this.renderForm();
+    }
+
+    private generateFieldHtml(field: FormField): string {
+        const validationAttrs = field.validation ? `
+            pattern="${field.validation.pattern || ''}"
+            min="${field.validation.min || ''}"
+            max="${field.validation.max || ''}"
+        ` : '';
+
+        switch (field.type) {
+            case 'select':
+                return `
+                    <div class="form-group">
+                        <label for="${field.name}">${field.label}</label>
+                        <select 
+                            class="form-control \${errors.${field.name} ? 'is-invalid' : ''}"
+                            id="${field.name}"
+                            value.bind="formData.${field.name}"
+                            required.bind="${field.required}"
+                        >
+                            <option value="">Select...</option>
+                            ${field.options?.map(opt => 
+                                `<option value="${opt.value}">${opt.label}</option>`
+                            ).join('')}
+                        </select>
+                        <div class="invalid-feedback">
+                            \${errors.${field.name}}
+                        </div>
+                    </div>
+                `;
+            
+            default:
+                return `
+                    <div class="form-group">
+                        <label for="${field.name}">${field.label}</label>
+                        <input 
+                            type="${field.type}"
+                            class="form-control \${errors.${field.name} ? 'is-invalid' : ''}"
+                            id="${field.name}"
+                            value.bind="formData.${field.name}"
+                            required.bind="${field.required}"
+                            ${validationAttrs}
+                        >
+                        <div class="invalid-feedback">
+                            \${errors.${field.name}}
+                        </div>
+                    </div>
+                `;
+        }
+    }
+
+    private async renderForm() {
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+            this.container.innerHTML = '';
+        }
+
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <form submit.trigger="submitForm($event)">
+                ${this.schema.map(field => 
+                    this.generateFieldHtml(field)
+                ).join('')}
+                <button type="submit" class="btn btn-primary">
+                    Submit
+                </button>
+            </form>
+        `;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'dynamic-form-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        const viewModel = {
+            formData: {},
+            errors: {},
+            validateField: (name: string, value: any) => {
+                const field = this.schema.find(f => f.name === name);
+                if (!field) return;
+
+                if (field.required && !value) {
+                    viewModel.errors[name] = 'This field is required';
+                    return false;
+                }
+
+                if (field.validation) {
+                    // Add validation logic here
+                    // Return false if validation fails
+                }
+
+                delete viewModel.errors[name];
+                return true;
+            },
+            submitForm: async (event: Event) => {
+                event.preventDefault();
+                
+                // Validate all fields
+                let isValid = true;
+                for (const field of this.schema) {
+                    const valid = viewModel.validateField(
+                        field.name, 
+                        viewModel.formData[field.name]
+                    );
+                    if (!valid) isValid = false;
+                }
+
+                if (!isValid) return;
+
+                if (this.onSubmit) {
+                    await this.onSubmit(viewModel.formData);
+                }
+            }
+        };
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(viewModel)
+        );
+    }
+}
+```
+
+Usage:
+```typescript
+@customElement({
+    template: `
+        <dynamic-form 
+            schema.bind="formSchema"
+            on-submit.call="handleSubmit($event)">
+        </dynamic-form>
+    `
+})
+export class FormPage {
+    formSchema: FormField[] = [
+        {
+            type: 'text',
+            name: 'username',
+            label: 'Username',
+            required: true,
+            validation: {
+                pattern: '^[a-zA-Z0-9]{3,}$',
+                message: 'Username must be at least 3 characters'
+            }
+        },
+        {
+            type: 'select',
+            name: 'role',
+            label: 'Role',
+            required: true,
+            options: [
+                { value: 'user', label: 'User' },
+                { value: 'admin', label: 'Admin' }
+            ]
+        }
+    ];
+
+    async handleSubmit(formData: any) {
+        try {
+            await fetch('/api/users', {
+                method: 'POST',
+                body: JSON.stringify(formData)
+            });
+        } catch (error) {
+            console.error('Submit failed:', error);
+        }
+    }
+}
+```
+
+## Advanced Topics and Patterns
+
+### 1. Dynamic Component Loading with Lazy Loading
+
+This example shows how to load and render components based on server configuration dynamically:
+
+```typescript
+interface ComponentConfig {
+    type: string;
+    props: Record<string, any>;
+    template: string;
+    scriptUrl?: string;
+}
+
+@customElement({
+    name: 'component-loader',
+    template: '<div ref="container"></div>'
+})
+export class ComponentLoader {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+
+    async loadComponent(config: ComponentConfig) {
+        try {
+            // Load external script if needed
+            if (config.scriptUrl) {
+                await this.loadScript(config.scriptUrl);
+            }
+
+            await this.renderComponent(config);
+        } catch (error) {
+            console.error('Failed to load component:', error);
+        }
+    }
+
+    private async loadScript(url: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const script = document.createElement('script');
+            script.src = url;
+            script.onload = () => resolve();
+            script.onerror = () => reject(new Error(`Failed to load script: ${url}`));
+            document.head.appendChild(script);
+        });
+    }
+
+    private async renderComponent(config: ComponentConfig) {
+        if (this.view) {
+            await this.view.deactivate(this.view, this.$controller);
+            this.container.innerHTML = '';
+        }
+
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = config.template;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: `dynamic-component-${Date.now()}`,
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(config.props)
+        );
+    }
+}
+```
+
+### 2. Interactive Dashboard Builder
+
+This example demonstrates building a dashboard with draggable widgets:
+
+```typescript
+interface DashboardWidget {
+    id: string;
+    type: 'chart' | 'table' | 'metrics';
+    position: { x: number; y: number };
+    size: { width: number; height: number };
+    config: Record<string, any>;
+}
+
+@customElement({
+    name: 'dashboard-builder',
+    template: '<div ref="container" class="dashboard-container"></div>'
+})
+export class DashboardBuilder {
+    private container: HTMLElement;
+    private view: ISyntheticView;
+    private readonly platform = resolve(IPlatform);
+    private readonly diContainer = resolve(IContainer);
+
+    $controller!: ICustomElementController<this>;
+    private widgets: DashboardWidget[] = [];
+
+    private generateWidgetHtml(widget: DashboardWidget): string {
+        const style = `
+            position: absolute;
+            left: ${widget.position.x}px;
+            top: ${widget.position.y}px;
+            width: ${widget.size.width}px;
+            height: ${widget.size.height}px;
+        `;
+
+        return `
+            <div class="widget" style="${style}"
+                 draggable="true"
+                 dragstart.trigger="startDrag($event, '${widget.id}')"
+                 dragend.trigger="endDrag($event)">
+                <div class="widget-header">
+                    ${widget.type.toUpperCase()}
+                    <button click.trigger="removeWidget('${widget.id}')">×</button>
+                </div>
+                <div class="widget-content">
+                    ${this.generateWidgetContent(widget)}
+                </div>
+            </div>
+        `;
+    }
+
+    private generateWidgetContent(widget: DashboardWidget): string {
+        switch (widget.type) {
+            case 'chart':
+                return `
+                    <canvas ref="chart-${widget.id}"
+                           afterAttach.call="initChart($event, '${widget.id}')">
+                    </canvas>
+                `;
+            case 'table':
+                return `
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                ${widget.config.columns.map(col => 
+                                    `<th>${col.header}</th>`
+                                ).join('')}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr repeat.for="row of widget.config.data">
+                                ${widget.config.columns.map(col => 
+                                    `<td>\${row[col.field]}</td>`
+                                ).join('')}
+                            </tr>
+                        </tbody>
+                    </table>
+                `;
+            case 'metrics':
+                return `
+                    <div class="metrics-grid">
+                        ${widget.config.metrics.map(metric => `
+                            <div class="metric-card">
+                                <div class="metric-value">\${${metric.value}}</div>
+                                <div class="metric-label">${metric.label}</div>
+                            </div>
+                        `).join('')}
+                    </div>
+                `;
+            default:
+                return '';
+        }
+    }
+
+    async attached() {
+        await this.renderDashboard();
+    }
+
+    private async renderDashboard() {
+        const template = this.platform.document.createElement('template');
+        template.innerHTML = `
+            <div class="dashboard">
+                ${this.widgets.map(widget => 
+                    this.generateWidgetHtml(widget)
+                ).join('')}
+                <div class="dashboard-controls">
+                    <button click.trigger="addWidget('chart')">Add Chart</button>
+                    <button click.trigger="addWidget('table')">Add Table</button>
+                    <button click.trigger="addWidget('metrics')">Add Metrics</button>
+                    <button click.trigger="saveDashboard()">Save Layout</button>
+                </div>
+            </div>
+        `;
+
+        this.container.appendChild(template);
+        const renderLocation = convertToRenderLocation(template);
+
+        const factory = new ViewFactory(
+            this.diContainer,
+            CustomElementDefinition.create({
+                name: 'dashboard-view',
+                template
+            })
+        );
+
+        this.view = factory.create(this.$controller)
+            .setLocation(renderLocation);
+
+        const viewModel = {
+            widgets: this.widgets,
+            startDrag: (event: DragEvent, widgetId: string) => {
+                event.dataTransfer.setData('widgetId', widgetId);
+            },
+            endDrag: (event: DragEvent) => {
+                const widgetId = event.dataTransfer.getData('widgetId');
+                const widget = this.widgets.find(w => w.id === widgetId);
+                if (widget) {
+                    widget.position = {
+                        x: event.clientX - this.container.offsetLeft,
+                        y: event.clientY - this.container.offsetTop
+                    };
+                    this.renderDashboard();
+                }
+            },
+            addWidget: async (type: DashboardWidget['type']) => {
+                const widget: DashboardWidget = {
+                    id: `widget-${Date.now()}`,
+                    type,
+                    position: { x: 0, y: 0 },
+                    size: { width: 300, height: 200 },
+                    config: await this.getDefaultConfig(type)
+                };
+                this.widgets.push(widget);
+                await this.renderDashboard();
+            },
+            removeWidget: async (widgetId: string) => {
+                this.widgets = this.widgets.filter(w => w.id !== widgetId);
+                await this.renderDashboard();
+            },
+            initChart: (element: HTMLCanvasElement, widgetId: string) => {
+                const widget = this.widgets.find(w => w.id === widgetId);
+                if (widget && widget.type === 'chart') {
+                    // Initialize chart using your preferred library
+                    // Example with Chart.js:
+                    new Chart(element, widget.config.chartConfig);
+                }
+            },
+            saveDashboard: async () => {
+                try {
+                    await fetch('/api/dashboard', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(this.widgets)
+                    });
+                } catch (error) {
+                    console.error('Failed to save dashboard:', error);
+                }
+            }
+        };
+
+        await this.view.activate(
+            this.view,
+            this.$controller,
+            Scope.create(viewModel)
+        );
+    }
+
+    private async getDefaultConfig(type: DashboardWidget['type']) {
+        // Return default configuration based on widget type
+        switch (type) {
+            case 'chart':
+                return {
+                    chartConfig: {
+                        // Default chart configuration
+                    }
+                };
+            case 'table':
+                return {
+                    columns: [
+                        { field: 'id', header: 'ID' },
+                        { field: 'name', header: 'Name' }
+                    ],
+                    data: []
+                };
+            case 'metrics':
+                return {
+                    metrics: [
+                        { label: 'Total', value: 0 },
+                        { label: 'Average', value: 0 }
+                    ]
+                };
+        }
+    }
+}
+```


### PR DESCRIPTION
The synthetic docs were outdated, referencing imports that no longer exist, like lifecycle flags, and some of the definitions of the functions changed. The existing docs were also not overly clear, so this makes them more clear.