### PR TITLE
chore(event-aggregator): order of subscriber invocation

### DIFF
--- a/packages/kernel/src/eventaggregator.ts
+++ b/packages/kernel/src/eventaggregator.ts
@@ -57,17 +57,17 @@ export class EventAggregator {
       let subscribers = this.eventLookup[channelOrInstance];
       if (subscribers !== void 0) {
         subscribers = subscribers.slice();
-        let i = subscribers.length;
+        const numSubscribers = subscribers.length;
 
-        while (i-- > 0) {
+        for (let i = 0; i < numSubscribers; i++) {
           subscribers[i](message, channelOrInstance);
         }
       }
     } else {
       const subscribers = this.messageHandlers.slice();
-      let i = subscribers.length;
+      const numSubscribers = subscribers.length;
 
-      while (i-- > 0) {
+      for (let i = 0; i < numSubscribers; i++) {
         subscribers[i].handle(channelOrInstance);
       }
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This PR changes the order of subscriber invocations. 

As of now, the subscribers were invoked in the reverse order of subscription/registration, when `EventAggregator.publish(EVENT, [EVENT_DATA])` is called. Generally, the order of the invocations for the subscribers is not mandatorily needs to be the same as the order of subscription/registration. However, it is more or less a fair expectation. 

The order of invocation can play a crucial role, when some subscription is made using `AppTask.xxx`, and then later a CE also subscribes to the same channel. It might be a fair assumption, the subscription handler made via the `AppTask` is executed before the subscription handler of the CE.

This PR corrects that.

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
