### PR TITLE
fix(rendering): render surrogate bindings before content bindings

### DIFF
--- a/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
@@ -322,6 +322,32 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
     assert.deepStrictEqual(logs, ['prop1: 2']);
   });
 
+  describe('surrogates', function () {
+    it('renders normal bindings before other bindings', function () {
+      let i = 0;
+      const { assertAttr } = createFixture(
+        '<el>',
+        {},
+        [
+          CustomElement.define({
+            name: 'el',
+            template: `<template data-id.one-time="id">
+              <div data-id.one-time="id">
+            `
+          },
+          class {
+            get id() {
+              return i++;
+            }
+          })
+        ]
+      );
+
+      assertAttr('el', 'data-id', '0');
+      assertAttr('div', 'data-id', '1');
+    });
+  });
+
   describe('event', function () {
     it('works with multi dot event name for trigger', function () {
       let clicked = 0;

--- a/packages/runtime-html/src/templating/rendering.ts
+++ b/packages/runtime-html/src/templating/rendering.ts
@@ -165,6 +165,20 @@ export class Rendering implements IRendering {
       throw createMappedError(ErrorNames.rendering_mismatch_length, ii, jj);
     }
 
+    // host is only null when rendering a synthetic view
+    // but we have a check here so that we dont need to read surrogates unnecessarily
+    if (host != null) {
+      row = definition.surrogates;
+      if ((jj = row.length) > 0) {
+        j = 0;
+        while (jj > j) {
+          instruction = row[j];
+          renderers[instruction.type].render(controller, host, instruction, this._platform, this._exprParser, this._observerLocator);
+          ++j;
+        }
+      }
+    }
+
     if (ii > 0) {
       while (ii > i) {
         row = rows[i];
@@ -177,18 +191,6 @@ export class Rendering implements IRendering {
           ++j;
         }
         ++i;
-      }
-    }
-
-    if (host != null) {
-      row = definition.surrogates;
-      if ((jj = row.length) > 0) {
-        j = 0;
-        while (jj > j) {
-          instruction = row[j];
-          renderers[instruction.type].render(controller, host, instruction, this._platform, this._exprParser, this._observerLocator);
-          ++j;
-        }
       }
     }
   }


### PR DESCRIPTION
## 📖 Description

Currently the bindings defined on the `<template>` element are rendered after the bindings inside it, causing weird order reported in #2093, also this is inconsistent since v1 has surrogate bindings rendered first. This PR fixes this issue.

### 🎫 Issues

Close #2093