### PR TITLE
fix(au-slot): slotchange callback does not rely on deco

### DIFF
--- a/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
@@ -603,6 +603,35 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       flush(); // for text update
       assert.deepStrictEqual(calls, [['default', 2], ['default', 1]]);
     });
+
+    it('calls slotchange without having to have @slotted gh #2071', async function () {
+      const calls: [string, number][] = [];
+      @customElement({
+        name: 'el',
+        template: '<au-slot slotchange.bind="log">'
+      })
+      class El {
+        log(name: string, nodes: Node[]) {
+          calls.push([name, nodes.length]);
+        }
+      }
+
+      const { component, flush } = createFixture(
+        '<el><div if.bind="show"></div><p>',
+        class App { show = false; },
+        [El,]
+      );
+
+      component.show = true;
+      await Promise.resolve(); // for mutation observer to tick
+      flush(); // for text update
+      assert.deepStrictEqual(calls, [['default', 2]]);
+
+      component.show = false;
+      await Promise.resolve(); // for mutation observer to tick
+      flush(); // for text update
+      assert.deepStrictEqual(calls, [['default', 2], ['default', 1]]);
+    });
   });
 
   describe('with shadow dom', function () {

--- a/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/au-slot.slotted.spec.ts
@@ -632,6 +632,36 @@ describe('3-runtime-html/au-slot.slotted.spec.ts', function () {
       flush(); // for text update
       assert.deepStrictEqual(calls, [['default', 2], ['default', 1]]);
     });
+
+    it('[containerless] calls slotchange without having to have @slotted gh #2071', async function () {
+      const calls: [string, number][] = [];
+      @customElement({
+        name: 'el',
+        containerless: true,
+        template: '<au-slot slotchange.bind="log">'
+      })
+      class El {
+        log(name: string, nodes: Node[]) {
+          calls.push([name, nodes.length]);
+        }
+      }
+
+      const { component, flush } = createFixture(
+        '<el><div if.bind="show"></div><p>',
+        class App { show = false; },
+        [El,]
+      );
+
+      component.show = true;
+      await Promise.resolve(); // for mutation observer to tick
+      flush(); // for text update
+      assert.deepStrictEqual(calls, [['default', 2]]);
+
+      component.show = false;
+      await Promise.resolve(); // for mutation observer to tick
+      flush(); // for text update
+      assert.deepStrictEqual(calls, [['default', 2], ['default', 1]]);
+    });
   });
 
   describe('with shadow dom', function () {

--- a/packages/runtime-html/src/resources/custom-elements/au-slot.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-slot.ts
@@ -1,4 +1,4 @@
-import { IContainer, InstanceProvider, Writable, emptyArray, onResolve, resolve } from '@aurelia/kernel';
+import { IContainer, InstanceProvider, Writable, emptyArray, isFunction, onResolve, resolve } from '@aurelia/kernel';
 import { Scope } from '@aurelia/runtime';
 import { IInstruction, type HydrateElementInstruction } from '@aurelia/template-compiler';
 import { IRenderLocation } from '../../dom';
@@ -213,7 +213,7 @@ export class AuSlot implements ICustomElementViewModel, IAuSlot {
       this.$controller,
       this._hasProjection ? this._outerScope! : this._parentScope!,
     ), () => {
-      if (this._hasSlotWatcher) {
+      if (this._hasSlotWatcher || isFunction(this.slotchange)) {
         this._slotwatchers.forEach(w => w.watch(this));
         this._observe();
         this._notifySlotChange();


### PR DESCRIPTION
## 📖 Description

Currently `<au-slot>` only observes dom mutation when there's a `@slotted` decorator, which means the following template will never have the callback `slotUpdated` called:
```html
<my-element slotchange.bind="(name, nodes) => slotUpdated(name, nodes)">
  <div repeat.for="i of items">...</div>
</my-element>
```
This PR fixes this issue. Thanks @euglv

### 🎫 Issues

Closes #2071 