### PR TITLE
fix(router-lite): support for conventional HTML-only component

### DIFF
--- a/docs/user-docs/router-lite/configuring-routes.md
+++ b/docs/user-docs/router-lite/configuring-routes.md
@@ -862,6 +862,102 @@ You can see this configuration in action below.
 
 {% embed url="https://stackblitz.com/edit/router-lite-component-ce-instance-jx3kee?ctl=1&embed=1&file=src/my-app.ts" %}
 
+### Using conventional HTML-only custom element
+
+When using HTML-only custom elements, facilitated via the convention, the custom element can be directly used while configuring routes.
+
+```diff
+  import { customElement } from '@aurelia/runtime-html';
+  import { route } from '@aurelia/router-lite';
+  import template from './my-app.html';
+- import { About } from './about';
+- import { Home } from './home';
++ import * as About from './about.html';
++ import * as Home from './home.html';
+
+  @route({
+    routes: [
+      {
+        path: ['', 'home'],
+        component: Home,
+        title: 'Home',
+      },
+      {
+        path: 'about',
+        component: About,
+        title: 'About',
+      },
+    ],
+  })
+@customElement({ name: 'my-app', template })
+export class MyApp {}
+```
+
+Using `import()` function directly is also supported.
+
+```diff
+  import { customElement } from '@aurelia/runtime-html';
+  import { route } from '@aurelia/router-lite';
+  import template from './my-app.html';
+- import { About } from './about';
+- import { Home } from './home';
+
+  @route({
+    routes: [
+      {
+        path: ['', 'home'],
+-       component: Home,
++       component: import('./home.html'),
+        title: 'Home',
+      },
+      {
+        path: 'about',
+-       component: About,
++       component: import('./about.html'),
+        title: 'About',
+      },
+    ],
+  })
+@customElement({ name: 'my-app', template })
+export class MyApp {}
+```
+
+When importing the HTML-only custom elements in the HTML file using `<require from="">` syntax, use the custom element name in the route configuration.
+
+```html
+  <require from="./about.html"></require>
+  <require from="./home.html"></require>
+
+  <au-viewport></au-viewport>
+```
+
+```diff
+  import { customElement } from '@aurelia/runtime-html';
+  import { route } from '@aurelia/router-lite';
+  import template from './my-app.html';
+- import { About } from './about';
+- import { Home } from './home';
+
+  @route({
+    routes: [
+      {
+        path: ['', 'home'],
+-       component: Home,
++       component: 'home',
+        title: 'Home',
+      },
+      {
+        path: 'about',
+-       component: About,
++       component: 'about',
+        title: 'About',
+      },
+    ],
+  })
+@customElement({ name: 'my-app', template })
+export class MyApp {}
+```
+
 ## Using classes as routes
 
 Using router-lite it is also possible to use the routed view model classes directly as routes configuration.

--- a/packages/__tests__/src/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/src/router-lite/smoke-tests.spec.ts
@@ -7585,4 +7585,140 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
     await au.stop(true);
   });
+
+  /**
+   * Reported in https://discourse.aurelia.io/t/router-questions/6360/3
+   * Use case:
+   *
+   * ```ts
+   * import { route } from '@aurelia/router-lite';
+   * import * about from './about.html'; // <-- loaded via convention plugin
+   * @route({
+   *   routes: [
+   *     {
+   *       path: 'about',
+   *       component: about,
+   *     },
+   *   ],
+   * })
+   * export class MyApp {}
+   * ```
+   */
+  it('Routing to conventional HTML-only custom element works', async function () {
+    const ceOne = {
+      name: 'ce-one',
+      template: 'ce-one',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceOne._e) {
+          ceOne._e = CustomElement.define({ name: ceOne.name, template: ceOne.template, dependencies: ceOne.dependencies, bindables: ceOne.bindables });
+        }
+        container.register(ceOne._e);
+      }
+    };
+    const ceTwo = {
+      name: 'ce-two',
+      template: 'ce-two',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceTwo._e) {
+          ceTwo._e = CustomElement.define({ name: ceTwo.name, template: ceTwo.template, dependencies: ceTwo.dependencies, bindables: ceTwo.bindables });
+        }
+        container.register(ceTwo._e);
+      }
+    };
+
+    @route({
+      routes: [
+        { id: 'ce-one', path: 'ce-one', component: ceOne },
+        { id: 'ce-two', path: 'ce-two', component: ceTwo },
+      ]
+    })
+    @customElement({ name: 'root', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { container, host, au } = await start({ appRoot: Root });
+
+    const router = container.get(IRouter);
+
+    await router.load('ce-one');
+    assert.html.textContent(host, 'ce-one');
+
+    await router.load('ce-two');
+    assert.html.textContent(host, 'ce-two');
+
+    await au.stop(true);
+  });
+
+  /**
+   * Reported in https://discourse.aurelia.io/t/router-questions/6360/3
+   * Use case:
+   *
+   * ```ts
+   * import { route } from '@aurelia/router-lite';
+   * import * about from './about.html'; // <-- loaded via convention plugin
+   * @route({
+   *   routes: [
+   *     {
+   *       path: 'about',
+   *       component: import('./about.html'),
+   *     },
+   *   ],
+   * })
+   * export class MyApp {}
+   * ```
+   */
+  it('Routing to conventional HTML-only custom element works - lazy loading', async function () {
+    const ceOne = {
+      name: 'ce-one',
+      template: 'ce-one',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceOne._e) {
+          ceOne._e = CustomElement.define({ name: ceOne.name, template: ceOne.template, dependencies: ceOne.dependencies, bindables: ceOne.bindables });
+        }
+        container.register(ceOne._e);
+      }
+    };
+    const ceTwo = {
+      name: 'ce-two',
+      template: 'ce-two',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceTwo._e) {
+          ceTwo._e = CustomElement.define({ name: ceTwo.name, template: ceTwo.template, dependencies: ceTwo.dependencies, bindables: ceTwo.bindables });
+        }
+        container.register(ceTwo._e);
+      }
+    };
+
+    @route({
+      routes: [
+        { id: 'ce-one', path: 'ce-one', component: Promise.resolve(ceOne) },
+        { id: 'ce-two', path: 'ce-two', component: Promise.resolve(ceTwo) },
+      ]
+    })
+    @customElement({ name: 'root', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { container, host, au } = await start({ appRoot: Root });
+
+    const router = container.get(IRouter);
+
+    await router.load('ce-one');
+    assert.html.textContent(host, 'ce-one');
+
+    await router.load('ce-two');
+    assert.html.textContent(host, 'ce-two');
+
+    await au.stop(true);
+  });
 });

--- a/packages/__tests__/src/router-lite/smoke-tests.spec.ts
+++ b/packages/__tests__/src/router-lite/smoke-tests.spec.ts
@@ -7721,4 +7721,66 @@ describe('router-lite/smoke-tests.spec.ts', function () {
 
     await au.stop(true);
   });
+
+  /**
+   * Reported in https://discourse.aurelia.io/t/router-questions/6360/3
+   * Use case:
+   *
+   * ```html
+   * <template>
+   *  <require from="./about.html"></require>
+   *  <require from="./home.html"></require>
+   *  <au-viewport></au-viewport>
+   * </template>
+   * ```
+   */
+  it('Routing to conventional HTML-only custom element works - required via HTML', async function () {
+    const ceOne = {
+      name: 'ce-one',
+      template: 'ce-one',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceOne._e) {
+          ceOne._e = CustomElement.define({ name: ceOne.name, template: ceOne.template, dependencies: ceOne.dependencies, bindables: ceOne.bindables });
+        }
+        container.register(ceOne._e);
+      }
+    };
+    const ceTwo = {
+      name: 'ce-two',
+      template: 'ce-two',
+      dependencies: [],
+      bindables: {},
+      _e: undefined,
+      register: (container) => {
+        if (!ceTwo._e) {
+          ceTwo._e = CustomElement.define({ name: ceTwo.name, template: ceTwo.template, dependencies: ceTwo.dependencies, bindables: ceTwo.bindables });
+        }
+        container.register(ceTwo._e);
+      }
+    };
+
+    @route({
+      routes: [
+        { id: 'ce-one', path: 'ce-one', component: 'ce-one' },
+        { id: 'ce-two', path: 'ce-two', component: 'ce-two' },
+      ]
+    })
+    @customElement({ name: 'root', template: '<au-viewport></au-viewport>', dependencies: [ceOne, ceTwo] })
+    class Root { }
+
+    const { container, host, au } = await start({ appRoot: Root });
+
+    const router = container.get(IRouter);
+
+    await router.load('ce-one');
+    assert.html.textContent(host, 'ce-one');
+
+    await router.load('ce-two');
+    assert.html.textContent(host, 'ce-two');
+
+    await au.stop(true);
+  });
 });

--- a/packages/router-lite/src/route-context.ts
+++ b/packages/router-lite/src/route-context.ts
@@ -15,7 +15,7 @@ import { type Endpoint, RecognizedRoute, RESIDUE, RouteRecognizer } from '@aurel
 import {
   Controller,
   CustomElement,
-  type CustomElementDefinition,
+  CustomElementDefinition,
   IAppRoot,
   IController,
   ICustomElementController,
@@ -52,7 +52,7 @@ import {
 } from './router';
 import { IRouterEvents } from './router-events';
 import { ensureArrayOfStrings } from './util';
-import { isPartialChildRouteConfig } from './validation';
+import { isPartialChildRouteConfig, isPartialCustomElementDefinition } from './validation';
 import { ViewportAgent, type ViewportRequest } from './viewport-agent';
 import { Events, debug, error, getMessage, logAndThrow, trace } from './events';
 
@@ -517,7 +517,14 @@ export class RouteContext {
         }
       }
 
-      if (defaultExport === void 0 && firstNonDefaultExport === void 0) throw new Error(getMessage(Events.rcInvalidLazyImport, promise));
+      if (defaultExport === void 0 && firstNonDefaultExport === void 0) {
+        if (!isPartialCustomElementDefinition(raw)) throw new Error(getMessage(Events.rcInvalidLazyImport, promise));
+
+        // use-case: import('./conventional-html-only-component.html')
+        const definition = CustomElementDefinition.create(raw);
+        CustomElement.define(definition);
+        return definition;
+      }
 
       return firstNonDefaultExport ?? defaultExport!;
     });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This PR adds support for routing to conventional HTML-only components.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

The issue is reported in [discourse](https://discourse.aurelia.io/t/router-questions/6360/3). Thanks @elmt1 for reporting this issue!

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
