### PR TITLE
fix(router-lite): cancelling navigation with redirection from canLoad hook from child route

### DIFF
--- a/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
+++ b/packages/__tests__/src/router-lite/lifecycle-hooks.spec.ts
@@ -6394,7 +6394,7 @@ describe('router-lite/lifecycle-hooks.spec.ts', function () {
     await au.stop(true);
   });
 
-  it.only('loading redirecting (from canLoad) route should work without error', async function () {
+  it('loading redirecting (from canLoad) route should work without error', async function () {
     @customElement({ name: 'c-1', template: `c1` })
     class C1 implements IRouteViewModel {
       canLoad(_params: Params, _next: RouteNode, _current: RouteNode | null): NavigationInstruction {

--- a/packages/router-lite/src/events.ts
+++ b/packages/router-lite/src/events.ts
@@ -158,6 +158,7 @@ export const enum Events {
   vpaUnexpectedDeactivation = 3351,
   vpaUnexpectedState = 3352,
   vpaUnexpectedGuardsResult = 3353,
+  vpaCanLoadGuardsResult = 3354,
   // #endregion
   // #region instruction
   instrInvalid = 3400,
@@ -331,6 +332,7 @@ const eventMessageMap: Record<Events, string> = {
   [Events.vpaUnexpectedDeactivation]: 'Unexpected viewport deactivation outside of a transition context at %s',
   [Events.vpaUnexpectedState]: 'Unexpected state at %s of %s',
   [Events.vpaUnexpectedGuardsResult]: 'Unexpected guardsResult %s at %s',
+  [Events.vpaCanLoadGuardsResult]: 'canLoad returned redirect result %s by the component agent %s',
   // #endregion
 
   // #region instruction

--- a/packages/router-lite/src/router.ts
+++ b/packages/router-lite/src/router.ts
@@ -646,6 +646,12 @@ export class Router {
         for (const node of all) {
           node.context.vpa._swap(tr, b);
         }
+      })._continueWith(b => {
+        // it is possible that some of the child routes are cancelling the navigation
+        if (tr.guardsResult !== true) {
+          b._push();
+          this._cancelNavigation(tr);
+        }
       })._continueWith(() => {
         if (__DEV__) trace(logger, Events.rtrRunFinalizing);
         // order doesn't matter for this operation

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -653,12 +653,6 @@ export class ViewportAgent {
           });
         }
       })._continueWith(b1 => {
-        if (tr.guardsResult !== true) {
-          b1._push();
-          this._cancelUpdate();
-          b1._pop();
-        }
-      })._continueWith(b1 => {
         if (tr.guardsResult !== true) return;
         for (const node of newChildren) {
           tr._run(() => {

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -281,7 +281,6 @@ export class ViewportAgent {
     })._continueWith(b1 => {
       if (tr.guardsResult !== true) {
         if (__DEV__) trace(logger, Events.vpaCanLoadGuardsResult, tr.guardsResult, this._nextCA);
-        this._nextState = State.nextLoadAborted;
         return;
       }
       const next = this._nextNode!;
@@ -332,7 +331,6 @@ export class ViewportAgent {
             node.context.vpa._canLoad(tr, b1);
           }
           return;
-        case State.nextLoadAborted:
         case State.nextIsEmpty:
           return;
         default:
@@ -760,7 +758,6 @@ export class ViewportAgent {
       case State.nextIsEmpty:
       case State.nextIsScheduled:
       case State.nextCanLoad:
-      case State.nextLoadAborted:
       case State.nextCanLoadDone:
         this._nextNode = null;
         this._nextState = State.nextIsEmpty;
@@ -804,8 +801,6 @@ export class ViewportAgent {
       const logger = /*@__PURE__*/ this._logger.scopeTo('endTransition()');
       ensureTransitionHasNotErrored(this._currTransition);
       switch (this._nextState) {
-        case State.nextLoadAborted:
-          break;
         case State.nextIsEmpty:
           switch (this._currState) {
             case State.currIsEmpty:
@@ -884,25 +879,23 @@ function ensureTransitionHasNotErrored(tr: Transition): void {
 _START_CONST_ENUM();
 /** @internal */
 export const enum State {
-  curr              = 0b1111_1111_0000_0000,
-  currIsEmpty       = 0b1000_0000_0000_0000,
-  currIsActive      = 0b0100_0000_0000_0000,
-  currCanUnload     = 0b0010_0000_0000_0000,
-  currUnloadAborted = 0b0001_0000_0000_0000,
-  currCanUnloadDone = 0b0000_1000_0000_0000,
-  currUnload        = 0b0000_0100_0000_0000,
-  currUnloadDone    = 0b0000_0010_0000_0000,
-  currDeactivate    = 0b0000_0001_0000_0000,
-  next              = 0b0000_0000_1111_1111,
-  nextIsEmpty       = 0b0000_0000_1000_0000,
-  nextIsScheduled   = 0b0000_0000_0100_0000,
-  nextCanLoad       = 0b0000_0000_0010_0000,
-  nextLoadAborted   = 0b0000_0000_0001_0000,
-  nextCanLoadDone   = 0b0000_0000_0000_1000,
-  nextLoad          = 0b0000_0000_0000_0100,
-  nextLoadDone      = 0b0000_0000_0000_0010,
-  nextActivate      = 0b0000_0000_0000_0001,
-  bothAreEmpty      = 0b1000_0000_1000_0000,
+  curr              = 0b1111111_0000000,
+  currIsEmpty       = 0b1000000_0000000,
+  currIsActive      = 0b0100000_0000000,
+  currCanUnload     = 0b0010000_0000000,
+  currCanUnloadDone = 0b0001000_0000000,
+  currUnload        = 0b0000100_0000000,
+  currUnloadDone    = 0b0000010_0000000,
+  currDeactivate    = 0b0000001_0000000,
+  next              = 0b0000000_1111111,
+  nextIsEmpty       = 0b0000000_1000000,
+  nextIsScheduled   = 0b0000000_0100000,
+  nextCanLoad       = 0b0000000_0010000,
+  nextCanLoadDone   = 0b0000000_0001000,
+  nextLoad          = 0b0000000_0000100,
+  nextLoadDone      = 0b0000000_0000010,
+  nextActivate      = 0b0000000_0000001,
+  bothAreEmpty      = 0b1000000_1000000,
 }
 _END_CONST_ENUM();
 
@@ -910,7 +903,6 @@ type CurrState = (
   State.currIsEmpty |
   State.currIsActive |
   State.currCanUnload |
-  State.currUnloadAborted |
   State.currCanUnloadDone |
   State.currUnload |
   State.currUnloadDone |
@@ -921,7 +913,6 @@ type NextState = (
   State.nextIsEmpty |
   State.nextIsScheduled |
   State.nextCanLoad |
-  State.nextLoadAborted |
   State.nextCanLoadDone |
   State.nextLoad |
   State.nextLoadDone |

--- a/packages/router-lite/src/viewport-agent.ts
+++ b/packages/router-lite/src/viewport-agent.ts
@@ -279,6 +279,11 @@ export class ViewportAgent {
           this._unexpectedState('canLoad');
       }
     })._continueWith(b1 => {
+      if (tr.guardsResult !== true) {
+        if (__DEV__) trace(logger, Events.vpaCanLoadGuardsResult, tr.guardsResult, this._nextCA);
+        this._nextState = State.nextLoadAborted;
+        return;
+      }
       const next = this._nextNode!;
       switch (this._$plan) {
         case 'none':
@@ -327,6 +332,7 @@ export class ViewportAgent {
             node.context.vpa._canLoad(tr, b1);
           }
           return;
+        case State.nextLoadAborted:
         case State.nextIsEmpty:
           return;
         default:
@@ -649,6 +655,13 @@ export class ViewportAgent {
           });
         }
       })._continueWith(b1 => {
+        if (tr.guardsResult !== true) {
+          b1._push();
+          this._cancelUpdate();
+          b1._pop();
+        }
+      })._continueWith(b1 => {
+        if (tr.guardsResult !== true) return;
         for (const node of newChildren) {
           tr._run(() => {
             b1._push();
@@ -658,6 +671,7 @@ export class ViewportAgent {
           });
         }
       })._continueWith(b1 => {
+        if (tr.guardsResult !== true) return;
         for (const node of newChildren) {
           tr._run(() => {
             b1._push();
@@ -746,6 +760,7 @@ export class ViewportAgent {
       case State.nextIsEmpty:
       case State.nextIsScheduled:
       case State.nextCanLoad:
+      case State.nextLoadAborted:
       case State.nextCanLoadDone:
         this._nextNode = null;
         this._nextState = State.nextIsEmpty;
@@ -789,6 +804,8 @@ export class ViewportAgent {
       const logger = /*@__PURE__*/ this._logger.scopeTo('endTransition()');
       ensureTransitionHasNotErrored(this._currTransition);
       switch (this._nextState) {
+        case State.nextLoadAborted:
+          break;
         case State.nextIsEmpty:
           switch (this._currState) {
             case State.currIsEmpty:
@@ -867,23 +884,25 @@ function ensureTransitionHasNotErrored(tr: Transition): void {
 _START_CONST_ENUM();
 /** @internal */
 export const enum State {
-  curr              = 0b1111111_0000000,
-  currIsEmpty       = 0b1000000_0000000,
-  currIsActive      = 0b0100000_0000000,
-  currCanUnload     = 0b0010000_0000000,
-  currCanUnloadDone = 0b0001000_0000000,
-  currUnload        = 0b0000100_0000000,
-  currUnloadDone    = 0b0000010_0000000,
-  currDeactivate    = 0b0000001_0000000,
-  next              = 0b0000000_1111111,
-  nextIsEmpty       = 0b0000000_1000000,
-  nextIsScheduled   = 0b0000000_0100000,
-  nextCanLoad       = 0b0000000_0010000,
-  nextCanLoadDone   = 0b0000000_0001000,
-  nextLoad          = 0b0000000_0000100,
-  nextLoadDone      = 0b0000000_0000010,
-  nextActivate      = 0b0000000_0000001,
-  bothAreEmpty      = 0b1000000_1000000,
+  curr              = 0b1111_1111_0000_0000,
+  currIsEmpty       = 0b1000_0000_0000_0000,
+  currIsActive      = 0b0100_0000_0000_0000,
+  currCanUnload     = 0b0010_0000_0000_0000,
+  currUnloadAborted = 0b0001_0000_0000_0000,
+  currCanUnloadDone = 0b0000_1000_0000_0000,
+  currUnload        = 0b0000_0100_0000_0000,
+  currUnloadDone    = 0b0000_0010_0000_0000,
+  currDeactivate    = 0b0000_0001_0000_0000,
+  next              = 0b0000_0000_1111_1111,
+  nextIsEmpty       = 0b0000_0000_1000_0000,
+  nextIsScheduled   = 0b0000_0000_0100_0000,
+  nextCanLoad       = 0b0000_0000_0010_0000,
+  nextLoadAborted   = 0b0000_0000_0001_0000,
+  nextCanLoadDone   = 0b0000_0000_0000_1000,
+  nextLoad          = 0b0000_0000_0000_0100,
+  nextLoadDone      = 0b0000_0000_0000_0010,
+  nextActivate      = 0b0000_0000_0000_0001,
+  bothAreEmpty      = 0b1000_0000_1000_0000,
 }
 _END_CONST_ENUM();
 
@@ -891,6 +910,7 @@ type CurrState = (
   State.currIsEmpty |
   State.currIsActive |
   State.currCanUnload |
+  State.currUnloadAborted |
   State.currCanUnloadDone |
   State.currUnload |
   State.currUnloadDone |
@@ -901,6 +921,7 @@ type NextState = (
   State.nextIsEmpty |
   State.nextIsScheduled |
   State.nextCanLoad |
+  State.nextLoadAborted |
   State.nextCanLoadDone |
   State.nextLoad |
   State.nextLoadDone |


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

This is reported in https://discord.com/channels/448698263508615178/1349513768077627403/1349885887378620456 by @simonfox. When returning a navigation instruction from a `canLoad` hook from a child route caused issue similar to the following.

```
Uncaught (in promise) Error: AUR3352:endTransition 3:VPA(state:currIsEmpty|nextCanLoadDone,plan:'replace',n:RN(ctx:'app-shell/feature-shell/feature-workspace',c:'FeatureWorkspace',path:'workspace'),c:null,viewport:VP(ctx:'app-shell/feature-shell',name:'default'))
    at ViewportAgent.jt (viewport-agent.ts:855:11)
    at ViewportAgent.ee (viewport-agent.ts:831:16)
    at viewport-agent.ts:784:26
    at Array.forEach (<anonymous>)
    at ViewportAgent.ee (viewport-agent.ts:783:31)
    at router.ts:653:28
    at Array.forEach (<anonymous>)
    at router.ts:652:13
    at Batch._ (util.ts:47:7)
    at Batch.$ (util.ts:37:13)
```

This PR handles the guard result correctly when generated by a (multilevel) child route. 

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
