### PR TITLE
feat(validation): make caching of validate behavior property info configurable

### DIFF
--- a/packages/validation-html/src/configuration.ts
+++ b/packages/validation-html/src/configuration.ts
@@ -2,7 +2,7 @@ import { Constructable, IContainer, noop, Registration } from '@aurelia/kernel';
 import { getDefaultValidationConfiguration, ValidationCustomizationOptions, ValidationConfiguration } from '@aurelia/validation';
 import { ValidationContainerCustomElement, defaultContainerDefinition, defaultContainerTemplate } from './subscribers/validation-container-custom-element';
 import { ValidationErrorsCustomAttribute } from './subscribers/validation-errors-custom-attribute';
-import { IDefaultTrigger, ValidateBindingBehavior, ValidationTrigger } from './validate-binding-behavior';
+import { IDefaultCacheBindingPropertyInfo, IDefaultTrigger, ValidateBindingBehavior, ValidationTrigger } from './validate-binding-behavior';
 import { IValidationController, ValidationControllerFactory } from './validation-controller';
 import { ValidationHtmlCustomizationOptions } from './validation-customization-options';
 import { CustomElement } from '@aurelia/runtime-html';
@@ -15,7 +15,8 @@ export function getDefaultValidationHtmlConfiguration(): ValidationHtmlCustomiza
     ValidationControllerFactoryType: ValidationControllerFactory,
     DefaultTrigger: ValidationTrigger.focusout,
     UseSubscriberCustomAttribute: true,
-    SubscriberCustomElementTemplate: defaultContainerTemplate
+    SubscriberCustomElementTemplate: defaultContainerTemplate,
+    DefaultCacheBindingPropertyInfo: true,
   };
 }
 
@@ -39,6 +40,7 @@ function createConfiguration(optionsProvider: ValidationConfigurationProvider) {
           }
         }),
         Registration.instance(IDefaultTrigger, options.DefaultTrigger),
+        Registration.instance(IDefaultCacheBindingPropertyInfo, options.DefaultCacheBindingPropertyInfo),
         ValidateBindingBehavior,
       );
       if (options.UseSubscriberCustomAttribute) {

--- a/packages/validation-html/src/validate-binding-behavior.ts
+++ b/packages/validation-html/src/validate-binding-behavior.ts
@@ -61,6 +61,8 @@ export enum ValidationTrigger {
 }
 
 export const IDefaultTrigger = /*@__PURE__*/DI.createInterface<ValidationTrigger>('IDefaultTrigger');
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const IDefaultCacheBindingPropertyInfo = /*@__PURE__*/DI.createInterface<Boolean>('IDefaultCacheBindingPropertyInfo');
 
 const validationConnectorMap = new WeakMap<IBinding, ValidationConnector>();
 const validationTargetSubscriberMap = new WeakMap<PropertyBinding, WithValidationTargetSubscriber>();
@@ -83,6 +85,7 @@ export class ValidateBindingBehavior implements BindingBehaviorInstance {
         this._platform,
         this._observerLocator,
         binding.get(IDefaultTrigger),
+        binding.get(IDefaultCacheBindingPropertyInfo) as boolean,
         binding as BindingWithBehavior,
         binding.get(IContainer)
       ));
@@ -110,7 +113,7 @@ export class ValidateBindingBehavior implements BindingBehaviorInstance {
 }
 BindingBehavior.define('validate', ValidateBindingBehavior);
 
-interface ValidationConnector extends IAstEvaluator, IObserverLocatorBasedConnectable, IConnectable {}
+interface ValidationConnector extends IAstEvaluator, IObserverLocatorBasedConnectable, IConnectable { }
 /**
  * Binding behavior. Indicates the bound property should be validated.
  */
@@ -122,6 +125,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
   private controller!: IValidationController;
   private isChangeTrigger: boolean = false;
   private readonly defaultTrigger: ValidationTrigger;
+  private readonly defaultCachePropertyInfo: boolean;
   public scope?: Scope;
   private isDirty: boolean = false;
   private validatedOnce: boolean = false;
@@ -132,23 +136,27 @@ class ValidationConnector implements ValidationResultsSubscriber {
   /** @internal */ private readonly _triggerMediator: BindingMediator<'handleTriggerChange'>;
   /** @internal */ private readonly _controllerMediator: BindingMediator<'handleControllerChange'>;
   /** @internal */ private readonly _rulesMediator: BindingMediator<'handleRulesChange'>;
+  /** @internal */ private readonly _cacheMediator: BindingMediator<'handleCacheChange'>;
 
   public constructor(
     platform: IPlatform,
     observerLocator: IObserverLocator,
     defaultTrigger: ValidationTrigger,
+    defaultCachePropertyInfo: boolean,
     propertyBinding: BindingWithBehavior,
     locator: IServiceLocator,
   ) {
     this.propertyBinding = propertyBinding;
     this.target = propertyBinding.target as HTMLElement;
     this.defaultTrigger = defaultTrigger;
+    this.defaultCachePropertyInfo = defaultCachePropertyInfo;
     this._platform = platform;
     this.oL = observerLocator;
     this.l = locator;
     this._triggerMediator = new BindingMediator('handleTriggerChange', this, observerLocator, locator);
     this._controllerMediator = new BindingMediator('handleControllerChange', this, observerLocator, locator);
     this._rulesMediator = new BindingMediator('handleRulesChange', this, observerLocator, locator);
+    this._cacheMediator = new BindingMediator('handleCacheChange', this, observerLocator, locator);
     if (locator.has(IValidationController, true)) {
       this.scopedController = locator.get(IValidationController);
     }
@@ -177,7 +185,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
     this.scope = scope;
     this.target = this._getTarget();
     const delta = this._processBindingExpressionArgs();
-    if(!this._processDelta(delta) && this.bindingInfo != null) {
+    if (!this._processDelta(delta) && this.bindingInfo != null) {
       this.controller?.registerBinding(this.propertyBinding, this.bindingInfo);
       this.controller?.addSubscriber(this);
     }
@@ -198,15 +206,19 @@ class ValidationConnector implements ValidationResultsSubscriber {
   }
 
   public handleTriggerChange(newValue: unknown, _previousValue: unknown): void {
-    this._processDelta(new ValidateArgumentsDelta(void 0, this._ensureTrigger(newValue), void 0));
+    this._processDelta(new ValidateArgumentsDelta(void 0, this._ensureTrigger(newValue), void 0, void 0));
   }
 
   public handleControllerChange(newValue: unknown, _previousValue: unknown): void {
-    this._processDelta(new ValidateArgumentsDelta(this._ensureController(newValue), void 0, void 0));
+    this._processDelta(new ValidateArgumentsDelta(this._ensureController(newValue), void 0, void 0, void 0));
   }
 
   public handleRulesChange(newValue: unknown, _previousValue: unknown): void {
-    this._processDelta(new ValidateArgumentsDelta(void 0, void 0, this._ensureRules(newValue)));
+    this._processDelta(new ValidateArgumentsDelta(void 0, void 0, this._ensureRules(newValue), void 0));
+  }
+
+  public handleCacheChange(newValue: unknown, _previousValue: unknown): void {
+    this._processDelta(new ValidateArgumentsDelta(void 0, void 0, void 0, this._ensureCache(newValue)));
   }
 
   public handleValidationEvent(event: ValidationEvent): void {
@@ -227,6 +239,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
     let rules: PropertyRule[] | undefined;
     let trigger: ValidationTrigger | undefined;
     let controller: ValidationController | undefined;
+    let cache: boolean | undefined;
 
     let ast = this.propertyBinding.ast as BindingBehaviorExpression;
     while (ast.name !== 'validate' && ast !== void 0) {
@@ -246,12 +259,15 @@ class ValidationConnector implements ValidationResultsSubscriber {
         case 2:
           rules = this._ensureRules(astEvaluate(arg, scope, this, this._rulesMediator));
           break;
+        case 3:
+          cache = this._ensureCache(astEvaluate(arg, scope, this, this._cacheMediator));
+          break;
         default:
           throw createMappedError(ErrorNames.validate_binding_behavior_extraneous_args, i + 1, astEvaluate(arg, scope, this, null));
       }
     }
 
-    return new ValidateArgumentsDelta(this._ensureController(controller), this._ensureTrigger(trigger), rules);
+    return new ValidateArgumentsDelta(this._ensureController(controller), this._ensureTrigger(trigger), rules, this._ensureCache(cache));
   }
 
   private task: ITask | null = null;
@@ -274,6 +290,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
     const trigger = delta.trigger ?? this.trigger;
     const controller = delta.controller ?? this.controller;
     const rules = delta.rules;
+    const cachePropertyInfo = delta.cachePropertyInfo ?? this.defaultCachePropertyInfo;
     if (this.trigger !== trigger) {
       let event = this.triggerEvent;
       if (event !== null) {
@@ -297,7 +314,7 @@ class ValidationConnector implements ValidationResultsSubscriber {
       this.controller?.unregisterBinding(this.propertyBinding);
 
       this.controller = controller;
-      controller.registerBinding(this.propertyBinding, this._setBindingInfo(rules));
+      controller.registerBinding(this.propertyBinding, this._setBindingInfo(rules, cachePropertyInfo));
       controller.addSubscriber(this);
       return true;
     }
@@ -332,6 +349,11 @@ class ValidationConnector implements ValidationResultsSubscriber {
   }
 
   /** @internal */
+  private _ensureCache(cache: unknown): boolean {
+    return cache !== false;
+  }
+
+  /** @internal */
   private _getTarget() {
     const target = this.propertyBinding.target;
     if (target instanceof this._platform.Node) {
@@ -362,8 +384,8 @@ class ValidationConnector implements ValidationResultsSubscriber {
   }
 
   /** @internal */
-  private _setBindingInfo(rules: PropertyRule[] | undefined): BindingInfo {
-    return this.bindingInfo = new BindingInfo(this.target, this.scope!, rules);
+  private _setBindingInfo(rules: PropertyRule[] | undefined, cachePropertyInfo: boolean): BindingInfo {
+    return this.bindingInfo = new BindingInfo(this.target, this.scope!, rules, cachePropertyInfo);
   }
 }
 
@@ -390,6 +412,7 @@ class ValidateArgumentsDelta {
     public controller?: ValidationController,
     public trigger?: ValidationTrigger,
     public rules?: PropertyRule[],
+    public cachePropertyInfo?: boolean,
   ) { }
 }
 

--- a/packages/validation-html/src/validation-controller.ts
+++ b/packages/validation-html/src/validation-controller.ts
@@ -100,6 +100,7 @@ export class BindingInfo {
    * @param {Element} target - The HTMLElement associated with the binding.
    * @param {Scope} scope - The binding scope.
    * @param {PropertyRule[]} [rules] - Rules bound to the binding behavior.
+   * @param {boolean} [cachePropertyInfo] - Cache property info on the binding info.
    * @param {(PropertyInfo | undefined)} [propertyInfo] - Information describing the associated property for the binding.
    * @memberof BindingInfo
    */
@@ -107,6 +108,7 @@ export class BindingInfo {
     public target: Element,
     public scope: Scope,
     public rules?: PropertyRule[],
+    public cachePropertyInfo?: boolean,
     public propertyInfo: PropertyInfo | undefined = void 0,
   ) { }
 }
@@ -127,7 +129,7 @@ export function getPropertyInfo(binding: BindingWithBehavior, info: BindingInfo)
 
   const scope = info.scope;
   let expression = binding.ast.expression;
-  let toCachePropertyName = true;
+  let toCachePropertyName = info.cachePropertyInfo;
   let propertyName: string = '';
   while (expression !== void 0 && expression?.$kind !== 'AccessScope') {
     let memberName: string;

--- a/packages/validation-html/src/validation-customization-options.ts
+++ b/packages/validation-html/src/validation-customization-options.ts
@@ -11,4 +11,5 @@ export interface ValidationHtmlCustomizationOptions extends ValidationCustomizat
   DefaultTrigger: ValidationTrigger;
   UseSubscriberCustomAttribute: boolean;
   SubscriberCustomElementTemplate: string;
+  DefaultCacheBindingPropertyInfo: boolean;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

see [Discord discusson](https://discord.com/channels/448698263508615178/605165596233170944/1354621721361252533) for details.

When using a binding source which is a projection object, syncing validation errors to the view does not work because the binding target element search uses cached property info and a reference equality check between the binding source and the cached source. In the context of redux/reselect, the entire projection object is replaced and so the binding source is different to that which was cached so the target element is skipped.

This change adds a fourth parameter to the validate binding behavior to disable caching of the property info. It also adds the ability to configure the plugin such that the default is to not use caching.
