### PR TITLE
fix(validation): invalidate property info cache when source changes

### DIFF
--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -1785,33 +1785,33 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
       await stop(true);
     });
 
-    it('replaced binding source validates', async function () {
-      class MyApp {
-        private _rules: IValidationRules;
-        public person: Person = new Person((void 0)!, (void 0)!);
-        public readonly validationController: IValidationController = resolve(newInstanceForScope(IValidationController));
-        public constructor()  {
-          this._rules = resolve(IValidationRules);
-          this.applyValidation();
-        }
-
-        replaceBindingSource(person: Person){
-          this._rules.off(this.person);
-          this.person = person;
-          this.applyValidation();
-        }
-
-        private applyValidation() {
-          this._rules
-          .on(this.person)
-          .ensure(x => x.name)
-          .required();
-        }
+    class MyAppReplaceableSource {
+      private _rules: IValidationRules;
+      public person: Person = new Person((void 0)!, (void 0)!);
+      public readonly validationController: IValidationController = resolve(newInstanceForScope(IValidationController));
+      public constructor()  {
+        this._rules = resolve(IValidationRules);
+        this.applyValidation();
       }
 
+      replaceBindingSource(person: Person){
+        this._rules.off(this.person);
+        this.person = person;
+        this.applyValidation();
+      }
+
+      private applyValidation() {
+        this._rules
+        .on(this.person)
+        .ensure(x => x.name)
+        .required();
+      }
+    }
+
+    it('replaced binding source validates', async function () {
       const { startPromise, stop, component, platform } = createFixture(
         `<input value.two-way="person.name & validate"></input>`,
-        MyApp,
+        MyAppReplaceableSource,
         [ValidationHtmlConfiguration]
       );
       await startPromise;
@@ -1867,32 +1867,9 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
     });
 
     it('replaced binding source invalidates cached property info', async function () {
-      class MyApp {
-        private _rules: IValidationRules;
-        public person: Person = new Person((void 0)!, (void 0)!);
-        public readonly validationController: IValidationController = resolve(newInstanceForScope(IValidationController));
-        public constructor()  {
-          this._rules = resolve(IValidationRules);
-          this.applyValidation();
-        }
-
-        replaceBindingSource(person: Person){
-          this._rules.off(this.person);
-          this.person = person;
-          this.applyValidation();
-        }
-
-        private applyValidation() {
-          this._rules
-          .on(this.person)
-          .ensure(x => x.name)
-          .required();
-        }
-      }
-
       const { startPromise, stop, component, platform } = createFixture(
         `<input value.two-way="person.name & validate"></input>`,
-        MyApp,
+        MyAppReplaceableSource,
         [ValidationHtmlConfiguration]
       );
       await startPromise;

--- a/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
+++ b/packages/__tests__/src/validation-html/validate-binding-behavior.spec.ts
@@ -30,6 +30,7 @@ import {
   ValidationTrigger,
   BindingMediator,
   type ControllerValidateResult,
+  BindingInfo,
 } from '@aurelia/validation-html';
 import { createSpecFunction, TestExecutionContext, TestFunction, ToNumberValueConverter, $TestSetupContext } from '../util.js';
 import { Address, Organization, Person } from '../validation/_test-resources.js';
@@ -1780,6 +1781,149 @@ describe('validation-html/validate-binding-behavior.spec.ts', function () {
         [['address.line1', true, undefined], ['name', true, undefined], ['age', true, undefined], ['age', true, undefined]],
         'validationResult.results 3'
       );
+
+      await stop(true);
+    });
+
+    it('replaced binding source validates', async function () {
+      class MyApp {
+        private _rules: IValidationRules;
+        public person: Person = new Person((void 0)!, (void 0)!);
+        public readonly validationController: IValidationController = resolve(newInstanceForScope(IValidationController));
+        public constructor()  {
+          this._rules = resolve(IValidationRules);
+          this.applyValidation();
+        }
+
+        replaceBindingSource(person: Person){
+          this._rules.off(this.person);
+          this.person = person;
+          this.applyValidation();
+        }
+
+        private applyValidation() {
+          this._rules
+          .on(this.person)
+          .ensure(x => x.name)
+          .required();
+        }
+      }
+
+      const { startPromise, stop, component, platform } = createFixture(
+        `<input value.two-way="person.name & validate"></input>`,
+        MyApp,
+        [ValidationHtmlConfiguration]
+      );
+      await startPromise;
+      const domQueue = platform.domQueue;
+
+      // round #1
+      const validationController = component.validationController;
+      let validationResult = await validationController.validate();
+      assert.strictEqual(validationResult.valid, false, 'validationResult.valid 1');
+      assert.deepStrictEqual(
+        validationResult.results.map(x => [x.propertyName, x.valid, x.message]),
+        [['name', false, 'Name is required.']],
+        'validationResult.results 1'
+      );
+
+      // round #2
+      component.person.name = 'Aurelia';
+      await domQueue.yield();
+
+      validationResult = await validationController.validate();
+      assert.strictEqual(validationResult.valid, true, 'validationResult2.valid 2');
+      assert.deepStrictEqual(
+        validationResult.results.map(x => [x.propertyName, x.valid, x.message]),
+        [['name', true, undefined]],
+        'validationResult.results 2'
+      );
+
+      // round #3 - replace the binding source
+      component.replaceBindingSource(new Person(void 0, void 0));
+      await domQueue.yield();
+
+      validationResult = await validationController.validate();
+      assert.strictEqual(validationResult.valid, false, 'validationResult.valid 1');
+      assert.deepStrictEqual(
+        validationResult.results.map(x => [x.propertyName, x.valid, x.message]),
+        [['name', false, 'Name is required.']],
+        'validationResult.results 3'
+      );
+
+      // round #4 - make new binding source valid
+      component.person.name = 'Replaced Aurelia';
+      await domQueue.yield();
+
+      validationResult = await validationController.validate();
+      assert.strictEqual(validationResult.valid, true, 'validationResult2.valid 2');
+      assert.deepStrictEqual(
+        validationResult.results.map(x => [x.propertyName, x.valid, x.message]),
+        [['name', true, undefined]],
+        'validationResult.results 2'
+      );
+
+      await stop(true);
+    });
+
+    it('replaced binding source invalidates cached property info', async function () {
+      class MyApp {
+        private _rules: IValidationRules;
+        public person: Person = new Person((void 0)!, (void 0)!);
+        public readonly validationController: IValidationController = resolve(newInstanceForScope(IValidationController));
+        public constructor()  {
+          this._rules = resolve(IValidationRules);
+          this.applyValidation();
+        }
+
+        replaceBindingSource(person: Person){
+          this._rules.off(this.person);
+          this.person = person;
+          this.applyValidation();
+        }
+
+        private applyValidation() {
+          this._rules
+          .on(this.person)
+          .ensure(x => x.name)
+          .required();
+        }
+      }
+
+      const { startPromise, stop, component, platform } = createFixture(
+        `<input value.two-way="person.name & validate"></input>`,
+        MyApp,
+        [ValidationHtmlConfiguration]
+      );
+      await startPromise;
+      const domQueue = platform.domQueue;
+      const controller = component.validationController;
+
+      let bindings = Array.from((controller['bindings'] as Map<IBinding, BindingInfo>).values()) as BindingInfo[];
+      let binding = bindings[0];
+
+      // round #1 nothing cached before validation
+      assert.equal(binding.propertyInfo, undefined);
+
+      // round #2
+      await controller.validate();
+      bindings = Array.from((controller['bindings'] as Map<IBinding, BindingInfo>).values()) as BindingInfo[];
+      binding = bindings[0];
+      assert.equal(binding.propertyInfo.object, component.person);
+
+      // round #3 - replace the binding source, property info removed
+      const replacement = new Person(void 0, void 0);
+      component.replaceBindingSource(replacement);
+      await domQueue.yield();
+      bindings = Array.from((controller['bindings'] as Map<IBinding, BindingInfo>).values()) as BindingInfo[];
+      binding = bindings[0];
+      assert.equal(binding.propertyInfo, undefined);
+
+      // round #4 - after validate, new source is cached
+      await controller.validate();
+      bindings = Array.from((controller['bindings'] as Map<IBinding, BindingInfo>).values()) as BindingInfo[];
+      binding = bindings[0];
+      assert.equal(binding.propertyInfo.object, replacement);
 
       await stop(true);
     });

--- a/packages/validation-html/src/validation-controller.ts
+++ b/packages/validation-html/src/validation-controller.ts
@@ -14,6 +14,7 @@ import {
 } from '@aurelia/expression-parser';
 import {
   astEvaluate,
+  IConnectable,
   type Scope,
 } from '@aurelia/runtime';
 import {
@@ -97,6 +98,7 @@ export interface ValidationResultsSubscriber {
  */
 export class BindingInfo {
   /**
+   * @param {IConnectable} sourceObserver - An observer for the binding source.
    * @param {Element} target - The HTMLElement associated with the binding.
    * @param {Scope} scope - The binding scope.
    * @param {PropertyRule[]} [rules] - Rules bound to the binding behavior.
@@ -104,6 +106,7 @@ export class BindingInfo {
    * @memberof BindingInfo
    */
   public constructor(
+    public sourceObserver: IConnectable,
     public target: Element,
     public scope: Scope,
     public rules?: PropertyRule[],
@@ -145,7 +148,7 @@ export function getPropertyInfo(binding: BindingWithBehavior, info: BindingInfo)
           toCachePropertyName = keyExpr.$kind === 'PrimitiveLiteral';
         }
         // eslint-disable-next-line
-        memberName = `[${(astEvaluate(keyExpr, scope, binding, null) as any).toString()}]`;
+        memberName = `[${(astEvaluate(keyExpr, scope, binding, info.sourceObserver) as any).toString()}]`;
         break;
       }
       default:
@@ -164,7 +167,7 @@ export function getPropertyInfo(binding: BindingWithBehavior, info: BindingInfo)
     propertyName = expression.name;
     object = scope.bindingContext;
   } else {
-    object = astEvaluate(expression, scope, binding, null);
+    object = astEvaluate(expression, scope, binding, info.sourceObserver);
   }
   if (object === null || object === void 0) {
     return (void 0);


### PR DESCRIPTION
this supercedes aurelia#2136

# Pull Request

## 📖 Description

see [Discord discusson](https://discord.com/channels/448698263508615178/605165596233170944/1354621721361252533) for details.

When using a binding source which is a projection object, syncing validation errors to the view does not work because the binding target element search uses cached property info and a reference equality check between the binding source and the cached source. In the context of redux/reselect, the entire projection object is replaced and so the binding source is different to that which was cached so the target element is skipped.

This change adds an observer to the binding that is used to invalidate the cached property info when the binding source changes.