### PR TITLE
feat(dialog): add standard html dialog renderer

### DIFF
--- a/docs/user-docs/aurelia-packages/dialog.md
+++ b/docs/user-docs/aurelia-packages/dialog.md
@@ -511,6 +511,27 @@ There are two ways to use your own dialog renderer: register your own default di
     }
     ```
 
+### The standard `<dialog>` element renderer
+
+Beside the default dialog renderer, Aurelia also provides an out-of-the-box renderer that uses the `<dialog>` element.
+
+Compared to the default renderer, this dialog renderer has the following differences:
+- the dialog wrapper doesn't come with any default style, so it will take the default user agent style, which could come with the strong dark border around the content.
+- the dialog dom does not have an overlay. Since only modal dialog has a backdrop for overlay purpose, the overlay isn't always needed.
+- the overlay, can be styled with a helper via a method on the dialog dom (`HtmlDialogDom`), like the following example:
+    ```ts
+    import { IDialogDom, HtmlDialogDom } from '@aurelia/dialog';
+
+    class MyDialogComponent {
+      dom = resolve(IDialogDom) as HtmlDialogDom;
+
+      binding() {
+        dom.setOverlayStyle('background: pink');
+      }
+    }
+    ```
+    Note that the backdrop of a `<dialog>` is a pseudo element, and thus its style cannot be modified like a normal element.
+
 ### Animation
 
 #### Using the `IDialogDomAnimator`

--- a/packages/__tests__/src/3-runtime-html/dialog/dialog-html-dom.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/dialog/dialog-html-dom.spec.ts
@@ -1,0 +1,57 @@
+import { delegateSyntax } from '@aurelia/compat-v1';
+import { Registration, noop, resolve } from '@aurelia/kernel';
+import {
+  INode,
+  customElement,
+  CustomElement,
+} from '@aurelia/runtime-html';
+import {
+  IDialogService,
+  IDialogSettings,
+  IDialogGlobalSettings,
+  DialogConfiguration,
+  DialogDefaultConfiguration,
+  DefaultDialogGlobalSettings,
+  DialogCancelError,
+  IDialogDom,
+  IDialogController,
+  DialogController,
+  DefaultDialogDom,
+  DialogService,
+  IDialogDomAnimator,
+  HtmlDialogDomRenderer,
+  DefaultDialogEventManager,
+} from '@aurelia/dialog';
+import {
+  createFixture,
+  assert,
+  createSpy,
+} from '@aurelia/testing';
+import { isNode } from '../../util.js';
+
+describe('3-runtime-html/dialog/dialog-html-dom.spec.ts', function () {
+  it('throws on empty configuration', async function () {
+    const { component, assertHtml, printHtml } = createFixture(
+      '',
+      class {
+        host = resolve(INode) as HTMLElement;
+        dialogService = resolve(IDialogService);
+      },
+      [
+        DialogConfiguration.customize(_ => { }, [
+          DialogService,
+          DefaultDialogGlobalSettings,
+          HtmlDialogDomRenderer,
+          DefaultDialogEventManager,
+        ]),
+      ]);
+
+    await component.dialogService.open({
+      host: component.host,
+      template: 'hey',
+    });
+
+    printHtml();
+    assertHtml('<dialog data-dialog-id="d-1"><div>hey</div></dialog>');
+  });
+});

--- a/packages/__tests__/src/3-runtime-html/dialog/dialog-html-dom.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/dialog/dialog-html-dom.spec.ts
@@ -1,57 +1,81 @@
-import { delegateSyntax } from '@aurelia/compat-v1';
-import { Registration, noop, resolve } from '@aurelia/kernel';
 import {
-  INode,
-  customElement,
-  CustomElement,
+  DialogController,
+  DialogStandardHtmlDialogConfiguration,
+  HtmlDialogDom,
+  IDialogService
+} from '@aurelia/dialog';
+import { resolve } from '@aurelia/kernel';
+import {
+  INode
 } from '@aurelia/runtime-html';
 import {
-  IDialogService,
-  IDialogSettings,
-  IDialogGlobalSettings,
-  DialogConfiguration,
-  DialogDefaultConfiguration,
-  DefaultDialogGlobalSettings,
-  DialogCancelError,
-  IDialogDom,
-  IDialogController,
-  DialogController,
-  DefaultDialogDom,
-  DialogService,
-  IDialogDomAnimator,
-  HtmlDialogDomRenderer,
-  DefaultDialogEventManager,
-} from '@aurelia/dialog';
-import {
-  createFixture,
-  assert,
-  createSpy,
+  createFixture
 } from '@aurelia/testing';
 import { isNode } from '../../util.js';
 
 describe('3-runtime-html/dialog/dialog-html-dom.spec.ts', function () {
-  it('throws on empty configuration', async function () {
-    const { component, assertHtml, printHtml } = createFixture(
+  // only deal with <dialog> in the browser
+  if (isNode()) return;
+
+  it('renders <dialog> element', async function () {
+    const { component, assertHtml } = createFixture(
       '',
       class {
         host = resolve(INode) as HTMLElement;
         dialogService = resolve(IDialogService);
       },
-      [
-        DialogConfiguration.customize(_ => { }, [
-          DialogService,
-          DefaultDialogGlobalSettings,
-          HtmlDialogDomRenderer,
-          DefaultDialogEventManager,
-        ]),
-      ]);
+      [DialogStandardHtmlDialogConfiguration]
+    );
 
     await component.dialogService.open({
       host: component.host,
       template: 'hey',
     });
 
-    printHtml();
-    assertHtml('<dialog data-dialog-id="d-1"><div>hey</div></dialog>');
+    assertHtml('<dialog data-dialog-id="d-1" open=""><div>hey</div></dialog>');
+  });
+
+  it('renders <dialog> element with overlay', async function () {
+    const { component, assertHtml } = createFixture(
+      '',
+      class {
+        host = resolve(INode) as HTMLElement;
+        dialogService = resolve(IDialogService);
+      },
+      [DialogStandardHtmlDialogConfiguration]
+    );
+
+    await component.dialogService.open({
+      host: component.host,
+      template: 'hey',
+      asModal: true,
+    });
+
+    assertHtml('<dialog data-dialog-id="d-2" open=""><div>hey</div></dialog>');
+  });
+
+  it('sets overlay style', async function () {
+    const { component, assertHtml } = createFixture(
+      '',
+      class {
+        host = resolve(INode) as HTMLElement;
+        dialogService = resolve(IDialogService);
+      },
+      [DialogStandardHtmlDialogConfiguration]
+    );
+
+    const result = await component.dialogService.open({
+      host: component.host,
+      template: 'hey',
+      asModal: true,
+    });
+
+    assertHtml('<dialog data-dialog-id="d-3" open=""><div>hey</div></dialog>');
+
+    ((result.dialog as DialogController)['dom'] as HtmlDialogDom).setOverlayStyle('background: red;');
+    assertHtml('<dialog data-dialog-id="d-3" open=""><style>[data-dialog-id="d-3"]::backdrop{background: red;}</style><div>hey</div></dialog>');
+
+    ((result.dialog as DialogController)['dom'] as HtmlDialogDom).setOverlayStyle({ backgroundColor: 'blue' });
+    assertHtml('<dialog data-dialog-id="d-3" open=""><style>[data-dialog-id="d-3"]::backdrop{background-color: blue;}</style><div>hey</div></dialog>');
   });
 });

--- a/packages/dialog/src/dialog-configuration.ts
+++ b/packages/dialog/src/dialog-configuration.ts
@@ -2,7 +2,7 @@ import { IContainer, IRegistry, noop } from '@aurelia/kernel';
 import { AppTask } from '@aurelia/runtime-html';
 
 import { IDialogGlobalSettings } from './dialog-interfaces';
-import { DefaultDialogGlobalSettings, DefaultDialogDomRenderer } from './dialog-default-impl';
+import { DefaultDialogGlobalSettings, DefaultDialogDomRenderer, HtmlDialogDomRenderer } from './dialog-default-impl';
 import { DialogService } from './dialog-service';
 import { singletonRegistration } from './utilities-di';
 import { ErrorNames, createMappedError } from './errors';
@@ -45,9 +45,22 @@ export const DialogConfiguration = /*@__PURE__*/createDialogConfiguration(() => 
   }
 }]);
 
+/**
+ * A configuration for Dialog that uses the light DOM for rendering dialog & its overlay.
+ */
 export const DialogDefaultConfiguration = /*@__PURE__*/createDialogConfiguration(noop, [
   DialogService,
   DefaultDialogGlobalSettings,
   DefaultDialogDomRenderer,
+  DefaultDialogEventManager,
+]);
+
+/**
+ * A configuration for Dialog that uses the `<dialog>` element.
+ */
+export const DialogStandardHtmlDialogConfiguration = /*@__PURE__*/createDialogConfiguration(noop, [
+  DialogService,
+  DefaultDialogGlobalSettings,
+  HtmlDialogDomRenderer,
   DefaultDialogEventManager,
 ]);

--- a/packages/dialog/src/dialog-event-manager.ts
+++ b/packages/dialog/src/dialog-event-manager.ts
@@ -24,7 +24,7 @@ export class DefaultDialogEventManager implements IDialogEventManager {
         void controller.cancel();
       }
     };
-    dom.overlay.addEventListener(mouseEvent, handleClick);
+    dom.overlay?.addEventListener(mouseEvent, handleClick);
 
     const handleSubmit = (e: SubmitEvent) => {
       const target = e.target as HTMLFormElement;
@@ -39,7 +39,7 @@ export class DefaultDialogEventManager implements IDialogEventManager {
     return {
       dispose: () => {
         this._remove(controller);
-        dom.overlay.removeEventListener(mouseEvent, handleClick);
+        dom.overlay?.removeEventListener(mouseEvent, handleClick);
         dom.contentHost.removeEventListener('submit', handleSubmit);
       }
     };

--- a/packages/dialog/src/dialog-interfaces.ts
+++ b/packages/dialog/src/dialog-interfaces.ts
@@ -54,7 +54,7 @@ export interface IDialogDomRenderer {
  */
 export const IDialogDom = /*@__PURE__*/createInterface<IDialogDom>('IDialogDom');
 export interface IDialogDom extends IDisposable {
-  readonly overlay: HTMLElement;
+  readonly overlay: HTMLElement | null;
   readonly contentHost: HTMLElement;
   /**
    * Called when the dialog should be shown. Application can use this for animations

--- a/packages/dialog/src/dialog-interfaces.ts
+++ b/packages/dialog/src/dialog-interfaces.ts
@@ -152,6 +152,19 @@ export interface IDialogSettings<
   lock?: boolean;
 
   /**
+   * When set to "true" the dialog will be modal.
+   * This means that the dialog will be displayed as a modal dialog.
+   * The default value is "false".
+   *
+   * Note that this depends on the renderer,
+   * Some renderers may not support this feature.
+   *
+   * Readmore on the modal behavior of dialogs on MDN
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement#opening_a_modal_dialog
+   */
+  asModal?: boolean;
+
+  /**
    * Allows for closing the top most dialog via the keyboard.
    * When set to "false" no action will be taken.
    * If set to "true", "Escape" or an array containing "Escape"

--- a/packages/dialog/src/dialog-service.ts
+++ b/packages/dialog/src/dialog-service.ts
@@ -121,7 +121,10 @@ export class DialogService implements IDialogService {
         })
       )
       .then(unclosedControllers =>
-        unclosedControllers.filter(unclosed => !!unclosed)
+        // something wrong with TS
+        // it's unable to recognize that the null values are filtered out already
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        unclosedControllers.filter(unclosed => !!unclosed) as IDialogController[]
       );
   }
 

--- a/packages/dialog/src/dialog-service.ts
+++ b/packages/dialog/src/dialog-service.ts
@@ -1,4 +1,4 @@
-import { isFunction, isPromise, IContainer, Registration, onResolve, onResolveAll, resolve } from '@aurelia/kernel';
+import { isFunction, IContainer, Registration, onResolve, onResolveAll, resolve } from '@aurelia/kernel';
 import { AppTask } from '@aurelia/runtime-html';
 
 import {
@@ -147,17 +147,15 @@ class DialogSettings<T extends object = object> implements IDialogSettings<T> {
     const loaded = this as IDialogLoadedSettings;
     const cmp = this.component;
     const template = this.template;
-    const maybePromise = onResolveAll(...[
+    const maybePromise = onResolveAll(
       cmp == null
         ? void 0
         : onResolve(cmp(), loadedCmp => { loaded.component = loadedCmp; }),
       isFunction(template)
         ? onResolve(template(), loadedTpl => { loaded.template = loadedTpl; })
         : void 0
-    ]);
-    return isPromise(maybePromise)
-      ? maybePromise.then(() => loaded)
-      : loaded;
+    );
+    return onResolve(maybePromise, () => loaded);
   }
 
   /** @internal */

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -51,6 +51,9 @@ export {
   DefaultDialogDom,
   DefaultDialogDomRenderer,
   DefaultDialogGlobalSettings,
+
+  HtmlDialogDomRenderer,
+  HtmlDialogDom,
 } from './dialog-default-impl';
 
 export {

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -44,6 +44,7 @@ export {
 export {
   DialogConfiguration,
   DialogDefaultConfiguration,
+  DialogStandardHtmlDialogConfiguration,
   type DialogConfigurationProvider,
 } from './dialog-configuration';
 

--- a/packages/testing/src/startup.ts
+++ b/packages/testing/src/startup.ts
@@ -1,7 +1,7 @@
 import { Constructable, EventAggregator, IContainer, ILogger } from '@aurelia/kernel';
 import { Metadata } from '@aurelia/metadata';
 import { IObserverLocator } from '@aurelia/runtime';
-import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig, PartialCustomElementDefinition } from '@aurelia/runtime-html';
+import { CustomElement, Aurelia, IPlatform, type ICustomElementViewModel, CustomElementDefinition, IAppRootConfig, PartialCustomElementDefinition, registerHostNode } from '@aurelia/runtime-html';
 import { assert } from './assert';
 import { hJsx } from './h';
 import { TestContext } from './test-context';
@@ -73,6 +73,8 @@ export function createFixture<T extends object>(
       'Consider using a different class, or context as it will likely cause surprises in tests.'
     );
   }
+
+  registerHostNode(container, host);
   const component = container.get(App);
 
   let startPromise: Promise<void> | void = void 0;


### PR DESCRIPTION
## 📖 Description

As per request from #2053 , add another renderer implementation for the dialog plugin that will renders the `<dialog>` element instead of a div with dialog like styling.
Also add a config `asModal` in the dialog open settings to support `modal` behavior for renderers.

BREAKING CHANGES:
- Dialog dom property `overlay` is now optional, since not all dialog needs an overlay, having it optional allows renderer to skip populating this altogether.

### 🎫 Issues

Close #2053

cc @ekzobrain @stopi