### PR TITLE
docs(router-lite): adds current route documentation

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -75,6 +75,7 @@
     * [Router hooks](router-lite/router-hooks.md)
     * [Router events](router-lite/router-events.md)
     * [Navigation model](router-lite/navigation-model.md)
+    * [Current route](router-lite/current-route.md)
     * [Transition plan](router-lite/transition-plans.md)
 * [App configuration and startup](getting-to-know-aurelia/app-configuration-and-startup.md)
 * [Enhance](getting-to-know-aurelia/enhance.md)

--- a/docs/user-docs/router-lite/current-route.md
+++ b/docs/user-docs/router-lite/current-route.md
@@ -1,0 +1,44 @@
+---
+description: Access information about the active route via ICurrentRoute.
+---
+
+# Current route
+
+`ICurrentRoute` is a dependency injection token that exposes details of the route that is currently active. The instance is updated whenever navigation finishes so that you can inspect the active path, URL and query information from any component or service.
+
+`ICurrentRoute` has the following shape:
+
+```ts
+interface ICurrentRoute {
+  readonly path: string;
+  readonly url: string;
+  readonly title: string;
+  readonly query: URLSearchParams;
+  readonly parameterInformation: readonly ParameterInformation[];
+}
+
+interface ParameterInformation {
+  readonly config: RouteConfig | null;
+  readonly viewport: string | null;
+  readonly params: Readonly<Params> | null;
+  readonly children: readonly ParameterInformation[];
+}
+```
+
+To use it, inject the token and read its properties:
+
+```ts
+import { ICurrentRoute } from '@aurelia/router-lite';
+import { resolve } from 'aurelia';
+
+export class MyApp {
+  private readonly currentRoute = resolve(ICurrentRoute);
+
+  attached() {
+    console.log('Active path:', this.currentRoute.path);
+    console.log('Active url:', this.currentRoute.url);
+  }
+}
+```
+
+The `parameterInformation` array mirrors the hierarchy of viewport instructions of the current navigation. It allows you to inspect route parameters and nested routes programmatically.

--- a/docs/user-docs/router-lite/router-events.md
+++ b/docs/user-docs/router-lite/router-events.md
@@ -125,3 +125,5 @@ export class MyApp {
   }
 }
 ```
+
+See [Current route](./current-route.md) for a deeper look at the service.

--- a/docs/user-docs/router-lite/routing-lifecycle.md
+++ b/docs/user-docs/router-lite/routing-lifecycle.md
@@ -248,6 +248,26 @@ export class ChildOne implements IRouteViewModel {
 
 {% embed url="https://stackblitz.com/edit/router-lite-loading-title?ctl=1&embed=1&file=src/main.ts" %}
 
+### Accessing parent route parameters
+
+If a child component needs to inspect parameters defined by its parent route, inject `IRouteContext` and use its `parent` property inside the `loading` hook.
+
+```ts
+import { resolve } from 'aurelia';
+import { IRouteContext, type Params } from '@aurelia/router-lite';
+
+export class ChildTwo {
+  private readonly ctx = resolve(IRouteContext);
+
+  loading(params: Params) {
+    console.log('child params', params);
+    console.log('parent params', this.ctx.parent?.params);
+  }
+}
+```
+
+See [Customize the routing context](./navigating.md#customize-the-routing-context) for more on working with `IRouteContext`.
+
 ## `canUnload`
 
 The `canUnload` method is called when a user attempts to leave a routed view.


### PR DESCRIPTION
Adds documentation for `ICurrentRoute`, a dependency injection token that exposes details of the active route.

Also adds a section about accessing parent route parameters using `IRouteContext`.