### PR TITLE
fix(i18n): Add isBound check in TranslationBinding.handleChange to prevent AUR0203

### DIFF
--- a/packages/__tests__/src/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-integration.spec.ts
@@ -322,6 +322,28 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       assertTextContent(host, 'span', translation.simple.text);
     }, { component: App });
   }
+  {
+    @customElement({ name: 'app', template: `<span if.bind='obj.condition'><span t.bind='obj.key'></span></span>` })
+    class App {
+      public obj: { key: string; condition: boolean } = { key: 'simple.text', condition: true };
+
+      public changeCondition() {
+        this.obj = { key: 'simple.text', condition: false };
+      }
+    }
+    $it('does not throw AUR0203 when handleChange is called after unbind in if.bind/t.bind scenario', function ({ host, app, ctx, en: translation }: I18nIntegrationTestContext<App>) {
+      assertTextContent(host, 'span > span', translation.simple.text, 'initial rendering');
+
+      app.changeCondition();
+      ctx.platform.domQueue.flush();
+      assert.equal((host as Element).querySelector('span > span'), null, 'inner span removed after unbind');
+
+      assert.doesNotThrow(() => {
+            app.obj.key = 'simple.attr';
+            ctx.platform.domQueue.flush();
+        }, 'AUR0203 error should not be thrown');
+    }, { component: App });
+  }
 
   describe('translation can be manipulated by using t-params', function () {
     {

--- a/packages/__tests__/src/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-integration.spec.ts
@@ -333,15 +333,16 @@ describe('i18n/t/translation-integration.spec.ts', function () {
     }
     $it('does not throw AUR0203 when handleChange is called after unbind in if.bind/t.bind scenario', function ({ host, app, ctx, en: translation }: I18nIntegrationTestContext<App>) {
       assertTextContent(host, 'span > span', translation.simple.text, 'initial rendering');
-
-      app.changeCondition();
-      ctx.platform.domQueue.flush();
-      assert.equal((host as Element).querySelector('span > span'), null, 'inner span removed after unbind');
-
       assert.doesNotThrow(() => {
-            app.obj.key = 'simple.attr';
-            ctx.platform.domQueue.flush();
-        }, 'AUR0203 error should not be thrown');
+        app.changeCondition();
+        ctx.platform.domQueue.flush();
+        app.obj.key = 'simple.attr';
+        ctx.platform.domQueue.flush();
+      }, 'AUR0203 error should not be thrown');
+      assert.equal((host as Element).querySelector('span > span'), null, 'inner span removed after unbind');
+      app.obj.condition = true;
+      ctx.platform.domQueue.flush();
+      assertTextContent(host, 'span > span', translation.simple.attr, 'final rendering');
     }, { component: App });
   }
 

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -196,6 +196,9 @@ export class TranslationBinding implements IBinding {
   }
 
   public handleChange(_newValue: string | i18next.TOptions, _previousValue: string | i18next.TOptions): void {
+    if (!this.isBound) {
+        return;
+    }
     this.obs.version++;
     this._keyExpression = astEvaluate(this.ast, this._scope, this, this) as string;
     this.obs.clear();


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes #2170 by adding an `isBound` check to `TranslationBinding.handleChange()` in `@aurelia/i18n`. This prevents an `AUR0203` error when the binding is unbound, such as in scenarios with `if.bind` and `t.bind`.

### 🎫 Issues

#2170


## 📑 Test Plan

- Ran `npm run dev -- --dev i18n --test i18n` to ensure no regressions.
