### PR TITLE
feat(state): adds memoized selector creator

### DIFF
--- a/docs/user-docs/aurelia-packages/state.md
+++ b/docs/user-docs/aurelia-packages/state.md
@@ -162,6 +162,51 @@ export class AutoSuggest {
 
 With the above, whenever the state changes, it will ensure the `keywords` property of the view model stays in sync with the `keywords` property on the global state.
 
+### Memoizing derived state
+
+Expensive computations in `@fromState` selectors will run on every state change by default. To avoid unnecessary work, the `createSelector` helper allows you to memoize derived values so they are recomputed only when their dependencies actually change.
+
+```ts
+import { fromState, createSelector } from '@aurelia/state';
+
+interface State { items: number[]; }
+
+const selectTotal = createSelector(
+  (s: State) => s.items,
+  items => items.reduce((a, b) => a + b, 0)
+);
+
+export class Summary {
+  @fromState(selectTotal)
+  total!: number;
+}
+```
+
+In the example above, the `selectTotal` function executes only when `items` changes by reference. Other state updates won't trigger a recalculation, keeping the component performant and giving derived logic a clear place to live.
+
+When you only need to read a value from state or perform a cheap calculation, passing a simple function directly to `@fromState` is usually adequate. The decorated property will update on every state change, which keeps things straightforward.
+
+`createSelector` shines when deriving data is expensive or shared across multiple components. Because the selector remembers its last inputs, recalculation happens only when those inputs change by reference. This reduces wasted work and centralizes complex logic.
+
+Here is another example using multiple selectors:
+
+```ts
+interface State { items: string[]; search: string; }
+
+const selectFiltered = createSelector(
+  (s: State) => s.items,
+  (s: State) => s.search,
+  (items, term) => items.filter(i => i.includes(term))
+);
+
+export class Results {
+  @fromState(selectFiltered)
+  results!: string[];
+}
+```
+
+In contrast, writing the filter inline like `@fromState(s => s.items.filter(i => i.includes(s.search)))` would rerun on every single state update, even when neither `items` nor `search` changed.
+
 ## Authoring action handlers
 
 As mentioned at the start of this guide, action handlers are the way to handle mutation of the global state. They are expected to return to a new state instead of mutating it. Even though normal mutation works, it may break future integration with devtool.

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -36,3 +36,4 @@ export {
 
 export { StateBindingBehavior } from './state-binding-behavior';
 export { fromState } from './state-decorator';
+export { createSelector } from './selectors';

--- a/packages/state/src/selectors.ts
+++ b/packages/state/src/selectors.ts
@@ -1,0 +1,59 @@
+export type Selector<S, R> = (state: S) => R;
+
+/**
+ * Create a memoized selector. The selector will only recompute the result
+ * when its dependencies change by reference.
+ *
+ * @param selectors - one or more selector functions. If multiple selectors are
+ * supplied, the last function is treated as the result function which receives
+ * the selected values. If a single selector function is supplied, it will be
+ * memoized directly.
+ */
+export function createSelector<S, R>(selector: Selector<S, R>): Selector<S, R>;
+export function createSelector<S, A, R>(
+  s1: Selector<S, A>,
+  resultFn: (a: A) => R,
+): Selector<S, R>;
+export function createSelector<S, A, B, R>(
+  s1: Selector<S, A>,
+  s2: Selector<S, B>,
+  resultFn: (a: A, b: B) => R,
+): Selector<S, R>;
+export function createSelector<S, A, B, C, R>(
+  s1: Selector<S, A>,
+  s2: Selector<S, B>,
+  s3: Selector<S, C>,
+  resultFn: (a: A, b: B, c: C) => R,
+): Selector<S, R>;
+export function createSelector<S>(
+  ...fns: (Selector<S, unknown> | ((...args: unknown[]) => unknown))[]
+): Selector<S, unknown> {
+  if (fns.length === 1) {
+    const selector = fns[0] as Selector<S, unknown>;
+    let lastState: S | undefined;
+    let lastResult: unknown;
+    return (state: S) => {
+      if (state === lastState) {
+        return lastResult;
+      }
+      lastState = state;
+      return (lastResult = selector(state));
+    };
+  }
+  const resultFn = fns[fns.length - 1] as (...args: unknown[]) => unknown;
+  const selectors = fns.slice(0, -1) as Selector<S, unknown>[];
+  let lastInputs: unknown[] | undefined;
+  let lastResult: unknown;
+  return (state: S) => {
+    const inputs = selectors.map(fn => fn(state));
+    if (
+      lastInputs !== undefined &&
+      inputs.length === lastInputs.length &&
+      inputs.every((v, i) => v === lastInputs![i])
+    ) {
+      return lastResult;
+    }
+    lastInputs = inputs;
+    return (lastResult = resultFn(...inputs));
+  };
+}


### PR DESCRIPTION
Implements `createSelector` to memoize derived state, preventing unnecessary recomputations. This improves performance by recalculating values only when their dependencies change.

Provides a clear and centralised way to define and share complex derived logic across components.

This is a PR branched from the middleware PR and will need to be rebased on main once the other PR is merged first.