### PR TITLE
fix(runtime): don't wrap non-configurable and non-writable object properties

### DIFF
--- a/packages/__tests__/src/2-runtime/proxy-observable.spec.ts
+++ b/packages/__tests__/src/2-runtime/proxy-observable.spec.ts
@@ -114,4 +114,19 @@ describe('2-runtime/proxy-observable.spec.ts', function () {
     ConnectableSwitcher.exit(connectable);
     assert.strictEqual(count, 0);
   });
+
+  it('does not wrap non-configurable and non-writable properties', function () {
+    const obj = {};
+    Reflect.defineProperty(obj, 'prop', { value: { test: 1 } });
+    const proxied = ProxyObservable.wrap(obj);
+
+    const connectable = {
+      observe() {},
+    } as unknown as IConnectable;
+    ConnectableSwitcher.enter(connectable);
+    const proxiedValue = proxied['prop'];
+    ConnectableSwitcher.exit(connectable);
+
+    assert.strictEqual(proxiedValue, obj['prop']);
+  });
 });

--- a/packages/runtime/src/array-observer.ts
+++ b/packages/runtime/src/array-observer.ts
@@ -364,7 +364,7 @@ export const getArrayObserver = /*@__PURE__*/ (() => {
     };
 
     for (const method of methods) {
-      rtDef(observe[method], 'observing', { value: true, writable: false, configurable: false, enumerable: false });
+      rtDef(observe[method], 'observing', { value: true });
     }
   }
 

--- a/packages/runtime/src/observer-locator.ts
+++ b/packages/runtime/src/observer-locator.ts
@@ -269,10 +269,7 @@ const getOwnPropDesc = Object.getOwnPropertyDescriptor;
 export const getObserverLookup = <T extends IObserver>(instance: object): Record<PropertyKey, T> => {
   let lookup = (instance as IObservable).$observers as Record<PropertyKey, T>;
   if (lookup === void 0) {
-    rtDef(instance, '$observers', {
-      enumerable: false,
-      value: lookup = createLookup(),
-    });
+    rtDef(instance, '$observers', { value: lookup = createLookup() });
   }
   return lookup;
 };

--- a/packages/runtime/src/proxy-observation.ts
+++ b/packages/runtime/src/proxy-observation.ts
@@ -92,7 +92,16 @@ const objectHandler: ProxyHandler<object> = {
     // todo: static
     connectable.observe(target, key);
 
-    return wrap(R$get(target, key, receiver));
+    const value = R$get(target, key, receiver);
+    const descriptor = Reflect.getOwnPropertyDescriptor(target, key);
+
+    // ensure Proxy spec compliance, value of non-configurable and non-writable property MUST be returned as is
+    // https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
+    if (descriptor?.configurable === false && descriptor.writable === false) {
+      return value;
+    }
+
+    return wrap(value);
   },
   deleteProperty(target, p) {
     if (__DEV__) {

--- a/packages/runtime/src/utilities.ts
+++ b/packages/runtime/src/utilities.ts
@@ -19,7 +19,6 @@ export const rtDef = Reflect.defineProperty;
 /** @internal */
 export function rtDefineHiddenProp<T>(obj: object, key: PropertyKey, value: T): T {
   rtDef(obj, key, {
-    enumerable: false,
     configurable: true,
     writable: true,
     value


### PR DESCRIPTION
Currently proxy observer violates Proxy spec (see Notes section): https://262.ecma-international.org/8.0/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver and browsers throw an exception "TypeError: proxy must report the same value for the non-writable, non-configurable property 'xxx'"
This PR is intended to fix it so that a proxy observer does not wrap such properties.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
