### PR TITLE
feat(state): adds memoized selector creator

### DIFF
--- a/docs/user-docs/aurelia-packages/state.md
+++ b/docs/user-docs/aurelia-packages/state.md
@@ -145,6 +145,51 @@ export class AutoSuggest {
 
 With the above, whenever the state changes, it will ensure the `keywords` property of the view model stays in sync with the `keywords` property on the global state.
 
+### Memoizing derived state
+
+Expensive computations in `@fromState` selectors will run on every state change by default. To avoid unnecessary work, the `createStateMemoizer` helper allows you to memoize derived values so they are recomputed only when their dependencies actually change.
+
+```ts
+import { fromState, createStateMemoizer } from '@aurelia/state';
+
+interface State { items: number[]; }
+
+const selectTotal = createStateMemoizer(
+  (s: State) => s.items,
+  items => items.reduce((a, b) => a + b, 0)
+);
+
+export class Summary {
+  @fromState(selectTotal)
+  total!: number;
+}
+```
+
+In the example above, the `selectTotal` function executes only when `items` changes by reference. Other state updates won't trigger a recalculation, keeping the component performant and giving derived logic a clear place to live.
+
+When you only need to read a value from state or perform a cheap calculation, passing a simple function directly to `@fromState` is usually adequate. The decorated property will update on every state change, which keeps things straightforward.
+
+`createStateMemoizer` shines when deriving data is expensive or shared across multiple components. Because the selector remembers its last inputs, recalculation happens only when those inputs change by reference. This reduces wasted work and centralizes complex logic.
+
+Here is another example using multiple selectors:
+
+```ts
+interface State { items: string[]; search: string; }
+
+const selectFiltered = createStateMemoizer(
+  (s: State) => s.items,
+  (s: State) => s.search,
+  (items, term) => items.filter(i => i.includes(term))
+);
+
+export class Results {
+  @fromState(selectFiltered)
+  results!: string[];
+}
+```
+
+In contrast, writing the filter inline like `@fromState(s => s.items.filter(i => i.includes(s.search)))` would rerun on every single state update, even when neither `items` nor `search` changed.
+
 ## Authoring action handlers
 
 As mentioned at the start of this guide, action handlers are the way to handle mutation of the global state. They are expected to return to a new state instead of mutating it. Even though normal mutation works, it may break future integration with devtool.

--- a/packages/__tests__/src/state/state.spec.ts
+++ b/packages/__tests__/src/state/state.spec.ts
@@ -1,6 +1,7 @@
 import { ValueConverter, customAttribute, customElement, ICustomAttributeController, IWindow } from '@aurelia/runtime-html';
+
 import { tasksSettled } from '@aurelia/runtime';
-import { StateDefaultConfiguration, fromState } from '@aurelia/state';
+import { StateDefaultConfiguration, fromState, createStateMemoizer } from '@aurelia/state';
 import { assert, createFixture, onFixtureCreated } from '@aurelia/testing';
 
 describe('state/state.spec.ts', function () {
@@ -592,6 +593,137 @@ describe('state/state.spec.ts', function () {
     });
   });
 
+  describe('createStateMemoizer', function () {
+    it('memoizes results based on dependencies', function () {
+      interface S { items: number[]; flag: boolean }
+      const items = [1, 2, 3];
+      let computeCalls = 0;
+      const total = createStateMemoizer(
+        (s: S) => s.items,
+        (i) => { computeCalls++; return i.reduce((a, b) => a + b, 0); }
+      );
+
+      const s1: S = { items, flag: true };
+      assert.strictEqual(total(s1), 6);
+      assert.strictEqual(computeCalls, 1);
+
+      const s2: S = { items, flag: false };
+      assert.strictEqual(total(s2), 6);
+      assert.strictEqual(computeCalls, 1);
+
+      const s3: S = { items: [1, 2, 3, 4], flag: false };
+      assert.strictEqual(total(s3), 10);
+      assert.strictEqual(computeCalls, 2);
+    });
+
+    it('memoizes when single selector is provided', function () {
+      interface S {
+        flag: boolean;
+      }
+      let calls = 0;
+      const selectFlag = createStateMemoizer((s: S) => { calls++; return s.flag; });
+
+      const s: S = { flag: true };
+      assert.strictEqual(selectFlag(s), true);
+      selectFlag(s);
+      assert.strictEqual(calls, 1);
+    });
+  });
+
+  it('works with the fromState decorator', async function () {
+    interface S { items: number[]; flag: boolean }
+    let computeCalls = 0;
+    const selectTotal = createStateMemoizer(
+      (s: S) => s.items,
+      items => { computeCalls++; return items.reduce((a, b) => a + b, 0); }
+    );
+
+    @customElement({ name: 'my-el', template: `\${total}` })
+    class MyEl {
+      @fromState<S>(selectTotal)
+      total: number;
+    }
+
+    const state: S = { items: [1, 2, 3], flag: false };
+    const { trigger, assertText } = await createFixture
+      .html`
+        <my-el></my-el>
+        <button id="flag" click.dispatch="{ type: 'toggle' }"></button>
+        <button id="add" click.dispatch="{ type: 'add', value: 4 }"></button>
+      `
+      .deps(
+        MyEl,
+        StateDefaultConfiguration.init(state, (s, a: { type: 'toggle' | 'add'; value?: number }) => {
+          if (a.type === 'toggle') { return { ...s, flag: !s.flag }; }
+          if (a.type === 'add') { return { ...s, items: [...s.items, a.value!] }; }
+          return s;
+        })
+      )
+      .build().started;
+
+    assertText('my-el', '6');
+    assert.strictEqual(computeCalls, 1);
+
+    trigger('#flag', 'click');
+    await Promise.resolve();
+    assertText('my-el', '6');
+    assert.strictEqual(computeCalls, 1);
+
+    trigger('#add', 'click');
+    await Promise.resolve();
+    assertText('my-el', '10');
+    assert.strictEqual(computeCalls, 2);
+  });
+
+  it('shares memoized results across components', async function () {
+    interface S { items: number[]; flag: boolean }
+    let computeCalls = 0;
+    const selectTotal = createStateMemoizer(
+      (s: S) => s.items,
+      items => { computeCalls++; return items.reduce((a, b) => a + b, 0); }
+    );
+
+    @customElement({ name: 'el-a', template: `\${total}` })
+    class ElA { @fromState<S>(selectTotal) total: number; }
+
+    @customElement({ name: 'el-b', template: `\${total}` })
+    class ElB { @fromState<S>(selectTotal) total: number; }
+
+    const state: S = { items: [1, 2, 3], flag: false };
+    const { trigger, assertText } = await createFixture
+      .html`
+        <el-a></el-a>
+        <el-b></el-b>
+        <button id="flag" click.dispatch="{ type: 'toggle' }"></button>
+        <button id="add" click.dispatch="{ type: 'add', value: 4 }"></button>
+      `
+      .deps(
+        ElA,
+        ElB,
+        StateDefaultConfiguration.init(state, (s, a: { type: 'toggle' | 'add'; value?: number }) => {
+          if (a.type === 'toggle') { return { ...s, flag: !s.flag }; }
+          if (a.type === 'add') { return { ...s, items: [...s.items, a.value!] }; }
+          return s;
+        })
+      )
+      .build().started;
+
+    assertText('el-a', '6');
+    assertText('el-b', '6');
+    assert.strictEqual(computeCalls, 1);
+
+    trigger('#flag', 'click');
+    await Promise.resolve();
+    assertText('el-a', '6');
+    assertText('el-b', '6');
+    assert.strictEqual(computeCalls, 1);
+
+    trigger('#add', 'click');
+    await Promise.resolve();
+    assertText('el-a', '10');
+    assertText('el-b', '10');
+    assert.strictEqual(computeCalls, 2);
+  });
 });
 
 const resolveAfter = <T>(time: number, value?: T) => new Promise<T>(r => setTimeout(() => r(value), time));

--- a/packages/state/src/index.ts
+++ b/packages/state/src/index.ts
@@ -30,3 +30,4 @@ export {
 
 export { StateBindingBehavior } from './state-binding-behavior';
 export { fromState } from './state-decorator';
+export { createStateMemoizer, type StateMemoizer } from './state-memorizer';

--- a/packages/state/src/state-memorizer.ts
+++ b/packages/state/src/state-memorizer.ts
@@ -1,0 +1,62 @@
+export type StateMemoizer<S, R> = (state: S) => R;
+
+/**
+ * Create a memoized selector. The selector will only recompute the result
+ * when its dependencies change by reference.
+ *
+ * @param selectors - one or more selector functions. If multiple selectors are
+ * supplied, the last function is treated as the result function which receives
+ * the selected values. If a single selector function is supplied, it will be
+ * memoized directly.
+ */
+export function createStateMemoizer<S, R>(memorizer: StateMemoizer<S, R>): StateMemoizer<S, R>;
+export function createStateMemoizer<S, A, R>(
+  m1: StateMemoizer<S, A>,
+  resultFn: (a: A) => R,
+): StateMemoizer<S, R>;
+export function createStateMemoizer<S, A, B, R>(
+  m1: StateMemoizer<S, A>,
+  m2: StateMemoizer<S, B>,
+  resultFn: (a: A, b: B) => R,
+): StateMemoizer<S, R>;
+export function createStateMemoizer<S, A, B, C, R>(
+  m1: StateMemoizer<S, A>,
+  m2: StateMemoizer<S, B>,
+  m3: StateMemoizer<S, C>,
+  resultFn: (a: A, b: B, c: C) => R,
+): StateMemoizer<S, R>;
+export function createStateMemoizer<S>(
+  ...fns: (StateMemoizer<S, unknown> | ((...args: unknown[]) => unknown))[]
+): StateMemoizer<S, unknown> {
+
+  if (fns.length === 1) {
+    // with only 1, result function is also a memorizer
+    const resultFn = fns[0] as StateMemoizer<S, unknown>;
+    let lastState: S | undefined;
+    let lastResult: unknown;
+    return (state: S) => {
+      if (state === lastState) {
+        return lastResult;
+      }
+      lastState = state;
+      return (lastResult = resultFn(state));
+    };
+  }
+
+  const resultFn = fns[fns.length - 1] as (...args: unknown[]) => unknown;
+  const memoizerFns = fns.slice(0, -1) as StateMemoizer<S, unknown>[];
+  let lastInputs: unknown[] | undefined;
+  let lastResult: unknown;
+  return (state: S) => {
+    const inputs = memoizerFns.map(fn => fn(state));
+    if (
+      lastInputs !== undefined &&
+      inputs.length === lastInputs.length &&
+      inputs.every((v, i) => v === lastInputs![i])
+    ) {
+      return lastResult;
+    }
+    lastInputs = inputs;
+    return (lastResult = resultFn(...inputs));
+  };
+}


### PR DESCRIPTION
Implements `createStateMemoizer` to memoize derived state, preventing unnecessary recomputations. This improves performance by running and recalculating final value only when its dependencies change.

Supersedes & closes #2182 