### PR TITLE
fix(binding): don't update source when unbound

### DIFF
--- a/packages/__tests__/karma.conf.cjs
+++ b/packages/__tests__/karma.conf.cjs
@@ -36,7 +36,7 @@ module.exports =
   const testFilePatterns = cliArgs.length > 0
     ? cliArgs.flatMap(arg => [
         `${baseUrl}/**/*${arg.replace(/(?:\.spec)?(?:\.[tj]s)?$/, '*.spec.js')}`,
-        `${baseUrl}/**/${arg}/**/*.spec.js`,
+        `${baseUrl}/**/*${arg}*/**/*.spec.js`,
     ])
     : [`${baseUrl}/**/*.spec.js`];
   const circleCiParallelismGlob = fs.existsSync('./tests.txt')

--- a/packages/__tests__/src/4-gh-issues/2163.spec.ts
+++ b/packages/__tests__/src/4-gh-issues/2163.spec.ts
@@ -1,0 +1,32 @@
+import { runTasks } from '@aurelia/runtime';
+import { createFixture } from '@aurelia/testing';
+
+describe('4-gh-issues/2163.spec.ts', function () {
+  it('should not throw when unbind a ref binding before other bindings', async function () {
+    const { getBy, assertText, trigger } = createFixture(
+      `
+        <div if.bind="message">
+          <el prop.bind="el"></el>
+        </div>
+        <div else>
+          else
+        </div>
+        <input type="checkbox" checked.bind="message">
+      `,
+      { message: 'hi', el: undefined },
+      [class El {
+        static $au = {
+          type: 'custom-element',
+          name: 'el',
+          template: '<div ref="prop"></div>',
+          bindables: [{ name: 'prop', mode: 'fromView' }]
+        };
+      }]
+    );
+
+    getBy('input').checked = false;
+    trigger('input', 'change');
+    runTasks();
+    assertText('else', { compact: true });
+  });
+});

--- a/packages/__tests__/tsc.dev.cjs
+++ b/packages/__tests__/tsc.dev.cjs
@@ -10,6 +10,7 @@ const config = {
   compilerOptions: {
     ...baseConfig.compilerOptions,
     composite: false,
+    incremental: false,
     tsBuildInfoFile: null,
   },
   include: [
@@ -22,6 +23,8 @@ const config = {
         `src/**/*${pattern}*.tsx`,
         `src/**/${pattern}/**/*.ts`,
         `src/**/${pattern}/**/*.tsx`,
+        `src/**/*${pattern}*/**/*.ts`,
+        `src/**/*${pattern}*/**/*.tsx`,
       ]
     })
   ],

--- a/packages/runtime-html/src/binding/binding-utils.ts
+++ b/packages/runtime-html/src/binding/binding-utils.ts
@@ -39,7 +39,13 @@ export class BindingTargetSubscriber implements ISubscriber {
   }
 
   public flush() {
-    this.b.updateSource(this._value);
+    // when the owning binding is unbound, there's cases where this subscriber still queued
+    // and will be flushed
+    // adding this check so that it does flush at an inappropriate time
+    // todo: maybe consider a way to dequeue this as well if necessary
+    if (this.b.isBound) {
+      this.b.updateSource(this._value);
+    }
   }
 
   // deepscan-disable-next-line
@@ -210,6 +216,9 @@ export const mixinAstEvaluator = /*@__PURE__*/(() => {
   };
 })();
 
+/**
+ * A synchronous queue used internally for ensuring update source are not called depth first
+ */
 export interface IFlushable {
   flush(): void;
 }

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -165,14 +165,15 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
     if (!this.isBound) return;
     this.isBound = false;
 
-    astUnbind(this.ast, this._scope!, this);
-
-    this._scope = void 0;
-
     if (this._targetSubscriber) {
       (this._targetObserver as IObserver).unsubscribe(this._targetSubscriber);
       this._targetSubscriber = null;
     }
+
+    astUnbind(this.ast, this._scope!, this);
+
+    this._scope = void 0;
+
     this.obs.clearAll();
   }
 

--- a/packages/runtime/src/queue.ts
+++ b/packages/runtime/src/queue.ts
@@ -702,6 +702,7 @@ export class RecurringTask {
     }, this._interval);
   }
 
+  /** @internal */
   private _tick(): void {
     queue.push(this);
     requestRun();


### PR DESCRIPTION
## 📖 Description

As noticed in #2163 when there's a combination a ref binding targeting some property, and a property binding observing the same property, the property binding may try to notify changes after it has been unbound, during the unbinding phase of the ref binding. This PR fixes this.

### 🎫 Issues

Closes #2163