### PR TITLE
fix(au-compose): dont re-compose when detached

### DIFF
--- a/packages/__tests__/src/4-gh-issues/2156.spec.ts
+++ b/packages/__tests__/src/4-gh-issues/2156.spec.ts
@@ -1,0 +1,46 @@
+import { assert, createFixture } from '@aurelia/testing';
+
+describe('4-gh-issues/2156.spec.ts', function () {
+  it('should not compose when deactivated', function () {
+    const logs = [];
+    const { component, assertText } = createFixture(
+      `<el if.bind="show">`,
+      class App {
+        show = true;
+      },
+      [class El2 {
+        static $au = {
+          type: 'custom-element',
+          name: 'el2',
+          template: 'Hi, el2 here'
+        };
+
+        activate(model) {
+          logs.push(model);
+        }
+      }, class El {
+        static $au = {
+          type: 'custom-element',
+          name: 'el',
+          template: '<au-compose model.bind="obj.model" component.bind="obj.component"></au-compose>'
+        };
+
+        obj = {
+          model: 'test',
+          component: 'el2'
+        };
+
+        unbinding() {
+          this.obj = null;
+        }
+      }]
+    );
+
+    assertText('Hi, el2 here');
+    assert.deepStrictEqual(logs, ['test']);
+    logs.length = 0;
+
+    component.show = false;
+    assert.deepStrictEqual(logs, []);
+  });
+});

--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -115,8 +115,10 @@ export class AuCompose {
   /** @internal */ private readonly _hydrationContext = resolve(IHydrationContext);
   /** @internal */ private readonly _exprParser = resolve(IExpressionParser);
   /** @internal */ private readonly _observerLocator = resolve(IObserverLocator);
+  /** @internal */ private _attached = false;
 
   public attaching(initiator: IHydratedController, _parent: IHydratedController): void | Promise<void> {
+    this._attached = true;
     return this._composing = onResolve(
       this.queue(new ChangeInfo(this.template, this.component, this.model, void 0), initiator),
       (context) => {
@@ -128,6 +130,7 @@ export class AuCompose {
   }
 
   public detaching(initiator: IHydratedController): void | Promise<void> {
+    this._attached = false;
     const cmpstn = this._composition;
     const pending = this._composing;
     this._contextFactory.invalidate();
@@ -137,6 +140,7 @@ export class AuCompose {
 
   /** @internal */
   public propertyChanged(name: ChangeSource): void {
+    if (!this._attached) return;
     if (name === 'composing' || name === 'composition') return;
     if (name === 'model' && this._composition != null) {
       this._composition.update(this.model);


### PR DESCRIPTION
## 📖 Description

In #2156 , it's observable that au-compose gets deactivated before some bindings that target it, making the au-compose instance trying to react to changes even after it has been deactivated.

It's unintentional that au-compose behaves this way. This PR added a boolean so au-compose will ignore incoming value when it has already been detached/deactivated.

### 🎫 Issues

Close #2156