### PR TITLE
docs(all): revising existing sections and more

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -82,7 +82,7 @@
 * [App configuration and startup](getting-to-know-aurelia/app-configuration-and-startup.md)
 * [Enhance](getting-to-know-aurelia/enhance.md)
 * [Template controllers](getting-to-know-aurelia/template-controllers.md)
-* [Understanding synchronous binding](getting-to-know-aurelia/synchronous-binding-system.md)
+* [Binding system and state management](getting-to-know-aurelia/synchronous-binding-system.md)
 * [Dynamic composition](getting-to-know-aurelia/dynamic-composition.md)
 * [Portalling elements](getting-to-know-aurelia/portalling-elements.md)
 * [Observation](getting-to-know-aurelia/observation/README.md)
@@ -98,6 +98,7 @@
 
 ## Developer Guides
 
+* [Developing with AI](developer-guides/developing-with-ai.md)
 * [Animation](developer-guides/animation.md)
 * [Testing](developer-guides/testing/overview.md)
   * [Overview](developer-guides/testing/overview.md)
@@ -169,6 +170,7 @@
   * [Setup and Configuration](aurelia-packages/fetch-client/setting-up.md)
   * [Response types](aurelia-packages/fetch-client/response-types.md)
   * [Working with forms](aurelia-packages/fetch-client/forms.md)
+  * [Request cancellation with AbortController](aurelia-packages/fetch-client/abort-controller.md)
   * [Intercepting responses & requests](aurelia-packages/fetch-client/interceptors.md)
   * [Advanced](aurelia-packages/fetch-client/advanced.md)
 * [Event Aggregator](aurelia-packages/event-aggregator.md)

--- a/docs/user-docs/aurelia-packages/fetch-client/abort-controller.md
+++ b/docs/user-docs/aurelia-packages/fetch-client/abort-controller.md
@@ -1,0 +1,585 @@
+# Request Cancellation with AbortController
+
+The Aurelia Fetch Client fully supports the native AbortController API for cancelling HTTP requests. Understanding how to properly use AbortController is crucial for building responsive applications and managing resource cleanup.
+
+## Basic Request Cancellation
+
+### Simple Abort Example
+
+```typescript
+import { IHttpClient } from '@aurelia/fetch-client';
+import { resolve } from '@aurelia/kernel';
+
+export class CancellableRequestService {
+  private http = resolve(IHttpClient);
+
+  async fetchDataWithCancellation(): Promise<{ data: any; abort: () => void }> {
+    const controller = new AbortController();
+    
+    const dataPromise = this.http.get('/api/large-dataset', {
+      signal: controller.signal
+    }).then(response => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return response.json();
+    });
+
+    return {
+      data: dataPromise,
+      abort: () => controller.abort()
+    };
+  }
+
+  // Usage example
+  async loadDataWithTimeout() {
+    const { data, abort } = await this.fetchDataWithCancellation();
+    
+    // Auto-cancel after 10 seconds
+    const timeoutId = setTimeout(() => {
+      abort();
+      console.log('Request cancelled due to timeout');
+    }, 10000);
+
+    try {
+      const result = await data;
+      clearTimeout(timeoutId);
+      return result;
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error.name === 'AbortError') {
+        console.log('Request was cancelled');
+        return null;
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### Component Integration
+
+```typescript
+export class SearchComponent {
+  private http = resolve(IHttpClient);
+  private currentSearchController: AbortController | null = null;
+
+  async search(query: string): Promise<any[]> {
+    // Cancel previous search if still running
+    if (this.currentSearchController) {
+      this.currentSearchController.abort();
+    }
+
+    // Create new controller for this search
+    this.currentSearchController = new AbortController();
+
+    try {
+      const response = await this.http.get(`/api/search?q=${encodeURIComponent(query)}`, {
+        signal: this.currentSearchController.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`Search failed: ${response.statusText}`);
+      }
+
+      const results = await response.json();
+      this.currentSearchController = null; // Clear completed request
+      return results;
+
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.log('Search cancelled');
+        return [];
+      }
+      this.currentSearchController = null;
+      throw error;
+    }
+  }
+
+  // Clean up on component destruction
+  dispose() {
+    if (this.currentSearchController) {
+      this.currentSearchController.abort();
+      this.currentSearchController = null;
+    }
+  }
+}
+```
+
+## AbortController with Interceptors
+
+### Interceptor Handling
+
+Interceptors properly handle aborted requests through the error chain:
+
+```typescript
+export class AbortAwareInterceptorService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupAbortHandling();
+  }
+
+  private setupAbortHandling() {
+    this.http.configure(config => config.withInterceptor({
+      request(request) {
+        console.log(`Starting request: ${request.method} ${request.url}`);
+        
+        // Check if request is already aborted
+        if (request.signal?.aborted) {
+          console.log('Request already aborted before sending');
+          throw new DOMException('Request was aborted', 'AbortError');
+        }
+        
+        return request;
+      },
+
+      response(response, request) {
+        console.log(`Request completed: ${request?.url} -> ${response.status}`);
+        return response;
+      },
+
+      responseError(error, request) {
+        if (error.name === 'AbortError') {
+          console.log(`Request cancelled: ${request?.url}`);
+          
+          // You can return a default response to recover from cancellation
+          // return new Response('{"cancelled": true}', { status: 499 });
+          
+          // Or let the error propagate (recommended)
+          throw error;
+        }
+
+        console.error(`Request failed: ${request?.url}`, error);
+        throw error;
+      }
+    }));
+  }
+}
+```
+
+## Critical Issue: AbortController + Retry Bug
+
+> **⚠️ Important Limitation**: There is a critical bug in the current retry mechanism when used with AbortController. When a request with an AbortSignal is retried, the retry attempts inherit the same (potentially aborted) signal, causing all retry attempts to immediately fail.
+
+### The Problem
+
+```typescript
+// ❌ This is broken in the current implementation:
+const controller = new AbortController();
+
+http.configure(config => config.withRetry({ maxRetries: 3 }));
+
+const promise = http.get('/api/data', { signal: controller.signal });
+
+// If you abort here, all 3 retry attempts will immediately fail
+// because they inherit the aborted signal
+controller.abort();
+```
+
+### Workaround Solutions
+
+#### Solution 1: Conditional Retry (Recommended)
+
+```typescript
+export class AbortSafeRetryService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupAbortSafeRetry();
+  }
+
+  private setupAbortSafeRetry() {
+    this.http.configure(config => config.withRetry({
+      maxRetries: 3,
+      strategy: RetryStrategy.exponential,
+      
+      // Don't retry aborted requests
+      doRetry: (response, request) => {
+        // Check if the request was aborted
+        if (request.signal?.aborted) {
+          console.log('Skipping retry for aborted request');
+          return false;
+        }
+        
+        // Only retry server errors
+        return response.status >= 500;
+      }
+    }));
+  }
+}
+```
+
+#### Solution 2: Manual Retry with Fresh AbortController
+
+```typescript
+export class ManualRetryService {
+  private http = resolve(IHttpClient);
+
+  async fetchWithRetry<T>(
+    url: string, 
+    options: RequestInit = {}, 
+    maxRetries = 3
+  ): Promise<T> {
+    let lastError: Error;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      // Create fresh AbortController for each attempt
+      const controller = new AbortController();
+      
+      try {
+        const response = await this.http.get(url, {
+          ...options,
+          signal: controller.signal
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        return await response.json();
+
+      } catch (error) {
+        lastError = error as Error;
+        
+        // Don't retry aborted requests
+        if (error.name === 'AbortError') {
+          throw error;
+        }
+        
+        // Don't retry client errors
+        if (error.message.includes('HTTP 4')) {
+          throw error;
+        }
+
+        if (attempt < maxRetries) {
+          // Wait before retry (exponential backoff)
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    }
+
+    throw new Error(`Request failed after ${maxRetries} attempts: ${lastError!.message}`);
+  }
+}
+```
+
+## Advanced Cancellation Patterns
+
+### Timeout with Custom Error Messages
+
+```typescript
+export class TimeoutService {
+  private http = resolve(IHttpClient);
+
+  async fetchWithTimeout<T>(
+    url: string,
+    timeoutMs: number,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const controller = new AbortController();
+    
+    // Set up timeout
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, timeoutMs);
+
+    try {
+      const response = await this.http.get(url, {
+        ...options,
+        signal: controller.signal
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return await response.json();
+
+    } catch (error) {
+      clearTimeout(timeoutId);
+      
+      if (error.name === 'AbortError') {
+        throw new Error(`Request timeout after ${timeoutMs}ms: ${url}`);
+      }
+      throw error;
+    }
+  }
+}
+```
+
+### Race Conditions and Multiple Requests
+
+```typescript
+export class RaceConditionService {
+  private http = resolve(IHttpClient);
+  private activeControllers = new Map<string, AbortController>();
+
+  async fetchExclusive(key: string, url: string): Promise<any> {
+    // Cancel any existing request with this key
+    const existingController = this.activeControllers.get(key);
+    if (existingController) {
+      existingController.abort();
+    }
+
+    // Create new controller for this request
+    const controller = new AbortController();
+    this.activeControllers.set(key, controller);
+
+    try {
+      const response = await this.http.get(url, {
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const data = await response.json();
+      
+      // Clean up successful request
+      this.activeControllers.delete(key);
+      return data;
+
+    } catch (error) {
+      // Clean up failed/cancelled request
+      this.activeControllers.delete(key);
+      
+      if (error.name === 'AbortError') {
+        console.log(`Request cancelled for key: ${key}`);
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  // Cancel all active requests
+  cancelAll() {
+    for (const [key, controller] of this.activeControllers.entries()) {
+      controller.abort();
+    }
+    this.activeControllers.clear();
+  }
+
+  // Cancel specific request
+  cancel(key: string) {
+    const controller = this.activeControllers.get(key);
+    if (controller) {
+      controller.abort();
+      this.activeControllers.delete(key);
+    }
+  }
+}
+```
+
+### File Upload Cancellation
+
+```typescript
+export class CancellableUploadService {
+  private http = resolve(IHttpClient);
+
+  async uploadFileWithCancellation(
+    file: File,
+    onProgress?: (percentage: number) => void
+  ): Promise<{ result: Promise<any>; cancel: () => void }> {
+    const controller = new AbortController();
+    const formData = new FormData();
+    formData.append('file', file);
+
+    // For upload progress, we need to use XMLHttpRequest
+    const uploadPromise = new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+
+      // Handle abort signal
+      controller.signal.addEventListener('abort', () => {
+        xhr.abort();
+      });
+
+      xhr.upload.addEventListener('progress', (event) => {
+        if (event.lengthComputable && onProgress) {
+          const percentage = Math.round((event.loaded / event.total) * 100);
+          onProgress(percentage);
+        }
+      });
+
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const result = JSON.parse(xhr.responseText);
+            resolve(result);
+          } catch (error) {
+            resolve(xhr.responseText);
+          }
+        } else {
+          reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
+        }
+      });
+
+      xhr.addEventListener('error', () => {
+        reject(new Error('Upload failed due to network error'));
+      });
+
+      xhr.addEventListener('abort', () => {
+        reject(new DOMException('Upload cancelled', 'AbortError'));
+      });
+
+      xhr.open('POST', '/api/files/upload');
+      xhr.send(formData);
+    });
+
+    return {
+      result: uploadPromise,
+      cancel: () => controller.abort()
+    };
+  }
+
+  // Usage example
+  async uploadWithUserCancellation(file: File) {
+    const { result, cancel } = await this.uploadFileWithCancellation(
+      file,
+      (percentage) => {
+        console.log(`Upload progress: ${percentage}%`);
+        
+        // Show cancel button to user
+        this.showCancelButton(() => {
+          cancel();
+          console.log('Upload cancelled by user');
+        });
+      }
+    );
+
+    try {
+      const uploadResult = await result;
+      this.hideCancelButton();
+      return uploadResult;
+    } catch (error) {
+      this.hideCancelButton();
+      if (error.name === 'AbortError') {
+        console.log('Upload was cancelled');
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private showCancelButton(onCancel: () => void) {
+    // Implementation depends on your UI framework
+  }
+
+  private hideCancelButton() {
+    // Implementation depends on your UI framework
+  }
+}
+```
+
+## Best Practices
+
+### Error Handling
+
+Always check for AbortError specifically:
+
+```typescript
+try {
+  const response = await http.get('/api/data', { signal: controller.signal });
+  return await response.json();
+} catch (error) {
+  if (error.name === 'AbortError') {
+    // Handle cancellation (usually not an error)
+    console.log('Request was cancelled');
+    return null; // or some default value
+  }
+  
+  // Handle actual errors
+  console.error('Request failed:', error);
+  throw error;
+}
+```
+
+### Resource Cleanup
+
+Always clean up AbortControllers when components are destroyed:
+
+```typescript
+export class ComponentWithRequests {
+  private activeControllers: AbortController[] = [];
+
+  async makeRequest(url: string) {
+    const controller = new AbortController();
+    this.activeControllers.push(controller);
+
+    try {
+      const response = await this.http.get(url, { signal: controller.signal });
+      return await response.json();
+    } finally {
+      // Remove from active list when done
+      const index = this.activeControllers.indexOf(controller);
+      if (index > -1) {
+        this.activeControllers.splice(index, 1);
+      }
+    }
+  }
+
+  // Call this when component is destroyed
+  dispose() {
+    // Cancel all active requests
+    this.activeControllers.forEach(controller => controller.abort());
+    this.activeControllers.length = 0;
+  }
+}
+```
+
+### Avoid Common Pitfalls
+
+1. **Don't reuse AbortControllers**: Create a new one for each request
+2. **Handle AbortError gracefully**: It's usually not an actual error condition  
+3. **Clean up timeouts**: Always clear timeout IDs when requests complete
+4. **Be aware of the retry bug**: Use workarounds when combining AbortController with retries
+
+## Integration with Aurelia Lifecycle
+
+```typescript
+import { IDisposable } from '@aurelia/kernel';
+
+export class AutoCleanupService implements IDisposable {
+  private http = resolve(IHttpClient);
+  private activeRequests = new Set<AbortController>();
+
+  async makeRequest(url: string): Promise<any> {
+    const controller = new AbortController();
+    this.activeRequests.add(controller);
+
+    try {
+      const response = await this.http.get(url, { signal: controller.signal });
+      
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error.name !== 'AbortError') {
+        console.error('Request failed:', error);
+      }
+      throw error;
+    } finally {
+      this.activeRequests.delete(controller);
+    }
+  }
+
+  // Aurelia will call this automatically when the service is disposed
+  dispose(): void {
+    console.log(`Cancelling ${this.activeRequests.size} active requests`);
+    
+    for (const controller of this.activeRequests) {
+      controller.abort();
+    }
+    
+    this.activeRequests.clear();
+  }
+}
+```
+
+Understanding these patterns and limitations will help you build robust, cancellable HTTP operations in your Aurelia applications while avoiding the current retry mechanism bug.

--- a/docs/user-docs/aurelia-packages/fetch-client/advanced.md
+++ b/docs/user-docs/aurelia-packages/fetch-client/advanced.md
@@ -1,91 +1,766 @@
-# Advanced Configuration
+# Advanced Configuration and Features
 
-Configuring the Fetch Client for specific needs like setting default headers, handling timeouts, or implementing retry logic can enhance application performance and reliability.
+The Aurelia Fetch Client offers powerful advanced features for enterprise applications, including sophisticated caching, request monitoring, custom interceptor patterns, and integration with complex authentication systems.
 
-## Setting Default Headers for JSON and Token Authorization
+## Advanced Header Management
 
-Setting default headers ensures that every request sent via the Fetch Client includes these headers, maintaining consistency and reducing redundancy in your code.
+### Dynamic Authorization Headers
+
+Headers can be functions that are evaluated for each request, perfect for handling token refresh scenarios:
 
 ```typescript
-import { HttpClient } from '@aurelia/fetch-client';
+import { IHttpClient } from '@aurelia/fetch-client';
+import { resolve } from '@aurelia/kernel';
 
-const http = new HttpClient();
-http.configure(config => {
-    config.withDefaults({
+export class AuthenticatedApiService {
+  private http = resolve(IHttpClient);
+  private tokenStorage = new TokenStorage();
+
+  constructor() {
+    this.http.configure(config => config
+      .withDefaults({
         headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer YOUR_TOKEN_HERE`
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'Authorization': () => {
+            const token = this.tokenStorage.getAccessToken();
+            return token ? `Bearer ${token}` : '';
+          },
+          'X-Client-Version': () => this.getClientVersion(),
+          'X-Request-ID': () => this.generateRequestId()
         }
+      })
+    );
+  }
+
+  private getClientVersion(): string {
+    return process.env.APP_VERSION || '1.0.0';
+  }
+
+  private generateRequestId(): string {
+    return `${Date.now()}-${Math.random().toString(36).substring(2)}`;
+  }
+}
+
+class TokenStorage {
+  getAccessToken(): string | null {
+    const tokenData = localStorage.getItem('auth_tokens');
+    if (!tokenData) return null;
+
+    const { accessToken, expiresAt } = JSON.parse(tokenData);
+    
+    // Check if token is expired
+    if (Date.now() >= expiresAt) {
+      this.refreshToken();
+      return this.getAccessToken(); // Recursive call after refresh
+    }
+
+    return accessToken;
+  }
+
+  private refreshToken(): void {
+    // Token refresh logic here
+    // This is synchronous for simplicity, but could be async
+  }
+}
+```
+
+### Conditional Headers
+
+Apply different headers based on request characteristics:
+
+```typescript
+export class ConditionalHeaderService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.http.configure(config => config.withInterceptor({
+      request(request) {
+        const url = new URL(request.url);
+        
+        // Add API key for external APIs
+        if (url.hostname !== window.location.hostname) {
+          request.headers.set('X-API-Key', this.getExternalApiKey(url.hostname));
+        }
+        
+        // Add CSRF token for state-changing operations
+        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method)) {
+          const csrfToken = this.getCsrfToken();
+          if (csrfToken) {
+            request.headers.set('X-CSRF-Token', csrfToken);
+          }
+        }
+        
+        // Add correlation ID for internal services
+        if (url.pathname.startsWith('/api/internal/')) {
+          request.headers.set('X-Correlation-ID', this.generateCorrelationId());
+        }
+
+        return request;
+      }
+    }));
+  }
+
+  private getExternalApiKey(hostname: string): string {
+    const keyMap = {
+      'api.external1.com': process.env.EXTERNAL_API_1_KEY,
+      'api.external2.com': process.env.EXTERNAL_API_2_KEY
+    };
+    return keyMap[hostname] || '';
+  }
+
+  private getCsrfToken(): string {
+    return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+  }
+
+  private generateCorrelationId(): string {
+    return `corr-${Date.now()}-${Math.random().toString(36).substring(2)}`;
+  }
+}
+```
+
+## Built-in Cache Interceptor
+
+The fetch client includes a sophisticated caching system with multiple storage options:
+
+```typescript
+import { IHttpClient, CacheInterceptor } from '@aurelia/fetch-client';
+import { DI } from '@aurelia/kernel';
+
+export class CachedApiService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupCaching();
+  }
+
+  private setupCaching() {
+    // Create cache interceptor with configuration
+    const cacheInterceptor = DI.getGlobalContainer().invoke(CacheInterceptor, [{
+      cacheTime: 300_000,        // Cache for 5 minutes
+      staleTime: 60_000,         // Data becomes stale after 1 minute
+      refreshStaleImmediate: false, // Don't block on stale refresh
+      refreshInterval: 30_000,   // Background refresh every 30 seconds
+    }]);
+
+    this.http.configure(config => config.withInterceptor(cacheInterceptor));
+  }
+
+  // Cache interceptor automatically handles these GET requests
+  async getUserProfile(userId: string) {
+    const response = await this.http.get(`/api/users/${userId}`);
+    return response.json();
+  }
+
+  async getStaticData() {
+    // This will be cached and refreshed in background
+    const response = await this.http.get('/api/config/static');
+    return response.json();
+  }
+}
+```
+
+### Custom Cache Storage
+
+Use different storage backends for caching:
+
+```typescript
+import { 
+  CacheInterceptor, 
+  BrowserLocalStorage, 
+  BrowserSessionStorage,
+  BrowserIndexDBStorage,
+  MemoryStorage 
+} from '@aurelia/fetch-client';
+
+export class CustomCacheService {
+  private http = resolve(IHttpClient);
+
+  setupPersistentCaching() {
+    // Use localStorage for persistent caching across sessions
+    const persistentCache = DI.getGlobalContainer().invoke(CacheInterceptor, [{
+      cacheTime: 3600_000, // 1 hour
+      storage: new BrowserLocalStorage()
+    }]);
+
+    this.http.configure(config => config.withInterceptor(persistentCache));
+  }
+
+  setupSessionCaching() {
+    // Use sessionStorage for session-only caching
+    const sessionCache = DI.getGlobalContainer().invoke(CacheInterceptor, [{
+      cacheTime: 1800_000, // 30 minutes
+      storage: new BrowserSessionStorage()
+    }]);
+
+    this.http.configure(config => config.withInterceptor(sessionCache));
+  }
+
+  setupIndexDBCaching() {
+    // Use IndexedDB for large data caching
+    const indexDbCache = DI.getGlobalContainer().invoke(CacheInterceptor, [{
+      cacheTime: 7200_000, // 2 hours
+      storage: new BrowserIndexDBStorage()
+    }]);
+
+    this.http.configure(config => config.withInterceptor(indexDbCache));
+  }
+}
+```
+
+## Request Event Monitoring
+
+Monitor and respond to request lifecycle events:
+
+```typescript
+export class RequestMonitoringService {
+  private http = resolve(IHttpClient);
+  private activeRequests = new Set<string>();
+
+  constructor() {
+    this.setupEventMonitoring();
+    this.setupRequestTracking();
+  }
+
+  private setupEventMonitoring() {
+    // Configure event dispatcher
+    this.http.configure(config => config.withDispatcher(document.body));
+
+    // Listen for request lifecycle events
+    document.body.addEventListener('aurelia-fetch-client-request-started', (event: CustomEvent) => {
+      console.log('Request started:', event.detail);
+      this.showLoadingIndicator();
     });
-});
-```
 
-This configuration sets the default `Accept` and `Content-Type` headers to handle JSON data and adds an `Authorization` header with a bearer token.
+    document.body.addEventListener('aurelia-fetch-client-requests-drained', () => {
+      console.log('All requests completed');
+      this.hideLoadingIndicator();
+    });
+  }
 
-## Response Caching
-
-Response caching can improve performance by storing and reusing responses for identical requests.
-
-```typescript
-const responseCache = new Map();
-
-function createCacheInterceptor() {
-    return {
-        request(request) {
-            const key = request.url + JSON.stringify(request.params);
-            if (responseCache.has(key)) {
-                return responseCache.get(key);
-            }
-            return request;
-        },
-        response(response, request) {
-            const key = request.url + JSON.stringify(request.params);
-            responseCache.set(key, response.clone()); // Clone the response for caching
-            return response;
+  private setupRequestTracking() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        const requestId = this.generateRequestId();
+        this.activeRequests.add(requestId);
+        
+        // Add tracking header
+        request.headers.set('X-Request-ID', requestId);
+        
+        console.log(`Starting request ${requestId}: ${request.method} ${request.url}`);
+        return request;
+      },
+      
+      response: (response, request) => {
+        const requestId = request?.headers.get('X-Request-ID');
+        if (requestId) {
+          this.activeRequests.delete(requestId);
+          console.log(`Completed request ${requestId}: ${response.status}`);
         }
-    };
-}
+        return response;
+      },
+      
+      responseError: (error, request) => {
+        const requestId = request?.headers.get('X-Request-ID');
+        if (requestId) {
+          this.activeRequests.delete(requestId);
+          console.error(`Failed request ${requestId}:`, error);
+        }
+        throw error;
+      }
+    }));
+  }
 
-http.configure(config => {
-    config.withInterceptor(createCacheInterceptor());
-});
+  private showLoadingIndicator() {
+    // Show global loading indicator
+    document.body.classList.add('loading');
+  }
+
+  private hideLoadingIndicator() {
+    // Hide global loading indicator
+    document.body.classList.remove('loading');
+  }
+
+  private generateRequestId(): string {
+    return `req-${Date.now()}-${Math.random().toString(36).substring(2)}`;
+  }
+
+  // Public API for monitoring
+  getActiveRequestCount(): number {
+    return this.activeRequests.size;
+  }
+
+  isRequestActive(): boolean {
+    return this.activeRequests.size > 0;
+  }
+}
 ```
 
-This configuration adds a simple caching layer, storing responses in a map and retrieving them for identical subsequent requests. It ensures faster response times for repeated requests to the same endpoints with the same parameters.
+## Advanced Authentication Patterns
 
-## Simple Retry Logic on Network Failure
+### Automatic Token Refresh
 
-This example sets up a retry mechanism that retries the request up to three times with a one-second delay between attempts, but only for certain types of errors (like network errors).
+Handle token expiration and refresh transparently:
 
 ```typescript
-function createRetryInterceptor(retries: number, delay: number) {
-    return {
-        response(response, request) {
-            return response;
-        },
-        responseError(error, request) {
-            if (retries > 0 && shouldRetry(error)) {
-                retries--;
-                return new Promise(resolve => setTimeout(resolve, delay))
-                    .then(() => http.fetch(request));
-            }
+export class TokenRefreshService {
+  private http = resolve(IHttpClient);
+  private refreshPromise: Promise<string> | null = null;
+
+  constructor() {
+    this.setupTokenRefresh();
+  }
+
+  private setupTokenRefresh() {
+    this.http.configure(config => config.withInterceptor({
+      async responseError(error, request, client) {
+        if (error instanceof Response && error.status === 401) {
+          // Token expired, try to refresh
+          try {
+            const newToken = await this.refreshAccessToken();
+            
+            // Retry original request with new token
+            const newRequest = new Request(request.url, {
+              method: request.method,
+              headers: {
+                ...Object.fromEntries(request.headers.entries()),
+                'Authorization': `Bearer ${newToken}`
+              },
+              body: request.body
+            });
+            
+            return client.fetch(newRequest);
+          } catch (refreshError) {
+            // Refresh failed, redirect to login
+            this.redirectToLogin();
             throw error;
+          }
         }
+        
+        throw error;
+      }
+    }));
+  }
+
+  private async refreshAccessToken(): Promise<string> {
+    // Prevent multiple simultaneous refresh attempts
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this.performTokenRefresh();
+    
+    try {
+      const token = await this.refreshPromise;
+      return token;
+    } finally {
+      this.refreshPromise = null;
+    }
+  }
+
+  private async performTokenRefresh(): Promise<string> {
+    const refreshToken = this.getRefreshToken();
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    const response = await fetch('/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken })
+    });
+
+    if (!response.ok) {
+      throw new Error('Token refresh failed');
+    }
+
+    const { accessToken, refreshToken: newRefreshToken } = await response.json();
+    
+    // Store new tokens
+    this.storeTokens(accessToken, newRefreshToken);
+    
+    return accessToken;
+  }
+
+  private getRefreshToken(): string | null {
+    const tokens = localStorage.getItem('auth_tokens');
+    return tokens ? JSON.parse(tokens).refreshToken : null;
+  }
+
+  private storeTokens(accessToken: string, refreshToken: string) {
+    const tokens = {
+      accessToken,
+      refreshToken,
+      expiresAt: Date.now() + (55 * 60 * 1000) // 55 minutes
     };
-}
+    localStorage.setItem('auth_tokens', JSON.stringify(tokens));
+  }
 
-function shouldRetry(error) {
-    // Define logic to determine if the request should be retried
-    // For example, retry on network errors but not on HTTP 4xx or 5xx errors
-    return error instanceof TypeError; // Network errors are TypeErrors in fetch
+  private redirectToLogin() {
+    localStorage.removeItem('auth_tokens');
+    window.location.href = '/login';
+  }
 }
-
-http.configure(config => {
-    config.withInterceptor(createRetryInterceptor(3, 1000)); // Retry 3 times, 1-second delay
-});
 ```
 
-{% hint style="info" %}
-The Fetch client provides a default implementation of retry interceptor similar like above, with more options for configuration. It's enabled when  called `httpClient.configure(c => c.withRetry(...))`
-{% endhint %}
+## Request Batching and Coordination
+
+### Request Deduplication
+
+Prevent duplicate concurrent requests:
+
+```typescript
+export class RequestDeduplicationService {
+  private http = resolve(IHttpClient);
+  private pendingRequests = new Map<string, Promise<Response>>();
+
+  constructor() {
+    this.setupDeduplication();
+  }
+
+  private setupDeduplication() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        // Only deduplicate GET requests
+        if (request.method !== 'GET') {
+          return request;
+        }
+
+        const key = this.getRequestKey(request);
+        const existingRequest = this.pendingRequests.get(key);
+
+        if (existingRequest) {
+          // Return the existing request's promise
+          return existingRequest.then(response => response.clone());
+        }
+
+        // Store the request promise
+        const requestPromise = fetch(request).then(response => {
+          // Clean up when request completes
+          this.pendingRequests.delete(key);
+          return response;
+        }).catch(error => {
+          // Clean up on error too
+          this.pendingRequests.delete(key);
+          throw error;
+        });
+
+        this.pendingRequests.set(key, requestPromise);
+        
+        // Return the request to continue normal processing
+        return request;
+      }
+    }));
+  }
+
+  private getRequestKey(request: Request): string {
+    // Create unique key based on URL and headers
+    const headers = Array.from(request.headers.entries()).sort();
+    return `${request.method}:${request.url}:${JSON.stringify(headers)}`;
+  }
+}
+```
+
+### Request Queuing
+
+Queue and coordinate multiple requests:
+
+```typescript
+export class RequestQueueService {
+  private http = resolve(IHttpClient);
+  private requestQueue: Array<() => Promise<any>> = [];
+  private isProcessing = false;
+  private maxConcurrent = 3;
+  private activeRequests = 0;
+
+  async queueRequest<T>(requestFn: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.requestQueue.push(async () => {
+        try {
+          const result = await requestFn();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      });
+
+      this.processQueue();
+    });
+  }
+
+  private async processQueue() {
+    if (this.isProcessing || this.activeRequests >= this.maxConcurrent) {
+      return;
+    }
+
+    const request = this.requestQueue.shift();
+    if (!request) {
+      return;
+    }
+
+    this.isProcessing = true;
+    this.activeRequests++;
+
+    try {
+      await request();
+    } finally {
+      this.activeRequests--;
+      this.isProcessing = false;
+      
+      // Process next request in queue
+      if (this.requestQueue.length > 0) {
+        setTimeout(() => this.processQueue(), 0);
+      }
+    }
+  }
+
+  // Usage example
+  async uploadFiles(files: File[]) {
+    const uploadPromises = files.map(file => 
+      this.queueRequest(() => 
+        this.http.post('/api/upload', { body: this.createFormData(file) })
+      )
+    );
+
+    return Promise.all(uploadPromises);
+  }
+
+  private createFormData(file: File): FormData {
+    const formData = new FormData();
+    formData.append('file', file);
+    return formData;
+  }
+}
+```
+
+## Performance Optimization
+
+### Request Timeout Management
+
+Implement sophisticated timeout handling:
+
+```typescript
+export class TimeoutService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupTimeouts();
+  }
+
+  private setupTimeouts() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        // Add timeout based on request type
+        const timeout = this.getTimeoutForRequest(request);
+        
+        if (timeout > 0) {
+          const controller = new AbortController();
+          const timeoutId = setTimeout(() => controller.abort(), timeout);
+          
+          // Store cleanup function
+          (request as any).__timeoutId = timeoutId;
+          
+          return new Request(request, { signal: controller.signal });
+        }
+        
+        return request;
+      },
+      
+      response: (response, request) => {
+        // Clear timeout on successful response
+        const timeoutId = (request as any).__timeoutId;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        return response;
+      },
+      
+      responseError: (error, request) => {
+        // Clear timeout on error
+        const timeoutId = (request as any).__timeoutId;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        
+        // Convert AbortError to TimeoutError for clarity
+        if (error.name === 'AbortError') {
+          throw new Error(`Request timeout: ${request?.url}`);
+        }
+        
+        throw error;
+      }
+    }));
+  }
+
+  private getTimeoutForRequest(request: Request): number {
+    const url = new URL(request.url);
+    
+    // Different timeouts for different types of requests
+    if (url.pathname.includes('/upload')) {
+      return 300_000; // 5 minutes for uploads
+    } else if (url.pathname.includes('/reports')) {
+      return 120_000; // 2 minutes for reports
+    } else if (request.method === 'GET') {
+      return 30_000;  // 30 seconds for GET requests
+    } else {
+      return 60_000;  // 1 minute for other requests
+    }
+  }
+}
+```
+
+### Response Compression Handling
+
+Handle compressed responses efficiently:
+
+```typescript
+export class CompressionService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupCompression();
+  }
+
+  private setupCompression() {
+    this.http.configure(config => config
+      .withDefaults({
+        headers: {
+          'Accept-Encoding': 'gzip, deflate, br'
+        }
+      })
+      .withInterceptor({
+        response: (response) => {
+          const encoding = response.headers.get('content-encoding');
+          
+          if (encoding) {
+            console.log(`Response compressed with: ${encoding}`);
+            
+            // The browser automatically decompresses, but we can log it
+            const originalSize = response.headers.get('content-length');
+            if (originalSize) {
+              console.log(`Compressed size: ${originalSize} bytes`);
+            }
+          }
+          
+          return response;
+        }
+      })
+    );
+  }
+}
+```
+
+## Testing and Debugging Support
+
+### Request/Response Logging
+
+Comprehensive logging for development and debugging:
+
+```typescript
+export class LoggingService {
+  private http = resolve(IHttpClient);
+  private isDevelopment = process.env.NODE_ENV === 'development';
+
+  constructor() {
+    if (this.isDevelopment) {
+      this.setupDetailedLogging();
+    } else {
+      this.setupProductionLogging();
+    }
+  }
+
+  private setupDetailedLogging() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        const requestId = this.generateRequestId();
+        (request as any).__requestId = requestId;
+        
+        console.group(`🚀 Request ${requestId}`);
+        console.log('Method:', request.method);
+        console.log('URL:', request.url);
+        console.log('Headers:', Object.fromEntries(request.headers.entries()));
+        
+        if (request.body) {
+          this.logRequestBody(request);
+        }
+        console.groupEnd();
+        
+        return request;
+      },
+      
+      response: async (response, request) => {
+        const requestId = (request as any).__requestId;
+        const responseClone = response.clone();
+        
+        console.group(`✅ Response ${requestId}`);
+        console.log('Status:', response.status, response.statusText);
+        console.log('Headers:', Object.fromEntries(response.headers.entries()));
+        
+        try {
+          const body = await responseClone.text();
+          if (body) {
+            console.log('Body:', this.formatResponseBody(body, response));
+          }
+        } catch (error) {
+          console.log('Body: (could not read)');
+        }
+        
+        console.groupEnd();
+        return response;
+      },
+      
+      responseError: (error, request) => {
+        const requestId = (request as any).__requestId;
+        
+        console.group(`❌ Error ${requestId}`);
+        console.error('Error:', error);
+        console.groupEnd();
+        
+        throw error;
+      }
+    }));
+  }
+
+  private setupProductionLogging() {
+    this.http.configure(config => config.withInterceptor({
+      responseError: (error, request) => {
+        // Only log errors in production
+        console.error('HTTP Error:', {
+          url: request?.url,
+          method: request?.method,
+          error: error.message,
+          timestamp: new Date().toISOString()
+        });
+        
+        throw error;
+      }
+    }));
+  }
+
+  private logRequestBody(request: Request) {
+    // Note: This is tricky because Request.body is a stream
+    // In practice, you might want to log at a higher level
+    console.log('Body: (stream - cannot log without consuming)');
+  }
+
+  private formatResponseBody(body: string, response: Response): any {
+    const contentType = response.headers.get('content-type') || '';
+    
+    if (contentType.includes('application/json')) {
+      try {
+        return JSON.parse(body);
+      } catch {
+        return body;
+      }
+    }
+    
+    return body.length > 200 ? `${body.substring(0, 200)}...` : body;
+  }
+
+  private generateRequestId(): string {
+    return Math.random().toString(36).substring(2, 8);
+  }
+}
+```
+
+These advanced patterns demonstrate the full power of the Aurelia Fetch Client for enterprise applications. The combination of interceptors, event monitoring, caching, and authentication patterns provides a robust foundation for complex HTTP client requirements.

--- a/docs/user-docs/aurelia-packages/fetch-client/forms.md
+++ b/docs/user-docs/aurelia-packages/fetch-client/forms.md
@@ -1,47 +1,647 @@
-# Working with Forms
+# Working with Forms and File Uploads
 
-Handling forms with the Fetch Client involves preparing FormData objects and sending them via HTTP requests. This is essential for tasks like submitting form data or uploading files.
+Form handling is a critical aspect of web applications. The Aurelia Fetch Client provides comprehensive support for various form submission methods, file uploads, and advanced form processing scenarios.
 
-## Submitting Form Data
+## Form Data Submission
 
-This example shows how to submit form data using `FormData`.
+### Basic Form Submission with FormData
 
 ```typescript
-async function submitForm(formData: FormData) {
-    const response = await http.fetch('submit-form-url', {
-        method: 'POST',
+import { IHttpClient } from '@aurelia/fetch-client';
+import { resolve } from '@aurelia/kernel';
+
+export class FormService {
+  private http = resolve(IHttpClient);
+
+  async submitForm(formElement: HTMLFormElement): Promise<any> {
+    const formData = new FormData(formElement);
+    
+    try {
+      const response = await this.http.post('/api/forms/submit', {
         body: formData
+      });
+
+      if (!response.ok) {
+        throw new Error(`Form submission failed: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error('Form submission error:', error);
+      throw error;
+    }
+  }
+
+  async submitFormData(data: Record<string, any>): Promise<any> {
+    const formData = new FormData();
+    
+    // Add form fields
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== null && value !== undefined) {
+        if (value instanceof File || value instanceof Blob) {
+          formData.append(key, value);
+        } else if (Array.isArray(value)) {
+          value.forEach(item => formData.append(`${key}[]`, item));
+        } else {
+          formData.append(key, String(value));
+        }
+      }
+    });
+
+    const response = await this.http.post('/api/forms/data', {
+      body: formData
     });
 
     if (!response.ok) {
-        // Handle errors
+      throw new Error(`Form submission failed: ${response.statusText}`);
     }
-    return await response.json();
-}
 
-// Usage
-const formElement = document.querySelector('form');
-const formData = new FormData(formElement);
-submitForm(formData);
+    return await response.json();
+  }
+}
 ```
 
-## Uploading a File
+### URL-Encoded Form Submission
 
-Here's how to upload a file using the Fetch Client, which is common in many web applications.
+For traditional form submissions that don't involve file uploads:
 
 ```typescript
-async function uploadFile(file: File) {
+export class UrlEncodedFormService {
+  private http = resolve(IHttpClient);
+
+  async submitUrlEncodedForm(data: Record<string, string | number | boolean>): Promise<any> {
+    const params = new URLSearchParams();
+    
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== null && value !== undefined) {
+        params.append(key, String(value));
+      }
+    });
+
+    const response = await this.http.post('/api/forms/urlencoded', {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    if (!response.ok) {
+      throw new Error(`Form submission failed: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async loginUser(username: string, password: string): Promise<{ token: string; user: any }> {
+    return this.submitUrlEncodedForm({
+      username,
+      password,
+      grant_type: 'password'
+    });
+  }
+}
+```
+
+## File Upload Operations
+
+### Single File Upload
+
+```typescript
+export class FileUploadService {
+  private http = resolve(IHttpClient);
+
+  async uploadSingleFile(
+    file: File, 
+    additionalData?: Record<string, any>
+  ): Promise<{ id: string; url: string; size: number }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('originalName', file.name);
+    formData.append('mimeType', file.type);
+    
+    // Add any additional form data
+    if (additionalData) {
+      Object.entries(additionalData).forEach(([key, value]) => {
+        formData.append(key, String(value));
+      });
+    }
+
+    const response = await this.http.post('/api/files/upload', {
+      body: formData
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async uploadProfileImage(file: File, userId: string): Promise<{ profileImageUrl: string }> {
+    // Validate file type
+    if (!file.type.startsWith('image/')) {
+      throw new Error('Only image files are allowed');
+    }
+
+    // Validate file size (e.g., max 5MB)
+    const maxSize = 5 * 1024 * 1024;
+    if (file.size > maxSize) {
+      throw new Error('File size must be less than 5MB');
+    }
+
+    return this.uploadSingleFile(file, { userId, type: 'profile' });
+  }
+}
+```
+
+### Multiple File Upload
+
+```typescript
+export class MultiFileUploadService {
+  private http = resolve(IHttpClient);
+
+  async uploadMultipleFiles(
+    files: FileList | File[],
+    onProgress?: (loaded: number, total: number) => void
+  ): Promise<Array<{ id: string; name: string; url: string }>> {
+    const formData = new FormData();
+    const fileArray = Array.from(files);
+    
+    fileArray.forEach((file, index) => {
+      formData.append(`files[${index}]`, file);
+      formData.append(`names[${index}]`, file.name);
+    });
+
+    // Add metadata
+    formData.append('fileCount', String(fileArray.length));
+    formData.append('uploadTimestamp', new Date().toISOString());
+
+    const response = await this.http.post('/api/files/upload-multiple', {
+      body: formData
+    });
+
+    if (!response.ok) {
+      throw new Error(`Multi-file upload failed: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+
+  async uploadDocuments(files: FileList): Promise<any> {
+    // Filter for document types
+    const allowedTypes = [
+      'application/pdf',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain'
+    ];
+
+    const validFiles = Array.from(files).filter(file => 
+      allowedTypes.includes(file.type)
+    );
+
+    if (validFiles.length === 0) {
+      throw new Error('No valid document files selected');
+    }
+
+    return this.uploadMultipleFiles(validFiles);
+  }
+}
+```
+
+### Upload with Progress Tracking
+
+```typescript
+export class ProgressUploadService {
+  private http = resolve(IHttpClient);
+
+  async uploadWithProgress(
+    file: File,
+    onProgress: (percentage: number, loaded: number, total: number) => void,
+    onComplete: (result: any) => void,
+    onError: (error: Error) => void
+  ): Promise<void> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('filename', file.name);
+
+    try {
+      // Note: Native fetch doesn't support upload progress directly
+      // This example shows the pattern, but you might need XMLHttpRequest for true upload progress
+      const xhr = new XMLHttpRequest();
+
+      xhr.upload.addEventListener('progress', (event) => {
+        if (event.lengthComputable) {
+          const percentage = Math.round((event.loaded / event.total) * 100);
+          onProgress(percentage, event.loaded, event.total);
+        }
+      });
+
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const result = JSON.parse(xhr.responseText);
+          onComplete(result);
+        } else {
+          onError(new Error(`Upload failed: ${xhr.statusText}`));
+        }
+      });
+
+      xhr.addEventListener('error', () => {
+        onError(new Error('Upload failed due to network error'));
+      });
+
+      xhr.open('POST', '/api/files/upload-progress');
+      xhr.send(formData);
+
+    } catch (error) {
+      onError(error as Error);
+    }
+  }
+
+  // Alternative approach using fetch with chunked upload for progress
+  async uploadFileChunked(
+    file: File,
+    onProgress: (percentage: number) => void
+  ): Promise<any> {
+    const chunkSize = 1024 * 1024; // 1MB chunks
+    const totalChunks = Math.ceil(file.size / chunkSize);
+    const uploadId = this.generateUploadId();
+
+    try {
+      // Initialize upload
+      await this.http.post('/api/files/upload/init', {
+        body: JSON.stringify({
+          uploadId,
+          filename: file.name,
+          fileSize: file.size,
+          totalChunks
+        }),
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      // Upload chunks
+      for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+        const start = chunkIndex * chunkSize;
+        const end = Math.min(start + chunkSize, file.size);
+        const chunk = file.slice(start, end);
+
+        const formData = new FormData();
+        formData.append('uploadId', uploadId);
+        formData.append('chunkIndex', String(chunkIndex));
+        formData.append('chunk', chunk);
+
+        await this.http.post('/api/files/upload/chunk', {
+          body: formData
+        });
+
+        const percentage = Math.round(((chunkIndex + 1) / totalChunks) * 100);
+        onProgress(percentage);
+      }
+
+      // Finalize upload
+      const response = await this.http.post('/api/files/upload/finalize', {
+        body: JSON.stringify({ uploadId }),
+        headers: { 'Content-Type': 'application/json' }
+      });
+
+      return await response.json();
+
+    } catch (error) {
+      // Cleanup on error
+      await this.http.delete(`/api/files/upload/${uploadId}`).catch(() => {});
+      throw error;
+    }
+  }
+
+  private generateUploadId(): string {
+    return `upload-${Date.now()}-${Math.random().toString(36).substring(2)}`;
+  }
+}
+```
+
+## Advanced Form Handling
+
+### Form Validation Integration
+
+```typescript
+interface ValidationError {
+  field: string;
+  message: string;
+  code: string;
+}
+
+export class ValidatedFormService {
+  private http = resolve(IHttpClient);
+
+  async submitWithValidation(formData: FormData): Promise<any> {
+    try {
+      const response = await this.http.post('/api/forms/validated', {
+        body: formData
+      });
+
+      if (!response.ok) {
+        if (response.status === 422) {
+          // Validation errors
+          const validationErrors: ValidationError[] = await response.json();
+          throw new ValidationError('Form validation failed', validationErrors);
+        }
+        throw new Error(`Form submission failed: ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        this.handleValidationErrors(error.errors);
+      }
+      throw error;
+    }
+  }
+
+  private handleValidationErrors(errors: ValidationError[]): void {
+    errors.forEach(error => {
+      const field = document.querySelector(`[name="${error.field}"]`);
+      if (field) {
+        field.classList.add('error');
+        
+        // Add error message
+        const errorElement = document.createElement('div');
+        errorElement.className = 'error-message';
+        errorElement.textContent = error.message;
+        field.parentElement?.appendChild(errorElement);
+      }
+    });
+  }
+}
+
+class ValidationError extends Error {
+  constructor(message: string, public errors: ValidationError[]) {
+    super(message);
+  }
+}
+```
+
+### Dynamic Form Building
+
+```typescript
+export class DynamicFormService {
+  private http = resolve(IHttpClient);
+
+  async submitDynamicForm(formConfig: any, values: Record<string, any>): Promise<any> {
+    const formData = new FormData();
+    
+    // Process form fields based on configuration
+    formConfig.fields.forEach((field: any) => {
+      const value = values[field.name];
+      
+      if (value !== null && value !== undefined) {
+        switch (field.type) {
+          case 'file':
+            if (value instanceof File) {
+              formData.append(field.name, value);
+            }
+            break;
+          case 'array':
+            if (Array.isArray(value)) {
+              value.forEach(item => formData.append(`${field.name}[]`, item));
+            }
+            break;
+          case 'json':
+            formData.append(field.name, JSON.stringify(value));
+            break;
+          default:
+            formData.append(field.name, String(value));
+        }
+      }
+    });
+
+    // Add form metadata
+    formData.append('_formType', formConfig.type);
+    formData.append('_version', formConfig.version);
+
+    const response = await this.http.post('/api/forms/dynamic', {
+      body: formData
+    });
+
+    if (!response.ok) {
+      throw new Error(`Dynamic form submission failed: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+}
+```
+
+### File Upload with AbortController
+
+```typescript
+export class AbortableUploadService {
+  private http = resolve(IHttpClient);
+
+  async uploadWithCancellation(
+    file: File,
+    onProgress?: (percentage: number) => void
+  ): Promise<{ result: any; abort: () => void }> {
+    const controller = new AbortController();
     const formData = new FormData();
     formData.append('file', file);
 
-    const response = await http.fetch('upload-url', {
-        method: 'POST',
-        body: formData
+    const uploadPromise = this.http.post('/api/files/upload', {
+      body: formData,
+      signal: controller.signal
+    }).then(response => {
+      if (!response.ok) {
+        throw new Error(`Upload failed: ${response.statusText}`);
+      }
+      return response.json();
+    });
+
+    return {
+      result: uploadPromise,
+      abort: () => controller.abort()
+    };
+  }
+
+  async uploadMultipleWithCancellation(
+    files: File[]
+  ): Promise<{ results: Promise<any>[]; abortAll: () => void }> {
+    const controllers = files.map(() => new AbortController());
+    
+    const uploadPromises = files.map((file, index) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      
+      return this.http.post('/api/files/upload', {
+        body: formData,
+        signal: controllers[index].signal
+      }).then(response => {
+        if (!response.ok) {
+          throw new Error(`Upload failed for ${file.name}: ${response.statusText}`);
+        }
+        return response.json();
+      });
+    });
+
+    return {
+      results: uploadPromises,
+      abortAll: () => controllers.forEach(controller => controller.abort())
+    };
+  }
+}
+```
+
+## Form Data Processing
+
+### Complex Data Structures
+
+```typescript
+export class ComplexFormService {
+  private http = resolve(IHttpClient);
+
+  async submitComplexForm(data: {
+    user: {
+      name: string;
+      email: string;
+      avatar?: File;
+    };
+    preferences: Record<string, any>;
+    documents: File[];
+    metadata: any;
+  }): Promise<any> {
+    const formData = new FormData();
+
+    // User data
+    formData.append('user[name]', data.user.name);
+    formData.append('user[email]', data.user.email);
+    if (data.user.avatar) {
+      formData.append('user[avatar]', data.user.avatar);
+    }
+
+    // Preferences (nested object)
+    Object.entries(data.preferences).forEach(([key, value]) => {
+      formData.append(`preferences[${key}]`, JSON.stringify(value));
+    });
+
+    // Multiple files
+    data.documents.forEach((file, index) => {
+      formData.append(`documents[${index}]`, file);
+    });
+
+    // Metadata as JSON
+    formData.append('metadata', JSON.stringify(data.metadata));
+
+    const response = await this.http.post('/api/forms/complex', {
+      body: formData
     });
 
     if (!response.ok) {
-        // Handle errors
+      throw new Error(`Complex form submission failed: ${response.statusText}`);
     }
+
     return await response.json();
+  }
 }
 ```
+
+## Best Practices
+
+### File Type and Size Validation
+
+```typescript
+export class FileValidationService {
+  validateFile(file: File, options: {
+    maxSize?: number;
+    allowedTypes?: string[];
+    allowedExtensions?: string[];
+  }): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    // Size validation
+    if (options.maxSize && file.size > options.maxSize) {
+      errors.push(`File size must be less than ${this.formatFileSize(options.maxSize)}`);
+    }
+
+    // Type validation
+    if (options.allowedTypes && !options.allowedTypes.includes(file.type)) {
+      errors.push(`File type ${file.type} is not allowed`);
+    }
+
+    // Extension validation
+    if (options.allowedExtensions) {
+      const extension = file.name.split('.').pop()?.toLowerCase();
+      if (!extension || !options.allowedExtensions.includes(extension)) {
+        errors.push(`File extension .${extension} is not allowed`);
+      }
+    }
+
+    return {
+      valid: errors.length === 0,
+      errors
+    };
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
+}
+```
+
+### Error Handling and Recovery
+
+```typescript
+export class RobustFormService {
+  private http = resolve(IHttpClient);
+
+  async submitWithRetry(
+    formData: FormData,
+    maxRetries: number = 3
+  ): Promise<any> {
+    let lastError: Error;
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await this.http.post('/api/forms/submit', {
+          body: formData
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        return await response.json();
+      } catch (error) {
+        lastError = error as Error;
+        
+        if (attempt < maxRetries) {
+          // Wait before retry (exponential backoff)
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    }
+
+    throw new Error(`Form submission failed after ${maxRetries} attempts: ${lastError!.message}`);
+  }
+}
+```
+
+### Memory Management
+
+Always clean up object URLs and large FormData objects when done:
+
+```typescript
+// Clean up blob URLs
+const blobUrl = URL.createObjectURL(file);
+// ... use the URL
+URL.revokeObjectURL(blobUrl);
+
+// For large forms, consider clearing FormData references
+let formData: FormData | null = new FormData();
+// ... use formData
+formData = null; // Help garbage collection
+```
+
+The Aurelia Fetch Client provides a robust foundation for handling all types of form submissions and file uploads. By following these patterns, you can build reliable, user-friendly form handling in your applications.

--- a/docs/user-docs/aurelia-packages/fetch-client/interceptors.md
+++ b/docs/user-docs/aurelia-packages/fetch-client/interceptors.md
@@ -85,22 +85,645 @@ function handleError(error) {
 }
 ```
 
-## Best Practices for Using Interceptors
+## Advanced Interceptor Patterns
 
-- **Single Responsibility**: Each interceptor should have a single responsibility, whether it's logging, adding headers, or error handling.
-- **Order Matters**: The order in which interceptors are added can affect their behavior, as they are executed in a pipeline.
-- **Error Recovery**: Consider implementing strategies within `requestError` and `responseError` interceptors for error recovery, such as retrying failed requests.
-- **Avoid Side Effects**: While interceptors can perform side effects, it's best to avoid them unless necessary for functionality like logging.
-- **Short-Circuiting**: Interceptors can short-circuit the fetch process by returning a `Response` object in the `request` interceptor.
+### Async Interceptors and Promise Handling
 
-## Considerations for Interceptors
+All interceptor methods support async operations and Promise returns:
 
-When implementing interceptors, it is important to be aware of their full potential and how to avoid common pitfalls:
+```typescript
+export class AsyncInterceptorService {
+  private http = resolve(IHttpClient);
 
-- **Interceptor Lifecycle**: Interceptors are executed in the order they are registered. Understanding this order is crucial when you have dependencies between interceptors' operations.
-- **Asynchronous Interceptors**: Interceptors can return `Promise`s, allowing for asynchronous operations. Ensure that any asynchronous code is handled properly to avoid unexpected behavior.
-- **Pitfalls to Avoid**: Be cautious when changing shared request configurations within an interceptor, as this might affect other application parts. Always treat the `Request` and `Response` objects as immutable.
-- **Performance Impacts**: Remember that complex logic within interceptors can impact the performance of your HTTP requests. Monitor the performance to ensure that interceptors do not introduce significant delays.
-- **Debugging Interceptors**: Use logging within interceptors to help identify the flow of requests and responses. This can be invaluable when debugging unexpected behavior.
-- **Organizing Interceptors**: For better maintainability, organize interceptors in a logical structure, such as grouping related interceptors together or keeping them close to the feature modules they relate to.
-- **Advanced Use Cases**: For more complex scenarios, consider using interceptors for response caching, request retries with backoff strategies, or implementing custom prioritization of outgoing requests.
+  constructor() {
+    this.setupAsyncInterceptors();
+  }
+
+  private setupAsyncInterceptors() {
+    this.http.configure(config => config.withInterceptor({
+      async request(request) {
+        // Async operation in request interceptor
+        const sessionData = await this.getSessionData();
+        
+        if (sessionData.requiresAuth) {
+          const token = await this.ensureValidToken();
+          request.headers.set('Authorization', `Bearer ${token}`);
+        }
+
+        return request;
+      },
+
+      async response(response, request) {
+        // Async response processing
+        if (response.status === 401) {
+          await this.handleAuthenticationFailure();
+        }
+
+        // Process response metadata
+        const responseTime = response.headers.get('X-Response-Time');
+        if (responseTime) {
+          await this.recordMetrics(request?.url, responseTime);
+        }
+
+        return response;
+      },
+
+      async responseError(error, request, client) {
+        // Async error recovery
+        if (error instanceof Response && error.status === 503) {
+          // Service unavailable - check health and retry
+          const isHealthy = await this.checkServiceHealth();
+          
+          if (isHealthy) {
+            // Service recovered, retry request
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            return client.fetch(request);
+          }
+        }
+
+        throw error;
+      }
+    }));
+  }
+
+  private async getSessionData() {
+    // Simulate async session check
+    return new Promise(resolve => 
+      setTimeout(() => resolve({ requiresAuth: true }), 100)
+    );
+  }
+
+  private async ensureValidToken(): Promise<string> {
+    // Simulate token validation/refresh
+    const storedToken = localStorage.getItem('access_token');
+    
+    if (this.isTokenExpired(storedToken)) {
+      return await this.refreshToken();
+    }
+    
+    return storedToken!;
+  }
+
+  private async recordMetrics(url: string, responseTime: string) {
+    // Send metrics to analytics service
+    await fetch('/analytics/metrics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, responseTime, timestamp: Date.now() })
+    });
+  }
+}
+```
+
+### Request Transformation Chain
+
+Create sophisticated request transformation pipelines:
+
+```typescript
+export class RequestTransformationService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupTransformationChain();
+  }
+
+  private setupTransformationChain() {
+    // Each interceptor adds specific transformations
+    this.http.configure(config => config
+      .withInterceptor(this.createSecurityInterceptor())
+      .withInterceptor(this.createCompressionInterceptor())
+      .withInterceptor(this.createCachingInterceptor())
+      .withInterceptor(this.createMetricsInterceptor())
+    );
+  }
+
+  private createSecurityInterceptor() {
+    return {
+      request: (request: Request) => {
+        // Add security headers
+        request.headers.set('X-Requested-With', 'XMLHttpRequest');
+        request.headers.set('X-Client-Version', this.getClientVersion());
+        
+        // Add CSRF protection for state-changing requests
+        if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method)) {
+          const csrfToken = this.getCsrfToken();
+          if (csrfToken) {
+            request.headers.set('X-CSRF-Token', csrfToken);
+          }
+        }
+
+        return request;
+      }
+    };
+  }
+
+  private createCompressionInterceptor() {
+    return {
+      request: (request: Request) => {
+        // Request compression for large payloads
+        const contentType = request.headers.get('content-type');
+        
+        if (contentType?.includes('application/json') && request.body) {
+          request.headers.set('Accept-Encoding', 'gzip, deflate, br');
+        }
+
+        return request;
+      }
+    };
+  }
+
+  private createCachingInterceptor() {
+    const cache = new Map<string, { response: Response; timestamp: number }>();
+    const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+    return {
+      request: (request: Request) => {
+        // Only cache GET requests
+        if (request.method !== 'GET') {
+          return request;
+        }
+
+        const cacheKey = this.getCacheKey(request);
+        const cached = cache.get(cacheKey);
+
+        if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+          console.log('Returning cached response for:', request.url);
+          return cached.response.clone();
+        }
+
+        return request;
+      },
+
+      response: (response: Response, request?: Request) => {
+        // Cache successful GET responses
+        if (request?.method === 'GET' && response.ok) {
+          const cacheKey = this.getCacheKey(request);
+          cache.set(cacheKey, {
+            response: response.clone(),
+            timestamp: Date.now()
+          });
+        }
+
+        return response;
+      }
+    };
+  }
+
+  private createMetricsInterceptor() {
+    return {
+      request: (request: Request) => {
+        // Add timing information
+        (request as any).__startTime = Date.now();
+        return request;
+      },
+
+      response: (response: Response, request?: Request) => {
+        const startTime = (request as any).__startTime;
+        if (startTime) {
+          const duration = Date.now() - startTime;
+          console.log(`Request to ${request?.url} took ${duration}ms`);
+          
+          // Record performance metrics
+          this.recordPerformanceMetric(request?.url, duration, response.status);
+        }
+
+        return response;
+      }
+    };
+  }
+
+  private getCacheKey(request: Request): string {
+    return request.url + JSON.stringify(Array.from(request.headers.entries()).sort());
+  }
+}
+```
+
+### Conditional Interceptor Application
+
+Apply interceptors selectively based on request characteristics:
+
+```typescript
+export class ConditionalInterceptorService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupConditionalInterceptors();
+  }
+
+  private setupConditionalInterceptors() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        const url = new URL(request.url);
+
+        // Apply different logic based on URL patterns
+        switch (true) {
+          case url.pathname.startsWith('/api/auth/'):
+            return this.handleAuthRequests(request);
+          
+          case url.pathname.startsWith('/api/files/'):
+            return this.handleFileRequests(request);
+          
+          case url.pathname.startsWith('/api/external/'):
+            return this.handleExternalApiRequests(request);
+          
+          case url.searchParams.has('cache'):
+            return this.handleCacheableRequests(request);
+          
+          default:
+            return this.handleStandardRequests(request);
+        }
+      },
+
+      response: (response, request) => {
+        const url = new URL(response.url);
+
+        // Different response handling based on endpoints
+        if (url.pathname.startsWith('/api/auth/')) {
+          return this.handleAuthResponses(response);
+        } else if (url.pathname.startsWith('/api/files/')) {
+          return this.handleFileResponses(response);
+        }
+
+        return response;
+      }
+    }));
+  }
+
+  private handleAuthRequests(request: Request): Request {
+    console.log('Processing auth request');
+    
+    // Remove auth headers for auth endpoints to avoid conflicts
+    request.headers.delete('Authorization');
+    
+    // Add special auth endpoint headers
+    request.headers.set('X-Auth-Client', 'web-app');
+    
+    return request;
+  }
+
+  private handleFileRequests(request: Request): Request {
+    console.log('Processing file request');
+    
+    // Set appropriate timeout for file operations
+    // Note: This would need custom timeout implementation
+    
+    // Don't add JSON content-type for file uploads
+    if (request.method === 'POST' && !request.headers.has('content-type')) {
+      // Let browser set content-type for FormData
+    }
+    
+    return request;
+  }
+
+  private handleExternalApiRequests(request: Request): Request {
+    console.log('Processing external API request');
+    
+    // Add API key for external services
+    const apiKey = this.getExternalApiKey(request.url);
+    if (apiKey) {
+      request.headers.set('X-API-Key', apiKey);
+    }
+    
+    // Set different user agent for external requests
+    request.headers.set('User-Agent', 'MyApp/1.0');
+    
+    return request;
+  }
+
+  private handleCacheableRequests(request: Request): Request {
+    console.log('Processing cacheable request');
+    
+    // Add cache control headers
+    request.headers.set('Cache-Control', 'max-age=300');
+    
+    return request;
+  }
+
+  private handleStandardRequests(request: Request): Request {
+    // Default request processing
+    if (!request.headers.has('Accept')) {
+      request.headers.set('Accept', 'application/json');
+    }
+    
+    return request;
+  }
+
+  private handleAuthResponses(response: Response): Response {
+    // Store auth tokens, update session, etc.
+    if (response.ok && response.headers.has('X-Auth-Token')) {
+      const token = response.headers.get('X-Auth-Token');
+      localStorage.setItem('auth_token', token!);
+    }
+    
+    return response;
+  }
+
+  private handleFileResponses(response: Response): Response {
+    // Handle file download headers
+    const disposition = response.headers.get('Content-Disposition');
+    if (disposition) {
+      console.log('File download response:', disposition);
+    }
+    
+    return response;
+  }
+}
+```
+
+### Interceptor Disposal and Cleanup
+
+Properly manage interceptor lifecycle and cleanup:
+
+```typescript
+export class ManagedInterceptorService implements IDisposable {
+  private http = resolve(IHttpClient);
+  private intervalIds: number[] = [];
+  private eventListeners: Array<{ target: EventTarget; type: string; listener: EventListener }> = [];
+
+  constructor() {
+    this.setupManagedInterceptors();
+  }
+
+  private setupManagedInterceptors() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        // Track request metrics
+        this.recordRequestMetric(request);
+        return request;
+      },
+
+      response: (response, request) => {
+        // Update health metrics
+        this.updateHealthMetrics(response.status);
+        return response;
+      },
+
+      // Interceptor cleanup method
+      dispose: () => {
+        console.log('Cleaning up interceptor resources');
+        this.cleanup();
+      }
+    }));
+
+    // Set up periodic cleanup
+    const cleanupInterval = setInterval(() => {
+      this.performPeriodicCleanup();
+    }, 60000); // Every minute
+
+    this.intervalIds.push(cleanupInterval);
+
+    // Set up event listeners
+    const visibilityListener = () => {
+      if (document.hidden) {
+        this.pauseMetrics();
+      } else {
+        this.resumeMetrics();
+      }
+    };
+
+    document.addEventListener('visibilitychange', visibilityListener);
+    this.eventListeners.push({
+      target: document,
+      type: 'visibilitychange',
+      listener: visibilityListener
+    });
+  }
+
+  private recordRequestMetric(request: Request) {
+    // Implementation for request metrics
+  }
+
+  private updateHealthMetrics(status: number) {
+    // Implementation for health metrics
+  }
+
+  private performPeriodicCleanup() {
+    // Clean up expired cache entries, metrics, etc.
+  }
+
+  private pauseMetrics() {
+    // Pause metric collection when page is hidden
+  }
+
+  private resumeMetrics() {
+    // Resume metric collection when page is visible
+  }
+
+  private cleanup() {
+    // Clear intervals
+    this.intervalIds.forEach(id => clearInterval(id));
+    this.intervalIds.length = 0;
+
+    // Remove event listeners
+    this.eventListeners.forEach(({ target, type, listener }) => {
+      target.removeEventListener(type, listener);
+    });
+    this.eventListeners.length = 0;
+  }
+
+  // Aurelia disposal interface
+  dispose(): void {
+    this.cleanup();
+  }
+}
+```
+
+## Best Practices and Advanced Considerations
+
+### Interceptor Ordering Strategy
+
+```typescript
+export class OrderedInterceptorService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupOrderedInterceptors();
+  }
+
+  private setupOrderedInterceptors() {
+    this.http.configure(config => config
+      // 1. Security (first - affects all subsequent requests)
+      .withInterceptor(this.createSecurityInterceptor())
+      
+      // 2. Authentication (needs to run before most other interceptors)
+      .withInterceptor(this.createAuthInterceptor())
+      
+      // 3. Request transformation (modify request before caching/metrics)
+      .withInterceptor(this.createTransformationInterceptor())
+      
+      // 4. Caching (should see final request form)
+      .withInterceptor(this.createCacheInterceptor())
+      
+      // 5. Metrics/Logging (should capture final request state)
+      .withInterceptor(this.createMetricsInterceptor())
+      
+      // 6. Retry (MUST be last - see documentation about retry limitations)
+      .withRetry({ maxRetries: 3, strategy: RetryStrategy.exponential })
+    );
+  }
+}
+```
+
+### Performance Optimization
+
+```typescript
+export class PerformantInterceptorService {
+  private http = resolve(IHttpClient);
+  private requestCache = new Map();
+  private metricsBuffer: any[] = [];
+
+  constructor() {
+    this.setupPerformantInterceptors();
+  }
+
+  private setupPerformantInterceptors() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        // Minimize work in request interceptor
+        
+        // Use efficient header checking
+        if (!request.headers.has('Accept')) {
+          request.headers.set('Accept', 'application/json');
+        }
+
+        // Batch expensive operations
+        this.queueMetricsUpdate('request', request.url);
+        
+        return request;
+      },
+
+      response: (response, request) => {
+        // Efficient response processing
+        
+        // Use cloning sparingly (it's expensive)
+        if (this.shouldCache(request)) {
+          const cacheKey = this.getCacheKey(request!);
+          this.requestCache.set(cacheKey, response.clone());
+        }
+
+        // Batch metrics updates
+        this.queueMetricsUpdate('response', request?.url, response.status);
+        
+        return response;
+      }
+    }));
+
+    // Process metrics in batches
+    setInterval(() => {
+      if (this.metricsBuffer.length > 0) {
+        this.processMetricsBatch([...this.metricsBuffer]);
+        this.metricsBuffer.length = 0;
+      }
+    }, 5000);
+  }
+
+  private shouldCache(request?: Request): boolean {
+    return request?.method === 'GET' && 
+           !request.url.includes('no-cache') &&
+           this.requestCache.size < 100; // Prevent memory leaks
+  }
+
+  private queueMetricsUpdate(type: string, url?: string, status?: number) {
+    this.metricsBuffer.push({ type, url, status, timestamp: Date.now() });
+    
+    // Prevent buffer from growing too large
+    if (this.metricsBuffer.length > 1000) {
+      this.metricsBuffer.splice(0, 500); // Remove oldest half
+    }
+  }
+
+  private processMetricsBatch(metrics: any[]) {
+    // Efficient batch processing of metrics
+    console.log(`Processing ${metrics.length} metrics updates`);
+  }
+}
+```
+
+### Debugging and Testing Support
+
+```typescript
+export class DebuggableInterceptorService {
+  private http = resolve(IHttpClient);
+  private isDebugMode = process.env.NODE_ENV === 'development';
+
+  constructor() {
+    this.setupDebuggableInterceptors();
+  }
+
+  private setupDebuggableInterceptors() {
+    this.http.configure(config => config.withInterceptor({
+      request: (request) => {
+        if (this.isDebugMode) {
+          this.debugRequest(request);
+        }
+
+        // Add debug headers in development
+        if (this.isDebugMode) {
+          request.headers.set('X-Debug-Mode', 'true');
+          request.headers.set('X-Debug-Timestamp', Date.now().toString());
+        }
+
+        return request;
+      },
+
+      response: (response, request) => {
+        if (this.isDebugMode) {
+          this.debugResponse(response, request);
+        }
+
+        return response;
+      },
+
+      responseError: (error, request) => {
+        if (this.isDebugMode) {
+          this.debugError(error, request);
+        }
+
+        // In development, add more context to errors
+        if (this.isDebugMode && error instanceof Error) {
+          error.message += ` (Request: ${request?.method} ${request?.url})`;
+        }
+
+        throw error;
+      }
+    }));
+  }
+
+  private debugRequest(request: Request) {
+    console.group(`📤 Request: ${request.method} ${request.url}`);
+    console.log('Headers:', Object.fromEntries(request.headers.entries()));
+    console.log('Mode:', request.mode);
+    console.log('Credentials:', request.credentials);
+    console.groupEnd();
+  }
+
+  private debugResponse(response: Response, request?: Request) {
+    console.group(`📥 Response: ${response.status} ${request?.url}`);
+    console.log('Headers:', Object.fromEntries(response.headers.entries()));
+    console.log('OK:', response.ok);
+    console.log('Redirected:', response.redirected);
+    console.groupEnd();
+  }
+
+  private debugError(error: any, request?: Request) {
+    console.group(`❌ Error: ${request?.url}`);
+    console.error('Error:', error);
+    console.log('Request method:', request?.method);
+    console.log('Request headers:', request ? Object.fromEntries(request.headers.entries()) : 'N/A');
+    console.groupEnd();
+  }
+}
+```
+
+## Key Takeaways
+
+1. **Interceptor Order Matters**: Design your interceptor chain thoughtfully
+2. **Async Support**: All interceptor methods can be async and return Promises
+3. **Performance Impact**: Monitor and optimize interceptor performance
+4. **Resource Management**: Implement proper cleanup in interceptor dispose methods
+5. **Conditional Logic**: Use URL patterns and headers to apply logic selectively
+6. **Debugging Support**: Add comprehensive logging for development environments
+7. **Error Recovery**: Implement sophisticated error handling and recovery strategies
+8. **Retry Limitations**: Be aware of AbortController compatibility issues with the retry interceptor
+
+Interceptors are the most powerful feature of the Aurelia Fetch Client, enabling sophisticated HTTP request/response processing pipelines that can handle authentication, caching, metrics, error recovery, and much more.

--- a/docs/user-docs/aurelia-packages/fetch-client/response-types.md
+++ b/docs/user-docs/aurelia-packages/fetch-client/response-types.md
@@ -1,56 +1,499 @@
-# Handling Different Response Types
+# Response Types and Data Handling
 
-The Aurelia Fetch Client can handle various response types, including JSON, Blob, and text. Proper handling of these types is crucial for correctly processing server responses.
+The Aurelia Fetch Client provides comprehensive support for all standard response types and data formats. Understanding how to properly handle different response types is crucial for building robust applications that work with various APIs and data sources.
 
-## Handling JSON Response
+## Response Type Detection
 
-This example demonstrates how to fetch and process a JSON response.
+The fetch client automatically handles content-type detection, but you should always check response headers and status codes for proper error handling:
 
 ```typescript
-async function fetchJson(url: string) {
-    const response = await http.fetch(URL);
-    if (response.ok) {
-        return await response.json();
-    } else {
-        // Handle errors
+import { IHttpClient } from '@aurelia/fetch-client';
+import { resolve } from '@aurelia/kernel';
+
+export class ApiService {
+  private http = resolve(IHttpClient);
+
+  async fetchWithTypeDetection(url: string) {
+    const response = await this.http.get(url);
+    
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
+
+    const contentType = response.headers.get('content-type') || '';
+    
+    if (contentType.includes('application/json')) {
+      return await response.json();
+    } else if (contentType.includes('text/')) {
+      return await response.text();
+    } else if (contentType.includes('image/') || contentType.includes('application/octet-stream')) {
+      return await response.blob();
+    } else {
+      return await response.arrayBuffer();
+    }
+  }
 }
 ```
 
-## Handling Blob (Binary Data)
+## JSON Responses
 
-This snippet shows how to handle binary data (like images or files) received from the server.
+JSON is the most common response type for modern APIs. Always include proper error handling and type safety:
 
 ```typescript
-async function fetchBlob(URL: string) {
-    const response = await http.fetch(URL);
-    if (response.ok) {
-        return await response.blob();
-    } else {
-        // Handle errors
-    }
+interface User {
+  id: number;
+  name: string;
+  email: string;
 }
-```
 
-## Response Transformation and Mapping
+export class UserService {
+  private http = resolve(IHttpClient);
 
-This interceptor transforms JSON responses using a custom transformData function, allowing for consistent data shaping across the application.
-
-```typescript
-http.configure(config => {
-    config.withInterceptor({
-        async response(response) {
-            if (response.ok && response.headers.get('Content-Type')?.includes('application/json')) {
-                const data = await response.json();
-                return transformData(data); // Custom transformation function
-            }
-            return response;
+  async getUser(id: number): Promise<User> {
+    try {
+      const response = await this.http.get(`/api/users/${id}`);
+      
+      if (!response.ok) {
+        // Handle different error types
+        if (response.status === 404) {
+          throw new Error('User not found');
+        } else if (response.status >= 500) {
+          throw new Error('Server error - please try again later');
+        } else {
+          const errorData = await response.json().catch(() => ({}));
+          throw new Error(errorData.message || `HTTP ${response.status}`);
         }
-    });
-});
+      }
 
-function transformData(data) {
-    // Transformation logic
-    return modifiedData;
+      const userData = await response.json();
+      return userData as User;
+    } catch (error) {
+      if (error instanceof TypeError) {
+        // Network error
+        throw new Error('Network error - please check your connection');
+      }
+      throw error;
+    }
+  }
+
+  async getUsers(): Promise<User[]> {
+    const response = await this.http.get('/api/users');
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch users: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
 }
 ```
+
+## Binary Data (Images, Files, Documents)
+
+Handle binary data like images, PDFs, and other files using Blob responses:
+
+```typescript
+export class FileService {
+  private http = resolve(IHttpClient);
+
+  async downloadFile(fileId: string): Promise<{ blob: Blob; filename: string }> {
+    const response = await this.http.get(`/api/files/${fileId}`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to download file: ${response.statusText}`);
+    }
+
+    const blob = await response.blob();
+    
+    // Extract filename from Content-Disposition header
+    const contentDisposition = response.headers.get('content-disposition');
+    const filename = contentDisposition
+      ? contentDisposition.split('filename=')[1]?.replace(/"/g, '')
+      : `file-${fileId}`;
+
+    return { blob, filename };
+  }
+
+  async downloadImage(imageId: string): Promise<string> {
+    const response = await this.http.get(`/api/images/${imageId}`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to download image: ${response.statusText}`);
+    }
+
+    const blob = await response.blob();
+    
+    // Create object URL for display
+    return URL.createObjectURL(blob);
+  }
+
+  async uploadImage(file: File): Promise<{ id: string; url: string }> {
+    const formData = new FormData();
+    formData.append('image', file);
+
+    const response = await this.http.post('/api/images', {
+      body: formData
+    });
+
+    if (!response.ok) {
+      throw new Error(`Upload failed: ${response.statusText}`);
+    }
+
+    return await response.json();
+  }
+}
+```
+
+## Text Responses
+
+Handle plain text, HTML, CSV, and other text-based responses:
+
+```typescript
+export class ContentService {
+  private http = resolve(IHttpClient);
+
+  async getPlainText(url: string): Promise<string> {
+    const response = await this.http.get(url);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch text: ${response.statusText}`);
+    }
+
+    return await response.text();
+  }
+
+  async getHtmlContent(pageId: string): Promise<string> {
+    const response = await this.http.get(`/api/pages/${pageId}`, {
+      headers: { 'Accept': 'text/html' }
+    });
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch HTML: ${response.statusText}`);
+    }
+
+    return await response.text();
+  }
+
+  async exportCsv(reportId: string): Promise<string> {
+    const response = await this.http.get(`/api/reports/${reportId}/export`, {
+      headers: { 'Accept': 'text/csv' }
+    });
+    
+    if (!response.ok) {
+      throw new Error(`Export failed: ${response.statusText}`);
+    }
+
+    return await response.text();
+  }
+}
+```
+
+## ArrayBuffer for Raw Binary Data
+
+Use ArrayBuffer for handling raw binary data that needs processing:
+
+```typescript
+export class BinaryDataService {
+  private http = resolve(IHttpClient);
+
+  async getRawBinaryData(url: string): Promise<ArrayBuffer> {
+    const response = await this.http.get(url);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch binary data: ${response.statusText}`);
+    }
+
+    return await response.arrayBuffer();
+  }
+
+  async processImageData(imageId: string): Promise<Uint8Array> {
+    const response = await this.http.get(`/api/images/${imageId}/raw`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch image data: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return new Uint8Array(arrayBuffer);
+  }
+}
+```
+
+## Streaming Responses
+
+Handle large responses using streams for better memory efficiency:
+
+```typescript
+export class StreamingService {
+  private http = resolve(IHttpClient);
+
+  async processLargeDataset(datasetId: string, onChunk: (chunk: any) => void): Promise<void> {
+    const response = await this.http.get(`/api/datasets/${datasetId}/stream`);
+    
+    if (!response.ok) {
+      throw new Error(`Stream failed: ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is not readable');
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        
+        if (done) break;
+
+        // Decode chunk and add to buffer
+        buffer += decoder.decode(value, { stream: true });
+        
+        // Process complete lines
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || ''; // Keep incomplete line in buffer
+        
+        for (const line of lines) {
+          if (line.trim()) {
+            try {
+              const chunk = JSON.parse(line);
+              onChunk(chunk);
+            } catch (error) {
+              console.warn('Failed to parse chunk:', line);
+            }
+          }
+        }
+      }
+
+      // Process final buffer content
+      if (buffer.trim()) {
+        try {
+          const chunk = JSON.parse(buffer);
+          onChunk(chunk);
+        } catch (error) {
+          console.warn('Failed to parse final chunk:', buffer);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async downloadWithProgress(
+    url: string, 
+    onProgress: (loaded: number, total: number) => void
+  ): Promise<Blob> {
+    const response = await this.http.get(url);
+    
+    if (!response.ok) {
+      throw new Error(`Download failed: ${response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error('Response body is not readable');
+    }
+
+    const contentLength = response.headers.get('content-length');
+    const total = contentLength ? parseInt(contentLength, 10) : 0;
+    
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let loaded = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        
+        if (done) break;
+
+        chunks.push(value);
+        loaded += value.length;
+        
+        if (total > 0) {
+          onProgress(loaded, total);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return new Blob(chunks);
+  }
+}
+```
+
+## Response Transformation with Interceptors
+
+Use interceptors to transform responses globally or conditionally:
+
+```typescript
+export class DataTransformService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.setupResponseTransformers();
+  }
+
+  private setupResponseTransformers() {
+    this.http.configure(config => config.withInterceptor({
+      async response(response, request) {
+        // Transform API responses based on content type and URL
+        const contentType = response.headers.get('content-type') || '';
+        const url = new URL(response.url);
+
+        if (contentType.includes('application/json')) {
+          // Transform JSON responses
+          if (url.pathname.startsWith('/api/v1/')) {
+            return this.transformV1Response(response);
+          } else if (url.pathname.startsWith('/api/legacy/')) {
+            return this.transformLegacyResponse(response);
+          }
+        }
+
+        return response;
+      }
+    }));
+  }
+
+  private async transformV1Response(response: Response): Promise<Response> {
+    const data = await response.json();
+    
+    // Transform V1 API structure to internal format
+    const transformedData = {
+      ...data,
+      timestamp: new Date(data.created_at),
+      metadata: {
+        version: 'v1',
+        source: 'api'
+      }
+    };
+
+    return new Response(JSON.stringify(transformedData), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers
+    });
+  }
+
+  private async transformLegacyResponse(response: Response): Promise<Response> {
+    const data = await response.json();
+    
+    // Transform legacy API structure
+    const transformedData = {
+      id: data.ID,
+      name: data.Name,
+      status: data.Status?.toLowerCase(),
+      createdAt: new Date(data.CreateTime),
+      metadata: {
+        version: 'legacy',
+        source: 'legacy-api'
+      }
+    };
+
+    return new Response(JSON.stringify(transformedData), {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers
+    });
+  }
+}
+```
+
+## Error Response Handling
+
+Properly handle different types of error responses:
+
+```typescript
+export class ErrorHandlingService {
+  private http = resolve(IHttpClient);
+
+  constructor() {
+    this.http.configure(config => config
+      .rejectErrorResponses()
+      .withInterceptor({
+        async responseError(error, request) {
+          if (error instanceof Response) {
+            return this.handleHttpError(error, request);
+          } else {
+            return this.handleNetworkError(error, request);
+          }
+        }
+      })
+    );
+  }
+
+  private async handleHttpError(response: Response, request?: Request): Promise<never> {
+    const contentType = response.headers.get('content-type') || '';
+    let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+    let errorDetails: any = {};
+
+    try {
+      if (contentType.includes('application/json')) {
+        errorDetails = await response.json();
+        errorMessage = errorDetails.message || errorDetails.error || errorMessage;
+      } else if (contentType.includes('text/')) {
+        const textError = await response.text();
+        errorMessage = textError || errorMessage;
+      }
+    } catch (parseError) {
+      // If we can't parse the error response, use the default message
+    }
+
+    const error = new Error(errorMessage);
+    (error as any).status = response.status;
+    (error as any).details = errorDetails;
+    (error as any).url = request?.url;
+
+    throw error;
+  }
+
+  private handleNetworkError(error: any, request?: Request): never {
+    const networkError = new Error(`Network error: ${error.message}`);
+    (networkError as any).originalError = error;
+    (networkError as any).url = request?.url;
+    (networkError as any).isNetworkError = true;
+
+    throw networkError;
+  }
+}
+```
+
+## Best Practices
+
+### Content-Type Validation
+Always check content-type headers before processing responses:
+
+```typescript
+const contentType = response.headers.get('content-type');
+if (!contentType?.includes('application/json')) {
+  throw new Error('Expected JSON response');
+}
+```
+
+### Memory Management
+For large responses, use streaming or dispose of object URLs:
+
+```typescript
+// For blob URLs, clean up when done
+const blobUrl = URL.createObjectURL(blob);
+// ... use the URL
+URL.revokeObjectURL(blobUrl); // Clean up
+```
+
+### Type Safety
+Use TypeScript interfaces for JSON responses:
+
+```typescript
+interface ApiResponse<T> {
+  data: T;
+  status: 'success' | 'error';
+  message?: string;
+}
+
+const response: ApiResponse<User[]> = await response.json();
+```
+
+### Error Boundaries
+Always wrap response processing in try-catch blocks and handle different error types appropriately.

--- a/docs/user-docs/developer-guides/developing-with-ai.md
+++ b/docs/user-docs/developer-guides/developing-with-ai.md
@@ -1,0 +1,213 @@
+# Developing with AI
+
+AI coding assistants are increasingly becoming valuable tools for Aurelia development. Modern AI tools can understand large codebases, generate framework-specific code, and help with complex development tasks. This guide covers practical approaches to integrating AI assistants effectively with Aurelia projects.
+
+## How AI Tools Help with Aurelia Development
+
+AI assistants can significantly enhance your Aurelia development workflow:
+
+- **Component generation**: Creating custom elements, attributes, and value converters that follow Aurelia conventions
+- **Service development**: Building properly structured services with dependency injection patterns
+- **Template work**: Generating binding expressions and template syntax
+- **Testing support**: Creating test setups using `@aurelia/testing` patterns
+- **Code explanation**: Understanding complex Aurelia patterns, lifecycle behaviors, and architectural decisions
+- **Migration assistance**: Converting between Aurelia versions or from other frameworks
+- **Refactoring**: Modernizing code to use current Aurelia best practices
+
+## Understanding AI Tool Capabilities
+
+Modern AI assistants have evolved to handle larger contexts and more complex scenarios:
+
+- **Codebase awareness**: Tools can now understand entire project structures and maintain context across multiple files  
+- **Framework expertise**: AI models are trained on extensive Aurelia documentation and code examples
+- **Pattern recognition**: They can identify and replicate established architectural patterns in your codebase
+- **Context-aware suggestions**: Recommendations adapt based on your project's specific configuration and conventions
+
+## Considerations for Different Experience Levels
+
+### Experienced Developers
+AI tools act as powerful accelerators for developers who understand Aurelia fundamentals. You can effectively guide AI suggestions and quickly identify when recommendations need adjustment for your specific use case.
+
+### Growing Developers  
+AI assistants can help you learn Aurelia patterns by example, but it's important to understand the generated code rather than simply copying it. Use AI suggestions as learning opportunities to explore framework concepts and best practices.
+
+### Best Practices for All Levels
+- Review generated code to ensure it follows your project's conventions
+- Test AI-generated components and services thoroughly
+- Use AI suggestions as starting points rather than final solutions
+- Leverage AI to understand complex code patterns and architectural decisions
+
+## Popular AI Development Tools
+
+The AI coding landscape has shifted significantly toward terminal-based tools in 2025, with 76% of developers now using or planning to use AI coding assistants. Here are the most widely adopted tools:
+
+### Terminal-Based AI Agents
+
+**Warp Terminal 2.0**: Advanced terminal with Agent Mode that can autonomously handle multi-step development workflows, including project setup, dependency management, and code generation.
+
+**Google Gemini CLI**: Open-source terminal AI agent with a massive 1M token context window, offering 1,000 free requests per day and strong codebase analysis capabilities.
+
+**Claude Code**: Interactive CLI from Anthropic, excelling at understanding large codebases and complex logic chains across multiple files, especially effective in monorepos.
+
+**Aider**: Command-line AI coding assistant that's consistently ranked among the top tools for terminal-based development workflows.
+
+### IDE-Integrated Tools
+
+**Cursor IDE**: Currently the most popular AI-powered IDE, offering advanced codebase analysis, multi-file editing, and context-aware suggestions.
+
+**GitHub Copilot**: Real-time code completion and chat functionality integrated into VS Code and other popular editors.
+
+**Windsurf**: Agentic development environment that can handle multi-step development tasks autonomously with advanced context understanding.
+
+## Setting Up AI Tools for Aurelia Projects
+
+Each AI tool benefits from project-specific configuration files that provide context about your Aurelia codebase, coding standards, and architectural decisions.
+
+### Configuration Files
+
+| Tool | Configuration File | Location |
+|------|-------------------|----------|
+| Claude Code | `CLAUDE.md` | Project root or hierarchical |
+| GitHub Copilot | `.github/copilot-instructions.md` | Repository root |
+| Cursor AI | `.cursorrules` (legacy) or `.cursor/rules/*.mdc` | Project root or `.cursor/rules/` |
+| Windsurf | `.windsurfrules` or `.windsurf/rules/` | Project root or workspace |
+| Warp Terminal | System prompts, MCP servers | Warp settings or project-level |
+| Gemini CLI | System prompts, MCP servers | CLI configuration |
+| Aider | `.aider.conf.yml` | Project root |
+
+## Practical Guidelines for AI-Assisted Development
+
+### Start Small and Specific
+
+Don't ask AI to "build a user management system." Instead:
+- "Create a basic custom element that displays a user's name and email"
+- "Generate a service that fetches user data with proper error handling"
+- "Write tests for this specific component method"
+
+### Always Review and Test
+
+AI-generated code often looks correct but has subtle issues:
+- **Run your tests** - AI might generate code that compiles but fails at runtime
+- **Check for security issues** - AI may suggest patterns with vulnerabilities
+- **Verify Aurelia conventions** - AI might use outdated v1 syntax or miss lifecycle requirements
+
+### Effective Configuration Strategies
+
+Provide AI tools with specific, actionable guidance about your Aurelia project:
+
+```markdown
+# Aurelia 2.x TypeScript Project
+
+## Framework Patterns
+- Use @customElement decorator with standalone components
+- Implement lifecycle hooks: binding, bound, attaching, attached, detaching, unbinding
+- Bindable properties should use explicit TypeScript interfaces
+- Services use @singleton or @transient decorators
+
+## Development Workflow  
+- Run `npm run build` after package changes, before testing
+- Tests are in packages/__tests__/ directory
+- Use @aurelia/testing package for component testing
+- Follow AAA pattern: Arrange, Act, Assert
+
+## Code Standards
+- TypeScript strict mode enabled
+- Prefer const over let, avoid var
+- Use kebab-case for custom element names
+- Use PascalCase for class names and interfaces
+```
+
+### Optimizing AI Interactions
+
+To get the best results from AI assistants:
+- Be specific about Aurelia version (2.x) to avoid outdated patterns
+- Provide examples of existing code patterns when possible
+- Reference specific requirements like TypeScript strict mode
+- Include context about your project's architectural decisions
+
+## Example Configuration Files
+
+This repository includes example configuration files for popular AI tools:
+
+- [CLAUDE.md Example](developing-with-ai/claude-md-example.md) - For Claude Code
+- [GitHub Copilot Instructions](developing-with-ai/copilot-instructions-example.md) - For GitHub Copilot  
+- [Cursor Rules](developing-with-ai/cursor-rules-example.md) - For Cursor AI
+- [Windsurf Rules](developing-with-ai/windsurf-rules-example.md) - For Windsurf
+- [Warp Terminal Configuration](developing-with-ai/warp-terminal-example.md) - For Warp Terminal 2.0
+- [Gemini CLI Setup](developing-with-ai/gemini-cli-example.md) - For Google Gemini CLI
+- [Aider Configuration](developing-with-ai/aider-example.md) - For Aider
+
+## Working Effectively with AI on Aurelia Projects
+
+### When Generating Components
+
+Be specific about what you actually need:
+
+**Instead of**: "Create a user profile component"  
+**Try**: "Create a custom element that displays user.name and user.email, with a bindable `user` property of type User, and implement unbinding() to clean up any subscriptions"
+
+### For Testing
+
+AI can help with test structure, but verify the logic:
+
+**Good prompt**: "Generate the test setup for testing this UserService.getUser() method, using @aurelia/testing patterns"
+
+**Then verify**: Does the test actually test the right behavior? Are edge cases covered?
+
+### Debugging Limitations
+
+AI can't effectively debug complex issues like:
+- Lifecycle timing problems
+- DI container configuration issues  
+- Template compilation errors
+- Cross-component communication problems
+
+For these, you'll need to understand the underlying Aurelia concepts yourself.
+
+## Common Challenges and Solutions
+
+### Ensuring Modern Aurelia Patterns
+**Challenge**: AI might suggest outdated Aurelia v1 syntax  
+**Solution**: Explicitly specify "Aurelia 2.x" in prompts and configuration files, and include examples of current decorators and patterns
+
+### Build and Test Integration  
+**Challenge**: Generated tests fail due to build requirements  
+**Solution**: Configure AI tools to understand that `npm run build` is required before testing, and include build commands in your setup instructions
+
+### Component Integration Issues
+**Challenge**: AI-generated components don't integrate properly with existing architecture  
+**Solution**: Provide AI with examples of your existing components and specify your DI patterns, lifecycle usage, and binding conventions
+
+## Team Development Guidelines
+
+### Code Review Process
+Apply the same review standards to AI-generated code as any other contribution:
+- Verify adherence to team coding standards and Aurelia best practices
+- Ensure proper testing coverage and error handling
+- Check for security implications and performance considerations  
+- Confirm maintainability and documentation quality
+
+### Recommended AI Usage Patterns
+**Effective applications**:
+- Component and service boilerplate generation
+- Test structure creation and test case generation
+- Documentation and code comments
+- Refactoring existing code to modern patterns
+- Exploring and understanding complex Aurelia concepts
+
+**Areas requiring careful consideration**:
+- Critical business logic implementation
+- Security-sensitive operations
+- Performance-critical code paths
+- Architectural and design decisions
+
+## Integration Best Practices
+
+AI tools work best when integrated thoughtfully into your development workflow:
+
+1. **Start with understanding**: Ensure team members understand Aurelia fundamentals before relying heavily on AI assistance
+2. **Iterate and refine**: Use AI suggestions as starting points and refine based on your project's specific needs
+3. **Maintain context**: Keep AI tools updated with your evolving project patterns and conventions
+4. **Balance assistance with learning**: Use AI to accelerate development while continuing to build framework expertise
+
+The goal is to leverage AI capabilities to enhance productivity while maintaining code quality and team knowledge.

--- a/docs/user-docs/developer-guides/developing-with-ai/aider-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/aider-example.md
@@ -1,0 +1,384 @@
+# Aider Configuration Example for Aurelia Projects
+
+This document shows how to configure Aider, a command-line AI coding assistant, for effective Aurelia development with proper git integration and codebase understanding.
+
+## Aider Overview
+
+Aider is a command-line AI coding assistant that excels at:
+- **Git integration**: Automatically commits changes with descriptive messages
+- **Codebase awareness**: Understands project structure and file relationships
+- **Incremental development**: Makes focused changes while preserving existing code
+- **Multiple file editing**: Can coordinate changes across multiple files
+- **Model flexibility**: Supports various AI models (Claude, GPT-4, etc.)
+
+## Installation and Setup
+
+### Installation
+
+```bash
+# Install Aider
+pip install aider-chat
+
+# Or use pipx for isolated installation
+pipx install aider-chat
+
+# Verify installation
+aider --version
+```
+
+### Initial Configuration
+
+```bash
+# Set up API keys (choose your preferred model)
+export ANTHROPIC_API_KEY=your_key_here  # For Claude
+export OPENAI_API_KEY=your_key_here     # For GPT-4
+
+# Initialize in your Aurelia project
+cd your-aurelia-project
+aider --help
+```
+
+## Project Configuration: .aider.conf.yml
+
+Create a configuration file in your project root:
+
+```yaml
+# .aider.conf.yml - Aurelia project configuration
+
+# Model selection (recommended for Aurelia development)
+model: claude-3-5-sonnet-20241022
+
+# Git configuration
+auto-commits: true
+commit-prompt: |
+  Please provide a concise commit message that:
+  - Starts with a conventional commit type (feat:, fix:, refactor:, test:, docs:)
+  - Describes the Aurelia-specific changes made
+  - Mentions component/service names when relevant
+  
+# File patterns to include automatically
+include:
+  - "src/**/*.ts"
+  - "src/**/*.html"
+  - "packages/**/*.ts"
+  - "packages/__tests__/**/*.ts"
+  - "package.json"
+  - "tsconfig.json"
+
+# File patterns to exclude
+exclude:
+  - "node_modules/**"
+  - "dist/**"
+  - "*.log"
+  - ".git/**"
+  - "coverage/**"
+
+# Aurelia-specific instructions
+system-prompt: |
+  You are an expert Aurelia 2.x developer. When working with this codebase:
+
+  ## Framework Context
+  - This is an Aurelia 2.x TypeScript application
+  - Use modern @customElement decorator syntax, not v1 registration
+  - Components follow MVVM with clear view/view-model separation
+  - Dependency injection via @aurelia/kernel with @singleton/@transient
+  - Lifecycle: creating → created → binding → bound → attaching → attached → detaching → unbinding
+
+  ## Critical Build Requirements
+  - Always run `npm run build` after changes to packages/ directory
+  - Build is required before running tests in packages/__tests__/
+  - Use `npm run dev -- -t "pattern"` for targeted testing
+  - Tests must use @aurelia/testing package
+
+  ## Code Standards
+  - TypeScript strict mode - never use `any` type
+  - Custom elements use kebab-case names, classes use PascalCase
+  - Always implement proper cleanup in unbinding() lifecycle hook
+  - Bindable properties need explicit TypeScript interfaces
+  - Services use @singleton for stateless, @transient for stateful
+  - Prefer const over let, never use var
+
+  ## When making changes:
+  1. Preserve existing patterns and architecture
+  2. Follow established naming conventions
+  3. Ensure proper lifecycle hook implementation
+  4. Add/update tests as needed
+  5. Maintain TypeScript type safety
+
+# Default files to add to chat
+default-files:
+  - "src/"
+  - "package.json"
+
+# Testing integration
+test-cmd: "npm run build && npm run test"
+
+# Linting integration  
+lint-cmd: "npm run lint"
+```
+
+## Usage Patterns for Aurelia Development
+
+### Component Development
+
+```bash
+# Create a new Aurelia component with proper structure
+aider --message "Create a user-avatar custom element that:
+- Takes a bindable user property with User interface
+- Shows user.name and user.avatar image
+- Has a size property (small, medium, large) 
+- Implements proper lifecycle hooks for cleanup
+- Includes comprehensive tests using @aurelia/testing"
+
+# Add the component files to the conversation
+aider src/components/user-avatar.ts src/components/user-avatar.html
+```
+
+### Service Development
+
+```bash
+# Generate a service with proper DI patterns
+aider --message "Create a NotificationService that:
+- Uses @singleton decorator
+- Has methods: show(message, type), dismiss(id), clear()
+- Manages notification state with proper cleanup
+- Integrates with existing EventAggregator
+- Includes error handling and logging
+- Has complete unit tests"
+
+# Include related files for context
+aider src/services/ src/interfaces/
+```
+
+### Refactoring and Modernization
+
+```bash
+# Modernize existing components
+aider --message "Refactor the UserProfile component to:
+- Use modern Aurelia 2.x patterns
+- Replace any remaining v1 syntax
+- Add proper TypeScript types for all properties
+- Implement missing lifecycle hooks
+- Update tests to use latest @aurelia/testing patterns"
+
+# Include the component and its tests
+aider src/components/user-profile.ts packages/__tests__/src/user-profile.spec.ts
+```
+
+### Bug Fixes and Debugging
+
+```bash
+# Fix complex issues with full context
+aider --message "The shopping cart component isn't updating when items are added. 
+Debug and fix the reactivity issue. The problem seems to be in the binding between 
+CartService and CartComponent."
+
+# Add relevant files to provide context
+aider src/components/shopping-cart.ts src/services/cart-service.ts src/interfaces/cart.ts
+```
+
+## Advanced Configuration Options
+
+### Model-Specific Settings
+
+```yaml
+# Claude-specific configuration for better Aurelia understanding
+model-settings:
+  claude-3-5-sonnet-20241022:
+    temperature: 0.1
+    max-tokens: 4096
+    system-prompt-append: |
+      Focus on TypeScript type safety and Aurelia lifecycle correctness.
+      Always validate that components properly implement cleanup in unbinding().
+
+# GPT-4 alternative configuration  
+  gpt-4:
+    temperature: 0.2
+    max-tokens: 4096
+    system-prompt-append: |
+      Prioritize Aurelia 2.x patterns over v1 syntax.
+      Ensure all generated code follows the project's TypeScript strict mode.
+```
+
+### Git Integration Settings
+
+```yaml
+# Enhanced git configuration
+git:
+  auto-commits: true
+  commit-prompt: |
+    Generate a commit message using conventional commits format:
+    
+    Types: feat, fix, docs, style, refactor, test, chore
+    Scope: component name, service name, or area (e.g., auth, cart, ui)
+    
+    Examples:
+    - feat(cart): add remove item functionality
+    - fix(user-profile): resolve binding update issue  
+    - refactor(services): modernize DI patterns
+    - test(components): add missing lifecycle tests
+
+  # Don't commit certain file types
+  ignore-files:
+    - "*.log"
+    - "dist/"
+    - "node_modules/"
+    - ".env*"
+```
+
+### Testing Integration
+
+```yaml
+# Test automation
+test-integration:
+  pre-commit-tests: true
+  test-command: "npm run build && npm run test"
+  lint-command: "npm run lint && npm run typecheck"
+  
+  # Run tests automatically after changes
+  auto-test-patterns:
+    - "src/components/**/*.ts"
+    - "src/services/**/*.ts"
+    - "packages/__tests__/**/*.ts"
+```
+
+## Workflow Examples
+
+### New Feature Development
+
+```bash
+# Start a new feature with proper git branch
+git checkout -b feature/user-preferences
+
+# Use Aider to develop the feature
+aider --message "Implement user preferences system:
+1. Create UserPreferences interface
+2. Create PreferencesService with save/load methods
+3. Create preferences-panel custom element
+4. Add proper error handling and validation
+5. Write comprehensive tests
+6. Update existing components to use preferences"
+
+# Aider will create multiple files and commit them appropriately
+```
+
+### Code Review Preparation
+
+```bash
+# Before creating a PR, use Aider to review changes
+aider --message "Review the changes in this branch for:
+- Aurelia best practices compliance
+- TypeScript type safety
+- Test coverage completeness
+- Performance implications
+- Accessibility considerations
+Make any necessary improvements."
+```
+
+### Legacy Code Modernization
+
+```bash
+# Modernize old Aurelia v1 code
+aider src/legacy/ --message "Modernize these legacy components to Aurelia 2.x:
+- Update decorator syntax
+- Add proper TypeScript types
+- Implement missing lifecycle hooks
+- Update binding expressions
+- Modernize DI patterns
+- Update tests to use @aurelia/testing"
+```
+
+## Integration with Development Tools
+
+### IDE Integration
+
+```bash
+# Create a shell script for easy IDE integration
+#!/bin/bash
+# scripts/aider-component.sh
+aider --message "Create Aurelia component: $1" src/components/
+```
+
+### Package.json Scripts
+
+```json
+{
+  "scripts": {
+    "ai:component": "aider --message 'Create new Aurelia component' src/components/",
+    "ai:service": "aider --message 'Create new Aurelia service' src/services/",
+    "ai:fix": "aider --message 'Fix issues in current files'",
+    "ai:test": "aider --message 'Add missing tests' packages/__tests__/",
+    "ai:refactor": "aider --message 'Refactor and modernize code'"
+  }
+}
+```
+
+### Pre-commit Hooks
+
+```bash
+#!/bin/bash
+# .git/hooks/pre-commit
+# Run Aider for final code review before commit
+
+if command -v aider &> /dev/null; then
+    echo "Running AI code review..."
+    aider --no-auto-commits --message "Review staged changes for:
+    - Code quality issues
+    - Aurelia convention compliance  
+    - Missing error handling
+    - Test coverage gaps
+    Fix any issues found."
+fi
+```
+
+## Best Practices
+
+### Effective Prompting
+
+- **Be specific**: "Create a UserService with CRUD operations" vs "Create a service"
+- **Include context**: Reference existing patterns and interfaces in your project
+- **Specify requirements**: Mention testing, error handling, TypeScript types
+- **Set boundaries**: Define what should/shouldn't be changed
+
+### File Management
+
+- Start conversations with relevant files already added
+- Use `aider --include` patterns to automatically include related files
+- Exclude large generated files that don't need AI modification
+- Keep conversations focused on related changes
+
+### Git Workflow
+
+- Use descriptive commit messages that Aider generates
+- Review changes before they're committed (use `--no-auto-commits` for manual control)
+- Create feature branches for larger changes
+- Use conventional commit format for better project history
+
+### Quality Assurance
+
+- Always run tests after Aider makes changes: `npm run build && npm run test`
+- Use linting integration to catch style issues early
+- Review generated TypeScript types for correctness
+- Verify that lifecycle hooks are properly implemented
+
+## Troubleshooting
+
+### Common Issues
+
+**Aider suggests outdated Aurelia patterns**
+- Update your system prompt with more specific v2 examples
+- Include recent Aurelia components as context files
+
+**Generated code doesn't build**
+- Ensure build requirements are clear in system prompt
+- Add TypeScript configuration files to context
+
+**Tests fail after changes**
+- Include existing test files in conversations
+- Specify `@aurelia/testing` requirements in system prompt
+
+**Git commits are too generic**
+- Customize the commit-prompt with project-specific guidelines
+- Review and edit commit messages before pushing
+
+Aider's git integration and incremental development approach make it particularly well-suited for maintaining and evolving Aurelia applications while preserving code quality and project conventions.

--- a/docs/user-docs/developer-guides/developing-with-ai/claude-md-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/claude-md-example.md
@@ -1,0 +1,110 @@
+# CLAUDE.md Example for Aurelia Projects
+
+This is an example `CLAUDE.md` file optimized for Aurelia development with Claude Code. Place this file in your project root or use hierarchical placement for monorepos.
+
+```markdown
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with this Aurelia application.
+
+## Framework & Architecture
+
+- Aurelia 2.x TypeScript application
+- Dependency injection with `@aurelia/kernel` - hierarchical containers
+- Template compiler with `@aurelia/template-compiler`
+- Resources follow MVVM pattern with clear separation of concerns
+- Components use lifecycle hooks: creating → created → binding → bound → attaching → attached
+
+## Project Structure
+
+- `/src/components/` - Custom elements following kebab-case naming
+- `/src/attributes/` - Custom attributes and behaviors
+- `/src/value-converters/` - Value converters and binding behaviors
+- `/src/services/` - Application services registered via DI
+- `/packages/__tests__/` - Test files (require building before execution)
+
+## Development Commands
+
+- `npm run build` - Build all packages (REQUIRED before testing)
+- `npm run test` - Run all tests
+- `npm run dev -- -t "pattern"` - Run specific test patterns
+- `npm run lint` - ESLint validation
+- `npm run rebuild` - Clean build from scratch
+
+## Code Standards
+
+### TypeScript
+- Strict mode enabled - avoid `any` type
+- Prefer interfaces over type aliases for object shapes
+- Use explicit return types for public methods
+- Handle undefined/null explicitly
+
+### Aurelia Patterns
+- Use `@singleton` for stateless services
+- Use `@transient` for stateful services  
+- Custom elements use kebab-case: `<user-profile>`
+- Classes use PascalCase: `UserProfileCustomElement`
+- Always implement proper cleanup in `detaching`/`unbinding`
+
+### DI Registration
+- Register resources via `StandardConfiguration.customize()`
+- Use constructor injection with `@resolve()` decorator
+- Services resolve through `container.get()` or injection
+
+### Testing
+- Use `@aurelia/testing` package for component tests
+- Follow AAA pattern: Arrange, Act, Assert
+- Test both happy path and error scenarios
+- Build packages before running tests
+
+## Key Conventions
+
+- Always quote file paths with spaces: `"path with spaces/file.ts"`
+- Use early returns to reduce nesting
+- Prefer const over let, never use var
+- Include TypeScript types for all bindable properties
+- Implement proper error handling in lifecycle hooks
+- Use Aurelia logger system (ILogger) instead of console.log
+
+## Architecture Notes
+
+- Resources have metadata and are discoverable via conventions
+- Templates compile to instruction objects for DOM binding
+- Observation system uses automatic dependency tracking
+- Container hierarchy enables scoped services per component tree
+```
+
+## Key Features of This Configuration
+
+### 1. **Concise and Focused**
+Following 2025 best practices, this configuration is under 500 lines and uses short, declarative bullet points rather than long paragraphs.
+
+### 2. **Aurelia-Specific Context**
+Provides essential information about Aurelia's architecture, DI system, and lifecycle patterns that Claude needs to generate appropriate code.
+
+### 3. **Development Workflow**
+Includes critical build requirements and commands specific to the Aurelia monorepo structure.
+
+### 4. **Code Quality Standards**
+Specifies TypeScript best practices and Aurelia-specific naming conventions to ensure consistent code generation.
+
+## Usage Tips
+
+### Hierarchical Placement
+For monorepos, you can place CLAUDE.md files at different levels:
+- Root `/CLAUDE.md` - Project-wide conventions
+- `/packages/runtime/CLAUDE.md` - Package-specific rules
+- `/examples/CLAUDE.md` - Example-specific context
+
+### Regular Refinement
+Update your CLAUDE.md file as your project evolves:
+- Add new architectural decisions
+- Update build commands
+- Refine coding standards based on team feedback
+- Remove outdated or redundant information
+
+### Auto-Generation
+Use Claude Code's `/init` command to automatically generate a CLAUDE.md file by analyzing your codebase, then refine it with project-specific details.
+
+### Integration with Existing Files
+This example works well with the existing `.cursorrules` file in the Aurelia repository, providing complementary guidance for different AI tools.

--- a/docs/user-docs/developer-guides/developing-with-ai/copilot-instructions-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/copilot-instructions-example.md
@@ -1,0 +1,215 @@
+# GitHub Copilot Instructions Example for Aurelia Projects
+
+This is an example `.github/copilot-instructions.md` file optimized for Aurelia development with GitHub Copilot. Place this file in your repository root.
+
+```markdown
+# GitHub Copilot Instructions
+
+## Project Overview
+
+This is an Aurelia 2.x TypeScript application using a monorepo structure with Turbo for build orchestration.
+
+## Architecture
+
+We use Aurelia's dependency injection system from `@aurelia/kernel` with hierarchical containers.
+
+Components follow MVVM pattern with clear separation between view models and templates.
+
+Resources (custom elements, attributes, value converters) are registered via `StandardConfiguration.customize()`.
+
+Templates compile to instruction objects that describe DOM bindings and component instantiation.
+
+## Folder Structure
+
+- `/packages/` - Core Aurelia packages
+- `/packages/__tests__/` - Test files requiring build before execution
+- `/packages-tooling/` - Development and build tools
+- `/src/` - Application source code in typical projects
+- `/examples/` - Example applications
+
+## Coding Standards
+
+### TypeScript
+We use strict TypeScript with explicit types - avoid `any` type.
+
+Prefer interfaces over type aliases for object shapes.
+
+Use union types and generic constraints appropriately.
+
+Handle undefined and null explicitly with strict null checks.
+
+### Aurelia Conventions
+Custom elements use kebab-case naming: `<user-profile>` maps to `UserProfileCustomElement`.
+
+Classes use PascalCase: `UserService`, `MyCustomElement`.
+
+Use `@singleton` decorator for stateless services.
+
+Use `@transient` decorator for stateful services.
+
+Bindable properties should have explicit TypeScript types.
+
+### Component Lifecycle
+Implement proper cleanup in `detaching` and `unbinding` lifecycle hooks.
+
+Use lifecycle hooks in order: creating → created → binding → bound → attaching → attached.
+
+Always handle errors in lifecycle methods appropriately.
+
+### Dependency Injection
+Use constructor injection with `@resolve()` decorator when needed.
+
+Register services in DI container before use.
+
+Services resolve through `container.get()` or constructor injection.
+
+## Development Workflow
+
+### Building
+Always run `npm run build` after making changes to packages before running tests.
+
+Use `npm run rebuild` for clean builds when encountering issues.
+
+Build is required for both package changes and test file modifications.
+
+### Testing
+Tests are located in `packages/__tests__` directory.
+
+Use `@aurelia/testing` package for component testing.
+
+Follow AAA pattern: Arrange, Act, Assert.
+
+Run specific tests with `npm run dev -- -t "pattern"` for faster feedback.
+
+### Code Quality
+Run `npm run lint` before committing changes.
+
+Prefer positive if statements over negative conditions.
+
+Use early returns to reduce nesting.
+
+Always use curly braces for control structures.
+
+Prefer const over let, never use var.
+
+## Framework-Specific Patterns
+
+### Custom Elements
+```typescript
+@customElement({
+  name: 'user-profile',
+  template: '<div>Template content</div>'
+})
+export class UserProfile {
+  @bindable public user?: User;
+  
+  public binding(): void {
+    // Setup logic
+  }
+  
+  public unbinding(): void {
+    // Cleanup logic
+  }
+}
+```
+
+### Services
+```typescript
+@singleton
+export class UserService {
+  constructor(@IHttpClient private readonly http: IHttpClient) {}
+}
+```
+
+### Value Converters
+```typescript
+@valueConverter('formatDate')
+export class DateFormatValueConverter {
+  public toView(value: Date, format?: string): string {
+    // Conversion logic
+  }
+}
+```
+
+## Logging
+
+Use Aurelia's logger system (ILogger) instead of console.log.
+
+Refer to router package for logging implementation patterns.
+
+## Error Handling
+
+Never expose or log secrets and keys.
+
+Handle binding and lifecycle errors gracefully.
+
+Provide meaningful error messages for development debugging.
+
+## Testing Patterns
+
+Avoid loops in unit tests - write explicit test cases.
+
+Use methods from `@aurelia/testing` package for assertions.
+
+Test both happy path and error scenarios.
+
+Create proper test setups and teardowns for component tests.
+```
+
+## Key Features of This Configuration
+
+### 1. **Repository-Wide Context**
+This file provides broad guidance that applies to all developers working with GitHub Copilot in the repository.
+
+### 2. **Short, Self-Contained Instructions**
+Each instruction is a simple statement that can be applied broadly across different coding scenarios.
+
+### 3. **Framework-Specific Patterns**
+Includes concrete examples of Aurelia patterns that Copilot can reference when generating code.
+
+### 4. **Development Workflow Integration**
+Covers build requirements and testing patterns specific to the Aurelia monorepo structure.
+
+## Alternative: Multiple Instruction Files
+
+For larger projects, consider using the newer `.github/instructions/` directory with multiple `.instructions.md` files:
+
+### `.github/instructions/components.instructions.md`
+```markdown
+---
+appliesTo:
+  - "src/components/**/*.ts"
+  - "packages/*/src/**/*element.ts"
+---
+
+Generate Aurelia custom elements with proper lifecycle hooks and TypeScript types.
+
+Use kebab-case for element names and PascalCase for classes.
+
+Always include proper cleanup in unbinding lifecycle hook.
+```
+
+### `.github/instructions/services.instructions.md`
+```markdown
+---
+appliesTo:
+  - "src/services/**/*.ts"
+  - "packages/*/src/**/*service.ts"
+---
+
+Create services with appropriate DI decorators (@singleton or @transient).
+
+Use constructor injection for dependencies.
+
+Implement proper error handling and logging.
+```
+
+## Team Collaboration
+
+Keep this file under version control and treat it as a living document.
+
+Update instructions as team coding practices evolve.
+
+All team members benefit from consistent Copilot behavior through shared instructions.
+
+Reference this file during code reviews to ensure Copilot suggestions align with project standards.

--- a/docs/user-docs/developer-guides/developing-with-ai/cursor-rules-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/cursor-rules-example.md
@@ -1,0 +1,220 @@
+# Cursor Rules Example for Aurelia Projects
+
+This document shows both legacy `.cursorrules` format and the modern `.cursor/rules/*.mdc` system for Aurelia development with Cursor AI.
+
+## Legacy Format: .cursorrules
+
+Place this file in your project root (note: this format will be deprecated):
+
+```markdown
+# Aurelia 2.x TypeScript Application Rules
+
+## Framework Context
+- Aurelia 2.x application with TypeScript strict mode
+- Dependency injection via @aurelia/kernel with hierarchical containers
+- MVVM architecture with clear view/view-model separation
+- Template compilation to instruction objects for DOM binding
+
+## Project Structure
+- /packages/ - Core Aurelia framework packages
+- /packages/__tests__/ - Test files (require npm run build before execution)
+- /src/components/ - Custom elements using kebab-case naming
+- /src/services/ - Application services with DI registration
+
+## Development Workflow
+- Always run `npm run build` after package changes before testing
+- Use `npm run dev -- -t "pattern"` for specific test execution
+- Build required for both package and test file modifications
+- Run `npm run lint` before committing changes
+
+## TypeScript Standards
+- Strict mode enabled - never use `any` type
+- Prefer interfaces over type aliases for object shapes
+- Use explicit return types for public methods
+- Handle undefined/null with strict null checks
+
+## Aurelia Conventions
+- Custom elements: kebab-case names, PascalCase classes
+- Services: @singleton for stateless, @transient for stateful
+- Lifecycle: creating → created → binding → bound → attaching → attached
+- Always implement cleanup in detaching/unbinding hooks
+- Use constructor injection with @resolve() when needed
+
+## Code Style
+- Prefer positive if statements over negative
+- Use early returns to reduce nesting
+- Always use curly braces for control structures
+- Prefer const over let, never use var
+- Use Aurelia logger (ILogger) instead of console.log
+
+## Testing Requirements
+- Use @aurelia/testing package for component tests
+- Follow AAA pattern (Arrange, Act, Assert)  
+- Test both happy path and error scenarios
+- Avoid loops in unit tests - write explicit cases
+```
+
+## Modern Format: .cursor/rules/*.mdc
+
+Create rule files in the `.cursor/rules/` directory with the `.mdc` extension:
+
+### `.cursor/rules/aurelia-framework.mdc`
+```markdown
+---
+description: "Aurelia framework patterns and conventions"
+globs: ["**/*.ts", "**/*.html"]
+alwaysApply: true
+---
+
+Generate Aurelia 2.x components following these patterns:
+
+- Use `@customElement` decorator with kebab-case names
+- Implement proper lifecycle hooks when needed
+- Use TypeScript strict mode with explicit types
+- Follow MVVM architecture principles
+```
+
+### `.cursor/rules/dependency-injection.mdc`
+```markdown
+---
+description: "Dependency injection patterns for Aurelia"
+globs: ["**/services/**/*.ts", "**/*service.ts"]
+alwaysApply: false
+---
+
+Create services with proper DI registration:
+
+- Use `@singleton` for stateless services
+- Use `@transient` for stateful services
+- Implement constructor injection for dependencies
+- Register services via StandardConfiguration.customize()
+```
+
+### `.cursor/rules/component-lifecycle.mdc`
+```markdown
+---
+description: "Aurelia component lifecycle management"
+globs: ["**/components/**/*.ts", "**/*element.ts"]
+alwaysApply: false
+---
+
+Implement Aurelia lifecycle hooks correctly:
+
+- Use lifecycle order: creating → created → binding → bound → attaching → attached
+- Always provide cleanup in detaching/unbinding hooks
+- Handle errors gracefully in lifecycle methods
+- Use bindable properties with explicit TypeScript types
+```
+
+### `.cursor/rules/testing-patterns.mdc`
+```markdown
+---
+description: "Testing patterns for Aurelia applications"
+globs: ["**/__tests__/**/*.ts", "**/*.spec.ts", "**/*.test.ts"]
+alwaysApply: false
+---
+
+Generate tests using Aurelia testing patterns:
+
+- Use @aurelia/testing package for component testing
+- Follow AAA pattern: Arrange, Act, Assert
+- Create explicit test cases instead of loops
+- Test both success and error conditions
+- Remember: `npm run build` required before test execution
+```
+
+### `.cursor/rules/build-requirements.mdc`
+```markdown
+---
+description: "Build and development workflow requirements"
+globs: ["**/*.ts", "**/*.js"]
+alwaysApply: true
+---
+
+Remember Aurelia build requirements:
+
+- Run `npm run build` after making changes to packages
+- Build required before running tests
+- Use `npm run dev -- -t "pattern"` for specific tests
+- Run `npm run lint` before committing
+```
+
+## Project-Specific Rules Directory Structure
+
+For larger projects, organize rules hierarchically:
+
+```
+project/
+├── .cursor/
+│   └── rules/
+│       ├── aurelia-framework.mdc      # Framework-wide rules
+│       ├── build-requirements.mdc     # Build workflow
+│       └── typescript-standards.mdc   # TypeScript conventions
+├── src/
+│   ├── components/
+│   │   └── .cursor/
+│   │       └── rules/
+│   │           └── component-patterns.mdc  # Component-specific rules
+│   └── services/
+│       └── .cursor/
+│           └── rules/
+│               └── service-patterns.mdc    # Service-specific rules
+```
+
+## Rule Generation with Cursor
+
+### Using the Command Palette
+1. Open Cursor Settings > Rules
+2. Click "New Cursor Rule" to create a rule file
+3. Use the command palette: "New Cursor Rule"
+
+### Auto-Generation from Conversations
+Use the `/Generate Cursor Rules` command during conversations to create rules based on decisions made during coding sessions.
+
+### Example Auto-Generated Rule
+After discussing Aurelia component patterns, you might generate:
+
+```markdown
+---
+description: "Custom element bindable properties pattern"
+globs: ["**/components/**/*.ts"]
+alwaysApply: false
+---
+
+When creating bindable properties for Aurelia custom elements:
+
+- Use @bindable decorator with explicit TypeScript types
+- Provide default values when appropriate
+- Consider property change callbacks for complex logic
+- Document bindable properties in component comments
+```
+
+## Best Practices for Cursor Rules
+
+### 1. Keep Rules Focused
+Each rule should address a specific pattern or convention, not multiple concerns.
+
+### 2. Use Appropriate Globs
+Target rules to relevant file types and locations to avoid context pollution.
+
+### 3. Set alwaysApply Strategically
+- `true` for fundamental patterns that always apply
+- `false` for context-specific rules that apply to certain file types
+
+### 4. Regular Refinement
+Update rules based on team feedback and evolving project needs.
+
+### 5. Team Collaboration
+Keep rule files in version control for consistent team experience.
+
+## Migration from Legacy .cursorrules
+
+To migrate from `.cursorrules` to the modern system:
+
+1. Create `.cursor/rules/` directory
+2. Break down your `.cursorrules` content into focused rule files
+3. Add appropriate frontmatter with globs and descriptions
+4. Test rules with relevant file types
+5. Remove or rename the legacy `.cursorrules` file
+
+The modern system provides better organization, context control, and team collaboration compared to the legacy format.

--- a/docs/user-docs/developer-guides/developing-with-ai/gemini-cli-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/gemini-cli-example.md
@@ -1,0 +1,394 @@
+# Google Gemini CLI Configuration Example for Aurelia Projects
+
+This document shows how to configure Google Gemini CLI for effective Aurelia development, leveraging its massive 1M token context window and open-source extensibility.
+
+## Gemini CLI Overview
+
+Google Gemini CLI is an open-source AI agent that brings Gemini directly into your terminal with:
+- **1M token context window**: Can process entire large codebases
+- **Free tier**: 1,000 requests per day, 60 per minute at no charge  
+- **MCP server support**: Extensible through Model Context Protocol
+- **Multimodal capabilities**: Can work with PDFs, sketches, and images
+- **ReAct loop**: Uses reason and act patterns for complex tasks
+
+## Initial Setup and Configuration
+
+### Installation and Authentication
+
+```bash
+# Install Gemini CLI
+npm install -g @google/gemini-cli
+
+# Authenticate with personal Google account for free tier
+gemini auth login
+
+# Verify installation
+gemini --version
+```
+
+### Basic Configuration
+
+Create a project-specific configuration for Aurelia development:
+
+```bash
+# Initialize Gemini CLI in your Aurelia project
+cd your-aurelia-project
+gemini init
+```
+
+## System Prompts for Aurelia Development
+
+### Core Aurelia Context
+
+```markdown
+# Aurelia 2.x Development Assistant
+
+You are an expert Aurelia 2.x developer. Key context about this project:
+
+## Framework Information
+- Aurelia 2.x TypeScript application using modern syntax
+- Architecture: MVVM with dependency injection via @aurelia/kernel
+- Components use @customElement decorator, not NgModules
+- Lifecycle: creating → created → binding → bound → attaching → attached → detaching → unbinding
+- Services registered with @singleton or @transient decorators
+
+## Project Structure
+```
+aurelia-project/
+├── packages/                 # Core framework packages  
+│   └── __tests__/           # Tests (require build first)
+├── src/
+│   ├── components/          # Custom elements (kebab-case)
+│   ├── services/           # DI services
+│   └── value-converters/   # Value converters & behaviors
+└── package.json
+```
+
+## Critical Build Requirements
+- ALWAYS run `npm run build` after changes to packages/
+- Build is required before running any tests
+- Use `npm run dev -- -t "pattern"` for targeted testing
+- Tests located in packages/__tests__/ directory
+
+## Code Standards
+- TypeScript strict mode enabled - never use `any`
+- Bindable properties must have explicit types
+- Custom elements use kebab-case: `<user-profile>`
+- Classes use PascalCase: `UserProfileCustomElement`
+- Always implement proper cleanup in unbinding() hook
+- Use early returns, prefer const over let
+```
+
+### Advanced Development Patterns
+
+```markdown
+## Aurelia Component Patterns
+
+### Standard Custom Element
+```typescript
+import { customElement, bindable } from '@aurelia/runtime-html';
+
+@customElement({
+  name: 'user-profile',
+  template: `<div class="user-profile">
+    <h3>\${user.name}</h3>
+    <p>\${user.email}</p>
+  </div>`
+})
+export class UserProfile {
+  @bindable public user?: User;
+  @bindable public readonly?: boolean = false;
+  
+  public binding(): void {
+    // Initialization logic
+    this.validateUser();
+  }
+  
+  public unbinding(): void {
+    // Cleanup: remove listeners, clear timers, etc.
+  }
+  
+  private validateUser(): void {
+    if (!this.user) {
+      throw new Error('UserProfile requires a user object');
+    }
+  }
+}
+```
+
+### Service Pattern
+```typescript
+import { singleton, IHttpClient } from '@aurelia/kernel';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+@singleton
+export class UserService {
+  constructor(@IHttpClient private readonly http: IHttpClient) {}
+  
+  public async getUser(id: string): Promise<User> {
+    try {
+      const response = await this.http.fetch(`/api/users/${id}`);
+      return await response.json();
+    } catch (error) {
+      this.logger.error('Failed to fetch user', { id, error });
+      throw new Error(`Unable to load user ${id}`);
+    }
+  }
+}
+```
+
+### Testing Pattern
+```typescript
+import { TestContext, assert } from '@aurelia/testing';
+import { UserProfile } from '../user-profile';
+
+describe('UserProfile', () => {
+  it('should render user information correctly', async () => {
+    // Arrange
+    const ctx = TestContext.create();
+    const { component } = ctx.createComponent(UserProfile);
+    const mockUser = { id: '1', name: 'John Doe', email: 'john@example.com' };
+    
+    // Act
+    component.user = mockUser;
+    await ctx.startPromise;
+    
+    // Assert
+    assert.includes(ctx.host.textContent, mockUser.name);
+    assert.includes(ctx.host.textContent, mockUser.email);
+  });
+});
+```
+```
+
+## MCP Server Configuration
+
+Gemini CLI supports MCP servers for enhanced functionality:
+
+### Aurelia-Specific MCP Server
+
+```json
+{
+  "mcpServers": {
+    "aurelia-dev": {
+      "command": "node",
+      "args": ["aurelia-mcp-server.js"],
+      "env": {
+        "AURELIA_PROJECT_ROOT": "."
+      }
+    }
+  }
+}
+```
+
+### Custom MCP Tools for Aurelia
+
+```javascript
+// aurelia-mcp-server.js
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+
+const server = new Server({
+  name: 'aurelia-dev-server',
+  version: '1.0.0'
+});
+
+// Tool for generating Aurelia components
+server.setRequestHandler('tools/call', async (request) => {
+  if (request.params.name === 'generate_aurelia_component') {
+    const { name, bindables, lifecycle } = request.params.arguments;
+    
+    return {
+      content: [{
+        type: 'text',
+        text: generateAureliaComponent(name, bindables, lifecycle)
+      }]
+    };
+  }
+});
+
+// Tool for running Aurelia build + test sequence
+server.setRequestHandler('tools/call', async (request) => {
+  if (request.params.name === 'aurelia_test_sequence') {
+    const { pattern } = request.params.arguments;
+    
+    // Run build first, then tests
+    const buildResult = await exec('npm run build');
+    if (buildResult.code === 0) {
+      const testResult = await exec(`npm run dev -- -t "${pattern}"`);
+      return { content: [{ type: 'text', text: testResult.stdout }] };
+    }
+    
+    return { content: [{ type: 'text', text: `Build failed: ${buildResult.stderr}` }] };
+  }
+});
+```
+
+## Effective Usage Patterns
+
+### Component Generation
+
+```bash
+# Generate a complete Aurelia component with tests
+gemini "Create a shopping-cart-item custom element that:
+- Has bindable properties: item (CartItem), quantity (number), readonly (boolean)
+- Implements binding() and unbinding() lifecycle hooks
+- Includes quantity change methods with validation  
+- Has comprehensive tests using @aurelia/testing
+- Follows our TypeScript strict mode requirements"
+```
+
+### Service Development
+
+```bash
+# Generate a service with proper DI patterns
+gemini "Create a ProductService that:
+- Uses @singleton decorator
+- Injects IHttpClient for API calls
+- Has methods: getProduct(id), searchProducts(query), updateProduct(product)
+- Implements proper error handling and logging
+- Includes TypeScript interfaces for all data types
+- Has complete unit tests with mocked HTTP calls"
+```
+
+### Codebase Analysis
+
+```bash
+# Leverage the 1M token context for large codebase analysis
+gemini "Analyze this entire Aurelia project and identify:
+- Components that don't implement proper cleanup in unbinding()
+- Services that could benefit from better error handling  
+- Test files that need to be updated for the latest patterns
+- Opportunities to modernize code to current Aurelia 2.x best practices"
+```
+
+### Debugging Complex Issues
+
+```bash
+# Multi-file debugging with full context
+gemini "I'm having an issue where the UserProfile component isn't updating when the user property changes. Here's the relevant code: @src/components/user-profile.ts @src/services/user-service.ts @src/app.ts
+
+Please analyze the binding flow and identify why the component isn't reactive to property changes."
+```
+
+## Advanced Features
+
+### Multimodal Development
+
+```bash
+# Work with design mockups or architecture diagrams
+gemini "Based on this UI mockup [attach image], generate an Aurelia component structure that implements this design with proper responsive behavior and accessibility features"
+
+# Convert PDF specifications to code
+gemini "From this API specification PDF [attach file], generate Aurelia service classes with proper TypeScript interfaces and error handling"
+```
+
+### Large Refactoring Tasks
+
+```bash
+# Leverage large context for major refactoring
+gemini "Refactor this entire Aurelia application to:
+- Migrate from constructor injection to property injection where appropriate
+- Update all components to use modern lifecycle patterns
+- Add proper TypeScript types throughout
+- Ensure all custom elements follow kebab-case naming conventions
+- Update tests to use latest @aurelia/testing patterns"
+```
+
+## Configuration Best Practices
+
+### Project-Level Configuration
+
+Create a `.gemini/config.json` file:
+
+```json
+{
+  "systemPrompt": "./aurelia-system-prompt.md",
+  "defaultModel": "gemini-2.5-pro",
+  "maxTokens": 1000000,
+  "temperature": 0.1,
+  "topP": 0.8,
+  "contextFiles": [
+    "package.json",
+    "tsconfig.json", 
+    "CLAUDE.md",
+    "src/**/*.ts"
+  ],
+  "excludePatterns": [
+    "node_modules/**",
+    "dist/**",
+    "*.log"
+  ]
+}
+```
+
+### Team Collaboration
+
+Version control your Gemini CLI configuration:
+
+```bash
+# Include in your repository
+.gemini/
+├── config.json           # Team configuration
+├── aurelia-prompts/      # Shared prompt templates
+│   ├── component.md
+│   ├── service.md
+│   └── testing.md
+└── mcp-servers/          # Custom MCP server configurations
+    └── aurelia-server.js
+```
+
+## Integration with Development Workflow
+
+### Pre-commit Hooks
+
+```bash
+# Use Gemini CLI in git hooks
+#!/bin/bash
+# .git/hooks/pre-commit
+gemini "Review these staged changes for Aurelia best practices, TypeScript compliance, and potential issues before commit"
+```
+
+### Continuous Integration
+
+```yaml
+# .github/workflows/ai-review.yml
+- name: AI Code Review
+  run: |
+    gemini "Analyze the changes in this PR for:
+    - Aurelia convention compliance
+    - TypeScript type safety
+    - Test coverage
+    - Performance implications
+    - Security considerations"
+```
+
+## Troubleshooting
+
+### Rate Limiting
+- Free tier: 60 requests/minute, 1,000/day
+- Plan usage with `gemini quota` command
+- Use efficient prompts to maximize free tier value
+
+### Context Window Management
+- 1M tokens can handle very large codebases
+- Use file exclusion patterns for better performance
+- Focus context on relevant files for specific tasks
+
+### Model Performance
+- Use temperature 0.1-0.3 for code generation
+- Higher temperature (0.7-0.9) for creative/exploratory tasks
+- Adjust topP based on desired response diversity
+
+## Security Considerations
+
+- Review generated code for security implications
+- Never include API keys or secrets in prompts
+- Use MCP servers for sensitive operations
+- Validate AI suggestions against Aurelia security best practices
+
+Gemini CLI's large context window and extensibility make it particularly powerful for understanding and working with complex Aurelia applications, while the free tier provides generous usage limits for individual developers.

--- a/docs/user-docs/developer-guides/developing-with-ai/warp-terminal-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/warp-terminal-example.md
@@ -1,0 +1,279 @@
+# Warp Terminal Configuration Example for Aurelia Projects
+
+This document shows how to configure Warp Terminal 2.0's AI features for effective Aurelia development using Agent Mode, Active AI, and system prompts.
+
+## Warp Terminal AI Features Overview
+
+Warp Terminal 2.0 offers several AI-powered features:
+- **Agent Mode**: Multi-step autonomous workflows using natural language
+- **Active AI**: Context-aware assistance triggered by errors and outputs
+- **Warp Dispatch**: Full AI control for building and fixing code (Ctrl + Shift + I)
+- **Suggested Prompts**: Reusable prompt templates for common tasks
+
+## System Prompt Configuration
+
+Configure Warp's AI with Aurelia-specific context through system prompts:
+
+### Basic Aurelia Context
+
+```markdown
+# Aurelia 2.x Development Context
+
+You are assisting with an Aurelia 2.x TypeScript application. Key context:
+
+## Framework Specifics
+- Use modern Aurelia 2.x syntax with @customElement decorator
+- Components follow MVVM architecture with clear view/view-model separation
+- Dependency injection via @aurelia/kernel with @singleton/@transient decorators
+- Lifecycle hooks: creating → created → binding → bound → attaching → attached → detaching → unbinding
+
+## Project Structure
+- /packages/ - Core framework packages (requires build before testing)
+- /packages/__tests__/ - Test files using @aurelia/testing
+- /src/components/ - Custom elements (kebab-case names)
+- /src/services/ - Application services with DI registration
+
+## Build Requirements
+- ALWAYS run `npm run build` after making changes to packages
+- Build is required before running any tests
+- Use `npm run dev -- -t "pattern"` for specific test execution
+- Run `npm run lint` before committing changes
+
+## Code Standards
+- TypeScript strict mode - no `any` types
+- Prefer const over let, never use var
+- Use explicit types for all bindable properties
+- Implement proper cleanup in unbinding() lifecycle hook
+```
+
+### Advanced Configuration
+
+For complex development tasks, include specific patterns:
+
+```markdown
+## Common Aurelia Patterns
+
+### Custom Element Pattern
+```typescript
+@customElement({ 
+  name: 'user-profile',
+  template: '<div class="user-profile">...</div>'
+})
+export class UserProfile {
+  @bindable public user?: User;
+  
+  public binding(): void {
+    // Setup logic
+  }
+  
+  public unbinding(): void {
+    // Cleanup subscriptions, timers, etc.
+  }
+}
+```
+
+### Service Pattern
+```typescript
+@singleton
+export class UserService {
+  constructor(@IHttpClient private readonly http: IHttpClient) {}
+  
+  public async getUser(id: string): Promise<User> {
+    // Implementation with proper error handling
+  }
+}
+```
+
+### Testing Pattern
+```typescript
+// Always build before testing
+// Use @aurelia/testing package
+// Follow AAA pattern: Arrange, Act, Assert
+```
+```
+
+## Agent Mode Usage Examples
+
+### Project Setup
+Use natural language commands for complex setup tasks:
+
+```bash
+# In Warp Terminal Agent Mode
+"Set up a new Aurelia component called order-summary that displays order details, includes proper TypeScript types, and has tests"
+```
+
+### Code Generation
+```bash
+"Create a service for managing shopping cart items with add, remove, and calculate total methods, using Aurelia dependency injection patterns"
+```
+
+### Debugging and Fixing
+```bash
+"The UserProfile component isn't updating when the user property changes. Help me debug and fix the binding issue"
+```
+
+## Active AI Configuration
+
+Configure Active AI to provide Aurelia-specific assistance for common errors:
+
+### Error Response Patterns
+
+When Warp detects build errors, configure it to suggest:
+1. Running `npm run build` for package changes
+2. Checking for missing lifecycle hooks
+3. Verifying dependency injection setup
+4. Confirming TypeScript type definitions
+
+### Command Suggestions
+
+Set up common Aurelia commands as suggested prompts:
+
+```yaml
+aurelia_commands:
+  - "npm run build && npm run test"
+  - "npm run dev -- -t component"
+  - "npm run lint && npm run typecheck"
+  - "npm run rebuild"  # Clean build for issues
+```
+
+## Warp Dispatch Configuration
+
+For autonomous AI development, configure allow/deny lists:
+
+### Safe Commands (Allow List)
+```yaml
+allow_commands:
+  - "npm run build"
+  - "npm run test"
+  - "npm run lint"
+  - "npm run dev -- -t *"
+  - "git status"
+  - "git diff"
+  # Add project-specific safe commands
+```
+
+### Restricted Commands (Deny List)
+```yaml
+deny_commands:
+  - "npm publish"
+  - "git push"
+  - "rm -rf"
+  - "sudo *"
+  # Prevent potentially destructive operations
+```
+
+## MCP Server Integration
+
+Warp Terminal supports Model Context Protocol (MCP) servers for enhanced functionality:
+
+### Aurelia-Specific MCP Server
+
+Configure an MCP server that understands:
+- Aurelia project structure and conventions  
+- Build requirements and test patterns
+- Component lifecycle and DI patterns
+- Common debugging scenarios
+
+### Example MCP Tools
+
+```json
+{
+  "tools": [
+    {
+      "name": "aurelia_component_generator",
+      "description": "Generate Aurelia custom elements with proper structure",
+      "parameters": {
+        "name": "string",
+        "bindables": "array",
+        "lifecycle_hooks": "array"
+      }
+    },
+    {
+      "name": "aurelia_test_runner", 
+      "description": "Run Aurelia tests with proper build sequence",
+      "parameters": {
+        "pattern": "string",
+        "build_first": "boolean"
+      }
+    }
+  ]
+}
+```
+
+## Suggested Prompts for Common Tasks
+
+Save frequently used prompts for Aurelia development:
+
+### Component Development
+```markdown
+"Create an Aurelia custom element for [COMPONENT_NAME] that:
+- Uses proper TypeScript types
+- Implements [LIFECYCLE_HOOKS] lifecycle hooks  
+- Has bindable properties: [PROPERTIES]
+- Includes basic tests using @aurelia/testing"
+```
+
+### Service Development  
+```markdown
+"Generate an Aurelia service for [SERVICE_PURPOSE] that:
+- Uses appropriate DI decorator (@singleton or @transient)
+- Implements proper error handling
+- Has TypeScript interfaces for all data types
+- Includes unit tests"
+```
+
+### Debugging Template
+```markdown
+"Help debug this Aurelia issue:
+- Component: [COMPONENT_NAME]
+- Problem: [DESCRIPTION]  
+- Error messages: [ERRORS]
+- Expected behavior: [EXPECTED]
+Please check lifecycle hooks, binding setup, and DI configuration"
+```
+
+## Integration with Development Workflow
+
+### Pre-commit Workflow
+```bash
+# Suggested prompt for pre-commit checks
+"Run full pre-commit validation: build packages, run tests, lint code, and check types. Report any issues found."
+```
+
+### Code Review Preparation
+```bash
+"Prepare this Aurelia component for code review: check for proper lifecycle implementation, TypeScript types, test coverage, and adherence to project conventions"
+```
+
+## Best Practices
+
+### Effective Prompting
+- Be specific about Aurelia version (2.x) to avoid outdated suggestions
+- Include context about your component's purpose and requirements
+- Mention build requirements upfront to avoid test failures
+- Specify TypeScript strict mode expectations
+
+### Safety Considerations  
+- Review generated code before execution, especially for complex operations
+- Test AI-generated components thoroughly before integration
+- Verify that lifecycle hooks are properly implemented
+- Ensure proper cleanup in unbinding() methods
+
+### Learning Integration
+- Use Warp's explanations to understand Aurelia patterns
+- Ask for clarification on generated code you don't understand
+- Request examples of best practices for specific scenarios
+- Leverage AI to explore advanced Aurelia concepts
+
+## Troubleshooting Common Issues
+
+### Agent Mode Not Understanding Aurelia Patterns
+**Solution**: Update system prompts with more specific Aurelia examples and current syntax patterns.
+
+### Build Failures After Code Generation
+**Solution**: Ensure prompts emphasize build requirements and include proper import statements.
+
+### Generated Code Using Outdated Patterns
+**Solution**: Explicitly specify "Aurelia 2.x" and include examples of modern syntax in your system prompts.
+
+Warp Terminal's AI features, when properly configured with Aurelia-specific context, can significantly accelerate development workflows while maintaining code quality and framework conventions.

--- a/docs/user-docs/developer-guides/developing-with-ai/windsurf-rules-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/windsurf-rules-example.md
@@ -1,0 +1,263 @@
+# Windsurf Rules Example for Aurelia Projects
+
+This document shows how to configure Windsurf AI IDE for optimal Aurelia development using both global and workspace-level rules.
+
+## Global Rules: ~/global_rules.md
+
+Place this file in your home directory for rules that apply to all Windsurf sessions:
+
+```markdown
+# Global Windsurf Rules for Aurelia Development
+
+## TypeScript Best Practices
+- Always use strict TypeScript - never use `any` type
+- Prefer interfaces over type aliases for object shapes
+- Use explicit return types for public methods
+- Handle undefined/null explicitly with strict null checks
+
+## Code Style Standards
+- Use positive if statements instead of negative conditions
+- Implement early returns to reduce nesting depth
+- Always use curly braces for if/for/switch statements
+- Prefer const over let, never use var
+- Use arrow functions over function declarations
+
+## Framework Agnostic Patterns
+- Follow Single Responsibility Principle
+- Implement proper error handling and logging
+- Write clear, self-documenting code
+- Use meaningful variable and function names
+- Avoid deep nesting - extract methods when needed
+```
+
+## Workspace Rules: .windsurf/rules/
+
+Create rule files in your project's `.windsurf/rules/` directory:
+
+### `aurelia-framework.md`
+```markdown
+# Aurelia Framework Rules
+
+## Architecture Context
+This is an Aurelia 2.x TypeScript application using dependency injection and MVVM patterns.
+
+Core packages: @aurelia/kernel, @aurelia/runtime, @aurelia/runtime-html, @aurelia/template-compiler.
+
+Components follow lifecycle: creating → created → binding → bound → attaching → attached.
+
+## Component Patterns
+- Custom elements use kebab-case names: `<user-profile>`
+- Classes use PascalCase: `UserProfileCustomElement`
+- Always implement proper cleanup in `detaching`/`unbinding` hooks
+- Use `@bindable` properties with explicit TypeScript types
+
+## Dependency Injection
+- Use `@singleton` decorator for stateless services
+- Use `@transient` decorator for stateful services
+- Implement constructor injection with `@resolve()` when needed
+- Register services via `StandardConfiguration.customize()`
+
+## Template Binding
+- Use `.bind` for two-way binding
+- Use `.one-way` for read-only binding
+- Use `.to-view` for display-only data
+- Handle binding expressions with proper null checking
+```
+
+### `build-workflow.md`
+```markdown
+# Build and Development Workflow
+
+## Critical Requirements
+- Always run `npm run build` after making changes to packages
+- Build is required before running any tests
+- Tests are located in `packages/__tests__/` directory
+- Use `npm run rebuild` for clean builds when encountering issues
+
+## Development Commands
+- `npm run build` - Build all packages (REQUIRED before testing)
+- `npm run test` - Run all tests
+- `npm run dev -- -t "pattern"` - Run specific test patterns
+- `npm run lint` - ESLint validation
+- `npm run typecheck` - TypeScript type checking
+
+## Project Structure
+- `/packages/` - Core Aurelia framework packages
+- `/packages/__tests__/` - Test files requiring build
+- `/packages-tooling/` - Development and build tools
+- `/examples/` - Example applications
+```
+
+### `testing-patterns.md`
+```markdown
+# Testing Patterns for Aurelia
+
+## Testing Framework
+Use `@aurelia/testing` package for all component and service testing.
+
+## Test Structure
+Follow AAA pattern consistently:
+- Arrange: Set up test data and dependencies
+- Act: Execute the code being tested  
+- Assert: Verify expected outcomes
+
+## Best Practices
+- Write explicit test cases instead of using loops
+- Test both happy path and error scenarios
+- Create proper setup and teardown for component tests
+- Use meaningful test descriptions that explain the scenario
+
+## Component Testing Example
+```typescript
+import { CustomElement } from '@aurelia/runtime-html';
+import { TestContext, assert } from '@aurelia/testing';
+
+it('should render user name when user is provided', async () => {
+  // Arrange
+  const ctx = TestContext.create();
+  const { component } = ctx.createComponent(UserProfile);
+  component.user = { name: 'John Doe' };
+  
+  // Act
+  await ctx.startPromise;
+  
+  // Assert
+  assert.includes(ctx.host.textContent, 'John Doe');
+});
+```
+
+## Service Testing
+Mock dependencies using appropriate testing patterns and verify service behavior.
+```
+
+### `code-quality.md`
+```markdown
+# Code Quality Standards
+
+## TypeScript Standards
+- Enable strict mode in tsconfig.json
+- Use explicit types for all public interfaces
+- Prefer readonly properties when data shouldn't change
+- Use union types and generic constraints appropriately
+
+## Aurelia-Specific Quality
+- Implement proper error handling in lifecycle hooks
+- Use Aurelia's logger system (ILogger) instead of console.log
+- Never expose secrets or API keys in configuration
+- Follow security best practices for user input handling
+
+## Performance Patterns
+- Implement proper cleanup to prevent memory leaks
+- Use appropriate observation strategies for data binding
+- Consider component lifecycle impact on performance
+- Optimize template binding expressions
+
+## Documentation
+- Document complex binding expressions and lifecycle logic  
+- Include JSDoc comments for public APIs
+- Provide usage examples for custom elements and attributes
+- Document service dependencies and their purposes
+```
+
+## Character Limits and Organization
+
+### Rule File Limits
+- Individual rule files are limited to 6,000 characters
+- Total combined characters for global and local rules: 12,000
+- Global rules take priority if limit is exceeded
+
+### Organization Tips
+- Break complex rules into focused, single-purpose files
+- Use clear, descriptive filenames
+- Keep rules concise and actionable
+- Avoid redundant information across files
+
+## Advanced Windsurf Configuration
+
+### Multiple Agent Windows
+For complex Aurelia projects, use multiple Cascade windows:
+
+```markdown
+# Multi-Agent Workflow
+
+## Frontend Components (Window 1)
+Focus on custom elements, templates, and UI logic.
+Context: src/components/, template files, styling.
+
+## Backend Services (Window 2)  
+Focus on services, business logic, and data access.
+Context: src/services/, API integration, data models.
+
+## Testing & Quality (Window 3)
+Focus on test generation, debugging, and code quality.
+Context: packages/__tests__/, quality assurance.
+```
+
+### Context Management
+Use `@` syntax to reference specific files and provide targeted context:
+
+- `@src/components/user-profile.ts` - Reference specific component
+- `@packages/__tests__/` - Reference test directory
+- `@package.json` - Reference build configuration
+
+## Example Prompts for Windsurf
+
+### Component Generation
+```
+Create an Aurelia custom element for displaying user statistics. Include:
+- Bindable properties for user data
+- Proper lifecycle hooks for data fetching
+- Error handling and loading states
+- TypeScript interfaces for type safety
+
+@src/interfaces/user.ts for user type definitions
+```
+
+### Service Creation
+```
+Generate a data service for managing user preferences with:
+- Singleton registration pattern
+- HTTP client injection
+- Proper error handling and logging
+- TypeScript return types
+
+Follow the patterns in @src/services/auth-service.ts
+```
+
+### Test Generation
+```
+Create comprehensive tests for the UserProfile component including:
+- Happy path rendering scenarios
+- Error handling cases
+- Lifecycle hook behavior
+- Bindable property updates
+
+Use @aurelia/testing patterns from @packages/__tests__/src/component-tests.ts
+```
+
+## Team Collaboration
+
+### Version Control
+Keep all `.windsurf/rules/` files in version control for consistent team experience.
+
+### Rule Evolution
+- Update rules based on team feedback and project evolution
+- Document rule changes in commit messages
+- Review rule effectiveness during retrospectives
+- Share successful patterns across team projects
+
+### Onboarding
+New team members benefit from pre-configured Windsurf rules that encode team knowledge and project-specific patterns.
+
+## Troubleshooting
+
+### Common Issues
+- **Rules not applying**: Check character limits and file locations
+- **Context overload**: Break complex rules into focused files
+- **Inconsistent suggestions**: Ensure rules don't contradict each other
+
+### Performance Optimization
+- Keep rules concise and specific
+- Use appropriate context references with `@` syntax
+- Avoid overlapping or redundant rule files
+- Test rule effectiveness with actual coding scenarios

--- a/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
+++ b/docs/user-docs/getting-to-know-aurelia/app-configuration-and-startup.md
@@ -2,23 +2,22 @@
 
 ## Application Startup
 
-Aurelia allows you to configure the application startup in a couple of different ways. A quick setup where some defaults are assumed and a verbose setup where you can configure some of the framework-specific behaviors.
+Aurelia provides two main approaches for application startup: a quick setup using static methods with sensible defaults, and a verbose setup that gives you complete control over configuration.
 
 ### Quick startup
 
-The quick startup approach is what most developers will choose.
+The quick startup approach uses static methods on the Aurelia class and is the most common choice for new applications.
 
 ```typescript
-import { RouterConfiguration } from '@aurelia/router-direct';
-import Aurelia, { StyleConfiguration } from 'aurelia';
+import Aurelia from 'aurelia';
+import { RouterConfiguration } from '@aurelia/router';
 
 import { MyRootComponent } from './my-root-component';
 
-// By default host to element name (<my-root-component> for MyRootComponent),
-// or <body> if <my-root-component> is absent.
+// Simplest startup - hosts to <my-root-component> element, or <body> if not found
 Aurelia.app(MyRootComponent).start();
 
-// Or load additional Aurelia features
+// Register additional features before startup
 Aurelia
   .register(
     RouterConfiguration.customize({ useUrlFragmentHash: false })
@@ -26,7 +25,7 @@ Aurelia
   .app(MyRootComponent)
   .start();
 
-// Or host to <my-start-tag>
+// Specify a custom host element
 Aurelia
   .register(
     RouterConfiguration.customize({ useUrlFragmentHash: false })
@@ -36,75 +35,231 @@ Aurelia
     host: document.querySelector('my-start-tag')
   })
   .start();
+
+// Async startup pattern (recommended)
+const app = Aurelia
+  .register(
+    RouterConfiguration.customize({ useUrlFragmentHash: false })
+  )
+  .app(MyRootComponent);
+
+await app.start();
 ```
 
 ### Verbose Startup
 
-To start an Aurelia application, create a `new Aurelia()` object with a target `host` and a root `component` and call `start()`.
+The verbose approach gives you complete control over the DI container and configuration. Use this when integrating Aurelia into existing applications or when you need fine-grained control.
 
 ```typescript
-import Aurelia, { StandardConfiguration } from 'aurelia';
+import { Aurelia, StandardConfiguration } from '@aurelia/runtime-html';
+import { RouterConfiguration } from '@aurelia/router';
+import { LoggerConfiguration, LogLevel } from '@aurelia/kernel';
 import { ShellComponent } from './shell';
 
-new Aurelia()
-  .register(StandardConfiguration)
-  .app({ host: document.querySelector('body'), component: ShellComponent })
-  .start();
+// Create Aurelia instance with explicit configuration
+const au = new Aurelia();
+
+au.register(
+  StandardConfiguration,  // Essential runtime configuration
+  RouterConfiguration.customize({ useUrlFragmentHash: false }),
+  LoggerConfiguration.create({ level: LogLevel.debug })
+);
+
+au.app({
+  host: document.querySelector('body'),
+  component: ShellComponent
+});
+
+// Always await start() for proper error handling
+await au.start();
 ```
 
-In most instances, you will not use the verbose approach to starting your Aurelia applications. The verbose approach is more aimed at developers integrating Aurelia into existing web applications and views.
+**When to use verbose startup:**
+- Integrating Aurelia into existing applications
+- Custom DI container configuration needed
+- Multiple Aurelia apps in one page
+- Advanced debugging or testing scenarios
 
-## Register a globally available custom element
+**StandardConfiguration** includes essential services like:
+- Template compiler and renderer
+- Binding engine and observers  
+- Custom element/attribute support
+- Built-in value converters and binding behaviors
+- DOM event handling and delegation
+- Shadow DOM and CSS module support
 
-### Registering a single element
+## Registering Global Resources
 
-To make a custom element globally available to your application, pass the custom element constructor to the `.register()` method on your Aurelia app.
+### Registering a single custom element
+
+To make a custom element globally available throughout your application, register it before calling `app()`.
 
 ```typescript
+import Aurelia from 'aurelia';
 import { CardCustomElement } from './components/card';
 
-// When using quick startup
+// Quick startup
 Aurelia
-  .register(...)
-  .register(<any>CardCustomElement);
-  .app({ ... })
+  .register(CardCustomElement)  // No type casting needed
+  .app(MyRootComponent)
   .start();
 
-// When using verbose startup
-new Aurelia()
-  .register(...)
-  .register(<any>CardCustomElement)
-  .app({ ... })
-  .start();
+// Verbose startup
+const au = new Aurelia();
+au.register(
+  StandardConfiguration,
+  CardCustomElement
+);
+au.app({ host: document.body, component: MyRootComponent });
+await au.start();
 ```
 
-### Register a set of elements
+### Registering multiple resources
 
-If you have a package that exports all your custom elements, you can pass the entire package to the `.register()` method on your Aurelia app.
+Group related components into resource modules for better organization.
 
-src/components/index.ts:
-
+**src/components/index.ts:**
 ```typescript
 export { CardCustomElement } from './card';
 export { CollapseCustomElement } from './collapse';
+export { ModalCustomElement } from './modal';
 ```
 
-src/main.ts:
+**src/main.ts:**
+```typescript
+import Aurelia from 'aurelia';
+import * as GlobalComponents from './components';
+
+// Register all exported components at once
+Aurelia
+  .register(GlobalComponents)
+  .app(MyRootComponent)
+  .start();
+```
+
+### Registering other resource types
 
 ```typescript
-import * as globalComponents from './components';
+import Aurelia from 'aurelia';
+import { MyValueConverter } from './converters/my-value-converter';
+import { MyBindingBehavior } from './behaviors/my-binding-behavior';
+import { MyCustomAttribute } from './attributes/my-custom-attribute';
 
-// When using quick startup
 Aurelia
-  .register(...)
-  .register(<any>globalComponents)
-  .app({ ... })
-  .start();
-
-// When using verbose startup
-new Aurelia()
-  .register(...)
-  .register(<any>globalComponents)
-  .app({ ... })
+  .register(
+    MyValueConverter,
+    MyBindingBehavior,
+    MyCustomAttribute
+  )
+  .app(MyRootComponent)
   .start();
 ```
+
+## Advanced Configuration
+
+### Custom DI registrations
+
+```typescript
+import { Registration } from '@aurelia/kernel';
+import { MyService, IMyService } from './services/my-service';
+
+Aurelia
+  .register(
+    Registration.singleton(IMyService, MyService)
+  )
+  .app(MyRootComponent)
+  .start();
+```
+
+### Environment-specific configuration
+
+```typescript
+import Aurelia, { LoggerConfiguration, LogLevel } from 'aurelia';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+Aurelia
+  .register(
+    LoggerConfiguration.create({
+      level: isProduction ? LogLevel.warn : LogLevel.debug
+    })
+  )
+  .app(MyRootComponent)
+  .start();
+```
+
+## Enhancement Mode
+
+Aurelia's enhancement mode allows you to integrate Aurelia functionality into existing DOM content without replacing it entirely. This is perfect for progressively enhancing existing applications or adding Aurelia to specific sections of a page.
+
+### Basic Enhancement
+
+```typescript
+import Aurelia from 'aurelia';
+
+// Enhance existing DOM content
+const host = document.querySelector('#existing-content');
+const enhanceRoot = await Aurelia.enhance({
+  host: host,
+  component: {
+    message: 'Hello from enhanced content!',
+    items: [1, 2, 3]
+  }
+});
+
+// Later, cleanup when needed
+await enhanceRoot.deactivate();
+```
+
+### Enhancement with Custom Components
+
+```typescript
+import Aurelia from 'aurelia';
+import { MyCustomElement } from './components/my-custom-element';
+
+// Register components before enhancement
+const enhanceRoot = await Aurelia
+  .register(MyCustomElement)
+  .enhance({
+    host: document.querySelector('#content'),
+    component: {
+      data: { name: 'John', age: 30 },
+      created() {
+        console.log('Enhanced component created');
+      }
+    }
+  });
+```
+
+### Enhancement with Custom Container
+
+```typescript
+import { Aurelia } from '@aurelia/runtime-html';
+import { DI } from '@aurelia/kernel';
+import { MyService } from './services/my-service';
+
+// Create custom container with specific services
+const container = DI.createContainer();
+container.register(MyService);
+
+const au = new Aurelia();
+const enhanceRoot = await au.enhance({
+  host: document.querySelector('#widget'),
+  component: { title: 'Enhanced Widget' },
+  container: container  // Use custom container
+});
+```
+
+### When to Use Enhancement
+
+- **Legacy Application Integration**: Add Aurelia to existing applications incrementally
+- **Widget Development**: Create interactive widgets within larger non-Aurelia pages
+- **Progressive Enhancement**: Enhance server-rendered content with client-side interactivity
+- **Content Management Systems**: Add dynamic behavior to CMS-generated content
+
+**Key Differences from Standard App Mode:**
+- No need to define a root custom element
+- Can target any existing DOM element
+- Binds directly to plain JavaScript objects
+- Multiple enhanced sections can coexist on one page
+- More lightweight for small interactive components

--- a/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
+++ b/docs/user-docs/getting-to-know-aurelia/dynamic-composition.md
@@ -1,242 +1,783 @@
-# Dynamic composition
+# Dynamic Composition
 
-Aurelia's dynamic composition enables you to render a view/view model pair—or just a view—dynamically at runtime. With `<au-compose>`, you can:
-- Render any custom element by binding its definition to the `component` property.
-- Render plain HTML templates.
-- Dynamically swap components based on user state or configuration.
-- Access lifecycle hooks (including an extra `activate` method) on the composed view model.
+Dynamic composition lets you decide what to render at runtime instead of at compile time. Think of `<au-compose>` as a placeholder that can become any component or template based on your application's state, user preferences, or data.
 
-## Basic Composition
+This is perfect for:
+- **Dashboard widgets** that change based on user configuration
+- **Conditional components** where you need to render different components based on data
+- **Plugin architectures** where components are loaded dynamically
+- **Form builders** that render different field types
+- **Content management** where layout components vary by content type
 
-To render a custom element using its component definition, bind the element to `<au-compose>`:
+## Component Composition
 
-{% code title="my-app.html" %}
-```html
-<au-compose component.bind="MyField"></au-compose>
-```
-{% endcode %}
+### Composing with Custom Element Definitions
 
-In your view model, define the component with a custom element definition:
+You can compose any custom element by passing its definition to the `component` property:
 
-{% code title="my-component.ts" %}
 ```typescript
+// dashboard.ts
 import { CustomElement } from '@aurelia/runtime-html';
 
-export class App {
-  MyField = CustomElement.define({
-    name: 'my-input',
-    template: '<input value.bind="value">'
+export class Dashboard {
+  // Define different widget types
+  ChartWidget = CustomElement.define({
+    name: 'chart-widget',
+    template: '<div class="chart">Chart: ${title}</div>'
   });
-}
-```
-{% endcode %}
 
-> **Info:** When a custom element is used, all standard lifecycle events (including `activate`) will be invoked.
+  ListWidget = CustomElement.define({
+    name: 'list-widget', 
+    template: '<ul><li repeat.for="item of items">${item}</li></ul>'
+  });
 
----
+  // Switch between widgets based on user choice
+  selectedWidget = this.ChartWidget;
+  
+  switchToChart() {
+    this.selectedWidget = this.ChartWidget;
+  }
 
-## Composition with a String Component
-
-If you pass a string to the `component` property, Aurelia treats it as the name of a custom element and performs a lookup. For example:
-
-```html
-<import from="./my-input"></import>
-<au-compose component="my-input"></au-compose>
-```
-
-If `my-input` is registered globally, the lookup will succeed; otherwise, an error is thrown if no matching element definition is found.
-
----
-
-## Composing Without a Custom Element
-
-Dynamic composition isn’t limited to custom elements. You can compose a view only or combine a simple view model (plain object) with a view.
-
-### Template-Only Composition
-
-Render a simple HTML template:
-
-```html
-<au-compose template="<p>Hello world</p>"></au-compose>
-```
-
-Here, Aurelia processes the HTML string with its template compiler and renders it in place.
-
-### Combining Template and Literal Object
-
-You can supply both a view (template) and a literal object as the component:
-
-```html
-<au-compose repeat.for="i of 5" component.bind="{ value: i }" template="<div>\${value}</div>"></au-compose>
-```
-
-> **Note:** When composing without a custom element as the view model, the composed component will by default use the parent scope—unless you override it using `scope-behavior`.
-
----
-
-## Customized Host Element
-
-By default, composing a custom element creates a host element based on the element’s name (e.g. `<my-input>`). For non-custom element compositions, Aurelia inserts a comment boundary:
-
-```html
-<au-compose template="<input class='input-field' value.bind='value'"></au-compose>
-```
-
-**Renders as:**
-```html
-<!--au-start--><input class='input-field'><!--au-end-->
-```
-
-To wrap the composed content in a real HTML element, use the `tag` bindable property:
-
-{% code title="my-component.html" %}
-```html
-<au-compose tag="div" class="form-field" template="<input class='input-field' value.bind='value'"></au-compose>
-```
-{% endcode %}
-
-**Renders as:**
-```html
-<div class="form-field"><input class="input-field"></div>
-```
-
-Bindings declared on `<au-compose>` will be transferred to the new host element.
-
----
-
-## Passing Data with `model.bind`
-
-The `model` bindable lets you pass data into the composed view model. When the `model` changes, the `activate` method of the composed view model is called with the new value.
-
-### Example – Passing a View Model
-
-```html
-<au-compose model.bind="myObject"></au-compose>
-```
-
-Or, pass an inline object:
-
-```html
-<au-compose model.bind="{ myProp: 'value', test: 'something' }"></au-compose>
-```
-
-In the composed component:
-
-```typescript
-export class MyComponent {
-  activate(model) {
-    // Access passed-in model properties.
+  switchToList() {
+    this.selectedWidget = this.ListWidget;
   }
 }
 ```
 
----
-
-## When to Use Dynamic Composition
-
-Dynamic composition is best suited for scenarios where standard custom element usage may be too rigid. Consider using `<au-compose>` when:
-
-| **Scenario**                                         | **Why Use Dynamic Composition**                                                             |
-|------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| **Dynamic Content Based on User Input or State**     | To render different views or components on the fly (e.g., dashboards, conditional widgets).  |
-| **Rendering Unknown Components at Runtime**          | In plugin-based architectures, where components are not known at compile time.               |
-| **Conditional Rendering of Multiple Views**          | Instead of complex `if.bind` or switch statements, use a single dynamic composition point.    |
-| **Complex Reusable Layouts**                         | To inject varying content into consistent layouts, promoting reusability and DRY code.         |
-| **Simplifying Component Interfaces**               | To encapsulate multiple parameters in a model object, avoiding overly complex interfaces.     |
-| **Decoupling Component Logic**                     | To separate the decision of what to render from the rendering logic itself.                  |
-| **Lazy Loading to Reduce Initial Load Time**         | To load components only when needed, improving performance in large, single-page applications. |
-
----
-
-## Accessing the Composed View Model
-
-Sometimes you need a reference to the view model of the composed component. Use the `component.ref` binding to capture it:
-
 ```html
-<au-compose component.ref="myCompose"></au-compose>
+<!-- dashboard.html -->
+<div class="widget-controls">
+  <button click.delegate="switchToChart()">Chart View</button>
+  <button click.delegate="switchToList()">List View</button>
+</div>
+
+<au-compose component.bind="selectedWidget" title="Sales Data" items.bind="['Q1', 'Q2', 'Q3']"></au-compose>
 ```
 
-This works similarly to `view-model.ref` in Aurelia 1, giving you programmatic access to the instance.
+### Composing with Component Names
 
----
+If you have components registered globally or imported, you can reference them by name:
 
-## Passing Props Through to the Composed Component
-
-Bindings declared on `<au-compose>` are automatically passed to the composed view model (if it is a custom element). For example:
-
-{% code title="app.html" %}
 ```html
-<au-compose component.bind="myInput" value.bind="item"></au-compose>
+<!-- These components must be registered or imported -->
+<au-compose component="user-profile"></au-compose>
+<au-compose component="admin-panel" if.bind="isAdmin"></au-compose>
 ```
-{% endcode %}
 
-Assuming the following component definition:
+## Template-Only Composition
 
-{% code title="my-input.ts" %}
+Sometimes you just need to render dynamic HTML without a full component. Template-only composition is perfect for this:
+
+### Basic Template Composition
+
+```html
+<!-- Render static HTML -->
+<au-compose template="<div class='alert'>Message sent successfully!</div>"></au-compose>
+
+<!-- Render dynamic content from parent scope -->
+<au-compose template="<h2>Welcome, ${user.name}!</h2>"></au-compose>
+```
+
+### Dynamic Templates with Data
+
 ```typescript
-export class MyInput {
-  @bindable() value;
+// notification.ts
+export class NotificationCenter {
+  notifications = [
+    { type: 'success', message: 'Profile updated', icon: '✓' },
+    { type: 'warning', message: 'Storage almost full', icon: '⚠' },
+    { type: 'error', message: 'Connection failed', icon: '✗' }
+  ];
+
+  getTemplate(notification) {
+    return `<div class="alert alert-${notification.type}">
+      <span class="icon">${notification.icon}</span>
+      <span class="message">${notification.message}</span>
+    </div>`;
+  }
 }
 ```
-{% endcode %}
-
-{% code title="my-input.html" %}
-```html
-<input value.bind="value">
-```
-{% endcode %}
-
-This works as if you had written in `app.html`:
 
 ```html
-<my-input value.bind="item"></my-input>
+<!-- notification.html -->
+<div class="notifications">
+  <au-compose 
+    repeat.for="notif of notifications"
+    template.bind="getTemplate(notif)">
+  </au-compose>
+</div>
 ```
 
----
+### Template with Component Object
 
-## Migrating from Aurelia 1 `<compose>`
-
-Dynamic composition in Aurelia 2 differs from Aurelia 1. Key changes include:
-
-### Template and Component Property Renames
-
-- **Aurelia 1:** `view.bind` and `view-model.bind`
-- **Aurelia 2:** Use `template.bind` and `component.bind`
-
-### String Values
-
-- Passing a string now only works for custom element names. A string passed to `template` is interpreted as literal HTML.
-
-### Scope Inheritance
-
-- By default, when composing a view only or a plain object, the parent scope is inherited. To disable this, set the `scope-behavior` attribute:
+You can combine a template with a simple object that provides data and methods:
 
 ```html
-<au-compose scope-behavior="scoped"></au-compose>
+<!-- Each item gets its own mini-component -->
+<au-compose 
+  repeat.for="item of products"
+  template="<div class='product'>
+    <h3>${name}</h3>  
+    <p>${description}</p>
+    <button click.delegate='addToCart()'>Add to Cart</button>
+  </div>"
+  component.bind="{ 
+    name: item.name, 
+    description: item.description,
+    addToCart: () => buyProduct(item) 
+  }">
+</au-compose>
 ```
 
-### Bindings Transfer
+## Controlling the Host Element
 
-- All bindings on `<au-compose>` are now transferred to the composed custom element’s view model. Thus, `component.ref` now returns the view model, not the composer itself.
+### Default Host Behavior
 
-### Dynamic Module Loading
+When you compose a custom element, it creates its own host element. But for template-only compositions, Aurelia doesn't create a wrapper element by default:
 
-If you need to load a module dynamically for the view, use a value converter:
-
-{% code title="my-component.html" %}
 ```html
-<au-compose template="https://my-server.com/templates/${componentName} | loadTemplate"></au-compose>
+<!-- Template-only composition - no wrapper element -->
+<au-compose template="<span>Hello</span><span>World</span>"></au-compose>
 ```
-{% endcode %}
 
-{% code title="load-template.ts" %}
+This renders as comment boundaries around your content:
+```html
+<!--au-start--><span>Hello</span><span>World</span><!--au-end-->
+```
+
+### Creating a Host Element with `tag`
+
+When you need a wrapper element around your composed content, use the `tag` property:
+
+```html
+<!-- Create a div wrapper -->
+<au-compose 
+  tag="div" 
+  class="notification-container"
+  template="<span class='icon'>✓</span><span class='message'>Success!</span>">
+</au-compose>
+```
+
+This renders as:
+```html
+<div class="notification-container">
+  <span class="icon">✓</span>
+  <span class="message">Success!</span>
+</div>
+```
+
+Any attributes you put on `<au-compose>` (like `class`, `style`, or event handlers) get transferred to the host element.
+
+### Practical Host Element Example
+
 ```typescript
-export class LoadTemplateValueConverter {
+// card-layout.ts
+export class CardLayout {
+  cards = [
+    { title: 'Sales', content: 'Revenue: $50,000', theme: 'success' },
+    { title: 'Issues', content: '3 open tickets', theme: 'warning' },
+    { title: 'Users', content: '1,250 active', theme: 'info' }
+  ];
+
+  getCardTemplate(card) {
+    return `<h3>${card.title}</h3><p>${card.content}</p>`;
+  }
+}
+```
+
+```html
+<!-- card-layout.html -->
+<div class="dashboard">
+  <au-compose
+    repeat.for="card of cards"
+    tag="div"
+    class="card card-${card.theme}"
+    template.bind="getCardTemplate(card)"
+    click.delegate="selectCard(card)">
+  </au-compose>
+</div>
+```
+
+## Passing Data with Models and the Activate Method
+
+### Understanding the Activate Lifecycle
+
+Composed components can implement an `activate` method that runs when the component is created and whenever the `model` changes. This is perfect for initialization and data updates:
+
+```typescript
+// user-widget.ts
+export class UserWidget {
+  user = null;
+  posts = [];
+
+  // Called when component is first created and when model changes
+  async activate(userData) {
+    this.user = userData;
+    
+    // Load user's posts when activated
+    if (userData?.id) {
+      this.posts = await this.loadUserPosts(userData.id);
+    }
+  }
+
+  async loadUserPosts(userId) {
+    // Simulate API call
+    return fetch(`/api/users/${userId}/posts`).then(r => r.json());
+  }
+}
+```
+
+### Using Models for Data Passing
+
+```html
+<!-- user-dashboard.html -->
+<div class="user-dashboard">
+  <au-compose 
+    component.bind="UserWidget"
+    model.bind="selectedUser">
+  </au-compose>
+</div>
+```
+
+```typescript
+// user-dashboard.ts  
+export class UserDashboard {
+  users = [
+    { id: 1, name: 'Alice', role: 'admin' },
+    { id: 2, name: 'Bob', role: 'user' }
+  ];
+
+  selectedUser = this.users[0];
+
+  selectUser(user) {
+    // This will trigger activate() in the composed component
+    this.selectedUser = user;
+  }
+}
+```
+
+### Model Updates vs Component Changes
+
+Important distinction: changing the `model` doesn't recreate the component, it just calls `activate()` again. This is efficient for data updates:
+
+```typescript
+// dashboard.ts
+export class Dashboard {
+  UserProfile = CustomElement.define({
+    name: 'user-profile',
+    template: '<div>User: ${user?.name}</div>'
+  });
+
+  currentUser = { id: 1, name: 'Alice' };
+
+  switchUser() {
+    // This calls activate() on existing component - efficient!
+    this.currentUser = { id: 2, name: 'Bob' };
+  }
+
+  switchComponent() {
+    // This recreates the entire component - more expensive
+    this.UserProfile = SomeOtherComponent;
+  }
+}
+```
+
+## Advanced Features
+
+### Promise Support
+
+Both `template` and `component` properties can accept promises, perfect for lazy loading:
+
+```typescript
+// lazy-dashboard.ts
+export class LazyDashboard {
+  selectedWidgetType = 'chart';
+
+  // Lazy load components based on user selection
+  get currentComponent() {
+    switch (this.selectedWidgetType) {
+      case 'chart':
+        return import('./widgets/chart-widget').then(m => m.ChartWidget);
+      case 'table':
+        return import('./widgets/table-widget').then(m => m.TableWidget);
+      case 'map':
+        return import('./widgets/map-widget').then(m => m.MapWidget);
+      default:
+        return Promise.resolve(null);
+    }
+  }
+
+  // Dynamically load templates from server
+  get dynamicTemplate() {
+    return fetch(`/api/templates/${this.selectedWidgetType}`)
+      .then(response => response.text());
+  }
+}
+```
+
+```html
+<!-- lazy-dashboard.html -->
+<div class="widget-selector">
+  <select value.bind="selectedWidgetType">
+    <option value="chart">Chart</option>
+    <option value="table">Table</option>
+    <option value="map">Map</option>
+  </select>
+</div>
+
+<!-- Shows loading state while promise resolves -->
+<au-compose 
+  component.bind="currentComponent"
+  model.bind="widgetData">
+</au-compose>
+```
+
+### Scope Behavior Control
+
+For template-only compositions, you can control whether they inherit the parent scope:
+
+```html
+<!-- Auto scope (default) - inherits parent properties -->
+<au-compose 
+  template="<div>Welcome, ${user.name}!</div>"
+  scope-behavior="auto">
+</au-compose>
+
+<!-- Scoped - isolated from parent, only uses component object -->
+<au-compose 
+  template="<div>Welcome, ${name}!</div>"
+  component.bind="{ name: user.name }"
+  scope-behavior="scoped">
+</au-compose>
+```
+
+### Accessing the Composition Controller
+
+Use the `composition` property to access the composed component's controller:
+
+```typescript
+// admin-panel.ts
+export class AdminPanel {
+  composition: ICompositionController;
+
+  async refreshWidget() {
+    // Access the composed component directly
+    if (this.composition?.controller) {
+      const widgetInstance = this.composition.controller.viewModel;
+      if (widgetInstance.refresh) {
+        await widgetInstance.refresh();
+      }
+    }
+  }
+
+  getComposedData() {
+    return this.composition?.controller?.scope?.bindingContext;
+  }
+}
+```
+
+```html
+<!-- admin-panel.html -->
+<au-compose 
+  component.bind="selectedWidget"
+  composition.bind="composition">
+</au-compose>
+
+<button click.delegate="refreshWidget()">Refresh Widget</button>
+```
+
+## Real-World Examples
+
+### Form Builder with Dynamic Fields
+
+```typescript
+// form-builder.ts
+export class FormBuilder {
+  TextInput = CustomElement.define({
+    name: 'text-input',
+    template: '<input type="text" value.bind="value" placeholder.bind="placeholder">'
+  });
+
+  NumberInput = CustomElement.define({
+    name: 'number-input', 
+    template: '<input type="number" value.bind="value" min.bind="min" max.bind="max">'
+  });
+
+  SelectInput = CustomElement.define({
+    name: 'select-input',
+    template: '<select value.bind="value"><option repeat.for="opt of options" value.bind="opt.value">${opt.label}</option></select>'
+  });
+
+  fieldTypes = {
+    text: this.TextInput,
+    number: this.NumberInput,
+    select: this.SelectInput
+  };
+
+  formConfig = [
+    { type: 'text', name: 'firstName', placeholder: 'First Name', value: '' },
+    { type: 'text', name: 'lastName', placeholder: 'Last Name', value: '' },
+    { type: 'number', name: 'age', min: 0, max: 120, value: null },
+    { type: 'select', name: 'country', options: [
+      { value: 'us', label: 'United States' },
+      { value: 'ca', label: 'Canada' }
+    ], value: '' }
+  ];
+
+  getFieldComponent(field) {
+    return this.fieldTypes[field.type];
+  }
+}
+```
+
+```html
+<!-- form-builder.html -->
+<form class="dynamic-form">
+  <div repeat.for="field of formConfig" class="field-group">
+    <label>${field.name | titleCase}:</label>
+    <au-compose 
+      component.bind="getFieldComponent(field)"
+      value.bind="field.value"
+      placeholder.bind="field.placeholder"
+      min.bind="field.min"
+      max.bind="field.max"
+      options.bind="field.options">
+    </au-compose>
+  </div>
+</form>
+```
+
+### Plugin Architecture with Dynamic Loading
+
+```typescript
+// plugin-host.ts
+export class PluginHost {
+  availablePlugins = [
+    { id: 'weather', name: 'Weather Widget', url: '/plugins/weather.js' },
+    { id: 'news', name: 'News Feed', url: '/plugins/news.js' },
+    { id: 'calendar', name: 'Calendar', url: '/plugins/calendar.js' }
+  ];
+
+  activePlugins = [];
+
+  async loadPlugin(pluginConfig) {
+    try {
+      // Dynamically import the plugin module
+      const module = await import(pluginConfig.url);
+      const PluginComponent = module.default;
+      
+      this.activePlugins.push({
+        id: pluginConfig.id,
+        name: pluginConfig.name,
+        component: PluginComponent,
+        config: await this.loadPluginConfig(pluginConfig.id)
+      });
+    } catch (error) {
+      console.error('Failed to load plugin:', error);
+    }
+  }
+
+  async loadPluginConfig(pluginId) {
+    return fetch(`/api/plugins/${pluginId}/config`).then(r => r.json());
+  }
+
+  removePlugin(pluginId) {
+    this.activePlugins = this.activePlugins.filter(p => p.id !== pluginId);
+  }
+}
+```
+
+```html
+<!-- plugin-host.html -->
+<div class="plugin-dashboard">
+  <div class="plugin-loader">
+    <h3>Available Plugins</h3>
+    <div repeat.for="plugin of availablePlugins">
+      <button click.delegate="loadPlugin(plugin)">
+        Load ${plugin.name}
+      </button>
+    </div>
+  </div>
+
+  <div class="active-plugins">
+    <div repeat.for="plugin of activePlugins" class="plugin-container">
+      <div class="plugin-header">
+        <h4>${plugin.name}</h4>
+        <button click.delegate="removePlugin(plugin.id)">Remove</button>
+      </div>
+      
+      <au-compose 
+        component.bind="plugin.component"
+        model.bind="plugin.config">
+      </au-compose>
+    </div>
+  </div>
+</div>
+```
+
+### Content Management with Dynamic Layouts
+
+```typescript
+// cms-renderer.ts
+export class CmsRenderer {
+  layoutComponents = {
+    'hero-section': CustomElement.define({
+      name: 'hero-section',
+      template: `
+        <section class="hero" style="background-image: url({{backgroundImage}})">
+          <h1>{{title}}</h1>
+          <p>{{subtitle}}</p>
+          <button if.bind="ctaText">{{ctaText}}</button>
+        </section>
+      `
+    }),
+    'text-block': CustomElement.define({
+      name: 'text-block', 
+      template: '<div class="text-content" innerHTML.bind="content"></div>'
+    }),
+    'image-gallery': CustomElement.define({
+      name: 'image-gallery',
+      template: `
+        <div class="gallery">
+          <img repeat.for="img of images" src.bind="img.url" alt.bind="img.alt">
+        </div>
+      `
+    })
+  };
+
+  pageContent = [
+    {
+      type: 'hero-section',
+      data: {
+        title: 'Welcome to Our Site',
+        subtitle: 'Building amazing experiences', 
+        backgroundImage: '/images/hero-bg.jpg',
+        ctaText: 'Get Started'
+      }
+    },
+    {
+      type: 'text-block',
+      data: {
+        content: '<h2>About Us</h2><p>We create innovative solutions...</p>'
+      }
+    },
+    {
+      type: 'image-gallery', 
+      data: {
+        images: [
+          { url: '/images/1.jpg', alt: 'Project 1' },
+          { url: '/images/2.jpg', alt: 'Project 2' }
+        ]
+      }
+    }
+  ];
+
+  getLayoutComponent(block) {
+    return this.layoutComponents[block.type];
+  }
+}
+```
+
+```html
+<!-- cms-renderer.html -->
+<div class="cms-page">
+  <au-compose
+    repeat.for="block of pageContent"
+    component.bind="getLayoutComponent(block)"
+    model.bind="block.data">
+  </au-compose>
+</div>
+```
+
+## Migrating from Aurelia 1
+
+If you're upgrading from Aurelia 1, here are the key changes you need to know:
+
+### Property Name Changes
+
+**Aurelia 1:**
+```html
+<compose view.bind="myTemplate" view-model.bind="myComponent"></compose>
+```
+
+**Aurelia 2:**
+```html
+<au-compose template.bind="myTemplate" component.bind="myComponent"></au-compose>
+```
+
+### Component Reference Changes
+
+**Aurelia 1:**
+```html
+<compose view-model.ref="composerRef"></compose>
+```
+
+**Aurelia 2:**
+```html
+<!-- Get the composition controller -->
+<au-compose composition.bind="compositionRef"></au-compose>
+
+<!-- Or get direct access to the view model (if it's a custom element) -->
+<au-compose component.ref="viewModelRef"></au-compose>
+```
+
+### String Handling Changes
+
+**Aurelia 1:**
+```html
+<!-- Both worked in v1 -->
+<compose view="./my-template.html"></compose>
+<compose view-model="./my-component"></compose>
+```
+
+**Aurelia 2:**
+```html
+<!-- Template strings are now literal HTML -->
+<au-compose template="<div>Hello World</div>"></au-compose>
+
+<!-- Component strings must be registered component names -->
+<au-compose component="my-registered-component"></au-compose>
+
+<!-- For dynamic imports, use promises -->
+<au-compose component.bind="import('./my-component')"></au-compose>
+```
+
+### Scope Inheritance Changes
+
+**Aurelia 1:**
+```html
+<!-- Default was isolated scope -->
+<compose view.bind="template" model.bind="data"></compose>
+```
+
+**Aurelia 2:**
+```html
+<!-- Default is now inherited scope -->
+<au-compose template.bind="template" scope-behavior="auto"></au-compose>
+
+<!-- For isolated scope like v1 default -->
+<au-compose template.bind="template" scope-behavior="scoped" component.bind="data"></au-compose>
+```
+
+### Migration Examples
+
+#### Before (Aurelia 1):
+```typescript
+// aurelia-1-dashboard.ts
+export class Dashboard {
+  selectedView = './widgets/chart-widget.html';
+  selectedViewModel = './widgets/chart-widget';
+  widgetData = { title: 'Sales Chart' };
+}
+```
+
+```html
+<!-- aurelia-1-dashboard.html -->
+<compose 
+  view.bind="selectedView"
+  view-model.bind="selectedViewModel" 
+  model.bind="widgetData">
+</compose>
+```
+
+#### After (Aurelia 2):
+```typescript
+// aurelia-2-dashboard.ts
+import { CustomElement } from '@aurelia/runtime-html';
+
+export class Dashboard {
+  // Define component inline or import it
+  ChartWidget = CustomElement.define({
+    name: 'chart-widget',
+    template: '<div class="chart">Chart: ${title}</div>'
+  });
+
+  selectedComponent = this.ChartWidget;
+  widgetData = { title: 'Sales Chart' };
+}
+```
+
+```html
+<!-- aurelia-2-dashboard.html -->
+<au-compose 
+  component.bind="selectedComponent"
+  model.bind="widgetData">
+</au-compose>
+```
+
+### Dynamic Module Loading Migration
+
+**Aurelia 1:**
+```typescript
+// System.js or RequireJS loading
+export class Dashboard {
+  async loadWidget(widgetName) {
+    const viewModel = await System.import(`./widgets/${widgetName}`);
+    return viewModel.Widget;
+  }
+}
+```
+
+**Aurelia 2:**
+```typescript
+// ES6 dynamic imports
+export class Dashboard {
+  async loadWidget(widgetName) {
+    const module = await import(`./widgets/${widgetName}`);
+    return module.Widget;
+  }
+
+  // Or use promises directly in template
+  get currentWidget() {
+    return import(`./widgets/${this.selectedWidgetName}`).then(m => m.Widget);
+  }
+}
+```
+
+```html
+<!-- Can bind promises directly -->
+<au-compose component.bind="currentWidget" model.bind="widgetData"></au-compose>
+```
+
+### Value Converter Pattern for Remote Templates
+
+If you need to load templates from URLs (like in Aurelia 1), create a value converter:
+
+```typescript
+// template-loader.ts
+export class TemplateLoaderValueConverter {
+  private cache = new Map<string, Promise<string>>();
+
   toView(url: string): Promise<string> {
-    return fetch(url).then(response => response.text());
+    if (!this.cache.has(url)) {
+      this.cache.set(url, 
+        fetch(url).then(response => response.text())
+      );
+    }
+    return this.cache.get(url)!;
   }
 }
 ```
-{% endcode %}
 
-This value converter fetches the template from a URL and returns its text.
+```html
+<!-- Use in template -->
+<au-compose template.bind="templateUrl | templateLoader"></au-compose>
+```
+
+### Common Migration Gotchas
+
+1. **Binding Transfer**: In Aurelia 2, ALL bindings on `<au-compose>` are passed to the composed component
+2. **Activation**: The `activate` method works the same but is now available on any component type
+3. **Lifecycle**: Custom elements get full lifecycle, plain objects get activate/deactivate only
+4. **Performance**: Aurelia 2's composition is more efficient with better change detection
+
+## Best Practices
+
+1. **Use promises for lazy loading** - Only load components when needed to improve performance
+2. **Leverage the activate method** - Perfect for data initialization and updates
+3. **Consider scope behavior** - Use `scoped` when you want isolation, `auto` for inheritance
+4. **Cache component definitions** - Don't recreate the same CustomElement definitions repeatedly
+5. **Handle loading states** - Show appropriate feedback while promises resolve
+6. **Use models efficiently** - Changing models is cheaper than changing components
+
+Dynamic composition gives you the flexibility to build truly dynamic UIs that adapt to your users' needs, load efficiently, and scale with your application's complexity.

--- a/docs/user-docs/getting-to-know-aurelia/enhance.md
+++ b/docs/user-docs/getting-to-know-aurelia/enhance.md
@@ -1,130 +1,405 @@
 ---
 description: >-
-  Learn how to use Aurelia with existing HTML (inside of other frameworks and
-  libraries), hydrating server-generated HTML or running multiple instances of
-  Aurelia in your application.
+  Learn how to use Aurelia's enhance feature to add interactivity to existing HTML,
+  integrate with other frameworks, hydrate server-rendered content, and create
+  multiple Aurelia instances in your application.
 ---
 
 # Enhance
 
-## An introduction to enhance
+## What is Enhancement?
 
-Enhancement in Aurelia allows for integrating Aurelia’s capabilities with existing DOM elements or dynamically inserted HTML content. This feature is particularly useful in scenarios where the application is not entirely built with Aurelia, such as when integrating with server-rendered pages or dynamically generated content.
+Enhancement allows you to bring Aurelia's data binding, templating, and component features to existing DOM content without replacing it entirely. Instead of starting with an empty element and rendering into it, enhancement takes existing HTML and makes it "Aurelia-aware".
 
-The [startup sections](app-configuration-and-startup.md) showed how to start Aurelia for an empty root node. While that's the most frequent use case, there might be other scenarios where we would like to work with an existing DOM tree with Aurelia.
+This is perfect for:
+- **Progressive enhancement** of server-rendered pages
+- **Integration** with existing applications or other frameworks  
+- **Widget development** where you control specific sections of a page
+- **Content Management Systems** where you want to add interactivity to generated content
+- **Legacy application modernization** done incrementally
 
-### Basic Syntax and Key Points
+The [startup sections](app-configuration-and-startup.md) showed how to start Aurelia for empty elements. Enhancement lets you work with existing DOM trees instead.
 
-The basic usage of `enhance` is straightforward:
+## Understanding What Gets Enhanced
+
+When you enhance an element, Aurelia treats that element as if it were the template of a custom element. The existing HTML becomes the "template" and your component object becomes the "view model" that provides data and behavior.
+
+### Basic Enhancement Syntax
 
 ```typescript
+// Using the convenience method (recommended)
+const enhanceRoot = await Aurelia.enhance({
+  host: document.querySelector('#my-content'),
+  component: { message: 'Hello World' }
+});
+
+// Using instance method  
 const au = new Aurelia();
-await au.enhance({ host, component: MyComponent });
+const enhanceRoot = await au.enhance({
+  host: document.querySelector('#my-content'),
+  component: { message: 'Hello World' }
+});
 ```
 
-Key Points to Understand:
+### Component Types: Classes, Instances, or Objects
 
-1. **Anonymous Custom Element Hydration:** The enhancement treats the target node as an anonymous custom element, allowing Aurelia to apply its behavior to the existing DOM structure.
-2. **Component Flexibility:** The component parameter in enhance can be a custom element class, a class instance, or an object literal. If a class is provided, it's instantiated by Aurelia's dependency injection container, which can be either provided or automatically created.
-3. **Host Element:** The host is typically an existing DOM node that is not yet under Aurelia's control. It's crucial to note that `enhance ' neither detaches nor attaches the `host` to the DOM. Existing event handlers on the `host` or its descendants remain unaffected.
-4. **Controller Deactivation:** an `enhance` call results in an application root that requires manual deactivation or integration into an existing controller hierarchy for automatic framework management.
-
-Example of deactivating an application root:
+You can enhance with three different component types:
 
 ```typescript
-const root = au.enhance({ host, component });
-root.deactivate();
+// 1. Plain object (most common for simple cases)
+const enhanceRoot = await Aurelia.enhance({
+  host: element,
+  component: {
+    message: 'Hello',
+    items: [1, 2, 3],
+    handleClick() { 
+      console.log('Clicked!'); 
+    }
+  }
+});
+
+// 2. Class instance (when you need constructor logic)
+class MyViewModel {
+  message = 'Hello';
+  constructor() {
+    // initialization logic
+  }
+}
+const enhanceRoot = await Aurelia.enhance({
+  host: element,
+  component: new MyViewModel()
+});
+
+// 3. Custom element class (for reusable components)
+@customElement({ name: 'my-widget' })
+class MyWidget {
+  @bindable message: string;
+}
+const enhanceRoot = await Aurelia.enhance({
+  host: element,
+  component: MyWidget
+});
 ```
 
-## Enhancing During Application Startup
+### Key Enhancement Concepts
 
-Enhance can be particularly useful during application startup, especially when integrating Aurelia into an existing web page or alongside other frameworks.
+1. **Existing DOM is preserved**: Enhancement doesn't replace your HTML - it makes it interactive
+2. **Existing event handlers remain**: Any JavaScript event listeners you've already attached stay functional  
+3. **Manual lifecycle management**: You're responsible for calling `deactivate()` when done
+4. **Template compilation**: Aurelia compiles the existing HTML for bindings and directives
 
-Let's create an `index.html` file containing some HTML markup you would encounter if you generated an Aurelia application using `npx makes aurelia` or other means.
+### Proper Cleanup
 
-Pay attention to the contents of the `<body>` as there is a container called `app` as well as some HTML tags `<my-app>`
+Always clean up enhanced content to prevent memory leaks:
 
-{% code title="index.html" %}
+```typescript
+const enhanceRoot = await Aurelia.enhance({ host, component });
+
+// Later, when you're done:
+await enhanceRoot.deactivate();
+```
+
+## Practical Enhancement Examples
+
+### Server-Rendered Content Enhancement
+
+Suppose your server renders this HTML:
+
 ```html
-<body>
-  <div id="app">
-    <my-app></my-app>
+<!-- Server-rendered content -->
+<div id="user-profile">
+  <h2>Welcome back!</h2>
+  <div class="stats">
+    <span>Loading user data...</span>
   </div>
-</body>
+  <button id="refresh-btn">Refresh</button>
+</div>
 ```
-{% endcode %}
 
-Now, let's enhance our application by using the `enhance`API inside of `main.ts`
+You can enhance it to make it interactive:
 
 ```typescript
 import Aurelia from 'aurelia';
-import { MyApp } from './my-app';
-try {
-Aurelia
-  .register(MyApp)
-  .enhance({
-      host: document.querySelector('div#app'),
-      component: {},
-  });
-} catch (error) {
-  console.error(error);
+
+// Your existing server-rendered element
+const profileElement = document.querySelector('#user-profile');
+
+// Enhance with Aurelia interactivity
+const enhanceRoot = await Aurelia.enhance({
+  host: profileElement,
+  component: {
+    username: 'Loading...',
+    loginCount: 0,
+    
+    async created() {
+      // Load user data when component initializes
+      const userData = await fetch('/api/user/profile').then(r => r.json());
+      this.username = userData.username;
+      this.loginCount = userData.loginCount;
+    },
+    
+    refreshData() {
+      this.created(); // Reload data
+    }
+  }
+});
+
+// Update your HTML to use bindings:
+// <h2>Welcome back, ${username}!</h2>
+// <div class="stats">
+//   <span>Login count: ${loginCount}</span>
+// </div>
+// <button click.delegate="refreshData()">Refresh</button>
+```
+
+### Widget Integration Example
+
+Create interactive widgets within existing pages:
+
+```html
+<!-- Existing page content -->
+<div class="article">
+  <h1>My Blog Post</h1>
+  <p>Some content...</p>
+  
+  <!-- Widget placeholder -->
+  <div id="comment-widget">
+    <h3>Comments</h3>
+    <div class="loading">Loading comments...</div>
+  </div>
+</div>
+```
+
+```typescript
+// Enhance just the comment widget
+const commentWidget = document.querySelector('#comment-widget');
+
+const enhanceRoot = await Aurelia.enhance({
+  host: commentWidget,
+  component: {
+    comments: [],
+    newComment: '',
+    
+    async created() {
+      this.comments = await this.loadComments();
+    },
+    
+    async loadComments() {
+      return fetch('/api/comments/123').then(r => r.json());
+    },
+    
+    async addComment() {
+      if (!this.newComment.trim()) return;
+      
+      await fetch('/api/comments', {
+        method: 'POST',
+        body: JSON.stringify({ text: this.newComment }),
+        headers: { 'Content-Type': 'application/json' }
+      });
+      
+      this.newComment = '';
+      this.comments = await this.loadComments();
+    }
+  }
+});
+
+// Update HTML to:
+// <div id="comment-widget">
+//   <h3>Comments (${comments.length})</h3>
+//   <div repeat.for="comment of comments">
+//     <p>${comment.text}</p>
+//   </div>
+//   <div>
+//     <input value.bind="newComment" placeholder="Add comment...">
+//     <button click.delegate="addComment()">Post</button>
+//   </div>
+// </div>
+```
+
+## Dynamic Content Enhancement
+
+Enhancement is perfect for content that gets added to the page after initial load.
+
+### Enhancing Dynamically Loaded Content
+
+```typescript
+import { Aurelia, resolve } from 'aurelia';
+
+export class DynamicContentComponent {
+  private enhancedRoots: Array<any> = [];
+  
+  constructor(private au = resolve(Aurelia)) {}
+
+  async loadMoreContent() {
+    // Load HTML from server
+    const response = await fetch('/api/content/next-page');
+    const htmlContent = await response.text();
+    
+    // Create container for new content
+    const container = document.createElement('div');
+    container.innerHTML = htmlContent;
+    document.querySelector('#content-area').appendChild(container);
+    
+    // Enhance the new content
+    const enhanceRoot = await this.au.enhance({
+      host: container,
+      component: {
+        currentUser: this.currentUser,
+        likePost: (postId) => this.likePost(postId),
+        sharePost: (postId) => this.sharePost(postId)
+      }
+    });
+    
+    // Keep track for cleanup
+    this.enhancedRoots.push(enhanceRoot);
+  }
+  
+  // Clean up when component is destroyed
+  async unbinding() {
+    for (const root of this.enhancedRoots) {
+      await root.deactivate();
+    }
+    this.enhancedRoots = [];
+  }
 }
 ```
-Or if your component has one of its lifecycle return a promise:
-```typescript
-import Aurelia from 'aurelia';
-import { MyApp } from './my-app';
 
-;(async () => {
-  try {
-    await Aurelia
-      .register(MyApp)
-      .enhance({
-          host: document.querySelector('div#app'),
-          component: {},
-      });
-  } catch (error) {
-    console.error(error);
-  }
-})();
-```
-
-We first wrap our async code in an anonymous async function. This allows us to catch errors and throw them to the console if enhancement fails, but take note of the `enhance` call itself. We supply the host element (in our case, it's a DIV with an ID of `app` as the host).
-
-Above our `enhance` call, we register our main component, `MyApp`, the initial component our application will render.
-
-{% hint style="warning" %}
-Pay attention to what you are enhancing. Please make sure you are enhancing the container and not the component itself. It's an easy mistake, and we have seen some developers get caught on.
-{% endhint %}
-
-This approach will work for existing applications as well. Say you have a WordPress website and want to create an Aurelia application on a specific page. You could create a container and pass the element to the `host` on the `enhance` call.
-
-## Enhancing on the fly within components
-
-While using the `enhance` during registration, the `enhance` API is convenient for situations where you want to control how an Aurelia application is enhanced. There are times when you want to enhance HTML programmatically from within components. This may be HTML loaded from the server or elements created on the fly.
-
-In the following example, we query our markup for an `item-list` element and insert some Aurelia-specific markup into it (a repeater).
+### Enhancing Modal or Dialog Content
 
 ```typescript
-import Aurelia, { IAurelia, resolve } from 'aurelia';
+export class ModalService {
+  private currentModal: any = null;
+  
+  async showModal(contentHtml: string, viewModel: any) {
+    // Create modal element
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.innerHTML = `
+      <div class="modal-content">
+        <button class="close" click.delegate="closeModal()">&times;</button>
+        ${contentHtml}
+      </div>
+    `;
+    
+    document.body.appendChild(modal);
 
-export class MyApp {
-  items = [1, 2, 3];
-
-  constructor(private readonly au = resolve(Aurelia)) {}
-
-  attached() {
-    const itemList = document.getElementById('item-list');
-    itemList.innerHTML = "<div repeat.for='item of items'>${item}</div>";
-
-    this.au.enhance({
-      component: { items: this.items },
-      host: itemList,
+    // Enhance the modal content
+    this.currentModal = await Aurelia.enhance({
+      host: modal,
+      component: {
+        ...viewModel,
+        closeModal: () => this.closeModal()
+      }
     });
   }
+  
+  async closeModal() {
+    if (this.currentModal) {
+      await this.currentModal.deactivate();
+      document.querySelector('.modal')?.remove();
+      this.currentModal = null;
+    }
+  }
 }
 ```
 
-As you can see, we are dynamically injecting some HTML into an existing element. Because this is being done after Aurelia has already compiled the view, it would not work. This is why we must call `enhance` to tell Aurelia to parse our inserted HTML.
+## Advanced Enhancement Patterns
 
-You can use this approach to enhance HTML inserted into the page after initial compilation, which is perfect for server-generated code.
+### Using Custom Containers
+
+When you need specific services or configurations for enhanced content:
+
+```typescript
+import { DI, Registration } from '@aurelia/kernel';
+import { LoggerConfiguration, LogLevel } from 'aurelia';
+
+// Create custom container for widget
+const widgetContainer = DI.createContainer()
+  .register(
+    Registration.singleton('ApiService', MyApiService),
+    LoggerConfiguration.create({ level: LogLevel.debug })
+  );
+
+const enhanceRoot = await Aurelia.enhance({
+  host: document.querySelector('#my-widget'),
+  component: MyWidget,
+  container: widgetContainer  // Use custom container
+});
+```
+
+### Lifecycle Hooks in Enhanced Components
+
+Enhanced components support all standard Aurelia lifecycle hooks:
+
+```typescript
+const enhanceRoot = await Aurelia.enhance({
+  host: element,
+  component: {
+    data: null,
+    
+    // Called when component is being set up
+    created() {
+      console.log('Component created');
+    },
+    
+    // Called before data binding starts
+    binding() {
+      console.log('Starting data binding');
+    },
+    
+    // Called after data binding completes
+    bound() {
+      console.log('Data binding complete');
+    },
+    
+    // Called when component is being attached to DOM
+    attaching() {
+      console.log('Attaching to DOM');
+    },
+    
+    // Called after component is attached to DOM
+    attached() {
+      console.log('Attached to DOM - ready for user interaction');
+      // Good place for focus, animations, etc.
+    },
+    
+    // Called when component is being removed
+    detaching() {
+      console.log('Detaching from DOM');
+    },
+    
+    // Called when data bindings are being torn down
+    unbinding() {
+      console.log('Unbinding data');
+      // Cleanup subscriptions, timers, etc.
+    }
+  }
+});
+```
+
+## Common Enhancement Patterns
+
+### Progressive Enhancement Checklist
+
+1. **Identify enhancement targets**: Elements that need interactivity
+2. **Preserve existing functionality**: Don't break existing event handlers
+3. **Plan your data flow**: How will data get to enhanced components?
+4. **Handle cleanup**: Always deactivate when done
+5. **Test without JavaScript**: Ensure basic functionality works without enhancement
+
+### Best Practices
+
+- **Start small**: Enhance specific widgets before entire sections
+- **Use meaningful component objects**: Include methods and properties that make sense
+- **Handle errors gracefully**: Enhancement might fail if DOM structure changes
+- **Document what gets enhanced**: Make it clear to other developers
+- **Consider performance**: Don't enhance too many elements at once
+
+### When NOT to Use Enhancement
+
+- **New applications**: Use regular `Aurelia.app()` for greenfield projects
+- **Full page control**: When you control the entire page, standard app startup is simpler
+- **Simple static content**: If content doesn't need interactivity
+- **Performance critical sections**: Enhancement has overhead compared to pre-compiled templates
+
+Enhancement shines when you need to add Aurelia's power to existing content without rebuilding everything from scratch.

--- a/docs/user-docs/getting-to-know-aurelia/synchronous-binding-system.md
+++ b/docs/user-docs/getting-to-know-aurelia/synchronous-binding-system.md
@@ -1,55 +1,94 @@
-# Understanding Aurelia's Synchronous Binding System
+# Understanding Aurelia's Binding System and State Management
 
-Aurelia v2 employs a synchronous binding system, which immediately notifies changes as they occur. This approach provides great control and predictability over state changes. However, managing multiple state updates that must be processed together requires careful handling to ensure consistency.
+Aurelia v2 uses a hybrid binding system that combines synchronous property notifications with asynchronous computed property updates. While observable property changes trigger immediate notifications, computed properties use asynchronous updates by default to prevent common issues like state tearing.
 
-Synchronous binding systems notify changes immediately, providing instant feedback and control. In contrast, asynchronous binding systems queue changes and notify them later, typically in the next microtask or tick, which can help avoid issues like state tearing but introduces other complexities like race conditions (if you worked with Aurelia 1, then you might be familiar with the need to use `queueMicroTask` to work around this in Aurelia 1).
+Understanding when updates are synchronous vs. asynchronous is crucial for managing complex state changes effectively. This document explains how Aurelia's binding system works and when you might need to use tools like `batch()` to ensure consistency.
 
-## Understanding state tearing
+## Synchronous vs Asynchronous Updates
 
-State tearing occurs when multiple state updates that should be processed together result in premature change notifications and recomputations. This can lead to inconsistent states and application errors. Aurelia v2’s synchronous binding system is particularly prone to this issue.
+### Observable Properties: Synchronous
+Regular observable properties notify changes immediately when set:
 
-Consider the following example:
-
-{% code title=“name-tag.ts” %}
 ```typescript
+import { observable } from 'aurelia';
+
+class User {
+  @observable firstName = '';
+  @observable lastName = '';
+}
+
+const user = new User();
+// This triggers immediate notifications
+user.firstName = 'John';  // Subscribers notified immediately
+user.lastName = 'Doe';   // Subscribers notified immediately
+```
+
+### Computed Properties: Asynchronous by Default
+Computed properties defer their updates to prevent state tearing:
+
+```typescript
+import { computed } from 'aurelia';
+
 class NameTag {
-    firstName = '';
-    lastName = '';
+    @observable firstName = '';
+    @observable lastName = '';
+
+    // Async by default - safe from state tearing
+    @computed({ flush: 'async' })
+    get fullName() {
+        return `${this.firstName} ${this.lastName}`;
+    }
+}
+```
+
+## Understanding State Tearing
+
+State tearing occurs when multiple related state updates trigger intermediate computations with incomplete data. While Aurelia's async-by-default computed properties prevent most state tearing, you can still encounter it with synchronous computed properties.
+
+### Example: Synchronous Computed Properties Can Still Tear
+
+```typescript
+import { observable, computed } from 'aurelia';
+
+class NameTag {
+    @observable firstName = '';
+    @observable lastName = '';
 
     update(first, last) {
-        this.firstName = first;
-        this.lastName = last;
+        this.firstName = first;  // Triggers sync computed immediately
+        this.lastName = last;    // Triggers sync computed again
     }
 
-    @computed()
+    // SYNC computed - prone to state tearing
+    @computed({ flush: 'sync' })
     get fullName() {
         if (!this.firstName || !this.lastName) {
-            throw new Error('Only accepting names with both first and last names');
+            throw new Error('Both names required');
         }
         return `${this.firstName} ${this.lastName}`;
     }
 }
 
 const nameTag = new NameTag();
-nameTag.update('John', 'Doe'); // 💥
+// This may throw an error because fullName is computed after firstName 
+// is updated but before lastName is updated
+nameTag.update('John', 'Doe'); // 💥 Potential error
 ```
-{% endcode %}
 
-In this example, updating `firstName` and `lastName` simultaneously causes an error. This happens because the synchronous change propagation causes the computed property `fullName` to be evaluated before both `firstName` and `lastName` have been updated.
+## Managing State Updates with Batch
 
-## Managing state updates with batch
+Aurelia provides the `batch` function to handle multiple state updates efficiently. The batch function groups state changes and defers change notifications until all updates within the batch are complete. This is essential when working with synchronous computed properties or when you need atomic updates.
 
-Aurelia provides the `batch` function to handle multiple state updates efficiently. The batch function groups state changes and defer change notifications until all updates within the batch are complete. This ensures that related states are updated together, maintaining consistency.
+### Fixing State Tearing with Batch
 
-Here’s how to use the batch function to manage state updates:
+Here's how to fix the previous example using `batch`:
 
-{% code title=“name-tag.ts” %}
 ```typescript
-import { batch } from 'aurelia';
+import { observable, computed, batch } from 'aurelia';
 
 class NameTag {
-    firstName = '';
-    lastName = '';
+    @observable firstName = '';
+    @observable lastName = '';
 
     update(first, last) {
         batch(() => {
@@ -58,26 +97,138 @@ class NameTag {
         });
     }
 
-    @computed()
+    @computed({ flush: 'sync' })
     get fullName() {
         if (!this.firstName || !this.lastName) {
-            throw new Error('Only accepting names with both first and last names');
+            throw new Error('Both names required');
         }
         return `${this.firstName} ${this.lastName}`;
     }
 }
 
 const nameTag = new NameTag();
-nameTag.update('John', 'Doe'); // No error
+nameTag.update('John', 'Doe'); // ✅ No error - both updates happen atomically
 ```
-{% endcode %}
 
-By wrapping the state updates in a `batch` function, change notifications for `firstName` and `lastName` are deferred until both updates are complete. This ensures that the `fullName` computed property is evaluated with the latest values of `firstName` and `lastName`.
+### Comparing Sync vs Async Computed Properties
 
-### Benefits of using batch
+```typescript
+import { observable, computed, batch, tasksSettled } from 'aurelia';
 
-- **Consistency:** Ensures that all related state changes are processed together, avoiding premature evaluations.
-- **Predictability:** Maintains the predictable nature of the synchronous binding system by controlling when notifications are sent.
-- **Performance:** Reduces unnecessary recomputations by grouping state changes.
+class ComparisonExample {
+    @observable count = 0;
 
-Aurelia’s synchronous binding system provides immediate change notifications, offering great control over state updates. Using the `batch` function, developers can efficiently manage multiple state updates, ensuring consistency and predictability in their applications. Proper use of batch enhances the robustness of Aurelia applications, making state management more reliable and efficient.
+    // Async computed (default) - updates after tasks settle
+    @computed({ flush: 'async' })
+    get asyncDouble() {
+        console.log('Computing async double:', this.count);
+        return this.count * 2;
+    }
+
+    // Sync computed - updates immediately
+    @computed({ flush: 'sync' })
+    get syncDouble() {
+        console.log('Computing sync double:', this.count);
+        return this.count * 2;
+    }
+
+    async demonstrateDifference() {
+        console.log('--- Without batch ---');
+        this.count = 1;  // Sync computed runs immediately
+        this.count = 2;  // Sync computed runs again
+        this.count = 3;  // Sync computed runs again
+        
+        // Async computed hasn't run yet
+        console.log('Before tasksSettled, asyncDouble:', this.asyncDouble); // Still 0
+        
+        await tasksSettled(); // Now async computed updates
+        console.log('After tasksSettled, asyncDouble:', this.asyncDouble); // Now 6
+
+        console.log('--- With batch ---');
+        batch(() => {
+            this.count = 4;  // Sync computed deferred
+            this.count = 5;  // Sync computed deferred  
+            this.count = 6;  // Sync computed deferred
+        });
+        // Sync computed runs only once with final value
+        
+        await tasksSettled();
+        console.log('Final values - sync:', this.syncDouble, 'async:', this.asyncDouble);
+    }
+}
+```
+
+## When to Use Sync vs Async Computed Properties
+
+### Use Async Computed Properties (Default) When:
+- **Performance matters**: Async computed properties prevent unnecessary intermediate calculations
+- **Complex dependencies**: When your computed property depends on multiple observable properties
+- **Template bindings**: Most template bindings work well with async updates
+- **Default choice**: Choose async unless you have a specific need for synchronous behavior
+
+```typescript
+// Good for templates - async by default
+@computed({ flush: 'async' })
+get displayName() {
+    return `${this.firstName} ${this.lastName}`.trim();
+}
+```
+
+### Use Sync Computed Properties When:
+- **Immediate consistency required**: When other code needs the computed value immediately
+- **Simple, fast computations**: When the computation is trivial and won't cause performance issues
+- **Legacy integration**: When integrating with code that expects synchronous updates
+
+```typescript
+// Use sync only when you need immediate consistency
+@computed({ flush: 'sync' })
+get isValidForm() {
+    return this.email.includes('@') && this.password.length >= 8;
+}
+```
+
+## Benefits of Using Batch
+
+- **Consistency**: Ensures that all related state changes are processed together, avoiding premature evaluations
+- **Performance**: Reduces unnecessary recomputations by grouping state changes
+- **Atomic updates**: Makes multiple property changes appear as a single update to observers
+- **Predictability**: Controls exactly when change notifications are sent
+
+## Best Practices
+
+1. **Prefer async computed properties** - They're safer and perform better
+2. **Use batch() for multiple related updates** - Especially when updating several properties that affect the same computed properties
+3. **Await tasksSettled() in tests** - Async computed properties require waiting for task completion
+4. **Only use sync computed properties when necessary** - They can cause performance issues with frequent updates
+
+```typescript
+// Example: Updating a user profile
+class UserProfile {
+    @observable firstName = '';
+    @observable lastName = '';
+    @observable email = '';
+    @observable avatar = '';
+
+    // Async computed - safe and performant
+    @computed({ flush: 'async' })
+    get displayInfo() {
+        return {
+            name: `${this.firstName} ${this.lastName}`,
+            contact: this.email,
+            hasAvatar: !!this.avatar
+        };
+    }
+
+    // Update multiple properties atomically
+    updateProfile(data) {
+        batch(() => {
+            this.firstName = data.firstName;
+            this.lastName = data.lastName;
+            this.email = data.email;
+            this.avatar = data.avatar;
+        });
+    }
+}
+```
+
+Aurelia's hybrid binding system gives you the flexibility to choose the right approach for your use case. The async-by-default behavior provides safety and performance, while batch() ensures consistency when you need atomic updates.

--- a/docs/user-docs/router/navigating.md
+++ b/docs/user-docs/router/navigating.md
@@ -1,11 +1,36 @@
 ---
-description: Learn to navigate from one view to another using the Router-Lite. Also learn about routing context.
+description: Learn to navigate from one view to another using the Aurelia router, including declarative and programmatic navigation patterns.
 ---
 
 # Navigating
 
-This section details the various ways that you can use to navigate from one part of your application to another part.
-For performing navigation the router offers couple of alternatives, namely the `href` and the `load` custom attributes, and the `IRouter#load` method.
+Aurelia's router provides multiple ways to navigate between routes in your application. This section covers all navigation methods from simple links to complex programmatic navigation patterns.
+
+## Navigation Methods Overview
+
+The router offers three primary navigation approaches:
+
+1. **Declarative Navigation**:
+   - `href` custom attribute - Natural anchor tag navigation
+   - `load` custom attribute - Structured navigation with advanced options
+
+2. **Programmatic Navigation**:
+   - `IRouter.load()` method - Full programmatic control
+   - Navigation with options (query params, fragments, context, etc.)
+
+3. **Path Generation**:
+   - Generate URLs for routes without navigating
+   - Useful for conditional navigation and dynamic link building
+
+Choose the method that best fits your use case:
+
+| Use Case | Best Method | Example |
+|----------|-------------|---------|
+| Simple navigation links | `href` | `<a href="about">About</a>` |
+| Links with parameters | `load` with params | `<a load="route: user; params.bind: {id: userId}">User</a>` |
+| Conditional navigation | `IRouter.load()` | `if (canAccess) router.load('admin')` |
+| Navigation with query params | `IRouter.load()` with options | `router.load('search', { queryParams: { q: 'term' }})` |
+| Dynamic link generation | `router.generatePath()` | `const url = await router.generatePath('user', userId)` |
 
 ## Using the `href` custom attribute
 
@@ -1131,6 +1156,215 @@ export class MyApp {
 }
 ```
 
+## Advanced Navigation Patterns
+
+### Error Handling and Navigation Guards Integration
+
+When using programmatic navigation, you should handle potential failures and integrate with navigation guards:
+
+```typescript
+import { IRouter } from '@aurelia/router';
+import { resolve } from '@aurelia/kernel';
+
+export class UserManagementComponent {
+  private readonly router = resolve(IRouter);
+
+  async navigateToUser(userId: string) {
+    try {
+      const success = await this.router.load(`user/${userId}`);
+      if (!success) {
+        // Navigation was blocked by guards or failed
+        console.log('Navigation was blocked or failed');
+        this.showErrorMessage('Unable to access user profile');
+      }
+    } catch (error) {
+      console.error('Navigation error:', error);
+      this.router.load('error');
+    }
+  }
+
+  private showErrorMessage(message: string) {
+    // Your error handling logic
+  }
+}
+```
+
+### Conditional Navigation with Permissions
+
+```typescript
+import { IRouter } from '@aurelia/router';
+import { resolve } from '@aurelia/kernel';
+
+export class NavigationService {
+  private readonly router = resolve(IRouter);
+
+  async navigateWithPermissionCheck(route: string, requiredPermission: string) {
+    if (!this.hasPermission(requiredPermission)) {
+      await this.router.load('unauthorized');
+      return false;
+    }
+
+    try {
+      return await this.router.load(route);
+    } catch {
+      await this.router.load('error');
+      return false;
+    }
+  }
+
+  private hasPermission(permission: string): boolean {
+    // Your permission checking logic
+    return true;
+  }
+}
+```
+
+### Navigation with State Preservation
+
+```typescript
+export class SearchComponent {
+  private readonly router = resolve(IRouter);
+  private searchTerm: string = '';
+  private currentPage: number = 1;
+
+  async search(term: string) {
+    this.searchTerm = term;
+    this.currentPage = 1;
+
+    // Preserve search state in URL
+    await this.router.load('search', {
+      queryParams: {
+        q: term,
+        page: this.currentPage
+      },
+      // Preserve in browser history state
+      state: {
+        searchTerm: term,
+        timestamp: Date.now()
+      }
+    });
+  }
+
+  async nextPage() {
+    this.currentPage++;
+    await this.router.load('search', {
+      queryParams: {
+        q: this.searchTerm,
+        page: this.currentPage
+      },
+      historyStrategy: 'replace' // Don't create new history entry
+    });
+  }
+}
+```
+
+### Dynamic Navigation Menu
+
+```typescript
+import { IRouter, ICurrentRoute } from '@aurelia/router';
+import { resolve } from '@aurelia/kernel';
+
+interface NavigationItem {
+  label: string;
+  route: string;
+  permission?: string;
+  params?: Record<string, unknown>;
+}
+
+export class NavigationMenuComponent {
+  private readonly router = resolve(IRouter);
+  private readonly currentRoute = resolve(ICurrentRoute);
+
+  private menuItems: NavigationItem[] = [
+    { label: 'Dashboard', route: 'dashboard' },
+    { label: 'Users', route: 'users', permission: 'users.read' },
+    { label: 'Settings', route: 'settings', permission: 'admin' },
+  ];
+
+  get visibleMenuItems() {
+    return this.menuItems.filter(item => 
+      !item.permission || this.hasPermission(item.permission)
+    );
+  }
+
+  async navigateToItem(item: NavigationItem) {
+    // Skip if already on this route
+    if (this.currentRoute.path === item.route) {
+      return;
+    }
+
+    await this.router.load(item.route, {
+      queryParams: item.params,
+      title: item.label
+    });
+  }
+
+  isActive(route: string): boolean {
+    return this.currentRoute.path === route;
+  }
+
+  private hasPermission(permission: string): boolean {
+    // Your permission checking logic
+    return true;
+  }
+}
+```
+
+### Navigation with Loading States
+
+```typescript
+export class AppComponent {
+  private readonly router = resolve(IRouter);
+  private isNavigating = false;
+  private navigationError: string | null = null;
+
+  async navigateWithLoadingState(route: string) {
+    this.isNavigating = true;
+    this.navigationError = null;
+
+    try {
+      const success = await this.router.load(route);
+      if (!success) {
+        this.navigationError = 'Navigation was blocked';
+      }
+    } catch (error) {
+      this.navigationError = `Navigation failed: ${error.message}`;
+    } finally {
+      this.isNavigating = false;
+    }
+  }
+}
+```
+
+### Bulk Navigation Operations
+
+For applications that need to perform multiple navigation operations:
+
+```typescript
+export class NavigationBatchService {
+  private readonly router = resolve(IRouter);
+  private navigationQueue: Array<{ route: string; options?: any }> = [];
+
+  queueNavigation(route: string, options?: any) {
+    this.navigationQueue.push({ route, options });
+  }
+
+  async processNavigationQueue() {
+    const operations = this.navigationQueue.splice(0); // Clear queue
+    
+    for (const operation of operations) {
+      try {
+        await this.router.load(operation.route, operation.options);
+        // Small delay to prevent overwhelming the router
+        await new Promise(resolve => setTimeout(resolve, 50));
+      } catch (error) {
+        console.error(`Failed to navigate to ${operation.route}:`, error);
+      }
+    }
+  }
+}
+```
+
 ## Path generation
 The router supports generating paths eagerly for a given route or navigation instruction. Paths can be generated using the router as well as the route context.
 
@@ -1234,3 +1468,153 @@ This example generates a path to the `child` route, relative to the root context
 Note that using parameters and/or nested children for path generation instructions are also supported by the `RouteContext` API, similar to the [`generatePath` method](#router-api).
 Those examples are avoided here for brevity.
 {% endhint %}
+
+## Best Practices and Common Patterns
+
+### When to Use Each Navigation Method
+
+**Use `href` custom attribute when:**
+- Creating simple navigation links
+- Navigation doesn't require complex logic
+- You want standard browser link behavior (right-click, etc.)
+- Building static navigation menus
+
+**Use `load` custom attribute when:**
+- You need to bind parameters from your view model
+- You want to leverage the `active` property for styling
+- You need structured parameter binding
+- Working with dynamic route data
+
+**Use `IRouter.load()` method when:**
+- Navigation depends on business logic
+- You need error handling
+- Working with complex navigation flows
+- Implementing programmatic redirects
+
+### Navigation Error Handling
+
+Always handle navigation failures gracefully:
+
+```typescript
+export class NavigationService {
+  private readonly router = resolve(IRouter);
+
+  async safeNavigate(route: string, options?: any): Promise<boolean> {
+    try {
+      const result = await this.router.load(route, options);
+      
+      if (!result) {
+        // Navigation was blocked by guards
+        this.handleNavigationBlocked(route);
+        return false;
+      }
+      
+      return true;
+    } catch (error) {
+      this.handleNavigationError(error, route);
+      return false;
+    }
+  }
+
+  private handleNavigationBlocked(route: string) {
+    console.warn(`Navigation to ${route} was blocked`);
+    // Show user-friendly message or redirect to appropriate page
+  }
+
+  private handleNavigationError(error: any, route: string) {
+    console.error(`Navigation to ${route} failed:`, error);
+    // Log error, show error page, or attempt recovery
+  }
+}
+```
+
+### Performance Considerations
+
+1. **Prefer `href` for simple links** - Less overhead than programmatic navigation
+2. **Cache generated paths** when generating many URLs:
+
+```typescript
+export class LinkGeneratorService {
+  private readonly router = resolve(IRouter);
+  private readonly pathCache = new Map<string, string>();
+
+  async getPath(route: string, params?: any): Promise<string> {
+    const cacheKey = `${route}:${JSON.stringify(params)}`;
+    
+    if (this.pathCache.has(cacheKey)) {
+      return this.pathCache.get(cacheKey)!;
+    }
+
+    const path = await this.router.generatePath({ component: route, params });
+    this.pathCache.set(cacheKey, path);
+    return path;
+  }
+}
+```
+
+3. **Batch multiple navigation operations** when possible to avoid router overwhelm
+
+### Accessibility Considerations
+
+When implementing custom navigation, maintain accessibility:
+
+```typescript
+export class AccessibleNavigationComponent {
+  private readonly router = resolve(IRouter);
+
+  async navigateWithAccessibility(route: string, announcement?: string) {
+    const success = await this.router.load(route);
+    
+    if (success && announcement) {
+      // Announce navigation to screen readers
+      this.announceToScreenReader(announcement);
+    }
+  }
+
+  private announceToScreenReader(message: string) {
+    const announcement = document.createElement('div');
+    announcement.setAttribute('aria-live', 'polite');
+    announcement.setAttribute('aria-atomic', 'true');
+    announcement.className = 'sr-only'; // Screen reader only class
+    announcement.textContent = message;
+    
+    document.body.appendChild(announcement);
+    setTimeout(() => document.body.removeChild(announcement), 1000);
+  }
+}
+```
+
+### Testing Navigation
+
+When testing components with navigation:
+
+```typescript
+import { IRouter } from '@aurelia/router';
+
+describe('NavigationComponent', () => {
+  let mockRouter: jasmine.SpyObj<IRouter>;
+  let component: NavigationComponent;
+
+  beforeEach(() => {
+    mockRouter = jasmine.createSpyObj('IRouter', ['load', 'generatePath']);
+    // Set up component with mock router
+  });
+
+  it('should navigate to user profile', async () => {
+    mockRouter.load.and.returnValue(Promise.resolve(true));
+    
+    await component.navigateToUser('123');
+    
+    expect(mockRouter.load).toHaveBeenCalledWith('user/123');
+  });
+
+  it('should handle navigation failure', async () => {
+    mockRouter.load.and.returnValue(Promise.resolve(false));
+    spyOn(component, 'showErrorMessage');
+    
+    await component.navigateToUser('123');
+    
+    expect(component.showErrorMessage).toHaveBeenCalled();
+  });
+});
+```

--- a/docs/user-docs/router/router-events.md
+++ b/docs/user-docs/router/router-events.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Learn about how to subscribe to and handle router events.
+  Learn about how to subscribe to and handle router events for advanced navigation monitoring and application state management.
 ---
 
 # Router events
@@ -9,22 +9,84 @@ You can use the lifecycle hooks ([instance](./routing-lifecycle.md) and [shared]
 However, if you want to tap into different navigation phases from a non-routed component, such as standalone service or a simple custom element, then you need to leverage router events.
 This section discusses that.
 
-## Emitted events
+## Router Event Types Overview
 
-The router emits the following events.
+The router emits five distinct events that cover the complete navigation lifecycle:
 
-- `au:router:location-change`: Emitted when the browser location is changed via the [`popstate`](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event) and [`hashchange`](https://developer.mozilla.org/en-US/docs/Web/API/Window/hashchange_event) events.
-- `au:router:navigation-start`: Emitted by router before executing a routing instruction; or in other words, before performing navigation.
-- `au:router:navigation-end`: Emitted when the navigation is completed successfully.
-- `au:router:navigation-cancel`: Emitted when the navigation is cancelled via a non-`true` return value from `canLoad` or `canUnload` lifecycle hooks.
-- `au:router:navigation-error`: Emitted when the navigation is erred.
+| Event | When Emitted | Use Cases |
+|-------|-------------|-----------|
+| `au:router:location-change` | Browser location changed via history API | Track URL changes, analytics, browser navigation |
+| `au:router:navigation-start` | Before navigation begins | Show loading states, cancel navigation, logging |
+| `au:router:navigation-end` | Navigation completes successfully | Hide loading states, update breadcrumbs, analytics |
+| `au:router:navigation-cancel` | Navigation cancelled by guards/hooks | Handle cancelled navigation, show messages |
+| `au:router:navigation-error` | Navigation encounters an error | Error handling, fallback routing, logging |
 
-## Subscribing to the events
+## Event Details and Properties
 
-The events can be subscribed to using the [event aggregator](../aurelia-packages/event-aggregator.md).
-However, there is another type-safe alternative to that.
+### `LocationChangeEvent`
+Triggered when the browser location changes through user navigation (back/forward buttons) or hash changes.
 
-To this end, inject the `IRouterEvents` and use the `IRouterEvents#subscribe`.
+```typescript
+interface LocationChangeEvent {
+  readonly id: number;           // Unique navigation ID
+  readonly url: string;          // New URL
+  readonly trigger: 'popstate' | 'hashchange';  // What caused the change
+  readonly state: {} | null;     // Browser history state
+}
+```
+
+### `NavigationStartEvent`
+Emitted before navigation execution begins, giving you a chance to prepare or cancel.
+
+```typescript
+interface NavigationStartEvent {
+  readonly id: number;                    // Unique navigation ID
+  readonly instructions: ViewportInstructionTree;  // Where we're navigating
+  readonly trigger: 'popstate' | 'hashchange' | 'api';  // What triggered navigation
+  readonly managedState: ManagedState | null;     // Router-managed state
+}
+```
+
+### `NavigationEndEvent`  
+Fired when navigation completes successfully, providing final instruction details.
+
+```typescript
+interface NavigationEndEvent {
+  readonly id: number;                    // Unique navigation ID
+  readonly instructions: ViewportInstructionTree;      // Original instructions
+  readonly finalInstructions: ViewportInstructionTree; // Final resolved instructions
+}
+```
+
+### `NavigationCancelEvent`
+Emitted when navigation is cancelled by lifecycle hooks returning `false` or throwing.
+
+```typescript
+interface NavigationCancelEvent {
+  readonly id: number;                    // Unique navigation ID
+  readonly instructions: ViewportInstructionTree;  // Attempted instructions
+  readonly reason: unknown;               // Cancellation reason
+}
+```
+
+### `NavigationErrorEvent`
+Triggered when navigation encounters errors during execution.
+
+```typescript
+interface NavigationErrorEvent {
+  readonly id: number;                    // Unique navigation ID
+  readonly instructions: ViewportInstructionTree;  // Failed instructions
+  readonly error: unknown;                // The error that occurred
+}
+```
+
+## Subscribing to Router Events
+
+You can subscribe to router events in two ways: using the event aggregator or the type-safe `IRouterEvents` service (recommended).
+
+### Type-Safe Event Subscription with `IRouterEvents`
+
+The recommended approach uses `IRouterEvents` for compile-time type safety and better developer experience:
 
 ```typescript
 import {
@@ -37,93 +99,581 @@ import {
 } from '@aurelia/router';
 import { IDisposable, resolve } from 'aurelia';
 
-export class SomeService implements IDisposable {
-  private readonly subscriptions: IDisposable[];
-  public log: string[] = [];
+export class NavigationService implements IDisposable {
+  private readonly subscriptions: IDisposable[] = [];
+  private currentNavigationId: number | null = null;
+
   public constructor() {
     const events = resolve(IRouterEvents);
+    
     this.subscriptions = [
-      events.subscribe('au:router:location-change',   (event: LocationChangeEvent)   => { /* handle event */ }),
-      events.subscribe('au:router:navigation-start',  (event: NavigationStartEvent)  => { /* handle event */ }),
-      events.subscribe('au:router:navigation-end',    (event: NavigationEndEvent)    => { /* handle event */ }),
-      events.subscribe('au:router:navigation-cancel', (event: NavigationCancelEvent) => { /* handle event */ }),
-      events.subscribe('au:router:navigation-error',  (event: NavigationErrorEvent)  => { /* handle event */ }),
+      // Track location changes from browser navigation
+      events.subscribe('au:router:location-change', (event: LocationChangeEvent) => {
+        console.log(`Location changed: ${event.url} via ${event.trigger}`);
+        this.handleLocationChange(event);
+      }),
+
+      // Prepare for navigation start
+      events.subscribe('au:router:navigation-start', (event: NavigationStartEvent) => {
+        this.currentNavigationId = event.id;
+        console.log(`Navigation #${event.id} starting to: ${event.instructions}`);
+        this.handleNavigationStart(event);
+      }),
+
+      // Handle successful navigation completion
+      events.subscribe('au:router:navigation-end', (event: NavigationEndEvent) => {
+        console.log(`Navigation #${event.id} completed successfully`);
+        this.handleNavigationEnd(event);
+        this.currentNavigationId = null;
+      }),
+
+      // Handle cancelled navigation
+      events.subscribe('au:router:navigation-cancel', (event: NavigationCancelEvent) => {
+        console.warn(`Navigation #${event.id} cancelled:`, event.reason);
+        this.handleNavigationCancel(event);
+        this.currentNavigationId = null;
+      }),
+
+      // Handle navigation errors
+      events.subscribe('au:router:navigation-error', (event: NavigationErrorEvent) => {
+        console.error(`Navigation #${event.id} failed:`, event.error);
+        this.handleNavigationError(event);
+        this.currentNavigationId = null;
+      }),
     ];
   }
+
+  private handleLocationChange(event: LocationChangeEvent): void {
+    // Update analytics, breadcrumbs, etc.
+  }
+
+  private handleNavigationStart(event: NavigationStartEvent): void {
+    // Show loading indicators, prepare UI state
+  }
+
+  private handleNavigationEnd(event: NavigationEndEvent): void {
+    // Hide loading indicators, update UI state
+  }
+
+  private handleNavigationCancel(event: NavigationCancelEvent): void {
+    // Show user feedback, restore previous state
+  }
+
+  private handleNavigationError(event: NavigationErrorEvent): void {
+    // Show error messages, log errors, fallback routing
+  }
+
   public dispose(): void {
-    const subscriptions = this.subscriptions;
+    this.subscriptions.forEach(subscription => subscription.dispose());
     this.subscriptions.length = 0;
-    const len = subscriptions.length;
-    for (let i = 0; i < len; i++) {
-      subscriptions[i].dispose();
+  }
+}
+```
+
+### Alternative: Event Aggregator Subscription
+
+You can also use the standard event aggregator, though you lose TypeScript type safety:
+
+```typescript
+import { IEventAggregator, resolve } from '@aurelia/kernel';
+
+export class BasicNavigationService {
+  private readonly ea: IEventAggregator = resolve(IEventAggregator);
+
+  public constructor() {
+    this.ea.subscribe('au:router:navigation-start', (event: any) => {
+      // Note: 'event' is typed as 'any' - no type safety
+    });
+  }
+}
+```
+
+**Important:** Using `IRouterEvents` provides type safety and IntelliSense support, making it the preferred approach.
+
+## Practical Use Cases and Examples
+
+### Global Loading Indicator
+
+Show a loading spinner during navigation:
+
+```typescript
+import { resolve } from '@aurelia/kernel';
+import { customElement, observable } from '@aurelia/runtime-html';
+import { IRouterEvents, NavigationStartEvent, NavigationEndEvent } from '@aurelia/router';
+
+@customElement({
+  name: 'loading-app',
+  template: `
+    <div class="app-container">
+      <!-- Global loading indicator -->
+      <div if.bind="isNavigating" class="loading-overlay">
+        <div class="spinner"></div>
+        <span>Loading...</span>
+      </div>
+      
+      <!-- Navigation breadcrumbs -->
+      <nav class="breadcrumb" if.bind="breadcrumbs.length">
+        <span repeat.for="crumb of breadcrumbs" class="breadcrumb-item">
+          \${crumb}
+        </span>
+      </nav>
+      
+      <!-- Main content -->
+      <au-viewport></au-viewport>
+    </div>
+  `
+})
+export class LoadingApp {
+  @observable isNavigating: boolean = false;
+  @observable breadcrumbs: string[] = [];
+
+  private readonly subscriptions = [
+    resolve(IRouterEvents).subscribe('au:router:navigation-start', (event: NavigationStartEvent) => {
+      this.isNavigating = true;
+      console.log(`Starting navigation to: ${event.instructions.toUrl()}`);
+    }),
+
+    resolve(IRouterEvents).subscribe('au:router:navigation-end', (event: NavigationEndEvent) => {
+      this.isNavigating = false;
+      this.updateBreadcrumbs(event.finalInstructions);
+      console.log(`Navigation completed: ${event.finalInstructions.toUrl()}`);
+    }),
+
+    resolve(IRouterEvents).subscribe('au:router:navigation-cancel', () => {
+      this.isNavigating = false;
+      console.log('Navigation was cancelled');
+    }),
+
+    resolve(IRouterEvents).subscribe('au:router:navigation-error', (event) => {
+      this.isNavigating = false;
+      this.handleNavigationError(event.error);
+    })
+  ];
+
+  private updateBreadcrumbs(instructions: ViewportInstructionTree): void {
+    // Extract route titles for breadcrumb navigation
+    this.breadcrumbs = instructions.root.children.map(child => child.title || 'Unknown');
+  }
+
+  private handleNavigationError(error: unknown): void {
+    console.error('Navigation failed:', error);
+    // Could show toast notification, redirect to error page, etc.
+  }
+
+  dispose(): void {
+    this.subscriptions.forEach(sub => sub.dispose());
+  }
+}
+```
+
+### Analytics and Tracking Service
+
+Track navigation events for analytics:
+
+```typescript
+import { singleton, resolve } from '@aurelia/kernel';
+import { IRouterEvents, NavigationEndEvent, LocationChangeEvent } from '@aurelia/router';
+
+@singleton
+export class AnalyticsService {
+  private readonly startTimes = new Map<number, number>();
+
+  public constructor() {
+    const events = resolve(IRouterEvents);
+
+    // Track page views
+    events.subscribe('au:router:navigation-end', (event: NavigationEndEvent) => {
+      this.trackPageView(event);
+      this.trackNavigationTiming(event);
+    });
+
+    // Track browser navigation
+    events.subscribe('au:router:location-change', (event: LocationChangeEvent) => {
+      this.trackLocationChange(event);
+    });
+
+    // Track navigation starts for timing
+    events.subscribe('au:router:navigation-start', (event) => {
+      this.startTimes.set(event.id, performance.now());
+    });
+  }
+
+  private trackPageView(event: NavigationEndEvent): void {
+    const url = event.finalInstructions.toUrl();
+    const title = this.extractPageTitle(event.finalInstructions);
+    
+    // Send to analytics service (Google Analytics, Adobe Analytics, etc.)
+    if (typeof gtag !== 'undefined') {
+      gtag('config', 'GA_TRACKING_ID', {
+        page_title: title,
+        page_location: window.location.href
+      });
+    }
+
+    console.log(`📊 Page view: ${title} (${url})`);
+  }
+
+  private trackNavigationTiming(event: NavigationEndEvent): void {
+    const startTime = this.startTimes.get(event.id);
+    if (startTime) {
+      const duration = performance.now() - startTime;
+      console.log(`⏱️ Navigation #${event.id} took ${duration.toFixed(2)}ms`);
+      
+      // Track slow navigations 
+      if (duration > 1000) {
+        console.warn(`🐌 Slow navigation detected: ${duration.toFixed(2)}ms`);
+      }
+
+      this.startTimes.delete(event.id);
+    }
+  }
+
+  private trackLocationChange(event: LocationChangeEvent): void {
+    console.log(`🔄 Location changed via ${event.trigger}: ${event.url}`);
+    
+    // Track back/forward button usage
+    if (event.trigger === 'popstate') {
+      // Send analytics event for browser navigation
+    }
+  }
+
+  private extractPageTitle(instructions: ViewportInstructionTree): string {
+    return instructions.root.children[0]?.title || 'Unknown Page';
+  }
+}
+```
+
+### Error Handling and Recovery Service
+
+Handle navigation errors gracefully:
+
+```typescript
+import { singleton, resolve } from '@aurelia/kernel';
+import { IRouter, IRouterEvents, NavigationErrorEvent, NavigationCancelEvent } from '@aurelia/router';
+
+interface ErrorRecoveryStrategy {
+  shouldRecover(error: unknown): boolean;
+  recover(error: unknown): Promise<void>;
+}
+
+@singleton  
+export class NavigationErrorService {
+  private readonly router: IRouter = resolve(IRouter);
+  private errorHistory: Array<{timestamp: number, error: unknown, url: string}> = [];
+
+  private recoveryStrategies: ErrorRecoveryStrategy[] = [
+    {
+      shouldRecover: (error) => error instanceof Error && error.message.includes('Component not found'),
+      recover: async (error) => {
+        console.log('Component not found, redirecting to home');
+        await this.router.load('/');
+      }
+    },
+    {
+      shouldRecover: (error) => error instanceof Error && error.message.includes('Permission denied'),
+      recover: async (error) => {
+        console.log('Permission denied, redirecting to login');
+        await this.router.load('/login');
+      }
+    }
+  ];
+
+  public constructor() {
+    const events = resolve(IRouterEvents);
+
+    events.subscribe('au:router:navigation-error', (event: NavigationErrorEvent) => {
+      this.handleNavigationError(event);
+    });
+
+    events.subscribe('au:router:navigation-cancel', (event: NavigationCancelEvent) => {
+      this.handleNavigationCancel(event);
+    });
+  }
+
+  private async handleNavigationError(event: NavigationErrorEvent): Promise<void> {
+    const url = event.instructions.toUrl();
+    
+    // Log error for debugging
+    this.errorHistory.push({
+      timestamp: Date.now(),
+      error: event.error,
+      url
+    });
+
+    console.error(`❌ Navigation error for ${url}:`, event.error);
+
+    // Try recovery strategies
+    for (const strategy of this.recoveryStrategies) {
+      if (strategy.shouldRecover(event.error)) {
+        try {
+          await strategy.recover(event.error);
+          console.log(`✅ Recovered from navigation error using strategy`);
+          return;
+        } catch (recoveryError) {
+          console.error('Recovery strategy failed:', recoveryError);
+        }
+      }
+    }
+
+    // Fallback: show error page or go to home
+    this.showErrorNotification(`Navigation failed: ${url}`);
+    await this.router.load('/error', { 
+      state: { originalUrl: url, error: event.error } 
+    });
+  }
+
+  private handleNavigationCancel(event: NavigationCancelEvent): void {
+    const url = event.instructions.toUrl();
+    console.warn(`⚠️ Navigation cancelled for ${url}:`, event.reason);
+    
+    // Show user-friendly message
+    if (typeof event.reason === 'string' && event.reason.includes('permission')) {
+      this.showErrorNotification('You do not have permission to access this page');
+    } else {
+      this.showErrorNotification('Navigation was cancelled');
+    }
+  }
+
+  private showErrorNotification(message: string): void {
+    // Implementation depends on your notification system
+    console.log(`🔔 ${message}`);
+  }
+
+  public getErrorHistory(): Array<{timestamp: number, error: unknown, url: string}> {
+    return [...this.errorHistory];
+  }
+
+  public clearErrorHistory(): void {
+    this.errorHistory.length = 0;
+  }
+}
+```
+
+### Navigation State Management
+
+Track and manage complex navigation states:
+
+```typescript
+import { singleton, resolve, observable } from '@aurelia/kernel';
+import { IRouterEvents, NavigationStartEvent, NavigationEndEvent } from '@aurelia/router';
+
+interface NavigationHistoryEntry {
+  id: number;
+  url: string;
+  timestamp: number;
+  duration?: number;
+  trigger: 'api' | 'popstate' | 'hashchange';
+}
+
+@singleton
+export class NavigationStateService {
+  @observable currentNavigation: NavigationHistoryEntry | null = null;
+  @observable navigationHistory: NavigationHistoryEntry[] = [];
+  @observable isNavigating: boolean = false;
+
+  private pendingNavigations = new Map<number, NavigationHistoryEntry>();
+
+  public constructor() {
+    const events = resolve(IRouterEvents);
+
+    events.subscribe('au:router:navigation-start', (event: NavigationStartEvent) => {
+      const entry: NavigationHistoryEntry = {
+        id: event.id,
+        url: event.instructions.toUrl(),
+        timestamp: Date.now(),
+        trigger: event.trigger
+      };
+
+      this.pendingNavigations.set(event.id, entry);
+      this.currentNavigation = entry;
+      this.isNavigating = true;
+    });
+
+    events.subscribe('au:router:navigation-end', (event: NavigationEndEvent) => {
+      const entry = this.pendingNavigations.get(event.id);
+      if (entry) {
+        entry.duration = Date.now() - entry.timestamp;
+        entry.url = event.finalInstructions.toUrl(); // Use final URL
+        
+        this.navigationHistory.push(entry);
+        this.pendingNavigations.delete(event.id);
+        
+        // Keep only last 50 entries
+        if (this.navigationHistory.length > 50) {
+          this.navigationHistory.shift();
+        }
+      }
+
+      this.isNavigating = false;
+      this.currentNavigation = null;
+    });
+
+    events.subscribe('au:router:navigation-cancel', (event) => {
+      this.pendingNavigations.delete(event.id);
+      this.isNavigating = false;
+      this.currentNavigation = null;
+    });
+
+    events.subscribe('au:router:navigation-error', (event) => {
+      this.pendingNavigations.delete(event.id);
+      this.isNavigating = false;
+      this.currentNavigation = null;
+    });
+  }
+
+  public getRecentNavigation(count: number = 10): NavigationHistoryEntry[] {
+    return this.navigationHistory.slice(-count);
+  }
+
+  public getAverageNavigationTime(): number {
+    const withDuration = this.navigationHistory.filter(entry => entry.duration);
+    if (withDuration.length === 0) return 0;
+    
+    const total = withDuration.reduce((sum, entry) => sum + (entry.duration || 0), 0);
+    return total / withDuration.length;
+  }
+
+  public getNavigationStats() {
+    return {
+      totalNavigations: this.navigationHistory.length,
+      averageTime: this.getAverageNavigationTime(),
+      currentlyNavigating: this.isNavigating,
+      triggerStats: this.getTriggerStats()
+    };
+  }
+
+  private getTriggerStats() {
+    return this.navigationHistory.reduce((stats, entry) => {
+      stats[entry.trigger] = (stats[entry.trigger] || 0) + 1;
+      return stats;
+    }, {} as Record<string, number>);
+  }
+}
+```
+
+## Best Practices for Router Events
+
+### Memory Management
+
+Always dispose of event subscriptions to prevent memory leaks:
+
+```typescript
+import { IDisposable, resolve } from '@aurelia/kernel';
+import { IRouterEvents } from '@aurelia/router';
+
+export class Component implements IDisposable {
+  private readonly subscriptions: IDisposable[] = [];
+
+  constructor() {
+    const events = resolve(IRouterEvents);
+    
+    this.subscriptions.push(
+      events.subscribe('au:router:navigation-start', (event) => {
+        // Handle event
+      })
+    );
+  }
+
+  dispose(): void {
+    this.subscriptions.forEach(sub => sub.dispose());
+    this.subscriptions.length = 0;
+  }
+}
+```
+
+### Performance Considerations
+
+1. **Debounce expensive operations** in event handlers
+2. **Use singleton services** for global event handlers
+3. **Unsubscribe** when components are disposed
+4. **Avoid heavy computations** in event handlers
+
+### Error Handling in Event Handlers
+
+Always handle errors in event subscribers:
+
+```typescript
+events.subscribe('au:router:navigation-end', (event) => {
+  try {
+    // Your event handling logic
+    this.updateUI(event);
+  } catch (error) {
+    console.error('Error in navigation-end handler:', error);
+    // Don't let handler errors break navigation
+  }
+});
+```
+
+### Debugging Router Events
+
+Enable detailed logging for debugging:
+
+```typescript
+export class RouterDebugService {
+  constructor() {
+    const events = resolve(IRouterEvents);
+    
+    if (process.env.NODE_ENV === 'development') {
+      events.subscribe('au:router:location-change', (event) => {
+        console.group(`🔄 Location Change #${event.id}`);
+        console.log('URL:', event.url);
+        console.log('Trigger:', event.trigger);
+        console.log('State:', event.state);
+        console.groupEnd();
+      });
+
+      events.subscribe('au:router:navigation-start', (event) => {
+        console.group(`🚀 Navigation Start #${event.id}`);
+        console.log('Instructions:', event.instructions.toString());
+        console.log('Trigger:', event.trigger);
+        console.groupEnd();
+      });
+
+      events.subscribe('au:router:navigation-end', (event) => {
+        console.group(`✅ Navigation End #${event.id}`);
+        console.log('Final URL:', event.finalInstructions.toUrl());
+        console.groupEnd();
+      });
+
+      events.subscribe('au:router:navigation-cancel', (event) => {
+        console.group(`❌ Navigation Cancel #${event.id}`);
+        console.log('Reason:', event.reason);
+        console.groupEnd();
+      });
+
+      events.subscribe('au:router:navigation-error', (event) => {
+        console.group(`💥 Navigation Error #${event.id}`);
+        console.error('Error:', event.error);
+        console.groupEnd();
+      });
     }
   }
 }
 ```
 
-Note that the event-data for every event has a different type.
-When you are using TypeScript, using `IRouterEvents` correctly types the event-data to the corresponding event type and naturally provides you with intellisense.
-This type information won't be available if you subscribe to the events using the event aggregator.
+## Using Current Route for Simple Cases
 
-The following example demonstrates the usage of router events, where the root component displays a spinner at the start of navigation, and removes it when the navigation ends.
-
-```typescript
-import { resolve } from 'aurelia';
-import { IRouterEvents } from '@aurelia/router';
-
-export class MyApp {
-  private navigating: boolean = false;
-  public constructor() {
-    const events = resolve(IRouterEvents);
-    events.subscribe(
-      'au:router:navigation-start',
-      () => (this.navigating = true)
-    );
-    events.subscribe(
-      'au:router:navigation-end',
-      () => (this.navigating = false)
-    );
-  }
-}
-```
-
-This is shown in action below.
-
-{% embed url="https://stackblitz.com/edit/router-lite-events?ctl=1&embed=1&file=src/my-app.ts" %}
-
-## Current route
-
-Sometimes, you only need the information about the current route.
-In that case, you can surely subscribe to the `au:router:navigation-end` event and get the current route from the event data.
-For the ease of use, there is a `ICurrentRoute` exposed from router that does exactly the same.
-You can directly inject it to your class to use it and avoid the boilerplate code altogether.
-Below is an example of how you can use it.
+For simple scenarios where you only need current route information without complex event handling, use `ICurrentRoute`:
 
 ```typescript
 import { resolve } from 'aurelia';
 import { ICurrentRoute } from '@aurelia/router';
 
-export class MyApp {
+export class SimpleComponent {
   private readonly currentRoute: ICurrentRoute = resolve(ICurrentRoute);
 
-  public attached(): void {
-    console.log(`path: ${this.currentRoute.path}`);
-    console.log(`url: ${this.currentRoute.url}`);
-    console.log(`title: ${this.currentRoute.title}`);
-    console.log(`query: ${this.currentRoute.query}`);
-
-    for (const pi of this.currentRoute.parameterInformation) {
-      this.logParameterInstruction(pi);
-    }
+  get currentPath(): string {
+    return this.currentRoute.path;
   }
 
-  private logParameterInstruction(pi: IParameterInstruction): void {
-    console.log(`config: ${pi.config.id}`);
-    console.log(`viewport: ${pi.viewport}`);
-    console.log(`params:`, pi.params);
-    pi.children.forEach((c) => this.logParameterInstruction(c));
+  get currentUrl(): string {
+    return this.currentRoute.url;
+  }
+
+  get routeTitle(): string {
+    return this.currentRoute.title;
   }
 }
 ```
 
-See [Current route](./current-route.md) for a deeper look at the service.
+See [Current route](./current-route.md) for detailed information about the `ICurrentRoute` service.

--- a/docs/user-docs/templates/custom-attributes.md
+++ b/docs/user-docs/templates/custom-attributes.md
@@ -71,7 +71,7 @@ This custom attribute adds a fixed size and a red background to any element it i
 import { INode, resolve } from 'aurelia';
 
 export class RedSquareCustomAttribute {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     // Set fixed dimensions and a red background on initialization
@@ -105,7 +105,7 @@ Classes ending with `CustomAttribute` are automatically recognized as custom att
 import { INode, resolve } from 'aurelia';
 
 export class RedSquareCustomAttribute {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     this.element.style.width = this.element.style.height = '100px';
@@ -125,7 +125,7 @@ import { customAttribute, INode, resolve } from 'aurelia';
 
 @customAttribute({ name: 'red-square' })
 export class RedSquare {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     this.element.style.width = this.element.style.height = '100px';
@@ -178,7 +178,7 @@ import { customAttribute, INode, resolve } from 'aurelia';
 
 @customAttribute({ name: 'red-square' })
 export class RedSquare {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     this.element.style.width = this.element.style.height = '100px';
@@ -196,7 +196,7 @@ import { customAttribute, INode, resolve } from 'aurelia';
 
 @customAttribute({ name: 'red-square', aliases: ['redify', 'redbox'] })
 export class RedSquare {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     this.element.style.width = this.element.style.height = '100px';
@@ -217,22 +217,24 @@ Now the attribute can be used interchangeably using any of the registered names:
 
 ## Single Value Binding
 
-For simple cases, you might want to pass a single value to your custom attribute without explicitly declaring a bindable property. Aurelia will automatically populate the value property if a value is provided.
+For simple cases, you might want to pass a single value to your custom attribute without explicitly declaring a bindable property. Aurelia will automatically populate the `value` property if a value is provided.
 
 ```typescript
 import { INode, resolve } from 'aurelia';
 
-export class RedSquareCustomAttribute {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
-  private value: string;
+export class HighlightCustomAttribute {
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
+  public value: string;
 
   constructor() {
-    this.element.style.width = this.element.style.height = '100px';
-    // Use a default color, but override it if a value is supplied during binding.
-    this.element.style.backgroundColor = 'red';
+    // Apply default highlighting style
+    this.element.style.backgroundColor = 'yellow';
+    this.element.style.padding = '2px 4px';
+    this.element.style.borderRadius = '3px';
   }
 
   bind() {
+    // Override default color if a specific color is provided
     if (this.value) {
       this.element.style.backgroundColor = this.value;
     }
@@ -240,29 +242,53 @@ export class RedSquareCustomAttribute {
 }
 ```
 
+**Usage:**
+```html
+<import from="./highlight"></import>
+
+<!-- Uses default yellow highlighting -->
+<span highlight>Important text</span>
+
+<!-- Uses custom color -->
+<span highlight="lightblue">Custom highlighted text</span>
+```
+
 To further handle changes in the value over time, you can define the property as bindable:
 
 ```typescript
 import { bindable, INode, resolve } from 'aurelia';
 
-export class RedSquareCustomAttribute {
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+export class HighlightCustomAttribute {
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
-  @bindable() private value: string;
+  @bindable() public value: string;
 
   constructor() {
-    this.element.style.width = this.element.style.height = '100px';
-    this.element.style.backgroundColor = 'red';
+    // Apply default highlighting style
+    this.element.style.backgroundColor = 'yellow';
+    this.element.style.padding = '2px 4px';
+    this.element.style.borderRadius = '3px';
+    this.element.style.transition = 'background-color 0.3s ease';
   }
 
   bound() {
-    this.element.style.backgroundColor = this.value;
+    if (this.value) {
+      this.element.style.backgroundColor = this.value;
+    }
   }
 
   valueChanged(newValue: string, oldValue: string) {
-    this.element.style.backgroundColor = newValue;
+    this.element.style.backgroundColor = newValue || 'yellow';
   }
 }
+```
+
+**Usage with dynamic binding:**
+```html
+<import from="./highlight"></import>
+
+<!-- Color changes reactively based on view model property -->
+<span highlight.bind="selectedColor">Dynamic highlighting</span>
 ```
 
 ---
@@ -279,12 +305,12 @@ Bindable properties support different binding modes that determine how data flow
 import { bindable, INode, resolve, BindingMode } from 'aurelia';
 
 export class InputWrapperCustomAttribute {
-  @bindable({ mode: BindingMode.twoWay }) value: string = '';
-  @bindable({ mode: BindingMode.toView }) placeholder: string = '';
-  @bindable({ mode: BindingMode.fromView }) isValid: boolean = true;
-  @bindable({ mode: BindingMode.oneTime }) label: string = '';
+  @bindable({ mode: BindingMode.twoWay }) public value: string = '';
+  @bindable({ mode: BindingMode.toView }) public placeholder: string = '';
+  @bindable({ mode: BindingMode.fromView }) public isValid: boolean = true;
+  @bindable({ mode: BindingMode.oneTime }) public label: string = '';
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   // ... implementation
 }
@@ -304,10 +330,10 @@ You can mark one property as primary, allowing simpler binding syntax:
 import { bindable, INode, resolve } from 'aurelia';
 
 export class ColorSquareCustomAttribute {
-  @bindable({ primary: true }) color: string = 'red';
-  @bindable() size: string = '100px';
+  @bindable({ primary: true }) public color: string = 'red';
+  @bindable() public size: string = '100px';
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   constructor() {
     this.applyStyles();
@@ -354,13 +380,13 @@ import { bindable, INode, resolve } from 'aurelia';
 export class ValidatedInputCustomAttribute {
   @bindable({
     set: (value: string) => value?.trim().toLowerCase()
-  }) email: string = '';
+  }) public email: string = '';
 
   @bindable({
     set: (value: number) => Math.max(0, Math.min(100, value))
-  }) progress: number = 0;
+  }) public progress: number = 0;
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 }
 ```
 
@@ -372,8 +398,8 @@ You can specify custom callback names for change handlers:
 import { bindable } from 'aurelia';
 
 export class DataVisualizationCustomAttribute {
-  @bindable({ callback: 'onDataUpdate' }) dataset: any[] = [];
-  @bindable({ callback: 'onConfigChange' }) config: any = {};
+  @bindable({ callback: 'onDataUpdate' }) public dataset: any[] = [];
+  @bindable({ callback: 'onConfigChange' }) public config: any = {};
 
   onDataUpdate(newData: any[], oldData: any[]) {
     // Handle data changes
@@ -419,11 +445,11 @@ import { customAttribute, INode, resolve, BindingMode } from 'aurelia';
   }
 })
 export class AdvancedInputCustomAttribute {
-  value: string;
-  placeholder: string;
-  validation: any;
+  public value: string;
+  public placeholder: string;
+  public validation: any;
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   validateInput(newValidation: any, oldValidation: any) {
     // Handle validation changes
@@ -447,11 +473,11 @@ export class AdvancedInput {
     }
   };
 
-  value: string;
-  placeholder: string;
-  validation: any;
+  public value: string;
+  public placeholder: string;
+  public validation: any;
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   validateInput(newValidation: any, oldValidation: any) {
     // Handle validation changes
@@ -482,9 +508,9 @@ import { bindable, INode, resolve, customAttribute, ICustomAttributeController, 
 
 @customAttribute({ name: 'lifecycle-demo' })
 export class LifecycleDemoCustomAttribute {
-  @bindable() value: string = '';
+  @bindable() public value: string = '';
 
-  private element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
 
   created(controller: ICustomAttributeController) {
     // Called when the attribute instance is created
@@ -569,9 +595,9 @@ import { bindable, customAttribute } from 'aurelia';
 
 @customAttribute('batch-processor')
 export class BatchProcessorCustomAttribute {
-  @bindable() prop1: string;
-  @bindable() prop2: number;
-  @bindable() prop3: boolean;
+  @bindable() public prop1: string;
+  @bindable() public prop2: number;
+  @bindable() public prop3: boolean;
 
   // Called when any bindable property changes (batched until next microtask)
   propertiesChanged(changes: Record<string, { newValue: unknown; oldValue: unknown }>) {
@@ -639,7 +665,7 @@ import { CustomAttribute, resolve, INode, customAttribute } from 'aurelia';
 
 @customAttribute('bar')
 export class Bar {
-  host: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly host: HTMLElement = resolve(INode) as HTMLElement;
 
   binding() {
     // Find the closest ancestor that has the 'foo' custom attribute
@@ -661,7 +687,7 @@ import { Foo } from './foo';
 
 @customAttribute('bar')
 export class Bar {
-  host: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly host: HTMLElement = resolve(INode) as HTMLElement;
 
   binding() {
     // Find the closest ancestor that is an instance of the Foo custom attribute
@@ -687,8 +713,8 @@ import { templateController, IViewFactory, ISyntheticView, IRenderLocation, reso
 
 @templateController('permission')
 export class PermissionTemplateController {
-  @bindable() userRole: string;
-  @bindable() requiredRole: string;
+  @bindable() public userRole: string;
+  @bindable() public requiredRole: string;
 
   public readonly $controller!: ICustomAttributeController<this>;
 
@@ -781,7 +807,7 @@ import { customAttribute } from 'aurelia';
   noMultiBindings: true
 })
 export class SimpleUrlCustomAttribute {
-  value: string; // Will receive the entire attribute value as a string
+  public value: string; // Will receive the entire attribute value as a string
 }
 ```
 
@@ -835,9 +861,9 @@ import { customAttribute, BindingMode } from 'aurelia';
   defaultBindingMode: BindingMode.twoWay
 })
 export class TwoWayDefaultCustomAttribute {
-  @bindable() value1: string; // Will default to two-way binding
-  @bindable() value2: string; // Will default to two-way binding
-  @bindable({ mode: BindingMode.toView }) value3: string; // Explicitly one-way
+  @bindable() public value1: string; // Will default to two-way binding
+  @bindable() public value2: string; // Will default to two-way binding
+  @bindable({ mode: BindingMode.toView }) public value3: string; // Explicitly one-way
 }
 ```
 
@@ -852,8 +878,8 @@ import { bindable, customAttribute, watch } from 'aurelia';
 
 @customAttribute('data-processor')
 export class DataProcessorCustomAttribute {
-  @bindable() data: any[];
-  @bindable() config: any;
+  @bindable() public data: any[];
+  @bindable() public config: any;
 
   @watch('data', { immediate: true })
   @watch('config')
@@ -892,14 +918,14 @@ import AwesomeSlider from 'awesome-slider';
 @customAttribute('awesome-slider')
 export class AwesomeSliderCustomAttribute {
   // Allow dynamic options to be bound from the view
-  @bindable() options: any = {};
+  @bindable() public options: any = {};
 
   // The instance of the third-party slider
   private sliderInstance: any;
 
   // Safely resolve the host element
-  private element: HTMLElement = resolve(INode) as HTMLElement;
-  private logger = resolve(ILogger);
+  private readonly element: HTMLElement = resolve(INode) as HTMLElement;
+  private readonly logger = resolve(ILogger);
 
   attached() {
     // Initialize the slider when the element is attached to the DOM.
@@ -937,28 +963,152 @@ In place of our hypothetical `AwesomeSlider` library, you can use any third-part
 ## Best Practices
 
 ### Separation of Concerns
-Keep your custom attribute logic focused on enhancing the host element, and avoid heavy business logic.
+Keep your custom attribute logic focused on enhancing the host element, and avoid heavy business logic. Custom attributes should be presentational or behavioral enhancements, not data processing units.
+
+```typescript
+// ✅ Good - focused on DOM enhancement
+@customAttribute('tooltip')
+export class TooltipCustomAttribute {
+  @bindable() public text: string;
+  // Implementation focused on showing/hiding tooltip
+}
+
+// ❌ Bad - mixing business logic
+@customAttribute('tooltip')
+export class TooltipCustomAttribute {
+  @bindable() public userId: string;
+  
+  async fetchUserData() {
+    // Don't do data fetching in custom attributes
+    return await this.api.getUser(this.userId);
+  }
+}
+```
 
 ### Performance
-- Minimize DOM manipulations inside change handlers
-- If multiple properties change at once, consider batching style updates using `propertiesChanged`
-- Use lifecycle hooks appropriately - prefer `attached()` for DOM-dependent initialization
+- **Minimize DOM manipulations**: Cache style properties and batch updates when possible
+- **Use `propertiesChanged`**: For multiple property changes, batch updates to reduce DOM thrashing
+- **Lifecycle hook timing**: Use appropriate hooks for initialization
+  - `constructor()`: Basic setup, non-DOM operations
+  - `attached()`: DOM-dependent initialization, third-party library setup
+  - `detaching()`: Cleanup before DOM removal
+
+```typescript
+@customAttribute('performance-optimized')
+export class PerformanceOptimizedCustomAttribute {
+  @bindable() public width: string;
+  @bindable() public height: string;
+  @bindable() public color: string;
+
+  // ✅ Batch multiple property changes
+  propertiesChanged(changes: Record<string, any>) {
+    const element = this.element;
+    if ('width' in changes) element.style.width = changes.width.newValue;
+    if ('height' in changes) element.style.height = changes.height.newValue;
+    if ('color' in changes) element.style.backgroundColor = changes.color.newValue;
+  }
+}
+```
 
 ### Memory Management
-- Always clean up event listeners in `detached()` or `unbind()`
-- Dispose of third-party library instances properly
-- Remove references to prevent memory leaks
+- **Clean up event listeners**: Always remove event listeners to prevent memory leaks
+- **Dispose third-party instances**: Call proper cleanup methods for external libraries
+- **Weak references**: Use WeakMap/WeakSet for object references when appropriate
+
+```typescript
+@customAttribute('event-handler')
+export class EventHandlerCustomAttribute {
+  private eventListener: EventListener;
+  private thirdPartyInstance: any;
+
+  attached() {
+    this.eventListener = this.handleClick.bind(this);
+    this.element.addEventListener('click', this.eventListener);
+    
+    this.thirdPartyInstance = new SomeLibrary(this.element);
+  }
+
+  detaching() {
+    // ✅ Always clean up
+    this.element.removeEventListener('click', this.eventListener);
+    this.thirdPartyInstance?.destroy();
+    this.thirdPartyInstance = null;
+  }
+}
+```
+
+### Error Handling
+- **Graceful degradation**: Handle initialization failures gracefully
+- **Validation**: Validate bindable property values
+- **Logging**: Use Aurelia's logging system for debugging
+
+```typescript
+@customAttribute('robust-attribute')
+export class RobustCustomAttribute {
+  @bindable() public config: any;
+  private readonly logger = resolve(ILogger);
+
+  attached() {
+    try {
+      this.initializeFeature();
+    } catch (error) {
+      this.logger.error('Failed to initialize feature:', error);
+      // Fallback behavior
+      this.element.classList.add('feature-unavailable');
+    }
+  }
+
+  configChanged(newConfig: any) {
+    if (!this.isValidConfig(newConfig)) {
+      this.logger.warn('Invalid configuration provided');
+      return;
+    }
+    this.updateConfiguration(newConfig);
+  }
+}
+```
 
 ### Testing
-Write unit tests for your custom attributes to ensure that lifecycle hooks and bindings work as expected.
+Write comprehensive unit tests covering lifecycle hooks, property changes, and edge cases:
 
-### Documentation
-Comment your code and document the expected behavior of your custom attributes, especially if you provide aliases or multiple bindable properties.
+```typescript
+// Example test structure
+describe('MyCustomAttribute', () => {
+  it('should initialize correctly', () => { /* ... */ });
+  it('should handle property changes', () => { /* ... */ });
+  it('should clean up on detach', () => { /* ... */ });
+  it('should handle invalid input gracefully', () => { /* ... */ });
+});
+```
 
-### Type Safety
-- Use TypeScript interfaces for complex bindable properties
-- Provide proper typing for change callbacks
-- Use generic constraints where appropriate
+### Documentation and Maintainability
+- **Document public APIs**: Clearly document bindable properties and their expected types
+- **Use meaningful names**: Choose descriptive names for attributes and properties  
+- **Provide usage examples**: Include HTML usage examples in comments
+- **Type everything**: Use strong TypeScript typing for better IDE support
+
+### Type Safety Best Practices
+```typescript
+// ✅ Strong typing with interfaces
+interface ChartConfiguration {
+  readonly type: 'line' | 'bar' | 'pie';
+  readonly data: ChartData;
+  readonly options?: ChartOptions;
+}
+
+@customAttribute('chart')
+export class ChartCustomAttribute {
+  @bindable() public config: ChartConfiguration;
+  
+  // ✅ Typed change handlers
+  configChanged(newConfig: ChartConfiguration, oldConfig: ChartConfiguration) {
+    // TypeScript will catch type errors
+    if (newConfig.type !== oldConfig?.type) {
+      this.recreateChart(newConfig);
+    }
+  }
+}
+```
 
 ```typescript
 interface SliderOptions {
@@ -969,8 +1119,8 @@ interface SliderOptions {
 
 @customAttribute('typed-slider')
 export class TypedSliderCustomAttribute {
-  @bindable() options: SliderOptions = { min: 0, max: 100, step: 1 };
-  @bindable() value: number = 0;
+  @bindable() public options: SliderOptions = { min: 0, max: 100, step: 1 };
+  @bindable() public value: number = 0;
 
   optionsChanged(newOptions: SliderOptions, oldOptions: SliderOptions) {
     // Type-safe change handling

--- a/docs/user-docs/templates/lambda-expressions.md
+++ b/docs/user-docs/templates/lambda-expressions.md
@@ -1,230 +1,376 @@
 ---
-description: Enhance your Aurelia applications by reducing boilerplate with powerful lambda expressions. This documentation provides a comprehensive guide to using lambda expressions in Aurelia templates, including examples, best practices, and performance considerations.
+description: Master lambda expressions in Aurelia templates to write cleaner, more expressive code. Learn the supported syntax, array operations, event handling, and performance considerations with real examples from the framework's test suite.
 ---
 
 # Lambda Expressions in Aurelia Templates
 
-Lambda expressions in Aurelia templates offer a concise and powerful approach to incorporating JavaScript-like functionality directly within your HTML. By leveraging a subset of JavaScript's arrow function syntax, Aurelia ensures your templates remain expressive, readable, and maintainable.
+Lambda expressions in Aurelia templates allow you to use arrow function syntax directly in your HTML bindings. This feature enables inline data transformations, filtering, and event handling without requiring additional methods in your view models.
 
 ## Table of Contents
 
-- [Introduction](#introduction)
-- [Benefits of Lambda Expressions](#benefits-of-lambda-expressions)
-- [Basic Syntax and Valid Usage](#basic-syntax-and-valid-usage)
-- [Unsupported Patterns and Restrictions](#unsupported-patterns-and-restrictions)
-- [Working with Array Methods](#working-with-array-methods)
-  - [Filtering with `repeat.for`](#filtering-with-repeatfor)
-  - [Chaining Operations: Filter, Sort, and Map](#chaining-operations-filter-sort-and-map)
-- [Event Callbacks Using Lambdas](#event-callbacks-using-lambdas)
-- [Interpolation Expressions](#interpolation-expressions)
-- [Advanced Examples](#advanced-examples)
-- [Performance Considerations and Best Practices](#performance-considerations-and-best-practices)
-- [Common Pitfalls and Debugging Tips](#common-pitfalls-and-debugging-tips)
-- [Frequently Asked Questions (FAQ)](#frequently-asked-questions-faq)
+- [What Are Lambda Expressions?](#what-are-lambda-expressions)
+- [Basic Syntax](#basic-syntax)  
+- [Supported Patterns](#supported-patterns)
+- [Restrictions and Limitations](#restrictions-and-limitations)
+- [Array Operations](#array-operations)
+- [Event Handling](#event-handling)
+- [Text Interpolation](#text-interpolation)
+- [Advanced Use Cases](#advanced-use-cases)
+- [Performance and Best Practices](#performance-and-best-practices)
+- [Common Pitfalls](#common-pitfalls)
 
-## Benefits of Lambda Expressions
+## What Are Lambda Expressions?
 
-- **Less Boilerplate:** Embed logic inline without extra view-model methods or value converters.
-- **Enhanced Readability:** Express inline operations in a way that clearly reflects the intended transformation or filtering.
-- **Flexibility:** Manipulate data on the fly right where it's rendered.
-- **Maintainability:** Localize small bits of logic with the markup, which in certain scenarios simplifies updates and debugging.
+Lambda expressions are arrow functions that you can write directly in Aurelia template bindings. They provide a way to perform inline data transformations, filtering, and calculations without defining separate methods in your view model.
 
-## Basic Syntax and Valid Usage
+**Key Benefits:**
+- **Inline Logic:** Write simple functions directly in templates
+- **Reduced Boilerplate:** Avoid creating view model methods for simple operations  
+- **Better Locality:** Keep related logic close to where it's used
+- **Reactive Updates:** Automatically re-evaluate when dependencies change
 
-Lambda expressions are defined using JavaScript's arrow function syntax. Supported forms include:
+## Basic Syntax
+
+Aurelia supports these arrow function patterns:
 
 ```html
 <!-- No parameters -->
-() => 42
+${(() => 42)()}
 
-<!-- Single parameter with parentheses omitted -->
-a => a
-
-<!-- Single parameter with explicit parentheses -->
-(a) => a
-
-<!-- With rest parameters -->
-(...args) => args[0]
+<!-- Single parameter (parentheses optional) -->
+${items.map(item => item.name)}
+${items.map((item) => item.name)}
 
 <!-- Multiple parameters -->
-(a, b) => `${a}${b}`
+${items.reduce((sum, item) => sum + item.price, 0)}
 
-<!-- Nested lambda -->
-a => b => a + b
+<!-- Rest parameters -->
+${((...args) => args[0] + args[1] + args[2])(1, 2, 3)}
+
+<!-- Nested arrow functions -->
+${((a => b => a + b)(1))(2)}
 ```
 
-### Inline Expressions in Templates
-
-You can integrate lambda expressions directly in your template expressions for filtering, transforming, or handling events:
-
+**Real Template Usage:**
 ```html
-<div repeat.for="i of items.filter(item => item.active)">
-  ${i.name}
+<div repeat.for="item of items.filter(item => item.isActive)">
+  ${item.name}
 </div>
 ```
 
-## Unsupported Patterns and Restrictions
+## Supported Patterns
 
-Aurelia supports a limited subset of the standard JavaScript arrow function syntax. The following patterns are **not supported**:
-
-- **Block Bodies:** Only expression bodies are permitted.
-  ```js
-  // Invalid: Block body is not allowed
-  () => { return 42; }
-  ```
-
-- **Default Parameters:** You cannot specify default values.
-  ```js
-  // Invalid: Default parameter syntax is not allowed
-  (a = 42) => a
-  ```
-
-- **Destructuring Parameters:** Both array and object destructuring are not supported.
-  ```js
-  // Invalid: Destructuring parameter
-  ([a]) => a
-  ({a}) => a
-  ```
-
-## Working with Array Methods
-
-Lambda expressions shine when working with array methods, especially inside `repeat.for` bindings.
-
-### Filtering with `repeat.for`
-
-Instead of using value converters for filtering, you can directly use lambda expressions:
+Lambda expressions work in multiple binding contexts:
 
 ```html
+<!-- Text interpolation -->
+${items.filter(item => item.active).length}
+
+<!-- Repeat bindings -->
+<div repeat.for="user of users.sort((a, b) => a.name.localeCompare(b.name))">
+  ${user.name}
+</div>
+
+<!-- Event bindings -->
+<button click.trigger="() => doSomething()">Click</button>
+
+<!-- Attribute bindings -->
+<div my-attr.bind="value => transform(value)"></div>
+
+<!-- With binding behaviors and value converters -->
+<div repeat.for="item of items.filter(i => i.active) & debounce:500">
+  ${item.name}
+</div>
+<div repeat.for="item of items.sort((a, b) => a - b) | take:10">
+  ${item.name}
+</div>
+```
+
+## Restrictions and Limitations
+
+Aurelia's lambda expressions support only **expression bodies**. The following JavaScript arrow function features are **not supported**:
+
+```html
+<!-- ❌ Block bodies with curly braces -->
+${items.filter(item => { return item.active; })}
+
+<!-- ❌ Default parameters -->
+${items.map((item = {}) => item.name)}
+
+<!-- ❌ Destructuring parameters -->
+${items.map(([first]) => first)}
+${items.map(({name}) => name)}
+```
+
+**Error Messages:**
+- Block bodies: `"arrow function with function body is not supported"`
+- Default parameters: `"arrow function with default parameters is not supported"`  
+- Destructuring: `"arrow function with destructuring parameters is not supported"`
+
+## Array Operations
+
+Lambda expressions work with all standard JavaScript array methods. Aurelia automatically observes array changes and property access within lambda expressions.
+
+### Basic Array Operations
+
+Lambda expressions work with all standard JavaScript array methods:
+
+```html
+<!-- Filtering -->
 <div repeat.for="item of items.filter(item => item.isVisible)">
   ${item.name}
 </div>
+
+<!-- Sorting numbers -->
+<div repeat.for="num of numbers.sort((a, b) => a - b)">
+  ${num}
+</div>
+
+<!-- Mapping and joining -->
+${items.map(item => item.name.toUpperCase()).join(', ')}
+
+<!-- Array search methods -->
+${items.find(item => item.id === selectedId)?.name}
+${items.findIndex(item => item.active)}
+${items.indexOf(targetValue)}
+${items.lastIndexOf(targetValue)}
+${items.includes(searchValue)}
+
+<!-- Array access -->
+${items.at(-1)} <!-- Last item -->
+
+<!-- Aggregation -->
+${cartItems.reduce((total, item) => total + item.price, 0)}
+${cartItems.reduceRight((acc, item) => acc + item.value)}
+
+<!-- Array tests -->
+${items.every(item => item.valid)}
+${items.some(item => item.hasError)}
+
+<!-- Array transformation -->
+${nested.flat()}
+${items.flatMap(item => item.tags)}
+${items.slice(0, 5)}
 ```
 
-### Chaining Operations: Filter, Sort, and Map
+### Chaining Operations
 
-You can chain multiple array operations to transform data inline:
+Combine multiple array methods for complex transformations:
 
 ```html
-<div repeat.for="item of items
-  .filter(item => item.selected)
-  .sort((a, b) => a.order - b.order)">
+<div repeat.for="product of products
+  .filter(p => p.inStock && p.category === currentCategory)
+  .sort((a, b) => b.rating - a.rating)
+  .slice(0, 10)">
+  ${product.name} - ${product.rating}⭐
+</div>
+```
+
+### Reactive Property Access
+
+Aurelia automatically tracks property access in lambda expressions:
+
+```html
+<!-- Changes to item.visible will trigger re-evaluation -->
+<div repeat.for="item of items.filter(item => item.visible)">
   ${item.name}
 </div>
 ```
 
-> **Note:** Aurelia observes only the properties referenced in the lambda expression. In the above example, changes to `selected` and `order` will trigger re-evaluation.
+## Event Handling
 
-{% hint style="info" %}
-**Tip:** For sorting that might mutate your original array, use a non-mutating clone:
+Lambda expressions work with all Aurelia event bindings:
+
 ```html
-<div repeat.for="item of items.filter(item => item.active).slice(0).sort((a, b) => a.order - b.order)">
+<!-- Simple event handlers -->
+<button click.trigger="() => count++">Increment</button>
+
+<!-- Passing event data -->
+<input input.trigger="event => search(event.target.value)">
+
+<!-- Multiple parameters -->
+<button click.trigger="event => deleteItem(event, item.id)">Delete</button>
+```
+
+**Custom Attributes with Lambdas:**
+```html
+<!-- Pass functions to custom attributes -->
+<div validate.bind="value => value.length > 3">
+  <input value.bind="inputValue">
+</div>
+```
+
+## Text Interpolation
+
+Use lambda expressions in text interpolation for inline calculations:
+
+```html
+<!-- Array transformations -->
+<p>Tags: ${tags.map(tag => tag.toUpperCase()).join(', ')}</p>
+
+<!-- Calculations -->
+<p>Total: $${items.reduce((sum, item) => sum + item.price, 0).toFixed(2)}</p>
+
+<!-- Conditional text -->
+<p>Status: ${items.every(item => item.completed) ? 'All Done!' : 'In Progress'}</p>
+
+<!-- String operations -->
+<p>Names: ${users.map(u => u.name).join(' and ')}</p>
+```
+
+### Accessing Template Context
+
+Lambda expressions can access `$this` and `$parent` for scope navigation:
+
+```html
+<!-- Access view model properties -->
+${items.filter(item => item.userId === $this.currentUserId).length}
+
+<!-- Access parent scope in nested contexts -->
+<div with.bind="childData">
+  ${items.find(item => item.id === $parent.selectedId)?.name}
+</div>
+```
+
+## Advanced Use Cases
+
+### Nested Array Processing
+
+Process complex nested data structures:
+
+```html
+<!-- Flatten nested hierarchies (based on framework tests) -->
+<div repeat.for="item of items.flatMap(x => 
+  [x].concat(x.children.flatMap(y => [y].concat(y.children))))">
+  ${item.name}
+</div>
+
+<!-- Access parent scope in nested operations -->
+<div repeat.for="item of items.flatMap(x => 
+  x.children.flatMap(y => ([x, y].concat(y.children))))">
   ${item.name}
 </div>
 ```
-{% endhint %}
 
-## Event Callbacks Using Lambdas
+### Dynamic Search and Filtering
 
-Lambda expressions can simplify event handlers by keeping the logic in the template:
-
-```html
-<my-input change.bind="value => updateValue(value)">
-<my-button click.trigger="event => handleClick(event)">
-```
-
-This inline style helps clarify what data is being passed to your handler.
-
-## Interpolation Expressions
-
-Lambda functions can also be used within interpolation expressions for dynamic data calculations.
-
-### Transforming and Joining Arrays
-
-For instance, to render a comma-separated list from an array of keywords:
+Create responsive search interfaces:
 
 ```html
-<p>${keywords.map(x => x.toUpperCase()).join(', ')}</p>
-```
+<input value.bind="searchQuery" placeholder="Search products...">
+<input value.bind="minPrice" type="number" placeholder="Min price">
+<input value.bind="maxPrice" type="number" placeholder="Max price">
 
-### Aggregating with Reduce
-
-Compute aggregate values inline, such as totals or averages:
-
-```html
-<p>Total: ${cartItems.reduce((total, item) => total + item.price, 0)}</p>
-```
-
-## Advanced Examples
-
-Here are several advanced examples showcasing the versatility of lambda expressions:
-
-### Multiple Array Operations Combined
-
-Perform filtering, slicing, sorting, and mapping in one chained expression:
-
-```html
-<div repeat.for="user of users.filter(u => u.active)
-                              .slice(0, 10)
-                              .sort((a, b) => a.name.localeCompare(b.name))">
-  ${user.name}
+<div repeat.for="product of products
+  .filter(p => p.name.toLowerCase().includes(searchQuery.toLowerCase()))
+  .filter(p => p.price >= (minPrice || 0))
+  .filter(p => p.price <= (maxPrice || 999999))
+  .sort((a, b) => b.rating - a.rating)">
+  ${product.name} - $${product.price} (${product.rating}⭐)
 </div>
 ```
 
-### Nested Array Transformation
+### Immediate Invoked Arrow Functions
 
-Flatten nested structures and dynamically generate lists:
+Execute functions immediately within templates:
 
 ```html
-<ul>
-  <li repeat.for="category of categories">
-    ${category.items.map(item => item.label).join(', ')}
-  </li>
-</ul>
+<!-- Simple IIFE (from framework tests) -->
+${(a => a)(42)}
+
+<!-- Nested arrow functions -->
+${((a => b => a + b)(1))(2)}
+
+<!-- Rest parameters -->
+${((...args) => args[0] + args[1] + args[2])(1, 2, 3)}
+
+<!-- Complex object creation -->
+${(((e) => ({ a: e.value }))({ value: 'test' })).a}
 ```
 
-### Complex Event Handling
+## Performance and Best Practices
 
-Pass additional context to event callbacks with inline lambdas:
+### Automatic Property Observation
 
-```html
-<button click.trigger="event => deleteItem(event, item.id)">
-  Delete
-</button>
-```
-
-### Real-time Filtering Based on User Input
-
-Implement a dynamic filter that updates as the user types:
+Aurelia automatically observes properties accessed within lambda expressions:
 
 ```html
-<input type="text" value.bind="filterText" placeholder="Filter names..." />
-<div repeat.for="person of people.filter(p => p.name.includes(filterText))">
-  ${person.name}
+<!-- Will update when item.status or item.priority changes -->
+<div repeat.for="item of items.filter(item => 
+  item.status === 'active' && item.priority > 3)">
+  ${item.name}
 </div>
 ```
 
-### Elaborate Aggregation with Reduce
+### Array Mutation Handling
 
-Calculate averages or other complex aggregates inline:
+Aurelia observes array mutations for most methods:
 
 ```html
-<p>
-  Average Rating: ${products.reduce((sum, product, index, array) =>
-                      sum + product.rating / array.length, 0).toFixed(2)}
-</p>
+<!-- These will automatically update when arrays change -->
+${items.map(item => item.name)}           <!-- ✅ Observes array changes -->
+${items.filter(item => item.active)}      <!-- ✅ Observes array changes -->
+${items.reduce((sum, item) => sum + item.price, 0)}  <!-- ✅ Observes array changes -->
 ```
 
-## Performance Considerations and Best Practices
+**Sorting Considerations:**
+```html
+<!-- ✅ Works for text interpolation -->
+${items.sort((a, b) => a - b)}
 
-While lambda expressions keep your templates clean, there are a few points to consider for optimal performance:
+<!-- ⚠️ Use slice() first for repeat.for to avoid issues -->
+<div repeat.for="item of items.slice().sort((a, b) => a.order - b.order)">
+  ${item.name}
+</div>
+```
 
-- **Observability:** Aurelia observes only the properties directly referenced in the lambda. Be sure to include all necessary properties to trigger re-evaluation.
-- **Array Mutations:** Methods that mutate the array (e.g., `sort`, `splice`) won't trigger the binding update. Prefer non-mutating techniques (e.g., using `slice` before sorting).
-- **Complexity:** Keep lambda expressions simple where possible. For logic that becomes too complex or involves multiple operations, consider moving it to the view-model.
-- **Debugging:** Inline expressions can be harder to debug. If you encounter issues, isolating the logic in the view-model might help identify problems.
+### Performance Guidelines
 
-## Common Pitfalls and Debugging Tips
+- **Keep expressions simple:** Complex logic should move to view model methods
+- **Avoid deep nesting:** Limit chained operations for readability  
+- **Use specific property access:** Reference specific properties for optimal observation
+- **Profile when needed:** Monitor performance in large lists with complex transformations
 
-- **Over-Complex Expressions:** When lambda logic is too complicated, it might hinder readability and may lead to performance bottlenecks. Refactor complex logic into a dedicated view-model method if necessary.
-- **Property Dependencies:** If updates to a property do not trigger a re-evaluation, confirm that the property is correctly referenced within the lambda.
-- **Mutating Methods:** Since some array methods do not automatically trigger binding updates, cloning or using non-mutating methods is recommended.
+## Common Pitfalls
+
+### Mutation vs. Immutable Operations
+
+```html
+<!-- ❌ Problematic: sort mutates original array -->
+<div repeat.for="item of items.sort((a, b) => a.name.localeCompare(b.name))">
+
+<!-- ✅ Better: use slice() to avoid mutation -->
+<div repeat.for="item of items.slice().sort((a, b) => a.name.localeCompare(b.name))">
+```
+
+### Expression Complexity
+
+```html
+<!-- ❌ Too complex for templates -->
+${items.filter(item => {
+  const category = categories.find(c => c.id === item.categoryId);
+  return category && category.active && item.stock > 0;
+})}
+
+<!-- ✅ Move complex logic to view model -->
+${getAvailableItems(items, categories)}
+```
+
+### Debugging Tips
+
+- **Isolate expressions:** Test lambda expressions in browser console first
+- **Use intermediate variables:** Break complex chains into steps in your view model
+- **Check property names:** Ensure referenced properties exist and are observable
+- **Verify data structure:** Confirm arrays and objects have expected shape
+
+## Summary
+
+Lambda expressions in Aurelia templates provide a powerful way to write inline logic without cluttering your view models. They excel at array transformations, simple calculations, and event handling. Remember to:
+
+- Use only **expression bodies** (no curly braces)
+- Leverage **automatic property observation** for reactive updates
+- Keep expressions **simple and readable**
+- Move complex logic to **view model methods** when needed
+- Use `slice()` before mutating operations like `sort()` for safety
+
+With these guidelines, lambda expressions can significantly improve your template code's clarity and maintainability.


### PR DESCRIPTION
This is a significant improvement to our docs. The existing docs were great, but over time as things have changed in Aurelia 2, so too have some of the exports from packages, migrating to `router-lite` as the core router and countless other facets of our docs. An ongoing audit has revealed many areas of the docs that were not kept up to date with changes, didn't fully cover all API's and configuration aspects (like our fetch docs lacked many things, like how to use retry interceptors, configure custom implementations, abort controller and more.

Inspired by Angular (thanks Angular) we have also added in a section for developers using AI. This provides tips for working with popular tools (including example prompt assist files in different formats).

Don't mind the large PR. This is a cumulation of a couple of weeks of docs work. There may be additional PRs, but probably not on this scale.