### PR TITLE
feat(plugin-conventions): add <let> support to template type-checker

### DIFF
--- a/packages-tooling/__tests__/src/plugin-conventions/type-checking/with-convention.let.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/type-checking/with-convention.let.spec.ts
@@ -1,0 +1,118 @@
+import { preprocessOptions, preprocessResource } from '@aurelia/plugin-conventions';
+import { assertFailure, assertSuccess, createMarkupReader, prop } from './_shared';
+
+describe('type-checking/with-convention.let', function () {
+  const options = preprocessOptions({
+    enableConventions: true,
+    experimentalTemplateTypeCheck: true,
+  });
+
+  for (const [lang, extn] of [['TypeScript', 'ts'], ['JavaScript', 'js'], ['ESM', 'mjs']] as const) {
+    const isTs = lang === 'TypeScript';
+
+    it(`basic pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let a.bind="person.name"></let>\n\${a.toUpperCase()}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+
+export class Entry {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+          filePair: markupFile,
+        },
+        options,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`basic fail - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let a.bind="person.name"></let>\n\${a.nonExistent}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+
+export class Entry {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+          filePair: markupFile,
+        },
+        options,
+      );
+      assertFailure(entry, result.code, [/Property 'nonExistent' does not exist on type 'string'/]);
+    });
+
+    it(`override + to-binding-context - pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let x.bind="1" to-binding-context></let>\n\${x.toFixed(2)}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+
+export class Entry {
+${prop('x', 'string', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+          filePair: markupFile,
+        },
+        options,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`scoping across controllers - pass/fail - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const pass = `<let v.bind="person.name"></let><template if.bind="true">\${v.toUpperCase()}</template>`;
+      const fail = `<template if.bind="true"><let z.bind="1"></let></template>\${z}`;
+
+      const passResult = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+
+export class Entry {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, pass),
+          filePair: markupFile,
+        },
+        options,
+      );
+      assertSuccess(entry, passResult.code);
+
+      const failResult = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+
+export class Entry {}
+`,
+          readFile: createMarkupReader(markupFile, fail),
+          filePair: markupFile,
+        },
+        options,
+      );
+      assertFailure(entry, failResult.code, [/Property 'z' does not exist on type '.*Entry.*'/]);
+    });
+  }
+});

--- a/packages-tooling/__tests__/src/plugin-conventions/type-checking/without-convention.let.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/type-checking/without-convention.let.spec.ts
@@ -1,0 +1,226 @@
+import { preprocessResource } from '@aurelia/plugin-conventions';
+import { assertFailure, assertSuccess, createMarkupReader, prop } from './_shared';
+import { nonConventionalOptions } from './without-convention.basic.spec';
+
+describe('type-checking/without-convention.let', function () {
+  for (const [lang, extn] of [['TypeScript', 'ts'], ['JavaScript', 'js'], ['ESM', 'mjs']] as const) {
+    const isTs = lang === 'TypeScript';
+
+    it(`basic pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let a.bind="person.name"></let>\n\${a.toUpperCase()}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`basic fail - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let a.bind="person.name"></let>\n\${a.nonExistent}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertFailure(entry, result.code, [/Property 'nonExistent' does not exist on type 'string'/]);
+    });
+
+    it(`multiple lets & override - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let v.bind="1"></let>\n<let v.bind="'hi'"></let>\n\${v.toUpperCase()}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`to-binding-context overlay + collision - pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      // VM has x: string, let x.bind=1 (to-binding-context) should override so .toFixed exists
+      const markup = `<let x.bind="1" to-binding-context></let>\n\${x.toFixed(2)}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('x', 'string', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`command variants (to-view/two-way) - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let a.to-view="person.name"></let>\n<let b.two-way="'ok'"></let>\n\${a.toUpperCase()} \${b.toUpperCase()}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`duplicate declarations in one <let> (last wins) - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      // a.bind first (number), then a.one-time string; last one should win -> toUpperCase ok
+      const markup = `<let a.bind="1" a.one-time="'hi'"></let>\n\${a.toUpperCase()}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`visibility: inside repeat - pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<template repeat.for="p of people">
+  <let upper.bind="p.name.toUpperCase()"></let>
+  \${upper}
+</template>`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('people', '{ name: string }[]', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`visibility: let inside repeat does not leak - fail - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<template repeat.for="i of 3"><let a.bind="i"></let></template>\n\${a}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertFailure(entry, result.code, [/Property 'a' does not exist on type '.*Foo.*'/]);
+    });
+
+    it(`visibility: before if.bind is visible inside branch - pass - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<let v.bind="person.name"></let>\n<template if.bind="true">\${v.toUpperCase()}</template>`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {
+${prop('person', '{ name: string }', isTs)}
+}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertSuccess(entry, result.code);
+    });
+
+    it(`visibility: let inside if-branch does not leak - fail - language: ${lang}`, function () {
+      const entry = `entry.${extn}`;
+      const markupFile = 'entry.html';
+      const markup = `<template if.bind="true"><let z.bind="1"></let></template>\n\${z}`;
+      const result = preprocessResource(
+        {
+          path: entry,
+          contents: `
+import { customElement } from '@aurelia/runtime-html';
+import template from './${markupFile}';
+@customElement({ name: 'foo', template })
+export class Foo {}
+`,
+          readFile: createMarkupReader(markupFile, markup),
+        },
+        nonConventionalOptions,
+      );
+      assertFailure(entry, result.code, [/Property 'z' does not exist on type '.*Foo.*'/]);
+    });
+  }
+});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

Adds **`<let>` support** to the experimental template type-checker in `plugin-conventions`.

- Introduces a container-lifetime overlay scope so `<let>` declarations are visible to subsequent siblings and their descendants, and stop at the container boundary.
- Handles `.bind`, `.one-time`, `.to-view`, `.two-way`
- Handles `to-binding-context`
- Infers variable types from RHS (literal type / path type, otherwise `any`)
- Uses `Omit<…,'k'> & { k: T }` overlays so last write wins (prevents `never` intersections)
- Skips wrapping primitive RHS in `access(...)` to avoid invalid lambdas; wraps non-primitives so TS still checks the expression

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

- The `Omit` pattern is avoid intersecting conflicting property types when the same `<let>` name is redeclared
- Container scope is pushed once per sibling list (localized to the walker)
- `to-binding-context` affects the current binding context type; names resolve as if they were VM members
- Events/`.call`/`.from-view` are ignored.


## 📑 Test Plan

- Basic pass/fail for single `<let>`
- Multiple `<let>`s with override/last-wins
- `to-binding-context` (including collision with existing VM prop)
- Interactions with `repeat` and `if` (visibility and no-leakage)
- Command variants (`.bind`, `.one-time`, `.to-view`, `.two-way`)


## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->

