### PR TITLE
fix(bindable): dont transform underscore in attribute names

### DIFF
--- a/packages/__tests__/src/3-runtime-html/custom-elements.syntax.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.syntax.spec.ts
@@ -1,0 +1,42 @@
+import {
+  CustomElement
+} from '@aurelia/runtime-html';
+import { createFixture } from '@aurelia/testing';
+
+describe('3-runtime-html/custom-elements.syntax.spec.ts', function () {
+  it('keeps underscore in the middle of attribute names', async function () {
+    const { assertText } = createFixture(
+      `<my-el my_prop.bind="message">`,
+      class App {
+        message = 'Hello Aurelia 2!';
+      },
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '${my_prop}',
+          bindables: ['my_prop']
+        })
+      ],
+    );
+
+    assertText('Hello Aurelia 2!');
+  });
+
+  it('keeps trailing underscore of attribute names', async function () {
+    const { assertText } = createFixture(
+      `<my-el _my_prop_.bind="message">`,
+      class App {
+        message = 'Hello Aurelia 2!';
+      },
+      [
+        CustomElement.define({
+          name: 'my-el',
+          template: '${_my_prop_}',
+          bindables: ['_my_prop_']
+        })
+      ],
+    );
+
+    assertText('Hello Aurelia 2!');
+  });
+});

--- a/packages/runtime-html/src/bindable.ts
+++ b/packages/runtime-html/src/bindable.ts
@@ -1,4 +1,4 @@
-import { kebabCase, getPrototypeChain, noop, type Class, createLookup, isString, type Constructable } from '@aurelia/kernel';
+import { getPrototypeChain, noop, type Class, createLookup, isString, type Constructable } from '@aurelia/kernel';
 import { ICoercionConfiguration } from '@aurelia/runtime';
 import { defaultMode, toView, twoWay } from './binding/interfaces-bindings';
 import { defineMetadata, getAnnotationKeyFor, getMetadata } from './utilities-metadata';
@@ -190,10 +190,16 @@ export class BindableDefinition {
     public readonly set: InterceptorFunc,
   ) { }
 
+  /** @internal */
+  private static readonly _cache: Record<string, string> = {};
+  public static toAttr(prop: string): string {
+    return this._cache[prop] ??= prop.replace(/([A-Z])/g, (_, $1: string) => `-${$1.toLowerCase()}`);
+  }
+
   public static create(prop: string, def: PartialBindableDefinition = {}): BindableDefinition {
     const mode = (def.mode ?? toView) as BindingMode;
     return new BindableDefinition(
-      def.attribute ?? kebabCase(prop),
+      def.attribute ?? BindableDefinition.toAttr(prop),
       def.callback ?? `${prop}Changed`,
       isString(mode) ? BindingMode[mode as keyof typeof BindingMode] ?? defaultMode : mode,
       def.primary ?? false,


### PR DESCRIPTION
## 📖 Description

Currently we treat underscores (`_`) in custom element/custom attribute props as a valid character to be replaced by `-` when transforming to kebab case, this leads to the following transformation:
```
_my_prop_    -> my-prop
my_prop    -> my-prop
```

This isn't how v1 works, and it also dismisses a valid usage of `_`. This PR changes the way attribute is parsed and converting element property names to attribute names will correctly leave `_` alone.