### PR TITLE
fix: computed observer callback timing same with normal

### DIFF
--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1267,7 +1267,7 @@ function createObservers(
         throw createMappedError(ErrorNames.controller_property_not_coercible, name);
       }
     }
-    if (instance[handler] != null
+    if (handler in instance
       || instance.propertyChanged != null
       || hasAggregatedCallbacks
     ) {

--- a/packages/runtime/src/computed-observer.ts
+++ b/packages/runtime/src/computed-observer.ts
@@ -222,10 +222,9 @@ export class ComputedObserver<T extends object> implements
     // so we are only notifying subscribers when it's the actual notify phase
 
     if (!this._notified || !areEqual(newValue, currValue)) {
-      // todo: wrong timing, this should be after notify
-      this._callback?.(newValue, oldValue);
       this.subs.notify(newValue, oldValue);
       this._oldValue = this._value = newValue;
+      this._callback?.(newValue, oldValue);
       this._notified = true;
     }
   }


### PR DESCRIPTION
## 📖 Description

Make computed observer callback timing the same with normal observer callback timing, which is after subscribers,
