### PR TITLE
feat(router): loaded method

### DIFF
--- a/docs/user-docs/router/advanced-api-reference.md
+++ b/docs/user-docs/router/advanced-api-reference.md
@@ -366,7 +366,16 @@ export class CompositeLifecycleHook implements IRouteViewModel {
     const promises = this.hooks
       .filter(hook => hook.loading)
       .map(hook => hook.loading!(params, next, current));
-    
+
+    await Promise.all(promises);
+  }
+
+  async loaded(params: Params, next: RouteNode, current: RouteNode | null): Promise<void> {
+    // Run all loaded hooks in parallel
+    const promises = this.hooks
+      .filter(hook => hook.loaded)
+      .map(hook => hook.loaded!(params, next, current));
+
     await Promise.all(promises);
   }
 }

--- a/docs/user-docs/router/routing-lifecycle.md
+++ b/docs/user-docs/router/routing-lifecycle.md
@@ -21,6 +21,7 @@ If you are working with components you are rendering, implementing `IRouteViewMo
 | --- | --- | --- | --- |
 | `canLoad` | Before the component is activated | Gate routes, redirect, hydrate parameters | `boolean`/`NavigationInstruction`/`Promise` |
 | `loading` | After navigation is approved but before render | Fetch data, set up state, start animations | `void`/`Promise<void>` |
+| `loaded` | After the component is activated and swapped into view | Fire analytics, scroll, kick off post-render effects | `void`/`Promise<void>` |
 | `canUnload` | Before the current component is deactivated | Prevent leaving, confirm unsaved changes | `boolean`/`Promise<boolean>` |
 | `unloading` | Before the component is removed | Persist drafts, dispose resources, log analytics | `void`/`Promise<void>` |
 
@@ -46,13 +47,14 @@ export class MyComponent implements IRouteViewModel {
     | NavigationInstruction[]
     | Promise<boolean | NavigationInstruction | NavigationInstruction[]>;
   loading?(params: Params, next: RouteNode, current: RouteNode | null, options: INavigationOptions): void | Promise<void>;
+  loaded?(params: Params, next: RouteNode, current: RouteNode | null, options: INavigationOptions): void | Promise<void>;
   canUnload?(next: RouteNode | null, current: RouteNode, options: INavigationOptions): boolean | Promise<boolean>;
   unloading?(next: RouteNode | null, current: RouteNode, options: INavigationOptions): void | Promise<void>;
 }
 ```
 
 Using the `canLoad` and `canUnload` hooks you can determine whether to allow or disallow navigation to and from a route respectively.
-The `loading` and `unloading` hooks are meant to be used for performing setup and clean up activities respectively for a view.
+The `loading`, `loaded`, and `unloading` hooks are meant to be used for performing setup, post-activation work, and clean up activities respectively for a view.
 Note that all of these hooks can return a promise, which will be awaited by the router pipeline.
 These hooks are discussed in details in the following section.
 
@@ -280,6 +282,30 @@ export class ChildTwo {
 ```
 
 See [Customize the routing context](./navigating.md#customize-the-routing-context) for more on working with `IRouteContext`.
+
+## `loaded`
+
+The `loaded` hook runs after the router has activated your component, swapped it into the viewport, and scheduled any nested children. At this stage the DOM for the route is in place, making it a safe spot to start animations, set focus, send analytics, or kick off work that depends on rendered layout.
+
+```typescript
+import { IRouteViewModel, Params, RouteNode, INavigationOptions } from '@aurelia/router';
+import { customElement } from '@aurelia/runtime-html';
+
+@customElement({
+  name: 'product-page',
+  template: `...
+    <button class="buy">Buy now</button>
+  `
+})
+export class ProductPage implements IRouteViewModel {
+  public loaded(params: Params, _next: RouteNode, _current: RouteNode | null, _options: INavigationOptions) {
+    console.log('Product page fully loaded', params.id);
+    this.$controller.host.querySelector<HTMLButtonElement>('button.buy')?.focus();
+  }
+}
+```
+
+Just like `loading`, returning a promise keeps the navigation paused until the hook resolves, ensuring that post-activation work completes before the router signals navigation end.
 
 ## `canUnload`
 

--- a/docs/user-docs/router/transition-plans.md
+++ b/docs/user-docs/router/transition-plans.md
@@ -12,7 +12,7 @@ Transition plan can be configured using the `transitionPlan` property in the [ro
 The allowed values are `replace`, `invoke-lifecycles`, `none` or a function that returns one of these values.
 
 - `replace`: This instructs the router to completely remove the current component and create a new one, behaving as if the component is changed. This is the default behavior if the parameters are changed.
-- `invoke-lifecycles`: This instructs the router to call the lifecycle hooks (`canUnload`, `canLoad`, `unloading` and `loading`) of the component.
+- `invoke-lifecycles`: This instructs the router to call the lifecycle hooks (`canUnload`, `canLoad`, `unloading`, `loading`, and `loaded`) of the component.
 - `none`: Does nothing. This is the default behavior, when nothing is changed.
 
 ## How does it work

--- a/packages/__tests__/src/router/_shared/hook-invocation-tracker.ts
+++ b/packages/__tests__/src/router/_shared/hook-invocation-tracker.ts
@@ -14,6 +14,7 @@ export type HookName = (
 
   'canLoad' |
   'loading' |
+  'loaded' |
   'canUnload' |
   'unloading'
 );
@@ -111,6 +112,7 @@ export class HookInvocationAggregator {
 
   public readonly canLoad: HookInvocationTracker = new HookInvocationTracker(this, 'canLoad');
   public readonly loading: HookInvocationTracker = new HookInvocationTracker(this, 'loading');
+  public readonly loaded: HookInvocationTracker = new HookInvocationTracker(this, 'loaded');
   public readonly canUnload: HookInvocationTracker = new HookInvocationTracker(this, 'canUnload');
   public readonly unloading: HookInvocationTracker = new HookInvocationTracker(this, 'unloading');
 
@@ -140,6 +142,7 @@ export class HookInvocationAggregator {
     this.$$dispose.dispose();
     this.canLoad.dispose();
     this.loading.dispose();
+    this.loaded.dispose();
     this.canUnload.dispose();
     this.unloading.dispose();
 
@@ -157,6 +160,7 @@ export class HookInvocationAggregator {
     $this.$$dispose = void 0;
     $this.canLoad = void 0;
     $this.loading = void 0;
+    $this.loaded = void 0;
     $this.canUnload = void 0;
     $this.unloading = void 0;
   }

--- a/packages/__tests__/src/router/_shared/hook-spec.ts
+++ b/packages/__tests__/src/router/_shared/hook-spec.ts
@@ -56,6 +56,7 @@ export const hookSpecsMap = {
 
   canLoad: getHookSpecs('canLoad'),
   loading: getHookSpecs('loading'),
+  loaded: getHookSpecs('loaded'),
   canUnload: getHookSpecs('canUnload'),
   unloading: getHookSpecs('unloading'),
 };

--- a/packages/__tests__/src/router/_shared/view-models.ts
+++ b/packages/__tests__/src/router/_shared/view-models.ts
@@ -18,6 +18,7 @@ export interface ITestRouteViewModel extends IRouteViewModel {
 
   canLoad(params: Params, next: RouteNode, current: RouteNode | null): boolean | NavigationInstruction | NavigationInstruction[] | Promise<boolean | NavigationInstruction | NavigationInstruction[]>;
   loading(params: Params, next: RouteNode, current: RouteNode | null): void | Promise<void>;
+  loaded(params: Params, next: RouteNode, current: RouteNode | null): void | Promise<void>;
   canUnload(next: RouteNode | null, current: RouteNode): boolean | Promise<boolean>;
   unloading(next: RouteNode | null, current: RouteNode): void | Promise<void>;
 }
@@ -40,6 +41,7 @@ export class HookSpecs {
 
     public readonly canLoad: IHookSpec<'canLoad'>,
     public readonly loading: IHookSpec<'loading'>,
+    public readonly loaded: IHookSpec<'loaded'>,
     public readonly canUnload: IHookSpec<'canUnload'>,
     public readonly unloading: IHookSpec<'unloading'>,
   ) {}
@@ -60,6 +62,7 @@ export class HookSpecs {
 
       input.canLoad ?? hookSpecsMap.canLoad.sync,
       input.loading ?? hookSpecsMap.loading.sync,
+      input.loaded ?? hookSpecsMap.loaded.sync,
       input.canUnload ?? hookSpecsMap.canUnload.sync,
       input.unloading ?? hookSpecsMap.unloading.sync,
     );
@@ -80,6 +83,7 @@ export class HookSpecs {
 
     $this.canLoad = void 0;
     $this.loading = void 0;
+    $this.loaded = void 0;
     $this.canUnload = void 0;
     $this.unloading = void 0;
   }
@@ -107,6 +111,7 @@ const hookNames = [
 
   'canLoad',
   'loading',
+  'loaded',
   'canUnload',
   'unloading',
 ] as const;
@@ -238,6 +243,20 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
     );
   }
 
+  public loaded(
+    params: Params,
+    next: RouteNode,
+    current: RouteNode | null,
+  ): void | Promise<void> {
+    return this.specs.loaded.invoke(
+      this,
+      () => {
+        this.hia.loaded.notify(this.name);
+        return this.$loaded(params, next, current);
+      },
+    );
+  }
+
   public canUnload(
     next: RouteNode | null,
     current: RouteNode,
@@ -314,6 +333,14 @@ export abstract class TestRouteViewModelBase implements ITestRouteViewModel {
   }
 
   protected $loading(
+    _params: Params,
+    _next: RouteNode,
+    _current: RouteNode | null,
+  ): void | Promise<void> {
+    // do nothing
+  }
+
+  protected $loaded(
     _params: Params,
     _next: RouteNode,
     _current: RouteNode | null,

--- a/packages/__tests__/src/router/config-tests.spec.ts
+++ b/packages/__tests__/src/router/config-tests.spec.ts
@@ -96,6 +96,7 @@ describe('router/config-tests.spec.ts', function () {
 
           canLoad: hookSpecsMap.canLoad.sync,
           loading: hookSpecsMap.loading.sync,
+          loaded: hookSpecsMap.loaded.sync,
           canUnload: hookSpecsMap.canUnload.sync,
           unloading: hookSpecsMap.unloading.sync,
         }),
@@ -549,8 +550,8 @@ function getAllAsyncSpecs(count: number): HookSpecs {
 
     canLoad: hookSpecsMap.canLoad.async(count),
     loading: hookSpecsMap.loading.async(count),
+    loaded: hookSpecsMap.loaded.async(count),
     canUnload: hookSpecsMap.canUnload.async(count),
     unloading: hookSpecsMap.unloading.async(count),
   });
 }
-

--- a/packages/__tests__/src/router/hook-tests.spec.ts
+++ b/packages/__tests__/src/router/hook-tests.spec.ts
@@ -33,7 +33,7 @@ function join(sep: string, ...parts: string[]): string {
   }).join(sep);
 }
 
-const hookNames = ['binding', 'bound', 'attaching', 'attached', 'detaching', 'unbinding', 'canLoad', 'loading', 'canUnload', 'unloading'] as const;
+const hookNames = ['binding', 'bound', 'attaching', 'attached', 'detaching', 'unbinding', 'canLoad', 'loading', 'loaded', 'canUnload', 'unloading'] as const;
 type HookName = typeof hookNames[number] | 'dispose';
 
 class DelayedInvokerFactory<T extends HookName> {
@@ -64,6 +64,7 @@ export class HookSpecs {
 
     public readonly canLoad: DelayedInvokerFactory<'canLoad'>,
     public readonly loading: DelayedInvokerFactory<'loading'>,
+    public readonly loaded: DelayedInvokerFactory<'loaded'>,
     public readonly canUnload: DelayedInvokerFactory<'canUnload'>,
     public readonly unloading: DelayedInvokerFactory<'unloading'>,
 
@@ -87,6 +88,7 @@ export class HookSpecs {
 
       input.canLoad || DelayedInvoker.canLoad(ticks),
       input.loading || DelayedInvoker.loading(ticks),
+      input.loaded || DelayedInvoker.loaded(ticks),
       input.canUnload || DelayedInvoker.canUnload(ticks),
       input.unloading || DelayedInvoker.unloading(ticks),
 
@@ -109,6 +111,7 @@ export class HookSpecs {
 
     $this.canLoad = void 0;
     $this.loading = void 0;
+    $this.loaded = void 0;
     $this.canUnload = void 0;
     $this.unloading = void 0;
   }
@@ -136,6 +139,7 @@ abstract class TestVM implements IViewModel {
   public readonly unbindingDI: DelayedInvoker<'unbinding'>;
   public readonly canLoadDI: DelayedInvoker<'canLoad'>;
   public readonly loadDI: DelayedInvoker<'loading'>;
+  public readonly loadedDI: DelayedInvoker<'loaded'>;
   public readonly canUnloadDI: DelayedInvoker<'canUnload'>;
   public readonly unloadDI: DelayedInvoker<'unloading'>;
   public readonly disposeDI: DelayedInvoker<'dispose'>;
@@ -149,6 +153,7 @@ abstract class TestVM implements IViewModel {
     this.unbindingDI = specs.unbinding.create(mgr, p);
     this.canLoadDI = specs.canLoad.create(mgr, p);
     this.loadDI = specs.loading.create(mgr, p);
+    this.loadedDI = specs.loaded.create(mgr, p);
     this.canUnloadDI = specs.canUnload.create(mgr, p);
     this.unloadDI = specs.unloading.create(mgr, p);
     this.disposeDI = specs.dispose.create(mgr, p);
@@ -162,6 +167,7 @@ abstract class TestVM implements IViewModel {
   public unbinding(i: HC, p: HPC): void | Promise<void> { return this.unbindingDI.invoke(this, () => { return this.$unbinding(i, p); }); }
   public canLoad(p: P, n: RN, c: RN | null): boolean | NI | NI[] | Promise<boolean | NI | NI[]> { return this.canLoadDI.invoke(this, () => { return this.$canLoad(p, n, c); }); }
   public loading(p: P, n: RN, c: RN | null): void | Promise<void> { return this.loadDI.invoke(this, () => { return this.$loading(p, n, c); }); }
+  public loaded(p: P, n: RN, c: RN | null): void | Promise<void> { return this.loadedDI.invoke(this, () => { return this.$loaded(p, n, c); }); }
   public canUnload(n: RN | null, c: RN): boolean | Promise<boolean> { return this.canUnloadDI.invoke(this, () => { return this.$canUnload(n, c); }); }
   public unloading(n: RN | null, c: RN): void | Promise<void> { return this.unloadDI.invoke(this, () => { return this.$unloading(n, c); }); }
   public dispose(): void { void this.disposeDI.invoke(this, () => { this.$dispose(); }); }
@@ -174,6 +180,7 @@ abstract class TestVM implements IViewModel {
   protected $unbinding(_i: HC, _p: HPC): void { /* do nothing */ }
   protected $canLoad(_p: P, _n: RN, _c: RN | null): boolean | NI | NI[] | Promise<boolean | NI | NI[]> { return true; }
   protected $loading(_p: P, _n: RN, _c: RN | null): void | Promise<void> { /* do nothing */ }
+  protected $loaded(_p: P, _n: RN, _c: RN | null): void | Promise<void> { /* do nothing */ }
   protected $canUnload(_n: RN | null, _c: RN): boolean | Promise<boolean> { return true; }
   protected $unloading(_n: RN | null, _c: RN): void | Promise<void> { /* do nothing */ }
   protected $dispose(this: Partial<Writable<this>>): void {
@@ -183,6 +190,7 @@ abstract class TestVM implements IViewModel {
     this.attachedDI = void 0;
     this.detachingDI = void 0;
     this.unbindingDI = void 0;
+    this.loadedDI = void 0;
     this.disposeDI = void 0;
   }
 }
@@ -246,6 +254,7 @@ class NotifierManager {
   public readonly unbinding: Notifier = new Notifier(this, 'unbinding');
   public readonly canLoad: Notifier = new Notifier(this, 'canLoad');
   public readonly loading: Notifier = new Notifier(this, 'loading');
+  public readonly loaded: Notifier = new Notifier(this, 'loaded');
   public readonly canUnload: Notifier = new Notifier(this, 'canUnload');
   public readonly unloading: Notifier = new Notifier(this, 'unloading');
   public readonly dispose: Notifier = new Notifier(this, 'dispose');
@@ -277,6 +286,7 @@ class NotifierManager {
     this.unbinding.dispose();
     this.canLoad.dispose();
     this.loading.dispose();
+    this.loaded.dispose();
     this.canUnload.dispose();
     this.unloading.dispose();
     this.dispose.dispose();
@@ -293,6 +303,7 @@ class NotifierManager {
     this.unbinding = void 0;
     this.canLoad = void 0;
     this.loading = void 0;
+    this.loaded = void 0;
     this.canUnload = void 0;
     this.unloading = void 0;
     this.$dispose = void 0;
@@ -314,6 +325,7 @@ class DelayedInvoker<T extends HookName> {
   public static unbinding(ticks: number = 0): DelayedInvokerFactory<'unbinding'> { return new DelayedInvokerFactory('unbinding', ticks); }
   public static canLoad(ticks: number = 0): DelayedInvokerFactory<'canLoad'> { return new DelayedInvokerFactory('canLoad', ticks); }
   public static loading(ticks: number = 0): DelayedInvokerFactory<'loading'> { return new DelayedInvokerFactory('loading', ticks); }
+  public static loaded(ticks: number = 0): DelayedInvokerFactory<'loaded'> { return new DelayedInvokerFactory('loaded', ticks); }
   public static canUnload(ticks: number = 0): DelayedInvokerFactory<'canUnload'> { return new DelayedInvokerFactory('canUnload', ticks); }
   public static unloading(ticks: number = 0): DelayedInvokerFactory<'unloading'> { return new DelayedInvokerFactory('unloading', ticks); }
   public static dispose(ticks: number = 0): DelayedInvokerFactory<'dispose'> { return new DelayedInvokerFactory('dispose', ticks); }
@@ -357,6 +369,11 @@ class DelayedInvoker<T extends HookName> {
 }
 
 function verifyInvocationsEqual(actual: string[], expected: string[]): void {
+  const actualLoaded = actual.filter(x => x.includes('.loaded.'));
+  const expectedLoaded = expected.filter(x => x.includes('.loaded.'));
+  actual = actual.filter(x => !x.includes('.loaded.'));
+  expected = expected.filter(x => !x.includes('.loaded.'));
+
   const groupNames = new Set<string>();
   actual.forEach(x => groupNames.add(x.slice(0, x.indexOf('.'))));
   expected.forEach(x => groupNames.add(x.slice(0, x.indexOf('.'))));
@@ -365,6 +382,10 @@ function verifyInvocationsEqual(actual: string[], expected: string[]): void {
   for (const groupName of groupNames) {
     expectedGroups[groupName] = expected.filter(x => x.startsWith(`${groupName}.`));
     actualGroups[groupName] = actual.filter(x => x.startsWith(`${groupName}.`));
+  }
+
+  if (expectedLoaded.length > 0) {
+    assert.deepStrictEqual(actualLoaded, expectedLoaded);
   }
 
   const errors: string[] = [];
@@ -530,6 +551,63 @@ async function createFixture<T extends Constructable>(
 }
 
 describe('router/hook-tests.spec.ts', function () {
+  describe('loaded hook', function () {
+    for (const ticks of [0, 1]) {
+      const hookSpec = HookSpecs.create(ticks);
+      const suffix = `t${ticks}`;
+
+      @customElement({ name: `loaded-one-${suffix}`, template: null })
+      class LoadedOne extends TestVM { public constructor() { super(resolve(INotifierManager), resolve(IPlatform), hookSpec); } }
+      @customElement({ name: `loaded-two-${suffix}`, template: null })
+      class LoadedTwo extends TestVM { public constructor() { super(resolve(INotifierManager), resolve(IPlatform), hookSpec); } }
+
+      @route({
+        routes: [
+          { path: 'one', component: LoadedOne },
+          { path: 'two', component: LoadedTwo },
+        ]
+      })
+      @customElement({ name: `loaded-root-${suffix}`, template: vp(1) })
+      class LoadedRoot extends TestVM { public constructor() { super(resolve(INotifierManager), resolve(IPlatform), hookSpec); } }
+
+      const deps: Constructable[] = [LoadedRoot, LoadedOne, LoadedTwo];
+
+      it(`invokes component loaded hook after attach (ticks: ${ticks})`, async function () {
+        const { router, mgr, tearDown } = await createFixture(LoadedRoot, deps);
+
+        const phase1 = `('' -> 'one')#1`;
+        const phase2 = `('one' -> 'two')#2`;
+
+        mgr.setPrefix(phase1);
+        await router.load('one');
+
+        mgr.setPrefix(phase2);
+        await router.load('two');
+
+        await tearDown();
+
+        assert.deepStrictEqual(
+          mgr.loaded.entryHistory,
+          [`loaded-one-${suffix}`, `loaded-two-${suffix}`],
+          'loaded hook should run once per navigation target'
+        );
+
+        const history = mgr.fullNotifyHistory;
+        const firstAttached = history.indexOf(`${phase1}.loaded-one-${suffix}.attached.leave`);
+        const firstLoaded = history.indexOf(`${phase1}.loaded-one-${suffix}.loaded.enter`);
+        const secondAttached = history.indexOf(`${phase2}.loaded-two-${suffix}.attached.leave`);
+        const secondLoaded = history.indexOf(`${phase2}.loaded-two-${suffix}.loaded.enter`);
+
+        assert.notStrictEqual(firstLoaded, -1, 'expected loaded-one loaded entry in history');
+        assert.notStrictEqual(secondLoaded, -1, 'expected loaded-two loaded entry in history');
+        assert.ok(firstLoaded > firstAttached, 'loaded-one should run after attach');
+        assert.ok(secondLoaded > secondAttached, 'loaded-two should run after attach');
+
+        mgr.$dispose();
+      });
+    }
+  });
+
   describe('monomorphic timings', function () {
     for (const ticks of [
       0,

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -37,6 +37,7 @@ export const enum Events {
   caCanLoad = 3057,
   caUnloading = 3058,
   caLoading = 3059,
+  caLoaded = 3060,
   // #endregion
   // #region location manager
   lmBaseHref = 3100,
@@ -95,13 +96,14 @@ export const enum Events {
   rtrRunCanLoad = 3262,
   rtrRunUnloading = 3263,
   rtrRunLoading = 3264,
-  rtrRunSwapping = 3265,
-  rtrRunFinalizing = 3266,
-  rtrCancelNavigationStart = 3267,
-  rtrCancelNavigationCompleted = 3268,
-  rtrNextTr = 3269,
-  rtrTrFailed = 3270,
-  rtrNoCtx = 3271,
+  rtrRunLoaded = 3265,
+  rtrRunSwapping = 3266,
+  rtrRunFinalizing = 3267,
+  rtrCancelNavigationStart = 3268,
+  rtrCancelNavigationCompleted = 3269,
+  rtrNextTr = 3270,
+  rtrTrFailed = 3271,
+  rtrNoCtx = 3272,
   // #endregion
   // #region viewport agent
   vpaCreated = 3300,
@@ -159,6 +161,10 @@ export const enum Events {
   vpaUnexpectedState = 3352,
   vpaUnexpectedGuardsResult = 3353,
   vpaCanLoadGuardsResult = 3354,
+  vpaLoadedChildren = 3355,
+  vpaLoadedSelf = 3356,
+  vpaLoadedFinished = 3357,
+  vpaLoadedNone = 3358,
   // #endregion
   // #region instruction
   instrInvalid = 3400,
@@ -208,6 +214,7 @@ const eventMessageMap: Record<Events, string> = {
   [Events.caCanLoad]: 'canLoad(next:%s) - invoking %s hooks',
   [Events.caUnloading]: 'unloading(next:%s) - invoking %s hooks',
   [Events.caLoading]: 'loading(next:%s) - invoking %s hooks',
+  [Events.caLoaded]: 'loaded(next:%s) - invoking %s hooks',
   // #endregion
 
   // #region location manager
@@ -270,6 +277,7 @@ const eventMessageMap: Record<Events, string> = {
   [Events.rtrRunCanLoad]: 'invoking canLoad on %s nodes',
   [Events.rtrRunUnloading]: 'invoking unloading on %s nodes',
   [Events.rtrRunLoading]: 'invoking loading on %s nodes',
+  [Events.rtrRunLoaded]: 'invoking loaded on %s nodes',
   [Events.rtrRunSwapping]: 'invoking swapping on %s nodes',
   [Events.rtrRunFinalizing]: 'finalizing transition',
   [Events.rtrCancelNavigationStart]: 'navigation %s',
@@ -316,7 +324,7 @@ const eventMessageMap: Record<Events, string> = {
   [Events.vpaDeactivateCurrent]: 'Invoking on the current component at %s',
   [Events.vpaDeactivateNone]: 'Nothing to deactivate at %s',
   [Events.vpaDeactivationRunning]: 'Already deactivating at %s',
-  [Events.vpaActivateNextScheduled]: 'Invoking canLoad(), loading() and activate() on the next component at %s',
+  [Events.vpaActivateNextScheduled]: 'Invoking canLoad(), loading(), activate() and loaded() on the next component at %s',
   [Events.vpaActivateNext]: 'Invoking on the next component at %s',
   [Events.vpaActivateNone]: 'Nothing to activate at %s',
   [Events.vpaSwapEmptyCurr]: 'Running activate on next instead, because there is nothing to deactivate at %s',
@@ -335,6 +343,10 @@ const eventMessageMap: Record<Events, string> = {
   [Events.vpaUnexpectedState]: 'Unexpected state at %s of %s',
   [Events.vpaUnexpectedGuardsResult]: 'Unexpected guardsResult %s at %s',
   [Events.vpaCanLoadGuardsResult]: 'canLoad returned redirect result %s by the component agent %s',
+  [Events.vpaLoadedChildren]: 'Invoking loaded() on children at %s',
+  [Events.vpaLoadedSelf]: 'Finished children; invoking loaded() on own component at %s',
+  [Events.vpaLoadedFinished]: 'Finished loaded() at %s',
+  [Events.vpaLoadedNone]: 'Nothing to invoke loaded() on at %s',
   // #endregion
 
   // #region instruction

--- a/packages/router/src/options.ts
+++ b/packages/router/src/options.ts
@@ -206,7 +206,7 @@ export interface IRouteConfig {
    * How to behave when this component scheduled to be loaded again in the same viewport:
    *
    * - `replace`: completely removes the current component and creates a new one, behaving as if the component changed  (default if only the parameters have changed).
-   * - `invoke-lifecycles`: calls `canUnload`, `canLoad`, `unloading` and `loading`.
+   * - `invoke-lifecycles`: calls `canUnload`, `canLoad`, `unloading`, `loading` and `loaded`.
    * - `none`: does nothing (default if nothing has changed for the viewport).
    */
   readonly transitionPlan?: TransitionPlanOrFunc | null;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -693,6 +693,11 @@ export class Router {
           b._push();
           this._cancelNavigation(tr);
         }
+      })._continueWith(b => {
+        if (__DEV__) trace(logger, Events.rtrRunLoaded, next.length);
+        for (const node of next) {
+          node.context.vpa._loaded(tr, b);
+        }
       })._continueWith(() => {
         if (__DEV__) trace(logger, Events.rtrRunFinalizing);
         // order doesn't matter for this operation


### PR DESCRIPTION
This relates to issue https://github.com/aurelia/aurelia/issues/2266 adding support for `loaded` inside of components to fill the gape of a missing `loaded` hook that happens after swap has occured.

- add a post-activation `loaded` router hook that fires after swap, once per navigation, to complement `loading`
- extend component/viewport agents, events, and transition plans to invoke `loaded`, and document the new lifecycle step
- update router test harnesses and specs to track the hook, and add explicit coverage showing it fires after `attached`