### PR TITLE
feat(router): refactor external link parsing

### DIFF
--- a/docs/user-docs/router/navigating.md
+++ b/docs/user-docs/router/navigating.md
@@ -396,21 +396,9 @@ If you want to globally deactivate the usage of `href`, then you can customize t
 
 To disable/bypass the default handling of router for any particular `href` attribute, you can avail couple of different ways as per your need and convenience.
 
-- Point the `href` to an absolute or protocol URL such as `http:`, `https:`, `mailto:`, `tel:`, `ftp:`, `ws:`, or a protocol-relative value like `//cdn.example.com`. The router automatically treats these as external links.
+- Point the `href` to an absolute or protocol URL such as `https://`, `mailto:`, `tel:`, `ftp:`, or a protocol-relative value like `//cdn.example.com`. The router automatically treats any value that the [`URL`](https://developer.mozilla.org/docs/Web/API/URL/URL) constructor can parse without a base as external, including custom schemes such as `myapp:deep-link`.
 - Using `external` or `data-external` attribute on the `a` tag for any other cases that should bypass the router.
 - Using a non-null value for the `target`, other than the current window name, or `_self`.
-
-If you need to support additional protocols (for example `myapp:` deep links), extend the allow list when registering the router. The router merges your additions with its defaults, so you only need to specify the extra schemes:
-
-```ts
-import { RouterConfiguration } from '@aurelia/router';
-
-app.register(
-  RouterConfiguration.customize({
-    externalUrlSchemes: ['myapp'],
-  }),
-);
-```
 
 Other than that, when clicking the link if either of the `alt`, `ctrl`, `shift`, `meta` key is pressed, the router ignores the routing instruction and the default handling of clicking a link takes place.
 

--- a/packages/__tests__/src/router/external.spec.ts
+++ b/packages/__tests__/src/router/external.spec.ts
@@ -158,7 +158,7 @@ describe('router/external.spec.ts', function () {
   }
 
   for (const useUrlFragmentHash of [true, false]) {
-    it(`respects customized external URL schemes via RouterConfiguration.customize - useUrlFragmentHash: ${useUrlFragmentHash}`, async function () {
+    it(`treats custom schemes as external when parseable by URL - useUrlFragmentHash: ${useUrlFragmentHash}`, async function () {
       @customElement({ name: 'a31', template: `a31${vp(1)}` })
       class A31 {}
       const customScheme = 'myapp';
@@ -182,7 +182,6 @@ describe('router/external.spec.ts', function () {
 
     const { router, host, tearDown } = await createFixture(Root3, [A31], getDefaultHIAConfig, () => ({
       useUrlFragmentHash,
-      externalUrlSchemes: [customScheme],
     }));
 
     const [internalLink, deepLink, httpLink] = host.querySelectorAll('a') as NodeListOf<HTMLAnchorElement>;

--- a/packages/router/src/options.ts
+++ b/packages/router/src/options.ts
@@ -65,17 +65,9 @@ export class RouterOptions {
      * @deprecated Will be removed in the next major version.
      */
     public readonly treatQueryAsParameters: boolean,
-    /**
-     * Schemes that should be treated as external when bound to `href`.
-     * Values are normalized to lower-case without surrounding whitespace.
-     */
-    public readonly externalUrlSchemes: readonly string[],
   ) {
     this._urlParser = useUrlFragmentHash ? fragmentUrlParser : pathUrlParser;
-    this._externalUrlSchemesSet = new Set(externalUrlSchemes);
-   }
-
-  /** @internal */ public readonly _externalUrlSchemesSet: ReadonlySet<string>;
+  }
 
   public static create(input: IRouterOptions): RouterOptions {
     return new RouterOptions(
@@ -87,7 +79,6 @@ export class RouterOptions {
       input.activeClass ?? null,
       input.restorePreviousRouteTreeOnError ?? true,
       input.treatQueryAsParameters ?? false,
-      RouterOptions._normalizeExternalUrlSchemes(input.externalUrlSchemes),
     );
   }
 
@@ -101,44 +92,6 @@ export class RouterOptions {
     }).join(',')})`;
   }
 
-  /** @internal */
-  private static readonly _defaultExternalUrlSchemes = Object.freeze([
-    'http',
-    'https',
-    'mailto',
-    'tel',
-    'sms',
-    'geo',
-    'ftp',
-    'ftps',
-    'ws',
-    'wss',
-    'data',
-    'file',
-    'blob',
-    'chrome',
-    'chrome-extension',
-    'javascript',
-  ]);
-  public static readonly defaultExternalUrlSchemes: readonly string[] = RouterOptions._defaultExternalUrlSchemes;
-
-  /** @internal */
-  private static _normalizeExternalUrlSchemes(input: IRouterOptions['externalUrlSchemes']): readonly string[] {
-    const normalized: string[] = [];
-    const seen = new Set<string>();
-    const add = (value: unknown) => {
-      if (typeof value !== 'string') return;
-      const trimmed = value.trim().toLowerCase();
-      if (trimmed === '' || seen.has(trimmed)) return;
-      seen.add(trimmed);
-      normalized.push(trimmed);
-    };
-    for (const scheme of RouterOptions._defaultExternalUrlSchemes) add(scheme);
-    if (Array.isArray(input)) {
-      for (const scheme of input) add(scheme);
-    }
-    return Object.freeze(normalized);
-  }
 }
 
 export interface INavigationOptions extends Partial<NavigationOptions> { }

--- a/packages/router/src/resources/href.ts
+++ b/packages/router/src/resources/href.ts
@@ -48,7 +48,6 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
   /** @internal */private _isEnabled: boolean;
   /** @internal */private _instructions: ViewportInstructionTree | null = null;
   /** @internal */private _treatAsExternal: boolean = false;
-  /** @internal */private static readonly _protocolLikePrefix = /^[a-z][a-z0-9+\-.]*:\/\//i;
 
   public readonly $controller!: ICustomAttributeController<this>;
 
@@ -146,16 +145,17 @@ export class HrefCustomAttribute implements ICustomAttributeViewModel {
       return true;
     }
 
-    if (HrefCustomAttribute._protocolLikePrefix.test(trimmed)) {
+    if (/^[a-z][a-z0-9+\-.]*:\/\//i.test(trimmed)) {
       return true;
     }
 
-    const protocolEnd = trimmed.indexOf(':');
-    if (protocolEnd <= 0) {
+    try {
+      // Treat URLs that can be parsed without a base as external (absolute URLs or schemes).
+      // Relative URLs will throw and are therefore handled internally.
+      new URL(trimmed);
+      return true;
+    } catch {
       return false;
     }
-
-    const protocol = trimmed.slice(0, protocolEnd).toLowerCase();
-    return this._router.options._externalUrlSchemesSet.has(protocol);
   }
 }


### PR DESCRIPTION
Allow the router to auto-detect absolute, protocol and protocol-relative hrefs as external rather than relying solely on explicit attributes.

Add a configurable allow-list of external URL schemes that is merged with sensible defaults; entries are normalised and cached for efficient checks. Update href handling to resolve a "treat as external" decision and avoid generating router instructions for external links.

Include tests for auto-detection and custom schemes and update documentation with a usage example.

Closes https://github.com/aurelia/aurelia/issues/2269