### PR TITLE
fix(au-compose): apply surrogate attributes to host

### DIFF
--- a/packages/runtime-html/src/resources/custom-elements/au-compose.ts
+++ b/packages/runtime-html/src/resources/custom-elements/au-compose.ts
@@ -313,11 +313,12 @@ export class AuCompose {
           name: CustomElement.generateName(),
           template: template,
         });
-        const viewFactory = this._rendering.getViewFactory(targetDef, childCtn);
-        const compiledDef = this._rendering.compile(viewFactory.def, childCtn);
+        const compiledDef = this._rendering.compile(targetDef, childCtn);
+        const viewFactory = this._rendering.getViewFactory(compiledDef, childCtn);
         const controller = Controller.$view(
           viewFactory,
-          $controller
+          $controller,
+          compositionHost,
         );
         const scope = this.scopeBehavior === 'auto'
           ? Scope.fromParent(this.parent.scope, comp)
@@ -325,24 +326,9 @@ export class AuCompose {
 
         controller.setHost(compositionHost);
         if (compositionLocation == null) {
-          const surrogates = compiledDef.surrogates;
-          if (surrogates.length > 0) {
-            const renderers = this._rendering.renderers;
-            for (let i = 0, ii = surrogates.length; i < ii; ++i) {
-              const instruction = surrogates[i];
-              renderers[instruction.type].render(
-                controller,
-                compositionHost,
-                instruction,
-                this._platform,
-                this._exprParser,
-                this._observerLocator,
-              );
-            }
-          }
           // only spread the bindings if there is an actual host
           // otherwise we may accidentally do unnecessary work
-          this._createSpreadBindings(compositionHost, compiledDef, aucomposeCapturedAttrs).forEach(b => controller.addBinding(b));
+          this._createSpreadBindings(compositionHost, viewFactory.def, aucomposeCapturedAttrs).forEach(b => controller.addBinding(b));
         } else {
           controller.setLocation(compositionLocation);
         }

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -310,12 +310,15 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
    * @param viewFactory - todo(comment)
    * @param flags - todo(comment)
    * @param parentController - the parent controller to connect the created view with. Used in activation
+   * @param host - when it's desirable to associate a synthetic view with a host node during hydration,
+   * it's possible to do so if a host is given here.
    *
    * Semi private API
    */
   public static $view(
     viewFactory: IViewFactory,
     parentController: ISyntheticView | ICustomElementController | ICustomAttributeController | undefined = void 0,
+    host: HTMLElement | null = null,
   ): ISyntheticView {
     const controller = new Controller(
       /* container      */viewFactory.container,
@@ -323,7 +326,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       /* definition     */null,
       /* viewFactory    */viewFactory,
       /* viewModel      */null,
-      /* host           */null,
+      /* host           */host,
       /* location       */null
     );
     controller.parent = parentController ?? null;
@@ -492,7 +495,7 @@ export class Controller<C extends IViewModel = IViewModel> implements IControlle
       /* controller */this as ISyntheticView,
       /* targets    */(this.nodes = this._rendering.createNodes(this._compiledDef)).findTargets(),
       /* definition */this._compiledDef,
-      /* host       */void 0,
+      /* host       */this.host,
     );
   }
 


### PR DESCRIPTION
Compiles the target definition to expose surrogates and applies them to the host when no explicit location is provided; uses the compiled definition for view factory and for collecting bindings. Enables correct application of inline surrogate attributes when a tag is supplied. 

- Inline template compositions now run through the template compiler before hydration so surrogate instructions (e.g., class, style) are replayed onto the generated host when tag is used. We switched to the compiled definition when creating spread bindings for the same scenario.
- Added a regression test under 3-runtime-html/au-compose.spec.ts that composes an inline <template class='message'>…</template> with tag="div" to ensure the host retains surrogate attributes.

Look, I'm gonna be honest. I feeled my way around this stuff. It looked somewhat familiar to me because of the template controller render instruction stuff I did a while back. So, if something I've done doesn't seem right, let me know so I can keep learning.

Working example that uses the same provided repo from the linked issue: https://stackblitz.com/edit/8iaevjzf

Closes #2271