### PR TITLE
docs(di): fix type alias injection examples

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/creating-services.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/creating-services.md
@@ -118,16 +118,40 @@ export class PaymentProcessor {
 export type IPaymentProcessor = PaymentProcessor;
 ```
 
-You can then use this type for injection and for defining the shape of your service without having to declare all methods explicitly:
+You can then use this type for injection and for defining the shape of your service without having to declare all methods explicitly. The important thing to remember is that a TypeScript `type` alias is removed during compilation. That means `IPaymentProcessor` exists only for tooling and static analysis—there is no runtime token by that name. When you ask the container for an instance, supply the class (or another runtime value) as the key:
 
 ```typescript
 import { resolve } from 'aurelia';
+import { PaymentProcessor } from './payment-processor';
+import type { IPaymentProcessor } from './payment-processor';
 
-export class CheckoutService {
-  private paymentProcessor: IPaymentProcessor = resolve(IPaymentProcessor);
-  // Use paymentProcessor
+export class CheckoutWorkflow {
+  private readonly paymentProcessor: IPaymentProcessor = resolve(PaymentProcessor);
+
+  completeCheckout(amount: number) {
+    this.paymentProcessor.processPayment(amount);
+  }
 }
 ```
+
+If you'd rather rely on constructor injection, pair the runtime token with the `@inject` decorator while keeping the parameter typed as the alias:
+
+```typescript
+import { inject } from 'aurelia';
+import { PaymentProcessor } from './payment-processor';
+import type { IPaymentProcessor } from './payment-processor';
+
+@inject(PaymentProcessor)
+export class CheckoutController {
+  constructor(private readonly paymentProcessor: IPaymentProcessor) {}
+
+  completeCheckout(amount: number) {
+    this.paymentProcessor.processPayment(amount);
+  }
+}
+```
+
+This pattern keeps the runtime registration focused on `PaymentProcessor` while exposing the alias everywhere else for enhanced editor and refactoring support.
 
 ## Conclusion
 

--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/resolvers.md
@@ -222,29 +222,27 @@ export class MyClass {
 
 #### Example
 
-If you have multiple instances of a service registered under the same key, last will ensure that you get the most recently registered instance:
+If you have multiple instances of a service registered under the same key, `last` will ensure that you get the most recently registered instance:
 
 ```typescript
-import { DI, IContainer, last, Registration } from 'aurelia';
+import { DI, last, Registration } from 'aurelia';
 
 const container = DI.createContainer();
 container.register(Registration.instance(MyService, new MyService('instance1')));
 container.register(Registration.instance(MyService, new MyService('instance2')));
 container.register(Registration.instance(MyService, new MyService('instance3')));
 
-const myClass = container.get(last(MyService));
-console.log(myClass.service); // Outputs: instance3
+const latestService = container.get(last(MyService));
+console.log(latestService?.name); // Logs the values from `instance3`
 ```
 
-In this example, `myClass.service` will be the instance of MyService registered last (i.e., `instance3`).
-
-If no instances are registered under the specified key, the last resolver will return undefined:
+If no instances are registered under the specified key, the `last` resolver will return `undefined`:
 
 ```typescript
 const container = DI.createContainer();
 
-const myClass = container.get(last(MyClass));
-console.log(myClass.service); // Outputs: undefined
+const maybeService = container.get(last(MyService));
+console.log(maybeService); // undefined
 ```
 
 ## Custom Resolvers
@@ -254,13 +252,15 @@ You can create custom resolvers by implementing the `IResolver` interface. Custo
 ### Example of a Custom Resolver
 
 ```typescript
-import { IResolver, IContainer, inject } from 'aurelia';
+import { inject } from 'aurelia';
+import type { IContainer, IResolver } from 'aurelia';
 
-class MyCustomResolver<T> implements IResolver {
-  $isResolver: true;
-  constructor(private key: new (...args: any[]) => T) {}
+class MyCustomResolver<T> implements IResolver<T> {
+  public readonly $isResolver = true;
 
-  resolve(handler: IContainer, requestor: IContainer): T {
+  public constructor(private readonly key: new (...args: any[]) => T) {}
+
+  public resolve(handler: IContainer, requestor: IContainer): T {
     // Custom resolution logic here
     return new this.key();
   }
@@ -269,7 +269,7 @@ class MyCustomResolver<T> implements IResolver {
 // Usage
 @inject(new MyCustomResolver(MyService))
 export class MyClass {
-  constructor(private service: MyService) {
+  public constructor(private readonly service: MyService) {
     // service is resolved using MyCustomResolver
   }
 }


### PR DESCRIPTION
- update the type alias guidance to resolve the concrete PaymentProcessor token and add a constructor-injection variant
- clarify that type aliases are compile-time only so readers pass a runtime key to resolve
- tighten the last resolver walkthrough and custom resolver snippet so they align with the current DI APIs

Closes: #2220 