### PR TITLE
docs(di): detail order of inject decorator

### DIFF
--- a/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/overview.md
+++ b/docs/user-docs/getting-to-know-aurelia/dependency-injection-di/overview.md
@@ -64,6 +64,10 @@ export class FileImporter {
 }
 ```
 
+{% hint style="info" %}
+Make sure the dependencies passed to `@inject` follow the same order as the constructor parameters so each argument receives the correct instance.
+{% endhint %}
+
 <!-- #### Using Compiler Metadata
 
 If you use TypeScript and have enabled metadata emission, you can leverage the TypeScript compiler to deduce the types to inject:


### PR DESCRIPTION
Provide info to the end user that inject and order on constructor must be the same.

Closes #2222 