### PR TITLE
fix(router): honor explicit transition plan for query-only loads

### DIFF
--- a/packages/__tests__/src/router/transition-plan.spec.ts
+++ b/packages/__tests__/src/router/transition-plan.spec.ts
@@ -1,0 +1,82 @@
+import { resolve } from '@aurelia/kernel';
+import { IRouteContext, IRouter, route } from '@aurelia/router';
+import { customElement } from '@aurelia/runtime-html';
+import { assert } from '@aurelia/testing';
+import { start } from './_shared/create-fixture.js';
+
+describe('router/transition-plan.spec.ts', function () {
+
+  it('reloads component when navigation options set transitionPlan to replace and only query params change', async function () {
+    @customElement({ name: 'qp-option-view', template: '' })
+    class QueryOptionView {
+      private readonly ctx = resolve(IRouteContext);
+      public static messages: string[] = [];
+      public loading(): void {
+        const params = this.ctx
+          .getRouteParameters<{ message?: unknown }>({ includeQueryParams: true });
+        const value = params.message;
+        QueryOptionView.messages.push(typeof value === 'string'
+          ? value
+          : value == null
+            ? ''
+            : JSON.stringify(value));
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'test', path: 'test', component: QueryOptionView }
+      ]
+    })
+    @customElement({ name: 'qp-option-root', template: '<au-viewport></au-viewport>' })
+    class QueryOptionRoot { }
+
+    const { au, container } = await start({ appRoot: QueryOptionRoot, registrations: [QueryOptionView] });
+    const router = container.get(IRouter);
+    QueryOptionView.messages = [];
+
+    await router.load('test', { transitionPlan: 'replace', queryParams: { message: 'one' } });
+    await router.load('test', { transitionPlan: 'replace', queryParams: { message: 'two' } });
+
+    assert.deepStrictEqual(QueryOptionView.messages, ['one', 'two']);
+
+    await au.stop(true);
+  });
+
+  it('does not reload component when route config transitionPlan is replace and only query params change', async function () {
+    @customElement({ name: 'qp-config-view', template: '' })
+    class QueryConfigView {
+      private readonly ctx = resolve(IRouteContext);
+      public static messages: string[] = [];
+      public loading(): void {
+        const params = this.ctx
+          .getRouteParameters<{ message?: unknown }>({ includeQueryParams: true });
+        const value = params.message;
+        QueryConfigView.messages.push(typeof value === 'string'
+          ? value
+          : value == null
+            ? ''
+            : JSON.stringify(value));
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'test', path: 'test', component: QueryConfigView, transitionPlan: 'replace' }
+      ]
+    })
+    @customElement({ name: 'qp-config-root', template: '<au-viewport></au-viewport>' })
+    class QueryConfigRoot { }
+
+    const { au, container } = await start({ appRoot: QueryConfigRoot, registrations: [QueryConfigView] });
+    const router = container.get(IRouter);
+    QueryConfigView.messages = [];
+
+    await router.load('test?message=one');
+    await router.load('test?message=two');
+
+    assert.deepStrictEqual(QueryConfigView.messages, ['one']);
+
+    await au.stop(true);
+  });
+});


### PR DESCRIPTION
- Keep query-only navigations non-reloading by default, matching router design that query strings are not part of route configuration matching.
- Ensure an explicit `Router#load(..., { transitionPlan })` still overrides the default same-route behavior for query-only loads.
- Add focused coverage for explicit navigation-option replacement and route-config query-only non-reload behavior.

Closes #2291