### PR TITLE
fix(build): correct package.json exports for development condition

### DIFF
--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -2,9 +2,6 @@ import { IOptionalPreprocessOptions, preprocess } from '@aurelia/plugin-conventi
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
-import { createRequire } from 'module';
-
-const require = createRequire(import.meta.url);
 
 export default function au(options: {
   include?: FilterPattern;
@@ -33,32 +30,12 @@ export default function au(options: {
         return;
       }
 
-      [
-        'platform',
-        'platform-browser',
-        'aurelia',
-        'fetch-client',
-        'router',
-        'kernel',
-        'metadata',
-        'i18n',
-        'state',
-        'route-recognizer',
-        'compat-v1',
-        'dialog',
-        'expression-parser',
-        'runtime',
-        'template-compiler',
-        'runtime-html',
-        'router-direct',
-      ].reduce((aliases, pkg) => {
-        const name = pkg === 'aurelia' ? pkg : `@aurelia/${pkg}`;
-        try {
-          const packageLocation = require.resolve(name);
-          aliases[name] = resolve(packageLocation, `../../esm/index.dev.mjs`);
-        } catch {/* needs not to do anything */}
-        return aliases;
-      }, ((config.resolve ??= {}).alias ??= {}) as Record<string, string>);
+      // Add 'development' to resolve.conditions so Vite uses the dev exports
+      // defined in each @aurelia/* package.json "exports" field
+      (config.resolve ??= {}).conditions ??= [];
+      if (!config.resolve.conditions.includes('development')) {
+        config.resolve.conditions.unshift('development');
+      }
     },
   };
 

--- a/packages/addons/package.json
+++ b/packages/addons/package.json
@@ -7,9 +7,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/aurelia/package.json
+++ b/packages/aurelia/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/compat-v1/package.json
+++ b/packages/compat-v1/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/expression-parser/package.json
+++ b/packages/expression-parser/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/fetch-client/package.json
+++ b/packages/fetch-client/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/route-recognizer/package.json
+++ b/packages/route-recognizer/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/router-direct/package.json
+++ b/packages/router-direct/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/router-html/package.json
+++ b/packages/router-html/package.json
@@ -7,9 +7,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/runtime-html/package.json
+++ b/packages/runtime-html/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/store-v1/package.json
+++ b/packages/store-v1/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/template-compiler/package.json
+++ b/packages/template-compiler/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/ui-virtualization/package.json
+++ b/packages/ui-virtualization/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/validation-html/package.json
+++ b/packages/validation-html/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/validation-i18n/package.json
+++ b/packages/validation-i18n/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -6,9 +6,12 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
+      "development": {
+        "require": "./dist/cjs/index.dev.cjs",
+        "import": "./dist/esm/index.dev.mjs"
+      },
       "require": "./dist/cjs/index.cjs",
-      "import": "./dist/esm/index.mjs",
-      "development": "./dist/esm/index.dev.mjs"
+      "import": "./dist/esm/index.mjs"
     },
     "./development": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

The `development` export condition in all 26 core package.json files was incorrectly placed at the same level as `require`/`import`, causing bundlers to resolve production builds before ever evaluating the development condition.

This restructures exports so `development` wraps the module format conditions:

```json
".": {
  "types": "...",
  "development": {
    "require": "./dist/cjs/index.dev.cjs",
    "import": "./dist/esm/index.dev.mjs"
  },
  "require": "./dist/cjs/index.cjs",
  "import": "./dist/esm/index.mjs"
}
```

Also simplified the Vite plugin by replacing 17 hardcoded package aliases with `resolve.conditions.unshift('development')`, since the standard exports mechanism now works.

### 🎫 Issues

Related: https://github.com/aurelia/aurelia-ls/pull/6
Related: https://github.com/aurelia/aurelia/pull/2311

## 👩‍💻 Reviewer Notes

- All 26 core packages have identical export structure changes
- The `./development` subpath export is retained for backwards compatibility
- Vite plugin now uses standard Node.js export conditions instead of manual aliasing

## 📑 Test Plan

Verified with Node.js:
```bash
# CJS: Default -> production
node -e "console.log(require.resolve('@aurelia/kernel'))"
# => dist/cjs/index.cjs

# CJS: With development condition -> dev build
node --conditions=development -e "console.log(require.resolve('@aurelia/kernel'))"
# => dist/cjs/index.dev.cjs

# ESM: Default -> production
node --input-type=module -e "console.log(await import.meta.resolve('@aurelia/kernel'))"
# => dist/esm/index.mjs

# ESM: With development condition -> dev build
node --conditions=development --input-type=module -e "console.log(await import.meta.resolve('@aurelia/kernel'))"
# => dist/esm/index.dev.mjs
```

## ⏭ Next Steps

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
