### PR TITLE
fix(ci): update Node 16 to 22 in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache node modules
         id: cache_npm
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: node_modules
@@ -45,7 +45,7 @@ jobs:
 
       - name: Cache build output
         id: cache_build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-build-dist-${{ github.sha }}
           restore-keys: |
@@ -90,10 +90,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       # - name: Restore cached node modules
       #   id: restore-cache-npm
@@ -133,10 +133,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
 
       # - name: Restore cached node modules
       #   id: restore-cache-npm
@@ -176,10 +176,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: npm run build:release
       # Run benchmarks. Ensure each job's results file has a unique name
@@ -200,10 +200,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: npm run build:release
       # Run benchmarks. Ensure each job's results file has a unique name


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes the GitHub Actions `main` workflow failure caused by Node.js 16 not supporting the `import ... with` syntax (import attributes) used in the rollup configuration.

### Changes

**`.github/workflows/main.yml`**
- Updated `node-version` from 16 to 22 across all benchmark jobs
- Updated `actions/checkout` from v3 to v4
- Updated `actions/setup-node` from v3 to v4
- Updated `actions/cache` from v3 to v4

### 🎫 Issues

- Fixes failing `main` workflow on master branch (SyntaxError: Unexpected token 'with')

## 👩‍💻 Reviewer Notes

The Node version mismatch was the root cause of the GitHub Actions failure:
- CircleCI uses Node 22.12.0
- Other GHA workflows use Node 22
- Only `main.yml` was still on Node 16

Node 16 reached end-of-life in September 2023 and doesn't support import attributes syntax which requires Node 18.20+ or 20.10+.

## 📑 Test Plan

- The fix can be verified by observing the `main` workflow pass after merge

## ⏭ Next Steps

The CircleCI `build_test` workflow on master still has 3 failing jobs that are unrelated to this Node version fix:
- `e2e_hmr_webpack`
- `e2e_type_check`
- `test_chrome`

These should be investigated separately.
