### PR TITLE
fix(webpack-loader): correct HMR code generation errors

### DIFF
--- a/packages-tooling/webpack-loader/src/index.ts
+++ b/packages-tooling/webpack-loader/src/index.ts
@@ -56,6 +56,7 @@ const getHmrCode = (className: string): string => {
 
   const code = `
     import { Metadata as $$M } from '@aurelia/metadata';
+    import { onResolve as $$onResolve } from '@aurelia/kernel';
     import { Controller as $$C, CustomElement as $$CE, IHydrationContext as $$IHC, refs as $$refs } from '@aurelia/runtime-html';
 
     // @ts-ignore
@@ -141,7 +142,7 @@ const getHmrCode = (className: string): string => {
           }
         });
         const h = controller.host;
-        const oldDef = delete controller._compiledDef;
+        const oldDef = controller._compiledDef;
         $$onResolve(controller.deactivate(controller, controller.parent ?? null, 0), () => {
           controller.container.deregister(oldDef.key);
           controller.container.deregister(oldDef.Type);


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fix HMR code generation in the webpack-loader that was causing TypeScript compilation errors in e2e tests.

Two bugs in the `getHmrCode` function:
1. `$$onResolve` was used but never imported
2. `const oldDef = delete controller._compiledDef` incorrectly assigned a boolean (the return value of `delete`) instead of storing the definition value before deletion

### 🎫 Issues

## 👩‍💻 Reviewer Notes

The HMR code is injected into user components at build time. The missing import and incorrect delete expression caused TypeScript errors when `ts-loader` processed the transformed code.

## 📑 Test Plan

- `e2e_hmr_webpack` and `e2e_type_check` CI jobs should pass after this fix

## ⏭ Next Steps

