### PR TITLE
fix(e2e): wait for URL change before testing backward navigation

### DIFF
--- a/packages/__e2e__/6-router/src/router.animation.spec.ts
+++ b/packages/__e2e__/6-router/src/router.animation.spec.ts
@@ -105,6 +105,11 @@ for (const useUrlFragmentHash of [true, false]) {
       await forwardNavPromise;
       await expect(page.locator('#root-vp')).toContainText('Two page');
 
+      // Wait for the TWO navigation to fully complete (including history push).
+      // The URL should contain '/two' (path mode) or '#/two' (hash mode) when navigation is complete.
+      // This is necessary because with async attaching hooks, history is pushed at the END of navigation.
+      await page.waitForURL(url => url.href.includes('/two'), { timeout: 5000 });
+
       console.log(`Forward EXIT: samples=${JSON.stringify(forwardExit.samples)}, direction=${forwardExit.direction}`);
       console.log(`Forward ENTRY: samples=${JSON.stringify(forwardEntry.samples)}, direction=${forwardEntry.direction}`);
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a race condition in the router animation e2e test that was exposed after PR #2337 changed `isPromise` to be Promise/A+ compliant.

**Root Cause:**
PR #2337 changed `isPromise` from `v instanceof Promise` to `typeof v?.then === 'function'`. This caused anime.js animation objects (which are thenables) returned from `attaching` lifecycle hooks to be properly awaited by the controller - which is the intended behavior.

However, this exposed a race condition in the test: the test was calling `goBack()` immediately after the forward navigation appeared complete visually, but BEFORE the browser history had been updated. With async attaching hooks, the router pushes history state at the END of navigation (after the `attached` lifecycle), not when the element first appears in the DOM.

**The Fix:**
Wait for the URL to contain '/two' before calling `goBack()`. This ensures the navigation has fully completed (including the history push) before testing backward navigation.

### 🎫 Issues

* Fixes #2339

## 👩‍💻 Reviewer Notes

The animation hooks in the e2e test app return anime.js animation objects from `attaching`:

```typescript
public attaching() {
  return this.isBack ? enterFromLeft(this.element) : enterFromRight(this.element);
}
```

**Before #2337**: These weren't detected as Promises (`instanceof Promise` = false), so the controller didn't wait. History was pushed immediately after the element was attached.

**After #2337**: These ARE detected as Promises (`.then` method exists), so the controller waits for the animation to complete (~900ms) before calling `attached` and pushing history.

The test sequence was:
1. Click link to TWO page
2. Wait for "Two page" text (element in DOM, but animation still running)
3. Call `goBack()` immediately
4. History hasn't been pushed yet, so browser goes back to HOME instead of ONE

The fix adds `await page.waitForURL(url => url.href.includes('/two'), { timeout: 5000 })` to ensure the URL has been updated (meaning navigation is fully complete) before testing backward navigation.

## 📑 Test Plan

- All 16 router e2e tests pass locally
- Animation tests now properly wait for navigation to complete before testing history operations

## 📦 Changeset

- [x] Not needed - this only affects e2e test code, not published packages

## 🤔 Design Consideration

This test fix works around a known timing behavior documented in issue #951: the router pushes history state at the END of navigation (after `attached`), not when navigation begins. This means `window.location.href` doesn't reflect the target URL during lifecycle hooks.

The workaround suggested in #951 was "use `attached`" - but that doesn't help when `attaching` itself is async (as with animations). PR #2337's `isPromise` fix simply made this timing gap more visible by correctly awaiting thenables.

**The test now passes, but it demonstrates a real edge case**: if a user presses the browser Back button during a page entry animation, they navigate to an unexpected page because the history entry hasn't been pushed yet.

This may warrant revisiting whether history should be pushed earlier in the navigation lifecycle (before async `attaching` hooks), which would align with how React Router, Vue Router, and Angular Router behave.