### PR TITLE
fix: don't try to handle multi bundle clash

### DIFF
--- a/packages/runtime/src/array-observer.ts
+++ b/packages/runtime/src/array-observer.ts
@@ -17,7 +17,7 @@ import {
 } from './subscriber-collection';
 import { rtDef, rtDefineHiddenProp, rtDefineMetadata, rtGetMetadata } from './utilities';
 import { addCollectionBatch, batching } from './subscriber-batch';
-import { type IIndexable, isFunction } from '@aurelia/kernel';
+import { isFunction } from '@aurelia/kernel';
 
 export interface ArrayObserver extends ICollectionObserver<'array'>, ICollectionSubscriberCollection {
   getIndexObserver(index: number): ArrayIndexObserver;
@@ -29,11 +29,7 @@ export interface ArrayIndexObserver extends IObserver, ISubscriberCollection {
 
 export const getArrayObserver = /*@__PURE__*/ (() => {
 
-  // multiple applications of Aurelia wouldn't have different observers for the same Array object
-  const lookupMetadataKey = Symbol.for('__au_arr_obs__');
-  const observerLookup = ((Array as IIndexable<typeof Array>)[lookupMetadataKey]
-    ?? rtDefineHiddenProp(Array, lookupMetadataKey, new WeakMap())
-  ) as WeakMap<unknown[], ArrayObserverImpl>;
+  const observerLookup = new WeakMap<unknown[], ArrayObserverImpl>();
 
   // https://tc39.github.io/ecma262/#sec-sortcompare
   function sortCompare(x: unknown, y: unknown): number {

--- a/packages/runtime/src/map-observer.ts
+++ b/packages/runtime/src/map-observer.ts
@@ -3,7 +3,6 @@ import { atObserver, createIndexMap } from './interfaces';
 import { subscriberCollection } from './subscriber-collection';
 import { rtDefineHiddenProp } from './utilities';
 
-import { type IIndexable } from '@aurelia/kernel';
 import type {
   AccessorType,
   ICollectionObserver,
@@ -14,11 +13,7 @@ import { addCollectionBatch, batching } from './subscriber-batch';
 export interface MapObserver extends ICollectionObserver<'map'>, ICollectionSubscriberCollection { }
 
 export const getMapObserver = /*@__PURE__*/ (() => {
-  // multiple applications of Aurelia wouldn't have different observers for the same Map object
-  const lookupMetadataKey = Symbol.for('__au_map_obs__');
-  const observerLookup = ((Map as IIndexable<typeof Map>)[lookupMetadataKey]
-    ?? rtDefineHiddenProp(Map, lookupMetadataKey, new WeakMap())
-  ) as WeakMap<Map<unknown, unknown>, MapObserverImpl>;
+  const observerLookup = new WeakMap<Map<unknown, unknown>, MapObserverImpl>();
 
   const { set: $set, clear: $clear, delete: $delete } = Map.prototype;
   const methods = ['set', 'clear', 'delete'] as const;

--- a/packages/runtime/src/set-observer.ts
+++ b/packages/runtime/src/set-observer.ts
@@ -1,4 +1,3 @@
-import { IIndexable } from '@aurelia/kernel';
 import { CollectionSizeObserver } from './collection-length-observer';
 import { atObserver, createIndexMap, type AccessorType, type ICollectionObserver, type ICollectionSubscriberCollection } from './interfaces';
 import { addCollectionBatch, batching } from './subscriber-batch';
@@ -8,11 +7,7 @@ import { rtDefineHiddenProp } from './utilities';
 export interface SetObserver extends ICollectionObserver<'set'>, ICollectionSubscriberCollection { }
 
 export const getSetObserver = /*@__PURE__*/ (() => {
-  // multiple applications of Aurelia wouldn't have different observers for the same Set object
-  const lookupMetadataKey = Symbol.for('__au_set_obs__');
-  const observerLookup = ((Set as IIndexable<typeof Set>)[lookupMetadataKey]
-    ?? rtDefineHiddenProp(Set, lookupMetadataKey, new WeakMap())
-  ) as WeakMap<Set<unknown>, SetObserverImpl>;
+  const observerLookup = new WeakMap<Set<unknown>, SetObserverImpl>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { add: $add, clear: $clear, delete: $delete } = Set.prototype as { [K in keyof Set<any>]: Set<any>[K] & { observing?: boolean } };


### PR DESCRIPTION
## 📖 Description

Sometimes ago I was trying to prepare for a scenario where multiple Aurelia applications can work & share objects together. When an object is observed in multiple applications (different bundles), the observation from different bundles need to work well together and thus, some markers on the global objects were employed. This is probably not necessary, as most of the time the observer is cached on the object, which is practical enough. I think it's better we leave it natural, and fix any issues that arise later rather than trying to predict/anticipate, which is likely inadequate/wrong.

cc @fkleuver @Sayan751 @ekzobrain 