### PR TITLE
fix(ui-virtualization): prevent multiple attached() calls when items assigned in attached hook

### DIFF
--- a/.changeset/fix-virtual-repeat-attached-calls.md
+++ b/.changeset/fix-virtual-repeat-attached-calls.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/ui-virtualization": patch
+---
+
+Fix virtual-repeat calling parent's attached() multiple times when items are assigned in attached hook. Closes #2350.

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -490,7 +490,7 @@ export class VirtualRepeat implements IVirtualRepeater {
         scope.overrideContext.$index = idx;
         scope.overrideContext.$length = itemCount;
         enhanceOverrideContext(scope.overrideContext);
-        void view.activate(repeatController, repeatController, scope);
+        void view.activate(view, repeatController, scope);
       }
 
       // Measure item size for variable sizing


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

When items are assigned in a component's `attached()` lifecycle hook, the virtual-repeat plugin incorrectly triggers the parent's `attached()` hook multiple times - once for each item in the list.

This occurs because views activated in `_handleItemsChanged()` use the `repeatController` as their initiator, causing the activation completion to propagate up through the controller hierarchy. When the parent component's state is still `activating` (e.g., during an async `attached()` hook), this propagation can incorrectly re-trigger the parent's `attached()` callback.

### 🎫 Issues

* Fixes #2350

## 💁 Your Solution

Changed the initiator argument when activating views in `_handleItemsChanged()` from `repeatController` to `view` (the view itself).

This matches the pattern already used in:
- `_createAndActivateFirstView()` at line 818: `void firstView.activate(firstView, repeatController, itemScope)`
- The standard `Repeat` template controller: `view.activate(initiator ?? view, $controller, scope)`

When a view is its own initiator, its activation completion does not propagate `_leaveActivating()` up the controller hierarchy (since `$initiator === this`), preventing unintended re-triggering of parent lifecycle hooks.

## 👩‍💻 Reviewer Notes

- The fix is a single-line change that aligns VirtualRepeat's behavior with the standard Repeat controller

## 📑 Test Plan

Added 2 new test cases in `packages/__tests__/src/ui-virtualization/virtual-repeat.spec.ts`:

1. **Sync test**: `'calls attached only once when items are assigned in attached hook'`
   - Verifies `attached()` is called exactly once when items are assigned synchronously

2. **Async test**: `'calls attached only once when items are assigned in async attached hook'`
   - Verifies `attached()` is called exactly once when items are assigned after an `await` in an async `attached()` hook

Both tests directly reproduce the issue from #2350 and verify the fix.

## 📦 Changeset

- [x] Added a changeset via `npx changeset`

## ⏭ Next Steps

- Consider documenting async lifecycle behavior with virtual-repeat (related to the existing TODO comment)
- The broader question of full async lifecycle support in virtual-repeat may warrant additional investigation
