### PR TITLE
fix(tests): remove http-server from validToolingPackages

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -121,8 +121,7 @@ const validToolingPackages =  [
   'babel-jest',
   'parcel-transformer',
   'vite-plugin',
-  'webpack-loader',
-  'http-server',
+  'webpack-loader'
 ];
 
 validToolingPackages


### PR DESCRIPTION
## 📖 Description

This PR tries to solve the problem addressed in the issue #2364

The steps in the "building and testing aurelia" [documentation](https://docs.aurelia.io/community-contribution/building-and-testing-aurelia)  stall when running npm run dev -- --test *

```
keith@Elitebook830:~/dev/davidsk-aurelia2$ npm run dev -- --test *
npm warn Unknown project config "link-workspace-packages". This will stop working in the next major version of npm.

@aurelia/monorepo@2.0.0-rc.0 dev
ts-node scripts/dev.ts --test CONTRIBUTING.md LICENSE README.md benchmarks docs examples node_modules package-lock.json package.json packages packages-tooling scripts test tsconfig.eslint.json tsconfig.json turbo.json

http-server has not been built before, building...
keith@Elitebook830:~/dev/davidsk-aurelia2$ 
```

## 📑 Test Plan

Run the npm run dev -- --test * command and check tests are performed
