### PR TITLE
feat(virtual-repeat): support static gap between items

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # shamefully-hoist=true
 link-workspace-packages=true
+ignore-scripts=true

--- a/docs/user-docs/developer-guides/ui-virtualization.md
+++ b/docs/user-docs/developer-guides/ui-virtualization.md
@@ -82,6 +82,19 @@ Examples:
 
 *Names can be in camelCase (`itemHeight`, `itemWidth`, etc.) or kebab-case (`item-height`, `item-width`, etc.).*
 
+### Gap between items
+
+Use `gap` to tell the virtualization math about spacing between items without folding that spacing into `item-height` or `item-width`.
+
+```html
+<div virtual-repeat.for="item of items; item-height: 48; gap: 12"
+     style="height: 48px; margin-bottom: 12px;">
+  ${item.name}
+</div>
+```
+
+For example, if each row is `48px` tall and has `margin-bottom: 12px`, keep `item-height: 48` and set `gap: 12`.
+
 ## Horizontal Scrolling
 
 The virtual repeat supports horizontal scrolling layouts, allowing you to create efficiently virtualized horizontal lists, carousels, and galleries.

--- a/packages/__e2e__/8-ui-virtualization/playwright/app.spec.ts
+++ b/packages/__e2e__/8-ui-virtualization/playwright/app.spec.ts
@@ -25,6 +25,11 @@ test.describe.serial('examples/ui-virtualization-e2e/app.spec.ts', function () {
     await page.waitForTimeout(16);
   };
 
+  const scrollVertically = async (page: Page, px: number) => {
+    await page.$eval('#repeat-container', (el, v) => (el as HTMLElement).scrollTop = v, px);
+    await page.waitForTimeout(16);
+  };
+
   test('test virtual-repeat, check rendered div counts when adding and removing items from array (incl empty array)', async ({ page }) => {
 
     // expectation of item/div count in virtual-repeat
@@ -208,5 +213,29 @@ test.describe.serial('examples/ui-virtualization-e2e/app.spec.ts', function () {
       expect(finalCounts.divs).toBeLessThanOrEqual(22);
     });
   });
-});
 
+  test('vertical gap route preserves spacing and scroll math', async ({ page }) => {
+    await test.step('load gap usage route and verify rendered view count', async () => {
+      await page.getByTestId('load-gap-usage').click();
+      expect(await getItemAndDivCount(page)).toStrictEqual({ items: 500, divs: 20 });
+    });
+
+    await test.step('verify rendered items keep a 12px gap', async () => {
+      const items = page.locator('#repeat-container .gap-item');
+      await expect(items).toHaveCount(18);
+
+      const firstBox = await items.nth(0).boundingBox();
+      const secondBox = await items.nth(1).boundingBox();
+      expect(firstBox).not.toBeNull();
+      expect(secondBox).not.toBeNull();
+      expect(Math.round(secondBox!.y - (firstBox!.y + firstBox!.height))).toBe(12);
+    });
+
+    await test.step('scroll and verify the first rendered item respects item height plus gap', async () => {
+      await scrollVertically(page, 434);
+
+      const firstRenderedText = await page.locator('#repeat-container .gap-item').first().textContent();
+      expect(firstRenderedText).toContain('item-0-7 @ index 7');
+    });
+  });
+});

--- a/packages/__e2e__/8-ui-virtualization/src/apps/gap-app.html
+++ b/packages/__e2e__/8-ui-virtualization/src/apps/gap-app.html
@@ -1,0 +1,31 @@
+<div>
+  <button click.trigger="newItems()">new</button>
+  <button click.trigger="clearItems()">clear</button>
+  Start:
+  <button click.trigger="addItemsAtStart(1)">+1</button>
+  <button click.trigger="addItemsAtStart(-1)">-1</button>
+  <button click.trigger="addItemsAtStart(10)">+10</button>
+  <button click.trigger="addItemsAtStart(-10)">-10</button>
+  <button click.trigger="addItemsAtStart(100)">+100</button>
+  <button click.trigger="addItemsAtStart(-100)">-100</button>
+  End:
+  <button click.trigger="addItemsAtEnd(1)" data-testid="add-1">+1</button>
+  <button click.trigger="addItemsAtEnd(-1)" data-testid="remove-1">-1</button>
+  <button click.trigger="addItemsAtEnd(10)" data-testid="add-10">+10</button>
+  <button click.trigger="addItemsAtEnd(-10)" data-testid="remove-10">-10</button>
+  <button click.trigger="addItemsAtEnd(100)" data-testid="add-100">+100</button>
+  <button click.trigger="addItemsAtEnd(-100)" data-testid="remove-100">-100</button>
+  <button click.trigger="addItemsAtEnd(-475)" data-testid="remove-475">-475</button>
+  Count:
+  <span data-testid="items-count">${items.length}</span>
+</div>
+<div id="repeat-container" style="overflow: auto; height: 500px">
+  <div
+    virtual-repeat.for="item of items; item-height: 50; gap: 12"
+    class="gap-item"
+    even-row.class="$even"
+    style="height: 50px; margin-bottom: 12px;"
+  >
+    ${item.name} @ index ${$index}
+  </div>
+</div>

--- a/packages/__e2e__/8-ui-virtualization/src/apps/gap-app.ts
+++ b/packages/__e2e__/8-ui-virtualization/src/apps/gap-app.ts
@@ -1,0 +1,5 @@
+import { BasicApp } from './basic-app';
+
+export class GapApp extends BasicApp {
+  public readonly gap = 12;
+}

--- a/packages/__e2e__/8-ui-virtualization/src/my-app.html
+++ b/packages/__e2e__/8-ui-virtualization/src/my-app.html
@@ -1,4 +1,5 @@
 <import from="./apps/basic-horizontal-app"></import>
+<import from="./apps/gap-app"></import>
 <import from="./apps/variable-width-horizontal-app"></import>
 <import from="./welcome-page"></import>
 <import from="./about-page.html"></import>
@@ -11,6 +12,7 @@
 
 <nav>
   <a load="basic-app" data-testid="load-basic-usage">Basic usage</a>
+  <a load="gap-app" data-testid="load-gap-usage">Gap usage</a>
   <a load="container-animation-transition">With scroller transition animation</a>
   <a load="table-app">Basic table usage</a>
   <a load="basic-horizontal-app" data-testid="load-basic-horizontal">Horizontal basic</a>

--- a/packages/__e2e__/8-ui-virtualization/src/shared/virtual-repeat-monitor.html
+++ b/packages/__e2e__/8-ui-virtualization/src/shared/virtual-repeat-monitor.html
@@ -28,6 +28,10 @@
         <td>${virtualRepeat.itemHeight}</td>
       </tr>
       <tr>
+        <td>Gap</td>
+        <td>${virtualRepeat.itemGap ?? 0}</td>
+      </tr>
+      <tr>
         <td>Total rendered height (px)</td>
         <td>${virtualRepeat.collectionStrategy.count * virtualRepeat.itemHeight}</td>
       </tr>

--- a/packages/__tests__/src/ui-virtualization/virtual-repeat.spec.ts
+++ b/packages/__tests__/src/ui-virtualization/virtual-repeat.spec.ts
@@ -100,6 +100,22 @@ describe('ui-virtualization/virtual-repeat.spec.ts', function () {
     assert.strictEqual(firstView.nodes.firstChild.textContent, `item-8`);
   });
 
+  it('rerenders when scrolled with gap', function () {
+    const { scrollBy } = createFixture(
+      createScrollerTemplate('<div virtual-repeat.for="item of items; item-height: 50; gap: 10" style="height: 50px">${item.name}</div>'),
+      class App { items = createItems(); },
+      virtualRepeatDeps
+    );
+
+    scrollBy('#scroller', 420);
+    runTasks();
+
+    const virtualRepeat = virtualRepeats[0];
+    const firstView = virtualRepeat.getViews()[0];
+    assert.deepStrictEqual(virtualRepeat.getDistances(), [420, (100 * 50 + 99 * 10) - 420 - (20 * 50 + 19 * 10)]);
+    assert.strictEqual(firstView.nodes.firstChild.textContent, 'item-7');
+  });
+
   describe('scroller resizing', function () {
     it('works with dynamic height scroller', async function () {
       const {getAllBy } = createFixture(
@@ -255,6 +271,16 @@ describe('ui-virtualization/virtual-repeat.spec.ts', function () {
       assert.deepStrictEqual(virtualRepeats[0].getDistances(), [0, (100 - 15) * 40]);
     });
 
+    it('accepts gap configuration', function () {
+      createFixture(
+        createScrollerTemplate('<div virtual-repeat.for="item of items; item-height: 50; gap: 10" style="height: 50px">${item}</div>'),
+        class App { items = createItems(); },
+        virtualRepeatDeps
+      );
+
+      assert.deepStrictEqual(virtualRepeats[0].getDistances(), [0, (100 - Math.ceil(600 / 60) * 2) * 60]);
+    });
+
     it('accepts horizontal layout with item-width configuration', function () {
       createFixture(
         createHorizontalScrollerTemplate('<div virtual-repeat.for="item of items; layout: horizontal; item-width: 100" style="width: 100px; height: 50px; display: inline-block">${item}</div>'),
@@ -293,6 +319,21 @@ describe('ui-virtualization/virtual-repeat.spec.ts', function () {
       const firstView = virtualRepeat.getViews()[0];
       const expectedFirstIndex = Math.floor(400 / 80); // Should be index 5 (400/80 = 5)
       assert.strictEqual(firstView.nodes.firstChild.textContent, `item-${expectedFirstIndex}`);
+    });
+
+    it('accounts for gap when scrolled horizontally', function () {
+      const { scrollBy } = createFixture(
+        createHorizontalScrollerTemplate('<div virtual-repeat.for="item of items; layout: horizontal; item-width: 80; gap: 20" style="width: 80px; height: 50px; display: inline-block">${item.name}</div>'),
+        class App { items = createItems(); },
+        virtualRepeatDeps
+      );
+
+      scrollBy('#scroller', { left: 420 });
+      runTasks();
+
+      const virtualRepeat = virtualRepeats[0];
+      const firstView = virtualRepeat.getViews()[0];
+      assert.strictEqual(firstView.nodes.firstChild.textContent, 'item-4');
     });
   });
 

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -80,12 +80,14 @@ export class VirtualRepeat implements IVirtualRepeater {
 
   private itemHeight = 0;
   private itemWidth = 0;
+  private itemGap = 0;
   private minViewsRequired = 0;
   private collectionStrategy?: ICollectionStrategy;
   private dom: IVirtualRepeatDom = null!;
 
   /** @internal */ private readonly _configuredItemHeight?: number;
   /** @internal */ private readonly _configuredItemWidth?: number;
+  /** @internal */ private readonly _configuredGap: number = 0;
   /** @internal */ private readonly _configuredBufferSize?: number;
   /** @internal */ private readonly _configuredMinViews?: number;
   /** @internal */ private readonly _configuredLayout: 'vertical' | 'horizontal' = 'vertical';
@@ -137,6 +139,12 @@ export class VirtualRepeat implements IVirtualRepeater {
           case 'item-width': {
             if (!Number.isNaN(valNum) && valNum > 0) {
               this._configuredItemWidth = valNum;
+            }
+            break;
+          }
+          case 'gap': {
+            if (!Number.isNaN(valNum) && valNum >= 0) {
+              this._configuredGap = valNum;
             }
             break;
           }
@@ -273,13 +281,14 @@ export class VirtualRepeat implements IVirtualRepeater {
       const viewCount = this.views.length;
       // when updating the dom
       // we will trigger an event and then handle it the next frame
-      this.dom.update(0, (isHorizontal ? itemWidth : itemHeight) * (itemCount - viewCount));
+      this.dom.update(0, this._getTailSize(itemCount - viewCount));
     }
 
     this.itemHeight = itemHeight;
     this.itemWidth = itemWidth;
+    this.itemGap = this._configuredGap;
 
-    const minViews = this._configuredMinViews ?? viewportSize / (isHorizontal ? itemWidth : itemHeight);
+    const minViews = this._configuredMinViews ?? viewportSize / this._getItemSpan();
     this.minViewsRequired = Math.ceil(minViews);
 
     // For variable sizing, measure the first item to initialize the arrays
@@ -297,6 +306,7 @@ export class VirtualRepeat implements IVirtualRepeater {
     this.minViewsRequired = 0;
     this.itemHeight = 0;
     this.itemWidth = 0;
+    this.itemGap = 0;
     this.dom.update(0, 0);
 
     // Reset variable sizing data
@@ -330,7 +340,7 @@ export class VirtualRepeat implements IVirtualRepeater {
     let cumulativeHeight = 0;
     for (let i = 0; i < itemCount; i++) {
       const height = this._itemHeights[i] ?? this.itemHeight;
-      cumulativeHeight += height;
+      cumulativeHeight += height + (i === 0 ? 0 : this.itemGap);
       this._cumulativeHeights[i] = cumulativeHeight;
     }
 
@@ -339,7 +349,7 @@ export class VirtualRepeat implements IVirtualRepeater {
     let cumulativeWidth = 0;
     for (let i = 0; i < itemCount; i++) {
       const width = this._itemWidths[i] ?? this.itemWidth;
-      cumulativeWidth += width;
+      cumulativeWidth += width + (i === 0 ? 0 : this.itemGap);
       this._cumulativeWidths[i] = cumulativeWidth;
     }
   }
@@ -350,10 +360,10 @@ export class VirtualRepeat implements IVirtualRepeater {
   private _findIndexByPosition(position: number, isHorizontal: boolean): number {
     const cumulative = isHorizontal ? this._cumulativeWidths : this._cumulativeHeights;
 
-    if (cumulative.length === 0) {
-      // Fallback to fixed sizing
-      const itemSize = this._getItemSize();
-      return itemSize > 0 ? Math.floor(position / itemSize) : 0;
+      if (cumulative.length === 0) {
+        // Fallback to fixed sizing
+      const itemSpan = this._getItemSpan();
+      return itemSpan > 0 ? Math.floor((position + this.itemGap) / itemSpan) : 0;
     }
 
     // Binary search to find the index
@@ -389,8 +399,7 @@ export class VirtualRepeat implements IVirtualRepeater {
 
     if (index >= cumulative.length) {
       // Fallback for out-of-bounds
-      const itemSize = this._getItemSize();
-      return index * itemSize;
+      return this._getTailSize(index);
     }
 
     return index > 0 ? cumulative[index - 1] : 0;
@@ -399,6 +408,28 @@ export class VirtualRepeat implements IVirtualRepeater {
   /** @internal */
   private _getItemSize() {
     return this._configuredLayout === 'horizontal' ? this.itemWidth : this.itemHeight;
+  }
+
+  /** @internal */
+  private _getItemSpan() {
+    return this._getItemSize() + this.itemGap;
+  }
+
+  /** @internal */
+  private _getTailSize(itemCount: number) {
+    return itemCount <= 0 ? 0 : (itemCount * this._getItemSize()) + (itemCount * this.itemGap);
+  }
+
+  /** @internal */
+  private _getTotalSize(itemCount: number, isHorizontal: boolean): number {
+    if (itemCount <= 0) {
+      return 0;
+    }
+    const cumulative = isHorizontal ? this._cumulativeWidths : this._cumulativeHeights;
+    if (cumulative.length >= itemCount) {
+      return cumulative[itemCount - 1];
+    }
+    return (itemCount * this._getItemSize()) + ((itemCount - 1) * this.itemGap);
   }
 
   /** @internal */
@@ -511,11 +542,12 @@ export class VirtualRepeat implements IVirtualRepeater {
     if ((isHorizontal && this._configuredVariableWidth) || (!isHorizontal && this._configuredVariableHeight)) {
       // Variable sizing: calculate actual cumulative sizes
       topBufferSize = this._getPositionForIndex(topCount, isHorizontal);
-      botBufferSize = this._getPositionForIndex(itemCount - firstIndex - realViewCount, isHorizontal);
+      const bottomBufferStartOffset = this._getPositionForIndex(itemCount - botCount, isHorizontal);
+      botBufferSize = this._getTotalSize(itemCount, isHorizontal) - bottomBufferStartOffset;
     } else {
       // Fixed sizing: use multiplication
-      topBufferSize = topCount * itemSize;
-      botBufferSize = botCount * itemSize;
+      topBufferSize = topCount * (itemSize + this.itemGap);
+      botBufferSize = botCount * (itemSize + this.itemGap);
     }
 
     this.dom.update(topBufferSize, botBufferSize);
@@ -579,7 +611,7 @@ export class VirtualRepeat implements IVirtualRepeater {
 
     let first_index_after_scroll_adjustment = realScroll === 0
       ? 0
-      : Math.floor(realScroll / itemSize);
+      : Math.floor((realScroll + this.itemGap) / (itemSize + this.itemGap));
 
     // if first index after scroll adjustment doesn't fit with number of possible view
     // it means the scroller has been too far down to the bottom and nolonger suitable to start from this index
@@ -748,11 +780,12 @@ export class VirtualRepeat implements IVirtualRepeater {
     if ((isHorizontal && this._configuredVariableWidth) || (!isHorizontal && this._configuredVariableHeight)) {
       // Variable sizing: calculate actual cumulative sizes
       topBufferSize = this._getPositionForIndex(topCount1, isHorizontal);
-      botBufferSize = this._getPositionForIndex(botCount1, isHorizontal);
+      const bottomBufferStartOffset = this._getPositionForIndex(collectionSize - botCount1, isHorizontal);
+      botBufferSize = this._getTotalSize(collectionSize, isHorizontal) - bottomBufferStartOffset;
     } else {
       // Fixed sizing: use multiplication
-      topBufferSize = topCount1 * itemSize;
-      botBufferSize = botCount1 * itemSize;
+      topBufferSize = topCount1 * (itemSize + this.itemGap);
+      botBufferSize = botCount1 * (itemSize + this.itemGap);
     }
 
     repeatDom.update(topBufferSize, botBufferSize);


### PR DESCRIPTION
## 📖 Description

With the current virtualisation implementation, there is not really a way to specify some gap between items, one can "hackaround" using container + padding but that'll get ugly quick. This PR adds an ability to specify gap between items so that it's possible to use margin for item gap.

### 🎫 Issues

Resolves #2402 

cc @MaximBalaganskiy 