### PR TITLE
fix(virtual-repeat): observe inner collection

### DIFF
--- a/packages/__tests__/src/ui-virtualization/virtual-repeat.spec.ts
+++ b/packages/__tests__/src/ui-virtualization/virtual-repeat.spec.ts
@@ -2,7 +2,7 @@ import { createFixture, assert } from '@aurelia/testing';
 import { DefaultVirtualizationConfiguration, VirtualRepeat, VIRTUAL_REPEAT_NEAR_BOTTOM, VIRTUAL_REPEAT_NEAR_TOP, type IVirtualRepeatNearBottomEvent, type IVirtualRepeatNearTopEvent } from '@aurelia/ui-virtualization';
 import { isNode } from '../util.js';
 import { runTasks, tasksSettled } from '@aurelia/runtime';
-import { LifecycleHooks } from '@aurelia/runtime-html';
+import { LifecycleHooks, ValueConverter } from '@aurelia/runtime-html';
 
 describe('ui-virtualization/virtual-repeat.spec.ts', function () {
   if (isNode()) {
@@ -98,6 +98,41 @@ describe('ui-virtualization/virtual-repeat.spec.ts', function () {
     const firstView = virtualRepeat.getViews()[0];
     assert.deepStrictEqual(virtualRepeat.getDistances(), [400, /* whole thing - top distance */4600 - /* rendered view (24 items * 50px) */1200]);
     assert.strictEqual(firstView.nodes.firstChild.textContent, `item-8`);
+  });
+
+  it('works with a value converter that returns a cloned array', async function () {
+    const { trigger, component } = createFixture(
+      createScrollerTemplate(`
+        <button click.trigger="addItem()">Add item</button>
+        <div virtual-repeat.for="item of items | cloneItems" style="height: 50px">\${item.name}</div>
+      `),
+      class App {
+        items = createItems(2);
+
+        public addItem() {
+          this.items.push({ idx: this.items.length, name: `item-${this.items.length}` });
+        }
+      },
+      [
+        ...virtualRepeatDeps,
+        ValueConverter.define('cloneItems', class {
+          public toView(value: any[]) {
+            return [...value];
+          }
+        })
+      ]
+    );
+
+    assert.deepStrictEqual(virtualRepeats[0].getDistances(), [0, 0]);
+    assert.strictEqual(virtualRepeats[0].getViews()[0].nodes.firstChild.textContent, 'item-0');
+
+    trigger('button', 'click');
+    await tasksSettled();
+
+    assert.strictEqual(component.items.length, 3);
+    assert.deepStrictEqual(virtualRepeats[0].getDistances(), [0, 0]);
+    assert.strictEqual(virtualRepeats[0].getViews().length, 3);
+    assert.strictEqual(virtualRepeats[0].getViews()[2].nodes.firstChild.textContent, 'item-2');
   });
 
   it('rerenders when scrolled with gap', function () {

--- a/packages/template-compiler/src/instructions.ts
+++ b/packages/template-compiler/src/instructions.ts
@@ -63,6 +63,9 @@ export interface IInstruction {
 }
 export const IInstruction = /*@__PURE__*/tcCreateInterface<IInstruction>('Instruction');
 
+/**
+ * @internal
+ */
 export function isInstruction(value: unknown): value is IInstruction {
   const type = (value as { type?: number }).type;
   return typeof type === 'number' && type >= 0 && type < 100;

--- a/packages/ui-virtualization/src/configuration.ts
+++ b/packages/ui-virtualization/src/configuration.ts
@@ -3,12 +3,20 @@ import { IContainer, IRegistry } from '@aurelia/kernel';
 import { VirtualRepeat } from './virtual-repeat';
 import { CollectionStrategyLocator } from './collection-strategy';
 import { DefaultDomRenderer } from './virtual-repeat-dom-renderer';
+import {
+  IterateBindingCommand,
+  IterateBindingRenderer,
+  VirtualRepeatForAttributePattern,
+} from './iterate-binding';
 
 export const DefaultVirtualizationConfiguration: IRegistry = {
   register(container: IContainer): IContainer {
     return container.register(
       CollectionStrategyLocator,
       DefaultDomRenderer,
+      VirtualRepeatForAttributePattern,
+      IterateBindingCommand,
+      IterateBindingRenderer,
       VirtualRepeat,
     );
   }

--- a/packages/ui-virtualization/src/iterate-binding.ts
+++ b/packages/ui-virtualization/src/iterate-binding.ts
@@ -1,0 +1,281 @@
+import { IContainer, type IServiceLocator, areEqual, camelCase, emptyArray, isString, registrableMetadataKey, resolve } from '@aurelia/kernel';
+import { IExpressionParser, type ForOfStatement, type IsBindingBehavior } from '@aurelia/expression-parser';
+import {
+  astBind,
+  astEvaluate,
+  astUnbind,
+  Collection,
+  connectable,
+  getCollectionObserver,
+  IndexMap,
+  type IAstEvaluator,
+  type ICollectionSubscriber,
+  type IObserverLocator,
+  type IObserverLocatorBasedConnectable,
+  type Scope,
+} from '@aurelia/runtime';
+import {
+  type IBinding,
+  type IBindingController,
+  type IController,
+  type ICustomAttributeViewModel,
+  type IHydratableController,
+  IPlatform,
+  renderer,
+  type IRenderer,
+  mixinAstEvaluator,
+  mixinUseScope,
+} from '@aurelia/runtime-html';
+import {
+  AttrSyntax,
+  type ICommandBuildInfo,
+  IAttributeParser,
+  type IInstruction,
+  itMultiAttr,
+  type MultiAttrInstruction,
+  AttributePattern,
+  BindingCommandStaticAuDefinition,
+} from '@aurelia/template-compiler';
+
+const itIterateBinding = 200;
+
+export interface IterateBindingInstruction extends IInstruction {
+  readonly type: typeof itIterateBinding;
+  readonly forOf: string | ForOfStatement;
+  readonly to: string;
+  readonly props: MultiAttrInstruction[];
+}
+
+export interface IIterateBindingTarget extends ICustomAttributeViewModel {
+  handleItemsChangeChange(items: Collection, indexMap?: IndexMap): void;
+}
+
+const wrappedExprs = [
+  'BindingBehavior',
+  'ValueConverter',
+] as const;
+
+export interface IterateBinding extends IAstEvaluator, IServiceLocator, IObserverLocatorBasedConnectable {
+  readonly l: IContainer;
+}
+
+interface IWrappedExpression {
+  readonly expression: IsBindingBehavior;
+}
+
+export class IterateBinding implements IBinding, ICollectionSubscriber {
+  public static mix = /*@__PURE__*/ (() => {
+    let mixed = false;
+    return () => {
+      if (mixed) {
+        return;
+      }
+      mixed = true;
+      mixinUseScope(IterateBinding);
+      connectable(IterateBinding, null!);
+      mixinAstEvaluator(IterateBinding);
+    };
+  })();
+
+  public isBound = false;
+
+  /** @internal */ public _scope?: Scope = void 0;
+  /** @internal */ public readonly oL: IObserverLocator;
+  /** @internal */ private readonly _controller: IBindingController;
+  /** @internal */ private _observer?: ReturnType<typeof getCollectionObserver>;
+  /** @internal */ private _observingInnerItems = false;
+  /** @internal */ private _reevaluating = false;
+  /** @internal */ private readonly _innerItemsExpression: IsBindingBehavior | null = null;
+  /** @internal */ private _items: Collection = null!;
+
+  public constructor(
+    controller: IBindingController,
+    locator: IContainer,
+    observerLocator: IObserverLocator,
+    public readonly ast: ForOfStatement,
+    public readonly target: IIterateBindingTarget,
+    public readonly l: IContainer,
+  ) {
+    this._controller = controller;
+    this.oL = observerLocator;
+
+    let expression: IsBindingBehavior | undefined = ast.iterable;
+    while (expression != null && wrappedExprs.includes(expression.$kind as typeof wrappedExprs[number])) {
+      expression = (expression as IsBindingBehavior & IWrappedExpression).expression;
+      this._observingInnerItems = true;
+    }
+    this._innerItemsExpression = expression ?? null;
+  }
+
+  public bind(scope: Scope): void {
+    if (this.isBound) {
+      if (this._scope === scope) {
+        return;
+      }
+      this.unbind();
+    }
+
+    this._scope = scope;
+    astBind(this.ast, scope, this);
+    this.isBound = true;
+    this._setItems(astEvaluate(this.ast, scope, this, this) as Collection);
+  }
+
+  public unbind(): void {
+    if (!this.isBound) {
+      return;
+    }
+
+    this.isBound = false;
+    astUnbind(this.ast, this._scope!, this);
+    this._scope = void 0;
+    this._observer?.unsubscribe(this);
+    this._observer = void 0;
+    this.obs.clearAll();
+  }
+
+  public handleChange(): void {
+    if (!this.isBound) {
+      return;
+    }
+
+    this.obs.version++;
+    const items = astEvaluate(this.ast, this._scope!, this, this) as Collection;
+    this.obs.clear();
+    this._setItems(items);
+  }
+
+  public handleCollectionChange(collection: Collection, indexMap: IndexMap): void {
+    if (!this.isBound) {
+      return;
+    }
+
+    if (this._observingInnerItems) {
+      if (this._reevaluating) {
+        return;
+      }
+      this._reevaluating = true;
+      const items = astEvaluate(this.ast, this._scope!, this, null) as Collection;
+      this._reevaluating = false;
+      this._setItems(items);
+      return;
+    }
+
+    this._setItems(collection, indexMap);
+  }
+
+  /** @internal */
+  private _setItems(items: Collection, indexMap?: IndexMap): void {
+    this._items = items;
+    this._refreshCollectionObserver();
+    this.target.handleItemsChangeChange(items, indexMap);
+  }
+
+  /** @internal */
+  private _refreshCollectionObserver(): void {
+    let observingInnerItems = this._observingInnerItems;
+    let observedItems = this._items;
+
+    if (observingInnerItems && this._innerItemsExpression != null && this._scope != null) {
+      const innerItems = astEvaluate(this._innerItemsExpression, this._scope, this, null) as Collection ?? null;
+      observingInnerItems = this._observingInnerItems = !areEqual(this._items, innerItems);
+      observedItems = observingInnerItems ? innerItems : this._items;
+    }
+
+    const newObserver = observedItems == null ? void 0 : getCollectionObserver(observedItems);
+    if (this._observer !== newObserver) {
+      this._observer?.unsubscribe(this);
+      this._observer = newObserver;
+      newObserver?.subscribe(this);
+    }
+  }
+}
+
+export class IterateBindingCommand {
+  public static readonly $au: BindingCommandStaticAuDefinition = {
+    type: 'binding-command',
+    name: 'forof',
+  };
+
+  public get ignoreAttr() { return false; }
+
+  /** @internal */
+  private readonly _attrParser = resolve(IAttributeParser);
+
+  public build(info: ICommandBuildInfo, exprParser: IExpressionParser): IterateBindingInstruction {
+    const target = info.bindable === null
+      ? camelCase(info.attr.target)
+      : info.bindable.name;
+    const forOf = exprParser.parse(info.attr.rawValue, 'IsIterator');
+    let props: MultiAttrInstruction[] = emptyArray;
+
+    if (forOf.semiIdx > -1) {
+      const attrsString = info.attr.rawValue.slice(forOf.semiIdx + 1);
+      const attrParts = attrsString.split(';');
+      const parsedProps: MultiAttrInstruction[] = [];
+
+      for (let j = 0, jj = attrParts.length; j < jj; j++) {
+        const attrPart = attrParts[j];
+        const colonIdx = attrPart.indexOf(':');
+        if (colonIdx === -1) {
+          continue;
+        }
+
+        const attrName = attrPart.slice(0, colonIdx).trim();
+        const attrValue = attrPart.slice(colonIdx + 1).trim();
+        const attrSyntax = this._attrParser.parse(attrName, attrValue);
+        parsedProps.push({ type: itMultiAttr, value: attrValue, to: attrSyntax.target, command: attrSyntax.command });
+      }
+
+      props = parsedProps;
+    }
+
+    return { type: itIterateBinding, forOf, to: target, props };
+  }
+}
+
+export class VirtualRepeatForAttributePattern {
+  public static [Symbol.metadata] = {
+    [registrableMetadataKey]: AttributePattern.create([{ pattern: 'virtual-repeat.for', symbols: '.-' }], VirtualRepeatForAttributePattern)
+  };
+  public 'virtual-repeat.for'(rawName: string, rawValue: string): AttrSyntax {
+    return new AttrSyntax(rawName, rawValue, 'virtual-repeat', 'forof');
+  }
+}
+
+export const IterateBindingRenderer = /*@__PURE__*/ renderer(class IterateBindingRenderer implements IRenderer {
+  public readonly target = itIterateBinding;
+
+  public constructor() {
+    IterateBinding.mix();
+  }
+
+  public render(
+    renderingCtrl: IHydratableController,
+    target: IController,
+    instruction: IterateBindingInstruction,
+    _platform: IPlatform,
+    exprParser: IExpressionParser,
+    observerLocator: IObserverLocator,
+  ): void {
+    renderingCtrl.addBinding(new IterateBinding(
+      renderingCtrl,
+      renderingCtrl.container,
+      observerLocator,
+      ensureIteratorExpression(exprParser, instruction.forOf),
+      getBindingTarget(target),
+      renderingCtrl.container,
+    ));
+  }
+}, null!);
+
+function ensureIteratorExpression(parser: IExpressionParser, srcOrExpr: string | ForOfStatement): ForOfStatement {
+  return isString(srcOrExpr)
+    ? parser.parse(srcOrExpr, 'IsIterator')
+    : srcOrExpr;
+}
+
+function getBindingTarget(target: IController): IIterateBindingTarget {
+  const maybeVm = (target as unknown as { viewModel?: object }).viewModel;
+  return (maybeVm ?? target) as IIterateBindingTarget;
+}

--- a/packages/ui-virtualization/src/utilities-repeat.ts
+++ b/packages/ui-virtualization/src/utilities-repeat.ts
@@ -2,14 +2,17 @@ import {
   type IsBindingBehavior,
 } from '@aurelia/expression-parser';
 
+/**
+ * @internal
+ */
 export function unwrapExpression(expression: IsBindingBehavior) {
   let unwrapped = false;
   let current: IsBindingBehavior | undefined = expression;
   while (current.$kind === 'BindingBehavior') {
-    current = current.expression as IsBindingBehavior;
+    current = current.expression;
   }
   while (current?.$kind === 'ValueConverter') {
-    current = current.expression as IsBindingBehavior;
+    current = current.expression;
     unwrapped = true;
   }
   return unwrapped ? current ?? null : null;

--- a/packages/ui-virtualization/src/virtual-repeat.ts
+++ b/packages/ui-virtualization/src/virtual-repeat.ts
@@ -1,13 +1,11 @@
 import { resolve } from "@aurelia/kernel";
-import { type IsBindingBehavior, ForOfStatement, BindingIdentifier } from '@aurelia/expression-parser';
+import { ForOfStatement, BindingIdentifier } from '@aurelia/expression-parser';
 import {
   Collection,
-  getCollectionObserver,
   IndexMap,
   Scope,
   type IOverrideContext,
   BindingContext,
-  astEvaluate,
   queueAsyncTask,
   Task,
 } from '@aurelia/runtime';
@@ -24,11 +22,7 @@ import {
 import {
   IInstruction,
   HydrateTemplateController,
-  IteratorBindingInstruction,
 } from '@aurelia/template-compiler';
-import {
-  unwrapExpression,
-} from "./utilities-repeat";
 import { createMappedError, ErrorNames } from './errors';
 import {
   ICollectionStrategyLocator,
@@ -49,10 +43,11 @@ import {
   getDistanceToScroller,
   getHorizontalDistanceToScroller
 } from "./utilities-dom";
+import { IterateBindingInstruction, IIterateBindingTarget } from './iterate-binding';
 
 export interface VirtualRepeat extends ICustomAttributeViewModel { }
 
-export class VirtualRepeat implements IVirtualRepeater {
+export class VirtualRepeat implements IVirtualRepeater, IIterateBindingTarget {
   public static readonly $au: CustomAttributeStaticAuDefinition = {
     type: 'custom-attribute',
     name: 'virtual-repeat',
@@ -70,13 +65,10 @@ export class VirtualRepeat implements IVirtualRepeater {
   // bindable
   public items: Collection | null | undefined = void 0;
 
-  /** @internal */ private readonly iterable: IsBindingBehavior;
-  // /** @internal */ private readonly forOf: ForOfStatement;
-  /** @internal */ private readonly _hasWrapExpression: boolean;
-  /** @internal */ private readonly _obsMediator: CollectionObservationMediator;
-
   /** @internal */ private readonly views: ISyntheticView[] = [];
   /** @internal */ private task: Task | null = null;
+  /** @internal */ private _items: Collection | null | undefined = void 0;
+  /** @internal */ private _ignoreItemsChanged = false;
 
   private itemHeight = 0;
   private itemWidth = 0;
@@ -108,11 +100,8 @@ export class VirtualRepeat implements IVirtualRepeater {
   /** @internal */ private readonly _domRenderer = resolve(IDomRenderer);
 
   public constructor() {
-    const iteratorInstruction = this.instruction.props[0] as IteratorBindingInstruction;
+    const iteratorInstruction = this.instruction.props[0] as IterateBindingInstruction;
     const forOf = iteratorInstruction.forOf as ForOfStatement;
-    const iterable = this.iterable = unwrapExpression(forOf.iterable) ?? forOf.iterable;
-    const hasWrapExpression = this._hasWrapExpression = forOf.iterable !== iterable;
-    this._obsMediator = new CollectionObservationMediator(this, () => hasWrapExpression ? this._handleInnerCollectionChange() : this._handleCollectionChange());
     this.local = (forOf.declaration as BindingIdentifier).name;
 
     const extraProps = (iteratorInstruction.props ?? []);
@@ -204,8 +193,8 @@ export class VirtualRepeat implements IVirtualRepeater {
         && (parentTag === 'TBODY' || parentTag === 'THEAD' || parentTag === 'TFOOT' || parentTag === 'TABLE')) {
       throw createMappedError(ErrorNames.virtual_repeat_horizontal_in_table);
     }
-    this._obsMediator.start(this.items);
-    this.collectionStrategy = this._strategyLocator.getStrategy(this.items);
+    this._items = this.items;
+    this.collectionStrategy = this._strategyLocator.getStrategy(this._items);
     this._unsubscribeScroller = this._observeScroller();
     this._attached = true;
     this._onResize();
@@ -220,7 +209,6 @@ export class VirtualRepeat implements IVirtualRepeater {
     this.task?.cancel();
     this._resetCalculation();
     this.dom.dispose();
-    this._obsMediator.stop();
 
     this.dom
       = this.task
@@ -296,7 +284,7 @@ export class VirtualRepeat implements IVirtualRepeater {
       this._measureAndStoreItemSize(firstView, 0);
     }
 
-    this._handleItemsChanged(this.items, this.collectionStrategy!);
+    this._handleItemsChanged(this._items, this.collectionStrategy!);
   }
 
   /**
@@ -555,8 +543,33 @@ export class VirtualRepeat implements IVirtualRepeater {
 
   /** @internal */
   public itemsChanged(items?: Collection | null): void {
-    this._obsMediator.start(items);
+    if (this._ignoreItemsChanged) {
+      return;
+    }
+    this._items = items;
     this.collectionStrategy = this._strategyLocator.getStrategy(items);
+    this._queueHandleItemsChanged();
+  }
+
+  /** @internal */
+  public handleItemsChangeChange(items: Collection, indexMap?: IndexMap): void {
+    const isMutation = indexMap !== void 0;
+    const sameItems = this._items === items;
+
+    if (!isMutation || !sameItems) {
+      this._items = items;
+      if (!sameItems) {
+        this.collectionStrategy = this._strategyLocator.getStrategy(items);
+      }
+      this._ignoreItemsChanged = true;
+      this.items = items;
+      this._ignoreItemsChanged = false;
+    }
+
+    if (!this._attached) {
+      return;
+    }
+
     this._queueHandleItemsChanged();
   }
 
@@ -799,33 +812,12 @@ export class VirtualRepeat implements IVirtualRepeater {
     return this.views.slice(0);
   }
 
-  /**
-   * todo: handle update based on collection, rather than always update
-   *
-   * @internal
-   */
-  public _handleCollectionChange(): void {
-    this._queueHandleItemsChanged();
-  }
-
-  /**
-   * @internal
-   */
-  public _handleInnerCollectionChange(): void {
-    const newItems = astEvaluate(this.iterable, this.parent.scope, { strict: true }, null) as Collection;
-    const oldItems = this.items;
-    this.items = newItems;
-    if (newItems === oldItems) {
-      this._queueHandleItemsChanged();
-    }
-  }
-
   /** @internal */
   private _queueHandleItemsChanged() {
     const task = this.task;
     this.task = queueAsyncTask(() => {
       this.task = null;
-      this._handleItemsChanged(this.items, this.collectionStrategy!);
+      this._handleItemsChanged(this._items, this.collectionStrategy!);
     });
     task?.cancel();
   }
@@ -865,29 +857,6 @@ export class VirtualRepeat implements IVirtualRepeater {
     const view = this._factory.create();
     views.push(view);
     return view;
-  }
-}
-
-class CollectionObservationMediator {
-  /** @internal */ private _collection!: Collection;
-
-  public constructor(
-    public repeat: VirtualRepeat,
-    public handleCollectionChange: (col: Collection, indexMap: IndexMap) => void,
-  ) { }
-
-  public start(c?: Collection | null): void {
-    if (this._collection === c) {
-      return;
-    }
-    this.stop();
-    if (c != null) {
-      getCollectionObserver(this._collection = c)?.subscribe(this);
-    }
-  }
-
-  public stop(): void {
-    getCollectionObserver(this._collection)?.unsubscribe(this);
   }
 }
 


### PR DESCRIPTION
## 📖 Description

As reported in #2405 , the virtual repeat current implementation currently doesnt observe original collection correctly, so if there's a value converter that returns a different array, i.e cloned one, then the virtual repeat will become unaware of the mutation. This PR fixes it, and some more cleanup:
- add a new iterate binding to manage the collection observation/notifying the virtual repeat
- the virtual repeat now conforms an interface for the iterate binding to communicate 

### 🎫 Issues

Resolves #2405

Thanks @MaximBalaganskiy for reporting issue.