### PR TITLE
fix: better typings for dialog whenclosed

### DIFF
--- a/packages/__tests__/src/3-runtime-html/computed-method.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/computed-method.spec.ts
@@ -4,6 +4,7 @@ import { assert, createFixture } from '@aurelia/testing';
 describe('3-runtime-html/computed-method.spec.ts', function () {
   it('should throw if applied to non-method', function () {
     assert.throws(() => class Test {
+      // @ts-expect-error - should error because it's not a method
       @computed()
       public property: string = 'test';
     });

--- a/packages/dialog/src/dialog-interfaces.ts
+++ b/packages/dialog/src/dialog-interfaces.ts
@@ -45,6 +45,13 @@ export interface IDialogService {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function testTypes(d: IDialogService) {
+  void d.open({
+    component: class Abc {},
+  }).whenClosed().then(result => {
+    const { status, value } = result;
+    return { status, value };
+  });
+
   return [
     d.open({
       model: { b: 2 },
@@ -118,7 +125,15 @@ export interface DialogOpenPromise extends Promise<DialogOpenResult> {
   /**
    * Add a callback that will be invoked when a dialog has been closed
    */
+  whenClosed(): Promise<DialogCloseResult>;
+  whenClosed<TResult1>(
+    onfulfilled?: ((value: DialogCloseResult) => TResult1 | PromiseLike<TResult1>) | null,
+  ): Promise<TResult1>;
   whenClosed<TResult1, TResult2>(
+    onfulfilled: ((value: DialogCloseResult) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+    onrejected: (reason: unknown) => TResult2 | PromiseLike<TResult2>
+  ): Promise<TResult1 | TResult2>;
+  whenClosed<TResult1, TResult2 = never>(
     onfulfilled?: (value: DialogCloseResult) => TResult1 | Promise<TResult1>,
     onrejected?: (reason: unknown) => TResult2 | Promise<TResult2>
   ): Promise<TResult1 | TResult2>;

--- a/packages/dialog/src/dialog-service.ts
+++ b/packages/dialog/src/dialog-service.ts
@@ -172,10 +172,22 @@ export class DialogService implements IDialogService {
   }
 }
 
-function whenClosed<TResult1 = unknown, TResult2 = unknown>(
+function whenClosed(
   this: Promise<DialogOpenResult>,
-  onfulfilled?: (r: DialogCloseResult) => TResult1 | Promise<TResult1>,
-  onrejected?: (err: unknown) => TResult2 | Promise<TResult2>
+): Promise<DialogCloseResult>;
+function whenClosed<TResult1>(
+  this: Promise<DialogOpenResult>,
+  onfulfilled?: ((r: DialogCloseResult) => TResult1 | PromiseLike<TResult1>) | null,
+): Promise<TResult1>;
+function whenClosed<TResult1, TResult2>(
+  this: Promise<DialogOpenResult>,
+  onfulfilled: ((r: DialogCloseResult) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+  onrejected: (err: unknown) => TResult2 | PromiseLike<TResult2>
+): Promise<TResult1 | TResult2>;
+function whenClosed<TResult1, TResult2 = never>(
+  this: Promise<DialogOpenResult>,
+  onfulfilled?: ((r: DialogCloseResult) => TResult1 | PromiseLike<TResult1>) | null,
+  onrejected?: ((err: unknown) => TResult2 | PromiseLike<TResult2>) | null
 ): Promise<TResult1 | TResult2> {
   return this.then(openResult => openResult.dialog.closed.then(onfulfilled, onrejected), onrejected);
 }
@@ -183,4 +195,17 @@ function whenClosed<TResult1 = unknown, TResult2 = unknown>(
 function asDialogOpenPromise(promise: Promise<unknown>): DialogOpenPromise {
   (promise as DialogOpenPromise).whenClosed = whenClosed;
   return promise as DialogOpenPromise;
+}
+
+/* eslint-disable */
+async function testApi(service: IDialogService) {
+  const a = await service.open({}).whenClosed();
+  if (a.status === 'ok' || a.status === 'cancel') {
+    // empty
+  }
+  if (a.value === null) {
+    // empty
+  }
+
+  const b = await service.open({}).whenClosed(x => x.status);
 }

--- a/packages/runtime-html/src/watch.ts
+++ b/packages/runtime-html/src/watch.ts
@@ -21,9 +21,14 @@ export type IWatchOptions = {
   flush?: 'async' | 'sync';
 };
 
-type AnyMethod<R = unknown> = (...args: unknown[]) => R;
+type AnyMethod<R = unknown> = (...args: any[]) => R;
 type WatchClassDecorator<T extends object> = (target: Constructable<T>, context: ClassDecoratorContext<Constructable<T>>) => void;
-type WatchMethodDecorator<T, TV extends AnyMethod> = (target: TV, context: ClassMethodDecoratorContext<T, TV>) => void;
+type WatchableMethod<T extends object, D, R = unknown>
+  = (() => R)
+  | ((newValue: D) => R)
+  | ((newValue: D, oldValue: D) => R)
+  | ((newValue: D, oldValue: D, vm: T) => R);
+type WatchMethodDecorator<T extends object, D> = <TV extends WatchableMethod<T, D>>(target: TV, context: ClassMethodDecoratorContext<T, TV>) => void;
 type MethodsOf<Type> = {
   [Key in keyof Type]: Type[Key] extends AnyMethod ? Key : never
 }[keyof Type];
@@ -57,10 +62,10 @@ export function watch<T extends object, D = unknown>(
 //    @watch(a => ...)
 //    method() {...}
 // }
-export function watch<T extends object = object, D = unknown, TV extends AnyMethod = AnyMethod>(
+export function watch<T extends object = object, D = unknown>(
   expressionOrPropertyAccessFn: PropertyKey | IDepCollectionFn<T, D>,
   options?: IWatchOptions,
-): WatchMethodDecorator<T, TV>;
+): WatchMethodDecorator<T, D>;
 
 export function watch<T extends object = object, TV extends AnyMethod = AnyMethod>(
   expressionOrPropertyAccessFn: PropertyKey | IDepCollectionFn<object>,
@@ -182,6 +187,7 @@ function testWatchDeco() {
   @watch(vm => vm.prop, (_, __, vm) => vm.prop, { flush: 'asyn' })
   class MyClass {
     public prop = 1;
+    public ctrl = { confirmUrl: '' };
 
     @watch('some.property')
     @watch('some.property', { flush: 'sync' })
@@ -199,5 +205,11 @@ function testWatchDeco() {
     // @ts-expect-error - type
     @watch((vm) => vm.prop, { flush: 'asyn' })
     public myMethod3() {/*  */}
+
+    @watch((vm) => vm.ctrl.confirmUrl)
+    public onConfirmUrlChanged(url: string) {/*  */}
+
+    @watch((vm) => vm.ctrl.confirmUrl)
+    public onConfirmUrlChanged2() {/*  */}
   }
 }

--- a/packages/runtime/src/computed-decorators.ts
+++ b/packages/runtime/src/computed-decorators.ts
@@ -7,9 +7,11 @@ import { rtObjectAssign } from './utilities';
 import { getRaw } from './proxy-observation';
 import { astTrackableMethodMarker } from './ast.eval';
 
-type ClassGetterFunction<T> = (target: () => unknown, context: ClassGetterDecoratorContext<T>) => void;
-// eslint-disable-next-line @typescript-eslint/ban-types
-type ClassMethodFunction = (target: Function, context: ClassMethodDecoratorContext) => void;
+type UniversalComputedDecorator<T extends object> = {
+  (target: () => unknown, context: ClassGetterDecoratorContext<T>): void;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  (target: Function, context: ClassMethodDecoratorContext<T>): void;
+};
 
 export type ComputedDependencyFn<T = unknown> = (instance: T) => unknown;
 export type ComputedDependency = string | symbol | ComputedDependencyFn;
@@ -68,18 +70,18 @@ export function computed(target: Function, context: ClassMethodDecoratorContext)
 
 // Universal overloads that work for both getters and methods
 // TypeScript can't distinguish at compile time, but runtime checks context.kind
-export function computed<T = unknown>(fn: ComputedDependencyFn<T>): any; // eslint-disable-line @typescript-eslint/no-explicit-any
-export function computed(...dependencies: (string | symbol)[]): any; // eslint-disable-line @typescript-eslint/no-explicit-any
-export function computed<T = unknown>(config: {
-  deps?: (string | symbol)[] | ComputedDependencyFn<T>;
+export function computed<TThis extends object>(fn: ComputedDependencyFn<TThis>): UniversalComputedDecorator<TThis>;
+export function computed<TThis extends object>(...dependencies: (string | symbol)[]): UniversalComputedDecorator<TThis>;
+export function computed<TThis extends object>(config: {
+  deps?: (string | symbol)[] | ComputedDependencyFn<TThis>;
   flush?: 'sync' | 'async';
   deep?: boolean;
-}): any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}): UniversalComputedDecorator<TThis>;
 
 export function computed<TThis extends object>(
   targetOrOptionsOrDependency?: unknown,
   ...rest: unknown[]
-): void | ClassGetterFunction<TThis> | ClassMethodFunction {
+): void | UniversalComputedDecorator<TThis> {
   // Direct method decoration: @computed
   if (isFunction(targetOrOptionsOrDependency) && isClassMethodDecoratorContext(rest[0])) {
     const trackableTarget = targetOrOptionsOrDependency as AnyFunction & { [astTrackableMethodMarker]?: ComputedMethodOptions };
@@ -151,7 +153,7 @@ export function computed<TThis extends object>(
         return observer;
       }
     });
-  } as ClassGetterFunction<TThis> | ClassMethodFunction;
+  } as UniversalComputedDecorator<TThis>;
 }
 /* eslint-enable @typescript-eslint/ban-types */
 
@@ -167,6 +169,7 @@ function testComputed() {
     @computed({ deps: ['value'] })
     @computed({ flush: 'sync' })
     @computed({ deps: ['nested'], deep: true })
+    @computed(x => x.method())
     public get getter5(): number {
       return this.nested.prop.length;
     }
@@ -178,7 +181,7 @@ function testComputed() {
     @computed({ deps: ['value', 'v'] })
     @computed({ deps: ['nested.prop'] })
     @computed({ deps: [] })
-    @computed({ deps: (vm: MyClass) => vm.value })
+    @computed({ deps: (vm) => vm.value })
     public method() {
       return this.value;
     }


### PR DESCRIPTION
## 📖 Description

Resolve typings related to
- dialog service `.whenClosed` reported in #2408
- watch decorator type inference reported in #2407
- computed decorator vm instance type inference

### 🎫 Issues

- Resolves #2408 thanks @rmja
- Resolves #2407