### PR TITLE
fix(vite-plugin): don't enforce development resolution for all packages when use dev is true

### DIFF
--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -51,6 +51,51 @@ describe('vite-plugin', function () {
     } as unknown as import('vite').ResolvedConfig;
   }
 
+  function createConfig(mode: string) {
+    return {
+      mode,
+      resolve: { alias: [], dedupe: [], conditions: [] },
+    } as unknown as import('vite').UserConfig;
+  }
+
+  function createPluginContext() {
+    return {
+      meta: { watchMode: false },
+      async resolve(id: string) {
+        return { id: `/resolved/${id}` };
+      },
+    };
+  }
+
+  it('does not mutate global resolve conditions when useDev is enabled', function () {
+    const [devPlugin] = au({ useDev: true });
+    const config = createConfig('development');
+
+    getHook(devPlugin.config)?.call({}, config);
+
+    assert.deepEqual(config.resolve?.conditions, []);
+  });
+
+  it('rewrites root Aurelia package imports to the development subpath when useDev is enabled', async function () {
+    const [devPlugin, resourcePlugin] = au({ useDev: true });
+    getHook(devPlugin.config)?.call({}, createConfig('development'));
+
+    const resolved = await getHook(resourcePlugin.resolveId)?.call(createPluginContext(), '@aurelia/kernel', '/src/app.ts', {});
+    assert.equal(resolved, '/resolved/@aurelia/kernel/development');
+  });
+
+  it('does not rewrite non-Aurelia or subpath imports when useDev is enabled', async function () {
+    const [devPlugin, resourcePlugin] = au({ useDev: true });
+    getHook(devPlugin.config)?.call({}, createConfig('development'));
+
+    const pluginContext = createPluginContext();
+    const thirdParty = await getHook(resourcePlugin.resolveId)?.call(pluginContext, 'typesense', '/src/app.ts', {});
+    const subpath = await getHook(resourcePlugin.resolveId)?.call(pluginContext, '@aurelia/router/lite', '/src/app.ts', {});
+
+    assert.equal(thirdParty, null);
+    assert.equal(subpath, null);
+  });
+
   it('rewrites conventional html imports for literal production mode', async function () {
     const fixture = createFixture();
     const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -21,21 +21,13 @@ export default function au(options: {
   } = options;
   const filter = createFilter(include, exclude);
   const isVirtualTsFileFromHtml = (id: string) => id.endsWith('.$au.ts');
+  const isAureliaBareImport = (id: string) => id === 'aurelia' || /^@aurelia\/[^/]+$/.test(id);
+  let useDevImports = false;
 
   const devPlugin: import('vite').Plugin = {
     name: 'aurelia:dev-alias',
     config(config) {
-      const isDev = useDev === true || (useDev == null && config.mode !== 'production');
-      if (!isDev) {
-        return;
-      }
-
-      // Add 'development' to resolve.conditions so Vite uses the dev exports
-      // defined in each @aurelia/* package.json "exports" field
-      (config.resolve ??= {}).conditions ??= [];
-      if (!config.resolve.conditions.includes('development')) {
-        config.resolve.conditions.unshift('development');
-      }
+      useDevImports = useDev === true || (useDev == null && config.mode !== 'production');
     },
   };
 
@@ -71,7 +63,11 @@ export default function au(options: {
       return result;
     },
 
-    resolveId(id, importer) {
+    async resolveId(id, importer, options) {
+      if (useDevImports && isAureliaBareImport(id) && !id.endsWith('/development')) {
+        return (await this.resolve(`${id}/development`, importer, { ...options, skipSelf: true }))?.id ?? `${id}/development`;
+      }
+
       if (!isVirtualTsFileFromHtml(id)) {
         return null;
       }

--- a/packages/__e2e__/1-gh-issues/playwright/app.spec.ts
+++ b/packages/__e2e__/1-gh-issues/playwright/app.spec.ts
@@ -12,6 +12,10 @@ test.describe.serial('examples/html-only/app.spec.ts', function () {
     await expect(page.locator('ul')).toContainText(`I'm a two!`);
   });
 
+  test('useDev keeps third-party browser resolution intact', async ({ page }) => {
+    await expect(page.locator('#dep-value')).toHaveText('browser');
+  });
+
   test.describe.serial('subclass resource - https://github.com/aurelia/aurelia/issues/1991', function () {
     test('custom element', async ({ page }) => {
       await expect(page.locator('#gh1991 ce-super')).toHaveText('sup-p1 sup-p2 sup-p3');
@@ -25,4 +29,3 @@ test.describe.serial('examples/html-only/app.spec.ts', function () {
     });
   });
 });
-

--- a/packages/__e2e__/1-gh-issues/src/app.html
+++ b/packages/__e2e__/1-gh-issues/src/app.html
@@ -3,6 +3,7 @@
 <import from="./gh-1991/cas"></import>
 
 <div class="message">${message}</div>
+<div id="dep-value">${depValue}</div>
 
 <button click.trigger="click()">Click Me</button>
 

--- a/packages/__e2e__/1-gh-issues/src/app.ts
+++ b/packages/__e2e__/1-gh-issues/src/app.ts
@@ -1,10 +1,12 @@
 import { IDialogService } from '@aurelia/dialog';
 import { MyDialog } from './my-dialog';
+import depValue from 'conditional-browser-package';
 
 export class App {
   static inject = [IDialogService];
 
   message = 'Hello World!';
+  depValue = depValue;
   dialogService: IDialogService;
 
   constructor(dialogService) {

--- a/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/browser.mjs
+++ b/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/browser.mjs
@@ -1,0 +1,1 @@
+export default 'browser';

--- a/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/default.mjs
+++ b/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/default.mjs
@@ -1,0 +1,1 @@
+export default 'default';

--- a/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/development.mjs
+++ b/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/development.mjs
@@ -1,0 +1,1 @@
+export default 'development';

--- a/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/package.json
+++ b/packages/__e2e__/1-gh-issues/vendor/conditional-browser-package/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "conditional-browser-package",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./browser.mjs",
+      "development": "./development.mjs",
+      "default": "./default.mjs"
+    }
+  }
+}

--- a/packages/__e2e__/1-gh-issues/vite.config.mjs
+++ b/packages/__e2e__/1-gh-issues/vite.config.mjs
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
 import au from '@aurelia/vite-plugin';
 
 export default defineConfig({
   server: {
     port: process.env.APP_PORT ?? 5173,
+  },
+  resolve: {
+    alias: {
+      'conditional-browser-package': resolve(import.meta.dirname, 'vendor/conditional-browser-package'),
+    },
   },
   build: {
     minify: false,


### PR DESCRIPTION
## 📖 Description

Per #2400 , we need a different way to resolve development build of aurelia when `useDev` is true, this PR adds that.

### 🎫 Issues

Resolves #2400