### PR TITLE
fix(vite-plugin): normalise filter id drive for windows

### DIFF
--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -131,4 +131,35 @@ describe('vite-plugin', function () {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }
   });
+
+  if (process.platform === 'win32') {
+    it('transforms files when Windows drive letter casing differs from cwd casing', async function () {
+      const fixture = createFixture();
+      const windowsId = fixture.tsFile[0].toLowerCase() + fixture.tsFile.slice(1);
+      const originalCwd = process.cwd;
+      let resourcePlugin!: ReturnType<typeof au>[1];
+
+      fs.mkdirSync(fixture.srcDir, { recursive: true });
+      fs.writeFileSync(fixture.htmlFile, '<template>Hello</template>', 'utf8');
+
+      try {
+        Object.defineProperty(process, 'cwd', {
+          configurable: true,
+          value: () => fixture.root,
+        });
+        [, resourcePlugin] = au({ include: 'src/**/*.{ts,js,html}' });
+        getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+        const result = await getHook(resourcePlugin.transform)?.call({}, 'export class FooBar {}\n', windowsId);
+        const code = typeof result === 'string' ? result : result?.code;
+
+        assert.match(String(code), /import \* as __au2ViewDef from '\.\/foo-bar\.\$au\.ts';/);
+      } finally {
+        Object.defineProperty(process, 'cwd', {
+          configurable: true,
+          value: originalCwd,
+        });
+        fs.rmSync(fixture.root, { recursive: true, force: true });
+      }
+    });
+  }
 });

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -3,6 +3,15 @@ import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
 
+export function normalizeFilterId(id: string, cwd: string = process.cwd(), platform: NodeJS.Platform = process.platform): string {
+  if (platform !== 'win32' || !/^[a-zA-Z]:/.test(id) || cwd.length === 0) {
+    return id;
+  }
+
+  const cwdDrive = cwd[0];
+  return id[0] === cwdDrive ? id : `${cwdDrive}${id.slice(1)}`;
+}
+
 export default function au(options: {
   include?: FilterPattern;
   exclude?: FilterPattern;
@@ -40,7 +49,7 @@ export default function au(options: {
       $config = config;
     },
     async transform(code, id) {
-      if (!filter(id)) return;
+      if (!filter(normalizeFilterId(id))) return;
       // .$au.ts = .html
       // which already preprocessed by the load hook of this plugin
       if (isVirtualTsFileFromHtml(id)) return;

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -3,15 +3,6 @@ import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
 
-export function normalizeFilterId(id: string, cwd: string = process.cwd(), platform: NodeJS.Platform = process.platform): string {
-  if (platform !== 'win32' || !/^[a-zA-Z]:/.test(id) || cwd.length === 0) {
-    return id;
-  }
-
-  const cwdDrive = cwd[0];
-  return id[0] === cwdDrive ? id : `${cwdDrive}${id.slice(1)}`;
-}
-
 export default function au(options: {
   include?: FilterPattern;
   exclude?: FilterPattern;
@@ -249,4 +240,16 @@ if (${moduleText}.hot) {
 }`;
 
   return code;
+}
+
+// Vite can surface Windows absolute paths with a drive letter casing that differs
+// from process.cwd(), likely due to fs.realpathSync.native() during resolution.
+// Normalize the drive letter before createFilter() so include/exclude checks stay stable.
+function normalizeFilterId(id: string, cwd: string = process.cwd(), platform: NodeJS.Platform = process.platform): string {
+  if (platform !== 'win32' || !/^[a-zA-Z]:/.test(id) || cwd.length === 0) {
+    return id;
+  }
+
+  const cwdDrive = cwd[0];
+  return id[0] === cwdDrive ? id : `${cwdDrive}${id.slice(1)}`;
 }


### PR DESCRIPTION
## 📖 Description

As reported in https://discourse.aurelia.io/t/default-typescript-aurelia-2-app-template-broken-host-undefined/6465/6, sometimes the drive is in lower case instead of upper case. This PR resolves that.