### PR TITLE
fix(runtime): prevent task queue false deadlock detection

### DIFF
--- a/.changeset/task-queue-hardening.md
+++ b/.changeset/task-queue-hardening.md
@@ -1,0 +1,12 @@
+---
+"@aurelia/runtime": patch
+"@aurelia/runtime-html": patch
+---
+
+Prevent large finite task queue workloads from falsely triggering the recursive deadlock guard. Applications can now queue very large finite batches, including work that queues more work during a drain, without hitting a deadlock error merely because the batch is large.
+
+Automatic `queueTask` drains now process work in timed slices and continue through host timer turns until the queue is idle. This gives the browser opportunities to paint and process input during unusually large flushes. As a result, code that needs to observe the completion of all queued work should use `tasksSettled()` instead of assuming that one microtask turn is always enough for very large automatic drains. Manual `runTasks()` calls remain synchronous and keep an internal deadlock guard for low-level tests and diagnostics.
+
+The task queue error surface is also more explicit. Multiple failures now reject or throw a `TaskQueueAggregateError`, which extends `AggregateError`, preserves the original errors in order, sets `cause` to the first error, and includes a more useful message with the error count and a short preview. Unobserved automatic queue errors are reported and cleared so later `tasksSettled()` cycles start fresh instead of failing with stale errors.
+
+Because automatic drains may now continue after other host events have run, delayed runtime-html work now re-checks lifecycle state before mutating DOM state. Queued layout writes and `show` updates no-op when their binding, controller, or attribute has already been torn down.

--- a/packages/__tests__/src/2-runtime/queue.spec.ts
+++ b/packages/__tests__/src/2-runtime/queue.spec.ts
@@ -1,4 +1,17 @@
-import { runTasks, queueAsyncTask, queueTask, TaskAbortError, tasksSettled, queueRecurringTask, getRecurringTasks } from '@aurelia/runtime';
+import {
+  configureTaskQueue,
+  getRecurringTasks,
+  getTaskQueueOptions,
+  isTaskQueueEmpty,
+  queueAsyncTask,
+  queueRecurringTask,
+  queueTask,
+  runTasks,
+  TaskAbortError,
+  TaskQueueAggregateError,
+  tasksSettled,
+  type Task,
+} from '@aurelia/runtime';
 import { assert, createFixture } from '@aurelia/testing';
 
 describe('2-runtime/queue.spec.ts', function () {
@@ -62,6 +75,388 @@ describe('2-runtime/queue.spec.ts', function () {
         'Sync3',
       ], 'stack mismatch');
     });
+  });
+
+  describe('public queue contract', function () {
+    it('reports and clears unobserved queueTask errors after an automatic drain', async function () {
+      const taskError = new Error('UnobservedQueueTaskError');
+      const reportedErrors: unknown[][] = [];
+      const originalConsoleError = console.error;
+      console.error = (...args: unknown[]) => {
+        reportedErrors.push(args);
+      };
+
+      try {
+        queueTask(() => {
+          throw taskError;
+        });
+
+        await Promise.resolve();
+      } finally {
+        console.error = originalConsoleError;
+      }
+
+      assert.strictEqual(reportedErrors.length, 1, 'an unobserved queueTask error should be reported once');
+      assert.strictEqual(reportedErrors[0][0], taskError, 'the original queueTask error should be reported');
+
+      let didRun = false;
+      queueTask(() => {
+        didRun = true;
+      });
+
+      assert.strictEqual(await tasksSettled(), true, 'later settle cycles should not reject with an old unobserved error');
+      assert.strictEqual(didRun, true, 'later queued work should still run');
+    });
+
+    it('clears task errors after manual runTasks throws without an observed settle promise', async function () {
+      const taskError = new Error('ManualFlushError');
+      let flushError: unknown = null;
+
+      queueTask(() => {
+        throw taskError;
+      });
+
+      try {
+        runTasks();
+      } catch (err) {
+        flushError = err;
+      }
+
+      assert.strictEqual(flushError, taskError, 'manual runTasks should throw the task error directly');
+
+      let didRun = false;
+      queueTask(() => {
+        didRun = true;
+      });
+
+      assert.strictEqual(await tasksSettled(), true, 'manual flush errors should not leak into the next settle cycle');
+      assert.strictEqual(didRun, true, 'later queued work should still run');
+    });
+
+    it('manual runTasks throws AggregateError for multiple task errors and then clears them', async function () {
+      const error1 = new Error('ManualAggregateError1');
+      const error2 = new Error('ManualAggregateError2');
+      let flushError: unknown = null;
+
+      queueTask(() => {
+        throw error1;
+      });
+      queueTask(() => {
+        throw error2;
+      });
+
+      try {
+        runTasks();
+      } catch (err) {
+        flushError = err;
+      }
+
+      assert.instanceOf(flushError, AggregateError, 'manual runTasks should throw an AggregateError for multiple task errors');
+      assert.instanceOf(flushError, TaskQueueAggregateError, 'manual runTasks should throw a task-queue-specific AggregateError');
+      assert.deepStrictEqual((flushError as AggregateError).errors, [error1, error2], 'manual AggregateError should preserve task errors in order');
+      assert.strictEqual((flushError as TaskQueueAggregateError).cause, error1, 'manual AggregateError cause should point at the first original error');
+      assert.includes((flushError as Error).message, 'Aurelia task queue failed with 2 errors.', 'AggregateError message should name the failing subsystem and count');
+      assert.includes((flushError as Error).message, 'ManualAggregateError1', 'AggregateError message should preview the first error');
+      assert.includes((flushError as Error).message, 'ManualAggregateError2', 'AggregateError message should preview the second error');
+
+      queueTask(() => { /* verifies a fresh settle cycle */ });
+      assert.strictEqual(await tasksSettled(), true, 'AggregateError contents should not leak into the next settle cycle');
+    });
+
+    it('returns the same tasksSettled promise while async work is pending', async function () {
+      const task = queueAsyncTask(() => {
+        return new Promise<void>(resolve => {
+          setTimeout(resolve, 5);
+        });
+      });
+
+      const settled1 = tasksSettled();
+      const settled2 = tasksSettled();
+
+      assert.strictEqual(settled2, settled1, 'tasksSettled should return the same promise while work is pending');
+      assert.strictEqual(await settled1, true, 'the pending settle promise should resolve to true after work completes');
+      assert.strictEqual(await task, undefined, 'the async task should remain awaitable directly');
+
+      const settled3 = tasksSettled();
+      assert.notStrictEqual(settled3, settled1, 'a new tasksSettled call after settlement should start a fresh idle check');
+      assert.strictEqual(await settled3, false, 'the fresh idle check should resolve to false');
+    });
+
+    it('tracks queue emptiness across queued, pending async, and settled work', async function () {
+      assert.strictEqual(isTaskQueueEmpty(), true, 'the queue should start empty');
+
+      queueTask(() => { /* noop */ });
+      assert.strictEqual(isTaskQueueEmpty(), false, 'a queued sync task should make the queue non-empty');
+      assert.strictEqual(await tasksSettled(), true, 'the sync task should settle');
+      assert.strictEqual(isTaskQueueEmpty(), true, 'the queue should be empty after the sync task settles');
+
+      queueAsyncTask(() => {
+        return new Promise<void>(resolve => {
+          setTimeout(resolve, 5);
+        });
+      });
+
+      const settled = tasksSettled();
+      await Promise.resolve();
+
+      assert.strictEqual(isTaskQueueEmpty(), false, 'a running async task should keep the queue non-empty');
+      assert.strictEqual(await settled, true, 'the async task should settle');
+      assert.strictEqual(isTaskQueueEmpty(), true, 'the queue should be empty after async work settles');
+    });
+
+    it('can cancel a later queueAsyncTask while the queue head has advanced', async function () {
+      const stack: string[] = [];
+      let taskToCancel!: Task<void>;
+
+      queueTask(() => {
+        stack.push('cancel');
+        assert.strictEqual(taskToCancel.cancel(), true, 'a later pending task should be cancellable during a drain');
+      });
+
+      taskToCancel = queueAsyncTask(() => {
+        stack.push('should_not_run');
+      });
+
+      queueTask(() => {
+        stack.push('after');
+      });
+
+      assert.strictEqual(await tasksSettled(), true, 'the drain should settle after cancellation');
+      assert.deepStrictEqual(stack, ['cancel', 'after'], 'the canceled task should be removed without disturbing later tasks');
+      assert.strictEqual(taskToCancel.status, 'canceled', 'the task should be canceled');
+
+      try {
+        await taskToCancel;
+        assert.fail('Canceled task should have rejected');
+      } catch (err) {
+        assert.instanceOf(err, TaskAbortError, 'canceled task should reject with TaskAbortError');
+      }
+    });
+
+    it('manual runTasks starts async tasks but leaves their promises to tasksSettled', async function () {
+      const stack: string[] = [];
+
+      queueAsyncTask(() => {
+        stack.push('sync_start');
+        return new Promise<void>(resolve => {
+          setTimeout(() => {
+            stack.push('async_done');
+            resolve();
+          });
+        });
+      });
+
+      runTasks();
+
+      assert.deepStrictEqual(stack, ['sync_start'], 'manual runTasks should run the synchronous part');
+      assert.strictEqual(isTaskQueueEmpty(), false, 'the pending async promise should keep the queue non-empty');
+      assert.strictEqual(await tasksSettled(), true, 'tasksSettled should wait for the async continuation');
+      assert.deepStrictEqual(stack, ['sync_start', 'async_done'], 'the async continuation should complete');
+      assert.strictEqual(isTaskQueueEmpty(), true, 'the queue should be empty after tasksSettled resolves');
+    });
+
+    it('configures automatic flush slicing and restores previous options', async function () {
+      const originalOptions = getTaskQueueOptions();
+      const previousOptions = configureTaskQueue({
+        flushBudget: 0,
+      });
+      let runCount = 0;
+
+      try {
+        assert.deepStrictEqual(previousOptions, originalOptions, 'configureTaskQueue should return the previous options');
+        assert.strictEqual(getTaskQueueOptions().flushBudget, 0, 'flushBudget should be configurable');
+
+        queueTask(() => {
+          queueTask(() => {
+            ++runCount;
+          });
+          queueTask(() => {
+            ++runCount;
+          });
+        });
+
+        const settled = tasksSettled();
+        await Promise.resolve();
+
+        assert.strictEqual(runCount, 0, 'a zero budget should still process the producer task before yielding');
+        assert.strictEqual(isTaskQueueEmpty(), false, 'yielded tasks should keep the queue non-empty');
+        assert.strictEqual(await settled, true, 'configured yielded continuations should still settle');
+        assert.strictEqual(runCount, 2, 'all yielded tasks should run');
+      } finally {
+        configureTaskQueue(previousOptions);
+      }
+
+      assert.deepStrictEqual(getTaskQueueOptions(), originalOptions, 'restoring previous options should recover the original scheduler configuration');
+    });
+
+    it('continues automatic flush slices through host timers', async function () {
+      let runCount = 0;
+      const externalTimer = new Promise<number>(resolve => {
+        setTimeout(() => {
+          resolve(runCount);
+        }, 0);
+      });
+      const previousOptions = configureTaskQueue({
+        flushBudget: 0,
+      });
+
+      try {
+        queueTask(() => {
+          queueTask(() => {
+            ++runCount;
+          });
+          queueTask(() => {
+            ++runCount;
+          });
+        });
+
+        const settled = tasksSettled();
+        await Promise.resolve();
+        const runCountAtExternalTimer = await externalTimer;
+
+        assert.strictEqual(runCountAtExternalTimer, 0, 'an existing host timer should be able to run before the yielded continuation');
+        assert.strictEqual(await settled, true, 'the timer continuation should still settle');
+        assert.strictEqual(runCount, 2, 'all follow-up tasks should run after the timer continuation');
+      } finally {
+        configureTaskQueue(previousOptions);
+      }
+    });
+  });
+
+  describe('large finite queue workloads', function () {
+    this.timeout(20_000);
+
+    it('drains a large prequeued breadth workload', async function () {
+      const taskCount = 100_000;
+      let runCount = 0;
+      const callback = () => {
+        ++runCount;
+      };
+
+      for (let i = 0; i < taskCount; ++i) {
+        queueTask(callback);
+      }
+
+      assert.strictEqual(await tasksSettled(), true, 'pre-queued finite breadth should settle');
+      assert.strictEqual(runCount, taskCount, 'all pre-queued tasks should run');
+    });
+
+    it('drains a large finite fan-out workload queued from one task', async function () {
+      const taskCount = 100_000;
+      let runCount = 0;
+      const callback = () => {
+        ++runCount;
+      };
+
+      queueTask(() => {
+        for (let i = 0; i < taskCount; ++i) {
+          queueTask(callback);
+        }
+      });
+
+      assert.strictEqual(await tasksSettled(), true, 'finite fan-out queued during a drain should settle');
+      assert.strictEqual(runCount, taskCount, 'all nested fan-out tasks should run');
+    });
+
+    it('drains a very large finite requeue chain', async function () {
+      const taskCount = 2_000_000;
+      let runCount = 0;
+      const callback = () => {
+        if (++runCount < taskCount) {
+          queueTask(callback);
+        }
+      };
+
+      queueTask(callback);
+
+      assert.strictEqual(await tasksSettled(), true, 'a finite requeue chain should settle');
+      assert.strictEqual(runCount, taskCount, 'all chained tasks should run');
+    });
+  });
+
+  describe('manual final guard', function () {
+    it('still throws for a synchronous runaway task that never lets the queue settle', async function () {
+      const callback = () => {
+        queueTask(callback);
+      };
+
+      queueTask(callback);
+
+      assert.throws(
+        () => runTasks(),
+        /Potential deadlock detected/,
+        'an unbounded requeue loop should still trip the final guard',
+      );
+    });
+  });
+
+  it('automatic drains keep yielding until external state lets a requeue loop settle', async function () {
+    const previousOptions = configureTaskQueue({
+      flushBudget: 0,
+    });
+    let runCount = 0;
+    let timerCount = 0;
+    let shouldContinue = true;
+    const callback = () => {
+      ++runCount;
+      if (shouldContinue) {
+        queueTask(callback);
+      }
+    };
+
+    try {
+      queueTask(callback);
+      const settled = tasksSettled();
+
+      await new Promise<void>(resolve => {
+        const stopAfterAFewTimers = () => {
+          if (++timerCount === 5) {
+            shouldContinue = false;
+            resolve();
+          } else {
+            setTimeout(stopAfterAFewTimers);
+          }
+        };
+        setTimeout(stopAfterAFewTimers);
+      });
+
+      assert.strictEqual(await settled, true, 'automatic requeueing should settle once the producer stops');
+      assert.greaterThanOrEqualTo(runCount, timerCount, 'automatic draining should keep making progress across yielded slices');
+    } finally {
+      configureTaskQueue(previousOptions);
+    }
+  });
+
+  it('tasksSettled waits for automatic drains that yield through a timer continuation', async function () {
+    const taskCount = 1_200;
+    let runCount = 0;
+    let timerObservedPartialDrain = false;
+    let timerObservedNonEmptyQueue = false;
+
+    queueTask(() => {
+      for (let i = 0; i < taskCount; ++i) {
+        queueTask(() => {
+          const end = performance.now() + 0.02;
+          while (performance.now() < end) { /* burn a tiny slice of time */ }
+          ++runCount;
+        });
+      }
+    });
+
+    const settled = tasksSettled();
+    await new Promise<void>(resolve => {
+      setTimeout(() => {
+        timerObservedPartialDrain = runCount < taskCount;
+        timerObservedNonEmptyQueue = !isTaskQueueEmpty();
+        resolve();
+      });
+    });
+
+    assert.strictEqual(timerObservedPartialDrain, true, 'automatic draining should yield to a timer before finishing large queues');
+    assert.strictEqual(timerObservedNonEmptyQueue, true, 'a yielded automatic drain should keep the task queue non-empty');
+    assert.strictEqual(await settled, true, 'tasksSettled should resolve once every yielded continuation has drained');
+    assert.strictEqual(runCount, taskCount, 'all yielded tasks should run');
+    assert.strictEqual(isTaskQueueEmpty(), true, 'the queue should be empty after yielded continuations drain');
   });
 
   describe('queueAsyncTask', function () {
@@ -165,6 +560,7 @@ describe('2-runtime/queue.spec.ts', function () {
         }, 0);
       });
     });
+    const rejectingAsyncTaskError = rejectingAsyncTask.catch(e => e);
 
     queueTask(() => {
       stack.push('SyncTask_Alongside');
@@ -199,12 +595,7 @@ describe('2-runtime/queue.spec.ts', function () {
     ], 'stack mismatch');
 
     assert.strictEqual(rejectingAsyncTask.status, 'canceled', 'rejecting task status should be canceled');
-    try {
-      await rejectingAsyncTask;
-      assert.fail('Rejecting task result should have rejected');
-    } catch (e: any) {
-      assert.strictEqual(e.message, 'AsyncFailure', 'rejecting task result error message incorrect');
-    }
+    assert.strictEqual(((await rejectingAsyncTaskError) as Error).message, 'AsyncFailure', 'rejecting task result error message incorrect');
 
     assert.strictEqual(succeedingAsyncTask.status, 'completed', 'succeeding task status should be completed');
     assert.strictEqual(await succeedingAsyncTask, 'SuccessData', 'succeeding task result data incorrect');
@@ -245,6 +636,32 @@ describe('2-runtime/queue.spec.ts', function () {
     }
   });
 
+  it('awaiting a rejected queueAsyncTask yields the original callback error', async function () {
+    let taskErr: Error;
+    const task = queueAsyncTask(() => {
+      taskErr = new Error('Task error');
+      throw taskErr;
+    });
+    const taskAwait = (async () => {
+      try {
+        await task;
+        assert.fail('Task should have rejected');
+      } catch (e: unknown) {
+        return e;
+      }
+    })();
+
+    try {
+      await tasksSettled();
+      assert.fail('tasksSettled should have rejected');
+    } catch (e) {
+      assert.strictEqual(e, taskErr, 'tasksSettled should reject with the task callback error');
+    }
+
+    assert.strictEqual(await taskAwait, taskErr, 'Task should return the error that was thrown inside the task');
+    assert.strictEqual(task.status, 'canceled', 'Task should be canceled after the callback throws');
+  });
+
   it('emits an unhandledRejection when a task throws a non-abort error', async function () {
     const unhandled: unknown[] = [];
     let handler: (reason: unknown) => void;
@@ -276,13 +693,7 @@ describe('2-runtime/queue.spec.ts', function () {
       dispose();
     }
 
-    try {
-      // Awaiting task should also yield the same error
-      await task;
-      assert.fail('Task should have rejected');
-    } catch (e: unknown) {
-      assert.strictEqual(e, taskErr, 'Task should return the error that was thrown inside the task');
-    }
+    assert.strictEqual(task.status, 'canceled', 'Task should be canceled after the callback throws');
   });
 
   it('emits an unhandledRejection when a task throws a non-abort error and tasksSettled is used', async function () {
@@ -322,13 +733,7 @@ describe('2-runtime/queue.spec.ts', function () {
       dispose();
     }
 
-    try {
-      // Awaiting task should also yield the same error
-      await task;
-      assert.fail('Task should have rejected');
-    } catch (e: unknown) {
-      assert.strictEqual(e, taskErr, 'Task should return the error that was thrown inside the task');
-    }
+    assert.strictEqual(task.status, 'canceled', 'Task should be canceled after the callback throws');
   });
 
   it('does not emit an unhandledRejection when a task throws a non-abort error that is handled by awaiting task', async function () {
@@ -351,6 +756,7 @@ describe('2-runtime/queue.spec.ts', function () {
       taskErr = new Error('Task error');
       throw taskErr;
     });
+    const taskRejection = task.catch(e => e);
 
     try {
       try {
@@ -360,12 +766,7 @@ describe('2-runtime/queue.spec.ts', function () {
         assert.strictEqual(e, taskErr);
       }
 
-      try {
-        await task;
-        assert.fail('Task should have rejected');
-      } catch (e: unknown) {
-        assert.strictEqual(e, taskErr, 'Task should return the error that was thrown inside the task');
-      }
+      assert.strictEqual(await taskRejection, taskErr, 'Task should return the error that was thrown inside the task');
 
       // Wait a macrotask turn (without using tasksSettled) to mimic application code with a rejection handler.
       await new Promise<void>(resolve => setTimeout(resolve));
@@ -515,6 +916,7 @@ describe('2-runtime/queue.spec.ts', function () {
 
       throw new Error('ErrorIn_FaultyAsync_SyncPart');
     });
+    const faultyAsyncTaskError = faultyAsyncTask.catch(e => e);
 
     queueTask(() => {
       stack.push('SyncTask_AfterFaulty');
@@ -549,9 +951,7 @@ describe('2-runtime/queue.spec.ts', function () {
 
     assert.strictEqual(faultyAsyncTask.status, 'canceled');
 
-    await faultyAsyncTask.catch(e => {
-      assert.strictEqual(e.message, 'ErrorIn_FaultyAsync_SyncPart');
-    });
+    assert.strictEqual(((await faultyAsyncTaskError) as Error).message, 'ErrorIn_FaultyAsync_SyncPart');
 
     assert.strictEqual(healthyAsyncTask.status, 'completed');
     assert.strictEqual(await healthyAsyncTask, 'HealthySuccess');
@@ -584,9 +984,14 @@ describe('2-runtime/queue.spec.ts', function () {
     }
 
     assert.instanceOf(settledError, AggregateError, 'settledError should be an AggregateError');
+    assert.instanceOf(settledError, TaskQueueAggregateError, 'settledError should be a task-queue-specific AggregateError');
     assert.strictEqual(settledError.errors.length, 2, 'AggregateError should contain 2 errors');
     assert.strictEqual(settledError.errors[0], error1, 'error1');
     assert.strictEqual(settledError.errors[1], error2, 'error2');
+    assert.strictEqual(settledError.cause, error1, 'AggregateError cause should point at the first original error');
+    assert.includes(settledError.message, 'Aurelia task queue failed with 2 errors.', 'AggregateError message should name the failing subsystem and count');
+    assert.includes(settledError.message, 'SyncError1', 'AggregateError message should preview the first error');
+    assert.includes(settledError.message, 'SyncError2', 'AggregateError message should preview the second error');
 
     assert.deepStrictEqual(stack, [
       'Sync1_Throws',
@@ -615,6 +1020,7 @@ describe('2-runtime/queue.spec.ts', function () {
         }, 0);
       });
     });
+    const rejectingAsyncTaskError = rejectingAsyncTask.catch(e => e);
 
     queueTask(() => {
       stack.push('Sync3_Runs');
@@ -627,9 +1033,13 @@ describe('2-runtime/queue.spec.ts', function () {
     }
 
     assert.instanceOf(settledError, AggregateError, 'settledError should be an AggregateError');
+    assert.instanceOf(settledError, TaskQueueAggregateError, 'settledError should be a task-queue-specific AggregateError');
     assert.strictEqual(settledError.errors.length, 2, 'AggregateError should contain 2 errors');
     assert.strictEqual(settledError.errors[0], syncError, 'SyncError');
     assert.strictEqual(settledError.errors[1], asyncError, 'AsyncError');
+    assert.strictEqual(settledError.cause, syncError, 'AggregateError cause should point at the first original error');
+    assert.includes(settledError.message, 'Mixed_SyncError', 'AggregateError message should preview the sync error');
+    assert.includes(settledError.message, 'Mixed_AsyncRejection', 'AggregateError message should preview the async error');
 
     assert.deepStrictEqual(stack, [
       'Sync1_Throws',
@@ -639,9 +1049,7 @@ describe('2-runtime/queue.spec.ts', function () {
     ], 'stack mismatch');
 
     assert.strictEqual(rejectingAsyncTask.status, 'canceled', 'RejectingAsyncTask status');
-    await rejectingAsyncTask.catch(e => {
-      assert.strictEqual(e, asyncError, 'RejectingAsyncTask result');
-    });
+    assert.strictEqual(await rejectingAsyncTaskError, asyncError, 'RejectingAsyncTask result');
   });
 
   it('tasksSettled reflects errors even if a manual flush() also processes them', async function () {

--- a/packages/__tests__/src/3-runtime-html/decorator-watch.computed.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/decorator-watch.computed.spec.ts
@@ -1157,7 +1157,8 @@ describe('3-runtime-html/decorator-watch.computed.spec.ts', function () {
           }
           assert.strictEqual(app.callCount, 0);
           if (ex instanceof AggregateError) {
-            assert.strictEqual(ex.message, 'One or more tasks failed.');
+            assert.match(ex.message, /Aurelia task queue failed with 2 errors\./);
+            assert.match(ex.message, /Inspect the AggregateError\.errors array/);
             assert.strictEqual(ex.errors.length, 2);
             assert.instanceOf(ex.errors[0], Error);
             assert.strictEqual(ex.errors[0].message, 'err');
@@ -1440,7 +1441,8 @@ describe('3-runtime-html/decorator-watch.computed.spec.ts', function () {
           }
           assert.strictEqual(app.callCount, 0);
           if (ex instanceof AggregateError) {
-            assert.strictEqual(ex.message, 'One or more tasks failed.');
+            assert.match(ex.message, /Aurelia task queue failed with 2 errors\./);
+            assert.match(ex.message, /Inspect the AggregateError\.errors array/);
             assert.strictEqual(ex.errors.length, 2);
             assert.instanceOf(ex.errors[0], Error);
             assert.strictEqual(ex.errors[0].message, 'err');

--- a/packages/__tests__/src/3-runtime-html/show.integration.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/show.integration.spec.ts
@@ -1,5 +1,5 @@
 import { Aurelia, customElement, ICustomElementViewModel, ICustomElementController } from '@aurelia/runtime-html';
-import { runTasks, tasksSettled } from '@aurelia/runtime';
+import { configureTaskQueue, queueTask, runTasks, tasksSettled } from '@aurelia/runtime';
 import { assert, TestContext } from '@aurelia/testing';
 
 function createFixture() {
@@ -120,6 +120,58 @@ describe('3-runtime-html/show.integration.spec.ts', function () {
       component.assert(`started after flushing dom writes`);
 
       await au.stop();
+    });
+
+    it('does not apply a queued show update after detaching during a yielded flush', async function () {
+      const { au, host } = createFixture();
+      let resolveDetaching: (() => void) | undefined;
+      let stopPromise: void | Promise<void> | undefined;
+      const previousOptions = configureTaskQueue({
+        flushBudget: 0,
+      });
+
+      @customElement({ name: 'app', template: '<div show.bind="show"></div>' })
+      class App implements ICustomElementViewModel {
+        public $controller!: ICustomElementController<this>;
+        public show: boolean = true;
+        public div!: HTMLDivElement;
+
+        public created() {
+          this.div = this.$controller.nodes.firstChild as HTMLDivElement;
+        }
+
+        public detaching() {
+          return new Promise<void>(resolve => {
+            resolveDetaching = resolve;
+          });
+        }
+      }
+
+      try {
+        const component = new App();
+        au.app({ host, component });
+
+        await au.start();
+        assert.strictEqual(component.div.style.getPropertyValue('display'), '', 'precondition');
+
+        queueTask(() => {
+          component.show = false;
+        });
+
+        await Promise.resolve();
+        stopPromise = au.stop();
+        await wait(20);
+
+        assert.strictEqual(component.div.style.getPropertyValue('display'), '', 'queued update should not write after detaching');
+
+        resolveDetaching?.();
+        await stopPromise;
+        await tasksSettled();
+      } finally {
+        resolveDetaching?.();
+        await stopPromise;
+        configureTaskQueue(previousOptions);
+      }
     });
   });
 
@@ -377,3 +429,7 @@ describe('3-runtime-html/show.integration.spec.ts', function () {
 
   // });
 });
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/__tests__/src/3-runtime-html/task-queue-yield.integration.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/task-queue-yield.integration.spec.ts
@@ -1,0 +1,111 @@
+import { configureTaskQueue, queueTask, tasksSettled } from '@aurelia/runtime';
+import { Aurelia, customElement, type ICustomElementController, type ICustomElementViewModel } from '@aurelia/runtime-html';
+import { assert, TestContext } from '@aurelia/testing';
+
+describe('3-runtime-html/task-queue-yield.integration.spec.ts', function () {
+  it('settles to the latest input state when input occurs between yielded flush chunks', async function () {
+    const ctx = TestContext.create();
+    const au = new Aurelia(ctx.container);
+    const host = ctx.createElement('div');
+    const previousOptions = configureTaskQueue({
+      flushBudget: 0,
+    });
+
+    @customElement({ name: 'app', template: '<input value.bind="message"><span>${message}</span>' })
+    class App implements ICustomElementViewModel {
+      public $controller!: ICustomElementController<this>;
+      public message: string = 'one';
+      public input!: HTMLInputElement;
+      public span!: HTMLSpanElement;
+
+      public created() {
+        this.input = this.$controller.nodes.firstChild as HTMLInputElement;
+        this.span = this.$controller.nodes.lastChild as HTMLSpanElement;
+      }
+    }
+
+    try {
+      const component = new App();
+      au.app({ host, component });
+
+      await au.start();
+      assert.strictEqual(component.input.value, 'one', 'input precondition');
+      assert.strictEqual(component.span.textContent, 'one', 'text precondition');
+
+      queueTask(() => {
+        component.message = 'two';
+      });
+
+      await Promise.resolve();
+      component.input.value = 'typed';
+      component.input.dispatchEvent(new ctx.CustomEvent('input'));
+      await tasksSettled();
+
+      assert.strictEqual(component.message, 'typed', 'source should keep the input value');
+      assert.strictEqual(component.input.value, 'typed', 'input should not be overwritten by an older queued write');
+      assert.strictEqual(component.span.textContent, 'typed', 'text binding should settle to the latest source value');
+
+      await au.stop();
+    } finally {
+      configureTaskQueue(previousOptions);
+    }
+  });
+
+  it('does not apply queued layout property writes while the controller is deactivating', async function () {
+    const ctx = TestContext.create();
+    const au = new Aurelia(ctx.container);
+    const host = ctx.createElement('div');
+    let resolveDetaching: (() => void) | undefined;
+    let stopPromise: void | Promise<void> | undefined;
+    const previousOptions = configureTaskQueue({
+      flushBudget: 0,
+    });
+
+    @customElement({ name: 'app', template: '<input value.bind="message">' })
+    class App implements ICustomElementViewModel {
+      public $controller!: ICustomElementController<this>;
+      public message: string = 'one';
+      public input!: HTMLInputElement;
+
+      public created() {
+        this.input = this.$controller.nodes.firstChild as HTMLInputElement;
+      }
+
+      public detaching() {
+        return new Promise<void>(resolve => {
+          resolveDetaching = resolve;
+        });
+      }
+    }
+
+    try {
+      const component = new App();
+      au.app({ host, component });
+
+      await au.start();
+      assert.strictEqual(component.input.value, 'one', 'precondition');
+
+      queueTask(() => {
+        component.message = 'two';
+      });
+
+      await Promise.resolve();
+      stopPromise = au.stop();
+      await wait(20);
+
+      assert.strictEqual(component.input.value, 'one', 'queued update should not write while deactivating');
+
+      resolveDetaching?.();
+      await stopPromise;
+      await tasksSettled();
+    } finally {
+      resolveDetaching?.();
+      await stopPromise;
+      configureTaskQueue(previousOptions);
+    }
+  });
+});
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/runtime-html/src/binding/property-binding.ts
+++ b/packages/runtime-html/src/binding/property-binding.ts
@@ -99,7 +99,9 @@ export class PropertyBinding implements IBinding, ISubscriber, ICollectionSubscr
 
       queueTask(() => {
         this._isQueued = false;
-        if (!this.isBound) return;
+        // Layout writes are delayed. The controller may start deactivating
+        // before this task runs, so repeat the synchronous activation guard.
+        if (!this.isBound || this._controller.state > activated) return;
 
         this._handleChange();
       });

--- a/packages/runtime-html/src/resources/custom-attributes/show.ts
+++ b/packages/runtime-html/src/resources/custom-attributes/show.ts
@@ -53,6 +53,9 @@ export class Show implements ICustomAttributeViewModel {
   private $prio: string = '';
   private readonly update = (): void => {
     this._isQueued = false;
+    // A queued toggle can survive detaching; inactive attributes must not
+    // mutate style after teardown has started.
+    if (!this._isActive) return;
 
     // Only compare at the synchronous moment when we're about to update, because the value might have changed since the update was queued.
     if (Boolean(this.value) !== this._isToggled) {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -25,14 +25,19 @@ export {
   queueTask,
   queueAsyncTask,
   queueRecurringTask,
+  configureTaskQueue,
   getRecurringTasks,
+  getTaskQueueOptions,
   runTasks,
   tasksSettled,
   isTaskQueueEmpty,
   Task,
   RecurringTask,
   TaskAbortError,
+  TaskQueueAggregateError,
   type TaskStatus,
+  type TaskQueueOptions,
+  type TaskQueueResolvedOptions,
 } from './queue';
 
 export {

--- a/packages/runtime/src/queue.ts
+++ b/packages/runtime/src/queue.ts
@@ -12,20 +12,82 @@ const tsCanceled = 'canceled';
 export type TaskStatus = typeof tsPending | typeof tsRunning | typeof tsCompleted | typeof tsCanceled;
 export type TaskCallback<T = any> = () => T;
 
+interface TaskQueueErrorRecord {
+  error: unknown;
+  reportWhenUnobserved: boolean;
+}
+
+export interface TaskQueueOptions {
+  /**
+   * Target maximum milliseconds an automatically scheduled queue drain should
+   * run before yielding to a host timer. Lower values give the browser more
+   * opportunities to paint and handle input during large flushes; higher
+   * values favor throughput. This is a pacing hint, not a frame-rate guarantee.
+   */
+  flushBudget?: number;
+}
+
+/**
+ * Fully resolved task queue options.
+ */
+export type TaskQueueResolvedOptions = Required<TaskQueueOptions>;
+
 const resolvedPromise = Promise.resolve();
+const taskQueueYieldDelay = 0;
+const taskQueueClockCheckInterval = 256;
+const taskQueueManualFlushBudget = 100;
+const defaultTaskQueueOptions: TaskQueueResolvedOptions = {
+  flushBudget: 8,
+};
+let taskQueueOptions: TaskQueueResolvedOptions = { ...defaultTaskQueueOptions };
 let runScheduled = false;
 let isAutoRun = false;
+let isFlushing = false;
 
 const queue: (Task | RecurringTask | (() => unknown))[] = [];
+let queueIndex = 0;
 const recurringTasks: RecurringTask[] = [];
 let pendingAsyncCount = 0;
 let settlePromise: Promise<boolean> | null = null;
-let taskErrors: unknown[] = [];
+let taskErrors: TaskQueueErrorRecord[] = [];
 let settlePromiseResolve: ((value: boolean) => void) | null = null;
 let settlePromiseReject: ((reason?: any) => void) | null = null;
 
+const normalizeBudget = (value: number | undefined, fallback: number) => {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+};
+
+/**
+ * Read the currently active task queue options.
+ */
+export const getTaskQueueOptions = (): TaskQueueResolvedOptions => {
+  return { ...taskQueueOptions };
+};
+
+/**
+ * Configure how automatic task queue drains pace themselves.
+ *
+ * The `flushBudget` option lets tests, host environments, and applications
+ * adjust roughly how long Aurelia works before yielding to a host timer.
+ * This can make large automatic flushes friendlier to browser rendering and
+ * input, or to favor raw throughput when the host can tolerate longer turns.
+ * It does not add an automatic deadlock timeout; explicit `runTasks()` calls
+ * remain synchronous and use an internal guard.
+ * The function returns the previous options so callers can restore them after
+ * overriding them.
+ */
+export const configureTaskQueue = (options: TaskQueueOptions): TaskQueueResolvedOptions => {
+  const previousOptions = getTaskQueueOptions();
+  taskQueueOptions = {
+    flushBudget: normalizeBudget(options.flushBudget, previousOptions.flushBudget),
+  };
+  return previousOptions;
+};
+
 const requestRun = () => {
-  if (!runScheduled) {
+  if (!runScheduled && !isFlushing) {
     runScheduled = true;
     void resolvedPromise.then(() => {
       runScheduled = false;
@@ -35,45 +97,150 @@ const requestRun = () => {
   }
 };
 
-const signalSettled = (hasPerformedWork: boolean) => {
-  if (settlePromise && queue.length === 0 && pendingAsyncCount === 0) {
-    settlePromise = null;
-    if (taskErrors.length > 0) {
-      const errors = taskErrors;
-      taskErrors = [];
-      if (errors.length === 1) {
-        settlePromiseReject!(errors[0]);
-      } else {
-        settlePromiseReject!(new AggregateError(errors, 'One or more tasks failed.'));
-      }
-    } else {
-      settlePromiseResolve!(hasPerformedWork);
+const requestTimerRun = () => {
+  if (!runScheduled) {
+    runScheduled = true;
+    Platform.getOrCreate(globalThis).setTimeout(() => {
+      runScheduled = false;
+      isAutoRun = true;
+      runTasks();
+    }, taskQueueYieldDelay);
+  }
+};
+
+const isQueueDrained = () => queueIndex >= queue.length;
+
+const clearQueue = () => {
+  queue.length = 0;
+  queueIndex = 0;
+};
+
+const compactQueue = () => {
+  if (queueIndex > 0) {
+    queue.splice(0, queueIndex);
+    queueIndex = 0;
+  }
+};
+
+const recordTaskError = (error: unknown, reportWhenUnobserved: boolean) => {
+  taskErrors.push({ error, reportWhenUnobserved });
+};
+
+const resetSettlePromise = () => {
+  settlePromise = null;
+  settlePromiseResolve = null;
+  settlePromiseReject = null;
+};
+
+const toErrorValues = (errors: TaskQueueErrorRecord[]) => errors.map(x => x.error);
+
+const getErrorSummary = (error: unknown) => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return String(error);
+};
+
+const createAggregateErrorMessage = (errors: readonly unknown[]) => {
+  const count = errors.length;
+  const preview = errors.slice(0, 3).map((error, index) => `\n  ${index + 1}. ${getErrorSummary(error)}`).join('');
+  const extra = count > 3 ? `\n  ...and ${count - 3} more.` : '';
+  return `Aurelia task queue failed with ${count} errors.${preview}${extra}\nInspect the AggregateError.errors array for the original errors and stack traces.`;
+};
+
+export class TaskQueueAggregateError extends AggregateError {
+  public override cause: unknown;
+
+  /**
+   * Creates an aggregate error with a task-queue-specific message while keeping
+   * every original error available through the standard `errors` property.
+   */
+  public constructor(errors: readonly unknown[]) {
+    super(errors, createAggregateErrorMessage(errors));
+    this.name = 'TaskQueueAggregateError';
+    this.cause = errors[0];
+  }
+}
+
+const createTaskQueueAggregateError = (errors: readonly unknown[]) => {
+  return new TaskQueueAggregateError(errors);
+};
+
+const reportUnobservedTaskErrors = (errors: TaskQueueErrorRecord[]) => {
+  const $console = (globalThis as { console?: { error(...args: unknown[]): void } }).console;
+  if ($console === undefined) {
+    return;
+  }
+  for (const { error, reportWhenUnobserved } of errors) {
+    if (reportWhenUnobserved) {
+      $console.error(error);
     }
   }
+};
+
+const rejectSettled = (error: unknown) => {
+  if (settlePromise !== null) {
+    settlePromiseReject!(error);
+    resetSettlePromise();
+  }
+};
+
+const signalSettled = (hasPerformedWork: boolean, reportUnobservedErrors = true) => {
+  if (isQueueDrained() && pendingAsyncCount === 0) {
+    const errors = taskErrors;
+    taskErrors = [];
+    if (settlePromise !== null) {
+      const resolve = settlePromiseResolve!;
+      const reject = settlePromiseReject!;
+      resetSettlePromise();
+      if (errors.length === 1) {
+        reject(errors[0].error);
+      } else if (errors.length > 1) {
+        reject(createTaskQueueAggregateError(toErrorValues(errors)));
+      } else {
+        resolve(hasPerformedWork);
+      }
+    } else if (reportUnobservedErrors && errors.length > 0) {
+      reportUnobservedTaskErrors(errors);
+    }
+  }
+};
+
+const failQueue = (error: Error) => {
+  clearQueue();
+  taskErrors = [];
+  rejectSettled(error);
 };
 
 /**
  * **Immediately drain** Aurelia's internal task queue.
  *
- * Normally the scheduler calls this automatically on the next micro-task
- * whenever you enqueue work with {@link queueTask} or {@link queueAsyncTask}.
+ * Normally the task queue starts this automatically on the next micro-task
+ * whenever you enqueue work with {@link queueTask} or a non-delayed
+ * {@link queueAsyncTask}. Delayed async tasks start after their timer expires.
+ * Very large automatic drains may yield to a host timer before continuing so
+ * the browser has a chance to breathe; use {@link tasksSettled} when you need
+ * to wait for the queue to become fully idle.
  * Calling it yourself is only useful in **low-level tests, debugging sessions,
  * or custom instrumentation** where you need a _synchronous_ flush.
  *
  * ### What it does
  * 1. Removes each item from the queue (FIFO) and runs it.
- * 2. If an item queues more work, the loop continues until the queue is empty,
- *    up to **10 000 extra tasks** – after that a "Potential deadlock" error is
- *    thrown and the queue is cleared.
+ * 2. If an item queues more work, the loop continues until the queue is empty.
+ *    Manual drains remain synchronous and are guarded by a small internal cap.
+ *    Automatic drains may continue through timer-backed slices until they
+ *    become idle; they do not throw a deadlock error merely because the queue
+ *    keeps producing work.
  * 3. Collects every uncaught exception.
  *    * When you invoke the function manually those errors are re-thrown —
- *      either the single error or an `AggregateError` if several tasks failed.*
- *    * During the scheduler's automatic run they are _suppressed_ and will only
- *      surface through `tasksSettled()` or the runtime console, so the app
- *      keeps running.
+ *      either the single error or a {@link TaskQueueAggregateError} if several
+ *      tasks failed.*
+ *    * During an automatic run they are captured so the app keeps
+ *      running. If `tasksSettled()` is observing the current cycle it rejects;
+ *      otherwise unobserved synchronous queue errors are reported to the console
+ *      and cleared from the cycle.
  * 4. Signals the internal "settled promise" so `await tasksSettled()` continues
- *    once _all_ **synchronous** callbacks have finished (async promises may
- *    still be pending).
+ *    once the queue and all tracked async work have finished.
  *
  * > **Tip:** In most cases you should prefer `await tasksSettled()`; it waits
  * > for both the synchronous drain **and** any asynchronous work started by
@@ -82,9 +249,10 @@ const signalSettled = (hasPerformedWork: boolean) => {
  *
  * @throws Error            If a task throws and you called the function
  *                          directly.
- * @throws AggregateError   If multiple tasks throw.
- * @throws Error            "Potential deadlock detected" when > 10 000 extra
- *                          tasks are re-queued in one drain.
+ * @throws TaskQueueAggregateError If multiple tasks throw.
+ * @throws Error            "Potential deadlock detected" when a synchronous
+ *                          manual drain does not settle within the internal
+ *                          guard budget.
  *
  * @example
  * Synchronous assertion in a non-async test
@@ -103,7 +271,7 @@ const signalSettled = (hasPerformedWork: boolean) => {
  * window.runTasks = runTasks;
  *
  * // After pausing in a breakpoint
- * window.runTasks(); // force the scheduler to drain now
+ * window.runTasks(); // force the task queue to drain now
  * ```
  *
  * @example
@@ -120,42 +288,67 @@ const signalSettled = (hasPerformedWork: boolean) => {
 export const runTasks = () => {
   const isManualRun = !isAutoRun;
   isAutoRun = false;
-  settlePromise ??= new Promise<boolean>((resolve, reject) => {
-    settlePromiseResolve = resolve;
-    settlePromiseReject = reject;
-  });
 
-  let extraTaskCount = -queue.length;
+  const isEmpty = isQueueDrained();
+  const platform = Platform.getOrCreate(globalThis);
+  const startedAt = platform.performanceNow();
+  const flushBudget = isManualRun
+    ? taskQueueManualFlushBudget
+    : taskQueueOptions.flushBudget;
+  let processedCount = 0;
+  let nextClockCheck = 1;
+  let shouldYield = false;
 
-  const isEmpty = queue.length === 0;
-  while (queue.length > 0) {
-    if (++extraTaskCount > 10000) {
-      const error = new Error(`Potential deadlock detected. More than 10000 extra tasks were queued from within tasks.`);
-      queue.length = 0;
-      settlePromiseReject?.(error);
-      settlePromise = null;
-      throw error;
-    }
-
-    const task = queue.shift()!;
-    if (typeof task === 'function') {
-      try {
-        task();
-      } catch (err) {
-        taskErrors.push(err);
+  isFlushing = true;
+  try {
+    while (queueIndex < queue.length) {
+      const task = queue[queueIndex++]!;
+      if (typeof task === 'function') {
+        try {
+          task();
+        } catch (err) {
+          recordTaskError(err, true);
+        }
+      } else {
+        task.run();
       }
-    } else {
-      task.run();
+
+      if (++processedCount === nextClockCheck && !isQueueDrained()) {
+        nextClockCheck += taskQueueClockCheckInterval;
+        const elapsed = platform.performanceNow() - startedAt;
+        if (elapsed >= flushBudget) {
+          if (isManualRun) {
+            const error = new Error(`Potential deadlock detected. The task queue did not settle within ${flushBudget}ms during a synchronous flush.`);
+            failQueue(error);
+            throw error;
+          }
+          shouldYield = true;
+          break;
+        }
+      }
     }
+  } catch (err) {
+    isFlushing = false;
+    throw err;
   }
+  isFlushing = false;
+
+  if (shouldYield) {
+    compactQueue();
+    requestTimerRun();
+    return;
+  }
+
+  compactQueue();
+
   // Make a copy; this is for testing, signalSettled will clear the array
-  const errors = taskErrors.slice();
-  signalSettled(!isEmpty);
+  const errors = toErrorValues(taskErrors);
+  signalSettled(!isEmpty, !isManualRun);
   if (isManualRun && errors.length > 0) {
     if (errors.length === 1) {
       throw errors[0];
     } else {
-      throw new AggregateError(errors, 'One or more tasks failed.');
+      throw createTaskQueueAggregateError(errors);
     }
   }
 };
@@ -164,7 +357,7 @@ export const runTasks = () => {
  * Gets a read-only copy of the list of all active recurring tasks.
  *
  * While the returned array is a copy, the `RecurringTask` objects within it
- * are the actual instances managed by the scheduler. This is useful for
+ * are the actual instances managed by the task queue. This is useful for
  * inspection or for cleaning up all active tasks by iterating over the array
  * and calling `task.cancel()` on each one.
  *
@@ -201,30 +394,30 @@ export const getRecurringTasks = () => {
 /**
  * @returns - true if there is pending work in the task queue and false otherwise.
  */
-export const isTaskQueueEmpty = () => queue.length === 0 && pendingAsyncCount === 0;
+export const isTaskQueueEmpty = () => isQueueDrained() && pendingAsyncCount === 0;
 
 /**
  * Return a promise that resolves once **all queued work has finished** and the
- * Aurelia scheduler is completely idle.
+ * Aurelia task queue is completely idle.
  *
  * Conceptually similar to a browser's "micro-task drain" (the classic
  * `await Promise.resolve()` trick) but extended to cover:
  *
- * * synchronous micro-tasks queued via {@link queueTask}
+ * * synchronous callbacks queued via {@link queueTask}
  * * asynchronous or delayed tasks queued via {@link queueAsyncTask}
  * * any promises those callbacks return
  *
- * Perfect for unit / component / e2e tests where you must wait for bindings,
- * observers, `requestAnimationFrame` chains and timers to flush **without
- * guessing a timeout**.
+ * Perfect for unit / component / e2e tests where you must wait for Aurelia
+ * bindings, observers, and queued async work to flush **without guessing a
+ * timeout**.
  *
  * #### Behaviour
  * | Situation                                                | Result                             |
  * |----------------------------------------------------------|------------------------------------|
- * | At least one task ran before the queue became empty      | **resolves `true`**                |
- * | Nothing was pending when you called the function         | **resolves `false`**               |
- * | One task throws                                          | **rejects** with that error        |
- * | Multiple tasks throw                                     | **rejects** with an `AggregateError` |
+ * | Work was pending or processed before the queue became idle | **resolves `true`**              |
+ * | Nothing was pending when you called the function           | **resolves `false`**             |
+ * | The observed cycle contains one task error                 | **rejects** with that error      |
+ * | The observed cycle contains multiple task errors           | **rejects** with a `TaskQueueAggregateError` |
  *
  * Re-invocations while work is still pending return the **same** promise; once
  * everything settles, the next call starts a fresh cycle.
@@ -239,7 +432,7 @@ export const isTaskQueueEmpty = () => queue.length === 0 && pendingAsyncCount ==
  * ```ts
  * vm.todoText = 'Write docs';
  * vm.addTodo();
- * await tasksSettled(); // wait for DOM & animations
+ * await tasksSettled(); // wait for DOM updates and queued async work
  * expect(list.children.length).toBe(1);
  * ```
  *
@@ -255,7 +448,7 @@ export const isTaskQueueEmpty = () => queue.length === 0 && pendingAsyncCount ==
  * }
  *
  * await page.getByRole('button', { name: 'Save' }).click();
- * await waitForIdle(page); // no arbitrary sleeps
+ * await waitForIdle(page); // no arbitrary sleeps for task-queue work
  * ```
  *
  * @example
@@ -267,7 +460,7 @@ export const isTaskQueueEmpty = () => queue.length === 0 && pendingAsyncCount ==
  * try {
  *   await tasksSettled();
  * } catch (e) {
- *   if (e instanceof AggregateError) {
+ *   if (e instanceof TaskQueueAggregateError) {
  *     console.log('Multiple failures:', e.errors.length);
  *   }
  * }
@@ -279,8 +472,8 @@ export const isTaskQueueEmpty = () => queue.length === 0 && pendingAsyncCount ==
  * afterEach(async () => {
  *   const didWork = await tasksSettled();
  *   if (didWork) {
- *     // Failing here highlights orphaned micro-tasks or timers left by the test
- *     throw new Error('Test left pending work on the Aurelia scheduler');
+ *     // Failing here highlights orphaned task-queue work left by the test
+ *     throw new Error('Test left pending work on the Aurelia task queue');
  *   }
  * });
  * ```
@@ -290,7 +483,7 @@ export const tasksSettled = (): Promise<boolean> => {
   if (settlePromise) {
     return settlePromise;
   }
-  if (queue.length > 0 || pendingAsyncCount > 0) {
+  if (!isQueueDrained() || pendingAsyncCount > 0) {
     return settlePromise ??= new Promise<boolean>((resolve, reject) => {
       settlePromiseResolve = resolve;
       settlePromiseReject = reject;
@@ -298,7 +491,7 @@ export const tasksSettled = (): Promise<boolean> => {
   }
   // Not strictly necessary but without this we need a lot of extra `await Promise.resolve()` in test code
   return resolvedPromise.then(() => {
-    if (queue.length > 0 || pendingAsyncCount > 0) {
+    if (!isQueueDrained() || pendingAsyncCount > 0) {
       return settlePromise ??= new Promise<boolean>((resolve, reject) => {
         settlePromiseResolve = resolve;
         settlePromiseReject = reject;
@@ -311,9 +504,11 @@ export const tasksSettled = (): Promise<boolean> => {
 /**
  * Queue a **synchronous** callback onto Aurelia's internal task queue.
  *
- * The callback is executed in the same micro-task drain as bindings,
- * computed observers, and other framework internals, immediately after the
- * current call-stack has unwound.
+ * The task queue starts on the next micro-task after the current call-stack has
+ * unwound. Small queues usually finish in that micro-task drain; very large
+ * queues may continue through timer-backed slices. Use {@link tasksSettled}
+ * when code needs to wait for completion rather than for the first task queue
+ * turn.
  * Because these tasks are *fire-and-forget* they:
  *
  * * **cannot be awaited** – if you need an awaitable handle use
@@ -327,7 +522,9 @@ export const tasksSettled = (): Promise<boolean> => {
  *
  * @param callback - A *synchronous* function to execute after the current
  *                   JavaScript turn.  Any exception it throws is captured and
- *                   surfaced collectively via `tasksSettled()` or `runTasks()`.
+ *                   surfaced collectively via `tasksSettled()` or `runTasks()`,
+ *                   or reported to the console when an automatic cycle is
+ *                   otherwise unobserved.
  */
 export const queueTask = (callback: TaskCallback) => {
   requestRun();
@@ -335,7 +532,7 @@ export const queueTask = (callback: TaskCallback) => {
 };
 
 /**
- * Queue a callback to run **asynchronously** on Aurelia's central scheduler
+ * Queue a callback to run **asynchronously** on Aurelia's task queue
  * and get back a {@link Task} object you can:
  *
  * * `await` – directly on the `Task` object itself
@@ -350,7 +547,7 @@ export const queueTask = (callback: TaskCallback) => {
  *             returns resolves to.
  *
  * @param callback  - A function to execute. It may be synchronous or asynchronous;
- *                    if it returns a promise, the scheduler treats the task as
+ *                    if it returns a promise, the task queue treats the task as
  *                    *running* until that promise settles.
  *
  * @param options.delay  - Optional delay **in milliseconds** before the callback
@@ -463,7 +660,7 @@ export class TaskAbortError<T = any> extends Error {
  * | State      | Meaning | When it changes |
  * |------------|---------|-----------------|
  * | `"pending"`   | Waiting in the queue <br>(or in a `setTimeout` delay). | Immediately after creation. |
- * | `"running"`   | `callback` is executing. | When the scheduler dequeues the task. |
+ * | `"running"`   | `callback` is executing. | When the task queue dequeues the task. |
  * | `"completed"` | Callback (and any returned promise) settled. | After `callback` finishes / promise resolves. |
  * | `"canceled"`  | Task was aborted **or** callback/promise rejected. | When `cancel()` succeeds, or on error. |
  *
@@ -592,7 +789,7 @@ export class Task<R = any> {
     } catch (err) {
       this._status = tsCanceled;
       this._reject(err);
-      taskErrors.push(err);
+      recordTaskError(err, false);
       return;
     }
 
@@ -604,7 +801,7 @@ export class Task<R = any> {
       }).catch(err => {
         this._status = tsCanceled;
         this._reject(err);
-        taskErrors.push(err);
+        recordTaskError(err, false);
       }).finally(() => {
         --pendingAsyncCount;
         signalSettled(true);
@@ -651,7 +848,7 @@ export class Task<R = any> {
       //   Nothing else is allowed to flow through `_reject()` here.
       // - If you ever change that invariant (e.g. forward another error or add
       //   logging-failures), you **must** either:
-      //     1. push the new error into `taskErrors` so the scheduler's aggregator
+      //     1. push the new error into `taskErrors` so the task queue aggregator
       //        surfaces it, or
       //     2. replace this with a *selective* handler that re-throws anything that
       //        isn't a TaskAbortError.
@@ -662,7 +859,7 @@ export class Task<R = any> {
     }
 
     if (this._status === tsPending) {
-      const idx = queue.indexOf(this);
+      const idx = queue.indexOf(this, queueIndex);
       if (idx > -1) {
         queue.splice(idx, 1);
         this._status = tsCanceled;
@@ -679,7 +876,7 @@ export class Task<R = any> {
 
 /**
  * Queue a callback to run **repeatedly** on a given interval, managed by
- * Aurelia's central scheduler.
+ * Aurelia's task queue.
  *
  * Unlike a one-off task from {@link queueAsyncTask}, this creates a persistent,
  * timer-based operation that continues until explicitly canceled. Each
@@ -691,7 +888,9 @@ export class Task<R = any> {
  *
  * @param callback  - The function to execute on each interval. Any exception
  *                    it throws is captured and surfaced collectively via
- *                    `tasksSettled()` or `runTasks()` (after awaiting `task.next()`).
+ *                    `tasksSettled()` or `runTasks()` (after awaiting
+ *                    `task.next()`), or reported to the console when an
+ *                    automatic cycle is otherwise unobserved.
  * @param opts.interval  - The delay **in milliseconds** between the end of one
  *                         execution and the start of the next. Defaults to `0`.
  * @returns A {@link RecurringTask} handle that lets you `cancel()` the
@@ -736,7 +935,7 @@ export class RecurringTask {
       // TODO: possibly store return value to connect to resolver
       this._callback();
     } catch (err) {
-      taskErrors.push(err);
+      recordTaskError(err, true);
       return;
     }
   }
@@ -806,7 +1005,7 @@ export class RecurringTask {
    * Permanently stops the recurring task.
    *
    * This action clears any pending timer, prevents future executions, removes
-   * the task from the scheduler's list of recurring tasks, and immediately
+   * the task from the task queue's list of recurring tasks, and immediately
    * resolves any pending promises created by `next()`.
    *
    * Once canceled, a recurring task cannot be restarted.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

This hardens the task queue so large finite workloads no longer trip the recursive deadlock guard just because many tasks are queued during a drain.

Automatic `queueTask` drains now process work in timed slices and continue through host timer turns until the queue is idle. Manual `runTasks()` calls remain synchronous and keep an internal guard for runaway synchronous flushes.

This also improves task queue error reporting. Multiple task failures now surface as `TaskQueueAggregateError`, which extends `AggregateError`, preserves the original errors, sets `cause` to the first failure, and includes a more useful task-queue-specific message.

Because automatic drains may now yield between chunks, queued runtime-html work now re-checks lifecycle state before mutating DOM or observation state. This prevents delayed layout writes and `show` updates from acting after teardown or unsubscribe.

### 🎫 Issues

No active github issues as far as I could tell, but there were some reports on Discord that prompted a deeper investigation.

## 👩‍💻 Reviewer Notes

The main contract change is that very large automatic drains may span more than one host turn. Code that needs full completion should await `tasksSettled()` rather than assuming a single microtask is enough for every possible queue size.

`configureTaskQueue({ flushBudget })` can be used to control automatic drain pacing. The manual deadlock guard or timer internals are not exposed until specific use cases require otherwise.

The runtime-html guards are paired with the queue change: once yielding is possible, user input, stop/detach, or unsubscribe can happen before a later queued chunk runs.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## 📦 Changeset

- [x] Added changeset: `.changeset/task-queue-hardening.md`

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
