### PR TITLE
fix(i18n): ensure text content is escaped

### DIFF
--- a/.changeset/fix-i18n-text-escaping.md
+++ b/.changeset/fix-i18n-text-escaping.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/i18n": patch
+---
+
+Default and `[text]` translations now render values as literal text instead of parsing markup. `[html]`, `[prepend]`, and `[append]` continue to support intentional HTML content. Fixes #2422.

--- a/packages/__tests__/src/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-integration.spec.ts
@@ -519,12 +519,36 @@ describe('i18n/t/translation-integration.spec.ts', function () {
   }
   {
     @customElement({
+      name: 'app', template: `<span id='a' t='html'></span>`
+    })
+    class App { }
+
+    $it('escapes markup for default textContent replacement - `t="key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
+      const span = (host as Element).querySelector('span');
+      assert.equal(span.textContent, translation.html);
+      assert.equal(span.querySelector('i'), null);
+    }, { component: App });
+  }
+  {
+    @customElement({
       name: 'app', template: `<span id='a' t='[text]simple.text'></span>`
     })
     class App { }
 
     $it('works for textContent replacement with explicit [text] attribute - `t="[text]key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
       assertTextContent(host, 'span', translation.simple.text);
+    }, { component: App });
+  }
+  {
+    @customElement({
+      name: 'app', template: `<span id='a' t='[text]html'></span>`
+    })
+    class App { }
+
+    $it('escapes markup for textContent replacement with explicit [text] attribute - `t="[text]key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
+      const span = (host as Element).querySelector('span');
+      assert.equal(span.textContent, translation.html);
+      assert.equal(span.querySelector('i'), null);
     }, { component: App });
   }
   {

--- a/packages/__tests__/src/i18n/t/translation-integration.spec.ts
+++ b/packages/__tests__/src/i18n/t/translation-integration.spec.ts
@@ -75,6 +75,8 @@ describe('i18n/t/translation-integration.spec.ts', function () {
       itemWithCount_other: '{{count}} items',
 
       html: 'this is a <i>HTML</i> content',
+      markupText: `<img onclick="document.body.dataset.i18nXss='fired'"><strong>markup</strong>&amp;`,
+      empty: '',
       pre: 'tic ',
       preHtml: '<b>tic</b><span>foo</span> ',
       mid: 'tac',
@@ -151,12 +153,93 @@ describe('i18n/t/translation-integration.spec.ts', function () {
   function assertTextContent(host: INode, selector: string, translation: string, message?: string) {
     assert.equal((host as Element).querySelector(selector).textContent, translation, message);
   }
+
+  function assertTextOnlyContent(host: INode, selector: string, translation: string) {
+    const target = (host as Element).querySelector(selector);
+    assert.equal(target.textContent, translation);
+    assert.equal(target.children.length, 0, 'translation should not create elements');
+    assert.equal(target.childNodes.length, 1, 'translation should create one text node');
+    assert.equal(target.firstChild.nodeType, 3, 'translated content should be a text node');
+  }
   {
     @customElement({ name: 'app', template: `<span t='simple.text'></span>` })
     class App { }
 
     $it('works for simple string literal key', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
       assertTextContent(host, 'span', translation.simple.text);
+    }, { component: App });
+  }
+  {
+    @customElement({
+      name: 'app',
+      template: `
+        <span id="default" t="markupText"></span>
+        <span id="explicit" t="[text]markupText"></span>
+      `,
+    })
+    class App { }
+
+    $it('renders markup-shaped default and [text] translations as literal text', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
+      assertTextOnlyContent(host, '#default', translation.markupText);
+      assertTextOnlyContent(host, '#explicit', translation.markupText);
+    }, { component: App });
+  }
+  {
+    @customElement({
+      name: 'app',
+      template: `
+        <span id="default" t="empty"><b>fallback</b></span>
+        <span id="text" t="[text]empty"><b>fallback</b></span>
+        <span id="html" t="[html]empty"><b>fallback</b></span>
+      `,
+    })
+    class App { }
+
+    $it('treats empty default, [text], and [html] translations as present content', async function ({ host }: I18nIntegrationTestContext<App>) {
+      for (const selector of ['#default', '#text', '#html']) {
+        const target = (host as Element).querySelector(selector);
+        assert.equal(target.textContent, '');
+        assert.equal(target.childNodes.length, 0, 'empty translation should remove fallback without adding a node');
+      }
+    }, { component: App });
+  }
+  {
+    @customElement({
+      name: 'app',
+      template: `
+        <span id="text-then-html" t="[text]markupText;[html]midHtml"></span>
+        <span id="html-then-text" t="[html]midHtml;[text]markupText"></span>
+        <span id="empty-html" t="[text]markupText;[html]empty"><b>fallback</b></span>
+      `,
+    })
+    class App { }
+
+    $it('prioritizes [html] over [text] independently of key order, including empty HTML', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
+      assert.equal((host as Element).querySelector('#text-then-html').innerHTML, translation.midHtml);
+      assert.equal((host as Element).querySelector('#html-then-text').innerHTML, translation.midHtml);
+      assert.equal((host as Element).querySelector('#empty-html').childNodes.length, 0);
+    }, { component: App });
+  }
+  {
+    @customElement({ name: 'app', template: `<span t.bind="key"></span>` })
+    class App {
+      public key: string = 'markupText';
+    }
+
+    $it('remains safe when switching between text and HTML translation modes', async function ({ host, en: translation, app }: I18nIntegrationTestContext<App>) {
+      assertTextOnlyContent(host, 'span', translation.markupText);
+
+      app.key = '[html]midHtml';
+      await tasksSettled();
+      assert.equal((host as Element).querySelector('span').innerHTML, translation.midHtml);
+
+      app.key = '[text]markupText';
+      await tasksSettled();
+      assertTextOnlyContent(host, 'span', translation.markupText);
+
+      app.key = 'empty';
+      await tasksSettled();
+      assert.equal((host as Element).querySelector('span').childNodes.length, 0);
     }, { component: App });
   }
   {
@@ -519,36 +602,12 @@ describe('i18n/t/translation-integration.spec.ts', function () {
   }
   {
     @customElement({
-      name: 'app', template: `<span id='a' t='html'></span>`
-    })
-    class App { }
-
-    $it('escapes markup for default textContent replacement - `t="key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
-      const span = (host as Element).querySelector('span');
-      assert.equal(span.textContent, translation.html);
-      assert.equal(span.querySelector('i'), null);
-    }, { component: App });
-  }
-  {
-    @customElement({
       name: 'app', template: `<span id='a' t='[text]simple.text'></span>`
     })
     class App { }
 
     $it('works for textContent replacement with explicit [text] attribute - `t="[text]key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
       assertTextContent(host, 'span', translation.simple.text);
-    }, { component: App });
-  }
-  {
-    @customElement({
-      name: 'app', template: `<span id='a' t='[text]html'></span>`
-    })
-    class App { }
-
-    $it('escapes markup for textContent replacement with explicit [text] attribute - `t="[text]key"`', async function ({ host, en: translation }: I18nIntegrationTestContext<App>) {
-      const span = (host as Element).querySelector('span');
-      assert.equal(span.textContent, translation.html);
-      assert.equal(span.querySelector('i'), null);
     }, { component: App });
   }
   {

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -309,8 +309,17 @@ export class TranslationBinding implements IBinding {
 
     this._addContentToTemplate(template, content.prepend, marker);
 
-    // build content: prioritize [html], then textContent, and falls back to original content
-    if (!this._addContentToTemplate(template, content.innerHTML ?? content.textContent, marker)) {
+    // [html] body content parses markup; default/[text] body content stays text.
+    let hasContent = this._addContentToTemplate(template, content.innerHTML, marker);
+
+    if (!hasContent && content.textContent !== void 0 && content.textContent !== null) {
+      const textNode = this._platform.document.createTextNode(content.textContent);
+      Reflect.set(textNode, marker, true);
+      template.content.append(textNode);
+      hasContent = true;
+    }
+
+    if (!hasContent) {
       for (const fallbackContent of fallBackContents) {
         template.content.append(fallbackContent);
       }

--- a/packages/i18n/src/t/translation-binding.ts
+++ b/packages/i18n/src/t/translation-binding.ts
@@ -307,15 +307,19 @@ export class TranslationBinding implements IBinding {
   private _prepareTemplate(content: ContentValue, marker: string, fallBackContents: ChildNode[]) {
     const template = this._platform.document.createElement('template');
 
-    this._addContentToTemplate(template, content.prepend, marker);
+    this._addHtmlContentToTemplate(template, content.prepend, marker);
 
-    // [html] body content parses markup; default/[text] body content stays text.
-    let hasContent = this._addContentToTemplate(template, content.innerHTML, marker);
-
-    if (!hasContent && content.textContent !== void 0 && content.textContent !== null) {
-      const textNode = this._platform.document.createTextNode(content.textContent);
-      Reflect.set(textNode, marker, true);
-      template.content.append(textNode);
+    // Only explicit [html] content is parsed. Default and [text] translations stay literal,
+    // while prepend and append retain their documented HTML-capable behavior.
+    let hasContent = false;
+    if (content.innerHTML != null) {
+      hasContent = this._addHtmlContentToTemplate(template, content.innerHTML, marker);
+    } else if (content.textContent != null) {
+      if (content.textContent.length > 0) {
+        const textNode = this._platform.document.createTextNode(content.textContent);
+        Reflect.set(textNode, marker, true);
+        template.content.append(textNode);
+      }
       hasContent = true;
     }
 
@@ -325,12 +329,12 @@ export class TranslationBinding implements IBinding {
       }
     }
 
-    this._addContentToTemplate(template, content.append, marker);
+    this._addHtmlContentToTemplate(template, content.append, marker);
     return template;
   }
 
   /** @internal */
-  private _addContentToTemplate(template: HTMLTemplateElement, content: string | undefined, marker: string) {
+  private _addHtmlContentToTemplate(template: HTMLTemplateElement, content: string | undefined, marker: string) {
     if (content !== void 0 && content !== null) {
       const parser = this._platform.document.createElement('div');
       parser.innerHTML = content;


### PR DESCRIPTION
Default and [text] replacements use textContent so markup is not parsed as HTML. [html] still permits markup. Added tests to verify markup is escaped for default and [text] replacements.

Relates to issue #2422