### PR TITLE
docs(agents): add agent and subtree guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# Repository Guidelines
+
+## Agent Operating Notes
+- Keep guidance repo-specific and actionable: commands, validation rules, code style, package boundaries, and known gotchas belong here.
+- Put package- or directory-specific rules in nested `AGENTS.md` files near the code they govern instead of adding broad root-level exceptions.
+- When delegating work in Codex, use native subagents for parallel exploration, implementation, or review. Do not orchestrate extra headless `codex exec` processes from shell unless the user explicitly asks for that fallback or native subagents are unavailable.
+- Keep delegated tasks tightly scoped and evidence-driven. The parent agent remains responsible for final verification and hand-off.
+
+## Project Structure & Module Organization
+Aurelia core uses npm workspaces. Framework and plugin source lives under `packages/` (for example `packages/runtime`, `packages/router`, `packages/state`), each with its own `src/` and local tests. Build tooling and adapters sit in `packages-tooling/`, while end-to-end fixtures reside in `packages/__e2e__/`. Documentation belongs in `docs/user-docs/`, runnable samples are in `examples/`, and performance harnesses live in `benchmarks/`. Shared automation scripts are under `scripts/`.
+
+## Build, Test, and Development Commands
+- `npm run build` - Turbo-powered full workspace build; always run after dependency or API changes and before kicking off the test suite.
+- `cd packages/<package> && npm run build` - Use the package-local builder when a workspace exposes its own script; run this immediately after editing that package.
+- `npm run lint` - ESLint across all packages plus script utilities; ensures style compliance.
+- `npm run dev` - Launches the development helper script for local experimentation.
+
+## Coding Style & Naming Conventions
+Write TypeScript with 2-space indentation, trailing commas, and single quotes as enforced by ESLint. Keep filenames kebab-case (for example, `subscriber-batch.ts`), prefer named exports from package entry points, and co-locate reusable helpers in `src/resources/` when a package provides templating resources. Run `npm run lint` before committing to catch formatting drift.
+- Prefer simple, direct implementations with descriptive names.
+- Keep functions focused; refactor only when it improves readability or reuse.
+- Add comments that explain why a choice was made, not what the code does.
+- Prefer inlined helpers for single-use logic; only extract new functions when the code is exported or reused in multiple places.
+
+### Framework-Friendly Implementations
+- Default to concise, memory-aware code paths. Minimize helper churn, prefer reusing existing utilities, and avoid creating large allocation footprints for hot paths.
+- Before introducing new helpers or abstractions, survey existing packages for analogous functionality you can extend instead of duplicating.
+- Keep new API surface incremental and well-justified; brief, well-named helpers with clear responsibilities are easier for downstream contributors to reason about and optimize.
+- When a change must be more involved, break it into small, testable pieces and explain the rationale inline or in docs so future maintainers understand why the complexity is necessary.
+- When prefixing properties or methods with an underscore e.g. `_myMethod` ensure they're denoted with an internal comment `/** @internal */`
+
+## Testing Guidelines
+Specs generally live beside source or within test workspaces. Use Jasmine/Mocha-style `describe`/`it` names and reference the feature or bug ID when practical. After rebuilding affected packages (`npm run build` or the scoped build commands above), run the relevant package-local or root test command. Follow nested `AGENTS.md` guidance for subtree-specific test commands.
+
+**Agent discipline:** if you change code, you must personally run the relevant build and test commands before reporting back. Note the exact commands in your hand-off so reviewers can see what already passed. Skipping validation or hand-waving about "should work" is not acceptable.
+
+### Docs-only exception
+When a task is **documentation-only** (for example, changes under `docs/` or updates to agent guidance Markdown files):
+
+- Do **not** run `npm run build`, `npm run lint`, or any test suites.
+- Do **not** modify runtime/core packages or tests unless the task explicitly requests code changes.
+
+## Commit & Pull Request Guidelines
+Follow Conventional Commits enforced by Commitlint: `type(scope): subject` with lower-case types such as `feat`, `fix`, `docs`, or `test`, a 100-character subject limit, and no trailing period. Scope names should mirror npm package names (for example, `feat(router): add fallback pipeline`). Each PR should include a clear summary, linked issues, confirmation of validation commands (`build`, `lint`, `test`), and screenshots or recordings for UI-affecting work. Update README and `docs/user-docs/` when user-facing behavior changes.
+
+## Environment & Tooling
+Target Node 22.12.x and npm 10.9.x as pinned in `package.json` and the Volta config. Use `npm ci` for clean installs. Husky hooks run linting and tests on commit; if they fail, resolve locally rather than bypassing the hook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+@AGENTS.md
+
+## Claude Code
+
+This file intentionally imports the shared project guidance from `AGENTS.md`. Keep shared rules in `AGENTS.md`; add only Claude-specific notes here when they cannot apply to other coding agents.

--- a/docs/user-docs/AGENTS.md
+++ b/docs/user-docs/AGENTS.md
@@ -1,0 +1,37 @@
+# User Documentation Guidelines
+
+## Scope
+This subtree contains the published user documentation. The root `AGENTS.md` still applies; this file adds GitBook and writing guidance.
+
+## GitBook Structure
+- Use GitBook-flavored Markdown.
+- `docs/user-docs/TOC.md` is the main navigation. When adding, moving, or renaming a page, update `TOC.md` in the same change.
+- Avoid orphan pages. Every user-facing page should be reachable from the main navigation unless it is intentionally hidden or included only through another page.
+- Keep frontmatter descriptions concise and useful when a page already has frontmatter.
+- Use relative links to other docs pages. Prefer human link text over filename-like labels.
+- Use fenced code blocks with language identifiers whenever possible.
+
+## GitBook Blocks
+- Preserve existing GitBook blocks such as `{% content-ref %}`, `{% hint %}`, `{% tabs %}`, and `{% tab %}`.
+- Use `{% hint style="info" %}` for context, `style="warning"` for non-destructive cautions, and `style="danger"` only for destructive or security-sensitive actions.
+- Use tab blocks for parallel platform or framework variants. Do not use tabs to hide required sequential steps.
+- Do not replace GitBook blocks with raw HTML unless GitBook Markdown cannot express the result.
+
+## Aurelia Examples
+- Always import `resolve` from `@aurelia/kernel` when showing dependency injection.
+- Use `resolve()` for injected dependencies: `private service = resolve(IService);`.
+- Do not use constructor parameter decorators such as `@IService` or `@inject(...)` in docs examples.
+- Do not wrap Aurelia 2 component HTML examples in `<template>` tags.
+- Keep examples small enough to teach one idea, then link to a larger recipe or guide when needed.
+
+## Voice And Style
+- Use American English spelling.
+- Write like a senior Aurelia maintainer explaining the feature to a developer who is trying to ship something.
+- Prefer direct, concrete sentences. Start with what the reader can do, then explain why it works.
+- Be accurate before being persuasive. Do not oversell Aurelia with vague claims such as "seamless", "powerful", "robust", "future-proof", or "game-changing" unless the sentence proves the claim with a specific behavior.
+- Acknowledge practical tradeoffs and common failure modes. Good docs include the "watch out for this" detail.
+- Avoid formulaic openings such as "In this guide, we'll explore", "Whether you're new to...", "Let's dive in", and "In today's landscape".
+- Avoid generic AI tells: "delve", "unlock", "leverage" as a verb, "utilize", "boasts", "serves as", "it is important to note", "not only... but also", and "X is not just Y; it is Z".
+- Avoid vague attribution such as "many developers say", "experts agree", or "it is widely known" unless you cite or name the source.
+- Vary paragraph length and sentence rhythm, but keep the tone calm and technical. Do not add jokes or personality flourishes that distract from the task.
+- Do not end pages with generic recap paragraphs. End when the reader has the next useful action, link, or verification step.

--- a/packages-tooling/AGENTS.md
+++ b/packages-tooling/AGENTS.md
@@ -1,0 +1,15 @@
+# Tooling Package Guidelines
+
+## Scope
+This subtree contains build and integration tooling packages such as the conventions plugin, bundler loaders, and Jest adapters. The root `AGENTS.md` still applies; this file adds tooling-specific rules.
+
+## Commands
+- For a single tooling package, run `npm run build` and `npm run lint` from that package directory when those scripts are present.
+- For shared tooling tests, run `npm run build` from `packages-tooling/__tests__`, then a targeted suite such as `npm run test-node:plugin-conventions`, `npm run test-node:webpack-loader`, `npm run test-node:vite-plugin`, `npm run test-node:babel-jest`, `npm run test-node:ts-jest`, or `npm run test-node:parcel-transformer`.
+- Use root `npm run dev:tooling` when you need the repository's tooling development helper.
+
+## Editing Rules
+- Keep package `exports`, `main`, `module`, and `types` fields aligned with generated `dist` outputs.
+- Do not change bundler-facing behavior without adding or updating coverage in `packages-tooling/__tests__` when practical.
+- Be careful with parser, template, and module-format changes. These packages are integration surfaces for downstream build tools.
+- Preserve existing package boundaries; do not move reusable tooling code into runtime packages unless the change explicitly requires it.

--- a/packages/__e2e__/AGENTS.md
+++ b/packages/__e2e__/AGENTS.md
@@ -1,0 +1,16 @@
+# E2E Fixture Guidelines
+
+## Scope
+This subtree contains runnable application fixtures for Playwright coverage. The root `AGENTS.md` still applies; this file adds fixture-specific rules.
+
+## Commands
+- Work from the individual fixture directory, for example `cd packages/__e2e__/6-router`.
+- Run the fixture's own `npm run test` or `npm run test:e2e` script unless the task names a narrower command.
+- Most fixtures start a dev server and Playwright together through `concurrently` with an `APP_PORT` value from that fixture's `package.json`; do not invent ports.
+- Use `npm run test:e2e:debugger` or `npm run test:debugger` only when an interactive Playwright debug run is actually needed.
+
+## Editing Rules
+- Keep fixture changes minimal and tied to the behavior under test.
+- Do not normalize all fixtures to one bundler or server command. Some intentionally use Vite, some webpack, and some production-build paths.
+- When adding a fixture, add it to the root workspace list and give it a unique `port`.
+- If a test depends on browser behavior, capture the exact fixture, command, and failure mode in the hand-off.

--- a/packages/__tests__/AGENTS.md
+++ b/packages/__tests__/AGENTS.md
@@ -1,0 +1,16 @@
+# Unit Test Package Guidelines
+
+## Scope
+This subtree contains the compiled test workspace for core packages. The root `AGENTS.md` still applies; this file adds test-package specifics.
+
+## Commands
+- After changing tests in this package, run `npm run build` from `packages/__tests__` before running any targeted suite.
+- Use targeted Node suites when possible, such as `npm run test-node:kernel`, `npm run test-node:runtime`, `npm run test-node:runtime-html`, `npm run test-node:router`, `npm run test-node:state`, or `npm run test-node:validation`.
+- Use `npm run test-chrome` for browser coverage and the root `npm run test` when the change needs the standard full Karma pass.
+- If a suite reports missing exports or stale generated JavaScript after TypeScript or template changes, remove `packages/__tests__/dist` before rebuilding.
+
+## Editing Rules
+- Keep specs close to the feature or package behavior under test.
+- Do not run targeted suites against stale `dist` output.
+- Preserve the existing Jasmine/Mocha-style `describe` and `it` naming patterns.
+- Prefer focused assertions over broad snapshots or overly mocked tests.


### PR DESCRIPTION
Introduce a repository-wide agents guide with actionable operating notes on delegation, project structure, build/test commands, coding and commit conventions, and docs authoring. Add specialised subtree guidance for tooling, e2e fixtures, unit test packages and user docs, plus a Claude-specific importer that references the shared guidance to standardise agent behaviour and validation steps

Closes #2425