### PR TITLE
feat(router): add setTitle to route nodes

### DIFF
--- a/.changeset/fix-router-route-node-title.md
+++ b/.changeset/fix-router-route-node-title.md
@@ -2,4 +2,4 @@
 "@aurelia/router": patch
 ---
 
-Add `RouteNode#setTitle()` for setting a route node's title during navigation lifecycle hooks.
+Make `RouteNode.title` writable so navigation lifecycle hooks can update a route node's title part.

--- a/.changeset/fix-router-route-node-title.md
+++ b/.changeset/fix-router-route-node-title.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/router": patch
+---
+
+Add `RouteNode#setTitle()` for setting a route node's title during navigation lifecycle hooks.

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -850,7 +850,7 @@ export class UserDetailPage implements IRouteViewModel {
     this.user = await this.userService.getUser(params.id);
 
     // Set this route node's title part based on loaded data
-    next.setTitle(`User: ${this.user.name}`);
+    next.title = `User: ${this.user.name}`;
   }
 
   canUnload(next: RouteNode | null, current: RouteNode): boolean | Promise<boolean> {

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -849,7 +849,7 @@ export class UserDetailPage implements IRouteViewModel {
     // Load data - much cleaner async support
     this.user = await this.userService.getUser(params.id);
 
-    // Set dynamic title based on loaded data
+    // Set this route node's title part based on loaded data
     next.setTitle(`User: ${this.user.name}`);
   }
 
@@ -895,7 +895,7 @@ export class MyApp {
 - **Type safety**: Full TypeScript support throughout
 - **Lazy loading**: Built-in support for code splitting
 - **Enhanced parameters**: Better access to route context and navigation state
-- **Dynamic titles**: Easy to set page titles based on loaded data
+- **Dynamic titles**: Set route node title parts based on loaded data
 {% endtab %}
 {% endtabs %}
 

--- a/docs/user-docs/router/README.md
+++ b/docs/user-docs/router/README.md
@@ -482,21 +482,26 @@ export class UserLayout {}
 
 ### How do I set/change the page title?
 ```typescript
-// In route configuration
+// Set a route node title part in route configuration
 {
   path: 'about',
   component: About,
   title: 'About Us'
 }
 
-// Programmatically
+// Set the final title for one navigation
 router.load('about', { title: 'Custom Title' });
+
+// Set a route node title part after loading data
+loading(params, next) {
+  next.setTitle(`About ${params.id}`);
+}
 
 // Custom title building
 RouterConfiguration.customize({
   buildTitle(transition) {
-    const titles = transition.routeTree.root.children.map(c => c.title);
-    return `${titles.join(' - ')} | My App`;
+    const title = transition.routeTree.root.getTitle(' - ');
+    return title ? `${title} | My App` : 'My App';
   }
 })
 ```

--- a/docs/user-docs/router/README.md
+++ b/docs/user-docs/router/README.md
@@ -489,12 +489,12 @@ export class UserLayout {}
   title: 'About Us'
 }
 
-// Set the final title for one navigation
+// Set a document title override for one navigation
 router.load('about', { title: 'Custom Title' });
 
 // Set a route node title part after loading data
 loading(params, next) {
-  next.setTitle(`About ${params.id}`);
+  next.title = `About ${params.id}`;
 }
 
 // Custom title building

--- a/docs/user-docs/router/api-reference.md
+++ b/docs/user-docs/router/api-reference.md
@@ -219,7 +219,7 @@ interface IRouterOptions {
   /** History interaction strategy. Default: 'push' */
   historyStrategy?: HistoryStrategy | ((instructions: ViewportInstructionTree) => HistoryStrategy);
 
-  /** Custom title builder function. Return null to skip title updates */
+  /** Custom final title builder function. Return null to skip document title updates */
   buildTitle?: ((transition: Transition) => string | null) | null;
 
   /** Generate navigation model for menus. Default: true */
@@ -252,7 +252,7 @@ interface INavigationOptions {
   /** Override router's history strategy for this navigation */
   historyStrategy?: HistoryStrategy | ((instructions: ViewportInstructionTree) => HistoryStrategy);
 
-  /** Page title for this navigation */
+  /** Final title for this navigation when no custom buildTitle is configured */
   title?: string | ((node: RouteNode) => string | null) | null;
 
   /** Separator between hierarchical titles. Default: ' | ' */
@@ -323,7 +323,7 @@ interface IRouteConfig {
   /** URL path pattern(s) to match */
   path?: string | string[] | null;
 
-  /** Page title when route is active */
+  /** Title part when route is active */
   title?: string | ((node: RouteNode) => string | null) | null;
 
   /** Redirect to another route when matched */
@@ -656,8 +656,14 @@ class RouteNode {
   /** Custom route data */
   readonly data: Readonly<Record<string, unknown>>;
 
-  /** Page title */
+  /** This route node's title part */
   readonly title: string | ((node: RouteNode) => string | null) | null;
+
+  /** Compose this node and its children into a title string */
+  getTitle(separator: string): string | null;
+
+  /** Set this route node's title part */
+  setTitle(title: string | ((node: RouteNode) => string | null) | null): void;
 
   /** Component definition */
   readonly component: CustomElementDefinition;

--- a/docs/user-docs/router/api-reference.md
+++ b/docs/user-docs/router/api-reference.md
@@ -219,7 +219,7 @@ interface IRouterOptions {
   /** History interaction strategy. Default: 'push' */
   historyStrategy?: HistoryStrategy | ((instructions: ViewportInstructionTree) => HistoryStrategy);
 
-  /** Custom final title builder function. Return null to skip document title updates */
+  /** Custom document title builder function. Return null to skip document title updates */
   buildTitle?: ((transition: Transition) => string | null) | null;
 
   /** Generate navigation model for menus. Default: true */
@@ -252,7 +252,7 @@ interface INavigationOptions {
   /** Override router's history strategy for this navigation */
   historyStrategy?: HistoryStrategy | ((instructions: ViewportInstructionTree) => HistoryStrategy);
 
-  /** Final title for this navigation when no custom buildTitle is configured */
+  /** Document title override for this navigation when no custom buildTitle is configured */
   title?: string | ((node: RouteNode) => string | null) | null;
 
   /** Separator between hierarchical titles. Default: ' | ' */
@@ -657,13 +657,10 @@ class RouteNode {
   readonly data: Readonly<Record<string, unknown>>;
 
   /** This route node's title part */
-  readonly title: string | ((node: RouteNode) => string | null) | null;
+  title: string | ((node: RouteNode) => string | null) | null;
 
   /** Compose this node and its children into a title string */
   getTitle(separator: string): string | null;
-
-  /** Set this route node's title part */
-  setTitle(title: string | ((node: RouteNode) => string | null) | null): void;
 
   /** Component definition */
   readonly component: CustomElementDefinition;

--- a/docs/user-docs/router/configuring-routes.md
+++ b/docs/user-docs/router/configuring-routes.md
@@ -364,6 +364,16 @@ You can customize this default behavior by using a [custom `buildTitle` function
 
 Note that, instead of a string, a function can also be used for `title` to lazily set the title.
 
+There are a few supported title entry points, and they apply at different levels:
+
+- Route configuration titles (`@route`, static `title`, and child `routes[].title`) set title parts for matching route nodes.
+- A route title can be a function: `(node: RouteNode) => string | null`. The router evaluates it when composing the title.
+- Lifecycle hooks and router hooks that receive the next `RouteNode` can call `next.setTitle(...)` to replace that node's title part during the current navigation.
+- `router.load(instruction, { title })` sets the final title for that navigation when no custom `buildTitle` is configured.
+- `buildTitle` takes over final title generation globally. Use `router.updateTitle()` to recompute the current title when external state used by `buildTitle` changes, such as the active locale.
+
+Directly assigning `document.title` is outside the router pipeline. The router may overwrite it on the next navigation, and `ICurrentRoute.title` will not be updated from that direct assignment.
+
 ## Redirect to another path
 
 By specifying the `redirectTo` property on our route, we can create route aliases.

--- a/docs/user-docs/router/configuring-routes.md
+++ b/docs/user-docs/router/configuring-routes.md
@@ -368,9 +368,9 @@ There are a few supported title entry points, and they apply at different levels
 
 - Route configuration titles (`@route`, static `title`, and child `routes[].title`) set title parts for matching route nodes.
 - A route title can be a function: `(node: RouteNode) => string | null`. The router evaluates it when composing the title.
-- Lifecycle hooks and router hooks that receive the next `RouteNode` can call `next.setTitle(...)` to replace that node's title part during the current navigation.
-- `router.load(instruction, { title })` sets the final title for that navigation when no custom `buildTitle` is configured.
-- `buildTitle` takes over final title generation globally. Use `router.updateTitle()` to recompute the current title when external state used by `buildTitle` changes, such as the active locale.
+- Lifecycle hooks and router hooks that receive the next `RouteNode` can assign `next.title` to replace that node's title part during the current navigation.
+- `router.load(instruction, { title })` provides a document title override for that navigation when no custom `buildTitle` is configured.
+- `buildTitle` takes over document title generation globally. Use `router.updateTitle()` to recompute the current title when external state used by `buildTitle` changes, such as the active locale.
 
 Directly assigning `document.title` is outside the router pipeline. The router may overwrite it on the next navigation, and `ICurrentRoute.title` will not be updated from that direct assignment.
 

--- a/docs/user-docs/router/navigating.md
+++ b/docs/user-docs/router/navigating.md
@@ -926,14 +926,15 @@ This section describes other available options.
 
 **`title`**
 
-The `title` property allows you to modify the title as you navigate to your route.
+The `title` property lets you set the final title for a single navigation.
 This looks like as follows.
 
 ```typescript
 router.load(Home, { title: 'Some title' });
 ```
 
-Note that defining the `title` like this, overrides the title defined via the route configuration.
+When no custom `buildTitle` is configured, defining `title` like this overrides the title that would otherwise be composed from route configuration title parts.
+When a custom `buildTitle` is configured, the builder controls the final title and can decide whether to use `transition.options.title`.
 This can also be seen in the action below where a random title is generated every time.
 
 {% embed url="https://stackblitz.com/edit/router-lite-load-nav-options-title?ctl=1&embed=1&file=src/my-app.ts" %}
@@ -948,6 +949,8 @@ Using this option, you can customize the separator.
 ```typescript
 router.load(Home, { titleSeparator: '-' });
 ```
+
+`titleSeparator` only affects the default route-tree title composition. It is ignored when `title` provides the final title for a navigation or when `buildTitle` takes over title generation.
 
 This can also be seen in the action below where a random title separator is selected every time.
 

--- a/docs/user-docs/router/navigating.md
+++ b/docs/user-docs/router/navigating.md
@@ -926,7 +926,7 @@ This section describes other available options.
 
 **`title`**
 
-The `title` property lets you set the final title for a single navigation.
+The `title` property lets you override the document title for a single navigation.
 This looks like as follows.
 
 ```typescript
@@ -934,7 +934,7 @@ router.load(Home, { title: 'Some title' });
 ```
 
 When no custom `buildTitle` is configured, defining `title` like this overrides the title that would otherwise be composed from route configuration title parts.
-When a custom `buildTitle` is configured, the builder controls the final title and can decide whether to use `transition.options.title`.
+When a custom `buildTitle` is configured, the builder controls document title generation and can decide whether to use `transition.options.title`.
 This can also be seen in the action below where a random title is generated every time.
 
 {% embed url="https://stackblitz.com/edit/router-lite-load-nav-options-title?ctl=1&embed=1&file=src/my-app.ts" %}
@@ -950,7 +950,7 @@ Using this option, you can customize the separator.
 router.load(Home, { titleSeparator: '-' });
 ```
 
-`titleSeparator` only affects the default route-tree title composition. It is ignored when `title` provides the final title for a navigation or when `buildTitle` takes over title generation.
+`titleSeparator` only affects the default route-tree title composition. It is ignored when `title` provides the document title override for a navigation or when `buildTitle` takes over title generation.
 
 This can also be seen in the action below where a random title separator is selected every time.
 

--- a/docs/user-docs/router/router-configuration.md
+++ b/docs/user-docs/router/router-configuration.md
@@ -22,7 +22,7 @@ The router accepts the following configuration options through `RouterConfigurat
 | `basePath` | `string \| null` | `null` | Overrides the base segment used to resolve relative routes. Defaults to `document.baseURI`. |
 | `activeClass` | `string \| null` | `null` | CSS class applied by the `load` attribute when a link is active. |
 | `useNavigationModel` | boolean | `true` | Generates the navigation model so you can build menus from `IRouteContext.routeConfigContext.navigationModel`. |
-| `buildTitle` | `(transition: Transition) => string \| null` | `null` | Customises how page titles are produced. Return `null` to skip title updates. |
+| `buildTitle` | `(transition: Transition) => string \| null` | `null` | Customises final document title generation. Return `null` to skip document title updates. |
 | `restorePreviousRouteTreeOnError` | boolean | `true` | Restores the previous route tree if a navigation throws, preventing partial states. |
 | `treatQueryAsParameters` | boolean | `false` (deprecated) | Treats query parameters as route parameters. Avoid new usage; scheduled for removal in the next major release. |
 | `useEagerLoading` | boolean | `false` | When `true`, eagerly loads all route configurations upfront when the application starts. |
@@ -247,6 +247,7 @@ Every call to `ViewportInstruction.toUrl`, `router.load`, or `router.generatePat
 ## Customizing title
 
 A `buildTitle` function can be used to customize the [default behavior of building the title](./configuring-routes.md#setting-the-title).
+When configured, `buildTitle` owns final title generation for every navigation. Route configuration titles, `RouteNode#setTitle(...)`, and navigation options are still available on the `Transition`, but the builder decides how to use them.
 For this example, we assume that we have the configured the routes as follows:
 
 ```typescript
@@ -265,7 +266,7 @@ export class MyApp implements IRouteViewModel {}
 ```
 
 With this route configuration in place, when we navigate to `/home`, the default-built title will be `Home | Aurelia`.
-We can use the following `buildTitle` function that will cause the title to be `Aurelia - Home` when users navigate to `/` or `/home` route.
+We can use the following `buildTitle` function to use ` - ` as the separator when users navigate to `/` or `/home` route.
 
 ```typescript
 // main.ts
@@ -275,10 +276,7 @@ const au = new Aurelia();
 au.register(
   RouterConfiguration.customize({
     buildTitle(tr: Transition) {
-      const root = tr.routeTree.root;
-      const baseTitle = root.context.routeConfigContext.config.title;
-      const titlePart = root.children.map(c => c.title).join(' - ');
-      return `${baseTitle} - ${titlePart}`;
+      return tr.routeTree.root.getTitle(' - ') ?? 'Aurelia';
     },
   }),
 );
@@ -656,10 +654,7 @@ RouterConfiguration.customize({
   restorePreviousRouteTreeOnError: true, // Graceful error recovery
   buildTitle: (transition) => {
     // Custom title building with SEO considerations
-    const routeTitle = transition.routeTree.root.children
-      .map(child => child.title)
-      .filter(title => title)
-      .join(' - ');
+    const routeTitle = transition.routeTree.root.getTitle(' - ');
     return routeTitle ? `${routeTitle} | My App` : 'My App';
   }
 })
@@ -680,7 +675,7 @@ RouterConfiguration.customize({
   restorePreviousRouteTreeOnError: !isDevelopment, // Let errors surface in dev, recover in prod
   buildTitle: isProduction
     ? (tr) => buildSEOTitle(tr)                 // SEO-optimised titles in production
-    : (tr) => `[DEV] ${tr.routeTree.root.title ?? 'Unknown route'}`,
+    : (tr) => `[DEV] ${tr.routeTree.root.getTitle(' / ') ?? 'Unknown route'}`,
 });
 ```
 
@@ -699,7 +694,7 @@ RouterConfiguration.customize({
   historyStrategy: 'push',
   buildTitle: (transition) => {
     const appName = microFrontendName.charAt(0).toUpperCase() + microFrontendName.slice(1);
-    const routeTitle = transition.routeTree.root.children[0]?.title;
+    const routeTitle = transition.routeTree.root.getTitle(' - ');
     return routeTitle ? `${routeTitle} - ${appName}` : appName;
   }
 })
@@ -740,7 +735,7 @@ RouterConfiguration.customize({
   buildTitle: (transition) => {
     // Detailed debugging information in title
     const route = transition.routeTree.root.children[0];
-    return `[${route?.component?.name || 'Unknown'}] ${route?.title || 'No Title'}`;
+    return `[${route?.component?.name || 'Unknown'}] ${route?.getTitle(' / ') || 'No Title'}`;
   }
 })
 ```

--- a/docs/user-docs/router/router-configuration.md
+++ b/docs/user-docs/router/router-configuration.md
@@ -247,7 +247,7 @@ Every call to `ViewportInstruction.toUrl`, `router.load`, or `router.generatePat
 ## Customizing title
 
 A `buildTitle` function can be used to customize the [default behavior of building the title](./configuring-routes.md#setting-the-title).
-When configured, `buildTitle` owns final title generation for every navigation. Route configuration titles, `RouteNode#setTitle(...)`, and navigation options are still available on the `Transition`, but the builder decides how to use them.
+When configured, `buildTitle` owns document title generation for every navigation. Route configuration titles, assigned route-node titles, and navigation options are still available on the `Transition`, but the builder decides how to use them.
 For this example, we assume that we have the configured the routes as follows:
 
 ```typescript

--- a/docs/user-docs/router/router-hooks.md
+++ b/docs/user-docs/router/router-hooks.md
@@ -829,7 +829,7 @@ export class QueryReadingHooks {
 }
 ```
 
-You can also do similar reading in `loading`, `canUnload`, etc. Hooks that receive the next `RouteNode` before navigation commits can call `next.setTitle(...)` to set that node's title part. This approach can be combined with injecting `ICurrentRoute` if your logic is broader than a single hook.
+You can also do similar reading in `loading`, `canUnload`, etc. Hooks that receive the next `RouteNode` before navigation commits can assign `next.title` to set that node's title part. This approach can be combined with injecting `ICurrentRoute` if your logic is broader than a single hook.
 
 ## Best Practices
 

--- a/docs/user-docs/router/router-hooks.md
+++ b/docs/user-docs/router/router-hooks.md
@@ -829,7 +829,7 @@ export class QueryReadingHooks {
 }
 ```
 
-You can also do similar reading in `loading`, `canUnload`, etc. This approach can be combined with injecting `ICurrentRoute` if your logic is broader than a single hook.
+You can also do similar reading in `loading`, `canUnload`, etc. Hooks that receive the next `RouteNode` before navigation commits can call `next.setTitle(...)` to set that node's title part. This approach can be combined with injecting `ICurrentRoute` if your logic is broader than a single hook.
 
 ## Best Practices
 

--- a/docs/user-docs/router/routing-lifecycle.md
+++ b/docs/user-docs/router/routing-lifecycle.md
@@ -242,7 +242,7 @@ One of the examples is refactored using `loading` hook that is shown below.
 
 {% embed url="https://stackblitz.com/edit/router-lite-loading?ctl=1&embed=1&file=src/child1.ts" %}
 
-Following is an additional example, that shows that you can use `next.setTitle()` to dynamically set this route node's title part from the `loading` hook. The router still composes the final document title from the route tree.
+Following is an additional example, that shows that you can assign `next.title` to dynamically set this route node's title part from the `loading` hook. The router still composes the document title from the route tree.
 
 ```typescript
 import { IRouteViewModel, Params, RouteNode } from '@aurelia/router';
@@ -256,12 +256,12 @@ export class ChildOne implements IRouteViewModel {
   private msg: string;
   public loading(params: Params, next: RouteNode) {
     this.msg = `loaded with id: ${params.id}`;
-    next.setTitle('Child One');
+    next.title = 'Child One';
   }
 }
 ```
 
-The same title setter can be used from other lifecycle hooks that receive the next `RouteNode` before navigation commits, such as `canLoad` and `loaded`.
+The same title assignment can be used from other lifecycle hooks that receive the next `RouteNode` before navigation commits, such as `canLoad` and `loaded`.
 
 {% embed url="https://stackblitz.com/edit/router-lite-loading-title?ctl=1&embed=1&file=src/main.ts" %}
 

--- a/docs/user-docs/router/routing-lifecycle.md
+++ b/docs/user-docs/router/routing-lifecycle.md
@@ -242,7 +242,7 @@ One of the examples is refactored using `loading` hook that is shown below.
 
 {% embed url="https://stackblitz.com/edit/router-lite-loading?ctl=1&embed=1&file=src/child1.ts" %}
 
-Following is an additional example, that shows that you can use the `next.title` property to dynamically set the route title from the `loading` hook.
+Following is an additional example, that shows that you can use `next.setTitle()` to dynamically set this route node's title part from the `loading` hook. The router still composes the final document title from the route tree.
 
 ```typescript
 import { IRouteViewModel, Params, RouteNode } from '@aurelia/router';
@@ -256,10 +256,12 @@ export class ChildOne implements IRouteViewModel {
   private msg: string;
   public loading(params: Params, next: RouteNode) {
     this.msg = `loaded with id: ${params.id}`;
-    next.title = 'Child One';
+    next.setTitle('Child One');
   }
 }
 ```
+
+The same title setter can be used from other lifecycle hooks that receive the next `RouteNode` before navigation commits, such as `canLoad` and `loaded`.
 
 {% embed url="https://stackblitz.com/edit/router-lite-loading-title?ctl=1&embed=1&file=src/main.ts" %}
 

--- a/packages/__tests__/src/router/current-route.spec.ts
+++ b/packages/__tests__/src/router/current-route.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { resolve } from '@aurelia/kernel';
-import { ICurrentRoute, IRouteViewModel, IRouter, ParameterInformation, Params, RouteConfig, route } from '@aurelia/router';
-import { customElement } from '@aurelia/runtime-html';
+import { ICurrentRoute, IRouteViewModel, IRouter, ParameterInformation, Params, RouteConfig, route, RouteNode } from '@aurelia/router';
+import { customElement, IPlatform } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 import { start } from './_shared/create-fixture.js';
 
@@ -165,6 +165,43 @@ describe('router/current-route.spec.ts', function () {
         }
       ]
     }, 'round#6');
+
+    await au.stop();
+  });
+
+  it('uses titles set from the loading hook', async function () {
+    @customElement({ name: 'home-page', template: '' })
+    class HomePage { }
+
+    @customElement({ name: 'shop-page', template: '' })
+    class ShopPage implements IRouteViewModel {
+      public loading(params: Params, next: RouteNode) {
+        next.setTitle(`Shop ${params.id}`);
+      }
+    }
+
+    @route({
+      routes: [
+        { id: 'home', path: '', component: HomePage, title: 'Home' },
+        { id: 'shop', path: 'shop/:id', component: ShopPage, title: 'Shop' },
+      ]
+    })
+    @customElement({ name: 'app', template: '<au-viewport></au-viewport>' })
+    class App {
+      public readonly currentRoute: ICurrentRoute = resolve(ICurrentRoute);
+    }
+
+    const { au, container, rootVm } = await start({ appRoot: App });
+    const router = container.get(IRouter);
+    const document = container.get(IPlatform).document;
+
+    assert.strictEqual(document.title, 'Home', 'initial document title');
+    assert.strictEqual(rootVm.currentRoute.title, 'Home', 'initial current route title');
+
+    await router.load('shop/42');
+
+    assert.strictEqual(document.title, 'Shop 42', 'updated document title');
+    assert.strictEqual(rootVm.currentRoute.title, 'Shop 42', 'updated current route title');
 
     await au.stop();
   });

--- a/packages/__tests__/src/router/current-route.spec.ts
+++ b/packages/__tests__/src/router/current-route.spec.ts
@@ -176,7 +176,7 @@ describe('router/current-route.spec.ts', function () {
     @customElement({ name: 'shop-page', template: '' })
     class ShopPage implements IRouteViewModel {
       public loading(params: Params, next: RouteNode) {
-        next.setTitle(`Shop ${params.id}`);
+        next.title = `Shop ${params.id}`;
       }
     }
 

--- a/packages/router/src/route-tree.ts
+++ b/packages/router/src/route-tree.ts
@@ -122,8 +122,8 @@ export class RouteNode {
      * @internal
      */
     public readonly _viewport: string | null,
-    /** This route node's title part. Use `setTitle` to change it from lifecycle hooks. */
-    public readonly title: string | ((node: RouteNode) => string | null) | null,
+    /** This route node's title part. */
+    public title: string | ((node: RouteNode) => string | null) | null,
     public readonly component: CustomElementDefinition,
     /**
      * Not-yet-resolved viewport instructions.
@@ -227,15 +227,6 @@ export class RouteNode {
       typeof this.title === 'function' ? this.title.call(void 0, this) : this.title,
     ].filter(x => x !== null);
     return titleParts.length === 0 ? null : titleParts.join(separator);
-  }
-
-  /**
-   * Sets this route node's title part.
-   *
-   * The router still composes the final document title from the route tree.
-   */
-  public setTitle(title: string | ((node: RouteNode) => string | null) | null): void {
-    (this as Writable<this>).title = title;
   }
 
   public computeAbsolutePath(): string {

--- a/packages/router/src/route-tree.ts
+++ b/packages/router/src/route-tree.ts
@@ -122,6 +122,7 @@ export class RouteNode {
      * @internal
      */
     public readonly _viewport: string | null,
+    /** This route node's title part. Use `setTitle` to change it from lifecycle hooks. */
     public readonly title: string | ((node: RouteNode) => string | null) | null,
     public readonly component: CustomElementDefinition,
     /**
@@ -226,6 +227,15 @@ export class RouteNode {
       typeof this.title === 'function' ? this.title.call(void 0, this) : this.title,
     ].filter(x => x !== null);
     return titleParts.length === 0 ? null : titleParts.join(separator);
+  }
+
+  /**
+   * Sets this route node's title part.
+   *
+   * The router still composes the final document title from the route tree.
+   */
+  public setTitle(title: string | ((node: RouteNode) => string | null) | null): void {
+    (this as Writable<this>).title = title;
   }
 
   public computeAbsolutePath(): string {


### PR DESCRIPTION
## Summary

- Add `RouteNode#setTitle()` for updating a route node title part during navigation lifecycle/router hooks while keeping `RouteNode.title` readonly.
- Cover dynamic route-node titles with a router test that asserts both `document.title` and `ICurrentRoute.title`.
- Align router docs around supported title paths: route config title parts, `setTitle`, navigation `title`, `buildTitle`, `updateTitle`, and direct `document.title` caveats.

Closes #2416.