### PR TITLE
docs(gettingstarted): add browser no-build guide

### DIFF
--- a/docs/user-docs/TOC.md
+++ b/docs/user-docs/TOC.md
@@ -15,6 +15,7 @@
 
 * [Complete Getting Started Guide](getting-started/complete-guide.md)
 * [Quick Install Guide](getting-started/quick-install-guide.md)
+* [Browser without a build step](getting-started/browser-no-build.md)
 * [Aurelia for New Developers](getting-started/aurelia-for-new-developers.md)
 * [Hello World Tutorial](getting-started/quick-start-guide/README.md)
 * [Intermediate Tutorial](getting-started/intermediate-tutorial.md)

--- a/docs/user-docs/developer-guides/cheat-sheet.md
+++ b/docs/user-docs/developer-guides/cheat-sheet.md
@@ -35,73 +35,9 @@ await app.app({
 }).start();
 ```
 
-### Script tag (Vanilla JS)
+### Browser without a build step
 
-Note: you can copy-paste the markup below into an html file and open it directly in the browser. There is no need for any tooling for this example.
-
-**index.html**
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>Aurelia 2 Script Example</title>
-  
-  <!-- Performance optimizations -->
-  <link rel="dns-prefetch" href="//cdn.jsdelivr.net">
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/aurelia@latest/+esm" crossorigin fetchpriority="high">
-</head>
-<body>
-  <app-root></app-root>
-
-  <script type="module">
-    import { Aurelia, CustomElement } from 'https://cdn.jsdelivr.net/npm/aurelia@latest/+esm';
-
-    const AppRoot = CustomElement.define({
-      name: 'app-root',
-      template: '${message}',
-    }, class {
-      message = 'Hello world!';
-    });
-
-    new Aurelia().app({ component: AppRoot, host: document.querySelector('app-root') }).start();
-  </script>
-</body>
-</html>
-```
-
-### Script tag (Vanilla JS - enhance)
-
-Note: you can copy-paste the markup below into an html file and open it directly in the browser. There is no need for any tooling for this example.
-
-**index.html**
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8" />
-  <title>${title}</title>
-  
-  <!-- Performance optimizations -->
-  <link rel="dns-prefetch" href="//cdn.jsdelivr.net">
-  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/aurelia@latest/+esm" crossorigin fetchpriority="high">
-</head>
-<body>
-  ${message}
-  <script type="module">
-    import { Aurelia } from 'https://cdn.jsdelivr.net/npm/aurelia@latest/+esm';
-
-    const aurelia = new Aurelia();
-    await aurelia.enhance({ component: { message: 'Hello world!' }, host: document.body }).start();
-    await aurelia.enhance({ component: { title: 'Aurelia' }, host: document.head }).start();
-  </script>
-</body>
-</html>
-```
+For plain HTML files, CodePen demos, and script-module startup examples, use [Run Aurelia in the browser without a build step](../getting-started/browser-no-build.md). That page is the canonical place for CDN URLs, version pinning, plugin registration, `CustomElement.define(...)`, and `enhance(...)` examples.
 
 ### Multi-root
 

--- a/docs/user-docs/getting-started/browser-no-build.md
+++ b/docs/user-docs/getting-started/browser-no-build.md
@@ -1,0 +1,163 @@
+---
+description: Run Aurelia 2 directly in the browser with a module script and CDN imports.
+---
+
+# Run Aurelia in the browser without a build step
+
+You can run Aurelia from a plain HTML page by importing the framework as a browser ES module. This works well for CodePen demos, reduced bug reproductions, documentation examples, and small pages where a Vite or Webpack setup would be more ceremony than value.
+
+For application development, the scaffolded Vite setup is still the recommended path. A build tool gives you TypeScript, file-based templates, CSS imports, optimized output, and local package management.
+
+## What to include
+
+A no-build Aurelia page needs these pieces:
+
+- A host element, such as `<app-root></app-root>`.
+- A `<script type="module">` block. Static `import` statements only work in module scripts.
+- An ESM CDN URL for `aurelia`.
+- `CustomElement.define(...)` for inline component definitions.
+- `new Aurelia().app({ component, host }).start()` to attach Aurelia to the host element.
+
+The smallest useful page looks like this:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Aurelia without a build step</title>
+    <link rel="modulepreload" href="https://esm.sh/aurelia@2.0.0-rc.1" crossorigin>
+  </head>
+  <body>
+    <app-root></app-root>
+
+    <script type="module">
+      import { Aurelia, CustomElement } from 'https://esm.sh/aurelia@2.0.0-rc.1';
+
+      const AppRoot = CustomElement.define({
+        name: 'app-root',
+        template: `
+          <h1>\${message}</h1>
+          <input value.bind="message">
+          <p>You typed: \${message}</p>
+        `,
+      }, class {
+        message = 'Hello from Aurelia';
+      });
+
+      await new Aurelia()
+        .app({
+          component: AppRoot,
+          host: document.querySelector('app-root'),
+        })
+        .start();
+    </script>
+  </body>
+</html>
+```
+
+In CodePen, put the host element and the `<script type="module">` block in the HTML panel. If you put the JavaScript in a normal script panel, the browser will reject static `import` statements unless that panel is explicitly configured to emit a module script.
+
+## Pin package versions
+
+Use `@latest` only for quick local experiments. For bug reports, examples in issues, CodePen links, and documentation, pin every Aurelia package to the same version:
+
+```javascript
+import { Aurelia, CustomElement } from 'https://esm.sh/aurelia@2.0.0-rc.1';
+import { I18nConfiguration } from 'https://esm.sh/@aurelia/i18n@2.0.0-rc.1';
+```
+
+When you update one Aurelia package URL, update the others in the same page. Mixing versions can produce duplicate containers, missing registrations, or subtle binding/runtime mismatches.
+
+Avoid bundling each Aurelia package URL independently in a multi-package browser demo. For example, do not add `?bundle` to both `aurelia` and `@aurelia/i18n` unless you have confirmed the CDN keeps a single shared copy of Aurelia's internals. Separate bundles can hide duplicated framework modules.
+
+The examples on this page use `esm.sh`. The same pattern also works with other CDNs that serve browser-ready ES modules. For example, jsDelivr exposes Aurelia's ESM build at `https://cdn.jsdelivr.net/npm/aurelia@2.0.0-rc.1/+esm`.
+
+## Add official Aurelia packages
+
+Import each package from the CDN and register its configuration before calling `.app(...).start()`. This i18n example shows the pattern:
+
+```html
+<app-root></app-root>
+
+<script type="module">
+  import { Aurelia, CustomElement } from 'https://esm.sh/aurelia@2.0.0-rc.1';
+  import { I18nConfiguration } from 'https://esm.sh/@aurelia/i18n@2.0.0-rc.1';
+
+  const AppRoot = CustomElement.define({
+    name: 'app-root',
+    template: `
+      <h1 t="heading"></h1>
+      <p t="[text]intro"></p>
+    `,
+  }, class {});
+
+  await new Aurelia()
+    .register(
+      I18nConfiguration.customize((options) => {
+        options.initOptions = {
+          lng: 'en',
+          resources: {
+            en: {
+              translation: {
+                heading: 'Hello from i18n',
+                intro: 'Text translations update textContent.',
+              },
+            },
+          },
+        };
+      }),
+    )
+    .app({
+      component: AppRoot,
+      host: document.querySelector('app-root'),
+    })
+    .start();
+</script>
+```
+
+The `t` attribute writes translated text by default. Use `t="[html]key"` only when the translated value is trusted HTML that you intentionally want inserted as markup.
+
+## Enhance existing HTML
+
+Use `enhance(...)` when the page already contains the markup you want Aurelia to bind. This is useful for progressive enhancement, server-rendered HTML, or a small demo that does not need a custom root element definition.
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Aurelia without a build step</title>
+  </head>
+  <body>
+    <p>${message}</p>
+
+    <script type="module">
+      import { Aurelia } from 'https://esm.sh/aurelia@2.0.0-rc.1';
+
+      await new Aurelia()
+        .enhance({
+          component: { message: 'Hello from enhanced HTML' },
+          host: document.body,
+        })
+        .start();
+    </script>
+  </body>
+</html>
+```
+
+Use `.app(...)` when Aurelia owns a component host such as `<app-root>`. Use `.enhance(...)` when Aurelia should bind markup that is already in the document.
+
+## Browser-only constraints
+
+No-build examples run as plain browser JavaScript. Keep these constraints in mind:
+
+- Browsers do not run TypeScript directly. Use JavaScript in the page, or use a build tool for TypeScript examples.
+- Decorator syntax needs transpilation. Prefer `CustomElement.define(...)` for no-build examples.
+- Local `.html`, `.css`, and `.json` imports are bundler features in most Aurelia apps. Inline small templates in the component definition, or fetch external data over HTTP.
+- If your example fetches local files, serve it from `http://localhost` instead of opening it with `file://`. Browser security rules block many `file://` fetches.
+- Keep CDN package versions aligned across `aurelia`, `@aurelia/*` packages, and any plugin packages used by those integrations.
+
+When an example grows beyond a single page, move it to the normal project setup from the [Quick Install Guide](quick-install-guide.md).

--- a/docs/user-docs/getting-started/complete-guide.md
+++ b/docs/user-docs/getting-started/complete-guide.md
@@ -26,40 +26,7 @@ You'll need:
 
 ## Quick Try (No Installation)
 
-Want to see Aurelia in action immediately? Copy this into an HTML file:
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Aurelia 2 Demo</title>
-</head>
-<body>
-  <my-app></my-app>
-
-  <script type="module">
-    import Aurelia, { CustomElement } from 'https://cdn.jsdelivr.net/npm/aurelia@latest/+esm';
-
-    const App = CustomElement.define({
-      name: 'my-app',
-      template: `
-        <h1>Hello, \${name}!</h1>
-        <input value.bind="name" placeholder="Enter your name">
-        <p>You typed: \${name}</p>
-      `
-    }, class {
-      name = 'World';
-    });
-
-    new Aurelia()
-      .app({ component: App, host: document.querySelector('my-app') })
-      .start();
-  </script>
-</body>
-</html>
-```
-
-Open it in your browser and start typing! This demonstrates Aurelia's automatic two-way data binding.
+Want to see Aurelia in action before creating a project? Use [Run Aurelia in the browser without a build step](browser-no-build.md). That page is the maintained no-install path for plain HTML files, CodePen demos, plugin imports, and reduced bug reproductions.
 
 ## Create Your First Project
 

--- a/docs/user-docs/getting-started/quick-install-guide.md
+++ b/docs/user-docs/getting-started/quick-install-guide.md
@@ -9,51 +9,14 @@ Get Aurelia up and running in 5 minutes or less.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/en/) (latest version recommended)
 - A code editor of your choice
+- [Node.js](https://nodejs.org/en/) (latest version recommended) for the scaffolded app path
 
-## Option 1: Try Aurelia Instantly (No Setup Required)
+## Option 1: Try Aurelia in the browser
 
-Want to try Aurelia immediately? Copy this into an HTML file and open it in your browser:
+Want to try Aurelia immediately without installing anything? Use [Run Aurelia in the browser without a build step](browser-no-build.md). That page is the canonical no-build setup and covers module scripts, CDN imports, version pinning, CodePen usage, and package registration.
 
-```html
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>Aurelia 2 Quick Try</title>
-    <base href="/" />
-    <link rel="dns-prefetch" href="//cdn.jsdelivr.net">
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/aurelia@latest/+esm" crossorigin fetchpriority="high">
-  </head>
-  <body>
-    <app-root></app-root>
-    <script type="module">
-      import { Aurelia, CustomElement } from 'https://cdn.jsdelivr.net/npm/aurelia@latest/+esm';
-
-      const App = CustomElement.define({
-        name: 'app-root',
-        template: `
-          <h1>Hello, \${name}!</h1>
-          <input value.bind="name" placeholder="Enter your name">
-          <p>You typed: \${name}</p>
-        `
-      }, class {
-        name = 'World';
-      });
-
-      new Aurelia()
-        .app({ component: App, host: document.querySelector('app-root') })
-        .start();
-    </script>
-  </body>
-</html>
-```
-
-{% hint style="info" %}
-**No installation required!** This uses Aurelia directly from a CDN. Perfect for experimentation or simple projects. For a more complete example, see the [realworld-vanilla example](https://github.com/aurelia/aurelia/tree/master/examples/realworld-vanilla) which demonstrates a full application with routing.
-{% endhint %}
+For a more complete no-build application, see the [realworld-vanilla example](https://github.com/aurelia/aurelia/tree/master/examples/realworld-vanilla), which demonstrates a full application with routing.
 
 ## Option 2: Create Your App
 
@@ -65,7 +28,7 @@ npx makes aurelia
 
 When prompted:
 - **Project name**: Enter your project name
-- **Setup**: Choose TypeScript (recommended) or ESNext  
+- **Setup**: Choose TypeScript (recommended) or ESNext
 - **Install dependencies**: Select "Yes"
 
 {% hint style="info" %}


### PR DESCRIPTION
Centralise no-build browser instructions and examples into a dedicated guide for plain HTML, CodePen and module-script usage. Replace duplicated inline CDN/script examples across the quick-install guide, complete guide and cheat-sheet with links to the new page, add it to the TOC, and clarify guidance on version pinning, enhance vs app, and browser constraints.