### PR TITLE
feat(vite-plugin): bundle template asset urls

### DIFF
--- a/.changeset/vite-template-assets.md
+++ b/.changeset/vite-template-assets.md
@@ -1,0 +1,6 @@
+---
+"@aurelia/plugin-conventions": patch
+"@aurelia/vite-plugin": patch
+---
+
+Bundle static relative asset URLs referenced from conventional HTML templates during Vite production builds.

--- a/docs/user-docs/developer-guides/bundlers/README.md
+++ b/docs/user-docs/developer-guides/bundlers/README.md
@@ -339,6 +339,21 @@ export class MyComponent {
 }
 ```
 
+With `@aurelia/vite-plugin`, static relative asset URLs in conventional HTML templates are also included in production builds:
+
+```html
+<template>
+  <img src="logo.svg" alt="Logo">
+  <img src="./logo.svg" alt="Logo">
+  <img src="../shared/shared-logo.svg" alt="Shared logo">
+  <img srcset="./logo.png 1x, ./logo@2x.png 2x" alt="Logo">
+</template>
+```
+
+Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+
+Use binding for dynamic URLs. Root-relative public paths, external URLs, data URLs, hashes, and missing files are left unchanged.
+
 ## Performance Optimization
 
 ### Bundle Splitting

--- a/package-lock.json
+++ b/package-lock.json
@@ -26383,6 +26383,7 @@
         "@aurelia/runtime": "2.0.0-rc.0",
         "@rollup/pluginutils": "5.0.2",
         "loader-utils": "^2.0.0",
+        "parse5": "^7.1.2",
         "vite": "^7.0.2"
       },
       "devDependencies": {

--- a/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
+++ b/packages-tooling/__tests__/src/plugin-conventions/preprocess-html-template.spec.ts
@@ -1243,5 +1243,39 @@ export function register(container) {
       );
       assert.equal(result.code, expected);
     });
+
+    it('preprocesses templates with transformHtmlTemplate option', function () {
+      const html = [
+        '<template><img src="./logo.png"></template>'
+      ].join('');
+      const expected = `import { CustomElement } from '@aurelia/runtime-html';
+import assetUrl from "./logo.png";
+export const name = "foo-bar";
+export const template = "<template><img src=\\"" + assetUrl + "\\"></template>";
+export default template;
+export const dependencies = [  ];
+export const bindables = {};
+let _e;
+export function register(container) {
+  if (!_e) {
+    _e = CustomElement.define({ name, template, dependencies, bindables });
+  }
+  container.register(_e);
+}
+`;
+      const result = preprocessHtmlTemplate(
+        { path: path.join('lo', 'foo-bar', 'index.html'), contents: html },
+        preprocessOptions({
+          hmr: false,
+          transformHtmlTemplate: () => ({
+            imports: ['import assetUrl from "./logo.png";\n'],
+            template: '"<template><img src=\\"" + assetUrl + "\\"></template>"',
+          }),
+        }),
+        false,
+        () => false
+      );
+      assert.equal(result.code, expected);
+    });
   });
 });

--- a/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
+++ b/packages-tooling/__tests__/src/vite-plugin/vite-plugin.spec.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { build as viteBuild } from 'vite';
 import au from '@aurelia/vite-plugin';
 
 describe('vite-plugin', function () {
@@ -127,6 +128,196 @@ describe('vite-plugin', function () {
       const code = typeof result === 'string' ? result : result?.code;
 
       assert.match(String(code), /import \* as __au2ViewDef from '\.\/foo-bar\.\$au\.ts';/);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('imports static relative template assets during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.mkdirSync(path.join(fixture.srcDir, 'nested'), { recursive: true });
+    fs.mkdirSync(path.join(fixture.root, 'shared'), { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'larger.png'), 'larger', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'nested', 'nested-logo.png'), 'nested-logo', 'utf8');
+    fs.writeFileSync(path.join(fixture.root, 'shared', 'shared-logo.png'), 'shared-logo', 'utf8');
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<img src="./logo.png" alt="Logo">',
+        '<img src="../shared/shared-logo.png" alt="Shared logo">',
+        '<img src="nested/nested-logo.png" alt="Nested logo">',
+        '<img srcset="./logo.png 1x, ./larger.png 2x">',
+        '<img src.bind="dynamicLogo">',
+        '<img src="/public-logo.png">',
+        '<img src="./missing.png">',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.match(String(code), /import __auViteAsset0 from "\.\/logo\.png";/);
+      assert.match(String(code), /import __auViteAsset1 from "\.\.\/shared\/shared-logo\.png";/);
+      assert.match(String(code), /import __auViteAsset2 from "\.\/nested\/nested-logo\.png";/);
+      assert.match(String(code), /import __auViteAsset3 from "\.\/larger\.png";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0.*__auViteAsset1.*__auViteAsset2.*__auViteAsset0.*__auViteAsset3/s);
+      assert.match(String(code), /src\.bind=\\"dynamicLogo\\"/);
+      assert.match(String(code), /src=\\"\/public-logo\.png\\"/);
+      assert.match(String(code), /src=\\"\.\/missing\.png\\"/);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('imports Vue-style static template asset attributes during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    [
+      'clip.mp4',
+      'poster.png',
+      'source.webm',
+      'source-2x.webm',
+      'image.svg',
+      'symbol.svg',
+    ].forEach(file => fs.writeFileSync(path.join(fixture.srcDir, file), file, 'utf8'));
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<video src="./clip.mp4" poster="./poster.png">',
+        '  <source src="./source.webm" srcset="./source.webm 1x, ./source-2x.webm 2x">',
+        '</video>',
+        '<svg>',
+        '  <image href="./image.svg" xlink:href="./image.svg"></image>',
+        '  <use href="./symbol.svg" xlink:href="./symbol.svg"></use>',
+        '</svg>',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.match(String(code), /import __auViteAsset0 from "\.\/clip\.mp4";/);
+      assert.match(String(code), /import __auViteAsset1 from "\.\/poster\.png";/);
+      assert.match(String(code), /import __auViteAsset2 from "\.\/source\.webm";/);
+      assert.match(String(code), /import __auViteAsset3 from "\.\/source-2x\.webm";/);
+      assert.match(String(code), /import __auViteAsset4 from "\.\/image\.svg";/);
+      assert.match(String(code), /import __auViteAsset5 from "\.\/symbol\.svg";/);
+      assert.match(String(code), /export const template = .*__auViteAsset0.*__auViteAsset1.*__auViteAsset2.*__auViteAsset2.*__auViteAsset3.*__auViteAsset4.*__auViteAsset4.*__auViteAsset5.*__auViteAsset5/s);
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('emits static relative template assets in Vite production builds', async function () {
+    const fixture = createFixture();
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(fixture.root, 'index.html'),
+      '<div id="app"></div><script type="module" src="/src/main.ts"></script>',
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(fixture.srcDir, 'main.ts'),
+      [
+        'import * as view from "./foo-bar.html";',
+        'console.log(view.template);',
+      ].join('\n'),
+      'utf8'
+    );
+    fs.writeFileSync(fixture.htmlFile, '<template><img id="logo" src="./logo.svg" alt="Logo"></template>', 'utf8');
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.svg'), '<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf8');
+
+    try {
+      await viteBuild({
+        root: fixture.root,
+        configFile: false,
+        logLevel: 'silent',
+        build: {
+          assetsInlineLimit: 0,
+          minify: false,
+        },
+        plugins: au() as unknown as import('vite').PluginOption[],
+      });
+
+      const distAssets = fs.readdirSync(path.join(fixture.root, 'dist', 'assets'));
+      assert.ok(distAssets.some(file => /^logo-.*\.svg$/.test(file)));
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves non-bundleable template asset URLs unchanged during production builds', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'ignored.png'), 'ignored', 'utf8');
+    fs.writeFileSync(
+      fixture.htmlFile,
+      [
+        '<template>',
+        '<img vite-ignore src="./ignored.png">',
+        '<img src="/public-logo.png">',
+        '<img src="https://example.com/logo.png">',
+        '<img src="//example.com/logo.png">',
+        '<img src="data:image/png;base64,AA==">',
+        '<img src="#symbol">',
+        '<img src="${logoUrl}">',
+        '</template>',
+      ].join('\n'),
+      'utf8'
+    );
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('production'));
+      const result = await getHook(resourcePlugin.load)?.call(createPluginContext(), fixture.htmlFile.replace(/\.html$/, '.$au.ts'));
+      const code = String(typeof result === 'string' ? result : result?.code);
+
+      assert.doesNotMatch(code, /__auViteAsset/);
+      assert.match(code, /src=\\"\.\/ignored\.png\\"/);
+      assert.match(code, /src=\\"\/public-logo\.png\\"/);
+      assert.match(code, /src=\\"https:\/\/example\.com\/logo\.png\\"/);
+      assert.match(code, /src=\\"\/\/example\.com\/logo\.png\\"/);
+      assert.match(code, /src=\\"data:image\/png;base64,AA==\\"/);
+      assert.match(code, /src=\\"#symbol\\"/);
+      assert.ok(code.includes('src=\\"${logoUrl}\\"'));
+    } finally {
+      fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not import static relative template assets during dev server transforms', async function () {
+    const fixture = createFixture();
+    const [, resourcePlugin] = au({ include: /\.(ts|js|html)$/ });
+
+    fs.mkdirSync(fixture.srcDir, { recursive: true });
+    fs.writeFileSync(path.join(fixture.srcDir, 'logo.png'), 'logo', 'utf8');
+    fs.writeFileSync(fixture.htmlFile, '<img src="./logo.png" alt="Logo">', 'utf8');
+
+    try {
+      getHook(resourcePlugin.configResolved)?.call({}, createResolvedConfig('development', 'serve'));
+      const result = await getHook(resourcePlugin.transform)?.call({}, '<img src="./logo.png" alt="Logo">', fixture.htmlFile);
+      const code = typeof result === 'string' ? result : result?.code;
+
+      assert.doesNotMatch(String(code), /__auViteAsset/);
+      assert.match(String(code), /export const template = "<img src=\\"\.\/logo\.png\\" alt=\\"Logo\\">";/);
     } finally {
       fs.rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/packages-tooling/plugin-conventions/src/index.ts
+++ b/packages-tooling/plugin-conventions/src/index.ts
@@ -7,6 +7,7 @@ export { preprocess } from './preprocess';
 export {
   type INameConvention,
   type IFileUnit,
+  type IHtmlTemplateTransformResult,
   type IOptionalPreprocessOptions,
   type IPreprocessOptions,
   defaultCssExtensions,

--- a/packages-tooling/plugin-conventions/src/options.ts
+++ b/packages-tooling/plugin-conventions/src/options.ts
@@ -18,6 +18,11 @@ export interface IFileUnit {
   readFile?(path: string): string;
 }
 
+export interface IHtmlTemplateTransformResult {
+  imports?: readonly string[];
+  template: string;
+}
+
 export interface IOptionalPreprocessOptions {
   defaultShadowOptions?: { mode: 'open' | 'closed' };
   // More details in ./preprocess-html-template.ts
@@ -52,6 +57,10 @@ export interface IOptionalPreprocessOptions {
    * Used to transform the HTML content of a template file during preprocessing.
    */
   transformHtml?: (html: string) => string;
+  /**
+   * Used to transform the final HTML content into a JavaScript template expression.
+   */
+  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *
@@ -93,6 +102,10 @@ export interface IPreprocessOptions {
    * Used to transform the HTML content of a template file during preprocessing.
    */
   transformHtml?: (html: string) => string;
+  /**
+   * Used to transform the final HTML content into a JavaScript template expression.
+   */
+  transformHtmlTemplate?: (html: string, unit: IFileUnit) => IHtmlTemplateTransformResult | undefined;
   /**
    * This gets the generated HMR code for the specified class
    *

--- a/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
+++ b/packages-tooling/plugin-conventions/src/preprocess-html-template.ts
@@ -137,8 +137,11 @@ export function preprocessHtmlTemplate(
     viewDeps.push(`cssModules(${cssModuleDeps.join(', ')})`);
   }
   statements.forEach(st => m.append(st));
+  const transformedHtml = options.transformHtml?.(html) ?? html;
+  const transformedTemplate = options.transformHtmlTemplate?.(transformedHtml, unit);
+  transformedTemplate?.imports?.forEach(st => m.append(st));
   m.append(`export const name = ${s(name)};
-export const template = ${s(options.transformHtml?.(html) ?? html)};
+export const template = ${transformedTemplate?.template ?? s(transformedHtml)};
 export default template;
 export const dependencies = [ ${viewDeps.join(', ')} ];
 `);
@@ -203,4 +206,3 @@ export function register(container) {
 function s(input: unknown) {
   return JSON.stringify(input);
 }
-

--- a/packages-tooling/vite-plugin/README.md
+++ b/packages-tooling/vite-plugin/README.md
@@ -52,6 +52,29 @@ declare module '*.html' {
 }
 ```
 
+### Template assets
+
+During production builds, the plugin processes static relative asset URLs in conventional HTML templates so Vite can emit and rewrite them:
+
+```html
+<template>
+  <img src="logo.svg" alt="Logo">
+  <img src="./logo.svg" alt="Logo">
+  <img src="../shared/shared-logo.svg" alt="Shared logo">
+  <img srcset="./logo.png 1x, ./logo@2x.png 2x" alt="Logo">
+</template>
+```
+
+Relative URLs are resolved from the HTML template file, so same-directory paths, `./`, `../`, and nested relative paths are supported.
+
+Use binding for dynamic URLs as usual:
+
+```html
+<img src.bind="logoUrl" alt="Logo">
+```
+
+Root-relative public paths such as `/logo.svg`, external URLs, data URLs, hashes, and missing files are left unchanged.
+
 ### Dev config
 
 By default, the aurelia vite plugin generates aliases to dev packages for better experience during development. It'll detect development mode based on the `mode` config from `vite`. You can also override using `useDev` options, in case there needs to be clarity into some behavior of the applications:

--- a/packages-tooling/vite-plugin/package.json
+++ b/packages-tooling/vite-plugin/package.json
@@ -52,7 +52,8 @@
     "@aurelia/runtime": "2.0.0-rc.1",
     "@rollup/pluginutils": "5.0.2",
     "vite": "^7.0.2",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.0",
+    "parse5": "^7.1.2"
   },
   "devDependencies": {
     "@types/loader-utils": "^2.0.3",

--- a/packages-tooling/vite-plugin/src/index.ts
+++ b/packages-tooling/vite-plugin/src/index.ts
@@ -1,7 +1,9 @@
-import { IOptionalPreprocessOptions, preprocess } from '@aurelia/plugin-conventions';
+import { preprocess } from '@aurelia/plugin-conventions';
+import type { IFileUnit, IOptionalPreprocessOptions } from '@aurelia/plugin-conventions';
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import { resolve, dirname } from 'path';
 import { promises } from 'fs';
+import { transformTemplateAssetUrls } from './template-assets';
 
 export default function au(options: {
   include?: FilterPattern;
@@ -17,6 +19,7 @@ export default function au(options: {
     exclude,
     pre = true,
     useDev,
+    transformHtmlTemplate,
     ...additionalOptions
   } = options;
   const filter = createFilter(include, exclude);
@@ -32,6 +35,10 @@ export default function au(options: {
   };
 
   let $config!: import('vite').ResolvedConfig;
+  const transformHtmlTemplateForVite = (html: string, unit: IFileUnit) => {
+    return transformHtmlTemplate?.(html, unit)
+      ?? ($config.command === 'build' ? transformTemplateAssetUrls(html, unit.path) : void 0);
+  };
 
   const auPlugin: import('vite').Plugin = {
     name: 'au2',
@@ -57,6 +64,7 @@ export default function au(options: {
             ? s.replace(/\.html$/, '.$au.ts')
             : s;
         },
+        transformHtmlTemplate: transformHtmlTemplateForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions
       });
@@ -98,6 +106,7 @@ export default function au(options: {
       }, {
         hmrModule: 'import.meta',
         transformHtmlImportSpecifier: s => s.replace(/\.html$/, '.$au.ts'),
+        transformHtmlTemplate: transformHtmlTemplateForVite,
         stringModuleWrap: (id) => `${id}?inline`,
         ...additionalOptions
       });

--- a/packages-tooling/vite-plugin/src/template-assets.ts
+++ b/packages-tooling/vite-plugin/src/template-assets.ts
@@ -1,0 +1,213 @@
+import { statSync } from 'fs';
+import type { IHtmlTemplateTransformResult } from '@aurelia/plugin-conventions';
+import { dirname, resolve } from 'path';
+import { parseFragment } from 'parse5';
+import type { DefaultTreeAdapterMap, Token } from 'parse5';
+
+type DefaultTreeNode = DefaultTreeAdapterMap['node'];
+type DefaultTreeElement = DefaultTreeAdapterMap['element'];
+type DefaultTreeTemplate = DefaultTreeAdapterMap['template'];
+type AttributeLocation = Token.Location;
+
+const htmlAssetAttributes: Record<string, { src?: readonly string[]; srcset?: readonly string[] }> = {
+  img: { src: ['src'], srcset: ['srcset'] },
+  image: { src: ['href', 'xlink:href'] },
+  source: { src: ['src'], srcset: ['srcset'] },
+  use: { src: ['href', 'xlink:href'] },
+  video: { src: ['src', 'poster'] },
+};
+
+interface Replacement {
+  start: number;
+  end: number;
+  value: string;
+}
+
+interface AssetToken {
+  token: string;
+  variable: string;
+  specifier: string;
+}
+
+export function transformTemplateAssetUrls(html: string, htmlId: string): IHtmlTemplateTransformResult | undefined {
+  const replacements: Replacement[] = [];
+  const assets: AssetToken[] = [];
+  const tree = parseFragment(html, { sourceCodeLocationInfo: true });
+
+  visitElements(tree.childNodes, (node) => {
+    const assetAttrs = htmlAssetAttributes[node.nodeName];
+    const attrs = getAttributes(node);
+    if (assetAttrs == null || attrs.has('vite-ignore')) return;
+
+    assetAttrs.src?.forEach((name) => {
+      const value = attrs.get(name);
+      const loc = node.sourceCodeLocation?.attrs?.[name];
+      if (value == null || loc == null) return;
+
+      const token = createAssetToken(value, htmlId, assets);
+      if (token == null) return;
+      const valueLocation = getAttributeValueLocation(html, loc);
+      if (valueLocation == null) return;
+      replacements.push({ ...valueLocation, value: token.token });
+    });
+
+    assetAttrs.srcset?.forEach((name) => {
+      const value = attrs.get(name);
+      const loc = node.sourceCodeLocation?.attrs?.[name];
+      if (value == null || loc == null) return;
+      replaceSrcset(value, loc, html, htmlId, replacements, assets);
+    });
+  });
+
+  if (assets.length === 0) return void 0;
+
+  const transformedHtml = applyReplacements(html, replacements);
+  const imports = assets.map(asset => `import ${asset.variable} from ${JSON.stringify(asset.specifier)};\n`);
+  return {
+    imports,
+    template: createTemplateExpression(transformedHtml, assets),
+  };
+}
+
+function visitElements(nodes: DefaultTreeNode[], callback: (node: DefaultTreeElement) => void): void {
+  for (const node of nodes) {
+    if (!('attrs' in node)) continue;
+
+    const element = node as DefaultTreeElement;
+    callback(element);
+
+    visitElements(element.childNodes, callback);
+    if (element.tagName === 'template') {
+      visitElements((element as DefaultTreeTemplate).content.childNodes, callback);
+    }
+  }
+}
+
+function getAttributes(node: DefaultTreeElement): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const attr of node.attrs) {
+    attrs.set(attr.prefix == null ? attr.name : `${attr.prefix}:${attr.name}`, attr.value);
+  }
+  return attrs;
+}
+
+function replaceSrcset(
+  value: string,
+  attrLocation: AttributeLocation,
+  html: string,
+  htmlId: string,
+  replacements: Replacement[],
+  assets: AssetToken[],
+): void {
+  const valueLocation = getAttributeValueLocation(html, attrLocation);
+  if (valueLocation == null) return;
+
+  let changed = false;
+  const srcset = value.replace(/(^|,)(\s*)([^,\s]+)([^,]*)/g, (match, separator: string, whitespace: string, url: string, descriptor: string) => {
+    const token = createAssetToken(url, htmlId, assets);
+    if (token == null) return match;
+    changed = true;
+    return `${separator}${whitespace}${token.token}${descriptor}`;
+  });
+
+  if (changed) {
+    replacements.push({ ...valueLocation, value: srcset });
+  }
+}
+
+function createAssetToken(specifier: string, htmlId: string, assets: AssetToken[]): AssetToken | undefined {
+  if (!shouldBundleAsset(specifier, htmlId)) return void 0;
+  const importSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`;
+  const existingAsset = assets.find(asset => asset.specifier === importSpecifier);
+  if (existingAsset != null) return existingAsset;
+
+  const token = `__au_vite_asset_${assets.length}__`;
+  const asset = {
+    token,
+    variable: `__auViteAsset${assets.length}`,
+    specifier: importSpecifier,
+  };
+  assets.push(asset);
+  return asset;
+}
+
+function shouldBundleAsset(specifier: string, htmlId: string): boolean {
+  if (
+    specifier === ''
+    || specifier.includes('${')
+    || specifier.startsWith('/')
+    || specifier.startsWith('#')
+    || /^[a-z][a-z\d+.-]*:/i.test(specifier)
+    || specifier.startsWith('//')
+  ) {
+    return false;
+  }
+
+  const filePath = getFilePath(specifier);
+  if (filePath == null) return false;
+
+  const resolved = resolve(dirname(htmlId), filePath);
+  try {
+    return statSync(resolved).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function getFilePath(specifier: string): string | undefined {
+  const [filePath] = specifier.split(/[?#]/, 1);
+  if (filePath === '') return void 0;
+  try {
+    return decodeURI(filePath);
+  } catch {
+    return void 0;
+  }
+}
+
+function getAttributeValueLocation(html: string, attrLocation: AttributeLocation): { start: number; end: number } | undefined {
+  const raw = html.slice(attrLocation.startOffset, attrLocation.endOffset);
+  const equals = raw.indexOf('=');
+  if (equals < 0) return void 0;
+
+  let start = attrLocation.startOffset + equals + 1;
+  while (/\s/.test(html[start])) {
+    start++;
+  }
+
+  const quote = html[start];
+  if (quote === '"' || quote === "'") {
+    return { start: start + 1, end: attrLocation.endOffset - 1 };
+  }
+
+  return { start, end: attrLocation.endOffset };
+}
+
+function applyReplacements(html: string, replacements: Replacement[]): string {
+  return replacements
+    .sort((a, b) => b.start - a.start)
+    .reduce((output, replacement) => {
+      return `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`;
+    }, html);
+}
+
+function createTemplateExpression(html: string, assets: AssetToken[]): string {
+  const tokenToVariable = new Map(assets.map(asset => [asset.token, asset.variable]));
+  const tokenPattern = new RegExp(assets.map(asset => asset.token).join('|'), 'g');
+  const parts: string[] = [];
+  let offset = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(html)) !== null) {
+    if (match.index > offset) {
+      parts.push(JSON.stringify(html.slice(offset, match.index)));
+    }
+    parts.push(tokenToVariable.get(match[0])!);
+    offset = match.index + match[0].length;
+  }
+
+  if (offset < html.length) {
+    parts.push(JSON.stringify(html.slice(offset)));
+  }
+
+  return parts.join(' + ');
+}


### PR DESCRIPTION
Process static relative asset URLs referenced from conventional HTML templates during Vite production builds so Vite can emit and rewrite them. Adds a transformHtmlTemplate hook to plugin-conventions, a template-assets transformer (uses parse5), accompanying tests and docs.

This tries to address issue #2371 but in a least destructive way.