### PR TITLE
fix(router): returning false from canUnload did not restore the route-context

### DIFF
--- a/.changeset/chilly-moons-kick.md
+++ b/.changeset/chilly-moons-kick.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/router": patch
+---
+
+fix(router): returning false from canUnload did not restore the route-context. PR #2431

--- a/packages/__tests__/src/router/smoke-tests.spec.ts
+++ b/packages/__tests__/src/router/smoke-tests.spec.ts
@@ -1,7 +1,7 @@
 import { LogLevel, Constructable, kebabCase, ILogConfig, Registration, IModule, inject, resolve, isArray } from '@aurelia/kernel';
 import { assert, MockBrowserHistoryLocation, TestContext } from '@aurelia/testing';
 import { tasksSettled } from '@aurelia/runtime';
-import { RouterConfiguration, IRouter, NavigationInstruction, IRouteContext, RouteNode, Params, route, INavigationModel, IRouterOptions, IRouteViewModel, IRouteConfig, Router, HistoryStrategy, IRouterEvents, ITypedNavigationInstruction_string, IViewportInstruction, RouteConfig, Routeable, RouterOptions, RouteContext, ViewportInstruction, INavigationOptions, ILocationManager } from '@aurelia/router';
+import { RouterConfiguration, IRouter, NavigationInstruction, IRouteContext, ICurrentRoute, RouteNode, Params, route, INavigationModel, IRouterOptions, IRouteViewModel, IRouteConfig, Router, HistoryStrategy, IRouterEvents, ITypedNavigationInstruction_string, IViewportInstruction, RouteConfig, Routeable, RouterOptions, RouteContext, ViewportInstruction, INavigationOptions, ILocationManager } from '@aurelia/router';
 import { Aurelia, valueConverter, customElement, CustomElement, ICustomElementViewModel, IHistory, IHydratedController, ILocation, INode, IPlatform, IWindow, watch } from '@aurelia/runtime-html';
 
 import { getLocationChangeHandlerRegistration, TestRouterConfiguration } from './_shared/configuration.js';
@@ -7593,4 +7593,69 @@ describe('router/smoke-tests.spec.ts', function () {
       await au.stop(true);
     });
   }
+
+  it('does not corrupt IRouteContext.node after a cancelled canUnload', async function () {
+    let canUnloadCount = 0;
+
+    @customElement({ name: 'c-1', template: 'c1' })
+    class C1 implements IRouteViewModel {
+      public async canUnload(): Promise<boolean> {
+        // First call returns false (block navigation), subsequent calls return true
+        return ++canUnloadCount > 1;
+      }
+    }
+
+    @customElement({ name: 'c-2', template: 'c2' })
+    class C2 { }
+
+    @route({
+      routes: [
+        { path: 'c1', component: C1 },
+        { path: 'c2', component: C2 },
+      ]
+    })
+    @customElement({ name: 'p-1', template: 'p1 <au-viewport></au-viewport>' })
+    class P1 {
+      public readonly ctx: IRouteContext = resolve(IRouteContext);
+      public readonly currentRoute: ICurrentRoute = resolve(ICurrentRoute);
+    }
+
+    @route({ routes: [P1] })
+    @customElement({ name: 'ro-ot', template: '<au-viewport></au-viewport>' })
+    class Root { }
+
+    const { au, container, host } = await start({ appRoot: Root });
+    const router = container.get(IRouter);
+
+    await router.load('p-1/c1');
+    assert.html.textContent(host, 'p1 c1', 'initial load');
+
+    const p1vm = CustomElement.for<P1>(host.querySelector('p-1')!).viewModel;
+    const ctx = p1vm.ctx;
+
+    assert.strictEqual(ctx.node.children.length, 1, 'before cancel: 1 child');
+    assert.strictEqual(ctx.node.children[0].component.name, 'c-1', 'before cancel: child is c-1');
+    assert.strictEqual(p1vm.currentRoute.path, 'p-1/c1', 'before cancel: current route path is p-1/c1');
+
+    // First navigation attempt - blocked by canUnload returning false
+    const result1 = await router.load('p-1/c2');
+    assert.strictEqual(result1, false, 'first navigation should be cancelled');
+    assert.html.textContent(host, 'p1 c1', 'after cancelled navigation: still showing c1');
+
+    // After failed navigation, IRouteContext.node must still reflect the active state (c1), not the cancelled state (c2)
+    assert.strictEqual(ctx.node.children.length, 1, 'after cancel: still 1 child');
+    assert.strictEqual(ctx.node.children[0].component.name, 'c-1', 'after cancel: child is still c-1');
+    assert.strictEqual(p1vm.currentRoute.path, 'p-1/c1', 'after cancel: current route path is still p-1/c1');
+
+    // Second navigation attempt - canUnload now returns true
+    const result2 = await router.load('p-1/c2');
+    assert.strictEqual(result2, true, 'second navigation should succeed');
+    assert.html.textContent(host, 'p1 c2', 'after successful navigation: showing c2');
+
+    assert.strictEqual(ctx.node.children.length, 1, 'after success: 1 child');
+    assert.strictEqual(ctx.node.children[0].component.name, 'c-2', 'after success: child is c-2');
+    assert.strictEqual(p1vm.currentRoute.path, 'p-1/c2', 'after success: current route path is p-1/c2');
+
+    await au.stop(true);
+  });
 });

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -751,6 +751,13 @@ export class Router {
 
       this._instructions = tr.prevInstructions;
       this._routeTree = tr.previousRouteTree;
+
+      // Restore context.node for every node in the previous route tree.
+      // RouteNode._clone() and createConfiguredNode both update context.node at the
+      // start of each navigation; those updates must be reverted when navigation is
+      // cancelled so that IRouteContext.node stays consistent with the active tree.
+      restoreRouteTreeContextNodes(tr.previousRouteTree.root);
+
       this._isNavigating = false;
       const guardsResult = tr.guardsResult;
       this._events.publish(new NavigationCancelEvent(tr.id, tr.instructions, `guardsResult is ${guardsResult}`));
@@ -772,6 +779,13 @@ export class Router {
         });
       }
     })._start();
+
+    function restoreRouteTreeContextNodes(node: RouteNode): void {
+      node.context.node = node;
+      for (const child of node.children) {
+        restoreRouteTreeContextNodes(child);
+      }
+    }
   }
 
   /** @internal */


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

Fixes this issue https://discord.com/channels/448698263508615178/1243519563283435520/1509732807042400430.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback.
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## 📦 Changeset

<!---
If this PR affects published packages (features, bug fixes, refactors), run `npx changeset` and commit the generated file.
Skip for docs-only, test-only, or non-published code changes.
-->

- [x] Added a changeset via `npx changeset` (or not needed for this PR)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->

<!--
Love Aurelia? Please consider supporting our collective:
👉  https://opencollective.com/aurelia
-->
