### PR TITLE
fix(runtime): ensure start/stop return promises

### DIFF
--- a/.changeset/fix-aurelia-start-stop-promises.md
+++ b/.changeset/fix-aurelia-start-stop-promises.md
@@ -1,0 +1,6 @@
+---
+"@aurelia/runtime-html": patch
+"aurelia": patch
+---
+
+Ensure `Aurelia.start()` and `Aurelia.stop()` always return `Promise<void>`. Fixes #2433.

--- a/packages/__tests__/src/3-runtime-html/aurelia.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/aurelia.spec.ts
@@ -1,0 +1,82 @@
+import { Aurelia, CustomElement } from '@aurelia/runtime-html';
+import { assert, TestContext } from '@aurelia/testing';
+
+describe('3-runtime-html/aurelia.spec.ts', function () {
+  it('returns promises from start and stop', async function () {
+    const ctx = TestContext.create();
+    const au = new Aurelia(ctx.container);
+    const host = ctx.createElement('div');
+    const App = CustomElement.define({ name: 'app', template: '' }, class {});
+
+    au.app({ host, component: App });
+
+    const startPromise = au.start();
+    assert.instanceOf(startPromise, Promise, 'start promise');
+    await startPromise;
+
+    const stopPromise = au.stop();
+    assert.instanceOf(stopPromise, Promise, 'stop promise');
+    await stopPromise;
+
+    const alreadyStoppedPromise = au.stop();
+    assert.instanceOf(alreadyStoppedPromise, Promise, 'already stopped promise');
+    await alreadyStoppedPromise;
+
+    au.dispose();
+  });
+
+  it('reuses in-flight promises during async start and stop', async function () {
+    const ctx = TestContext.create();
+    const au = new Aurelia(ctx.container);
+    const host = ctx.createElement('div');
+    const startGate = createGate();
+    const stopGate = createGate();
+    let attachedCount = 0;
+    let detachingCount = 0;
+    const App = CustomElement.define({ name: 'app', template: '' }, class {
+      public attached(): Promise<void> {
+        attachedCount++;
+        return startGate.promise;
+      }
+
+      public detaching(): Promise<void> {
+        detachingCount++;
+        return stopGate.promise;
+      }
+    });
+
+    au.app({ host, component: App });
+
+    const startPromise = au.start();
+    const duplicateStartPromise = au.start();
+    assert.strictEqual(duplicateStartPromise, startPromise, 'start promise');
+    assert.strictEqual(attachedCount, 1, 'attached count before start resolves');
+
+    startGate.resolve();
+    await startPromise;
+    assert.strictEqual(au.isRunning, true, 'is running after start');
+
+    const stopPromise = au.stop();
+    const duplicateStopPromise = au.stop();
+    assert.strictEqual(duplicateStopPromise, stopPromise, 'stop promise');
+    assert.strictEqual(detachingCount, 1, 'detaching count before stop resolves');
+
+    const restartPromise = au.start();
+    assert.instanceOf(restartPromise, Promise, 'restart promise');
+    assert.strictEqual(attachedCount, 1, 'restart waits for stop before attaching again');
+
+    stopGate.resolve();
+    await Promise.all([stopPromise, restartPromise]);
+    assert.strictEqual(attachedCount, 2, 'attached count after restart');
+    assert.strictEqual(au.isRunning, true, 'is running after restart');
+
+    await au.stop();
+    au.dispose();
+  });
+});
+
+function createGate(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => { resolve = r; });
+  return { promise, resolve };
+}

--- a/packages/aurelia/src/api-test.ts
+++ b/packages/aurelia/src/api-test.ts
@@ -1,8 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import Aurelia from '.';
+import Aurelia, { CustomElement } from '.';
+
+type AssertPromise<T extends Promise<void>> = T;
+type _StaticAppStartReturnsPromise = AssertPromise<ReturnType<ReturnType<typeof Aurelia.app>['start']>>;
 
 function testAureliaApp() {
+  const App = CustomElement.define({ name: 'app', template: '' }, class {});
+
   void Aurelia.app({ host: document.body, component: class { } }).start();
+  void Aurelia.app(App).start().then(() => undefined);
+  void Aurelia.app(App).start().then((au) => {
+    const value: void = au;
+    return value;
+  });
   void Aurelia.enhance({ host: document.body, component: class { } });
 }

--- a/packages/runtime-html/src/api-test.ts
+++ b/packages/runtime-html/src/api-test.ts
@@ -2,14 +2,19 @@
 import { onResolve } from '@aurelia/kernel';
 import { Aurelia } from './aurelia';
 
+type AssertPromise<T extends Promise<void>> = T;
+type _StartReturnsPromise = AssertPromise<ReturnType<Aurelia['start']>>;
+type _StopReturnsPromise = AssertPromise<ReturnType<Aurelia['stop']>>;
+
 // test .app + .enhance
 // but mostly test the auto inferrence of the component type on the .enhance API
 function testAureliaApi(au: Aurelia) {
   class Abc { public abc = 5; }
+  const startPromise: Promise<void> = au.app({ host: document.body, component: Abc }).start();
   return [
     // if necessary, we can try enhance the typing for Aurelia & IAurelia
     // to make it auto infer the type of the component in the main app root
-    onResolve(au.app({ host: document.body, component: Abc }).start(), (root) => {
+    onResolve(startPromise, (root) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       return au.root.controller.viewModel.abc;

--- a/packages/runtime-html/src/aurelia.ts
+++ b/packages/runtime-html/src/aurelia.ts
@@ -118,7 +118,7 @@ export class Aurelia implements IDisposable {
 
   /** @internal */
   private _startPromise: Promise<void> | void = void 0;
-  public start(root: IAppRoot | undefined = this.next): void | Promise<void> {
+  public start(root: IAppRoot | undefined = this.next): Promise<void> {
     if (root == null) {
       throw createMappedError(ErrorNames.no_composition_root);
     }
@@ -127,7 +127,7 @@ export class Aurelia implements IDisposable {
       return this._startPromise;
     }
 
-    return this._startPromise = onResolve(this.stop(), () => {
+    const startPromise = onResolve(this._stop(), () => {
       if (!refs.hideProp) {
         Reflect.set(root.host, '$aurelia', this);
       }
@@ -141,11 +141,20 @@ export class Aurelia implements IDisposable {
         this._dispatchEvent(root, 'au-started', root.host);
       });
     });
+    return isPromise(startPromise)
+      ? this._startPromise = startPromise
+      : Promise.resolve();
   }
 
   /** @internal */
   private _stopPromise: Promise<void> | void = void 0;
-  public stop(dispose: boolean = false): void | Promise<void> {
+  public stop(dispose: boolean = false): Promise<void> {
+    const stopPromise = this._stop(dispose);
+    return isPromise(stopPromise) ? stopPromise : Promise.resolve();
+  }
+
+  /** @internal */
+  private _stop(dispose: boolean = false): void | Promise<void> {
     if (isPromise(this._stopPromise)) {
       return this._stopPromise;
     }


### PR DESCRIPTION
Ensure Aurelia.start() and Aurelia.stop() always return Promise<void> (even for synchronous paths) and reuse in‑flight promises so concurrent calls share the same promise. Added unit and type tests to verify the behaviour. Fixes #2433.