### PR TITLE
fix(kernel): report correct errors for unregistered interfaces

### DIFF
--- a/.changeset/fix-di-interface-errors.md
+++ b/.changeset/fix-di-interface-errors.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/kernel": patch
+---
+
+Fix error reporting for interfaces without a registration or default implementation. Resolving one reports AUR0012. Resolving one through `newInstanceOf` or `newInstanceForScope` reports AUR0017, including before any interface with a default implementation has been resolved.

--- a/packages/__tests__/src/1-kernel/di.exception.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.exception.spec.ts
@@ -2,20 +2,23 @@ import { DI, optional, resolve } from '@aurelia/kernel';
 import { assert } from '@aurelia/testing';
 
 describe('1-kernel/di.exception.spec.ts', function () {
-  it('No registration for interface', function () {
+  it('reports AUR0012 for an unregistered interface without a default', function () {
     const container = DI.createContainer();
 
     interface Foo {}
 
     const Foo = DI.createInterface<Foo>('Foo');
+    const expectedError = /AUR0012.*Foo/;
 
     class Bar {
       public readonly foo: Foo = resolve(Foo);
     }
 
-    assert.throws(() => container.get(Foo), /.*Foo*/, 'throws once');
-    assert.throws(() => container.get(Foo), /.*Foo*/, 'throws twice'); // regression test
-    assert.throws(() => container.get(Bar), /.*Foo.*/, 'throws on inject into');
+    assert.throws(() => container.get(Foo), expectedError, 'throws once');
+    assert.throws(() => container.get(Foo), expectedError, 'throws twice'); // regression test
+    assert.throws(() => container.getResolver(Foo, true), expectedError, 'throws from auto-registering getResolver');
+    assert.strictEqual(container.getResolver(Foo, false), null, 'does not throw when auto-registration is disabled');
+    assert.throws(() => container.get(Bar), expectedError, 'throws on inject into');
   });
 
   it('cyclic dependency', function () {

--- a/packages/__tests__/src/1-kernel/di.get.spec.ts
+++ b/packages/__tests__/src/1-kernel/di.get.spec.ts
@@ -548,10 +548,31 @@ describe('1-kernel/di.get.spec.ts', function () {
   });
 
   describe('@newInstanceOf', function () {
-    it('throws when there is no registration for interface', function () {
+    it('throws AUR0017 for a no-default interface regardless of prior default activation', function () {
       const container = DI.createContainer();
-      const I = DI.createInterface('I');
-      assert.throws(() => container.get(newInstanceOf(I)), `No registration for interface: 'I'`);
+      const Missing = DI.createInterface('Missing');
+      const expectedError = /AUR0017.*InterfaceSymbol<Missing>/;
+      const assertMissingInterface = (phase: string) => {
+        assert.throws(
+          () => container.get(newInstanceOf(Missing)),
+          expectedError,
+          `newInstanceOf ${phase}`,
+        );
+        assert.throws(
+          () => container.get(newInstanceForScope(Missing)),
+          expectedError,
+          `newInstanceForScope ${phase}`,
+        );
+      };
+
+      // Exercise both missing-interface paths before the first default-interface activation in this spec.
+      assertMissingInterface('before default activation');
+
+      class Impl {}
+      const WithDefault = DI.createInterface('WithDefault', x => x.singleton(Impl));
+      assert.instanceOf(container.get(newInstanceOf(WithDefault)), Impl);
+
+      assertMissingInterface('after default activation');
     });
 
     it('instantiates when there is an constructable registration for an interface', function () {

--- a/packages/kernel/src/di.container.ts
+++ b/packages/kernel/src/di.container.ts
@@ -583,7 +583,7 @@ export class Container implements IContainer {
   /** @internal */
   private _jitRegister(keyAsValue: any, handler: Container): IResolver {
     const $isRegistry = isRegistry(keyAsValue);
-    if (!isFunction(keyAsValue) && !$isRegistry) {
+    if (!isFunction(keyAsValue) && !$isRegistry && keyAsValue?.$isInterface !== true) {
       throw createMappedError(ErrorNames.unable_jit_non_constructor, keyAsValue);
     }
 
@@ -603,7 +603,6 @@ export class Container implements IContainer {
       return registrationResolver as IResolver;
     }
 
-    // TODO(sayan): remove potential dead code
     if (keyAsValue.$isInterface) {
       throw createMappedError(ErrorNames.no_jit_interface, keyAsValue.friendlyName);
     }

--- a/packages/kernel/src/di.resolvers.ts
+++ b/packages/kernel/src/di.resolvers.ts
@@ -263,8 +263,8 @@ const createNewInstance = (key: any, handler: IContainer, requestor: IContainer)
       if (hasDefault) {
         // creating a new container as we do not want to pollute the resolver registry
         factory = (newInstanceContainer ??= createContainer()).getResolver(key, true)?.getFactory?.(handler);
+        newInstanceContainer.dispose();
       }
-      newInstanceContainer.dispose();
     } else {
       factory = resolver.getFactory?.(handler);
     }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

DI interfaces without a registration or default implementation could report incorrect or order-dependent errors. Direct resolution reported AUR0009 instead of AUR0012, while the first use of `newInstanceOf` or `newInstanceForScope` could throw a raw `TypeError` instead of AUR0017.

## 💁 Your Solution

Allow interface symbols to reach the dedicated no-registration error path, and only dispose the new-instance scratch container when that path initialized it.

## 📑 Test Plan

Added regression coverage for:

- Direct and injected interface resolution.
- Auto-registering and non-auto-registering `getResolver` calls.
- `newInstanceOf` and `newInstanceForScope` before and after resolving a default-backed interface.

The full build and kernel test suite pass.

## 📦 Changeset

- [x] Added a changeset via `npx changeset`