### PR TITLE
fix(runtime): detach collection length and size observers

### DIFF
--- a/.changeset/fix-collection-length-observer-unsubscribe.md
+++ b/.changeset/fix-collection-length-observer-unsubscribe.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime": patch
+---
+
+Fix collection length and size observers to detach from their owning collection after their final subscriber unsubscribes.

--- a/packages/__tests__/src/2-runtime/collection-length-observer.spec.ts
+++ b/packages/__tests__/src/2-runtime/collection-length-observer.spec.ts
@@ -1,0 +1,57 @@
+import {
+  getCollectionObserver,
+  type Collection,
+  type CollectionObserver,
+  type ICollectionSubscriberCollection,
+  type ISubscriber,
+} from '@aurelia/runtime';
+import { assert, createSpy } from '@aurelia/testing';
+
+const cases: readonly [name: string, createCollection: () => Collection][] = [
+  ['array length', () => []],
+  ['map size', () => new Map()],
+  ['set size', () => new Set()],
+];
+
+describe('2-runtime/collection-length-observer.spec.ts', function () {
+  for (const [name, createCollection] of cases) {
+    it(`subscribes and unsubscribes the ${name} observer with its owner`, function () {
+      const owner = getCollectionObserver(createCollection()) as CollectionObserver & ICollectionSubscriberCollection;
+      const observer = owner.getLengthObserver();
+      const subscribeSpy = createSpy(owner, 'subscribe', true);
+      const unsubscribeSpy = createSpy(owner, 'unsubscribe', true);
+      const subscriber1: ISubscriber = { handleChange() {} };
+      const subscriber2: ISubscriber = { handleChange() {} };
+
+      try {
+        observer.subscribe(subscriber1);
+        assert.strictEqual(subscribeSpy.calls.length, 1, 'subscribes to the owner for the first subscriber');
+        assert.strictEqual(owner.subs.count, 1, 'owner has one subscriber');
+
+        observer.subscribe(subscriber2);
+        assert.strictEqual(subscribeSpy.calls.length, 1, 'does not subscribe to the owner again');
+        assert.strictEqual(owner.subs.count, 1, 'owner still has one subscriber');
+
+        observer.unsubscribe(subscriber1);
+        assert.strictEqual(unsubscribeSpy.calls.length, 0, 'stays subscribed to the owner while one subscriber remains');
+        assert.strictEqual(owner.subs.count, 1, 'owner still has one subscriber');
+
+        observer.unsubscribe(subscriber2);
+        assert.strictEqual(subscribeSpy.calls.length, 1, 'does not subscribe to the owner during final removal');
+        assert.strictEqual(unsubscribeSpy.calls.length, 1, 'unsubscribes from the owner after the final subscriber');
+        assert.strictEqual(owner.subs.count, 0, 'owner has no subscribers');
+
+        observer.subscribe(subscriber1);
+        assert.strictEqual(subscribeSpy.calls.length, 2, 'resubscribes to the owner for a new subscriber');
+        assert.strictEqual(owner.subs.count, 1, 'owner has one subscriber after resubscription');
+
+        observer.unsubscribe(subscriber1);
+        assert.strictEqual(unsubscribeSpy.calls.length, 2, 'unsubscribes from the owner again');
+        assert.strictEqual(owner.subs.count, 0, 'owner has no subscribers after the second cycle');
+      } finally {
+        subscribeSpy.restore();
+        unsubscribeSpy.restore();
+      }
+    });
+  }
+});

--- a/packages/runtime/src/collection-length-observer.ts
+++ b/packages/runtime/src/collection-length-observer.ts
@@ -136,6 +136,6 @@ function subscribe(this: CollectionLengthObserverImpl, subscriber: ISubscriber):
 
 function unsubscribe(this: CollectionLengthObserverImpl, subscriber: ISubscriber): void {
   if (this.subs.remove(subscriber) && this.subs.count === 0) {
-    this.owner.subscribe(this);
+    this.owner.unsubscribe(this);
   }
 }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Collection length and size observers remained attached to their owning collection after their final subscriber unsubscribed, causing unnecessary collection-change work.

## 💁 Your Solution

Detach the observer from its owner on the zero-subscriber transition.

## 📑 Test Plan

Added lifecycle regression coverage for array length, map size, and set size observers.

## 📦 Changeset

- [x] Added a changeset