### PR TITLE
fix(router): preserve static nav and derive convention route ids

### DIFF
--- a/.changeset/fix-route-config-normalization.md
+++ b/.changeset/fix-route-config-normalization.md
@@ -1,0 +1,7 @@
+---
+"@aurelia/router": patch
+---
+
+Object-form route configurations now preserve a component's static `nav` value when no explicit override is supplied.
+
+Convention-only routes now derive their ID from the primary effective custom element path, including child configuration and configuration-hook path overrides.

--- a/packages/__tests__/src/router/config-tests.spec.ts
+++ b/packages/__tests__/src/router/config-tests.spec.ts
@@ -181,6 +181,31 @@ describe('router/config-tests.spec.ts', function () {
       await fixture.tearDown();
     });
 
+    it('preserves an explicit configuration hook ID through a child path override', async function () {
+      @customElement({ name: 'explicit-hook-route', template: null })
+      class ExplicitHookRoute implements IRouteViewModel {
+        public getRouteConfig(): IRouteConfig {
+          return { id: 'hook-id', path: 'hook-path' };
+        }
+      }
+
+      const hookFixture = await createFixture(ExplicitHookRoute, [], getDefaultHIAConfig);
+      const hookConfig = Route.getConfig(ExplicitHookRoute);
+      assert.strictEqual(hookConfig.id, 'hook-id');
+      assert.deepStrictEqual(hookConfig.path, ['hook-path']);
+      await hookFixture.tearDown();
+
+      @route({ routes: [{ path: 'child-path', component: ExplicitHookRoute }] })
+      @customElement({ name: 'hook-parent', template: vp(1), dependencies: [ExplicitHookRoute] })
+      class HookParent {}
+
+      const parentFixture = await createFixture(HookParent, [], getDefaultHIAConfig);
+      const childConfig = await parentFixture.router.routeTree.root.context.routeConfigContext.childRoutes[0];
+      assert.strictEqual(childConfig.id, 'hook-id');
+      assert.deepStrictEqual(childConfig.path, ['child-path']);
+      await parentFixture.tearDown();
+    });
+
     it('preserves configured and static route identity precedence', function () {
       @route({ id: 'configured-id', path: ['configured-path', 'configured-alias'] })
       @customElement({ name: 'configured-element', template: null })

--- a/packages/__tests__/src/router/config-tests.spec.ts
+++ b/packages/__tests__/src/router/config-tests.spec.ts
@@ -81,6 +81,131 @@ export abstract class SimpleActivityTrackingVMBase {
 }
 
 describe('router/config-tests.spec.ts', function () {
+  describe('RouteConfig normalization', function () {
+    it('applies explicit, static, and default nav values in precedence order', function () {
+      @route({ path: 'static-nav' })
+      @customElement({ name: 'static-nav', template: null })
+      class StaticNav {
+        public static readonly nav = false;
+      }
+
+      @route({ path: 'explicit-nav', nav: true })
+      @customElement({ name: 'explicit-nav', template: null })
+      class ExplicitNav {
+        public static readonly nav = false;
+      }
+
+      @customElement({ name: 'default-nav', template: null })
+      class DefaultNav {}
+
+      assert.strictEqual(Route.getConfig(StaticNav).nav, false);
+      assert.strictEqual(Route.getConfig(ExplicitNav).nav, true);
+      assert.strictEqual(Route.getConfig(DefaultNav).nav, true);
+    });
+
+    it('derives convention IDs from the primary custom element path', function () {
+      @customElement({
+        name: 'convention-route',
+        aliases: ['convention-alias', 'other-alias'],
+        template: null,
+      })
+      class ConventionRoute {}
+
+      const config = Route.getConfig(ConventionRoute);
+      assert.strictEqual(config.id, 'convention-route');
+      assert.deepStrictEqual(config.path, ['convention-route', 'convention-alias', 'other-alias']);
+    });
+
+    it('derives child IDs from each effective child path', async function () {
+      @customElement({
+        name: 'convention-child',
+        aliases: ['child-alias'],
+        template: null,
+      })
+      class ConventionChild {}
+
+      @customElement({ name: 'empty-path-child', aliases: ['empty-path-alias'], template: null })
+      class EmptyPathChild {}
+
+      @route({
+        routes: [
+          ConventionChild,
+          { path: 'configured-child', component: ConventionChild },
+          { path: [], component: EmptyPathChild },
+        ],
+      })
+      @customElement({ name: 'child-root', template: vp(1), dependencies: [ConventionChild, EmptyPathChild] })
+      class ChildRoot {}
+
+      const fixture = await createFixture(ChildRoot, [], getDefaultHIAConfig);
+      const childRoutes = fixture.router.routeTree.root.context.routeConfigContext.childRoutes;
+      const bareConfig = await childRoutes[0];
+      assert.strictEqual(bareConfig.id, 'convention-child');
+      assert.deepStrictEqual(bareConfig.path, ['convention-child', 'child-alias']);
+
+      const objectConfig = await childRoutes[1];
+      assert.strictEqual(objectConfig.id, 'configured-child');
+      assert.deepStrictEqual(objectConfig.path, ['configured-child']);
+
+      const emptyPathConfig = await childRoutes[2];
+      assert.strictEqual(emptyPathConfig.id, 'empty-path-child');
+      assert.deepStrictEqual(emptyPathConfig.path, ['empty-path-child', 'empty-path-alias']);
+      await fixture.tearDown();
+    });
+
+    it('derives convention IDs with either route and custom element decorator order', function () {
+      @route({})
+      @customElement({ name: 'route-outermost', template: null })
+      class RouteOutermost {}
+
+      @customElement({ name: 'element-outermost', template: null })
+      @route({})
+      class ElementOutermost {}
+
+      assert.strictEqual(Route.getConfig(RouteOutermost).id, 'route-outermost');
+      assert.strictEqual(Route.getConfig(ElementOutermost).id, 'element-outermost');
+    });
+
+    it('updates convention IDs when a configuration hook replaces the effective path', async function () {
+      @customElement({ name: 'hook-route', template: null })
+      class HookRoute implements IRouteViewModel {
+        public getRouteConfig(): IRouteConfig {
+          return { path: 'hook-path' };
+        }
+      }
+
+      const fixture = await createFixture(HookRoute, [], getDefaultHIAConfig);
+      const config = Route.getConfig(HookRoute);
+      assert.strictEqual(config.id, 'hook-path');
+      assert.deepStrictEqual(config.path, ['hook-path']);
+      await fixture.tearDown();
+    });
+
+    it('preserves configured and static route identity precedence', function () {
+      @route({ id: 'configured-id', path: ['configured-path', 'configured-alias'] })
+      @customElement({ name: 'configured-element', template: null })
+      class ConfiguredIdentity {
+        public static readonly id = 'static-id';
+        public static readonly path = 'static-path';
+      }
+
+      @route({})
+      @customElement({ name: 'static-element', template: null })
+      class StaticIdentity {
+        public static readonly id = 'static-id';
+        public static readonly path = ['static-path', 'static-alias'];
+      }
+
+      const configured = Route.getConfig(ConfiguredIdentity);
+      assert.strictEqual(configured.id, 'configured-id');
+      assert.deepStrictEqual(configured.path, ['configured-path', 'configured-alias']);
+
+      const staticConfig = Route.getConfig(StaticIdentity);
+      assert.strictEqual(staticConfig.id, 'static-id');
+      assert.deepStrictEqual(staticConfig.path, ['static-path', 'static-alias']);
+    });
+  });
+
   describe('monomorphic timings', function () {
     const componentSpecs: IComponentSpec[] = [
       {

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -148,9 +148,6 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
       this._component, // The RouteConfig is created using a definitive Type as component; do not overwrite it.
       config.nav ?? this.nav,
     );
-    if (config.id == null && config.path == null && conventionIdConfigs.has(this)) {
-      conventionIdConfigs.add(childConfig);
-    }
     return finalizeRouteConfigId(childConfig);
   }
 

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -13,6 +13,11 @@ import { Events, getMessage } from './events';
 import { RecognizedRoute, RESIDUE } from '@aurelia/route-recognizer';
 
 export const noRoutes = emptyArray as RouteConfig['routes'];
+// A convention ID cannot be resolved in _create because @route may initialize before @customElement. Route.getConfig
+// finalizes it once the custom-element definition exists, but membership remains here so child configs and hooks can
+// distinguish the derived ID from an explicit/static one and rederive it when they replace the effective path.
+// External bookkeeping also preserves id as an own enumerable RouteConfig field.
+const conventionIdConfigs = new WeakSet<RouteConfig>();
 
 // Every kind of route configurations are normalized to this `RouteConfig` class.
 export class RouteConfig implements IRouteConfig, IChildRouteConfig {
@@ -45,6 +50,7 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
     component: Routeable | NavigationStrategy,
     public readonly nav: boolean,
   ) {
+    if (id === void 0) conventionIdConfigs.add(this);
     this._component = component;
     this._isNavigationStrategy = component instanceof NavigationStrategy;
   }
@@ -111,7 +117,7 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
         children,
         config.fallback ?? Type?.fallback ?? null,
         (config as IChildRouteConfig).component ?? Type ?? null,
-        config.nav ?? true,
+        config.nav ?? Type?.nav ?? true,
       );
     } else {
       expectType('string, function/class or object', '', configOrPath);
@@ -128,8 +134,8 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
   public _applyChildRouteConfig(config: IChildRouteConfig, parentConfig: RouteConfig | null): RouteConfig {
     validateRouteConfig(config, this.path[0] ?? '');
     const path = ensureArrayOfStrings(config.path ?? this.path);
-    return new RouteConfig(
-      ensureString(config.id ?? this.id ?? path),
+    const childConfig = new RouteConfig(
+      ensureString(config.id ?? (conventionIdConfigs.has(this) ? path : this.id)),
       path,
       config.title ?? this.title,
       config.redirectTo ?? this.redirectTo,
@@ -142,6 +148,10 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
       this._component, // The RouteConfig is created using a definitive Type as component; do not overwrite it.
       config.nav ?? this.nav,
     );
+    if (config.id == null && config.path == null && conventionIdConfigs.has(this)) {
+      conventionIdConfigs.add(childConfig);
+    }
+    return finalizeRouteConfigId(childConfig);
   }
 
   /** @internal */
@@ -180,8 +190,13 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
         validateRouteConfig(value, parentPath);
 
         // the value from the hook takes precedence
-        (this as Writable<RouteConfig>).id = value.id ?? this.id;
         (this as Writable<RouteConfig>)._path = ensureArrayOfStrings(value.path ?? this.path);
+        if (value.id != null) {
+          conventionIdConfigs.delete(this);
+          (this as Writable<RouteConfig>).id = value.id;
+        } else {
+          finalizeRouteConfigId(this);
+        }
         (this as Writable<RouteConfig>).title = value.title ?? this.title;
         (this as Writable<RouteConfig>).redirectTo = value.redirectTo ?? this.redirectTo;
         (this as Writable<RouteConfig>).caseSensitive = value.caseSensitive ?? this.caseSensitive;
@@ -196,7 +211,7 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
 
   /** @internal */
   public _clone(): RouteConfig {
-    return new RouteConfig(
+    const clone = new RouteConfig(
       this.id,
       this.path,
       this.title,
@@ -210,6 +225,8 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
       this._component,
       this.nav,
     );
+    if (conventionIdConfigs.has(this)) conventionIdConfigs.add(clone);
+    return finalizeRouteConfigId(clone);
   }
 
   /** @internal */
@@ -263,6 +280,13 @@ export class RouteConfig implements IRouteConfig, IChildRouteConfig {
   }
 }
 
+function finalizeRouteConfigId(config: RouteConfig): RouteConfig {
+  if (conventionIdConfigs.has(config)) {
+    (config as Writable<RouteConfig>).id = ensureString(config.path);
+  }
+  return config;
+}
+
 export const Route = {
   name: /*@__PURE__*/getResourceKeyFor('route-configuration'),
   /**
@@ -293,7 +317,7 @@ export const Route = {
       Route.configure({}, Type);
     }
 
-    return Metadata.get(Route.name, Type)!;
+    return finalizeRouteConfigId(Metadata.get(Route.name, Type)!);
   },
 };
 


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

- **Static navigation:** Object-form route configurations ignored a component’s static `nav` value.
- **Convention route IDs:** Convention-only routes could expose an undefined or stale ID when their effective path was resolved later.

## 💁 Your Solution

- **Static navigation:** Preserve the static `nav` value when no explicit override is supplied.
- **Convention route IDs:** Derive the ID from the primary effective path, including child configuration and configuration-hook overrides.

## 📑 Test Plan

Added RouteConfig normalization coverage for both static navigation precedence and convention-derived route IDs.

## 📦 Changeset

- [x] Added a changeset