### PR TITLE
fix(runtime): handle cyclic graphs and stale computed observer state

### DIFF
--- a/.changeset/fix-deep-computed-observation-cycles.md
+++ b/.changeset/fix-deep-computed-observation-cycles.md
@@ -1,0 +1,9 @@
+---
+"@aurelia/runtime": patch
+---
+
+Deep computed observation now traverses cyclic object, array, map, and set graphs without overflowing the stack.
+
+Computed observers now finish queued reconciliation without retaining dependencies after their final subscriber detaches.
+
+Setter-backed computed properties no longer suppress assignments based on dirty or detached cached values, and successful assignments invalidate the cached getter value even when the setter updates otherwise unobservable state.

--- a/packages/__tests__/src/2-runtime/computed-observer.spec.ts
+++ b/packages/__tests__/src/2-runtime/computed-observer.spec.ts
@@ -4,6 +4,7 @@ import {
   IObserverLocator,
   INodeObserverLocator,
   ComputedObserver,
+  ISubscriberCollection,
   runTasks,
 } from '@aurelia/runtime';
 import {
@@ -428,5 +429,253 @@ describe('2-runtime/computed-observer.spec.ts', function () {
     assert.strictEqual(observer.getValue(), 2);
     // shouldn't compute again
     assert.strictEqual(obj.prop, 2);
+  });
+
+  describe('queued dependency graphs', function () {
+    const subscriber = { handleChange() {/* empty */} };
+
+    it('compares a setter value against the current dirty value', function () {
+      const { locator } = createFixture();
+      let setterCalls = 0;
+      class ViewModel {
+        public backing = 0;
+        public get value(): number {
+          return this.backing;
+        }
+        public set value(value: number) {
+          setterCalls++;
+          this.backing = value;
+        }
+      }
+
+      const vm = new ViewModel();
+      const observer = locator.getObserver(vm, 'value') as ComputedObserver<ViewModel>;
+      observer.subscribe(subscriber);
+
+      // The dependency changes synchronously, but the computed notification is
+      // still queued. Assigning the old cached value must compare against the
+      // live dirty getter rather than suppressing the setter.
+      vm.backing = 1;
+      observer.setValue(0);
+
+      assert.strictEqual(setterCalls, 1);
+      assert.strictEqual(vm.backing, 0);
+      runTasks();
+      assert.strictEqual(observer.getValue(), 0);
+    });
+
+    it('invalidates an attached cache after a setter updates unobservable state', function () {
+      const { locator } = createFixture();
+      let backing = 0;
+      const setterValues: number[] = [];
+      class ViewModel {
+        public get value(): number {
+          return backing;
+        }
+        public set value(value: number) {
+          setterValues.push(value);
+          backing = value;
+        }
+      }
+
+      const vm = new ViewModel();
+      const observer = locator.getObserver(vm, 'value') as ComputedObserver<ViewModel>;
+      observer.subscribe(subscriber);
+
+      // Neither accessor touches an observable property. The first accepted
+      // assignment must still invalidate the attached cache, otherwise the
+      // old cached value suppresses the second assignment before the queue drains.
+      observer.setValue(1);
+      observer.setValue(0);
+      assert.deepStrictEqual(setterValues, [1, 0]);
+      assert.strictEqual(backing, 0);
+
+      runTasks();
+      observer.setValue(2);
+      assert.strictEqual(observer.getValue(), 2, 'an accepted setter invalidates the cached getter value');
+      runTasks();
+    });
+
+    it('reconciles and detaches a queued branched getter after final unsubscribe', function () {
+      const { locator } = createFixture();
+      let evaluations = 0;
+      let setterCalls = 0;
+      class ViewModel {
+        public useLeft = true;
+        public left = 1;
+        public right = 5;
+        public get selected(): number {
+          evaluations++;
+          return this.useLeft ? this.left : this.right;
+        }
+        public set selected(value: number) {
+          setterCalls++;
+          if (this.useLeft) {
+            this.left = value;
+          } else {
+            this.right = value;
+          }
+        }
+      }
+
+      const vm = new ViewModel();
+      const observer = locator.getObserver(vm, 'selected') as ComputedObserver<ViewModel>;
+      observer.subscribe(subscriber);
+      assert.strictEqual(evaluations, 1);
+
+      vm.left = 2;
+      observer.unsubscribe(subscriber);
+      vm.useLeft = false;
+      runTasks();
+
+      // The queued run advances to the current branch, then releases every
+      // dependency because the observer is dormant.
+      assert.strictEqual(evaluations, 2);
+      for (const key of ['useLeft', 'left', 'right'] as const) {
+        const dependency = locator.getObserver(vm, key) as unknown as ISubscriberCollection;
+        assert.strictEqual(dependency.subs.count, 0, `${key} dependency is detached`);
+      }
+
+      // The previously cached value was 1, while the active branch currently
+      // contains 5. Returning to 1 must therefore reach the setter.
+      observer.setValue(1);
+      assert.strictEqual(setterCalls, 1);
+      assert.strictEqual(vm.right, 1);
+      runTasks();
+      assert.strictEqual(evaluations, 3);
+      assert.strictEqual(observer.obs.count, 0);
+    });
+
+    it('uses live values through a detached chain of computed getters', function () {
+      const { locator } = createFixture();
+      let setterCalls = 0;
+      class ViewModel {
+        public leaf: string | undefined = void 0;
+        public get inner(): string | undefined {
+          return this.leaf;
+        }
+        public get outer(): string | undefined {
+          return this.inner;
+        }
+        public set outer(value: string | undefined) {
+          setterCalls++;
+          this.leaf = value;
+        }
+      }
+
+      const vm = new ViewModel();
+      locator.getObserver(vm, 'inner');
+      const outer = locator.getObserver(vm, 'outer') as ComputedObserver<ViewModel>;
+      outer.subscribe(subscriber);
+      const leaf = locator.getObserver(vm, 'leaf') as unknown as ISubscriberCollection;
+      assert.strictEqual(leaf.subs.count, 1);
+
+      // The inner getter is queued, but detaching the outer getter prevents the
+      // inner notification from refreshing the outer cache.
+      vm.leaf = 'a';
+      outer.unsubscribe(subscriber);
+      runTasks();
+      assert.strictEqual(leaf.subs.count, 0);
+
+      // `undefined` equals the outer observer's stale cache, but not the value
+      // obtained through the live inner getter. The setter must not be skipped.
+      outer.setValue(void 0);
+      assert.strictEqual(setterCalls, 1);
+      assert.strictEqual(vm.leaf, void 0);
+      runTasks();
+      assert.strictEqual(leaf.subs.count, 0);
+
+      // Detached equality is still suppressed when the live value really is equal.
+      outer.setValue(void 0);
+      assert.strictEqual(setterCalls, 1);
+    });
+
+    it('preserves a chained getter across unsubscribe and resubscribe before drain', function () {
+      const { locator } = createFixture();
+      class ViewModel {
+        public leaf = 1;
+        public get inner(): number {
+          return this.leaf * 2;
+        }
+        public get outer(): number {
+          return this.inner + 1;
+        }
+      }
+
+      const vm = new ViewModel();
+      locator.getObserver(vm, 'inner');
+      const outer = locator.getObserver(vm, 'outer') as ComputedObserver<ViewModel>;
+      const changes: [number, number][] = [];
+      const changeSubscriber = {
+        handleChange(newValue: number, oldValue: number) {
+          changes.push([newValue, oldValue]);
+        }
+      };
+
+      outer.subscribe(changeSubscriber);
+      assert.strictEqual(outer.getValue(), 3);
+
+      vm.leaf = 2;
+      outer.unsubscribe(changeSubscriber);
+      outer.subscribe(changeSubscriber);
+      assert.strictEqual(outer.getValue(), 5);
+
+      // The old inner task is still queued. A second mutation must be folded
+      // into that task without losing the resubscribed outer dependency.
+      vm.leaf = 3;
+      runTasks();
+      assert.deepStrictEqual(changes, [[7, 5]]);
+
+      vm.leaf = 4;
+      runTasks();
+      assert.deepStrictEqual(changes, [[7, 5], [9, 7]]);
+    });
+
+    it('keeps a diamond-shaped getter graph current after an orphaned drain', function () {
+      const { locator } = createFixture();
+      class ViewModel {
+        public leaf = 1;
+        public get left(): number {
+          return this.leaf * 2;
+        }
+        public get right(): number {
+          return this.leaf * 3;
+        }
+        public get total(): number {
+          return this.left + this.right;
+        }
+      }
+
+      const vm = new ViewModel();
+      locator.getObserver(vm, 'left');
+      locator.getObserver(vm, 'right');
+      const total = locator.getObserver(vm, 'total') as ComputedObserver<ViewModel>;
+      const changes: [number, number][] = [];
+      const changeSubscriber = {
+        handleChange(newValue: number, oldValue: number) {
+          changes.push([newValue, oldValue]);
+        }
+      };
+
+      total.subscribe(changeSubscriber);
+      assert.strictEqual(total.getValue(), 5);
+
+      vm.leaf = 2;
+      total.unsubscribe(changeSubscriber);
+      runTasks();
+      const leaf = locator.getObserver(vm, 'leaf') as unknown as ISubscriberCollection;
+      assert.strictEqual(leaf.subs.count, 0, 'both orphaned branches detach');
+
+      total.subscribe(changeSubscriber);
+      assert.strictEqual(total.getValue(), 10);
+
+      // Both branches invalidate the same downstream getter. Each scheduler
+      // turn must publish one fully settled value, never an intermediate sum.
+      vm.leaf = 3;
+      runTasks();
+      vm.leaf = 4;
+      runTasks();
+      assert.deepStrictEqual(changes, [[15, 10], [20, 15]]);
+    });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/computed-decorator.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/computed-decorator.spec.ts
@@ -1,4 +1,4 @@
-import { computed, ICoercionConfiguration, runTasks } from '@aurelia/runtime';
+import { computed, ICoercionConfiguration, ISubscriberCollection, ProxyObservable, runTasks } from '@aurelia/runtime';
 import { AppTask, bindable } from '@aurelia/runtime-html';
 import { assert, createFixture } from '@aurelia/testing';
 
@@ -817,6 +817,268 @@ describe('3-runtime-html/computed-decorator.spec.ts', function () {
       runTasks();
       assertText('Hey 2!!!');
       assert.strictEqual(i, 2, `1 initial + 2nd when computed observer changes + reuse when binding evaluates`);
+    });
+  });
+
+  describe('deep cyclic dependencies', function () {
+    type Leaf = { value: number };
+    type CyclicGraph = { root: object; leaf: Leaf };
+
+    function createDeepFixture<TRoot extends object>(
+      root: TRoot,
+      read: (root: TRoot) => number,
+      flush: 'async' | 'sync' = 'async',
+    ) {
+      let evaluations = 0;
+      const fixture = createFixture(
+        '${value}',
+        class App {
+          public graph = root;
+
+          @computed({ deps: ['graph'], deep: true, flush })
+          public get value(): number {
+            evaluations++;
+            return read(this.graph);
+          }
+        },
+      );
+      return { fixture, getEvaluationCount: () => evaluations };
+    }
+
+    const graphCases: readonly [name: string, create: () => CyclicGraph][] = [
+      ['a self-referential object', () => {
+        const leaf = { value: 0 };
+        const root: { leaf: Leaf; self?: object } = { leaf };
+        root.self = root;
+        return { root, leaf };
+      }],
+      ['two mutually-referential class instances', () => {
+        class Node {
+          public next!: Node;
+          public constructor(public leaf: Leaf) {}
+        }
+        const leaf = { value: 0 };
+        const root = new Node(leaf);
+        const child = new Node(leaf);
+        root.next = child;
+        child.next = root;
+        return { root, leaf };
+      }],
+      ['a self-containing array', () => {
+        const leaf = { value: 0 };
+        const root: unknown[] = [];
+        root.push(root, leaf);
+        return { root, leaf };
+      }],
+      ['a map containing itself as both a key and value', () => {
+        const leaf = { value: 0 };
+        const root = new Map<unknown, unknown>();
+        root.set(root, root);
+        root.set('leaf', leaf);
+        return { root, leaf };
+      }],
+      ['a self-containing set', () => {
+        const leaf = { value: 0 };
+        const root = new Set<unknown>();
+        root.add(root);
+        root.add(leaf);
+        return { root, leaf };
+      }],
+    ];
+
+    for (const [name, createGraph] of graphCases) {
+      it(`observes ${name}`, function () {
+        const { root, leaf } = createGraph();
+        const { fixture, getEvaluationCount } = createDeepFixture(root, () => leaf.value);
+
+        // A reachable mutation proves that traversal did not merely stop at the
+        // cycle: it retained the property subscriptions found elsewhere in the graph.
+        fixture.assertText('0');
+        assert.strictEqual(getEvaluationCount(), 1, 'initial evaluation');
+
+        leaf.value = 1;
+        assert.strictEqual(getEvaluationCount(), 1, 'async change remains queued');
+        runTasks();
+        fixture.assertText('1');
+        assert.strictEqual(getEvaluationCount(), 2, 'one evaluation for mutation');
+      });
+    }
+
+    it('observes a cyclic object with sync flushing', function () {
+      const { root, leaf } = graphCases[0][1]();
+      const { fixture, getEvaluationCount } = createDeepFixture(root, () => leaf.value, 'sync');
+
+      fixture.assertText('0');
+      leaf.value = 1;
+      assert.strictEqual(getEvaluationCount(), 2, 'sync change evaluates immediately');
+      runTasks();
+      fixture.assertText('1');
+      assert.strictEqual(getEvaluationCount(), 2, 'binding reuses the computed value');
+    });
+
+    type CyclicCollectionGraph = {
+      root: object;
+      leaves: Leaf[];
+      add(leaf: Leaf): void;
+    };
+
+    const collectionCases: readonly [name: string, create: () => CyclicCollectionGraph][] = [
+      ['array', () => {
+        const leaves = [{ value: 1 }];
+        const root: unknown[] = [];
+        root.push(root, leaves[0]);
+        return {
+          root,
+          leaves,
+          add(leaf) {
+            leaves.push(leaf);
+            root.push(leaf);
+          },
+        };
+      }],
+      ['map', () => {
+        const leaves = [{ value: 1 }];
+        const root = new Map<unknown, unknown>();
+        root.set(root, root);
+        root.set('leaf-0', leaves[0]);
+        return {
+          root,
+          leaves,
+          add(leaf) {
+            leaves.push(leaf);
+            root.set(`leaf-${leaves.length - 1}`, leaf);
+          },
+        };
+      }],
+      ['set', () => {
+        const leaves = [{ value: 1 }];
+        const root = new Set<unknown>([leaves[0]]);
+        root.add(root);
+        return {
+          root,
+          leaves,
+          add(leaf) {
+            leaves.push(leaf);
+            root.add(leaf);
+          },
+        };
+      }],
+    ];
+
+    for (const [name, createGraph] of collectionCases) {
+      it(`discovers new members of a cyclic ${name}`, function () {
+        const graph = createGraph();
+        const { fixture, getEvaluationCount } = createDeepFixture(
+          graph.root,
+          () => graph.leaves.reduce((total, leaf) => total + leaf.value, 0),
+        );
+
+        fixture.assertText('1');
+        const addedLeaf = { value: 2 };
+        graph.add(addedLeaf);
+        assert.strictEqual(getEvaluationCount(), 1, 'collection mutation remains queued');
+        runTasks();
+        fixture.assertText('3');
+        assert.strictEqual(getEvaluationCount(), 2, 'collection mutation triggers one evaluation');
+
+        // The collection change forces a fresh traversal. The newly reachable
+        // object's property must therefore participate in subsequent updates.
+        addedLeaf.value = 3;
+        runTasks();
+        fixture.assertText('4');
+        assert.strictEqual(getEvaluationCount(), 3, 'new member mutation triggers one evaluation');
+      });
+    }
+
+    it('normalizes raw and observation-proxy aliases to one reachable object', function () {
+      const leaf = { value: 0 };
+      let traversalCount = 0;
+      const target: { leaf: Leaf; parent?: object } = { leaf };
+      const raw = new Proxy(target, {
+        ownKeys(target) {
+          traversalCount++;
+          return Reflect.ownKeys(target);
+        },
+      });
+      const root: { raw: object; proxy: object; self?: object } = {
+        raw,
+        proxy: ProxyObservable.wrap(raw),
+      };
+      root.self = root;
+      target.parent = root;
+      const { fixture, getEvaluationCount } = createDeepFixture(root, () => leaf.value);
+      const { assertText, observerLocator } = fixture;
+      const leafObserver = observerLocator.getObserver(leaf, 'value') as unknown as ISubscriberCollection;
+
+      assert.strictEqual(traversalCount, 1, 'raw/proxy aliases are visited once in the initial pass');
+      assert.strictEqual(leafObserver.subs.count, 1, 'shared leaf has one deep observer');
+      traversalCount = 0;
+      leaf.value = 1;
+      runTasks();
+
+      assertText('1');
+      assert.strictEqual(getEvaluationCount(), 2, 'shared leaf triggers one evaluation');
+      assert.ok(traversalCount > 0, 'invalidation traverses with a fresh identity set');
+      assert.strictEqual(leafObserver.subs.count, 1, 'shared leaf remains singly observed after rebuilding');
+    });
+
+    it('does not reattach a queued deep observer after unbinding', function () {
+      const leaf = { value: 0 };
+      const root: { leaf: Leaf; self?: object } = { leaf };
+      root.self = root;
+      const { fixture, getEvaluationCount } = createDeepFixture(root, () => leaf.value);
+      const { observerLocator, stop } = fixture;
+      const leafObserver = observerLocator.getObserver(leaf, 'value') as unknown as ISubscriberCollection;
+
+      assert.strictEqual(leafObserver.subs.count, 1, 'deep observer is attached');
+      leaf.value = 1;
+      void stop();
+      assert.strictEqual(leafObserver.subs.count, 0, 'unbind detaches the queued deep observer');
+
+      // The already queued deep walker still completes, preserving the normal
+      // ComputedObserver ordering, but must release everything it recollects.
+      runTasks();
+      assert.strictEqual(getEvaluationCount(), 1, 'detached user getter does not evaluate');
+      assert.strictEqual(leafObserver.subs.count, 0, 'queued work does not reattach the deep observer');
+    });
+
+    it('does not reattach an obsolete deep observer after replacing its root', function () {
+      const createGraph = (value: number) => {
+        const leaf = { value };
+        const root: { leaf: Leaf; self?: object } = { leaf };
+        root.self = root;
+        return { root, leaf };
+      };
+      const oldGraph = createGraph(1);
+      const newGraph = createGraph(2);
+      const { fixture, getEvaluationCount } = createDeepFixture(
+        oldGraph.root,
+        graph => graph.leaf.value,
+      );
+      const { component, assertText, observerLocator } = fixture;
+      const oldLeafObserver = observerLocator.getObserver(oldGraph.leaf, 'value') as unknown as ISubscriberCollection;
+      const newLeafObserver = observerLocator.getObserver(newGraph.leaf, 'value') as unknown as ISubscriberCollection;
+
+      assertText('1');
+      component.graph = newGraph.root;
+      oldGraph.leaf.value = 10;
+
+      // Root replacement is queued first. The old graph's nested change is
+      // queued second and becomes obsolete when replacement detaches its walker.
+      runTasks();
+      assertText('2');
+      assert.strictEqual(getEvaluationCount(), 2, 'root replacement triggers one evaluation');
+      assert.strictEqual(oldLeafObserver.subs.count, 0, 'old graph remains detached');
+      assert.strictEqual(newLeafObserver.subs.count, 1, 'new graph is observed');
+
+      oldGraph.leaf.value = 11;
+      runTasks();
+      assert.strictEqual(getEvaluationCount(), 2, 'old graph no longer triggers evaluation');
+
+      newGraph.leaf.value = 3;
+      runTasks();
+      assertText('3');
+      assert.strictEqual(getEvaluationCount(), 3, 'new graph remains observable');
     });
   });
 });

--- a/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
@@ -831,6 +831,44 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
       assertText('1');
     });
 
+    it('does not skip rapid updates to an otherwise unobserved getter bindable', async function () {
+      const values: (string | undefined)[] = [];
+      @customElement({ name: 'my-el', template: '' })
+      class MyEl {
+        private _message: string | undefined = void 0;
+
+        @bindable
+        public get message(): string | undefined {
+          return this._message;
+        }
+        public set message(value: string | undefined) {
+          values.push(value);
+          this._message = value;
+        }
+      }
+      class App {
+        public value: string | undefined = 'a';
+        public el!: MyEl;
+      }
+
+      const { component } = createFixture(
+        `<my-el component.ref="el" message.bind="value">`,
+        App,
+        [MyEl],
+      );
+      assert.deepStrictEqual(values, ['a']);
+
+      // The empty child template leaves its getter observer without subscribers.
+      // All three writes can therefore land before its queued reconciliation.
+      component.value = 'b';
+      component.value = void 0;
+
+      assert.deepStrictEqual(values, ['a', 'b', void 0]);
+      assert.strictEqual(component.el.message, void 0);
+      await tasksSettled();
+      assert.deepStrictEqual(values, ['a', 'b', void 0]);
+    });
+
     it('works with readonly bindable', async function () {
       const { assertText, trigger } = createFixture(
         `<my-el component.ref=el message.from-view="message">`,

--- a/packages/runtime/src/computed-observer.ts
+++ b/packages/runtime/src/computed-observer.ts
@@ -127,8 +127,13 @@ export class ComputedObserver<T extends object> implements
       if (this._coercer !== void 0) {
         v = this._coercer.call(null, v, this._coercionConfig);
       }
-      if (!areEqual(v, this._value)) {
+      // Keep the cached fast path, but verify a would-be no-op against the
+      // current getter because dirty and detached caches can be stale.
+      if (!areEqual(v, this._value) || !areEqual(v, this.getValue())) {
         this.$set.call(this._obj, v);
+        // A setter may update state that is not observable. Invalidate the
+        // cached getter value before this assignment is reconciled.
+        this.handleDirty();
         this.run();
       }
     } else {
@@ -253,6 +258,11 @@ export class ComputedObserver<T extends object> implements
     } finally {
       this.obs.clear();
       exitConnectable(this);
+      // A queued run can outlive its final subscriber. Preserve its value and
+      // callback reconciliation, but leave the observer dormant afterwards.
+      if (this.subs.count === 0) {
+        this.obs.clearAll();
+      }
     }
   }
 }

--- a/packages/runtime/src/controlled-computed-observer.ts
+++ b/packages/runtime/src/controlled-computed-observer.ts
@@ -168,17 +168,20 @@ export class ControlledComputedObserver implements IObserver, ISubscriberCollect
   }
 }
 function observeDeep(obj: unknown, requestor: IObserverLocator) {
-  function walk(obj: unknown, connectable: IConnectable) {
+  function walk(obj: unknown, connectable: IConnectable, seen: WeakSet<object>) {
     const raw = unwrap(obj);
 
-    if (!isObject(raw)) {
+    // Deep dependencies are object graphs, not necessarily trees. Keying the
+    // traversal by raw identity handles cycles as well as raw/proxy aliases.
+    if (!isObject(raw) || seen.has(raw)) {
       return;
     }
+    seen.add(raw);
 
     if (isArray(raw)) {
       connectable.observeCollection(raw);
       for (let i = 0; i < raw.length; i++) {
-        walk(raw[i], connectable);
+        walk(raw[i], connectable, seen);
       }
       return;
     }
@@ -186,8 +189,8 @@ function observeDeep(obj: unknown, requestor: IObserverLocator) {
     if (isMap(raw)) {
       connectable.observeCollection(raw);
       for (const [k, v] of raw) {
-        walk(k, connectable);
-        walk(v, connectable);
+        walk(k, connectable, seen);
+        walk(v, connectable, seen);
       }
       return;
     }
@@ -195,18 +198,20 @@ function observeDeep(obj: unknown, requestor: IObserverLocator) {
     if (isSet(raw)) {
       connectable.observeCollection(raw);
       for (const v of raw) {
-        walk(v, connectable);
+        walk(v, connectable, seen);
       }
       return;
     }
 
     for (const key of Object.keys(raw)) {
       connectable.observe(raw, key);
-      walk((raw as Record<string, unknown>)[key], connectable);
+      walk((raw as Record<string, unknown>)[key], connectable, seen);
     }
   }
 
   return requestor.getObserver(obj, ((obj, connectable) => {
-    walk(obj, connectable);
+    // ComputedObserver recollects after graph changes. A fresh set preserves
+    // that lifecycle while visiting each reachable identity once per pass.
+    walk(obj, connectable, new WeakSet());
   }));
 }


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

Deep computed observation overflowed the stack on cyclic graphs and repeatedly traversed shared references.

Computed observers could also retain dependencies after queued work outlived their final subscriber.

Setter-backed observers could suppress valid assignments or expose stale cached values.

## 💁 Your Solution

Visit each raw object once per deep-observation pass.

Complete queued reconciliation before releasing dormant dependencies.

Validate would-be setter no-ops against the live getter and invalidate the cache after accepted assignments.

## 📑 Test Plan

Added lifecycle and scheduler regressions covering cyclic collections, shared aliases, orphaned queues, dependency graphs, and rapid getter-bindable writes.

A/B benchmarked unique and shared graph traversal. No perf regressions found.

## 📦 Changeset

- [x] Added a changeset