### PR TITLE
fix(router): normalize navigation paths and base handling

### DIFF
--- a/.changeset/calm-routes-agree.md
+++ b/.changeset/calm-routes-agree.md
@@ -1,0 +1,9 @@
+---
+"@aurelia/router": patch
+---
+
+Fix application-root navigation under configured base paths. Root-prefixed string instructions now retain their application-root meaning when the base is removed, and a base such as `/app` is stripped only at a path, query, or fragment boundary—not from paths such as `/apple`.
+
+Consume excess leading `../` prefixes while clamping route-context traversal at the application root. This prevents unresolved parent syntax from leaking into browser URLs after intercepted navigation has already resolved at the root.
+
+Keep hash-mode `load` links under the configured application base, matching `href` links and the destination used by router navigation.

--- a/packages/__e2e__/6-router/src/router.basic.spec.ts
+++ b/packages/__e2e__/6-router/src/router.basic.spec.ts
@@ -169,10 +169,13 @@ test.describe('router.basic', () => {
         await page.goto(`${baseURL}/?useUrlFragmentHash=true`);
       }
 
+      // `href1` is a native href. The remaining values are produced by `load`
+      // on an as-element anchor, a native anchor, and a button. Every surface
+      // must materialize the same application-qualified URL in both modes.
       const href1 = `${baseURL}${useUrlFragmentHash ? '/#' : ''}/sub/1`;
-      const href2 = `${useUrlFragmentHash ? '/#' : baseURL}/sub/2`;
-      const href3 = `${useUrlFragmentHash ? '/#' : baseURL}/sub/3`;
-      const href4 = `${useUrlFragmentHash ? '/#' : baseURL}/sub/4`;
+      const href2 = `${baseURL}${useUrlFragmentHash ? '/#' : ''}/sub/2`;
+      const href3 = `${baseURL}${useUrlFragmentHash ? '/#' : ''}/sub/3`;
+      const href4 = `${baseURL}${useUrlFragmentHash ? '/#' : ''}/sub/4`;
 
       await test.step('navigates to sub route', async () => {
         await page.click('a:has-text("Sub")');

--- a/packages/__tests__/src/router/context-router.spec.ts
+++ b/packages/__tests__/src/router/context-router.spec.ts
@@ -1,5 +1,5 @@
 import { lazy, optional, resolve } from '@aurelia/kernel';
-import { IContextRouter, route } from '@aurelia/router';
+import { IContextRouter, IRouteContext, route } from '@aurelia/router';
 import { CustomElement, customElement } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 import { start } from './_shared/create-fixture.js';
@@ -9,6 +9,7 @@ describe('router/context-router.spec.ts', function () {
   abstract class BaseViewModel {
     public readonly lazyContextRouter: () => IContextRouter = resolve(lazy(IContextRouter));
     public readonly contextRouter?: IContextRouter = resolve(optional(IContextRouter));
+    public readonly routeContext?: IRouteContext = resolve(optional(IRouteContext));
   }
 
   it('captures context and enables context-specific routing', async function () {
@@ -61,7 +62,26 @@ describe('router/context-router.spec.ts', function () {
     assert.html.textContent(host, 'root c-11 gc-12', 'round#2');
 
     let grandChildVm = CustomElement.for<Gc12>(host.querySelector('gc-12')!).viewModel;
-    await grandChildVm.contextRouter.load('../gc1');
+    const siblingInstructions = Object.freeze([
+      Object.freeze({ component: '../gc1', recognizedRoute: null }),
+      Object.freeze({ component: '../gc2', recognizedRoute: null }),
+    ]);
+    const siblingTree = grandChildVm.contextRouter.createViewportInstructions(siblingInstructions, null, null);
+    assert.strictEqual(siblingTree.options.context, childVm.routeContext, 'sibling instructions share the rebased parent context');
+    assert.deepStrictEqual(
+      siblingTree.children.map(instruction => instruction.component.toUrlComponent()),
+      ['gc1', 'gc2'],
+      'later sibling prefixes are consumed without cumulative traversal',
+    );
+    assert.deepStrictEqual(
+      siblingInstructions.map(instruction => instruction.component),
+      ['../gc1', '../gc2'],
+      'sibling inputs remain unchanged',
+    );
+
+    const frozenViewportInstruction = Object.freeze({ component: '../gc1', recognizedRoute: null });
+    await grandChildVm.contextRouter.load(frozenViewportInstruction);
+    assert.strictEqual(frozenViewportInstruction.component, '../gc1', 'round#3 instruction remains unchanged');
     assert.html.textContent(host, 'root c-11 gc-11', 'round#3');
 
     grandChildVm = CustomElement.for<Gc11>(host.querySelector('gc-11')!).viewModel;
@@ -69,7 +89,9 @@ describe('router/context-router.spec.ts', function () {
     assert.html.textContent(host, 'root c-12 gc-14', 'round#4');
 
     childVm = CustomElement.for<C12>(host.querySelector('c-12')!).viewModel;
-    await childVm.contextRouter.load('gc1');
+    const frozenInstructions = Object.freeze(['gc1']);
+    await childVm.contextRouter.load(frozenInstructions);
+    assert.deepStrictEqual(frozenInstructions, ['gc1'], 'round#5 instructions remain unchanged');
     assert.html.textContent(host, 'root c-12 gc-13', 'round#5');
 
     await au.stop(true);

--- a/packages/__tests__/src/router/location-manager.spec.ts
+++ b/packages/__tests__/src/router/location-manager.spec.ts
@@ -1,5 +1,5 @@
-import { resolve } from '@aurelia/kernel';
-import { INavigationOptions, IRouter, IRouterEvents, Params, route, RouteNode, ServerLocationManager } from '@aurelia/router';
+import { Registration, resolve } from '@aurelia/kernel';
+import { ILocationManager, INavigationOptions, IRouter, IRouterEvents, Params, route, RouteNode, ServerLocationManager } from '@aurelia/router';
 import { customElement, IHistory, IWindow } from '@aurelia/runtime-html';
 import { assert } from '@aurelia/testing';
 import { isNode } from '../util.js';
@@ -587,9 +587,31 @@ describe('router/location-manager.spec.ts', function () {
     });
   }
 
-  // =============================================================================
-  // ServerLocationManager - SSR Location Manager
-  // =============================================================================
+  describe('router/BrowserLocationManager', function () {
+    it('removes only a complete deployment-base path segment', async function () {
+      @customElement({ name: 'app-root', template: '' })
+      class Root { }
+
+      const { au, container } = await start({
+        appRoot: Root,
+        registrations: [
+          Registration.instance(IWindow, {
+            document: {
+              baseURI: 'https://portal.example.com/app/',
+            },
+            removeEventListener() { /** noop */ },
+            addEventListener() { /** noop */ },
+          }),
+        ],
+      });
+      const manager = container.get(ILocationManager);
+
+      assert.strictEqual(manager.removeBaseHref('/app/page'), '/page');
+      assert.strictEqual(manager.removeBaseHref('/apple/page'), '/apple/page');
+
+      await au.stop(true);
+    });
+  });
 
   describe('router/ServerLocationManager', function () {
     describe('getPath', function () {
@@ -658,6 +680,19 @@ describe('router/location-manager.spec.ts', function () {
       it('returns normalized path when base href not present', function () {
         const manager = new ServerLocationManager('/', '/app');
         assert.strictEqual(manager.removeBaseHref('/other/page'), '/other/page');
+      });
+
+      it('removes a base href at exact, query, and fragment boundaries', function () {
+        const manager = new ServerLocationManager('/', '/app/');
+        assert.strictEqual(manager.removeBaseHref('/app'), '');
+        assert.strictEqual(manager.removeBaseHref('/app/'), '');
+        assert.strictEqual(manager.removeBaseHref('/app?query=value'), '?query=value');
+        assert.strictEqual(manager.removeBaseHref('/app#fragment'), '#fragment');
+      });
+
+      it('does not remove a partial path-segment match', function () {
+        const manager = new ServerLocationManager('/', '/app');
+        assert.strictEqual(manager.removeBaseHref('/apple/page'), '/apple/page');
       });
 
       it('handles root base href', function () {

--- a/packages/__tests__/src/router/resources/load.spec.ts
+++ b/packages/__tests__/src/router/resources/load.spec.ts
@@ -1,8 +1,8 @@
 import { IRouteContext, IRouteViewModel, Params, route, RouteNode } from '@aurelia/router';
-import { CustomElement, customElement, ILocation } from '@aurelia/runtime-html';
+import { CustomElement, customElement, ILocation, IWindow } from '@aurelia/runtime-html';
 import { assert, MockBrowserHistoryLocation } from '@aurelia/testing';
 import { start } from '../_shared/create-fixture.js';
-import { resolve } from '@aurelia/kernel';
+import { Registration, resolve } from '@aurelia/kernel';
 import { tasksSettled } from '@aurelia/runtime';
 
 describe('router/resources/load.spec.ts', function () {
@@ -671,11 +671,32 @@ describe('router/resources/load.spec.ts', function () {
     })
     class Root { }
 
-    const { au, host } = await start({ appRoot: Root, useHash: true, registrations: [CeOne, CeTwo] });
+    const { au, host } = await start({
+      appRoot: Root,
+      useHash: true,
+      registrations: [
+        CeOne,
+        CeTwo,
+        Registration.instance(IWindow, {
+          document: {
+            baseURI: 'https://portal.example.com/app/',
+          },
+          removeEventListener() { /** noop */ },
+          addEventListener() { /** noop */ },
+        }),
+      ],
+    });
     await tasksSettled();
 
     const anchors = Array.from(host.querySelectorAll('a'));
-    assert.deepStrictEqual(anchors.map(a => a.getAttribute('href')), ['/#/ce-one', '/#/ce-two', '/#/ce-two']);
+    assert.deepStrictEqual(
+      anchors.map(a => a.href),
+      [
+        'https://portal.example.com/app/#/ce-one',
+        'https://portal.example.com/app/#/ce-two',
+        'https://portal.example.com/app/#/ce-two',
+      ],
+    );
 
     anchors[1].click();
     await tasksSettled();

--- a/packages/__tests__/src/router/smoke-tests.spec.ts
+++ b/packages/__tests__/src/router/smoke-tests.spec.ts
@@ -4542,6 +4542,101 @@ describe('router/smoke-tests.spec.ts', function () {
     });
   }
 
+  const rootedNavigationCases = [
+    {
+      description: 'preserves application-root navigation from a nested context',
+      instruction: '/root-target',
+      basePath: '/',
+      serializedBase: '',
+    },
+    {
+      description: 'clamps excess parent traversal to the application root',
+      instruction: '../../../root-target',
+      basePath: '/app/',
+      serializedBase: 'app/',
+    },
+  ] as const;
+  for (const { description, instruction, basePath, serializedBase } of rootedNavigationCases) {
+    for (const attr of ['load', 'href']) {
+      for (const useHash of [false, true]) {
+        it(`${description} - ${attr} - useHash: ${useHash}`, async function () {
+          // The nested and root contexts deliberately expose the same route
+          // path, making context selection observable. Both instructions must
+          // select application root; the excess-parent case must also serialize
+          // without leaving `../` for the browser to reinterpret.
+          @customElement({ name: 'nested-shadow', template: 'nested shadow' })
+          class NestedShadow { }
+
+          @route({
+            routes: [
+              { path: 'root-target', component: NestedShadow },
+            ],
+          })
+          @customElement({ name: 'nested-child', template: `<a ${attr}="${instruction}">root target</a><au-viewport></au-viewport>` })
+          class NestedChild { }
+
+          @route({
+            path: 'parent',
+            routes: [
+              { path: 'child', component: NestedChild },
+            ],
+          })
+          @customElement({ name: 'nested-parent', template: 'parent <au-viewport></au-viewport>' })
+          class NestedParent { }
+
+          @customElement({ name: 'root-target', template: 'root target' })
+          class RootTarget { }
+
+          @route({
+            routes: [
+              NestedParent,
+              RootTarget,
+            ],
+          })
+          @customElement({ name: 'rooted-navigation-app', template: 'root <au-viewport></au-viewport>' })
+          class Root { }
+
+          const ctx = TestContext.create();
+          const { container } = ctx;
+          container.register(Registration.instance(IWindow, {
+            document: {
+              baseURI: 'https://portal.example.com/',
+            },
+            removeEventListener() { /** noop */ },
+            addEventListener() { /** noop */ },
+          }));
+          container.register(
+            TestRouterConfiguration.for(LogLevel.warn),
+            RouterConfiguration.customize({ basePath, useUrlFragmentHash: useHash }),
+            NestedChild,
+            NestedParent,
+            NestedShadow,
+            RootTarget,
+          );
+
+          const au = new Aurelia(container);
+          const host = ctx.createElement('div');
+          await au.app({ component: Root, host }).start();
+          await container.get(IRouter).load('parent/child');
+
+          assert.html.textContent(host, 'root parent root target', 'initial content includes the nested link text');
+          const anchor = host.querySelector<HTMLAnchorElement>('a')!;
+          assert.strictEqual(
+            anchor.href,
+            `https://portal.example.com/${serializedBase}${useHash ? '#/' : ''}root-target`,
+            'rooted browser URL',
+          );
+
+          anchor.click();
+          await tasksSettled();
+          assert.html.textContent(host, 'root root target', 'rooted target content');
+
+          await au.stop(true);
+        });
+      }
+    }
+  }
+
   it('multiple paths can redirect to same path', async function () {
     @customElement({ name: 'ce-p1', template: 'p1' })
     class P1 { }

--- a/packages/router/src/context-router.ts
+++ b/packages/router/src/context-router.ts
@@ -104,9 +104,9 @@ export class ContextRouter {
     return this._router.generatePath(instructionOrInstructions, this._context);
   }
 
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
     return this._router.createViewportInstructions(instructionOrInstructions, { context: this._context, ...options }, parentRoutePath, traverseChildren as true);
   }
 

--- a/packages/router/src/instructions.ts
+++ b/packages/router/src/instructions.ts
@@ -266,14 +266,14 @@ export class ViewportInstructionTree {
   }
 
   public static create(
-    instructionOrInstructions: NavigationInstruction | NavigationInstruction[],
+    instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[],
     routerOptions: RouterOptions,
     options: INavigationOptions | NavigationOptions | null,
     rootCtx: IRouteContext | null,
     parentRoutePath: string | null,
   ): ViewportInstructionTree;
   public static create(
-    instructionOrInstructions: NavigationInstruction | NavigationInstruction[],
+    instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[],
     routerOptions: RouterOptions,
     options: INavigationOptions | NavigationOptions | null,
     rootCtx: IRouteContext | null,
@@ -281,7 +281,7 @@ export class ViewportInstructionTree {
     traverseChildren: true,
   ): ViewportInstructionTree | Promise<ViewportInstructionTree>;
   public static create(
-    instructionOrInstructions: NavigationInstruction | NavigationInstruction[],
+    instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[],
     routerOptions: RouterOptions,
     options: INavigationOptions | NavigationOptions | null,
     rootCtx: IRouteContext | null,

--- a/packages/router/src/location-manager.ts
+++ b/packages/router/src/location-manager.ts
@@ -109,10 +109,7 @@ export class BrowserLocationManager {
   }
 
   public removeBaseHref(path: string): string {
-    const basePath = this._baseHref.pathname;
-    if (path.startsWith(basePath)) {
-      path = path.slice(basePath.length);
-    }
+    path = removeBasePath(path, this._baseHref.pathname);
 
     if (this._useUrlFragmentHash && path.startsWith('#')) {
       path = path.slice(1);
@@ -151,6 +148,35 @@ export function normalizePath(path: string): string {
 
 function normalizeQuery(query: string): string {
   return query.length > 0 && !query.startsWith('?') ? `?${query}` : query;
+}
+
+/**
+ * Strip one deployment-base occurrence from a location-shaped string.
+ *
+ * This is a path-boundary check, not an arbitrary prefix check: `/app` matches
+ * `/app`, `/app/...`, `/app?...`, and `/app#...`, but not `/apple`. A trailing
+ * slash is ignored for non-root bases. Root remains special because consuming
+ * `/` also consumes the spelling that denotes an application-root instruction;
+ * callers that need that meaning must retain it before stripping.
+ *
+ * This operation has no input-provenance information, so it cannot distinguish
+ * a base-qualified location from an already-rebased route whose first segment
+ * happens to equal the base.
+ */
+function removeBasePath(path: string, basePath: string): string {
+  if (basePath.length === 0) return path;
+  if (basePath.length > 1 && basePath.endsWith('/')) {
+    basePath = basePath.slice(0, -1);
+  }
+
+  const hasBasePath = basePath === '/'
+    ? path.startsWith('/')
+    : path === basePath
+      || path.startsWith(`${basePath}/`)
+      || path.startsWith(`${basePath}?`)
+      || path.startsWith(`${basePath}#`);
+
+  return hasBasePath ? path.slice(basePath.length) : path;
 }
 
 /**
@@ -203,9 +229,6 @@ export class ServerLocationManager {
   }
 
   public removeBaseHref(path: string): string {
-    if (path.startsWith(this._baseHref)) {
-      path = path.slice(this._baseHref.length);
-    }
-    return normalizePath(path);
+    return normalizePath(removeBasePath(path, this._baseHref));
   }
 }

--- a/packages/router/src/resources/load.ts
+++ b/packages/router/src/resources/load.ts
@@ -98,7 +98,12 @@ export class LoadCustomAttribute implements ICustomAttributeViewModel {
     }
 
     const hasHref = this._href !== null;
-    const url = hasHref ? (options.useUrlFragmentHash ? this._href : this._locationMgr.addBaseHref(this._href!)) : null;
+    // `toUrl` owns route serialization; the location manager owns the
+    // deployment base. In hash mode the serialized value is application-rooted
+    // (`/#/...`) but still not deployment-qualified. Materialize both modes
+    // here so `load` and `href`, including native or modified-click activation,
+    // target the same URL.
+    const url = hasHref ? this._locationMgr.addBaseHref(this._href!) : null;
     const controller = CustomElement.for(this._el, { optional: true });
     if (controller !== null) {
       (controller.viewModel as IIndexable)[this.attribute] = url;

--- a/packages/router/src/route-context.ts
+++ b/packages/router/src/route-context.ts
@@ -12,7 +12,6 @@ import {
   emptyArray,
   MaybePromise,
   isArray,
-  Writable,
   isPromise,
 } from '@aurelia/kernel';
 import { type Endpoint, RecognizedRoute, RESIDUE, RouteRecognizer } from '@aurelia/route-recognizer';
@@ -601,26 +600,41 @@ export class RouteContext {
     );
   }
 
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
+  /**
+   * Normalize public instructions and select the context for one instruction tree.
+   *
+   * After removing any configured deployment base from a scalar instruction,
+   * this boundary interprets only leading route-context prefixes. It must not
+   * recognize target routes or introduce a second interpretation of the route
+   * grammar; recognition remains in the downstream route pipeline. An
+   * instruction array shares one selected context. Caller-owned arrays and
+   * viewport-instruction objects are treated as readonly here; construction of
+   * internal instruction snapshots remains downstream.
+   */
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
     if (instructionOrInstructions instanceof ViewportInstructionTree) return instructionOrInstructions;
 
     let context: IRouteContext | null = (options?.context ?? this) as IRouteContext | null;
-    let contextChanged = false;
+    // Preserve the router's existing single-context behavior for an instruction
+    // array. At most one `../` prefix run traverses from that shared context;
+    // after the tree has been rebased, later `../` prefixes are consumed without
+    // further traversal. A `/` prefix always selects application root for the
+    // shared tree. Independently relative entries would require a separate
+    // multi-viewport semantics decision.
+    let hasRebasedContext = false;
 
-    if (!isArray(instructionOrInstructions)) {
-      instructionOrInstructions = processStringInstruction.call(this, instructionOrInstructions);
-    } else {
-      const len = instructionOrInstructions.length;
-      for (let i = 0; i < len; ++i) {
-        instructionOrInstructions[i] = processStringInstruction.call(this, instructionOrInstructions[i]);
-      }
-    }
+    // Instructions are public, caller-owned values. Context normalization may
+    // need to rewrite a component string, so return replacement values instead
+    // of assigning into the supplied array or viewport-instruction object.
+    const processedInstructions = !isArray(instructionOrInstructions)
+      ? normalizeInstruction.call(this, instructionOrInstructions)
+      : instructionOrInstructions.map(instruction => normalizeInstruction.call(this, instruction));
 
     const routerOptions = this._router.options;
     return ViewportInstructionTree.create(
-      instructionOrInstructions,
+      processedInstructions,
       routerOptions,
       NavigationOptions.create(routerOptions, { ...options, context }),
       this.root,
@@ -628,25 +642,39 @@ export class RouteContext {
       traverseChildren as true,
     );
 
-    function processStringInstruction(this: RouteContext, instr: NavigationInstruction): NavigationInstruction {
+    function normalizeInstruction(this: RouteContext, instr: NavigationInstruction): NavigationInstruction {
+      // Scalar strings may contain the configured deployment base. When that
+      // base is `/`, removing it also removes the slash that selects the
+      // application route context, so retain the semantic marker first.
+      const hadRootPrefixBeforeBaseRemoval = typeof instr === 'string' && instr.startsWith('/');
       if (typeof instr === 'string') instr = this._locationMgr.removeBaseHref(instr);
 
       const isVpInstr = isPartialViewportInstruction(instr);
       let $instruction = isVpInstr ? (instr as IViewportInstruction).component : instr;
       if (typeof $instruction === 'string') {
-        // '/path' -> root
-        // '../path' -> parent
-        // 'path', './path' -> current
-        if ($instruction.startsWith('/')) {
+        // These prefixes select route contexts; they are not a general URI
+        // dot-segment algorithm. `/` always selects the application root, a run
+        // of `../` selects parent contexts unless this shared tree has already
+        // been rebased, and `./` or no prefix keeps the current context. Route
+        // recognition remains in the authoritative route pipeline after this
+        // lexical context selection.
+        if (hadRootPrefixBeforeBaseRemoval || $instruction.startsWith('/')) {
           context = this.root;
-          contextChanged = true;
-          $instruction = $instruction.slice(1);
-        } else if ($instruction.startsWith('../') && context !== null) {
-          while (($instruction as string).startsWith('../') && ((context?.parent ?? null) !== null || contextChanged)) {
-            $instruction = ($instruction as string).slice(3);
-            if (!contextChanged) context = context!.parent;
+          hasRebasedContext = true;
+          if ($instruction.startsWith('/')) {
+            $instruction = $instruction.slice(1);
           }
-          contextChanged = true;
+        } else if ($instruction.startsWith('../') && context !== null) {
+          // Consume every leading parent prefix even after traversal reaches
+          // root. Leaking an excess `../` into the serialized URL would make
+          // native/reloaded navigation disagree with intercepted navigation.
+          while (($instruction as string).startsWith('../')) {
+            $instruction = ($instruction as string).slice(3);
+            if (!hasRebasedContext) {
+              context = context.parent ?? context;
+            }
+          }
+          hasRebasedContext = true;
         } else {
           if (context == null) logAndThrow(new Error(getMessage(Events.rcNoContextStringComponent)), this._logger);
           if ($instruction.startsWith('./')) {
@@ -655,11 +683,14 @@ export class RouteContext {
         }
       }
       if (isVpInstr) {
-        (instr as Writable<IViewportInstruction>).component = $instruction;
-      } else {
-        instr = $instruction;
+        const viewportInstruction = instr as IViewportInstruction;
+        // Preserve readonly public inputs: return the original object when its
+        // component is unchanged; otherwise clone it with the normalized value.
+        return $instruction === viewportInstruction.component
+          ? viewportInstruction
+          : { ...viewportInstruction, component: $instruction };
       }
-      return instr;
+      return $instruction;
     }
   }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -421,9 +421,9 @@ export class Router {
     );
   }
 
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
-  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null): ViewportInstructionTree;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren: true): ViewportInstructionTree | Promise<ViewportInstructionTree>;
+  public createViewportInstructions(instructionOrInstructions: NavigationInstruction | readonly NavigationInstruction[], options: INavigationOptions | null, parentRoutePath: string | null, traverseChildren?: boolean): ViewportInstructionTree | Promise<ViewportInstructionTree> {
     if (instructionOrInstructions instanceof ViewportInstructionTree) return instructionOrInstructions;
 
     let context: IRouteContext | null = (options?.context ?? null) as IRouteContext | null;


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

#2369 established the router's current context-relative navigation contract:

- `/path` starts at the application route root;
- `path` and `./path` start at the current route context;
- each leading `../` selects one parent route context.

This PR fixes cases where the implementation violates that contract or where the materialized browser URL does not represent the destination selected by the router. It does not change the public navigation syntax or add another route resolution policy.

### Part 1: Correctness under the current contract

- **Application-root navigation:** Removing the configured base can erase the leading `/` before route-context selection. A rooted instruction issued from a nested component can consequently resolve in that nested context.
- **Parent traversal:** More leading `../` prefixes than available route parents can survive normalization and leak into the rendered browser URL.
- **Deployment bases:** Base matching treats `/app` as a prefix of `/apple`.
- **Hash-mode `load` URLs:** `load` links can omit a non-root application base even though `href`, intercepted navigation, and history-mode `load` retain it.

### Part 2: Relationship to the earlier work

- #2250 and #2254 established that rendered links, intercepted clicks, native activation, direct entry, and reload must represent the same destination.
- #2279 explored similar path behavior by adding nearest-ancestor recognition. #2369 superseded that work with explicit route-context prefixes. This PR does not resume the additional recognition path.
- #2391 made `load` materialize its generated target URL on native anchors, `as-element` anchors, and other elements. This PR completes its deployment-base handling in hash mode.
- #2256 also contains a broader proposal to separate URL navigation, route identity, and multi-viewport navigation at the public API level. That design and its compatibility implications remain separate from these fixes.

## 💁 Your Solution

- **Application-root navigation:** Record a scalar instruction's root intent before removing the deployment base, then use that retained intent only to select the application route context.
- **Parent traversal:** Consume every leading parent prefix while clamping route-context traversal at application root.
- **Readonly normalization:** Normalize into replacement instruction values rather than rewriting caller-supplied instruction arrays or viewport instruction objects.
- **Deployment bases:** Strip a base only at an exact path, query, or fragment boundary.
- **Hash-mode `load` URLs:** Materialize `load` targets through the location manager in both routing modes.

Route recognition remains in the existing authoritative pipeline. This PR does not add the ancestor-recognition layer from #2279 or introduce another route grammar.

## 📑 Test Plan

- Cover application-root and excess-parent navigation from a nested route under history and hash routing, through both `load` and `href`.
- Include a same-named nested route so an ancestor lookup cannot hide loss of the application-root marker.
- Cover frozen instruction arrays and viewport instruction objects at the prefix-normalization boundary.
- Cover exact, trailing-slash, query, fragment, and partial-segment base matching in browser and server location managers.
- Assert that non-root hash `load` targets retain the deployment base.
- Run the full framework build, full router Node/JSDOM suite, router lint, and router Playwright suite.

## 👩‍💻 Reviewer Notes

This PR deliberately implements the existing route-context semantics; it is not general URL-reference resolution. A future explicit URL-target API can resolve and recognize public URLs separately without adding a second recognizer here. This PR therefore does not add bare `..`, general dot-segment processing, URL-segment-relative handling of multi-segment routes, or independently relative entries within one multi-viewport instruction array.

Base stripping also still lacks provenance. With deployment base `/app`, the browser URL `/app/app/dashboard` can be stripped once by location reading and again by scalar instruction normalization. Solving that pre-existing collision requires provenance across browser events, SSR, and programmatic input.

## 📦 Changeset

- [x] Added `.changeset/calm-routes-agree.md`
