### PR TITLE
fix(runtime-html): remove obsolete define lifecycle residue

### DIFF
--- a/.changeset/clean-dry-hooks.md
+++ b/.changeset/clean-dry-hooks.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime-html": patch
+---
+
+Remove the obsolete `define` component lifecycle declaration. The runtime hook was removed previously but remained exposed through types and documentation.

--- a/docs/user-docs/components/component-lifecycles.md
+++ b/docs/user-docs/components/component-lifecycles.md
@@ -14,13 +14,12 @@ Lifecycle hooks apply to **custom elements** and **custom attributes**. Syntheti
 
 ```mermaid
 flowchart LR
-  ctor["Constructor"] --> define --> hydrating --> hydrated --> created --> binding --> bound --> attaching --> attached --> detaching --> unbinding --> dispose
+  ctor["Constructor"] --> hydrating --> hydrated --> created --> binding --> bound --> attaching --> attached --> detaching --> unbinding --> dispose
 ```
 
 | Phase | Hook | Runs | Child-parent order | Async? |
 | ----- | ---- | ---- | ------------------ | ------ |
 | Construction | `constructor` | once | – | – |
-|  | `define` | once | **top ➞ down** | no |
 |  | `hydrating` | once | **top ➞ down** | no |
 |  | `hydrated` | once | **top ➞ down** | no |
 |  | `created` | once | **bottom ➞ up** | no |
@@ -51,21 +50,7 @@ export class MyComponent {
 }
 ```
 
-### 2. Define
-
-```typescript
-define(
-  controller: IDryCustomElementController<this>,
-  hydrationContext: IHydrationContext | null,
-  definition: CustomElementDefinition
-): PartialCustomElementDefinition | void {}
-```
-
-* Opportunity to **modify the component definition** before hydration begins.
-* Can return a partial definition to override aspects of the component's behavior.
-* Runs **synchronously**, parent before children.
-
-### 3. Hydrating
+### 2. Hydrating
 
 ```typescript
 hydrating(controller: IContextualCustomElementController<this>): void {}
@@ -74,7 +59,7 @@ hydrating(controller: IContextualCustomElementController<this>): void {}
 * Opportunity to **register dependencies** in `controller.container` that are needed while **compiling** the view template.
 * Runs **synchronously**, parent before children.
 
-### 4. Hydrated
+### 3. Hydrated
 
 ```typescript
 hydrated(controller: ICompiledCustomElementController<this>): void {}
@@ -83,7 +68,7 @@ hydrated(controller: ICompiledCustomElementController<this>): void {}
 * View template has been compiled, child components are **not** yet created.
 * Last chance to influence how the soon-to-be-created child components resolve their dependencies.
 
-### 5. Created
+### 4. Created
 
 ```typescript
 created(controller: ICustomElementController<this> | ICustomAttributeController<this>): void {}
@@ -93,7 +78,7 @@ created(controller: ICustomElementController<this> | ICustomAttributeController<
 * Executes **once** per instance, **children before parent**.
 * Great for logic that must run after the whole subtree is constructed but **before binding**.
 
-### 6. Binding
+### 5. Binding
 
 ```typescript
 // Custom Elements
@@ -107,7 +92,7 @@ binding(initiator: IHydratedController, parent: IHydratedController): void | Pro
 * Runs **parent ➞ child**.
 * Return a `Promise` (or mark the method `async`) to **block** binding/attaching of children until resolved.
 
-### 7. Bound
+### 6. Bound
 
 ```typescript
 // Custom Elements
@@ -120,7 +105,7 @@ bound(initiator: IHydratedController, parent: IHydratedController): void | Promi
 * View-to-view-model bindings are active; `ref`, `let`, and `from-view` values are available.
 * Executes **child ➞ parent**.
 
-### 8. Attaching
+### 7. Attaching
 
 ```typescript
 // Custom Elements
@@ -134,7 +119,7 @@ attaching(initiator: IHydratedController, parent: IHydratedController): void | P
 * Queue animations or setup 3rd-party libraries here.
 * A returned `Promise` is awaited **before** `attached` is invoked on this component **but does not block children**.
 
-### 9. Attached
+### 8. Attached
 
 ```typescript
 attached(initiator: IHydratedController): void | Promise<void> {}
@@ -144,7 +129,7 @@ attached(initiator: IHydratedController): void | Promise<void> {}
 * Executes **child ➞ parent**.
 * Note: Only receives the `initiator` parameter, **not** the parent.
 
-### 10. Detaching
+### 9. Detaching
 
 ```typescript
 // Custom Elements
@@ -157,7 +142,7 @@ detaching(initiator: IHydratedController, parent: IHydratedController): void | P
 * Called when the framework removes the component's element from the DOM.
 * Executes **child ➞ parent**. Any returned `Promise` (e.g., an outgoing animation) is awaited **in parallel** with sibling promises.
 
-### 11. Unbinding
+### 10. Unbinding
 
 ```typescript
 // Custom Elements
@@ -170,7 +155,7 @@ unbinding(initiator: IHydratedController, parent: IHydratedController): void | P
 * Runs after `detaching` finishes and bindings have been disconnected.
 * Executes **child ➞ parent**.
 
-### 12. Dispose
+### 11. Dispose
 
 ```typescript
 dispose(): void {}

--- a/docs/user-docs/components/lifecycle-diagrams.md
+++ b/docs/user-docs/components/lifecycle-diagrams.md
@@ -25,21 +25,20 @@ Timeline:
 Time  Parent              Child-1            Child-2
 ────  ──────              ───────            ───────
   0   constructor()
-  1   define()
-  2   hydrating()
-  3   hydrated()
+  1   hydrating()
+  2   hydrated()
       created() ←──────── created() ←─────── created()
                           │                  │
                           └─ children first ─┘
 
-  4   binding() ──────┐
+  3   binding() ──────┐
       ↓ (if async,    │
       blocks children)│
                       │
-  5   ← resolve ──────┘
+  4   ← resolve ──────┘
       bind() (connects bindings)
 
-  6   attaching() ────┐
+  5   attaching() ────┐
       _attach() DOM ──┤  binding() ────┐   binding() ────┐
                       │                │                  │
                       │  bind()        │   bind()         │
@@ -51,13 +50,13 @@ Time  Parent              Child-1            Child-2
                   │   (parent's attaching() and
                   │    children activation run in PARALLEL)
                   │
-  7               └─→ Wait for all to complete
+  6               └─→ Wait for all to complete
 
       attached() ←───── attached() ←──── attached()
       │                 │                 │
       └─ children first (bottom-up) ─────┘
 
-  8   ACTIVATED
+  7   ACTIVATED
 
 
 DETAILED ACTIVATION FLOW
@@ -70,10 +69,6 @@ DETAILED ACTIVATION FLOW
 │ Parent.constructor()                               │
 │   → Child1.constructor()                           │
 │   → Child2.constructor()                           │
-│                                                    │
-│ Parent.define()                                    │
-│   → Child1.define()                                │
-│   → Child2.define()                                │
 │                                                    │
 │ Parent.hydrating()                                 │
 │   → Child1.hydrating()                             │

--- a/docs/user-docs/developer-guides/cheat-sheet.md
+++ b/docs/user-docs/developer-guides/cheat-sheet.md
@@ -595,10 +595,6 @@ You can import and implement these in your components as a type-checking aid, bu
 
 ```typescript
 interface ICustomElementViewModel {
-  define(
-    controller: IDryCustomElementController,
-    parentContainer: IContainer,
-    definition: CustomElementDefinition): PartialCustomElementDefinition | void
   hydrating(controller: IContextualCustomElementController): void;
   hydrated(controller: ICompiledCustomElementController): void;
   created(controller: ICustomElementController): void;

--- a/docs/user-docs/developer-guides/developing-with-ai/claude-md-example.md
+++ b/docs/user-docs/developer-guides/developing-with-ai/claude-md-example.md
@@ -7,7 +7,7 @@ Guidance for Claude Code when working with this Aurelia 2 app.
 - Aurelia 2.x TypeScript application
 - DI via `aurelia` and `@aurelia/kernel`, hierarchical containers
 - MVVM separation of concerns
-- Lifecycle order: constructor → define → hydrating → hydrated → created → binding → bound → attaching → attached → detaching → unbinding → dispose
+- Lifecycle order: constructor → hydrating → hydrated → created → binding → bound → attaching → attached → detaching → unbinding → dispose
 
 ## Project Structure
 

--- a/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
+++ b/docs/user-docs/developer-guides/migrating-to-aurelia-2/side-by-side-comparison.md
@@ -425,12 +425,6 @@ export class UserProfile {
     // Basic initialization - same as v1
   }
 
-  // NEW: Modify component definition before hydration
-  define(controller: ICustomElementController, definition: CustomElementDefinition) {
-    // Rare use case - modify component behavior dynamically
-    return { ...definition, shadowOptions: { mode: 'open' } };
-  }
-
   // NEW: Add contextual DI registrations
   hydrating(controller: ICustomElementController) {
     // Register services that child components might need
@@ -490,7 +484,7 @@ export class UserProfile {
 ```
 
 **V2 Lifecycle Order:**
-constructor → define → hydrating → hydrated → created → binding → bound → attaching → attached → detaching → unbinding → dispose
+constructor → hydrating → hydrated → created → binding → bound → attaching → attached → detaching → unbinding → dispose
 
 **Key improvements:**
 - **More granular control**: Additional hooks for different stages

--- a/packages/__tests__/src/3-runtime-html/lifecycle-hooks.all-in-one.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/lifecycle-hooks.all-in-one.spec.ts
@@ -6,7 +6,60 @@ import {
 import { IActivationHooks, ICompileHooks, IHydratedController } from '@aurelia/runtime-html/dist/types/templating/controller';
 import { assert, createFixture } from '@aurelia/testing';
 
+type ViewModelHook = keyof ICompileHooks | keyof IActivationHooks<IHydratedController>;
+
+const expectedViewModelHooks: Record<ViewModelHook, true> = {
+  hydrating: true,
+  hydrated: true,
+  created: true,
+  binding: true,
+  bound: true,
+  attaching: true,
+  attached: true,
+  detaching: true,
+  unbinding: true,
+  dispose: true,
+  accept: true,
+};
+
 describe('3-runtime-html/lifecycle-hooks.all-in-one.spec.ts', function () {
+  it('keeps view-model hook detection aligned with the lifecycle interfaces', async function () {
+    const invokedHooks = new Set<ViewModelHook>();
+    class App {
+      hydrating() { invokedHooks.add('hydrating'); }
+      hydrated() { invokedHooks.add('hydrated'); }
+      created() { invokedHooks.add('created'); }
+      binding() { invokedHooks.add('binding'); }
+      bound() { invokedHooks.add('bound'); }
+      attaching() { invokedHooks.add('attaching'); }
+      attached() { invokedHooks.add('attached'); }
+      detaching() { invokedHooks.add('detaching'); }
+      unbinding() { invokedHooks.add('unbinding'); }
+      dispose() { invokedHooks.add('dispose'); }
+      accept() { invokedHooks.add('accept'); }
+    }
+
+    const fixture = await createFixture
+      .component(App)
+      .html``
+      .build().started;
+    const controller = fixture.component.$controller!;
+    const detectedHooks = Object.fromEntries(
+      Object.entries((controller as unknown as { _vmHooks: Record<string, boolean> })._vmHooks)
+        .map(([name, isPresent]) => [name.slice(1), isPresent])
+    );
+
+    assert.deepStrictEqual(detectedHooks, expectedViewModelHooks);
+
+    controller.accept(() => {});
+    await fixture.tearDown();
+
+    assert.deepStrictEqual(
+      Array.from(invokedHooks).sort(),
+      Object.keys(expectedViewModelHooks).sort()
+    );
+  });
+
   describe('[synchronous]', function () {
     let tracker: LifeycyleTracker | null = null;
 
@@ -51,10 +104,6 @@ describe('3-runtime-html/lifecycle-hooks.all-in-one.spec.ts', function () {
 
       unbinding() {
         tracker.unbinding++;
-      }
-
-      define() {
-        throw new Error('ni');
       }
 
       dispose() {

--- a/packages/runtime-html/src/templating/controller.ts
+++ b/packages/runtime-html/src/templating/controller.ts
@@ -1481,8 +1481,6 @@ export function isCustomElementViewModel(value: unknown): value is ICustomElemen
 class HooksDefinition {
   public static readonly none: Readonly<HooksDefinition> = new HooksDefinition({});
 
-  public readonly _define: boolean;
-
   public readonly _hydrating: boolean;
   public readonly _hydrated: boolean;
   public readonly _created: boolean;
@@ -1499,8 +1497,6 @@ class HooksDefinition {
   public readonly _accept: boolean;
 
   public constructor(target: object) {
-    this._define = 'define' in target;
-
     this._hydrating = 'hydrating' in target;
     this._hydrated = 'hydrated' in target;
     this._created = 'created' in target;
@@ -1771,7 +1767,7 @@ export interface ICustomAttributeController<C extends ICustomAttributeViewModel 
 }
 
 /**
- * A representation of `IController` specific to a custom element whose `create` hook is about to be invoked (if present).
+ * A representation of `IController` specific to a custom element before it is hydrated.
  *
  * It is not yet hydrated (hence 'dry') with any render-specific information.
  */
@@ -1782,7 +1778,7 @@ export interface IDryCustomElementController<C extends IViewModel = IViewModel> 
   /**
    * The scope that belongs to this custom element. This property is set immediately after the controller is created and is always guaranteed to be available.
    *
-   * It may be overwritten by end user during the `create()` hook.
+   * It may be overwritten by end user during the `hydrating()` hook.
    *
    * By default, the scope's `bindingContext` will be the same instance as this controller's `viewModel` property.
    */
@@ -1905,16 +1901,6 @@ export interface IActivationHooks<TParent> {
 }
 
 export interface ICompileHooks {
-  define?(
-    controller: IDryCustomElementController<this>,
-    /**
-     * The context where this element is hydrated.
-     *
-     * This is created by the controller associated with the CE creating this this controller
-     */
-    hydrationContext: IHydrationContext | null,
-    definition: CustomElementDefinition,
-  ): PartialCustomElementDefinition | void;
   hydrating?(
     controller: IContextualCustomElementController<this>,
   ): void;
@@ -1969,10 +1955,9 @@ export interface IHydratedCustomAttributeViewModel extends ICustomAttributeViewM
 
 export interface IControllerElementHydrationInstruction {
   /**
-   * An internal mechanism to manually halt + resume hydration process
+   * An internal mechanism to defer controller hydration.
    *
-   * - 0: no hydration
-   * - 1: hydrate until define() lifecycle
+   * When `false`, the controller is created without being hydrated immediately.
    *
    * @internal
    */


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

The removed `define` component lifecycle hook remained exposed through public types, hook detection, and documentation even though it was no longer invoked.

## 💁 Your Solution

Remove the obsolete declaration and detector entry, correct related controller comments, and update lifecycle documentation to list only supported hooks.

## 📑 Test Plan

Added lifecycle parity coverage for public hook declarations, runtime detection, and invocation through startup, traversal, and teardown.

## 📦 Changeset

- [x] Added a changeset