### PR TITLE
fix(runtime-html): include Z in default key mappings

### DIFF
--- a/.changeset/fix-default-z-key-mappings.md
+++ b/.changeset/fix-default-z-key-mappings.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/runtime-html": patch
+---
+
+Add the missing Z entries to the default keyboard modifier mappings so `:z`, `:90`, and `:122` work consistently with A-Y.

--- a/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.spec.ts
@@ -552,15 +552,21 @@ describe('3-runtime-html/custom-elements.spec.ts', function () {
       assert.strictEqual(entered, 1);
     });
 
-    it('works with keycode for upper key by default', async function () {
-      let entered = 0;
-      const { trigger } = createFixture(
-        '<button keydown.trigger:ctrl+107="enter()"></button>',
-        { enter: () => entered = 1 },
-      );
-      trigger('button', 'keydown', { key: 'k', ctrlKey: true });
-      assert.strictEqual(entered, 1);
-    });
+    for (const [modifier, key] of [
+      ['z', 'z'],
+      ['90', 'Z'],
+      ['122', 'z'],
+    ]) {
+      it(`works with default keyboard mapping ${modifier} -> ${key}`, async function () {
+        let entered = 0;
+        const { trigger } = createFixture(
+          `<button keydown.trigger:${modifier}="enter()"></button>`,
+          { enter: () => entered = 1 },
+        );
+        trigger('button', 'keydown', { key });
+        assert.strictEqual(entered, 1);
+      });
+    }
 
     it('works with custom keyboard mapping', async function () {
       let entered = 0;

--- a/packages/runtime-html/src/binding/listener-binding.ts
+++ b/packages/runtime-html/src/binding/listener-binding.ts
@@ -155,7 +155,7 @@ export const IKeyMapping = /*@__PURE__*/createInterface<IKeyMapping>('IKeyMappin
     space: 'Space',
     tab: 'tab',
     // by default, maps the key a-z and A-Z to their respective keycodes
-    ...Array.from({ length: 25 }).reduce((acc: Record<string, string>, _, idx) => {
+    ...Array.from({ length: 26 }).reduce((acc: Record<string, string>, _, idx) => {
       // map keycode of upper case character from A-Z
       let char = String.fromCharCode(idx + 65);
       acc[idx + 65] = char;


### PR DESCRIPTION
# 🐛 Bug Fix

## 📖 Description

The default keyboard mapping omitted `z`, `90`, and `122` because its generated A-Z range stopped at Y.

## 💁 Your Solution

Generate all 26 letter mappings.

## 📑 Test Plan

Added event-modifier integration coverage for `:z`, `:90`, and `:122`.

## 📦 Changeset

- [x] Added a changeset