### PR TITLE
fix: underscore in let shouldnt be converted to camelcase

### DIFF
--- a/.changeset/tired-rats-chew.md
+++ b/.changeset/tired-rats-chew.md
@@ -1,0 +1,5 @@
+---
+"@aurelia/template-compiler": patch
+---
+
+dont apply camelcase for \_ for let bindings

--- a/packages/__tests__/src/3-runtime-html/custom-elements.let.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/custom-elements.let.spec.ts
@@ -20,6 +20,12 @@ describe('3-runtime-html/custom-elements.let.spec.ts', function () {
 
       assertText('1');
     });
+
+    it(`keeps underscores in the target with binding command [${command}]`, function () {
+      const { assertText } = createFixture(`<let my_prop.${command}="1"></let>\${my_prop}`);
+
+      assertText('1');
+    });
   }
 
   it('removes <let> element', function () {
@@ -29,6 +35,12 @@ describe('3-runtime-html/custom-elements.let.spec.ts', function () {
 
   it('camel-cases the target with interpolation', function () {
     const { assertText } = createFixture(`<let my-prop="\${1}"></let>\${myProp}`);
+
+    assertText('1');
+  });
+
+  it('keeps underscores in the target with interpolation', function () {
+    const { assertText } = createFixture(`<let my_prop="\${1}"></let>\${my_prop}`);
 
     assertText('1');
   });
@@ -52,6 +64,25 @@ describe('3-runtime-html/custom-elements.let.spec.ts', function () {
     assertText('1');
   });
 
+  it('works with underscore targets, and warns when encountering literal', function () {
+    const { ctx, assertText, start } = createFixture(
+      `<let my_prop="1"></let>\${my_prop}`,
+      class { my_prop = 0; },
+      [],
+      false
+    );
+
+    const logger = ctx.container.get(ILogger);
+    const callArgs = [];
+    logger.warn = (fn => (...args: unknown[]) => {
+      callArgs.push(args);
+      return fn.apply(logger, args);
+    })(logger.warn);
+
+    void start();
+    assertText('1');
+  });
+
   // //<let [to-binding-context] />
   it('assigns to vm with <let to-binding-context>', function () {
     const { component } = createFixture(
@@ -60,5 +91,14 @@ describe('3-runtime-html/custom-elements.let.spec.ts', function () {
       { firstName: 'a', lastName: 'b', fullName: '' }
     );
     assert.strictEqual(component.fullName, 'a b');
+  });
+
+  it('assigns underscore targets to vm with <let to-binding-context>', function () {
+    const { component } = createFixture(
+      `<let to-binding-context full_name.bind="firstName + \` \` + lastName"></let>
+      <div>\${full_name}</div></template>`,
+      { firstName: 'a', lastName: 'b', full_name: '' }
+    );
+    assert.strictEqual(component.full_name, 'a b');
   });
 });

--- a/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
+++ b/packages/__tests__/src/3-runtime-html/template-compiler.spec.ts
@@ -500,6 +500,20 @@ describe('3-runtime-html/template-compiler.spec.ts', function () {
             ]);
           });
 
+          it('keeps underscores in let target names', function () {
+            const { instructions } = compileWith(`<let my_prop.bind="b" my_other="\${d}"></let>`);
+            verifyInstructions((instructions[0][0] as HydrateLetElementInstruction).instructions, [
+              {
+                toVerify: ['type', 'to', 'srcOrExp'],
+                type: itLetBinding, to: 'my_prop', from: 'b'
+              },
+              {
+                toVerify: ['type', 'to'],
+                type: itLetBinding, to: 'my_other'
+              }
+            ]);
+          });
+
           describe('[to-binding-context]', function () {
             it('understands [to-binding-context]', function () {
               const { instructions } = compileWith(`<template><let to-binding-context></let></template>`);

--- a/packages/template-compiler/src/template-compiler.ts
+++ b/packages/template-compiler/src/template-compiler.ts
@@ -434,7 +434,7 @@ export class TemplateCompiler implements ITemplateCompiler {
           letInstructions.push({
             type: itLetBinding,
             from: exprParser.parse(realAttrValue, etIsProperty),
-            to: camelCase(realAttrTarget)
+            to: normalizeLetBindingTarget(realAttrTarget)
           } as LetBindingInstruction);
         } else {
           throw createMappedError(ErrorNames.compiler_invalid_let_command, attrSyntax);
@@ -456,7 +456,7 @@ export class TemplateCompiler implements ITemplateCompiler {
       letInstructions.push({
         type: itLetBinding,
         from: expr === null ? createPrimitiveLiteralExpression(realAttrValue) : expr,
-        to: camelCase(realAttrTarget)
+        to: normalizeLetBindingTarget(realAttrTarget)
       } as LetBindingInstruction);
     }
     context.rows.push([{
@@ -1463,6 +1463,12 @@ export class TemplateCompiler implements ITemplateCompiler {
 
     return projections;
   }
+}
+
+function normalizeLetBindingTarget(target: string): string {
+  return target.includes('_')
+    ? target.replace(/-+([A-Za-z0-9])/g, (_, ch: string) => ch.toUpperCase())
+    : camelCase(target);
 }
 
 const TEMPLATE_NODE_NAME = 'TEMPLATE';


### PR DESCRIPTION
## 📖 Description

For normal attribute:
```html
<div my_prop.bind="5">
<el my_prop.bind="5"></el>
```
are trreated as `my_prop` bindings, but for let it's not:
```html
<let my_prop.bind="5">
<div>${my_prop} is undefined</div>
<div>But ${myProp} is 5</div>
```

This PR makes this behavior consistent.